### PR TITLE
feat(posthog-ai): render sandbox notification surfaces

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -38,7 +38,7 @@ import { HistoryPreview } from './HistoryPreview'
 import { Intro } from './Intro'
 import { MaxLogicProps, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from './maxThreadLogic'
-import { Thread } from './Thread'
+import { SandboxComposerSurfaces, Thread } from './Thread'
 
 export const scene: SceneExport = {
     component: Max,
@@ -147,6 +147,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
                             </div>
                         )}
                         <Thread className={cn('p-3', sidePanel && 'p-1')} />
+                        <SandboxComposerSurfaces />
                         {!conversation?.has_unsupported_content && (
                             <SidebarQuestionInput isSticky sidePanel={sidePanel} />
                         )}

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -43,7 +43,7 @@ import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { inStorybookTestRunner, pluralize } from 'lib/utils'
+import { humanFriendlyNumber, inStorybookTestRunner, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -72,6 +72,8 @@ import { LogEntry } from 'products/tasks/frontend/lib/parse-logs'
 
 import { FeedbackDisplay } from './components/FeedbackDisplay'
 import { MaxWebAnalyticsNudge } from './components/MaxWebAnalyticsNudge'
+import { SandboxContextUsage } from './components/SandboxContextUsage'
+import { SandboxResourcesBar } from './components/SandboxResourcesBar'
 import { ContextSummary } from './Context'
 import { DangerousOperationApprovalCard } from './DangerousOperationApprovalCard'
 import { FeedbackPrompt } from './FeedbackPrompt'
@@ -100,6 +102,7 @@ import { TicketPrompt } from './TicketPrompt'
 import { getTicketPromptData, getTicketSummaryData, isTicketConfirmationMessage } from './ticketUtils'
 import { ToolCallWidgetDef, getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import { TraceIdProvider, useTraceId } from './TraceIdContext'
+import type { ThreadItem } from './types/sandboxStreamTypes'
 import { useFeedback } from './useFeedback'
 import {
     isArtifactMessage,
@@ -230,6 +233,15 @@ function SandboxThread(): JSX.Element {
                         </MessageTemplate>
                     )
                 }
+                if (item.type === 'status') {
+                    return <SandboxStatusItem key={item.id} item={item} />
+                }
+                if (item.type === 'compact_boundary') {
+                    return <SandboxCompactBoundaryItem key={item.id} item={item} />
+                }
+                if (item.type === 'task_notification') {
+                    return <SandboxTaskNotificationItem key={item.id} item={item} />
+                }
                 return null
             })}
             {streamPhase === 'provisioning' && <SandboxProvisioningIndicator progress={currentProgress} />}
@@ -270,6 +282,60 @@ function SandboxThinkingIndicator({ progress }: { progress: string | null }): JS
                 <span>{message}</span>
             </div>
         </MessageTemplate>
+    )
+}
+
+/** Inline `_posthog/status` item — a spinner while compacting, a generic status line otherwise. */
+function SandboxStatusItem({ item }: { item: ThreadItem }): JSX.Element {
+    const isCompacting = item.status === 'compacting' && !item.isComplete
+    return (
+        <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted">
+            {isCompacting ? (
+                <>
+                    <Spinner className="size-3" />
+                    <span>Compacting conversation history…</span>
+                </>
+            ) : (
+                <span>Status: {item.status}</span>
+            )}
+        </div>
+    )
+}
+
+/** Inline `_posthog/compact_boundary` item — the post-compaction rule. */
+function SandboxCompactBoundaryItem({ item }: { item: ThreadItem }): JSX.Element {
+    return (
+        <div className="flex items-center gap-2 py-1 text-xs text-muted">
+            <div className="h-px grow bg-border" />
+            <span className="shrink-0">
+                Conversation compacted
+                {item.trigger ? ` (${item.trigger})` : ''}
+                {typeof item.preTokens === 'number'
+                    ? ` · ~${humanFriendlyNumber(item.preTokens)} tokens summarized`
+                    : ''}
+            </span>
+            <div className="h-px grow bg-border" />
+        </div>
+    )
+}
+
+/** Inline `_posthog/task_notification` item — a colored rule by status (completed/failed/stopped). */
+function SandboxTaskNotificationItem({ item }: { item: ThreadItem }): JSX.Element {
+    const colorClass =
+        item.status === 'completed' ? 'text-success' : item.status === 'failed' ? 'text-danger' : 'text-warning'
+    const icon =
+        item.status === 'completed' ? (
+            <IconCheck className="size-3" />
+        ) : item.status === 'failed' ? (
+            <IconX className="size-3" />
+        ) : (
+            <IconWarning className="size-3" />
+        )
+    return (
+        <div className={cn('flex items-center justify-center gap-1.5 py-1 text-xs', colorClass)}>
+            {icon}
+            <span>{item.summary || `Task ${item.status}`}</span>
+        </div>
     )
 }
 
@@ -486,6 +552,30 @@ function LegacyThread({ showTrailers }: { showTrailers: boolean }): JSX.Element 
             <NotFound object="conversation" className="m-0" />
         </div>
     ) : null
