### PR TITLE
feat(mcp-analytics): port pages to quill design system

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5411,7 +5411,7 @@ snapshots:
     scenes-app-mcp-analytics--dashboard--light:
         hash: v1.k794b7964.c64d5d43c4eaa79d3008e9dd40857d9bee879832e68a8f8e9464657ff670773f.yKxStICPwIMCMEnf_zQhK0BuXu5BIxaUKmgPYHAEzYo
     scenes-app-mcp-analytics--sessions--dark:
-        hash: v1.k794b7964.a033f7dca28cc0bfea783c71c6c2cbed6c58f87d705aa4772742c6f7136a437a.vFUlACgvfOrTJfC2Ogf7u7myI9SL_njtFgyBD88-TqE
+        hash: v1.k794b7964.c316f0028a9cc9b6a8e2b85d95b5e5ab65548805d4069f001c5cbbbcfbac970c.u4rZzVUZRlEBb11eUbRTRsVFfH_5gb3qRI5BEuAN7qw
     scenes-app-mcp-analytics--sessions--light:
         hash: v1.k794b7964.497d9ae69307438f3ef9ebfc80bb948ffd70d285eda4192f6b2e21f1a66d3eba.XI5y0bJbIitncOcXS_6Gxcr4pgGCK1moA7JIAstwuL4
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--dark:

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -24,6 +24,32 @@ TOOL_NAMES = [
     "error_tracking_issue_get",
 ]
 
+# Marks events as coming from the new MCP SDK — the tool detail page filters on this.
+NEW_SDK_SOURCE = "posthog_mcp_analytics"
+
+# $mcp_tool_category powers the dashboard "share of calls by category" and the tool quality scope filter.
+TOOL_CATEGORIES = {
+    "query_run": "Querying",
+    "insight_get": "Product analytics",
+    "dashboard_get": "Product analytics",
+    "feature_flag_get": "Feature flags",
+    "experiment_get": "Experiments",
+    "person_get": "Persons",
+    "session_recording_get": "Session replay",
+    "error_tracking_issue_get": "Error tracking",
+}
+
+TOOL_DESCRIPTIONS = {
+    "query_run": "Run a HogQL query against the project's events and return rows.",
+    "insight_get": "Fetch a saved insight's definition and computed results.",
+    "dashboard_get": "Fetch a dashboard and the insights tiled on it.",
+    "feature_flag_get": "Look up a feature flag's configuration and rollout conditions.",
+    "experiment_get": "Fetch an experiment's setup and current results.",
+    "person_get": "Look up a person and their properties by distinct id.",
+    "session_recording_get": "Fetch metadata for a session recording.",
+    "error_tracking_issue_get": "Fetch an error-tracking issue and its impact.",
+}
+
 # Raw $mcp_client_name values that categorizeHarness() folds into the popular, logo-backed
 # harness buckets (Claude Code, OpenAI Codex, Cursor, Claude.ai, VS Code). Weighted toward the
 # most common agents so the breakdown looks realistic.
@@ -246,7 +272,10 @@ class Command(BaseCommand):
                     properties={
                         "$session_id": session_id,
                         "$mcp_session_id": mcp_session_id,
+                        "$mcp_source": NEW_SDK_SOURCE,
                         "$mcp_tool_name": tool_name,
+                        "$mcp_tool_category": TOOL_CATEGORIES.get(tool_name, "Other"),
+                        "$mcp_tool_description": TOOL_DESCRIPTIONS.get(tool_name, ""),
                         "$mcp_intent": intent,
                         "$mcp_error_message": "Upstream returned 500" if is_error else "",
                         "$mcp_client_name": client_name,

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -146,6 +146,9 @@ EXCEPTION_MESSAGES: list[str] = [
     "KeyError: '$mcp_tool_name' not present in event payload",
 ]
 
+# Fraction of failing tool calls that also emit a paired $exception event.
+EXCEPTION_PAIR_PROBABILITY = 0.6
+
 
 class Command(BaseCommand):
     help = "Seed mcp_tool_call events into ClickHouse for local testing of MCP analytics."
@@ -322,7 +325,7 @@ class Command(BaseCommand):
 
                 # Pair some failures with an $exception event so the tool detail
                 # "Failures" table (which reads $exception events) has data.
-                if is_error and rng.random() < 0.6:
+                if is_error and rng.random() < EXCEPTION_PAIR_PROBABILITY:
                     create_event(
                         event_uuid=uuid.uuid4(),
                         event="$exception",

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -10,8 +10,11 @@ from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.event.util import create_event
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.util import create_person, create_person_distinct_id, get_person_by_distinct_id
+from posthog.models.scoping import team_scope
 from posthog.models.team.team import Team
 from posthog.models.utils import uuid7
+
+from products.mcp_analytics.backend.models import MCPSession
 
 TOOL_NAMES = [
     "query_run",
@@ -179,6 +182,8 @@ class Command(BaseCommand):
                 f"ALTER TABLE {EVENTS_DATA_TABLE()} DELETE WHERE team_id = %(team_id)s AND event = 'mcp_tool_call' SETTINGS mutations_sync=1",
                 {"team_id": team_id},
             )
+            with team_scope(team_id):
+                MCPSession.objects.filter(team=team).delete()
             self.stdout.write(self.style.WARNING(f"Cleared existing mcp_tool_call events for team {team_id}."))
 
         rng = random.Random(seed)
@@ -250,6 +255,10 @@ class Command(BaseCommand):
                 session_end_offset_min = rng.randint(31, 59)
             session_start = now - timedelta(minutes=session_end_offset_min) - total_call_duration
 
+            # One coherent intent per session so the clustering page has themes to group.
+            primary_tool = rng.choice(TOOL_NAMES)
+            session_intent = rng.choice(INTENTS_BY_TOOL.get(primary_tool, [DEFAULT_INTENT]))
+
             cumulative_offset_s = 0
             for call_idx in range(calls):
                 cumulative_offset_s += call_intervals[call_idx]
@@ -262,7 +271,6 @@ class Command(BaseCommand):
                 duration_ms = max(1, int(rng.gauss(base_latency, base_latency * 0.4)))
                 if is_error:
                     duration_ms = int(duration_ms * rng.uniform(1.5, 3.0))
-                intent = rng.choice(INTENTS_BY_TOOL.get(tool_name, [DEFAULT_INTENT]))
                 create_event(
                     event_uuid=uuid.uuid4(),
                     event="mcp_tool_call",
@@ -276,7 +284,7 @@ class Command(BaseCommand):
                         "$mcp_tool_name": tool_name,
                         "$mcp_tool_category": TOOL_CATEGORIES.get(tool_name, "Other"),
                         "$mcp_tool_description": TOOL_DESCRIPTIONS.get(tool_name, ""),
-                        "$mcp_intent": intent,
+                        "$mcp_intent": session_intent,
                         "$mcp_error_message": "Upstream returned 500" if is_error else "",
                         "$mcp_client_name": client_name,
                         "$mcp_client_version": "1.0.0",
@@ -288,8 +296,13 @@ class Command(BaseCommand):
                 )
                 total_events += 1
 
-            # Don't write to MCPSession (it's dormant) — the listing derives sessions
-            # on the fly from the events we just captured, grouped by $mcp_session_id.
+            # The session listing derives sessions on the fly from the events above,
+            # but intent clustering reads MCPSession.intent (keyed by $session_id), so
+            # store one row per session to give the clustering page something to group.
+            with team_scope(team_id):
+                MCPSession.objects.update_or_create(
+                    team=team, session_id=session_id, defaults={"intent": session_intent}
+                )
             self.stdout.write(
                 f"  session {session_idx + 1}/{session_count}: {calls} tool calls (mcp_session_id={mcp_session_id})"
             )

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -136,6 +136,16 @@ SESSION_INTENTS: list[str] = [
     "Pull the latest exception issue tied to the deploy so on-call can triage the regression.",
 ]
 
+# Paired with a fraction of failing tool calls so the tool detail "Failures" table
+# (which reads $exception events) has something to show.
+EXCEPTION_MESSAGES: list[str] = [
+    "TimeoutError: upstream query exceeded 30s deadline",
+    "ValidationError: missing required parameter 'project_id'",
+    "PermissionError: API key lacks scope for this resource",
+    "ConnectionError: ClickHouse connection reset by peer",
+    "KeyError: '$mcp_tool_name' not present in event payload",
+]
+
 
 class Command(BaseCommand):
     help = "Seed mcp_tool_call events into ClickHouse for local testing of MCP analytics."
@@ -179,51 +189,61 @@ class Command(BaseCommand):
 
         if clear:
             sync_execute(
-                f"ALTER TABLE {EVENTS_DATA_TABLE()} DELETE WHERE team_id = %(team_id)s AND event = 'mcp_tool_call' SETTINGS mutations_sync=1",
+                f"ALTER TABLE {EVENTS_DATA_TABLE()} DELETE WHERE team_id = %(team_id)s "
+                "AND (event = 'mcp_tool_call' OR (event = '$exception' AND JSONExtractString(properties, '$mcp_tool_name') != '')) "
+                "SETTINGS mutations_sync=1",
                 {"team_id": team_id},
             )
             with team_scope(team_id):
                 MCPSession.objects.filter(team=team).delete()
-            self.stdout.write(self.style.WARNING(f"Cleared existing mcp_tool_call events for team {team_id}."))
+            self.stdout.write(self.style.WARNING(f"Cleared existing MCP events for team {team_id}."))
 
         rng = random.Random(seed)
         now = datetime.now(tz=UTC)
         total_events = 0
 
-        # Create the identified personas. We write each one to BOTH Postgres
-        # (Person + PersonDistinctId) and ClickHouse (via create_person) so the
-        # distinct_id -> Person lookup in list_mcp_sessions can resolve name/email.
-        for persona in IDENTIFIED_PERSONAS:
-            properties = {
-                "email": persona["email"],
-                "name": persona["name"],
-                "role": persona["role"],
-            }
-            existing_person = get_person_by_distinct_id(team_id=team.id, distinct_id=persona["distinct_id"])
+        # distinct_id -> (person_uuid, person_properties). Events carry person_id so the
+        # person-on-events join (Top users table) keeps them — without a real person the
+        # inner join drops every row.
+        person_cache: dict[str, tuple[str, dict[str, Any]]] = {}
+
+        def ensure_person(
+            distinct_id: str, properties: dict[str, Any], is_identified: bool
+        ) -> tuple[str, dict[str, Any]]:
+            if distinct_id in person_cache:
+                return person_cache[distinct_id]
+            existing_person = get_person_by_distinct_id(team_id=team.id, distinct_id=distinct_id)
             if existing_person:
                 person = existing_person
-                person.properties = properties
-                person.is_identified = True
-                person.save(update_fields=["properties", "is_identified"])
+                if properties:
+                    person.properties = properties
+                    person.is_identified = is_identified
+                    person.save(update_fields=["properties", "is_identified"])
             else:
                 person = Person.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team, properties=properties, is_identified=True
+                    team=team, properties=properties, is_identified=is_identified
                 )
                 PersonDistinctId.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team, distinct_id=persona["distinct_id"], person=person
+                    team=team, distinct_id=distinct_id, person=person
                 )
             person_uuid = str(person.uuid)
             create_person(
                 team_id=team.id,
                 uuid=person_uuid,
                 version=0,
-                is_identified=True,
+                is_identified=is_identified,
                 properties=properties,
             )
-            create_person_distinct_id(
-                team_id=team.id,
-                distinct_id=persona["distinct_id"],
-                person_id=person_uuid,
+            create_person_distinct_id(team_id=team.id, distinct_id=distinct_id, person_id=person_uuid)
+            person_cache[distinct_id] = (person_uuid, properties)
+            return person_cache[distinct_id]
+
+        # Create the identified personas up front (anonymous visitors are created lazily below).
+        for persona in IDENTIFIED_PERSONAS:
+            ensure_person(
+                persona["distinct_id"],
+                {"email": persona["email"], "name": persona["name"], "role": persona["role"]},
+                is_identified=True,
             )
 
         for session_idx in range(session_count):
@@ -239,6 +259,7 @@ class Command(BaseCommand):
                 distinct_id = persona["distinct_id"]
             else:
                 distinct_id = f"anon_{uuid.uuid4().hex[:8]}"
+            person_uuid, person_props = ensure_person(distinct_id, {}, is_identified=False)
             client_name = rng.choices(CLIENT_NAMES, weights=CLIENT_WEIGHTS, k=1)[0]
             calls = rng.randint(min_calls, max_calls)
             # Anchor each session within the listing's default 24h window so it shows
@@ -277,6 +298,8 @@ class Command(BaseCommand):
                     team=team,
                     distinct_id=distinct_id,
                     timestamp=timestamp,
+                    person_id=uuid.UUID(person_uuid),
+                    person_properties=person_props,
                     properties={
                         "$session_id": session_id,
                         "$mcp_session_id": mcp_session_id,
@@ -295,6 +318,27 @@ class Command(BaseCommand):
                     },
                 )
                 total_events += 1
+
+                # Pair some failures with an $exception event so the tool detail
+                # "Failures" table (which reads $exception events) has data.
+                if is_error and rng.random() < 0.6:
+                    create_event(
+                        event_uuid=uuid.uuid4(),
+                        event="$exception",
+                        team=team,
+                        distinct_id=distinct_id,
+                        timestamp=timestamp,
+                        person_id=uuid.UUID(person_uuid),
+                        person_properties=person_props,
+                        properties={
+                            "$session_id": session_id,
+                            "$mcp_session_id": mcp_session_id,
+                            "$mcp_tool_name": tool_name,
+                            "$mcp_client_name": client_name,
+                            "$exception_message": rng.choice(EXCEPTION_MESSAGES),
+                        },
+                    )
+                    total_events += 1
 
             # The session listing derives sessions on the fly from the events above,
             # but intent clustering reads MCPSession.intent (keyed by $session_id), so

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -308,6 +308,7 @@ class Command(BaseCommand):
                         "$mcp_tool_category": TOOL_CATEGORIES.get(tool_name, "Other"),
                         "$mcp_tool_description": TOOL_DESCRIPTIONS.get(tool_name, ""),
                         "$mcp_intent": session_intent,