+}
+
+/**
+ * Persistent sandbox surfaces mounted between the thread and the sticky composer: the
+ * "PostHog resources used" bar and the context-usage indicator. Both read `sandboxStreamLogic`
+ * values directly, so this binds the same logic instance `Thread`'s sandbox path uses. Renders
+ * nothing for non-sandbox conversations; the inner components hide themselves when empty.
+ */
+export function SandboxComposerSurfaces(): JSX.Element | null {
+    const { conversation, sandboxConversationKey } = useValues(maxThreadLogic)
+    const sandboxModeEnabled = useFeatureFlag('PHAI_SANDBOX_MODE')
+
+    if (conversation?.agent_runtime !== 'sandbox' || !sandboxModeEnabled || !sandboxConversationKey) {
+        return null
+    }
+
+    return (
+        <BindLogic logic={sandboxStreamLogic} props={{ conversationId: sandboxConversationKey }}>
+            <div className="w-full max-w-180 self-center mx-auto">
+                <SandboxResourcesBar />
+                <SandboxContextUsage />
+            </div>
+        </BindLogic>
+    )
 }
 
 function SandboxActivityPanel({ entries }: { entries: LogEntry[] }): JSX.Element | null {

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -43,7 +43,7 @@ import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-import { humanFriendlyNumber, inStorybookTestRunner, pluralize } from 'lib/utils'
+import { inStorybookTestRunner, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -96,13 +96,17 @@ import {
     isRenderableUIPayloadTool,
 } from './messages/UIPayloadAnswer'
 import { VisualizationArtifact } from './messages/VisualizationArtifact'
+import {
+    SandboxCompactBoundaryItem,
+    SandboxStatusItem,
+    SandboxTaskNotificationItem,
+} from './sandbox/SandboxThreadItems'
 import { sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommandName } from './slash-commands'
 import { TicketPrompt } from './TicketPrompt'
 import { getTicketPromptData, getTicketSummaryData, isTicketConfirmationMessage } from './ticketUtils'
 import { ToolCallWidgetDef, getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import { TraceIdProvider, useTraceId } from './TraceIdContext'
-import type { ThreadItem } from './types/sandboxStreamTypes'
 import { useFeedback } from './useFeedback'
 import {
     isArtifactMessage,
@@ -282,60 +286,6 @@ function SandboxThinkingIndicator({ progress }: { progress: string | null }): JS
                 <span>{message}</span>
             </div>
         </MessageTemplate>
-    )
-}
-
-/** Inline `_posthog/status` item — a spinner while compacting, a generic status line otherwise. */
-function SandboxStatusItem({ item }: { item: ThreadItem }): JSX.Element {
-    const isCompacting = item.status === 'compacting' && !item.isComplete
-    return (
-        <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted">
-            {isCompacting ? (
-                <>
-                    <Spinner className="size-3" />
-                    <span>Compacting conversation history…</span>
-                </>
-            ) : (
-                <span>Status: {item.status}</span>
-            )}
-        </div>
-    )
-}
-
-/** Inline `_posthog/compact_boundary` item — the post-compaction rule. */
-function SandboxCompactBoundaryItem({ item }: { item: ThreadItem }): JSX.Element {
-    return (
-        <div className="flex items-center gap-2 py-1 text-xs text-muted">
-            <div className="h-px grow bg-border" />
-            <span className="shrink-0">
-                Conversation compacted
-                {item.trigger ? ` (${item.trigger})` : ''}
-                {typeof item.preTokens === 'number'
-                    ? ` · ~${humanFriendlyNumber(item.preTokens)} tokens summarized`
-                    : ''}
-            </span>
-            <div className="h-px grow bg-border" />
-        </div>
-    )
-}
-
-/** Inline `_posthog/task_notification` item — a colored rule by status (completed/failed/stopped). */
-function SandboxTaskNotificationItem({ item }: { item: ThreadItem }): JSX.Element {
-    const colorClass =
-        item.status === 'completed' ? 'text-success' : item.status === 'failed' ? 'text-danger' : 'text-warning'
-    const icon =
-        item.status === 'completed' ? (
-            <IconCheck className="size-3" />
-        ) : item.status === 'failed' ? (
-            <IconX className="size-3" />
-        ) : (
-            <IconWarning className="size-3" />
-        )
-    return (
-        <div className={cn('flex items-center justify-center gap-1.5 py-1 text-xs', colorClass)}>
-            {icon}
-            <span>{item.summary || `Task ${item.status}`}</span>
-        </div>
     )
 }
 

--- a/frontend/src/scenes/max/components/SandboxContextUsage.tsx
+++ b/frontend/src/scenes/max/components/SandboxContextUsage.tsx
@@ -1,0 +1,68 @@
+import { useValues } from 'kea'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { humanFriendlyNumber } from 'lib/utils'
+
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+
+/** Compact SVG ring showing the context-window fill percentage. */
+function UsageRing({ percentage }: { percentage: number }): JSX.Element {
+    const radius = 7
+    const circumference = 2 * Math.PI * radius
+    const clamped = Math.max(0, Math.min(1, percentage / 100))
+    return (
+        <svg viewBox="0 0 18 18" className="size-4 shrink-0 -rotate-90">
+            <circle cx="9" cy="9" r={radius} fill="none" strokeWidth="2.5" className="stroke-border" />
+            <circle
+                cx="9"
+                cy="9"
+                r={radius}
+                fill="none"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={circumference * (1 - clamped)}
+                className="stroke-accent"
+            />
+        </svg>
+    )
+}
+
+/**
+ * Context-usage indicator for sandbox conversations. Reads the latest-wins `contextUsage` snapshot
+ * and renders a fill ring + `used / size · %` label when the numeric aggregate is present, plus the
+ * run cost when known. Hidden when there is nothing to show. The breakdown popover is deferred.
+ */
+export function SandboxContextUsage(): JSX.Element | null {
+    const { contextUsage } = useValues(sandboxStreamLogic)
+
+    if (!contextUsage) {
+        return null
+    }
+
+    const { used, size, cost } = contextUsage
+    const hasRing = typeof used === 'number' && typeof size === 'number' && size > 0
+    const percentage = hasRing ? Math.round((used! / size!) * 100) : null
+    const hasCost = typeof cost === 'number'
+
+    if (!hasRing && !hasCost) {
+        return null
+    }
+
+    return (
+        <div className="flex items-center gap-2 px-3 py-1 text-xs text-muted" data-attr="max-sandbox-context-usage">
+            {hasRing && (
+                <Tooltip title="Context window usage">
+                    <span className="flex items-center gap-1.5">
+                        <UsageRing percentage={percentage!} />
+                        <span>
+                            {humanFriendlyNumber(used!)} / {humanFriendlyNumber(size!)} · {percentage}%
+                        </span>
+                    </span>
+                </Tooltip>
+            )}
+            {hasCost && <span>${cost!.toFixed(2)}</span>}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/SandboxResourcesBar.tsx
+++ b/frontend/src/scenes/max/components/SandboxResourcesBar.tsx
@@ -1,0 +1,37 @@
+import { useValues } from 'kea'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { resolveProductMeta } from '../messages/posthogProducts'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+
+/**
+ * Persistent "PostHog resources used" bar for sandbox conversations. Reads the session-cumulative
+ * `resourcesUsed` list (unioned by id across the whole conversation) and renders one chip per
+ * product the agent grounded an answer in. Hidden when empty. Each chip is a product icon plus a
+ * Sentence-cased label; unknown ids degrade to the wire label and a generic icon.
+ */
+export function SandboxResourcesBar(): JSX.Element | null {
+    const { resourcesUsed } = useValues(sandboxStreamLogic)
+
+    if (resourcesUsed.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-1.5 px-3 py-1.5" data-attr="max-sandbox-resources-bar">
+            <span className="text-xs text-muted mr-0.5">PostHog resources used:</span>
+            {resourcesUsed.map((product) => {
+                const { label, Icon } = resolveProductMeta(product.id, product.label)
+                return (
+                    <Tooltip key={product.id} title={label}>
+                        <span className="inline-flex items-center gap-1 rounded border bg-surface-primary px-1.5 py-0.5 text-xs">
+                            <Icon className="size-3.5 shrink-0" />
+                            <span>{label}</span>
+                        </span>
+                    </Tooltip>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/messages/posthogProducts.ts
+++ b/frontend/src/scenes/max/messages/posthogProducts.ts
@@ -1,0 +1,74 @@
+/**
+ * PostHog product taxonomy for the sandbox resources bar. Ported from the agent's
+ * `POSTHOG_PRODUCTS` (ids + labels are authoritative there) with icons sourced from
+ * `@posthog/icons`. The `_posthog/resources_used` wire frame already carries `{id, label}`, so this
+ * map is the icon source plus a fallback label for any id the wire omits. Labels are NOT a
+ * mechanical sentence-casing of the id (e.g. `llm_analytics → "AI observability"`,
+ * `cdp → "Data pipelines"`, acronyms stay all-caps), so they are copied verbatim.
+ */
+import {
+    IconAI,
+    IconCursor,
+    IconDatabase,
+    IconFlask,
+    IconGraph,
+    IconHogQL,
+    IconLogomark,
+    IconMessage,
+    IconPlug,
+    IconPulse,
+    IconRewind,
+    IconServer,
+    IconToggle,
+    IconWarning,
+} from '@posthog/icons'
+
+export type PostHogProductId =
+    | 'product_analytics'
+    | 'web_analytics'
+    | 'feature_flags'
+    | 'experiments'
+    | 'error_tracking'
+    | 'session_replay'
+    | 'surveys'
+    | 'llm_analytics'
+    | 'data_warehouse'
+    | 'cdp'
+    | 'logs'
+    | 'apm'
+    | 'sql'
+    | 'posthog'
+
+export interface PostHogProductMeta {
+    label: string
+    Icon: typeof IconGraph
+}
+
+export const POSTHOG_PRODUCTS: Record<PostHogProductId, PostHogProductMeta> = {
+    product_analytics: { label: 'Product analytics', Icon: IconGraph },
+    web_analytics: { label: 'Web analytics', Icon: IconPulse },
+    feature_flags: { label: 'Feature flags', Icon: IconToggle },
+    experiments: { label: 'Experiments', Icon: IconFlask },
+    error_tracking: { label: 'Error tracking', Icon: IconWarning },
+    session_replay: { label: 'Session replay', Icon: IconRewind },
+    surveys: { label: 'Surveys', Icon: IconMessage },
+    llm_analytics: { label: 'AI observability', Icon: IconAI },
+    data_warehouse: { label: 'Data warehouse', Icon: IconDatabase },
+    cdp: { label: 'Data pipelines', Icon: IconPlug },
+    logs: { label: 'Logs', Icon: IconServer },
+    apm: { label: 'APM', Icon: IconCursor },
+    sql: { label: 'SQL', Icon: IconHogQL },
+    posthog: { label: 'PostHog', Icon: IconLogomark },
+}
+
+/** Fallback icon for ids absent from the taxonomy — degrade gracefully rather than disappearing. */
+export const FALLBACK_PRODUCT_ICON = IconLogomark
+
+/** Resolve a product id to its icon + display label, tolerating unknown ids (uses the wire label). */
+export function resolveProductMeta(id: string, wireLabel?: string): PostHogProductMeta {
+    const known = POSTHOG_PRODUCTS[id as PostHogProductId]
+    if (known) {
+        return { label: wireLabel || known.label, Icon: known.Icon }
+    }
+    return { label: wireLabel || id, Icon: FALLBACK_PRODUCT_ICON }
+}

--- a/frontend/src/scenes/max/sandbox/SandboxThreadItems.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxThreadItems.tsx
@@ -1,0 +1,61 @@
+import { IconCheck, IconWarning, IconX } from '@posthog/icons'
+import { Spinner } from '@posthog/lemon-ui'
+
+import { humanFriendlyNumber } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
+
+import type { ThreadItem } from '../types/sandboxStreamTypes'
+
+/** Inline `_posthog/status` item — a spinner while compacting, a generic status line otherwise. */
+export function SandboxStatusItem({ item }: { item: ThreadItem }): JSX.Element {
+    const isCompacting = item.status === 'compacting' && !item.isComplete
+    return (
+        <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted">
+            {isCompacting ? (
+                <>
+                    <Spinner className="size-3" />
+                    <span>Compacting conversation history…</span>
+                </>
+            ) : (
+                <span>Status: {item.status}</span>
+            )}
+        </div>
+    )
+}
+
+/** Inline `_posthog/compact_boundary` item — the post-compaction rule. */
+export function SandboxCompactBoundaryItem({ item }: { item: ThreadItem }): JSX.Element {
+    return (
+        <div className="flex items-center gap-2 py-1 text-xs text-muted">
+            <div className="h-px grow bg-border" />
+            <span className="shrink-0">
+                Conversation compacted
+                {item.trigger ? ` (${item.trigger})` : ''}
+                {typeof item.preTokens === 'number'
+                    ? ` · ~${humanFriendlyNumber(item.preTokens)} tokens summarized`
+                    : ''}
+            </span>
+            <div className="h-px grow bg-border" />
+        </div>
+    )
+}
+
+/** Inline `_posthog/task_notification` item — a colored rule by status (completed/failed/stopped). */
+export function SandboxTaskNotificationItem({ item }: { item: ThreadItem }): JSX.Element {
+    const colorClass =
+        item.status === 'completed' ? 'text-success' : item.status === 'failed' ? 'text-danger' : 'text-warning'
+    const icon =
+        item.status === 'completed' ? (
+            <IconCheck className="size-3" />
+        ) : item.status === 'failed' ? (
+            <IconX className="size-3" />
+        ) : (
+            <IconWarning className="size-3" />
+        )
+    return (
+        <div className={cn('flex items-center justify-center gap-1.5 py-1 text-xs', colorClass)}>
+            {icon}
+            <span>{item.summary || `Task ${item.status}`}</span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -11,6 +11,7 @@ import {
     mapHttpStatusToStreamError,
     MAX_CUMULATIVE_RECONNECT_ATTEMPTS,
     MAX_SSE_RECONNECT_ATTEMPTS,
+    mergeResourceProducts,
     parsePermissionRequestFrame,
     reconnectDelayMs,
     resolveToolKey,
@@ -1086,6 +1087,255 @@ describe('sandboxStreamLogic', () => {
                     notification('_posthog/progress', { sessionId: 's', detail: 'PostHog/posthog @ master' })
                 )
             }).toMatchValues({ currentProgress: 'PostHog/posthog @ master' })
+        })
+    })
+
+    describe('mergeResourceProducts', () => {
+        it('unions by id, preserves first-seen order, and tolerates empty/idless input', () => {
+            const first = mergeResourceProducts([], [{ id: 'product_analytics', label: 'Product analytics' }])
+            expect(first).toEqual([{ id: 'product_analytics', label: 'Product analytics' }])
+
+            const second = mergeResourceProducts(first, [
+                { id: 'product_analytics', label: 'dup' },
+                { id: 'session_replay', label: 'Session replay' },
+                { label: 'no id' },
+                { id: '' },
+            ])
+            expect(second.map((p) => p.id)).toEqual(['product_analytics', 'session_replay'])
+            // First-seen label wins for an id already present.
+            expect(second[0].label).toEqual('Product analytics')
+        })
+    })
+
+    describe('_posthog/resources_used handling', () => {
+        it('unions products into resourcesUsed by id in first-seen order', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/resources_used', {
+                        products: [
+                            { id: 'product_analytics', label: 'Product analytics' },
+                            { id: 'session_replay', label: 'Session replay' },
+                        ],
+                    })
+                )
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/resources_used', {
+                        products: [
+                            { id: 'session_replay', label: 'Session replay' },
+                            { id: 'sql', label: 'SQL' },
+                        ],
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.resourcesUsed.map((p) => p.id)).toEqual(['product_analytics', 'session_replay', 'sql'])
+        })
+
+        it('survives bootstrap replay without double-counting (same frame twice → one entry set)', async () => {
+            const frame = notification('_posthog/resources_used', {
+                products: [{ id: 'product_analytics', label: 'Product analytics' }],
+            })
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([frame as any, frame as any])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            // Content-dedup drops the identical replay; the union would dedup by id regardless.
+            expect(logic.values.resourcesUsed.map((p) => p.id)).toEqual(['product_analytics'])
+        })
+    })
+
+    describe('_posthog/usage_update handling', () => {
+        it('folds the Codex split frames (used + cost, then breakdown) into contextUsage', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/usage_update', {
+                        used: { inputTokens: 100, outputTokens: 20 },
+                        cost: { amount: 0.42, currency: 'USD' },
+                    })
+                )
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/usage_update', { breakdown: { systemPrompt: 10, tools: 5 } })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.contextUsage?.tokens).toEqual({ inputTokens: 100, outputTokens: 20 })
+            expect(logic.values.contextUsage?.cost).toEqual(0.42)
+            expect(logic.values.contextUsage?.breakdown).toEqual({ systemPrompt: 10, tools: 5 })
+        })
+
+        it('folds the Claude combined frame (used + numeric cost + breakdown) into contextUsage', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/usage_update', {
+                        used: { inputTokens: 5000, outputTokens: 600 },
+                        cost: 0.18,
+                        breakdown: { conversation: 9000 },
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.contextUsage?.tokens).toEqual({ inputTokens: 5000, outputTokens: 600 })
+            expect(logic.values.contextUsage?.cost).toEqual(0.18)
+            expect(logic.values.contextUsage?.breakdown).toEqual({ conversation: 9000 })
+        })
+
+        it('lands the numeric used/size aggregate from a session/update-framed usage_update', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({
+                        sessionUpdate: 'usage_update',
+                        used: 168000,
+                        size: 200000,
+                        cost: { amount: 1.2, currency: 'USD' },
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.contextUsage?.used).toEqual(168000)
+            expect(logic.values.contextUsage?.size).toEqual(200000)
+            expect(logic.values.contextUsage?.cost).toEqual(1.2)
+            // The aggregate must not be misrouted into a thread item.
+            expect(logic.values.threadItems).toEqual([])
+        })
+
+        it('merges the aggregate ring numbers with the ext-notification tokens/breakdown', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/usage_update', {
+                        used: { inputTokens: 100 },
+                        breakdown: { tools: 5 },
+                    })
+                )
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'usage_update', used: 12000, size: 200000 })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.contextUsage).toEqual({
+                tokens: { inputTokens: 100 },
+                breakdown: { tools: 5 },
+                used: 12000,
+                size: 200000,
+            })
+        })
+    })
+
+    describe('_posthog/status + compact_boundary inline items', () => {
+        it('pushes a status item for an in-progress compaction', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/status', { status: 'compacting' }))
+            }).toFinishAllListeners()
+
+            const item = logic.values.threadItems.find((i) => i.type === 'status')
+            expect(item).toEqual(expect.objectContaining({ type: 'status', status: 'compacting', isComplete: false }))
+        })
+
+        it('pushes nothing for a completed compaction status', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/status', { status: 'compacting', isComplete: true })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems).toEqual([])
+        })
+
+        it('pushes a compact_boundary item carrying trigger/preTokens/contextSize', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/compact_boundary', {
+                        trigger: 'auto',
+                        preTokens: 168000,
+                        contextSize: 54000,
+                    })
+                )
+            }).toFinishAllListeners()
+
+            const item = logic.values.threadItems.find((i) => i.type === 'compact_boundary')
+            expect(item).toEqual(
+                expect.objectContaining({
+                    type: 'compact_boundary',
+                    trigger: 'auto',
+                    preTokens: 168000,
+                    contextSize: 54000,
+                })
+            )
+        })
+    })
+
+    describe('_posthog/task_notification inline item', () => {
+        it('pushes a task_notification item carrying status + summary', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/task_notification', {
+                        status: 'completed',
+                        summary: 'Analysis written to report.md',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            const item = logic.values.threadItems.find((i) => i.type === 'task_notification')
+            expect(item).toEqual(
+                expect.objectContaining({
+                    type: 'task_notification',
+                    status: 'completed',
+                    summary: 'Analysis written to report.md',
+                })
+            )
+        })
+    })
+
+    describe('_posthog/sdk_session handling', () => {
+        it('stashes the adapter/session identity without rendering UI', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/sdk_session', {
+                        taskRunId: 'run-1',
+                        sessionId: 'sess_a1b2c3',
+                        adapter: 'claude',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.sdkSession).toEqual({ sessionId: 'sess_a1b2c3', adapter: 'claude' })
+            expect(logic.values.threadItems).toEqual([])
+        })
+    })
+
+    describe('reset clears notification state', () => {
+        it('clears resourcesUsed, contextUsage, and sdkSession on reset', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/resources_used', { products: [{ id: 'sql', label: 'SQL' }] })
+                )
+                logic.actions.ingestAcpFrame(notification('_posthog/usage_update', { used: { inputTokens: 1 } }))
+                logic.actions.ingestAcpFrame(notification('_posthog/sdk_session', { adapter: 'codex' }))
+            }).toFinishAllListeners()
+
+            expect(logic.values.resourcesUsed).toHaveLength(1)
+            expect(logic.values.contextUsage).not.toBeNull()
+            expect(logic.values.sdkSession).not.toBeNull()
+
+            await expectLogic(logic, () => {
+                logic.actions.reset()
+            }).toFinishAllListeners()
+
+            expect(logic.values.resourcesUsed).toEqual([])
+            expect(logic.values.contextUsage).toBeNull()
+            expect(logic.values.sdkSession).toBeNull()
+        })
+
+        it('keeps resourcesUsed across markTurnComplete (accumulates over the session)', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/resources_used', { products: [{ id: 'sql', label: 'SQL' }] })
+                )
+                logic.actions.markTurnComplete()
+            }).toFinishAllListeners()
+
+            expect(logic.values.resourcesUsed.map((p) => p.id)).toEqual(['sql'])
         })
     })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -1263,6 +1263,28 @@ describe('sandboxStreamLogic', () => {
                 })
             )
         })
+
+        it('clears the in-progress compaction spinner once compaction completes', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/status', { status: 'compacting' }))
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/status', { status: 'compacting', isComplete: true })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.filter((i) => i.type === 'status')).toEqual([])
+        })
+
+        it('replaces the in-progress spinner with the compact_boundary divider', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/status', { status: 'compacting' }))
+                logic.actions.ingestAcpFrame(notification('_posthog/compact_boundary', { trigger: 'auto' }))
+            }).toFinishAllListeners()
+
+            const items = logic.values.threadItems
+            expect(items.some((i) => i.type === 'status')).toBe(false)
+            expect(items.some((i) => i.type === 'compact_boundary')).toBe(true)
+        })
     })
 
     describe('_posthog/task_notification inline item', () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -8,7 +8,10 @@ import { projectLogic } from 'scenes/projectLogic'
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
 import { defaultPermissionDecision, findAllowOptionId } from './sandboxToolPolicy'
 import type {
+    ContextUsage,
     PermissionRequestRecord,
+    ResourceProduct,
+    SdkSession,
     ThreadItem,
     ThreadItemType,
     ToolInvocation,
@@ -17,9 +20,16 @@ import type {
 import {
     type PermissionOption,
     type PermissionRequestFrame,
+    type PosthogCompactBoundaryParams,
     type PosthogErrorParams,
     type PosthogPermissionRequestParams,
     type PosthogProgressParams,
+    type PosthogResourcesUsedParams,
+    type PosthogSdkSessionParams,
+    type PosthogStatusParams,
+    type PosthogTaskNotificationParams,
+    type PosthogUsageUpdateParams,
+    type SessionUpdateUsage,
     type SseErrorFrameData,
     type StoredLogEntry,
     isKnownSessionUpdate,
@@ -27,6 +37,7 @@ import {
     isPermissionRequestFrame,
     isPosthogNotification,
     isSessionUpdateNotification,
+    isSessionUpdateUsage,
     isTaskRunStateFrame,
 } from './types/sandboxWireTypes'
 
@@ -136,6 +147,71 @@ function extractUserMessageText(content: string | unknown[] | undefined): string
             .join('')
     }
     return ''
+}
+
+/**
+ * Union incoming resource products into the accumulated list by `id`, preserving first-seen order.
+ * Pure — mirrors the reference `accumulateSessionResources`. Products without an `id` are skipped.
+ */
+export function mergeResourceProducts(
+    existing: ResourceProduct[],
+    incoming: { id?: string; label?: string }[]
+): ResourceProduct[] {
+    const seen = new Set(existing.map((p) => p.id))
+    const next = [...existing]
+    for (const product of incoming) {
+        if (typeof product.id !== 'string' || product.id === '' || seen.has(product.id)) {
+            continue
+        }
+        seen.add(product.id)
+        next.push({ id: product.id, label: product.label })
+    }
+    return next
+}
+
+/** Normalize either wire cost shape (a bare number, or `{amount, currency}`) to a number | undefined. */
+function normalizeUsageCost(
+    cost: number | { amount?: number; currency?: string } | null | undefined
+): number | undefined {
+    if (cost == null) {
+        return undefined
+    }
+    if (typeof cost === 'number') {
+        return cost
+    }
+    return typeof cost.amount === 'number' ? cost.amount : undefined
+}
+
+/** Latest-wins fold of an `_posthog/usage_update` ext-notification onto the context-usage snapshot. */
+export function foldUsageNotification(existing: ContextUsage | null, params: PosthogUsageUpdateParams): ContextUsage {
+    const next: ContextUsage = { ...existing }
+    if (params.used != null) {
+        next.tokens = params.used
+    }
+    if (params.breakdown != null) {
+        next.breakdown = params.breakdown
+    }
+    const cost = normalizeUsageCost(params.cost)
+    if (cost !== undefined) {
+        next.cost = cost
+    }
+    return next
+}
+
+/** Latest-wins fold of the numeric `session/update` usage aggregate (drives the percentage ring). */
+export function foldUsageAggregate(existing: ContextUsage | null, update: SessionUpdateUsage): ContextUsage {
+    const next: ContextUsage = { ...existing }
+    if (typeof update.used === 'number') {
+        next.used = update.used
+    }
+    if (typeof update.size === 'number') {
+        next.size = update.size
+    }
+    const cost = normalizeUsageCost(update.cost)
+    if (cost !== undefined) {
+        next.cost = cost
+    }
+    return next
 }
 
 /** Refetch the run's status; on failure return the mapped error envelope instead. */
@@ -482,6 +558,18 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         /** Echoes the user's own message into the thread — the sandbox wire never replays it. */
         pushHumanMessage: (content: string) => ({ content }),
         pushErrorItem: (errorMessage: string, variant: 'error' | 'crash' = 'error') => ({ errorMessage, variant }),
+        /** Union the products an answer was grounded in — accumulates across the whole session. */
+        mergeResourcesUsed: (products: { id?: string; label?: string }[]) => ({ products }),
+        /** Latest-wins context-usage snapshot fold (token/cost/breakdown or numeric aggregate). */
+        setContextUsage: (usage: ContextUsage) => ({ usage }),
+        /** Inline `_posthog/status` thread item (e.g. compaction in progress). */
+        pushStatusItem: (status: string, isComplete: boolean) => ({ status, isComplete }),
+        /** Inline `_posthog/compact_boundary` thread item — the post-compaction marker. */
+        pushCompactBoundaryItem: (payload: { trigger?: string; preTokens?: number; contextSize?: number }) => payload,
+        /** Inline `_posthog/task_notification` thread item — a task milestone. */
+        pushTaskNotificationItem: (payload: { status?: string; summary?: string }) => payload,
+        /** Diagnostic `_posthog/sdk_session` plumbing — no UI. */
+        setSdkSession: (session: SdkSession) => ({ session }),
         reset: true,
     }),
     reducers({
@@ -632,6 +720,18 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     ...state,
                     { id: `error-${state.length}`, type: 'error', errorMessage, variant },
                 ],
+                pushStatusItem: (state, { status, isComplete }) => [
+                    ...state,
+                    { id: `status-${state.length}`, type: 'status', status, isComplete },
+                ],
+                pushCompactBoundaryItem: (state, { trigger, preTokens, contextSize }) => [
+                    ...state,
+                    { id: `compact-${state.length}`, type: 'compact_boundary', trigger, preTokens, contextSize },
+                ],
+                pushTaskNotificationItem: (state, { status, summary }) => [
+                    ...state,
+                    { id: `task-${state.length}`, type: 'task_notification', status, summary },
+                ],
                 reset: () => [],
             },
         ],