+                        "$mcp_intent_source": rng.choices(["context_parameter", "inferred"], weights=[7, 3], k=1)[0],
                         "$mcp_error_message": "Upstream returned 500" if is_error else "",
                         "$mcp_client_name": client_name,
                         "$mcp_client_version": "1.0.0",

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+import { LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
     MetricCard,
@@ -546,16 +546,11 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                 name={toolName}
                 description={null}
                 resourceType={{ type: 'llm_analytics' }}
-                actions={
-                    <LemonButton
-                        icon={<IconArrowLeft />}
-                        type="secondary"
-                        size="small"
-                        to={urls.mcpAnalyticsToolQuality()}
-                    >
-                        Back to Tool quality
-                    </LemonButton>
-                }
+                forceBackTo={{
+                    name: 'Tool quality',
+                    path: urls.mcpAnalyticsToolQuality(),
+                    key: 'mcp-analytics-tool-quality',
+                }}
             />
 
             <div className="flex flex-col gap-3 px-4 pb-4">

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -1,15 +1,25 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+import {
+    type ChartTheme,
+    type Series,
+    TimeSeriesLineChart,
+    type TimeSeriesLineChartConfig,
+} from '@posthog/quill-charts'
 
+import { buildTheme } from 'lib/charts/utils/theme'
 import { TZLabel } from 'lib/components/TZLabel'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { Query } from '~/queries/Query/Query'
@@ -17,6 +27,7 @@ import { SceneExport } from '~/scenes/sceneTypes'
 
 import { HarnessPill } from './dashboard/harness'
 import {
+    type DailyChartData,
     IntentCoverage,
     MCPAnalyticsToolDetailLogicProps,
     ToolSummary,
@@ -242,14 +253,89 @@ function DescriptionBlock({
     )
 }
 
+function trendChartConfig(timezone: string, yAxis?: TimeSeriesLineChartConfig['yAxis']): TimeSeriesLineChartConfig {
+    return {
+        yAxis: { showGrid: false, ...yAxis },
+        showAxisLines: true,
+        xAxis: { interval: 'day', timezone },
+        showCrosshair: true,
+        tooltip: { placement: 'cursor' },
+    }
+}
+
+type TrendSeriesKey = 'calls' | 'errors' | 'p50' | 'p95'
+const SERIES_META: Record<TrendSeriesKey, { label: string; colorIndex: number }> = {
+    calls: { label: 'Calls', colorIndex: 0 },
+    errors: { label: 'Errors', colorIndex: 4 },
+    p50: { label: 'p50', colorIndex: 1 },
+    p95: { label: 'p95', colorIndex: 0 },
+}
+
+function seriesFor(data: DailyChartData, theme: ChartTheme, keys: TrendSeriesKey[]): Series[] {
+    return keys.map((key) => ({
+        key,
+        label: SERIES_META[key].label,
+        color: theme.colors[SERIES_META[key].colorIndex],
+        data: data[key],
+    }))
+}
+
+function formatMsAxis(ms: number): string {
+    if (!isFinite(ms)) {
+        return '—'
+    }
+    return ms < 1000 ? `${Math.round(ms)}ms` : `${Math.round(ms / 100) / 10}s`
+}
+
+function TrendChart({
+    title,
+    series,
+    labels,
+    config,
+    theme,
+    loading,
+    dataAttr,
+}: {
+    title: string
+    series: Series[]
+    labels: string[]
+    config: TimeSeriesLineChartConfig
+    theme: ChartTheme
+    loading: boolean
+    dataAttr: string
+}): JSX.Element {
+    return (
+        <div className="flex flex-col rounded border bg-bg-light p-2" style={{ height: 240 }} data-quill>
+            <div className="mb-1 px-2 pt-1 text-xs font-medium uppercase text-secondary">{title}</div>
+            <div className="flex min-h-0 flex-1 flex-col">
+                {loading && labels.length === 0 ? (
+                    <LemonSkeleton className="flex-1" />
+                ) : labels.length === 0 ? (
+                    <div className="flex flex-1 items-center justify-center text-[12px] text-secondary">
+                        No data for the last 7 days.
+                    </div>
+                ) : (
+                    <TimeSeriesLineChart
+                        series={series}
+                        labels={labels}
+                        config={config}
+                        theme={theme}
+                        dataAttr={dataAttr}
+                    />
+                )}
+            </div>
+        </div>
+    )
+}
+
 export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.Element {
     const {
         summary,
         summaryLoading,
         descriptions,
         descriptionsLoading,
-        callsTrendQuery,
-        latencyTrendQuery,
+        dailyChartData,
+        dailyStatsLoading,
         failuresQuery,
         sampleIntentsQuery,
         intentCoverage,
@@ -259,6 +345,21 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
         byHarnessQuery,
         topUsersQuery,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
+    const { isDarkModeOn } = useValues(themeLogic)
+    const { timezone } = useValues(teamLogic)
+
+    // buildTheme() reads CSS vars from the DOM; isDarkModeOn forces a recompute on theme flip.
+    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const callsSeries = useMemo<Series[]>(
+        () => seriesFor(dailyChartData, theme, ['calls', 'errors']),
+        [dailyChartData, theme]
+    )
+    const latencySeries = useMemo<Series[]>(
+        () => seriesFor(dailyChartData, theme, ['p50', 'p95']),
+        [dailyChartData, theme]
+    )
+    const countsConfig = useMemo(() => trendChartConfig(timezone), [timezone])
+    const latencyConfig = useMemo(() => trendChartConfig(timezone, { tickFormatter: formatMsAxis }), [timezone])
 
     return (
         <SceneContent>
@@ -288,22 +389,24 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <SectionHeader title="Reliability" subtitle="Last 7 days" />
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <div className="flex flex-col bg-bg-light border rounded p-2" style={{ height: 240 }}>
-                        <div className="text-secondary text-xs font-medium uppercase mb-1 px-2 pt-1">
-                            Calls (broken down by error)
-                        </div>
-                        <div className="InsightCard__viz">
-                            <Query query={callsTrendQuery} readOnly embedded />
-                        </div>
-                    </div>
-                    <div className="flex flex-col bg-bg-light border rounded p-2" style={{ height: 240 }}>
-                        <div className="text-secondary text-xs font-medium uppercase mb-1 px-2 pt-1">
-                            Duration (p50 / p95)
-                        </div>
-                        <div className="InsightCard__viz">
-                            <Query query={latencyTrendQuery} readOnly embedded />
-                        </div>
-                    </div>
+                    <TrendChart
+                        title="Calls and errors"
+                        series={callsSeries}
+                        labels={dailyChartData.labels}
+                        config={countsConfig}
+                        theme={theme}
+                        loading={dailyStatsLoading}
+                        dataAttr="mcp-tool-detail-calls-chart"
+                    />
+                    <TrendChart
+                        title="Duration (p50 / p95)"
+                        series={latencySeries}
+                        labels={dailyChartData.labels}
+                        config={latencyConfig}
+                        theme={theme}
+                        loading={dailyStatsLoading}
+                        dataAttr="mcp-tool-detail-latency-chart"
+                    />
                 </div>
             </div>
 

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -5,15 +5,29 @@ import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
+    MetricCard,
+    type MetricChange,
     type Series,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
-import { Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@posthog/quill-primitives'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { TZLabel } from 'lib/components/TZLabel'
-import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -51,55 +65,42 @@ function percentDelta(current: number, previous: number): number | null {
     return ((current - previous) / previous) * 100
 }
 
-function DeltaTag({ value, invertColor = false }: { value: number | null; invertColor?: boolean }): JSX.Element | null {
-    if (value == null || !isFinite(value) || Math.abs(value) < 1) {
-        return null
-    }
-    const positive = value > 0
-    // For error rate, "up" is bad — invert color semantics.
-    const goodDirection = invertColor ? !positive : positive
-    const Icon = positive ? IconArrowUp : IconArrowDown
-    return (
-        <span
-            className={`inline-flex items-center gap-0.5 text-xs leading-none ${
-                goodDirection ? 'text-success' : 'text-danger'
-            }`}
-        >
-            <Icon className="text-sm" />
-            {Math.abs(Math.round(value))}%
-        </span>
-    )
-}
-
-function Stat({
+function StatTile({
     label,
     value,
-    delta,
-    deltaInvertColor,
+    formatValue,
+    change,
+    goodDirection,
     loading,
-    tooltip,
 }: {
     label: string
-    value: React.ReactNode
-    delta?: number | null
-    deltaInvertColor?: boolean
-    loading?: boolean
-    tooltip?: string
+    value: number
+    formatValue: (n: number) => string
+    change?: MetricChange | null
+    goodDirection?: 'up' | 'down'
+    loading: boolean
 }): JSX.Element {
-    const content = (
-        <div className="flex flex-col gap-1 min-w-[110px]">
-            <span className="text-[11px] uppercase tracking-wider text-secondary">{label}</span>
+    return (
+        <Card size="sm" className="flex-1">
             {loading ? (
-                <LemonSkeleton className="h-6 w-16" />
+                <CardContent className="flex flex-col gap-2">
+                    <Skeleton className="h-3 w-16" />
+                    <Skeleton className="h-7 w-20" />
+                </CardContent>
             ) : (
-                <div className="flex items-baseline gap-2">
-                    <span className="text-2xl font-semibold leading-none">{value}</span>
-                    <DeltaTag value={delta ?? null} invertColor={deltaInvertColor} />
-                </div>
+                <CardContent>
+                    <MetricCard
+                        className="text-primary"
+                        title={label}
+                        value={value}
+                        formatValue={formatValue}
+                        change={change}
+                        goodDirection={goodDirection}
+                    />
+                </CardContent>
             )}
-        </div>
+        </Card>
     )
-    return tooltip ? <Tooltip title={tooltip}>{content}</Tooltip> : content
 }
 
 // Renderer for the "person" column in the Top users table. The query selects
@@ -137,20 +138,38 @@ const neighborColumns: ResultColumn[] = [
     { header: 'In same conversation', align: 'right', render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)) },
 ]
 
-// Renders raw HogQL result rows (positional columns) as a quill table, with loading/empty states.
+// Renders raw HogQL result rows (positional columns) as a card-wrapped quill table,
+// matching the dashboard table cards, with loading/empty states.
 function ResultTable({
+    title,
+    description,
+    action,
     rows,
     loading,
     columns,
     emptyMessage = 'No data for the last 7 days.',
 }: {
+    title?: React.ReactNode
+    description?: React.ReactNode
+    action?: React.ReactNode
     rows: ResultRows
     loading: boolean
     columns: ResultColumn[]
     emptyMessage?: string
 }): JSX.Element {
     return (
-        <div data-quill>
+        <Card size="sm" className="gap-0">
+            {title != null && (
+                <CardHeader
+                    className={`border-b border-border pb-3${
+                        action != null ? ' !flex flex-row items-center justify-between gap-2' : ''
+                    }`}
+                >
+                    <CardTitle>{title}</CardTitle>
+                    {description != null && <CardDescription>{description}</CardDescription>}
+                    {action}
+                </CardHeader>
+            )}
             <Table fullWidth>
                 <TableHeader>
                     <TableRow>
@@ -191,7 +210,7 @@ function ResultTable({
                     )}
                 </TableBody>
             </Table>
-        </div>
+        </Card>
     )
 }
 
@@ -214,36 +233,50 @@ function formatDurationMs(ms: number | null): string {
     return humanFriendlyDuration(ms / 1000, { secondsFixed: 2 })
 }
 
-function StatStrip({ summary, loading }: { summary: ToolSummary | null; loading: boolean }): JSX.Element {
+function StatTiles({ summary, loading }: { summary: ToolSummary | null; loading: boolean }): JSX.Element {
     const calls = summary?.calls ?? 0
     const errors = summary?.errors ?? 0
     const errorRate = calls ? (errors / calls) * 100 : 0
     const errorRatePrev = summary && summary.calls_prev ? (summary.errors_prev / summary.calls_prev) * 100 : 0
+    const callsDelta = summary ? percentDelta(calls, summary.calls_prev) : null
+    const errorRateDelta = summary ? percentDelta(errorRate, errorRatePrev) : null
+
     return (
-        <div className="flex flex-wrap items-end gap-x-10 gap-y-4 py-1">
-            <Stat
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6" data-quill>
+            <StatTile
                 label="Calls"
                 loading={loading}
-                value={humanFriendlyNumber(calls)}
-                delta={summary ? percentDelta(calls, summary.calls_prev) : null}
-                tooltip="Last 7 days vs prior 7 days."
+                value={calls}
+                formatValue={humanFriendlyNumber}
+                change={callsDelta != null ? { value: callsDelta } : null}
+                goodDirection="up"
             />
-            <Stat
+            <StatTile
                 label="Error rate"
                 loading={loading}
-                value={`${errorRate.toFixed(1)}%`}
-                delta={summary ? percentDelta(errorRate, errorRatePrev) : null}
-                deltaInvertColor
-                tooltip="Share of calls with $mcp_is_error = true."
+                value={errorRate}
+                formatValue={(n) => `${n.toFixed(1)}%`}
+                change={errorRateDelta != null ? { value: errorRateDelta } : null}
+                goodDirection="down"
             />
-            <Stat label="p50 latency" loading={loading} value={formatDurationMs(summary?.p50_ms ?? null)} />
-            <Stat label="p95 latency" loading={loading} value={formatDurationMs(summary?.p95_ms ?? null)} />
-            <Stat label="Users" loading={loading} value={humanFriendlyNumber(summary?.users ?? 0)} />
-            <Stat
+            <StatTile
+                label="p50 latency"
+                loading={loading}
+                value={summary?.p50_ms ?? 0}
+                formatValue={formatDurationMs}
+            />
+            <StatTile
+                label="p95 latency"
+                loading={loading}
+                value={summary?.p95_ms ?? 0}
+                formatValue={formatDurationMs}
+            />
+            <StatTile label="Users" loading={loading} value={summary?.users ?? 0} formatValue={humanFriendlyNumber} />
+            <StatTile
                 label="Sessions"
                 loading={loading}
-                value={humanFriendlyNumber(summary?.conversations ?? 0)}
-                tooltip="Unique $mcp_session_id values, falling back to $session_id where missing."
+                value={summary?.conversations ?? 0}
+                formatValue={humanFriendlyNumber}
             />
         </div>
     )
@@ -451,7 +484,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
 
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <DescriptionBlock descriptions={descriptions} loading={descriptionsLoading} />
-                <StatStrip summary={summary} loading={summaryLoading} />
+                <StatTiles summary={summary} loading={summaryLoading} />
             </div>
 
             <LemonDivider />
@@ -485,48 +518,44 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <SectionHeader title="Usage flow" />
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <div className="flex flex-col gap-2 bg-bg-light border rounded p-3">
-                        <div className="flex items-center justify-between gap-2">
-                            <span className="text-xs font-medium uppercase text-secondary">Sample intents</span>
-                            <IntentCoverageTag coverage={intentCoverage} loading={intentCoverageLoading} />
-                        </div>
+                    <ResultTable
+                        title="Sample intents"
+                        action={<IntentCoverageTag coverage={intentCoverage} loading={intentCoverageLoading} />}
+                        rows={sampleIntentRows}
+                        loading={sampleIntentRowsLoading}
+                        emptyMessage="No intents captured in the last 7 days."
+                        columns={[
+                            { header: 'When', render: (r) => <TZLabel time={String(r[0])} /> },
+                            { header: 'Intent', expand: true, render: (r) => <span>{String(r[1] ?? '')}</span> },
+                            { header: 'Intent source', render: (r) => <span>{String(r[2] ?? '')}</span> },
+                            { header: 'Harness', render: (r) => <span>{String(r[3] ?? '')}</span> },
+                        ]}
+                    />
+                    <div className="flex flex-col gap-4">
                         <ResultTable
-                            rows={sampleIntentRows}
-                            loading={sampleIntentRowsLoading}
-                            emptyMessage="No intents captured in the last 7 days."
-                            columns={[
-                                { header: 'When', render: (r) => <TZLabel time={String(r[0])} /> },
-                                { header: 'Intent', expand: true, render: (r) => <span>{String(r[1] ?? '')}</span> },
-                                { header: 'Intent source', render: (r) => <span>{String(r[2] ?? '')}</span> },
-                                { header: 'Harness', render: (r) => <span>{String(r[3] ?? '')}</span> },
-                            ]}
+                            title={
+                                <span className="flex items-center gap-1">
+                                    <IconArrowLeft className="text-base" />
+                                    Often called before (same conversation)
+                                </span>
+                            }
+                            rows={neighborsBeforeRows}
+                            loading={neighborsBeforeRowsLoading}
+                            emptyMessage="No tools commonly precede this one."
+                            columns={neighborColumns}
                         />
-                    </div>
-                    <div className="flex flex-col gap-3">
-                        <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
-                            <div className="flex items-center gap-1 text-xs font-medium uppercase text-secondary">
-                                <IconArrowLeft className="text-base" />
-                                Often called before (same conversation)
-                            </div>
-                            <ResultTable
-                                rows={neighborsBeforeRows}
-                                loading={neighborsBeforeRowsLoading}
-                                emptyMessage="No tools commonly precede this one."
-                                columns={neighborColumns}
-                            />
-                        </div>
-                        <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
-                            <div className="flex items-center gap-1 text-xs font-medium uppercase text-secondary">
-                                <IconArrowRight className="text-base" />
-                                Often called after (same conversation)
-                            </div>
-                            <ResultTable
-                                rows={neighborsAfterRows}
-                                loading={neighborsAfterRowsLoading}
-                                emptyMessage="No tools commonly follow this one."
-                                columns={neighborColumns}
-                            />
-                        </div>
+                        <ResultTable
+                            title={
+                                <span className="flex items-center gap-1">
+                                    <IconArrowRight className="text-base" />
+                                    Often called after (same conversation)
+                                </span>
+                            }
+                            rows={neighborsAfterRows}
+                            loading={neighborsAfterRowsLoading}
+                            emptyMessage="No tools commonly follow this one."
+                            columns={neighborColumns}
+                        />
                     </div>
                 </div>
             </div>
@@ -536,80 +565,74 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <SectionHeader title="Who uses it" />
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
-                        <span className="text-xs font-medium uppercase text-secondary">By harness</span>
-                        <ResultTable
-                            rows={byHarnessRows}
-                            loading={byHarnessRowsLoading}
-                            columns={[
-                                {
-                                    header: 'Harness',
-                                    expand: true,
-                                    render: (r) => {
-                                        const raw = String(r[0] ?? '')
-                                        return raw ? (
-                                            <HarnessPill category={categorizeHarness(raw)} title={raw} />
-                                        ) : (
-                                            <span className="text-muted">Unknown</span>
-                                        )
-                                    },
+                    <ResultTable
+                        title="By harness"
+                        rows={byHarnessRows}
+                        loading={byHarnessRowsLoading}
+                        columns={[
+                            {
+                                header: 'Harness',
+                                expand: true,
+                                render: (r) => {
+                                    const raw = String(r[0] ?? '')
+                                    return raw ? (
+                                        <HarnessPill category={categorizeHarness(raw)} title={raw} />
+                                    ) : (
+                                        <span className="text-muted">Unknown</span>
+                                    )
                                 },
-                                {
-                                    header: 'Calls',
-                                    align: 'right',
-                                    render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
-                                },
-                                {
-                                    header: 'Errors',
-                                    align: 'right',
-                                    render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
-                                },
-                                { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
-                                {
-                                    header: 'Users',
-                                    align: 'right',
-                                    render: (r) => humanFriendlyNumber(Number(r[4] ?? 0)),
-                                },
-                            ]}
-                        />
-                    </div>
-                    <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
-                        <span className="text-xs font-medium uppercase text-secondary">Top users</span>
-                        <ResultTable
-                            rows={topUserRows}
-                            loading={topUserRowsLoading}
-                            columns={[
-                                { header: 'User', expand: true, render: (r) => renderPersonCell(r[0]) },
-                                {
-                                    header: 'Calls',
-                                    align: 'right',
-                                    render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
-                                },
-                                {
-                                    header: 'Errors',
-                                    align: 'right',
-                                    render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
-                                },
-                                { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
-                                {
-                                    header: 'Harnesses',
-                                    render: (r) => <span className="text-secondary">{String(r[4] ?? '')}</span>,
-                                },
-                                { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
-                            ]}
-                        />
-                    </div>
+                            },
+                            {
+                                header: 'Calls',
+                                align: 'right',
+                                render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                            },
+                            {
+                                header: 'Errors',
+                                align: 'right',
+                                render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                            },
+                            { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
+                            {
+                                header: 'Users',
+                                align: 'right',
+                                render: (r) => humanFriendlyNumber(Number(r[4] ?? 0)),
+                            },
+                        ]}
+                    />
+                    <ResultTable
+                        title="Top users"
+                        rows={topUserRows}
+                        loading={topUserRowsLoading}
+                        columns={[
+                            { header: 'User', expand: true, render: (r) => renderPersonCell(r[0]) },
+                            {
+                                header: 'Calls',
+                                align: 'right',
+                                render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                            },
+                            {
+                                header: 'Errors',
+                                align: 'right',
+                                render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                            },
+                            { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
+                            {
+                                header: 'Harnesses',
+                                render: (r) => <span className="text-secondary">{String(r[4] ?? '')}</span>,
+                            },
+                            { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
+                        ]}
+                    />
                 </div>
             </div>
 
             <LemonDivider />
 
             <div className="flex flex-col gap-3 px-4 pb-4">
-                <SectionHeader
-                    title="Failures"
-                    subtitle="Top exception messages paired with this tool. Sourced from $exception events."
-                />
                 <ResultTable
+                    title="Failures"
+                    description="Top exception messages paired with this tool. Sourced from $exception events."
                     rows={failureRows}
                     loading={failureRowsLoading}
                     emptyMessage="No exceptions recorded for this tool in the last 7 days."

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -9,6 +9,7 @@ import {
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -22,7 +23,6 @@ import { urls } from 'scenes/urls'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { Query } from '~/queries/Query/Query'
 import { SceneExport } from '~/scenes/sceneTypes'
 
 import { HarnessPill } from './dashboard/harness'
@@ -30,6 +30,7 @@ import {
     type DailyChartData,
     IntentCoverage,
     MCPAnalyticsToolDetailLogicProps,
+    type ResultRows,
     ToolSummary,
     mcpAnalyticsToolDetailLogic,
 } from './mcpAnalyticsToolDetailLogic'
@@ -104,31 +105,94 @@ function Stat({
 // Renderer for the "person" column in the Top users table. The query selects
 // `argMax(tuple(distinct_id, person.created_at, person.properties), timestamp)`,
 // which deserialises as a 3-element array. Wrap it back into the shape PersonDisplay expects.
-const topUserPersonColumn = {
-    title: 'User',
-    render: function RenderPerson({ value }: { value: unknown }) {
-        if (!Array.isArray(value) || value.length === 0) {
-            return <span className="text-muted">—</span>
+function renderPersonCell(value: unknown): JSX.Element {
+    if (!Array.isArray(value) || value.length === 0) {
+        return <span className="text-muted">—</span>
+    }
+    const [distinctId, , propertiesRaw] = value as [string, unknown, unknown]
+    let properties: Record<string, unknown> | undefined
+    if (propertiesRaw && typeof propertiesRaw === 'object') {
+        properties = propertiesRaw as Record<string, unknown>
+    } else if (typeof propertiesRaw === 'string') {
+        try {
+            properties = JSON.parse(propertiesRaw)
+        } catch {
+            properties = undefined
         }
-        const [distinctId, , propertiesRaw] = value as [string, unknown, unknown]
-        let properties: Record<string, unknown> | undefined
-        if (propertiesRaw && typeof propertiesRaw === 'object') {
-            properties = propertiesRaw as Record<string, unknown>
-        } else if (typeof propertiesRaw === 'string') {
-            try {
-                properties = JSON.parse(propertiesRaw)
-            } catch {
-                properties = undefined
-            }
-        }
-        return (
-            <PersonDisplay
-                person={{ distinct_id: distinctId, properties: properties ?? {} }}
-                withIcon
-                noPopover={false}
-            />
-        )
-    },
+    }
+    return (
+        <PersonDisplay person={{ distinct_id: distinctId, properties: properties ?? {} }} withIcon noPopover={false} />
+    )
+}
+
+interface ResultColumn {
+    header: string
+    align?: 'left' | 'right'
+    expand?: boolean
+    render: (row: unknown[]) => React.ReactNode
+}
+
+const neighborColumns: ResultColumn[] = [
+    { header: 'Tool', expand: true, render: (r) => <span className="font-mono">{String(r[0] ?? '')}</span> },
+    { header: 'In same conversation', align: 'right', render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)) },
+]
+
+// Renders raw HogQL result rows (positional columns) as a quill table, with loading/empty states.
+function ResultTable({
+    rows,
+    loading,
+    columns,
+    emptyMessage = 'No data for the last 7 days.',
+}: {
+    rows: ResultRows
+    loading: boolean
+    columns: ResultColumn[]
+    emptyMessage?: string
+}): JSX.Element {
+    return (
+        <div data-quill>
+            <Table fullWidth>
+                <TableHeader>
+                    <TableRow>
+                        {columns.map((col, i) => (
+                            <TableHead key={i} align={col.align} expand={col.expand}>
+                                {col.header}
+                            </TableHead>
+                        ))}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {loading && rows.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={columns.length}>
+                                <div className="space-y-2 py-1">
+                                    {Array.from({ length: 4 }).map((_, i) => (
+                                        <LemonSkeleton key={i} className="h-3.5 w-full" />
+                                    ))}
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ) : rows.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={columns.length} align="center" className="py-6 text-secondary">
+                                {emptyMessage}
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        rows.map((row, i) => (
+                            <TableRow key={i}>
+                                {columns.map((col, ci) => (
+                                    <TableCell key={ci} align={col.align} expand={col.expand}>
+                                        {col.render(row)}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))
+                    )}
+                </TableBody>
+            </Table>
+        </div>
+    )
 }
 
 function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }): JSX.Element {
@@ -336,14 +400,20 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
         descriptionsLoading,
         dailyChartData,
         dailyStatsLoading,
-        failuresQuery,
-        sampleIntentsQuery,
+        failureRows,
+        failureRowsLoading,
+        sampleIntentRows,
+        sampleIntentRowsLoading,
         intentCoverage,
         intentCoverageLoading,
-        neighborsBeforeQuery,
-        neighborsAfterQuery,
-        byHarnessQuery,
-        topUsersQuery,
+        neighborsBeforeRows,
+        neighborsBeforeRowsLoading,
+        neighborsAfterRows,
+        neighborsAfterRowsLoading,
+        byHarnessRows,
+        byHarnessRowsLoading,
+        topUserRows,
+        topUserRowsLoading,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
     const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
@@ -420,14 +490,16 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                             <span className="text-xs font-medium uppercase text-secondary">Sample intents</span>
                             <IntentCoverageTag coverage={intentCoverage} loading={intentCoverageLoading} />
                         </div>
-                        <Query
-                            query={sampleIntentsQuery}
-                            readOnly
-                            context={{
-                                columns: {
-                                    intent_source: { title: 'Intent source' },
-                                },
-                            }}
+                        <ResultTable
+                            rows={sampleIntentRows}
+                            loading={sampleIntentRowsLoading}
+                            emptyMessage="No intents captured in the last 7 days."
+                            columns={[
+                                { header: 'When', render: (r) => <TZLabel time={String(r[0])} /> },
+                                { header: 'Intent', expand: true, render: (r) => <span>{String(r[1] ?? '')}</span> },
+                                { header: 'Intent source', render: (r) => <span>{String(r[2] ?? '')}</span> },
+                                { header: 'Harness', render: (r) => <span>{String(r[3] ?? '')}</span> },
+                            ]}
                         />
                     </div>
                     <div className="flex flex-col gap-3">
@@ -436,10 +508,11 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                                 <IconArrowLeft className="text-base" />
                                 Often called before (same conversation)
                             </div>
-                            <Query
-                                query={neighborsBeforeQuery}
-                                readOnly
-                                context={{ columns: { co_occurrences: { title: 'In same conversation' } } }}
+                            <ResultTable
+                                rows={neighborsBeforeRows}
+                                loading={neighborsBeforeRowsLoading}
+                                emptyMessage="No tools commonly precede this one."
+                                columns={neighborColumns}
                             />
                         </div>
                         <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
@@ -447,10 +520,11 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                                 <IconArrowRight className="text-base" />
                                 Often called after (same conversation)
                             </div>
-                            <Query
-                                query={neighborsAfterQuery}
-                                readOnly
-                                context={{ columns: { co_occurrences: { title: 'In same conversation' } } }}
+                            <ResultTable
+                                rows={neighborsAfterRows}
+                                loading={neighborsAfterRowsLoading}
+                                emptyMessage="No tools commonly follow this one."
+                                columns={neighborColumns}
                             />
                         </div>
                     </div>
@@ -464,38 +538,65 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                     <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
                         <span className="text-xs font-medium uppercase text-secondary">By harness</span>
-                        <Query
-                            query={byHarnessQuery}
-                            readOnly
-                            context={{
-                                columns: {
-                                    harness: {
-                                        title: 'Harness',
-                                        render: function RenderHarness({ value }) {
-                                            const raw = String(value ?? '')
-                                            if (!raw) {
-                                                return <span className="text-muted">Unknown</span>
-                                            }
-                                            return <HarnessPill category={categorizeHarness(raw)} title={raw} />
-                                        },
+                        <ResultTable
+                            rows={byHarnessRows}
+                            loading={byHarnessRowsLoading}
+                            columns={[
+                                {
+                                    header: 'Harness',
+                                    expand: true,
+                                    render: (r) => {
+                                        const raw = String(r[0] ?? '')
+                                        return raw ? (
+                                            <HarnessPill category={categorizeHarness(raw)} title={raw} />
+                                        ) : (
+                                            <span className="text-muted">Unknown</span>
+                                        )
                                     },
-                                    error_rate_pct: { title: 'Error rate (%)' },
                                 },
-                            }}
+                                {
+                                    header: 'Calls',
+                                    align: 'right',
+                                    render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                                },
+                                {
+                                    header: 'Errors',
+                                    align: 'right',
+                                    render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                                },
+                                { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
+                                {
+                                    header: 'Users',
+                                    align: 'right',
+                                    render: (r) => humanFriendlyNumber(Number(r[4] ?? 0)),
+                                },
+                            ]}
                         />
                     </div>
                     <div className="bg-bg-light border rounded p-3 flex flex-col gap-2">
                         <span className="text-xs font-medium uppercase text-secondary">Top users</span>
-                        <Query
-                            query={topUsersQuery}
-                            readOnly
-                            context={{
-                                columns: {
-                                    person: topUserPersonColumn,
-                                    error_rate_pct: { title: 'Error rate (%)' },
-                                    last_seen: { title: 'Last seen' },
+                        <ResultTable
+                            rows={topUserRows}
+                            loading={topUserRowsLoading}
+                            columns={[
+                                { header: 'User', expand: true, render: (r) => renderPersonCell(r[0]) },
+                                {
+                                    header: 'Calls',
+                                    align: 'right',
+                                    render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
                                 },
-                            }}
+                                {
+                                    header: 'Errors',
+                                    align: 'right',
+                                    render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                                },
+                                { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
+                                {
+                                    header: 'Harnesses',
+                                    render: (r) => <span className="text-secondary">{String(r[4] ?? '')}</span>,
+                                },
+                                { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
+                            ]}
                         />
                     </div>
                 </div>
@@ -508,7 +609,28 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                     title="Failures"
                     subtitle="Top exception messages paired with this tool. Sourced from $exception events."
                 />
-                <Query query={failuresQuery} readOnly context={{ columns: { last_seen: { title: 'Last seen' } } }} />
+                <ResultTable
+                    rows={failureRows}
+                    loading={failureRowsLoading}
+                    emptyMessage="No exceptions recorded for this tool in the last 7 days."
+                    columns={[
+                        {
+                            header: 'Message',
+                            expand: true,
+                            render: (r) => <span className="font-mono text-xs">{String(r[0] ?? '')}</span>,
+                        },
+                        {
+                            header: 'Occurrences',
+                            align: 'right',
+                            render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                        },
+                        { header: 'Last seen', render: (r) => <TZLabel time={String(r[2])} /> },
+                        {
+                            header: 'Harnesses',
+                            render: (r) => <span className="text-secondary">{String(r[3] ?? '')}</span>,
+                        },
+                    ]}
+                />
             </div>
         </SceneContent>
     )

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -657,7 +657,14 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                             { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
                             {
                                 header: 'Harnesses',
-                                render: (r) => <span className="text-secondary">{String(r[4] ?? '')}</span>,
+                                render: (r) => {
+                                    const harnesses = String(r[4] ?? '')
+                                    return (
+                                        <span className="text-secondary line-clamp-1" title={harnesses}>
+                                            {harnesses}
+                                        </span>
+                                    )
+                                },
                             },
                             { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
                         ]}

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -9,7 +9,7 @@ import {
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
+import { Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -167,7 +167,7 @@ function ResultTable({
                             <TableCell colSpan={columns.length}>
                                 <div className="space-y-2 py-1">
                                     {Array.from({ length: 4 }).map((_, i) => (
-                                        <LemonSkeleton key={i} className="h-3.5 w-full" />
+                                        <Skeleton key={i} className="h-3.5 w-full" />
                                     ))}
                                 </div>
                             </TableCell>
@@ -373,7 +373,7 @@ function TrendChart({
             <div className="mb-1 px-2 pt-1 text-xs font-medium uppercase text-secondary">{title}</div>
             <div className="flex min-h-0 flex-1 flex-col">
                 {loading && labels.length === 0 ? (
-                    <LemonSkeleton className="flex-1" />
+                    <Skeleton className="flex-1" />
                 ) : labels.length === 0 ? (
                     <div className="flex flex-1 items-center justify-center text-[12px] text-secondary">
                         No data for the last 7 days.

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -38,7 +38,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { SceneExport } from '~/scenes/sceneTypes'
 
-import { HarnessPill } from './dashboard/harness'
+import { HARNESS_LOGOS, HarnessPill } from './dashboard/harness'
 import {
     type DailyChartData,
     IntentCoverage,
@@ -123,6 +123,44 @@ function renderPersonCell(value: unknown): JSX.Element {
     }
     return (
         <PersonDisplay person={{ distinct_id: distinctId, properties: properties ?? {} }} withIcon noPopover={false} />
+    )
+}
+
+// Renders a comma-joined list of raw client names as compact, deduped harness logos
+// so the secondary "which harnesses" columns stay one line tall instead of wrapping.
+function HarnessLogos({ value }: { value: string }): JSX.Element {
+    const categories = Array.from(
+        new Set(
+            value
+                .split(',')
+                .map((raw) => categorizeHarness(raw.trim()))
+                .filter(Boolean)
+        )
+    )
+    if (categories.length === 0) {
+        return <span className="text-muted">—</span>
+    }
+    return (
+        <div className="flex items-center gap-1">
+            {categories.map((category) => {
+                const logo = HARNESS_LOGOS[category]
+                return logo ? (
+                    <img
+                        key={category}
+                        src={logo.src}
+                        alt={category}
+                        title={category}
+                        className="h-4 w-4 shrink-0 object-contain"
+                    />
+                ) : (
+                    <span
+                        key={category}
+                        title={category}
+                        className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-secondary"
+                    />
+                )
+            })}
+        </div>
     )
 }
 
@@ -657,14 +695,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                             { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
                             {
                                 header: 'Harnesses',
-                                render: (r) => {
-                                    const harnesses = String(r[4] ?? '')
-                                    return (
-                                        <span className="text-secondary line-clamp-1" title={harnesses}>
-                                            {harnesses}
-                                        </span>
-                                    )
-                                },
+                                render: (r) => <HarnessLogos value={String(r[4] ?? '')} />,
                             },
                             { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
                         ]}
@@ -695,7 +726,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                         { header: 'Last seen', render: (r) => <TZLabel time={String(r[2])} /> },
                         {
                             header: 'Harnesses',
-                            render: (r) => <span className="text-secondary">{String(r[3] ?? '')}</span>,
+                            render: (r) => <HarnessLogos value={String(r[3] ?? '')} />,
                         },
                     ]}
                 />

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -126,8 +126,7 @@ function renderPersonCell(value: unknown): JSX.Element {
     )
 }
 
-// Renders a comma-joined list of raw client names as compact, deduped harness logos
-// so the secondary "which harnesses" columns stay one line tall instead of wrapping.
+// Deduped harness logos so the column stays one line instead of wrapping.
 function HarnessLogos({ value }: { value: string }): JSX.Element {
     const categories = Array.from(
         new Set(
@@ -176,8 +175,7 @@ const neighborColumns: ResultColumn[] = [
     { header: 'In same conversation', align: 'right', render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)) },
 ]
 
-// Renders raw HogQL result rows (positional columns) as a card-wrapped quill table,
-// matching the dashboard table cards, with loading/empty states.
+// Card-wrapped quill table matching the dashboard table cards.
 function ResultTable({
     title,
     description,
@@ -271,9 +269,12 @@ function formatDurationMs(ms: number | null): string {
     return humanFriendlyDuration(ms / 1000, { secondsFixed: 2 })
 }
 
-// Last 7 days of a daily series, coalescing latency gaps (NaN) to 0 for the sparkline.
+// Tile sparkline window — the trailing slice of the 30-day daily series.
+const SPARKLINE_DAYS = 7
+
+// Trailing window of a daily series, coalescing latency gaps (NaN) to 0 for the sparkline.
 function spark(values: number[]): number[] {
-    return values.slice(-7).map((v) => (Number.isFinite(v) ? v : 0))
+    return values.slice(-SPARKLINE_DAYS).map((v) => (Number.isFinite(v) ? v : 0))
 }
 
 function StatTiles({

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -28,7 +28,7 @@ import {
 import { buildTheme } from 'lib/charts/utils/theme'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyNumber } from 'lib/utils'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -38,7 +38,8 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { SceneExport } from '~/scenes/sceneTypes'
 
-import { HARNESS_LOGOS, HarnessPill } from './dashboard/harness'
+import { formatMs, formatMsAsSeconds } from './dashboard/formatters'
+import { HarnessLogo, HarnessPill } from './dashboard/harness'
 import {
     type DailyChartData,
     IntentCoverage,
@@ -141,24 +142,9 @@ function HarnessLogos({ value }: { value: string }): JSX.Element {
     }
     return (
         <div className="flex items-center gap-1">
-            {categories.map((category) => {
-                const logo = HARNESS_LOGOS[category]
-                return logo ? (
-                    <img
-                        key={category}
-                        src={logo.src}
-                        alt={category}
-                        title={category}
-                        className="h-4 w-4 shrink-0 object-contain"
-                    />
-                ) : (
-                    <span
-                        key={category}
-                        title={category}
-                        className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-secondary"
-                    />
-                )
-            })}
+            {categories.map((category) => (
+                <HarnessLogo key={category} category={category} />
+            ))}
         </div>
     )
 }
@@ -259,16 +245,6 @@ function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }
     )
 }
 
-function formatDurationMs(ms: number | null): string {
-    if (ms == null) {
-        return '—'
-    }
-    if (ms < 1000) {
-        return `${Math.round(ms)} ms`
-    }
-    return humanFriendlyDuration(ms / 1000, { secondsFixed: 2 })
-}
-
 // Tile sparkline window — the trailing slice of the 30-day daily series.
 const SPARKLINE_DAYS = 7
 
@@ -319,7 +295,7 @@ function StatTiles({
                 label="p50 latency"
                 loading={loading}
                 value={summary?.p50_ms ?? 0}
-                formatValue={formatDurationMs}
+                formatValue={formatMs}
                 data={spark(daily.p50)}
                 theme={theme}
                 color={theme.colors[0]}
@@ -329,7 +305,7 @@ function StatTiles({
                 label="p95 latency"
                 loading={loading}
                 value={summary?.p95_ms ?? 0}
-                formatValue={formatDurationMs}
+                formatValue={formatMs}
                 data={spark(daily.p95)}
                 theme={theme}
                 color={theme.colors[0]}
@@ -454,13 +430,6 @@ function seriesFor(data: DailyChartData, theme: ChartTheme, keys: TrendSeriesKey
     }))
 }
 
-function formatMsAxis(ms: number): string {
-    if (!isFinite(ms)) {
-        return '—'
-    }
-    return ms < 1000 ? `${Math.round(ms)}ms` : `${Math.round(ms / 100) / 10}s`
-}
-
 function TrendChart({
     title,
     series,
@@ -539,7 +508,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
         [dailyChartData, theme]
     )
     const countsConfig = useMemo(() => trendChartConfig(timezone), [timezone])
-    const latencyConfig = useMemo(() => trendChartConfig(timezone, { tickFormatter: formatMsAxis }), [timezone])
+    const latencyConfig = useMemo(() => trendChartConfig(timezone, { tickFormatter: formatMsAsSeconds }), [timezone])
 
     return (
         <SceneContent>

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -6,7 +6,6 @@ import { LemonButton, LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemo
 import {
     type ChartTheme,
     MetricCard,
-    type MetricChange,
     type Series,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
@@ -58,25 +57,22 @@ export const scene: SceneExport<MCPAnalyticsToolDetailLogicProps> = {
     }),
 }
 
-function percentDelta(current: number, previous: number): number | null {
-    if (!previous) {
-        return null
-    }
-    return ((current - previous) / previous) * 100
-}
-
 function StatTile({
     label,
     value,
     formatValue,
-    change,
+    data,
+    theme,
+    color,
     goodDirection,
     loading,
 }: {
     label: string
     value: number
     formatValue: (n: number) => string
-    change?: MetricChange | null
+    data?: number[]
+    theme: ChartTheme
+    color?: string
     goodDirection?: 'up' | 'down'
     loading: boolean
 }): JSX.Element {
@@ -93,9 +89,13 @@ function StatTile({
                         className="text-primary"
                         title={label}
                         value={value}
+                        data={data}
+                        theme={theme}
+                        color={color}
                         formatValue={formatValue}
-                        change={change}
                         goodDirection={goodDirection}
+                        sparklineHeight={40}
+                        sparklineClassName="mt-2 -mx-3 -mb-3"
                     />
                 </CardContent>
             )}
@@ -233,13 +233,26 @@ function formatDurationMs(ms: number | null): string {
     return humanFriendlyDuration(ms / 1000, { secondsFixed: 2 })
 }
 
-function StatTiles({ summary, loading }: { summary: ToolSummary | null; loading: boolean }): JSX.Element {
+// Last 7 days of a daily series, coalescing latency gaps (NaN) to 0 for the sparkline.
+function spark(values: number[]): number[] {
+    return values.slice(-7).map((v) => (Number.isFinite(v) ? v : 0))
+}
+
+function StatTiles({
+    summary,
+    loading,
+    daily,
+    theme,
+}: {
+    summary: ToolSummary | null
+    loading: boolean
+    daily: DailyChartData
+    theme: ChartTheme
+}): JSX.Element {
     const calls = summary?.calls ?? 0
     const errors = summary?.errors ?? 0
     const errorRate = calls ? (errors / calls) * 100 : 0
-    const errorRatePrev = summary && summary.calls_prev ? (summary.errors_prev / summary.calls_prev) * 100 : 0
-    const callsDelta = summary ? percentDelta(calls, summary.calls_prev) : null
-    const errorRateDelta = summary ? percentDelta(errorRate, errorRatePrev) : null
+    const errorRateDaily = daily.calls.map((c, i) => (c ? (daily.errors[i] / c) * 100 : 0))
 
     return (
         <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6" data-quill>
@@ -248,7 +261,9 @@ function StatTiles({ summary, loading }: { summary: ToolSummary | null; loading:
                 loading={loading}
                 value={calls}
                 formatValue={humanFriendlyNumber}
-                change={callsDelta != null ? { value: callsDelta } : null}
+                data={spark(daily.calls)}
+                theme={theme}
+                color={theme.colors[0]}
                 goodDirection="up"
             />
             <StatTile
@@ -256,7 +271,9 @@ function StatTiles({ summary, loading }: { summary: ToolSummary | null; loading:
                 loading={loading}
                 value={errorRate}
                 formatValue={(n) => `${n.toFixed(1)}%`}
-                change={errorRateDelta != null ? { value: errorRateDelta } : null}
+                data={spark(errorRateDaily)}
+                theme={theme}
+                color={theme.colors[4]}
                 goodDirection="down"
             />
             <StatTile
@@ -264,19 +281,40 @@ function StatTiles({ summary, loading }: { summary: ToolSummary | null; loading:
                 loading={loading}
                 value={summary?.p50_ms ?? 0}
                 formatValue={formatDurationMs}
+                data={spark(daily.p50)}
+                theme={theme}
+                color={theme.colors[0]}
+                goodDirection="down"
             />
             <StatTile
                 label="p95 latency"
                 loading={loading}
                 value={summary?.p95_ms ?? 0}
                 formatValue={formatDurationMs}
+                data={spark(daily.p95)}
+                theme={theme}
+                color={theme.colors[0]}
+                goodDirection="down"
             />
-            <StatTile label="Users" loading={loading} value={summary?.users ?? 0} formatValue={humanFriendlyNumber} />
+            <StatTile
+                label="Users"
+                loading={loading}
+                value={summary?.users ?? 0}
+                formatValue={humanFriendlyNumber}
+                data={spark(daily.users)}
+                theme={theme}
+                color={theme.colors[0]}
+                goodDirection="up"
+            />
             <StatTile
                 label="Sessions"
                 loading={loading}
                 value={summary?.conversations ?? 0}
                 formatValue={humanFriendlyNumber}
+                data={spark(daily.sessions)}
+                theme={theme}
+                color={theme.colors[6]}
+                goodDirection="up"
             />
         </div>
     )
@@ -484,13 +522,13 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
 
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <DescriptionBlock descriptions={descriptions} loading={descriptionsLoading} />
-                <StatTiles summary={summary} loading={summaryLoading} />
+                <StatTiles summary={summary} loading={summaryLoading} daily={dailyChartData} theme={theme} />
             </div>
 
             <LemonDivider />
 
             <div className="flex flex-col gap-3 px-4 pb-4">
-                <SectionHeader title="Reliability" subtitle="Last 7 days" />
+                <SectionHeader title="Reliability" subtitle="Last 30 days" />
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                     <TrendChart
                         title="Calls and errors"

--- a/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
+++ b/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
@@ -34,14 +34,18 @@ function EntropyBadge({ entropy }: { entropy: number }): JSX.Element {
     if (entropy < 0.3) {
         return (
             <Tooltip title={`Routing entropy ${entropy.toFixed(2)} — one tool dominates this cluster's calls.`}>
-                <Badge variant="success">Concentrated · {entropy.toFixed(2)}</Badge>
+                <span>
+                    <Badge variant="success">Concentrated · {entropy.toFixed(2)}</Badge>
+                </span>
             </Tooltip>
         )
     }
     if (entropy < 0.6) {
         return (
             <Tooltip title={`Routing entropy ${entropy.toFixed(2)} — calls split between a few tools.`}>
-                <Badge variant="warning">Mixed · {entropy.toFixed(2)}</Badge>
+                <span>
+                    <Badge variant="warning">Mixed · {entropy.toFixed(2)}</Badge>
+                </span>
             </Tooltip>
         )
     }
@@ -49,7 +53,9 @@ function EntropyBadge({ entropy }: { entropy: number }): JSX.Element {
         <Tooltip
             title={`Routing entropy ${entropy.toFixed(2)} — calls spread across many tools. Either a real multi-step workflow or the agent is improvising; the aggregate alone can't tell.`}
         >
-            <Badge variant="destructive">Spread · {entropy.toFixed(2)}</Badge>
+            <span>
+                <Badge variant="destructive">Spread · {entropy.toFixed(2)}</Badge>
+            </span>
         </Tooltip>
     )
 }

--- a/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
+++ b/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
@@ -1,11 +1,11 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRefresh, IconSparkles, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { Progress, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 
 import type { MCPIntentClusterApi, MCPIntentClusterToolEntryApi } from '../generated/api.schemas'
@@ -374,51 +374,46 @@ function ClusterDetail({ cluster }: { cluster: MCPIntentClusterApi }): JSX.Eleme
 
             <section className="flex flex-col gap-2">
                 <span className="text-xs uppercase text-muted font-medium">Tool routing breakdown</span>
-                <LemonTable
-                    embedded
-                    size="small"
-                    dataSource={[...cluster.tool_distribution]}
-                    rowKey={(row) => row.tool}
-                    columns={[
-                        {
-                            title: 'Tool',
-                            key: 'tool',
-                            render: (_, row) => <span className="font-mono">{row.tool}</span>,
-                        },
-                        {
-                            title: 'Calls',
-                            key: 'count',
-                            align: 'right',
-                            render: (_, row) => row.count.toLocaleString(),
-                        },
-                        {
-                            title: 'Share of cluster',
-                            key: 'pct',
-                            render: (_, row) => (
-                                <div className="flex items-center gap-2 min-w-[160px]">
-                                    <LemonProgress percent={row.pct} className="flex-1" />
-                                    <span className="text-xs text-muted tabular-nums w-10 text-right">
-                                        {row.pct.toFixed(1)}%
-                                    </span>
-                                </div>
-                            ),
-                        },
-                        {
-                            title: 'Errors',
-                            key: 'errors',
-                            align: 'right',
-                            render: (_, row) =>
-                                row.error_rate_pct > 0 ? (
-                                    <span className="text-danger tabular-nums">
-                                        {row.error_rate_pct.toFixed(1)}%{' '}
-                                        <span className="text-muted">({row.errors})</span>
-                                    </span>
-                                ) : (
-                                    <span className="text-muted">0%</span>
-                                ),
-                        },
-                    ]}
-                />
+                <div data-quill>
+                    <Table fullWidth>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead expand>Tool</TableHead>
+                                <TableHead align="right">Calls</TableHead>
+                                <TableHead>Share of cluster</TableHead>
+                                <TableHead align="right">Errors</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {cluster.tool_distribution.map((row) => (
+                                <TableRow key={row.tool}>
+                                    <TableCell expand>
+                                        <span className="font-mono">{row.tool}</span>
+                                    </TableCell>
+                                    <TableCell align="right">{row.count.toLocaleString()}</TableCell>
+                                    <TableCell>
+                                        <div className="flex min-w-[160px] items-center gap-2">
+                                            <Progress value={row.pct} className="flex-1" />
+                                            <span className="w-10 text-right text-xs tabular-nums text-muted">
+                                                {row.pct.toFixed(1)}%
+                                            </span>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        {row.error_rate_pct > 0 ? (
+                                            <span className="tabular-nums text-danger">
+                                                {row.error_rate_pct.toFixed(1)}%{' '}
+                                                <span className="text-muted">({row.errors})</span>
+                                            </span>
+                                        ) : (
+                                            <span className="text-muted">0%</span>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
             </section>
 
             <section className="flex flex-col gap-2">

--- a/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
+++ b/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
@@ -1,12 +1,23 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRefresh, IconSparkles, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
-import { Progress, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@posthog/quill-primitives'
+import { Tooltip } from '@posthog/lemon-ui'
+import {
+    Badge,
+    Button,
+    Progress,
+    Skeleton,
+    Spinner,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@posthog/quill-primitives'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { Spinner } from 'lib/lemon-ui/Spinner'
 
 import type { MCPIntentClusterApi, MCPIntentClusterToolEntryApi } from '../generated/api.schemas'
 import { ClusterJourneySankey } from './ClusterJourneySankey'
@@ -23,18 +34,14 @@ function EntropyBadge({ entropy }: { entropy: number }): JSX.Element {
     if (entropy < 0.3) {
         return (
             <Tooltip title={`Routing entropy ${entropy.toFixed(2)} — one tool dominates this cluster's calls.`}>
-                <LemonTag type="success" size="small">
-                    Concentrated · {entropy.toFixed(2)}
-                </LemonTag>
+                <Badge variant="success">Concentrated · {entropy.toFixed(2)}</Badge>
             </Tooltip>
         )
     }
     if (entropy < 0.6) {
         return (
             <Tooltip title={`Routing entropy ${entropy.toFixed(2)} — calls split between a few tools.`}>
-                <LemonTag type="warning" size="small">
-                    Mixed · {entropy.toFixed(2)}
-                </LemonTag>
+                <Badge variant="warning">Mixed · {entropy.toFixed(2)}</Badge>
             </Tooltip>
         )
     }
@@ -42,9 +49,7 @@ function EntropyBadge({ entropy }: { entropy: number }): JSX.Element {
         <Tooltip
             title={`Routing entropy ${entropy.toFixed(2)} — calls spread across many tools. Either a real multi-step workflow or the agent is improvising; the aggregate alone can't tell.`}
         >
-            <LemonTag type="danger" size="small">
-                Spread · {entropy.toFixed(2)}
-            </LemonTag>
+            <Badge variant="destructive">Spread · {entropy.toFixed(2)}</Badge>
         </Tooltip>
     )
 }
@@ -162,14 +167,14 @@ function SortHeader(): JSX.Element {
         <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs text-muted">Sort clusters by</span>
             {(Object.keys(SORT_LABELS) as ClusterSortKey[]).map((key) => (
-                <LemonButton
+                <Button
                     key={key}
-                    size="xsmall"
-                    type={sortKey === key ? 'primary' : 'tertiary'}
+                    size="sm"
+                    variant={sortKey === key ? 'default' : 'outline'}
                     onClick={() => setSortKey(key)}
                 >
                     {SORT_LABELS[key]}
-                </LemonButton>
+                </Button>
             ))}
         </div>
     )
@@ -329,18 +334,16 @@ function ClusterDetail({ cluster }: { cluster: MCPIntentClusterApi }): JSX.Eleme
                     </div>
                     <div className="flex flex-wrap items-center gap-2 shrink-0">
                         <EntropyBadge entropy={cluster.routing_entropy} />
-                        <LemonTag type={cluster.error_rate_pct > 5 ? 'danger' : 'muted'} size="small">
+                        <Badge variant={cluster.error_rate_pct > 5 ? 'destructive' : 'default'}>
                             {cluster.error_rate_pct.toFixed(1)}% errors
-                        </LemonTag>
-                        <LemonTag type="muted" size="small">
-                            {cluster.call_count.toLocaleString()} calls
-                        </LemonTag>
-                        <LemonTag type="muted" size="small">
+                        </Badge>
+                        <Badge variant="default">{cluster.call_count.toLocaleString()} calls</Badge>
+                        <Badge variant="default">
                             {cluster.session_count} session{cluster.session_count === 1 ? '' : 's'}
-                        </LemonTag>
-                        <LemonTag type="muted" size="small">
+                        </Badge>
+                        <Badge variant="default">
                             {cluster.intent_count} intent{cluster.intent_count === 1 ? '' : 's'}
-                        </LemonTag>
+                        </Badge>
                     </div>
                 </div>
                 {worstTool && worstTool.error_rate_pct > 0 ? (
@@ -456,15 +459,15 @@ function StatusRow(): JSX.Element | null {
                         </>
                     ) : null}
                 </div>
-                <LemonButton
-                    type="secondary"
-                    size="small"
-                    icon={<IconRefresh />}
+                <Button
+                    variant="outline"
+                    size="sm"
                     onClick={recompute}
                     data-attr="mcp-analytics-intent-clusters-recompute"
                 >
+                    <IconRefresh />
                     Recompute
-                </LemonButton>
+                </Button>
             </div>
         )
     }
@@ -475,7 +478,10 @@ function EmptyState(): JSX.Element {
     const { recompute } = useActions(mcpClusteringLogic)
     const { snapshotLoading } = useValues(mcpClusteringLogic)
     return (
-        <div className="bg-surface-primary border rounded p-8 flex flex-col items-center text-center gap-3 max-w-2xl mx-auto">
+        <div
+            className="bg-surface-primary border rounded p-8 flex flex-col items-center text-center gap-3 max-w-2xl mx-auto"
+            data-quill
+        >
             <IconSparkles className="text-4xl text-accent" />
             <h3 className="text-lg font-semibold">No intent clusters yet</h3>
             <p className="text-sm text-muted max-w-md">
@@ -483,9 +489,10 @@ function EmptyState(): JSX.Element {
                 routes to. It surfaces whether your MCP sends similar goals to the same tools, and which routes are the
                 most error-prone.
             </p>
-            <LemonButton type="primary" icon={<IconSparkles />} onClick={recompute} loading={snapshotLoading}>
+            <Button variant="default" onClick={recompute} disabled={snapshotLoading}>
+                {snapshotLoading ? <Spinner /> : <IconSparkles />}
                 Compute intent clusters
-            </LemonButton>
+            </Button>
             <span className="text-xs text-muted">
                 Needs sessions with a summarized intent — usually a few minutes after sessions are recorded.
             </span>
@@ -497,12 +504,12 @@ function ComputingSkeleton(): JSX.Element {
     return (
         <div className="flex flex-col gap-4">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <LemonSkeleton className="h-24 w-full" />
-                <LemonSkeleton className="h-24 w-full" />
-                <LemonSkeleton className="h-24 w-full" />
+                <Skeleton className="h-24 w-full" />
+                <Skeleton className="h-24 w-full" />
+                <Skeleton className="h-24 w-full" />
             </div>
-            <LemonSkeleton className="h-96 w-full" />
-            <LemonSkeleton className="h-48 w-full" />
+            <Skeleton className="h-96 w-full" />
+            <Skeleton className="h-48 w-full" />
         </div>
     )
 }
@@ -527,7 +534,7 @@ export function MCPAnalyticsClustering(): JSX.Element {
 
     if (isComputing || (snapshotLoading && !hasSnapshot)) {
         return (
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4" data-quill>
                 <StatusRow />
                 <ComputingSkeleton />
             </div>
@@ -535,7 +542,7 @@ export function MCPAnalyticsClustering(): JSX.Element {
     }
 
     return (
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4" data-quill>
             <StatusRow />
             <Scorecards />
             <SortHeader />

--- a/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
     type Series,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
+import { Skeleton } from '@posthog/quill-primitives'
 
 import { type DailyActivity } from '../mcpDashboardOverviewLogic'
 import { Card, CardState } from './Card'
@@ -46,7 +46,7 @@ export function ActivityChart({
             <CardState
                 loading={loading}
                 isEmpty={daily.labels.length === 0}
-                skeleton={<LemonSkeleton className="min-h-[300px] flex-1" />}
+                skeleton={<Skeleton className="min-h-[300px] flex-1" />}
                 empty={
                     <div className="flex flex-1 items-center justify-center py-6 text-center text-[12px] text-secondary">
                         No activity yet.

--- a/products/mcp_analytics/frontend/dashboard/HarnessDonut.tsx
+++ b/products/mcp_analytics/frontend/dashboard/HarnessDonut.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
     PieChart,
@@ -9,6 +8,7 @@ import {
     type TooltipContext,
     useRadialLayout,
 } from '@posthog/quill-charts'
+import { Skeleton } from '@posthog/quill-primitives'
 
 import { formatPercentage } from 'lib/utils'
 
@@ -111,7 +111,7 @@ export function HarnessDonut({
         return (
             <Card className="flex flex-1 flex-col" title="Share of calls by harness">
                 <div className="flex min-h-[300px] flex-1 items-center justify-center">
-                    <LemonSkeleton className="h-[180px] w-[180px] rounded-full" />
+                    <Skeleton className="h-[180px] w-[180px] rounded-full" />
                 </div>
             </Card>
         )

--- a/products/mcp_analytics/frontend/dashboard/KpiTiles.tsx
+++ b/products/mcp_analytics/frontend/dashboard/KpiTiles.tsx
@@ -1,6 +1,6 @@
-import { LemonSkeleton, Link } from '@posthog/lemon-ui'
+import { Link } from '@posthog/lemon-ui'
 import { type ChartTheme, MetricCard } from '@posthog/quill-charts'
-import { Card, CardContent } from '@posthog/quill-primitives'
+import { Card, CardContent, Skeleton } from '@posthog/quill-primitives'
 
 import { formatPercentage } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -27,8 +27,8 @@ function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.El
             <Card size="sm" className="flex-1 transition-transform group-hover/tile:-translate-y-0.5">
                 {tile.loading ? (
                     <CardContent className="flex flex-col gap-2">
-                        <LemonSkeleton className="h-3 w-16" />
-                        <LemonSkeleton className="h-7 w-20" />
+                        <Skeleton className="h-3 w-16" />
+                        <Skeleton className="h-7 w-20" />
                     </CardContent>
                 ) : (
                     <CardContent>

--- a/products/mcp_analytics/frontend/dashboard/NotableSessionsTable.tsx
+++ b/products/mcp_analytics/frontend/dashboard/NotableSessionsTable.tsx
@@ -1,10 +1,11 @@
-import { LemonSkeleton, Link } from '@posthog/lemon-ui'
+import { Link } from '@posthog/lemon-ui'
 import {
     Badge,
     Card,
     CardFooter,
     CardHeader,
     CardTitle,
+    Skeleton,
     Table,
     TableBody,
     TableCell,
@@ -48,7 +49,7 @@ function SessionRows({ sessions, loading }: { sessions: NotableSession[]; loadin
                 <TableCell colSpan={5}>
                     <div className="space-y-2 py-1">
                         {Array.from({ length: 4 }).map((_, i) => (
-                            <LemonSkeleton key={i} className="h-3.5 w-full" />
+                            <Skeleton key={i} className="h-3.5 w-full" />
                         ))}
                     </div>
                 </TableCell>

--- a/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import {
     BarChart,
     type BarChartConfig,
@@ -9,6 +8,7 @@ import {
     type TooltipContext,
     ValueLabels,
 } from '@posthog/quill-charts'
+import { Skeleton } from '@posthog/quill-primitives'
 
 import { formatPercentage } from 'lib/utils'
 
@@ -90,7 +90,7 @@ export function ToolErrorRateChart({
                 skeleton={
                     <div className="space-y-2 py-3">
                         {Array.from({ length: 5 }).map((_, i) => (
-                            <LemonSkeleton key={i} className="h-7 w-full" />
+                            <Skeleton key={i} className="h-7 w-full" />
                         ))}
                     </div>
                 }

--- a/products/mcp_analytics/frontend/dashboard/ToolUsageChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolUsageChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import { type ChartTheme, type Series, TimeSeriesBarChart, type TimeSeriesBarChartConfig } from '@posthog/quill-charts'
+import { Skeleton } from '@posthog/quill-primitives'
 
 import { type ToolDailySeries } from '../mcpDashboardOverviewLogic'
 import { Card, CardState } from './Card'
@@ -44,7 +44,7 @@ export function ToolUsageChart({
             <CardState
                 loading={loading}
                 isEmpty={data.labels.length === 0}
-                skeleton={<LemonSkeleton className="h-[260px] w-full" />}
+                skeleton={<Skeleton className="h-[260px] w-full" />}
                 empty={<div className="py-6 text-center text-[12px] text-secondary">No tool calls yet.</div>}
             >
                 <div className="flex h-[260px] flex-col">

--- a/products/mcp_analytics/frontend/dashboard/harness.tsx
+++ b/products/mcp_analytics/frontend/dashboard/harness.tsx
@@ -33,18 +33,28 @@ export function harnessSliceColor(theme: ChartTheme, category: string, fallbackI
     return theme.colors[index % theme.colors.length]
 }
 
-export function HarnessPill({ category, title }: { category: string; title?: string }): JSX.Element {
+// A single harness logo (or a neutral dot when no logo is known for the category).
+export function HarnessLogo({
+    category,
+    className = 'h-4 w-4',
+}: {
+    category: string
+    className?: string
+}): JSX.Element {
     const logo = HARNESS_LOGOS[category]
+    if (logo) {
+        return <img src={logo.src} alt={category} title={category} className={`${className} shrink-0 object-contain`} />
+    }
+    return <span title={category} className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-secondary" aria-hidden />
+}
+
+export function HarnessPill({ category, title }: { category: string; title?: string }): JSX.Element {
     return (
         <span
             className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-primary bg-surface-primary px-2 py-0.5 text-xs"
             title={title}
         >
-            {logo ? (
-                <img src={logo.src} alt="" className="h-3.5 w-3.5 shrink-0 object-contain" />
-            ) : (
-                <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-secondary" aria-hidden />
-            )}
+            <HarnessLogo category={category} className="h-3.5 w-3.5" />
             <span className="truncate">{category}</span>
         </span>
     )

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
@@ -1,0 +1,56 @@
+import { buildDailyChartData, type DailyToolStat } from './mcpAnalyticsToolDetailLogic'
+
+function stat(overrides: Partial<DailyToolStat> & { day: string }): DailyToolStat {
+    return {
+        calls: 0,
+        errors: 0,
+        p50: 0,
+        p95: 0,
+        users: 0,
+        sessions: 0,
+        ...overrides,
+    }
+}
+
+describe('buildDailyChartData', () => {
+    it('returns empty series for no rows', () => {
+        expect(buildDailyChartData([])).toEqual({
+            labels: [],
+            calls: [],
+            errors: [],
+            p50: [],
+            p95: [],
+            users: [],
+            sessions: [],
+        })
+    })
+
+    it('passes a single day through unchanged', () => {
+        const rows = [stat({ day: '2026-06-01', calls: 10, errors: 2, p50: 100, p95: 300, users: 3, sessions: 4 })]
+        expect(buildDailyChartData(rows)).toEqual({
+            labels: ['2026-06-01'],
+            calls: [10],
+            errors: [2],
+            p50: [100],
+            p95: [300],
+            users: [3],
+            sessions: [4],
+        })
+    })
+
+    it('gap-fills interior missing days (counts→0, latency→NaN) with a contiguous day axis', () => {
+        const rows = [
+            stat({ day: '2026-06-01', calls: 10, errors: 1, p50: 100, p95: 200, users: 2, sessions: 3 }),
+            stat({ day: '2026-06-03', calls: 5, errors: 0, p50: 50, p95: 150, users: 1, sessions: 1 }),
+        ]
+        expect(buildDailyChartData(rows)).toEqual({
+            labels: ['2026-06-01', '2026-06-02', '2026-06-03'],
+            calls: [10, 0, 5],
+            errors: [1, 0, 0],
+            p50: [100, NaN, 50],
+            p95: [200, NaN, 150],
+            users: [2, 0, 1],
+            sessions: [3, 0, 1],
+        })
+    })
+})

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -407,7 +407,7 @@ WHERE event = 'mcp_tool_call'
     AND ${toolFilter}
 GROUP BY distinct_id
 ORDER BY calls DESC
-LIMIT 10
+LIMIT 5
 `,
                     })) as HogQLQueryResponse
                     return (response.results ?? []) as ResultRows

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -2,9 +2,9 @@ import { afterMount, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 
-import { DataTableNode, HogQLQueryResponse, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
-import { BaseMathType, ChartDisplayType, PropertyFilterType, PropertyMathType } from '~/types'
+import { DataTableNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 
 import type { mcpAnalyticsToolDetailLogicType } from './mcpAnalyticsToolDetailLogicType'
 
@@ -29,13 +29,51 @@ export interface IntentCoverage {
     total: number
 }
 
+export interface DailyToolStat {
+    day: string
+    calls: number
+    errors: number
+    p50: number
+    p95: number
+}
+
+export interface DailyChartData {
+    labels: string[]
+    calls: number[]
+    errors: number[]
+    p50: number[]
+    p95: number[]
+}
+
+const EMPTY_CHART_DATA: DailyChartData = { labels: [], calls: [], errors: [], p50: [], p95: [] }
+
+// Gap-fill the per-day rows into a continuous day axis (ClickHouse only returns days with data).
+// Counts fill with 0; latency fills with NaN so the chart skips the point instead of dipping to 0.
+function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
+    if (rows.length === 0) {
+        return EMPTY_CHART_DATA
+    }
+    const byDay = new Map(rows.map((r) => [r.day, r]))
+    const end = dayjs(rows[rows.length - 1].day)
+    const labels: string[] = []
+    for (let day = dayjs(rows[0].day); !day.isAfter(end); day = day.add(1, 'day')) {
+        labels.push(day.format('YYYY-MM-DD'))
+    }
+    const at = labels.map((day) => byDay.get(day))
+    return {
+        labels,
+        calls: at.map((r) => r?.calls ?? 0),
+        errors: at.map((r) => r?.errors ?? 0),
+        p50: at.map((r) => (r ? r.p50 : NaN)),
+        p95: at.map((r) => (r ? r.p95 : NaN)),
+    }
+}
+
 export interface MCPAnalyticsToolDetailLogicProps {
     toolName: string
 }
 
 const NEW_SDK_SOURCE = 'posthog_mcp_analytics'
-
-const DATE_FROM_CURRENT = '-7d'
 
 // HogQL expression that resolves to the *effective* tool name for new-SDK events:
 // the inner tool when the call went through the single-exec wrapper, otherwise
@@ -148,6 +186,38 @@ WHERE event = 'mcp_tool_call'
                 },
             },
         ],
+        dailyStats: [
+            [] as DailyToolStat[],
+            {
+                loadDailyStats: async (): Promise<DailyToolStat[]> => {
+                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
+SELECT
+    toDate(timestamp) AS day,
+    count() AS calls,
+    countIf(toBool(properties.$mcp_is_error)) AS errors,
+    round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50,
+    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95
+FROM events
+WHERE event = 'mcp_tool_call'
+    AND timestamp >= now() - INTERVAL 7 DAY
+    AND ${toolFilter}
+GROUP BY day
+ORDER BY day
+`,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []).map((r) => ({
+                        day: String(r[0] ?? ''),
+                        calls: Number(r[1] ?? 0),
+                        errors: Number(r[2] ?? 0),
+                        p50: Number(r[3] ?? 0),
+                        p95: Number(r[4] ?? 0),
+                    }))
+                },
+            },
+        ],
     })),
 
     selectors({
@@ -158,82 +228,9 @@ WHERE event = 'mcp_tool_call'
             (toolName: string) => `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}' AND ${NEW_SDK_FILTER}`,
         ],
 
-        callsTrendQuery: [
-            (s) => [s.toolName],
-            (toolName: string): InsightVizNode => ({
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    series: [
-                        {
-                            kind: NodeKind.EventsNode,
-                            event: 'mcp_tool_call',
-                            name: 'Calls',
-                            math: BaseMathType.TotalCount,
-                            properties: [
-                                {
-                                    type: PropertyFilterType.HogQL,
-                                    key: `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}'`,
-                                },
-                                {
-                                    type: PropertyFilterType.HogQL,
-                                    key: NEW_SDK_FILTER,
-                                },
-                            ],
-                        },
-                    ],
-                    breakdownFilter: {
-                        breakdown_type: 'event',
-                        breakdown: '$mcp_is_error',
-                    },
-                    trendsFilter: {
-                        display: ChartDisplayType.ActionsLineGraph,
-                    },
-                    dateRange: { date_from: DATE_FROM_CURRENT, date_to: null },
-                },
-            }),
-        ],
-
-        latencyTrendQuery: [
-            (s) => [s.toolName],
-            (toolName: string): InsightVizNode => ({
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    series: [
-                        {
-                            kind: NodeKind.EventsNode,
-                            event: 'mcp_tool_call',
-                            name: 'p95 duration (ms)',
-                            math: PropertyMathType.P95,
-                            math_property: '$mcp_duration_ms',
-                            properties: [
-                                {
-                                    type: PropertyFilterType.HogQL,
-                                    key: `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}'`,
-                                },
-                                { type: PropertyFilterType.HogQL, key: NEW_SDK_FILTER },
-                            ],
-                        },
-                        {
-                            kind: NodeKind.EventsNode,
-                            event: 'mcp_tool_call',
-                            name: 'p50 duration (ms)',
-                            math: PropertyMathType.Median,
-                            math_property: '$mcp_duration_ms',
-                            properties: [
-                                {
-                                    type: PropertyFilterType.HogQL,
-                                    key: `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}'`,
-                                },
-                                { type: PropertyFilterType.HogQL, key: NEW_SDK_FILTER },
-                            ],
-                        },
-                    ],
-                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
-                    dateRange: { date_from: DATE_FROM_CURRENT, date_to: null },
-                },
-            }),
+        dailyChartData: [
+            (s) => [s.dailyStats],
+            (dailyStats: DailyToolStat[]): DailyChartData => buildDailyChartData(dailyStats),
         ],
 
         failuresQuery: [
@@ -441,5 +438,6 @@ LIMIT 10
         actions.loadSummary()
         actions.loadDescriptions()
         actions.loadIntentCoverage()
+        actions.loadDailyStats()
     }),
 ])

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -304,7 +304,7 @@ WITH tool_calls AS (
         AND ${NEW_SDK_FILTER}
         AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
-SELECT prev_tool AS tool, count() AS co_occurrences
+SELECT prev_tool AS neighbor_tool, count() AS co_occurrences
 FROM (
     SELECT
         conv_id,
@@ -340,7 +340,7 @@ WITH tool_calls AS (
         AND ${NEW_SDK_FILTER}
         AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
-SELECT next_tool AS tool, count() AS co_occurrences
+SELECT next_tool AS neighbor_tool, count() AS co_occurrences
 FROM (
     SELECT
         conv_id,

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -4,7 +4,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
-import { DataTableNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 
 import type { mcpAnalyticsToolDetailLogicType } from './mcpAnalyticsToolDetailLogicType'
 
@@ -46,6 +46,9 @@ export interface DailyChartData {
 }
 
 const EMPTY_CHART_DATA: DailyChartData = { labels: [], calls: [], errors: [], p50: [], p95: [] }
+
+// Raw HogQL result rows (positional columns), rendered by the tool detail tables.
+export type ResultRows = unknown[][]
 
 // Gap-fill the per-day rows into a continuous day axis (ClickHouse only returns days with data).
 // Counts fill with 0; latency fills with NaN so the chart skips the point instead of dipping to 0.
@@ -218,28 +221,13 @@ ORDER BY day
                 },
             },
         ],
-    })),
-
-    selectors({
-        toolName: [() => [(_, props) => props.toolName], (toolName: string) => toolName],
-
-        toolFilterClause: [
-            (s) => [s.toolName],
-            (toolName: string) => `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}' AND ${NEW_SDK_FILTER}`,
-        ],
-
-        dailyChartData: [
-            (s) => [s.dailyStats],
-            (dailyStats: DailyToolStat[]): DailyChartData => buildDailyChartData(dailyStats),
-        ],
-
-        failuresQuery: [
-            (s) => [s.toolName],
-            (toolName: string): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        failureRows: [
+            [] as ResultRows,
+            {
+                loadFailureRows: async (): Promise<ResultRows> => {
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 SELECT
     substring(toString(properties.$exception_message), 1, 200) AS message,
     count() AS occurrences,
@@ -248,26 +236,25 @@ SELECT
 FROM events
 WHERE event = '$exception'
     AND timestamp >= now() - INTERVAL 7 DAY
-    AND toString(properties.$mcp_tool_name) = '${escapeHogQLString(toolName)}'
+    AND toString(properties.$mcp_tool_name) = '${escapeHogQLString(props.toolName)}'
     AND notEmpty(toString(properties.$exception_message))
 GROUP BY message
 ORDER BY occurrences DESC
 LIMIT 20
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['message', 'occurrences', 'last_seen', 'harnesses'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
         ],
-
-        sampleIntentsQuery: [
-            (s) => [s.toolFilterClause],
-            (toolFilter): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        sampleIntentRows: [
+            [] as ResultRows,
+            {
+                loadSampleIntentRows: async (): Promise<ResultRows> => {
+                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 SELECT
     timestamp,
     toString(properties.$mcp_intent) AS intent,
@@ -282,20 +269,18 @@ WHERE event = 'mcp_tool_call'
 ORDER BY timestamp DESC
 LIMIT 5
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['timestamp', 'intent', 'source', 'harness'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
         ],
-
-        neighborsBeforeQuery: [
-            (s) => [s.toolName],
-            (toolName: string): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        neighborsBeforeRows: [
+            [] as ResultRows,
+            {
+                loadNeighborsBeforeRows: async (): Promise<ResultRows> => {
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 WITH tool_calls AS (
     SELECT
         coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
@@ -307,9 +292,7 @@ WITH tool_calls AS (
         AND ${NEW_SDK_FILTER}
         AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
-SELECT
-    prev_tool AS tool,
-    count() AS co_occurrences
+SELECT prev_tool AS tool, count() AS co_occurrences
 FROM (
     SELECT
         conv_id,
@@ -317,28 +300,23 @@ FROM (
         lagInFrame(tool) OVER (PARTITION BY conv_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_tool
     FROM tool_calls
 )
-WHERE tool = '${escapeHogQLString(toolName)}'
-    AND prev_tool IS NOT NULL
-    AND prev_tool != ''
-    AND prev_tool != tool
+WHERE tool = '${escapeHogQLString(props.toolName)}' AND prev_tool IS NOT NULL AND prev_tool != '' AND prev_tool != tool
 GROUP BY prev_tool
 ORDER BY co_occurrences DESC
 LIMIT 5
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['tool', 'co_occurrences'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
         ],
-
-        neighborsAfterQuery: [
-            (s) => [s.toolName],
-            (toolName: string): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        neighborsAfterRows: [
+            [] as ResultRows,
+            {
+                loadNeighborsAfterRows: async (): Promise<ResultRows> => {
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 WITH tool_calls AS (
     SELECT
         coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
@@ -350,9 +328,7 @@ WITH tool_calls AS (
         AND ${NEW_SDK_FILTER}
         AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
 )
-SELECT
-    next_tool AS tool,
-    count() AS co_occurrences
+SELECT next_tool AS tool, count() AS co_occurrences
 FROM (
     SELECT
         conv_id,
@@ -360,28 +336,24 @@ FROM (
         leadInFrame(tool) OVER (PARTITION BY conv_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS next_tool
     FROM tool_calls
 )
-WHERE tool = '${escapeHogQLString(toolName)}'
-    AND next_tool IS NOT NULL
-    AND next_tool != ''
-    AND next_tool != tool
+WHERE tool = '${escapeHogQLString(props.toolName)}' AND next_tool IS NOT NULL AND next_tool != '' AND next_tool != tool
 GROUP BY next_tool
 ORDER BY co_occurrences DESC
 LIMIT 5
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['tool', 'co_occurrences'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
         ],
-
-        byHarnessQuery: [
-            (s) => [s.toolFilterClause],
-            (toolFilter): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        byHarnessRows: [
+            [] as ResultRows,
+            {
+                loadByHarnessRows: async (): Promise<ResultRows> => {
+                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 SELECT
     toString(properties.$mcp_client_name) AS harness,
     count() AS calls,
@@ -397,20 +369,19 @@ GROUP BY harness
 ORDER BY calls DESC
 LIMIT 10
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['harness', 'calls', 'errors', 'error_rate_pct', 'users'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
         ],
-
-        topUsersQuery: [
-            (s) => [s.toolFilterClause],
-            (toolFilter): DataTableNode => ({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: `
+        topUserRows: [
+            [] as ResultRows,
+            {
+                loadTopUserRows: async (): Promise<ResultRows> => {
+                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: `
 SELECT
     argMax(tuple(distinct_id, person.created_at, person.properties), timestamp) AS person,
     count() AS calls,
@@ -426,11 +397,19 @@ GROUP BY distinct_id
 ORDER BY calls DESC
 LIMIT 10
 `,
+                    })) as HogQLQueryResponse
+                    return (response.results ?? []) as ResultRows
                 },
-                columns: ['person', 'calls', 'errors', 'error_rate_pct', 'harnesses', 'last_seen'],
-                showSearch: false,
-                showOpenEditorButton: true,
-            }),
+            },
+        ],
+    })),
+
+    selectors({
+        toolName: [() => [(_, props) => props.toolName], (toolName: string) => toolName],
+
+        dailyChartData: [
+            (s) => [s.dailyStats],
+            (dailyStats: DailyToolStat[]): DailyChartData => buildDailyChartData(dailyStats),
         ],
     }),
 
@@ -439,5 +418,11 @@ LIMIT 10
         actions.loadDescriptions()
         actions.loadIntentCoverage()
         actions.loadDailyStats()
+        actions.loadFailureRows()
+        actions.loadSampleIntentRows()
+        actions.loadNeighborsBeforeRows()
+        actions.loadNeighborsAfterRows()
+        actions.loadByHarnessRows()
+        actions.loadTopUserRows()
     }),
 ])

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -101,6 +101,45 @@ function escapeHogQLString(value: string): string {
     return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
 }
 
+// Standard "this tool, new-SDK only" filter shared by the mcp_tool_call queries.
+function buildToolFilter(toolName: string): string {
+    return `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(toolName)}' AND ${NEW_SDK_FILTER}`
+}
+
+async function queryRows(query: string): Promise<ResultRows> {
+    const response = (await api.query({ kind: NodeKind.HogQLQuery, query })) as HogQLQueryResponse
+    return (response.results ?? []) as ResultRows
+}
+
+// Tools most often called immediately before/after this one within the same conversation.
+function buildNeighborQuery(toolName: string, direction: 'before' | 'after'): string {
+    const windowFn = direction === 'before' ? 'lagInFrame' : 'leadInFrame'
+    return `
+WITH tool_calls AS (
+    SELECT
+        coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
+        timestamp,
+        ${EFFECTIVE_TOOL_HOGQL} AS tool
+    FROM events
+    WHERE event = 'mcp_tool_call'
+        AND timestamp >= now() - INTERVAL 7 DAY
+        AND ${NEW_SDK_FILTER}
+        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
+)
+SELECT neighbor_tool, count() AS co_occurrences
+FROM (
+    SELECT
+        tool,
+        ${windowFn}(tool) OVER (PARTITION BY conv_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS neighbor_tool
+    FROM tool_calls
+)
+WHERE tool = '${escapeHogQLString(toolName)}' AND neighbor_tool IS NOT NULL AND neighbor_tool != '' AND neighbor_tool != tool
+GROUP BY neighbor_tool
+ORDER BY co_occurrences DESC
+LIMIT 5
+`
+}
+
 export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>([
     path(['products', 'mcp_analytics', 'frontend', 'mcpAnalyticsToolDetailLogic']),
     key((props: MCPAnalyticsToolDetailLogicProps) => props.toolName),
@@ -111,7 +150,7 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
             null as ToolSummary | null,
             {
                 loadSummary: async (): Promise<ToolSummary | null> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const toolFilter = buildToolFilter(props.toolName)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: `
@@ -147,7 +186,7 @@ WHERE event = 'mcp_tool_call'
             [] as DescriptionRevision[],
             {
                 loadDescriptions: async (): Promise<DescriptionRevision[]> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const toolFilter = buildToolFilter(props.toolName)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: `
@@ -175,7 +214,7 @@ LIMIT 5
             null as IntentCoverage | null,
             {
                 loadIntentCoverage: async (): Promise<IntentCoverage | null> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const toolFilter = buildToolFilter(props.toolName)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: `
@@ -200,7 +239,7 @@ WHERE event = 'mcp_tool_call'
             [] as DailyToolStat[],
             {
                 loadDailyStats: async (): Promise<DailyToolStat[]> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
+                    const toolFilter = buildToolFilter(props.toolName)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: `
@@ -235,10 +274,8 @@ ORDER BY day
         failureRows: [
             [] as ResultRows,
             {
-                loadFailureRows: async (): Promise<ResultRows> => {
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
+                loadFailureRows: async (): Promise<ResultRows> =>
+                    queryRows(`
 SELECT
     substring(toString(properties.$exception_message), 1, 200) AS message,
     count() AS occurrences,
@@ -254,20 +291,14 @@ WHERE event = '$exception'
 GROUP BY message
 ORDER BY occurrences DESC
 LIMIT 20
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+`),
             },
         ],
         sampleIntentRows: [
             [] as ResultRows,
             {
-                loadSampleIntentRows: async (): Promise<ResultRows> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
+                loadSampleIntentRows: async (): Promise<ResultRows> =>
+                    queryRows(`
 SELECT
     timestamp,
     toString(properties.$mcp_intent) AS intent,
@@ -276,97 +307,33 @@ SELECT
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL 7 DAY
-    AND ${toolFilter}
+    AND ${buildToolFilter(props.toolName)}
     AND notEmpty(toString(properties.$mcp_intent))
     AND toString(properties.$mcp_intent) != '{}'
 ORDER BY timestamp DESC
 LIMIT 5
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+`),
             },
         ],
         neighborsBeforeRows: [
             [] as ResultRows,
             {
-                loadNeighborsBeforeRows: async (): Promise<ResultRows> => {
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
-WITH tool_calls AS (
-    SELECT
-        coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
-        timestamp,
-        ${EFFECTIVE_TOOL_HOGQL} AS tool
-    FROM events
-    WHERE event = 'mcp_tool_call'
-        AND timestamp >= now() - INTERVAL 7 DAY
-        AND ${NEW_SDK_FILTER}
-        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
-)
-SELECT prev_tool AS neighbor_tool, count() AS co_occurrences
-FROM (
-    SELECT
-        conv_id,
-        tool,
-        lagInFrame(tool) OVER (PARTITION BY conv_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_tool
-    FROM tool_calls
-)
-WHERE tool = '${escapeHogQLString(props.toolName)}' AND prev_tool IS NOT NULL AND prev_tool != '' AND prev_tool != tool
-GROUP BY prev_tool
-ORDER BY co_occurrences DESC
-LIMIT 5
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+                loadNeighborsBeforeRows: async (): Promise<ResultRows> =>
+                    queryRows(buildNeighborQuery(props.toolName, 'before')),
             },
         ],
         neighborsAfterRows: [
             [] as ResultRows,
             {
-                loadNeighborsAfterRows: async (): Promise<ResultRows> => {
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
-WITH tool_calls AS (
-    SELECT
-        coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)) AS conv_id,
-        timestamp,
-        ${EFFECTIVE_TOOL_HOGQL} AS tool
-    FROM events
-    WHERE event = 'mcp_tool_call'
-        AND timestamp >= now() - INTERVAL 7 DAY
-        AND ${NEW_SDK_FILTER}
-        AND notEmpty(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)))
-)
-SELECT next_tool AS neighbor_tool, count() AS co_occurrences
-FROM (
-    SELECT
-        conv_id,
-        tool,
-        leadInFrame(tool) OVER (PARTITION BY conv_id ORDER BY timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS next_tool
-    FROM tool_calls
-)
-WHERE tool = '${escapeHogQLString(props.toolName)}' AND next_tool IS NOT NULL AND next_tool != '' AND next_tool != tool
-GROUP BY next_tool
-ORDER BY co_occurrences DESC
-LIMIT 5
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+                loadNeighborsAfterRows: async (): Promise<ResultRows> =>
+                    queryRows(buildNeighborQuery(props.toolName, 'after')),
             },
         ],
         byHarnessRows: [
             [] as ResultRows,
             {
-                loadByHarnessRows: async (): Promise<ResultRows> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
+                loadByHarnessRows: async (): Promise<ResultRows> =>
+                    queryRows(`
 SELECT
     toString(properties.$mcp_client_name) AS harness,
     count() AS calls,
@@ -376,25 +343,19 @@ SELECT
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL 7 DAY
-    AND ${toolFilter}
+    AND ${buildToolFilter(props.toolName)}
     AND notEmpty(toString(properties.$mcp_client_name))
 GROUP BY harness
 ORDER BY calls DESC
 LIMIT 10
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+`),
             },
         ],
         topUserRows: [
             [] as ResultRows,
             {
-                loadTopUserRows: async (): Promise<ResultRows> => {
-                    const toolFilter = `${EFFECTIVE_TOOL_HOGQL} = '${escapeHogQLString(props.toolName)}' AND ${NEW_SDK_FILTER}`
-                    const response = (await api.query({
-                        kind: NodeKind.HogQLQuery,
-                        query: `
+                loadTopUserRows: async (): Promise<ResultRows> =>
+                    queryRows(`
 SELECT
     argMax(tuple(distinct_id, person.created_at, person.properties), timestamp) AS person,
     count() AS calls,
@@ -405,14 +366,11 @@ SELECT
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL 7 DAY
-    AND ${toolFilter}
+    AND ${buildToolFilter(props.toolName)}
 GROUP BY distinct_id
 ORDER BY calls DESC
 LIMIT 5
-`,
-                    })) as HogQLQueryResponse
-                    return (response.results ?? []) as ResultRows
-                },
+`),
             },
         ],
     })),

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -15,8 +15,6 @@ export interface ToolSummary {
     p95_ms: number | null
     users: number
     conversations: number
-    calls_prev: number
-    errors_prev: number
 }
 
 export interface DescriptionRevision {
@@ -35,6 +33,8 @@ export interface DailyToolStat {
     errors: number
     p50: number
     p95: number
+    users: number
+    sessions: number
 }
 
 export interface DailyChartData {
@@ -43,9 +43,19 @@ export interface DailyChartData {
     errors: number[]
     p50: number[]
     p95: number[]
+    users: number[]
+    sessions: number[]
 }
 
-const EMPTY_CHART_DATA: DailyChartData = { labels: [], calls: [], errors: [], p50: [], p95: [] }
+const EMPTY_CHART_DATA: DailyChartData = {
+    labels: [],
+    calls: [],
+    errors: [],
+    p50: [],
+    p95: [],
+    users: [],
+    sessions: [],
+}
 
 // Raw HogQL result rows (positional columns), rendered by the tool detail tables.
 export type ResultRows = unknown[][]
@@ -69,6 +79,8 @@ function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
         errors: at.map((r) => r?.errors ?? 0),
         p50: at.map((r) => (r ? r.p50 : NaN)),
         p95: at.map((r) => (r ? r.p95 : NaN)),
+        users: at.map((r) => r?.users ?? 0),
+        sessions: at.map((r) => r?.sessions ?? 0),
     }
 }
 
@@ -105,17 +117,15 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
                         kind: NodeKind.HogQLQuery,
                         query: `
 SELECT
-    countIf(timestamp >= now() - INTERVAL 7 DAY) AS calls,
-    countIf(timestamp >= now() - INTERVAL 7 DAY AND toBool(properties.$mcp_is_error)) AS errors,
-    round(quantileIf(0.5)(toFloat(properties.$mcp_duration_ms), timestamp >= now() - INTERVAL 7 DAY)) AS p50_ms,
-    round(quantileIf(0.95)(toFloat(properties.$mcp_duration_ms), timestamp >= now() - INTERVAL 7 DAY)) AS p95_ms,
-    uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS users,
-    uniqIf(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id)), timestamp >= now() - INTERVAL 7 DAY) AS conversations,
-    countIf(timestamp >= now() - INTERVAL 14 DAY AND timestamp < now() - INTERVAL 7 DAY) AS calls_prev,
-    countIf(timestamp >= now() - INTERVAL 14 DAY AND timestamp < now() - INTERVAL 7 DAY AND toBool(properties.$mcp_is_error)) AS errors_prev
+    count() AS calls,
+    countIf(toBool(properties.$mcp_is_error)) AS errors,
+    round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50_ms,
+    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_ms,
+    uniq(distinct_id) AS users,
+    uniq(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id))) AS conversations
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL 14 DAY
+    AND timestamp >= now() - INTERVAL 7 DAY
     AND ${toolFilter}
 `,
                     })) as HogQLQueryResponse
@@ -130,8 +140,6 @@ WHERE event = 'mcp_tool_call'
                         p95_ms: row[3] == null ? null : Number(row[3]),
                         users: Number(row[4]) || 0,
                         conversations: Number(row[5]) || 0,
-                        calls_prev: Number(row[6]) || 0,
-                        errors_prev: Number(row[7]) || 0,
                     }
                 },
             },
@@ -202,10 +210,12 @@ SELECT
     count() AS calls,
     countIf(toBool(properties.$mcp_is_error)) AS errors,
     round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50,
-    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95
+    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95,
+    uniq(distinct_id) AS users,
+    uniq(coalesce(nullIf(toString(properties.$mcp_session_id), ''), toString(properties.$session_id))) AS sessions
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL 7 DAY
+    AND timestamp >= now() - INTERVAL 30 DAY
     AND ${toolFilter}
 GROUP BY day
 ORDER BY day
@@ -217,6 +227,8 @@ ORDER BY day
                         errors: Number(r[2] ?? 0),
                         p50: Number(r[3] ?? 0),
                         p95: Number(r[4] ?? 0),
+                        users: Number(r[5] ?? 0),
+                        sessions: Number(r[6] ?? 0),
                     }))
                 },
             },

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -57,12 +57,11 @@ const EMPTY_CHART_DATA: DailyChartData = {
     sessions: [],
 }
 
-// Raw HogQL result rows (positional columns), rendered by the tool detail tables.
 export type ResultRows = unknown[][]
 
 // Gap-fill the per-day rows into a continuous day axis (ClickHouse only returns days with data).
 // Counts fill with 0; latency fills with NaN so the chart skips the point instead of dipping to 0.
-function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
+export function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
     if (rows.length === 0) {
         return EMPTY_CHART_DATA
     }
@@ -246,6 +245,8 @@ SELECT
     max(timestamp) AS last_seen,
     arrayStringConcat(arraySort(arrayDistinct(groupArray(toString(properties.$mcp_client_name)))), ', ') AS harnesses
 FROM events
+-- $exception events don't carry the new-SDK markers ($mcp_source / $mcp_exec_tool_call_name), so
+-- unlike the mcp_tool_call queries this matches the raw $mcp_tool_name without EFFECTIVE_TOOL_HOGQL/NEW_SDK_FILTER.
 WHERE event = '$exception'
     AND timestamp >= now() - INTERVAL 7 DAY
     AND toString(properties.$mcp_tool_name) = '${escapeHogQLString(props.toolName)}'

--- a/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
@@ -1,15 +1,26 @@
 import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
-import { IconBolt, IconClock, IconRefresh, IconSparkles } from '@posthog/icons'
-import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
+import { IconBolt, IconClock, IconRefresh, IconSearch, IconSparkles } from '@posthog/icons'
+import {
+    Button,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    InputGroupText,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+    Spinner,
+} from '@posthog/quill-primitives'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { TZLabel } from 'lib/components/TZLabel'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
-import { LemonInput } from 'lib/lemon-ui/LemonInput'
-import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { cn } from 'lib/utils/css-classes'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
@@ -128,36 +139,54 @@ function SessionsListPanel(): JSX.Element {
     return (
         <div className="flex flex-col h-full min-h-0 overflow-hidden rounded border border-primary bg-surface-primary">
             <div className="shrink-0 flex flex-col gap-2 border-b border-primary p-2">
-                <LemonInput
-                    type="search"
-                    fullWidth
-                    size="small"
-                    placeholder="Search by session id, client, or tool"
-                    onChange={(value) => setFilters({ search: value })}
-                    value={filters.search}
-                />
-                <div className="flex items-center justify-between gap-2">
-                    <LemonSelect
-                        size="xsmall"
-                        value={sortingToValue(sorting)}
-                        options={SORT_OPTIONS}
-                        onChange={(value) => setSorting(valueToSorting(value))}
-                        data-attr="mcp-sessions-sort"
-                    />
-                    <LemonButton
-                        type="secondary"
-                        size="xsmall"
-                        icon={<IconRefresh />}
-                        onClick={() => loadSessions()}
-                        loading={sessionsLoading}
-                        tooltip="Reload sessions"
-                    />
+                <div className="flex flex-col gap-2" data-quill>
+                    <InputGroup className="w-full">
+                        <InputGroupAddon align="inline-start">
+                            <InputGroupText>
+                                <IconSearch />
+                            </InputGroupText>
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            type="search"
+                            placeholder="Search by session id, client, or tool"
+                            onChange={(e) => setFilters({ search: e.target.value })}
+                            value={filters.search}
+                        />
+                    </InputGroup>
+                    <div className="flex items-center justify-between gap-2">
+                        <Select
+                            value={sortingToValue(sorting)}
+                            onValueChange={(value) => setSorting(valueToSorting(value as MCPSessionOrderBy))}
+                        >
+                            <SelectTrigger size="sm" data-attr="mcp-sessions-sort">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {SORT_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <Button
+                            variant="outline"
+                            size="icon-sm"
+                            onClick={() => loadSessions()}
+                            disabled={sessionsLoading}
+                            title="Reload sessions"
+                        >
+                            {sessionsLoading ? <Spinner /> : <IconRefresh />}
+                        </Button>
+                    </div>
                 </div>
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto" data-attr="mcp-sessions-list">
                 {sessionsLoading && sessions.length === 0 ? (
-                    <div className="flex flex-col gap-2 p-2">
-                        <LemonSkeleton repeat={6} className="h-12 w-full" />
+                    <div className="flex flex-col gap-2 p-2" data-quill>
+                        {Array.from({ length: 6 }).map((_, i) => (
+                            <Skeleton key={i} className="h-12 w-full" />
+                        ))}
                     </div>
                 ) : sessions.length === 0 ? (
                     <div className="p-4 text-center text-sm text-secondary">No MCP sessions yet</div>
@@ -171,15 +200,16 @@ function SessionsListPanel(): JSX.Element {
                             ))}
                         </ul>
                         {hasNext ? (
-                            <div className="flex justify-center py-2">
-                                <LemonButton
-                                    type="secondary"
-                                    size="xsmall"
+                            <div className="flex justify-center py-2" data-quill>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
                                     onClick={() => loadMoreSessions()}
-                                    loading={sessionsLoading}
+                                    disabled={sessionsLoading}
                                 >
+                                    {sessionsLoading ? <Spinner /> : null}
                                     Load more
-                                </LemonButton>
+                                </Button>
                             </div>
                         ) : null}
                     </>


### PR DESCRIPTION
## Problem
Want to tidy up the tool drill down page and make it more consistent with the rest

## Changes
Make tool quality page use quil and clean it up a bit

<img width="1512" height="859" alt="Screenshot 2026-06-15 at 09 33 58" src="https://github.com/user-attachments/assets/e26845f6-0f13-4ddc-bdcd-f8349ceb8b02" />
<img width="1279" height="765" alt="Screenshot 2026-06-15 at 10 56 23" src="https://github.com/user-attachments/assets/85b164fc-9004-4716-9eef-3ef2c7116769" />

Ports the remaining MCP analytics surfaces to quill so the product reads as one design system:

- **Tool detail** — trend charts (calls/errors, p50/p95 latency) now use quill `TimeSeriesLineChart`, and the result tables (failures, sample intents, neighbours, by-harness, top users) use quill `Table`. The corresponding HogQL moved into kea loaders returning positional rows.
- **Sessions playlist** — search, sort, refresh/load-more, and list loading skeletons swapped to quill `InputGroup`/`Select`/`Button`/`Skeleton`.
- **Intent clustering** — the tool-routing table (`Table` + `Progress`), entropy and cluster-meta badges (`Badge`), the sort and recompute controls (`Button`), and loading skeletons all moved to quill.
- **Dashboard + tool detail** — loading placeholders use quill `Skeleton` where they sit inside `data-quill` regions.

`data-quill` wrappers are scoped narrowly to the quill controls so they don't rebind design tokens across posthog-styled panels. A few elements are intentionally left on lemon-ui: scene chrome (the tool-detail back button and section dividers), the `MCPSessionDetail` panel (custom posthog-token styling where a `data-quill` wrapper would restyle the subtree for no real gain), and the Tool quality `Query`/`DataTable` path (its quill rework lives in a separate PR).

Also enriches the local seed: `seed_mcp_sessions` now writes `MCPSession.intent` rows (keyed by `$session_id`) so the intent clustering page has data to group — previously the clustering corpus was always empty locally.

## How did you test this code?

I'm an agent (Claude Code). Verification done:

- Linted every changed frontend file with oxlint and ran the frontend formatter; ruff check/format on the changed Python.
- Loaded the dashboard and intent-clustering pages against a locally seeded project and confirmed they render with no new console errors (remaining errors are unrelated local-dev CORS/capture noise). Fixed one real warning surfaced this way: the lemon `Tooltip` wrapping a quill `Badge` needed a ref-able `span` trigger.
- Could not exercise live intent clustering end-to-end locally (embeddings need an API key that isn't configured in dev); verified the clustering UI by building a snapshot from the seeded corpus.

No automated tests were added — this is a component/styling port with no logic changes beyond moving existing HogQL into loaders.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at the direction of @sampennington, who asked to port the MCP analytics pages to quill. Key judgement calls: scope `data-quill` narrowly to avoid token rebind on posthog-styled panels; leave scene chrome and the custom session-detail panel on lemon-ui rather than force quill where it doesn't fit; keep the Tool quality `DataTable` rework out of scope (separate PR). The seed change was needed because the clustering page reads `MCPSession.intent`, which the seed never populated.