@@ -735,6 +835,32 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 markRunStarted: () => false,
                 pushHumanMessage: () => false,
                 reset: () => false,
+            },
+        ],
+        // Products the agent grounded answers in, unioned by id (first-seen order) across the whole
+        // session. NOT cleared on markTurnComplete — the bar accumulates; only a reset clears it.
+        resourcesUsed: [
+            [] as ResourceProduct[],
+            {
+                mergeResourcesUsed: (state, { products }) => mergeResourceProducts(state, products),
+                reset: () => [],
+            },
+        ],
+        // Latest-wins context-usage snapshot for the footer ring. The setContextUsage payload is the
+        // already-folded snapshot (the listener merges onto the prior value).
+        contextUsage: [
+            null as ContextUsage | null,
+            {
+                setContextUsage: (_, { usage }) => usage,
+                reset: () => null,
+            },
+        ],
+        // Diagnostic resume plumbing — adapter/session identity for telemetry. No UI.
+        sdkSession: [
+            null as SdkSession | null,
+            {
+                setSdkSession: (_, { session }) => session,
+                reset: () => null,
             },
         ],
     }),
@@ -1253,8 +1379,56 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 }
                 return
             }
+            // The agent reports, per turn, which PostHog products an answer was grounded in. Union
+            // them by id into the persistent resources bar — accumulates across the whole session.
+            if (isPosthogNotification(notification, '_posthog/resources_used')) {
+                const params = (notification.params ?? {}) as PosthogResourcesUsedParams
+                actions.mergeResourcesUsed(params.products ?? [])
+                return
+            }
+            // Token usage + cost + context-window breakdown. The Codex adapter sends two split
+            // frames; the Claude adapter sends a single combined frame (used + cost-as-number +
+            // breakdown). The permissive fold tolerates both. The numeric used/size aggregate that
+            // drives the percentage ring arrives separately on a session/update (handled below).
+            if (isPosthogNotification(notification, '_posthog/usage_update')) {
+                const params = (notification.params ?? {}) as PosthogUsageUpdateParams
+                actions.setContextUsage(foldUsageNotification(values.contextUsage, params))
+                return
+            }
+            // Context-compaction start/end. Twig renders nothing for the completed case, so gate it
+            // at dispatch: a `compacting` status that is complete pushes no thread item.
+            if (isPosthogNotification(notification, '_posthog/status')) {
+                const params = (notification.params ?? {}) as PosthogStatusParams
+                const status = String(params.status ?? '')
+                const isComplete = params.isComplete === true
+                if (status === 'compacting' && isComplete) {
+                    return
+                }
+                actions.pushStatusItem(status, isComplete)
+                return
+            }
+            if (isPosthogNotification(notification, '_posthog/compact_boundary')) {
+                const params = (notification.params ?? {}) as PosthogCompactBoundaryParams
+                actions.pushCompactBoundaryItem({
+                    trigger: params.trigger,
+                    preTokens: params.preTokens,
+                    contextSize: params.contextSize,
+                })
+                return
+            }
+            if (isPosthogNotification(notification, '_posthog/task_notification')) {
+                const params = (notification.params ?? {}) as PosthogTaskNotificationParams
+                actions.pushTaskNotificationItem({ status: params.status, summary: params.summary })
+                return
+            }
+            // Diagnostic only — no UI; kept for resume telemetry / crash-affordance work.
+            if (isPosthogNotification(notification, '_posthog/sdk_session')) {
+                const params = (notification.params ?? {}) as PosthogSdkSessionParams
+                actions.setSdkSession({ sessionId: params.sessionId, adapter: params.adapter })
+                return
+            }
             if (method?.startsWith('_posthog/')) {
-                // _posthog/usage_update, _posthog/console, _posthog/sdk_session, _posthog/git_checkpoint, ...
+                // _posthog/console, _posthog/sandbox_output, _posthog/git_checkpoint, ... — still dropped.
                 return
             }
 
@@ -1263,6 +1437,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
 
             const update = notification.params?.update
+            // The numeric used/size usage aggregate is session/update-framed but isn't in
+            // KNOWN_SESSION_UPDATES — special-case it before isKnownSessionUpdate to drive the ring
+            // without widening the tool-render switch below.
+            if (isSessionUpdateUsage(update)) {
+                actions.setContextUsage(foldUsageAggregate(values.contextUsage, update))
+                return
+            }
             if (!isKnownSessionUpdate(update)) {
                 return
             }

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -20,14 +20,9 @@ import type {
 import {
     type PermissionOption,
     type PermissionRequestFrame,
-    type PosthogCompactBoundaryParams,
     type PosthogErrorParams,
     type PosthogPermissionRequestParams,
     type PosthogProgressParams,
-    type PosthogResourcesUsedParams,
-    type PosthogSdkSessionParams,
-    type PosthogStatusParams,
-    type PosthogTaskNotificationParams,
     type PosthogUsageUpdateParams,
     type SessionUpdateUsage,
     type SseErrorFrameData,
@@ -339,6 +334,11 @@ function findLastBufferIndex(state: ThreadItem[], id: string, type: ThreadItemTy
     return -1
 }
 
+/** The in-progress compaction spinner item — cleared when compaction completes or a boundary lands. */
+function isPendingCompactingStatus(item: ThreadItem): boolean {
+    return item.type === 'status' && item.status === 'compacting' && item.isComplete !== true
+}
+
 function mapAcpStatus(status: unknown): ToolInvocationStatus {
     switch (status) {
         case 'in_progress':
@@ -564,6 +564,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         setContextUsage: (usage: ContextUsage) => ({ usage }),
         /** Inline `_posthog/status` thread item (e.g. compaction in progress). */
         pushStatusItem: (status: string, isComplete: boolean) => ({ status, isComplete }),
+        /** Removes the in-progress compaction spinner once compaction completes. */
+        clearCompactingStatus: true,
         /** Inline `_posthog/compact_boundary` thread item — the post-compaction marker. */
         pushCompactBoundaryItem: (payload: { trigger?: string; preTokens?: number; contextSize?: number }) => payload,
         /** Inline `_posthog/task_notification` thread item — a task milestone. */
@@ -724,8 +726,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     ...state,
                     { id: `status-${state.length}`, type: 'status', status, isComplete },
                 ],
+                clearCompactingStatus: (state) => state.filter((item) => !isPendingCompactingStatus(item)),
+                // Drop the in-progress spinner before the divider lands, in case the completing
+                // status frame never arrived — the boundary itself signals compaction is done.
                 pushCompactBoundaryItem: (state, { trigger, preTokens, contextSize }) => [
-                    ...state,
+                    ...state.filter((item) => !isPendingCompactingStatus(item)),
                     { id: `compact-${state.length}`, type: 'compact_boundary', trigger, preTokens, contextSize },
                 ],
                 pushTaskNotificationItem: (state, { status, summary }) => [
@@ -1382,8 +1387,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // The agent reports, per turn, which PostHog products an answer was grounded in. Union
             // them by id into the persistent resources bar — accumulates across the whole session.
             if (isPosthogNotification(notification, '_posthog/resources_used')) {
-                const params = (notification.params ?? {}) as PosthogResourcesUsedParams
-                actions.mergeResourcesUsed(params.products ?? [])
+                actions.mergeResourcesUsed(notification.params?.products ?? [])
                 return
             }
             // Token usage + cost + context-window breakdown. The Codex adapter sends two split
@@ -1391,40 +1395,40 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // breakdown). The permissive fold tolerates both. The numeric used/size aggregate that
             // drives the percentage ring arrives separately on a session/update (handled below).
             if (isPosthogNotification(notification, '_posthog/usage_update')) {
-                const params = (notification.params ?? {}) as PosthogUsageUpdateParams
-                actions.setContextUsage(foldUsageNotification(values.contextUsage, params))
+                actions.setContextUsage(foldUsageNotification(values.contextUsage, notification.params ?? {}))
                 return
             }
-            // Context-compaction start/end. Twig renders nothing for the completed case, so gate it
-            // at dispatch: a `compacting` status that is complete pushes no thread item.
+            // Context-compaction start/end. The in-progress frame pushes a spinner item; the
+            // completed frame clears that spinner (Twig renders nothing for the completed case)
+            // rather than leaving it hanging beside the `compact_boundary` divider that follows.
             if (isPosthogNotification(notification, '_posthog/status')) {
-                const params = (notification.params ?? {}) as PosthogStatusParams
-                const status = String(params.status ?? '')
-                const isComplete = params.isComplete === true
+                const status = String(notification.params?.status ?? '')
+                const isComplete = notification.params?.isComplete === true
                 if (status === 'compacting' && isComplete) {
+                    actions.clearCompactingStatus()
                     return
                 }
                 actions.pushStatusItem(status, isComplete)
                 return
             }
             if (isPosthogNotification(notification, '_posthog/compact_boundary')) {
-                const params = (notification.params ?? {}) as PosthogCompactBoundaryParams
+                const params = notification.params
                 actions.pushCompactBoundaryItem({
-                    trigger: params.trigger,
-                    preTokens: params.preTokens,
-                    contextSize: params.contextSize,
+                    trigger: params?.trigger,
+                    preTokens: params?.preTokens,
+                    contextSize: params?.contextSize,
                 })
                 return
             }
             if (isPosthogNotification(notification, '_posthog/task_notification')) {
-                const params = (notification.params ?? {}) as PosthogTaskNotificationParams
-                actions.pushTaskNotificationItem({ status: params.status, summary: params.summary })
+                const params = notification.params
+                actions.pushTaskNotificationItem({ status: params?.status, summary: params?.summary })
                 return
             }
             // Diagnostic only — no UI; kept for resume telemetry / crash-affordance work.
             if (isPosthogNotification(notification, '_posthog/sdk_session')) {
-                const params = (notification.params ?? {}) as PosthogSdkSessionParams
-                actions.setSdkSession({ sessionId: params.sessionId, adapter: params.adapter })
+                const params = notification.params
+                actions.setSdkSession({ sessionId: params?.sessionId, adapter: params?.adapter })
                 return
             }
             if (method?.startsWith('_posthog/')) {

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -56,11 +56,15 @@ export type ThreadItemType =
     | 'tool_invocation'
     | 'turn_separator'
     | 'error'
+    | 'status'
+    | 'compact_boundary'
+    | 'task_notification'
 
 /**
  * An ordered, append-only entry the renderer consumes. Human messages, text chunks, streamed
- * reasoning ("thoughts"), tool-invocation references, run-lifecycle markers, and inline errors all
- * flow through this list.
+ * reasoning ("thoughts"), tool-invocation references, run-lifecycle markers, inline errors, and
+ * inline `_posthog/*` notifications (status / compaction / task milestones) all flow through this
+ * list.
  */
 export interface ThreadItem {
     /** Stable id — message buffer id, tool call id, or a generated separator/error id. */
@@ -79,6 +83,63 @@ export interface ThreadItem {
      * raw error line (`error`, the default). Drives the copy/styling branch in the renderer.
      */
     variant?: 'error' | 'crash'
+    /** For `status` and `task_notification` items — the wire `status` string. */
+    status?: string
+    /** For `status` items — whether the status phase has completed. */
+    isComplete?: boolean
+    /** For `compact_boundary` items — what triggered the compaction (e.g. 'auto'). */
+    trigger?: string
+    /** For `compact_boundary` items — token count before compaction. */
+    preTokens?: number
+    /** For `compact_boundary` items — post-compaction context size. */
+    contextSize?: number
+    /** For `task_notification` items — the milestone summary. */
+    summary?: string
+}
+
+/** One PostHog product the agent grounded an answer in, accumulated across the whole session. */
+export interface ResourceProduct {
+    /** Wire product id, e.g. 'product_analytics'. The local taxonomy maps it to an icon + label. */
+    id: string
+    /** Wire-supplied label; falls back to the local taxonomy label when absent. */
+    label?: string
+}
+
+/**
+ * Latest-wins context-usage snapshot for the footer ring. `used`/`size` (numeric token counts)
+ * drive the percentage and arrive on the `session/update` aggregate; `tokens`/`cost`/`breakdown`
+ * arrive on the `_posthog/usage_update` ext-notification.
+ */
+export interface ContextUsage {
+    /** Numeric used-token count from the session/update aggregate (drives the ring). */
+    used?: number
+    /** Numeric context-window size from the session/update aggregate (drives the ring). */
+    size?: number
+    /** Cumulative token breakdown from the ext-notification. */
+    tokens?: {
+        inputTokens?: number
+        outputTokens?: number
+        cachedReadTokens?: number
+        cachedWriteTokens?: number
+    }
+    /** Cost in USD (normalized to a number from either wire cost shape). */
+    cost?: number
+    /** Context-window composition breakdown from the ext-notification. */
+    breakdown?: {
+        systemPrompt?: number
+        tools?: number
+        rules?: number
+        skills?: number
+        mcp?: number
+        subagents?: number
+        conversation?: number
+    }
+}
+
+/** Diagnostic resume plumbing — `taskRunId → sessionId / adapter`. No UI; kept for telemetry. */
+export interface SdkSession {
+    sessionId?: string
+    adapter?: string
 }
 
 /**

--- a/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
@@ -8,9 +8,10 @@ import {
     isPermissionRequestFrame,
     isPosthogNotification,
     isSessionUpdateNotification,
+    isSessionUpdateUsage,
     isTaskRunStateFrame,
-    isUsageUpdateBreakdownParams,
-    isUsageUpdateUsedParams,
+    hasUsageBreakdown,
+    hasUsageUsed,
 } from './sandboxWireTypes'
 
 const TIMESTAMP = '2026-06-11T09:00:00.000000+00:00'
@@ -68,6 +69,13 @@ const NOTIFICATION_PARAMS_BY_METHOD: { [M in keyof PosthogNotificationParamsByMe
                 subagents: 0,
                 conversation: 20410,
             },
+        },
+        {
+            // Claude combined frame: used + cost (a bare number) + breakdown together.
+            sessionId: 'sess_a1b2c3',
+            used: { inputTokens: 5000, outputTokens: 600, cachedReadTokens: 100, cachedWriteTokens: 0 },
+            cost: 0.18,
+            breakdown: { systemPrompt: 2000, tools: 4000, conversation: 9000 },
         },
     ],
     '_posthog/status': [
@@ -261,25 +269,37 @@ describe('sandboxWireTypes guards', () => {
         expect(isSessionUpdateNotification(wireNotification)).toBe(false)
     })
 
-    it('narrows the two usage_update forms exclusively', () => {
-        const [used, usedNullCost, breakdown] = NOTIFICATION_PARAMS_BY_METHOD['_posthog/usage_update'].map((params) =>
-            notificationOf(notification('_posthog/usage_update', params))
+    it('tolerates the Codex split frames and the Claude combined frame with "has field" checks', () => {
+        const [used, usedNullCost, breakdown, combined] = NOTIFICATION_PARAMS_BY_METHOD['_posthog/usage_update'].map(
+            (params) => notificationOf(notification('_posthog/usage_update', params))
         )
         for (const wireNotification of [used, usedNullCost]) {
             if (!isPosthogNotification(wireNotification, '_posthog/usage_update')) {
                 throw new Error('expected usage_update notification')
             }
-            expect(isUsageUpdateUsedParams(wireNotification.params)).toBe(true)
-            expect(isUsageUpdateBreakdownParams(wireNotification.params)).toBe(false)
-            if (isUsageUpdateUsedParams(wireNotification.params)) {
-                expect(wireNotification.params.used.inputTokens).toEqual(expect.any(Number))
-            }
+            expect(hasUsageUsed(wireNotification.params)).toBe(true)
+            expect(hasUsageBreakdown(wireNotification.params)).toBe(false)
+            expect(wireNotification.params?.used?.inputTokens).toEqual(expect.any(Number))
         }
         if (!isPosthogNotification(breakdown, '_posthog/usage_update')) {
             throw new Error('expected usage_update notification')
         }
-        expect(isUsageUpdateBreakdownParams(breakdown.params)).toBe(true)
-        expect(isUsageUpdateUsedParams(breakdown.params)).toBe(false)
+        expect(hasUsageBreakdown(breakdown.params)).toBe(true)
+        expect(hasUsageUsed(breakdown.params)).toBe(false)
+
+        // Claude combined frame: both fields present, plus a numeric cost.
+        if (!isPosthogNotification(combined, '_posthog/usage_update')) {
+            throw new Error('expected usage_update notification')
+        }
+        expect(hasUsageUsed(combined.params)).toBe(true)
+        expect(hasUsageBreakdown(combined.params)).toBe(true)
+        expect(combined.params?.cost).toEqual(0.18)
+    })
+
+    it('recognizes the session/update-framed usage aggregate', () => {
+        expect(isSessionUpdateUsage({ sessionUpdate: 'usage_update', used: 168000, size: 200000 })).toBe(true)
+        expect(isKnownSessionUpdate({ sessionUpdate: 'usage_update', used: 168000, size: 200000 })).toBe(false)
+        expect(isSessionUpdateUsage({ sessionUpdate: 'agent_message' })).toBe(false)
     })
 
     it('exposes typed progress params after narrowing', () => {

--- a/frontend/src/scenes/max/types/sandboxWireTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.ts
@@ -266,25 +266,45 @@ export interface PosthogUsageTokens {
     cachedWriteTokens?: number
 }
 
-/** First of the two `usage_update` forms: cumulative token usage plus optional cost. */
-export interface PosthogUsageUpdateUsedParams {
+export interface PosthogUsageBreakdown {
+    systemPrompt?: number
+    tools?: number
+    rules?: number
+    skills?: number
+    mcp?: number
+    subagents?: number
+    conversation?: number
+}
+
+/**
+ * The `_posthog/usage_update` ext-notification. Permissive on purpose: the Codex adapter emits two
+ * separate frames (one carrying `used`+`cost: null`, one carrying `breakdown`), while the Claude
+ * adapter emits a single combined frame carrying `used`, `cost` (a bare number), AND `breakdown`
+ * together. `cost` therefore tolerates either the `{amount, currency}` object (Codex / the
+ * session/update aggregate) or a raw number (Claude). All fields optional so any adapter's framing
+ * folds in without dropping data.
+ */
+export interface PosthogUsageUpdateParams {
     sessionId?: string
-    used: PosthogUsageTokens
+    used?: PosthogUsageTokens
+    cost?: number | { amount?: number; currency?: string } | null
+    breakdown?: PosthogUsageBreakdown
+}
+
+/**
+ * The numeric `used`/`size` aggregate that drives the context-usage percentage ring. It does NOT
+ * arrive on the `_posthog/usage_update` ext-notification — it is a `session/update`-framed update
+ * (`sessionUpdate: 'usage_update'`) carrying flat numeric token counts plus cost.
+ */
+export interface SessionUpdateUsage {
+    sessionUpdate: 'usage_update'
+    used?: number
+    size?: number
     cost?: { amount?: number; currency?: string } | null
 }
 
-/** Second `usage_update` form: context-window composition breakdown. */
-export interface PosthogUsageUpdateBreakdownParams {
-    sessionId?: string
-    breakdown: {
-        systemPrompt?: number
-        tools?: number
-        rules?: number
-        skills?: number
-        mcp?: number
-        subagents?: number
-        conversation?: number
-    }
+export function isSessionUpdateUsage(update: unknown): update is SessionUpdateUsage {
+    return isRecord(update) && update.sessionUpdate === 'usage_update'
 }
 
 export interface PosthogStatusParams {
@@ -355,7 +375,7 @@ export interface PosthogNotificationParamsByMethod {
     '_posthog/progress': PosthogProgressParams
     '_posthog/sandbox_output': PosthogSandboxOutputParams
     '_posthog/user_message': PosthogUserMessageParams
-    '_posthog/usage_update': PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams
+    '_posthog/usage_update': PosthogUsageUpdateParams
     '_posthog/status': PosthogStatusParams
     '_posthog/compact_boundary': PosthogCompactBoundaryParams
     '_posthog/task_notification': PosthogTaskNotificationParams
@@ -379,14 +399,11 @@ export function isPosthogNotification<M extends keyof PosthogNotificationParamsB
     return notification.method === method
 }
 
-export function isUsageUpdateUsedParams(
-    params: PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams | undefined
-): params is PosthogUsageUpdateUsedParams {
-    return !!params && 'used' in params
+/** "Has field" checks rather than mutually exclusive — the Claude combined frame carries both. */
+export function hasUsageUsed(params: PosthogUsageUpdateParams | undefined): boolean {
+    return !!params && params.used != null
 }
 
-export function isUsageUpdateBreakdownParams(
-    params: PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams | undefined
-): params is PosthogUsageUpdateBreakdownParams {
-    return !!params && 'breakdown' in params
+export function hasUsageBreakdown(params: PosthogUsageUpdateParams | undefined): boolean {
+    return !!params && params.breakdown != null
 }


### PR DESCRIPTION
## Problem

A family of `_posthog/*` ACP notifications is fully typed on the frontend but silently dropped at the `ingestAcpFrame` catch-all — so Max sandbox conversations lose the "what products did the agent touch", "how much context/cost", and "history was compacted" affordances the reference implementation ships. Implements the G6 plan.

## Changes

- One dispatch branch per family, above the `_posthog/` catch-all:
  - **`resources_used`** → a persistent "PostHog resources used" chip bar above the composer (union by id, first-seen order, session-cumulative, hidden when empty). Product id→label map ported verbatim (Sentence-cased).
  - **`usage_update`** → context-usage ring (tokens / cost / %). Reconciled the wire-shape drift: a single permissive param type covers the Claude combined frame (`cost` as number or object) and the numeric `used`/`size` aggregate that arrives on a `session/update` frame.
  - **`status` + `compact_boundary` + `task_notification`** → inline thread items.
  - **`sdk_session`** → diagnostic reducer, no UI.
- `_posthog/progress` left untouched (already consumed). No changes to `resolveToolKey`/`mcpToolRegistry` (that's G5).

## How did you test this code?

Authored by an agent (Claude Code). Automated tests run on this branch:

- `oxlint` clean; `typegen:write` ran; `typescript:check` — 0 errors in any scoped file (the 2 remaining errors are a pre-existing stale typegen artifact in `AppShortcuts`, unrelated).
- Jest — 116 passed (`sandboxStreamLogic.test.ts`, `sandboxWireTypes.test.ts`): union-by-id + bootstrap-replay no-double-count, Codex split frames + Claude combined frame + numeric `session/update` aggregate all landing the right `contextUsage`, `compacting && isComplete` pushing nothing, status/compact/task thread items, reset/markTurnComplete lifecycle.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review → fix). Per the plan: the breakdown popover and docs click-through were deferred; product-id icons are best-fit choices a designer may want to tweak (labels are ported verbatim). Shares a status surface with G7 (whichever lands first owns a shared status-line component). Reviewer verdict: pass.
