### PR TITLE
feat(posthog-ai): sandbox streaming resilience and crash affordance

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -154,7 +154,7 @@ function toolInvocationToMessage(
 function SandboxThread(): JSX.Element {
     // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
     // message while the run is active, falling back to the canned rotation.
-    const { threadItems, toolInvocations, currentProgress, isThinking } = useValues(sandboxStreamLogic)
+    const { threadItems, toolInvocations, currentProgress, isThinking, streamPhase } = useValues(sandboxStreamLogic)
 
     return (
         <>
@@ -209,6 +209,21 @@ function SandboxThread(): JSX.Element {
                     )
                 }
                 if (item.type === 'error') {
+                    if (item.variant === 'crash') {
+                        return (
+                            <MessageTemplate key={item.id} type="ai" boxClassName="border-danger">
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-danger">
+                                        The agent encountered a fatal error and stopped. You can send a new message to
+                                        try again.
+                                    </span>
+                                    {item.errorMessage && (
+                                        <span className="text-xs text-muted">{item.errorMessage}</span>
+                                    )}
+                                </div>
+                            </MessageTemplate>
+                        )
+                    }
                     return (
                         <MessageTemplate key={item.id} type="ai" boxClassName="text-danger">
                             {item.errorMessage}
@@ -217,8 +232,26 @@ function SandboxThread(): JSX.Element {
                 }
                 return null
             })}
+            {streamPhase === 'provisioning' && <SandboxProvisioningIndicator progress={currentProgress} />}
             {isThinking && <SandboxThinkingIndicator progress={currentProgress} />}
         </>
+    )
+}
+
+/**
+ * Pre-first-message status line for sandbox conversations. While the workflow provisions the sandbox
+ * and starts the agent (before `_posthog/run_started`), the thinking indicator is gated off — so this
+ * surfaces the already-ingested `_posthog/progress` label with a setup-oriented fallback.
+ */
+function SandboxProvisioningIndicator({ progress }: { progress: string | null }): JSX.Element {
+    const message = progress?.trim() ? progress : 'Setting up your workspace…'
+    return (
+        <MessageTemplate type="ai">
+            <div className="flex items-center gap-2 text-muted">
+                <Spinner className="size-4" />
+                <span>{message}</span>
+            </div>
+        </MessageTemplate>
     )
 }
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -9,11 +9,14 @@ import { initKeaTests } from '~/test/init'
 
 import {
     mapHttpStatusToStreamError,
+    MAX_CUMULATIVE_RECONNECT_ATTEMPTS,
     MAX_SSE_RECONNECT_ATTEMPTS,
     parsePermissionRequestFrame,
     reconnectDelayMs,
     resolveToolKey,
     sandboxStreamLogic,
+    SSE_HEALTHY_CONNECTION_MS,
+    SSE_RECONNECT_BASE_DELAY_MS,
     SSE_RECONNECT_MAX_DELAY_MS,
 } from './sandboxStreamLogic'
 import type { PermissionRequestFrame, StoredLogEntry } from './types/sandboxWireTypes'
@@ -1252,6 +1255,192 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.currentRunStatus).toEqual('completed')
             const lifecycleEvents = ['task_run_started', 'task_run_terminated', 'tool_call_completed']
             expect(captureSpy.mock.calls.filter((c) => lifecycleEvents.includes(c[0] as string))).toEqual([])
+        })
+    })
+
+    describe('crash affordance', () => {
+        it('pushes a crash-variant error item and still captures task_run_terminated', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', traceId: 'trace-1' })
+
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({
+                    status: 'failed',
+                    errorMessage: 'Agent server crashed: boom',
+                })
+            }).toFinishAllListeners()
+
+            const errorItem = logic.values.threadItems.find((item) => item.type === 'error')
+            expect(errorItem?.variant).toEqual('crash')
+            expect(errorItem?.errorMessage).toEqual('Agent server crashed: boom')
+            // The existing termination telemetry is unchanged.
+            const terminated = captureSpy.mock.calls.find((c) => c[0] === 'task_run_terminated')
+            expect(terminated?.[1]).toEqual(
+                expect.objectContaining({ status: 'failed', error_message: 'Agent server crashed: boom' })
+            )
+        })
+
+        it('renders a plain failed run without the crash prefix as a raw error item', async () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({ status: 'failed', errorMessage: 'usage limit reached' })
+            }).toFinishAllListeners()
+
+            const errorItem = logic.values.threadItems.find((item) => item.type === 'error')
+            expect(errorItem?.variant).toEqual('error')
+            expect(errorItem?.errorMessage).toEqual('usage limit reached')
+        })
+
+        it('does not push an error item for a failed run carrying no error message', async () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({ status: 'failed' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.some((item) => item.type === 'error')).toEqual(false)
+        })
+
+        it('does not push an error item for a failed run replayed from history', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.handleTerminalStatus({
+                    status: 'failed',
+                    errorMessage: 'Agent server crashed: old',
+                    replayedFromHistory: true,
+                })
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.some((item) => item.type === 'error')).toEqual(false)
+        })
+    })
+
+    describe('stream-disconnect telemetry', () => {
+        it('captures sandbox_stream_disconnected with attempt counters and pushes a visible error item', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', traceId: 'trace-1' })
+            // Drive the per-drop counter to the cap so the next drop exhausts the budget.
+            logic.actions.sseReconnecting(MAX_SSE_RECONNECT_ATTEMPTS)
+
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            expect(logic.values.sseStatus).toEqual('error')
+            const disconnect = captureSpy.mock.calls.find((c) => c[0] === 'sandbox_stream_disconnected')
+            expect(disconnect?.[1]).toEqual(
+                expect.objectContaining({
+                    conversation_id: 'test-conversation',
+                    trace_id: 'trace-1',
+                    run_id: 'run-1',
+                    task_id: 'task-1',
+                    error_title: 'Cloud stream failed',
+                    retryable: true,
+                    reconnect_attempts: MAX_SSE_RECONNECT_ATTEMPTS,
+                    cumulative_reconnect_attempts: 1,
+                    was_bootstrapping: false,
+                    execution_type: 'sandbox',
+                })
+            )
+            expect(logic.values.threadItems.some((item) => item.type === 'error')).toEqual(true)
+        })
+
+        it('reports was_bootstrapping=true when the run never connected before erroring', async () => {
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined as any)
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockRejectedValue({ status: 500 })
+
+            logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            const disconnect = captureSpy.mock.calls.find((c) => c[0] === 'sandbox_stream_disconnected')
+            expect(disconnect?.[1]).toEqual(expect.objectContaining({ was_bootstrapping: true }))
+        })
+    })
+
+    describe('stream phase', () => {
+        it('is provisioning while the stream is open before run_started, then flips to thinking', async () => {
+            expect(logic.values.streamPhase).toEqual('idle')
+
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            MockEventSource.latest().emitOpen()
+
+            // SSE open, agent not started yet — provisioning, surfacing _posthog/progress.
+            logic.actions.ingestAcpFrame(notification('_posthog/progress', { label: 'Setting up sandbox' }))
+            expect(logic.values.streamPhase).toEqual('provisioning')
+            expect(logic.values.currentProgress).toEqual('Setting up sandbox')
+
+            // run_started arrives — phase flips to thinking.
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            expect(logic.values.streamPhase).toEqual('thinking')
+
+            // turn_complete ends the turn — back to idle.
+            logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
+            expect(logic.values.streamPhase).toEqual('idle')
+        })
+
+        it('tracks the optional task_run_state stage off the wire', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            await expectLogic(logic, () => {
+                source.onmessage?.({
+                    data: JSON.stringify({ type: 'task_run_state', status: 'in_progress', stage: 'build' }),
+                } as MessageEvent<string>)
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentStage).toEqual('build')
+        })
+    })
+
+    describe('reconnect refinements', () => {
+        it('forgives a healthy connection drop — no reconnectAttempt increment but still schedules a reopen', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            const source = MockEventSource.latest()
+
+            jest.useFakeTimers()
+            // sseOpened stamps cache.sseConnectedAtMs; advance past the healthy threshold before dropping.
+            source.emitOpen()
+            const beforeDrop = MockEventSource.instances.length
+            jest.advanceTimersByTime(SSE_HEALTHY_CONNECTION_MS + 1_000)
+
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            // Healthy drop: per-drop budget untouched, but cumulative still grows and a reopen is scheduled.
+            expect(logic.values.reconnectAttempt).toEqual(0)
+            expect(logic.values.cumulativeReconnectAttempt).toEqual(1)
+            expect(logic.values.sseStatus).toEqual('reconnecting')
+
+            jest.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS)
+            expect(MockEventSource.instances.length).toEqual(beforeDrop + 1)
+            jest.useRealTimers()
+        })
+
+        it('fails on the cumulative cap even when the per-drop counter keeps resetting', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            MockEventSource.latest().emitOpen()
+            // Drive the cumulative counter to the cap without growing the per-drop counter, as a
+            // clean-EOF reopen loop would (every reopen resets reconnectAttempt to 0).
+            for (let i = 0; i < MAX_CUMULATIVE_RECONNECT_ATTEMPTS; i++) {
+                logic.actions.sseReconnecting(0)
+            }
+            expect(logic.values.cumulativeReconnectAttempt).toEqual(MAX_CUMULATIVE_RECONNECT_ATTEMPTS)
+
+            logic.actions.sseDropped()
+            await flushPromises()
+
+            // The (cumulative + 1)th reconnect crosses the bound → terminal error.
+            expect(logic.values.sseStatus).toEqual('error')
         })
     })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -41,6 +41,17 @@ export interface SandboxStreamLogicProps {
 export const MAX_SSE_RECONNECT_ATTEMPTS = 5
 export const SSE_RECONNECT_BASE_DELAY_MS = 2_000
 export const SSE_RECONNECT_MAX_DELAY_MS = 30_000
+/**
+ * Cumulative cap across all drops in a run — bounds runaway clean-EOF loops that keep dodging the
+ * per-drop counter (a connection that opens, immediately drops, and reopens resets `reconnectAttempt`
+ * to 0 every cycle, so only this counter catches the loop).
+ */
+export const MAX_CUMULATIVE_RECONNECT_ATTEMPTS = 30
+/** A connection open at least this long before dropping is healthy — its drop is forgiven. */
+export const SSE_HEALTHY_CONNECTION_MS = 60_000
+
+/** The crash-error string the in-sandbox agent server writes on a fatal exception. */
+const AGENT_CRASH_PREFIX = 'Agent server crashed'
 
 const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled'])
 
@@ -464,11 +475,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         updateToolInvocation: (toolCallId: string, patch: Partial<ToolInvocation>) => ({ toolCallId, patch }),
         setCurrentMode: (mode: string) => ({ mode }),
         setCurrentProgress: (progress: string) => ({ progress }),
+        /** Optional `task_run_state.stage` — wired for a future richer status surface (G6). */
+        setCurrentStage: (stage: string | null) => ({ stage }),
         markRunStarted: true,
         markTurnComplete: true,
         /** Echoes the user's own message into the thread — the sandbox wire never replays it. */
         pushHumanMessage: (content: string) => ({ content }),
-        pushErrorItem: (errorMessage: string) => ({ errorMessage }),
+        pushErrorItem: (errorMessage: string, variant: 'error' | 'crash' = 'error') => ({ errorMessage, variant }),
         reset: true,
     }),
     reducers({
@@ -489,6 +502,17 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 sseReconnecting: (_, { attempt }) => attempt,
                 // A successful (re)connection clears the counter; bootstrapping a run starts fresh.
                 sseOpened: () => 0,
+                bootstrapRun: () => 0,
+                reset: () => 0,
+            },
+        ],
+        // Counts every drop in the run regardless of the per-drop counter (healthy-connection drops
+        // don't bump `reconnectAttempt`, and a clean-EOF reopen loop keeps resetting it). Bounds
+        // runaway loops via MAX_CUMULATIVE_RECONNECT_ATTEMPTS. Cleared only on a fresh bootstrap.
+        cumulativeReconnectAttempt: [
+            0,
+            {
+                sseReconnecting: (state) => state + 1,
                 bootstrapRun: () => 0,
                 reset: () => 0,
             },
@@ -604,9 +628,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     { id: `human-${state.length}`, type: 'human_message', text: content, complete: true },
                 ],
                 markTurnComplete: (state) => [...state, { id: `turn-${state.length}`, type: 'turn_separator' }],
-                pushErrorItem: (state, { errorMessage }) => [
+                pushErrorItem: (state, { errorMessage, variant }) => [
                     ...state,
-                    { id: `error-${state.length}`, type: 'error', errorMessage },
+                    { id: `error-${state.length}`, type: 'error', errorMessage, variant },
                 ],
                 reset: () => [],
             },
@@ -684,6 +708,16 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 reset: () => null,
             },
         ],
+        // Optional `task_run_state.stage` — generally unset for PHAI runs, but cheap to track so a
+        // future richer status surface (G6) can render "research / plan / build" without re-touching
+        // this logic. No render consumes it yet.
+        currentStage: [
+            null as string | null,
+            {
+                setCurrentStage: (_, { stage }) => stage,
+                reset: () => null,
+            },
+        ],
         runStarted: [
             false,
             {
@@ -724,6 +758,26 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return runInFlight && !turnComplete
             },
         ],
+        /**
+         * Stream lifecycle phase for the pre-first-message status line. `provisioning` = the stream
+         * is opening or open but the agent hasn't started yet (the workflow is still setting up the
+         * sandbox and emitting `_posthog/progress`), so the thinking indicator's `run_started` gate
+         * would otherwise hide that progress; `thinking` = the agent is working a turn (mirrors
+         * `isThinking`); `idle` otherwise (terminal, errored, or not yet connecting).
+         */
+        streamPhase: [
+            (s) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus],
+            (runStarted, isThinking, currentRunStatus, sseStatus): 'provisioning' | 'thinking' | 'idle' => {
+                if (isThinking) {
+                    return 'thinking'
+                }
+                const connecting = sseStatus === 'connecting' || sseStatus === 'open' || sseStatus === 'reconnecting'
+                if (connecting && !runStarted && !isTerminalRunStatus(currentRunStatus)) {
+                    return 'provisioning'
+                }
+                return 'idle'
+            },
+        ],
     }),
     listeners(({ values, actions, cache, props }) => ({
         bootstrapRun: async ({ taskId, runId, justCreatedRun }, breakpoint) => {
@@ -732,6 +786,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 actions.handleStreamError({ errorTitle: 'No current project', retryable: false })
                 return
             }
+
+            // Persistent provisioning flag for disconnect telemetry: stays true across the async
+            // gap between bootstrap and the first connection/run_started, unlike `cache.bootstrapReplay`
+            // (which is only true inside the synchronous history-replay forEach). Cleared on the first
+            // `sseOpened`/`_posthog/run_started`.
+            cache.isBootstrapping = true
 
             // Fresh-run fast path: nothing historical to assemble — go straight to SSE.
             if (justCreatedRun) {
@@ -818,6 +878,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                                 actions.routePermissionRequest(record)
                             }
                         } else if (isTaskRunStateFrame(data)) {
+                            // `stage` is dropped by handleTerminalStatus's status-only path; track it
+                            // separately for a future richer status surface. Generally unset for PHAI.
+                            if (data.stage !== undefined) {
+                                actions.setCurrentStage(data.stage ?? null)
+                            }
                             actions.handleTerminalStatus({
                                 status: data.status as SandboxRunStatus,
                                 errorMessage: data.error_message ?? null,
@@ -853,6 +918,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 { pauseOnPageHidden: false }
             )
         },
+        sseOpened: () => {
+            // Provisioning ends at the first successful connection; clear the flag the disconnect
+            // telemetry reads. Stamp the connection time for the healthy-connection rule in sseDropped.
+            cache.isBootstrapping = false
+            cache.sseConnectedAtMs = Date.now()
+        },
         sseDropped: async (_, breakpoint) => {
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
             if (!activeRun) {
@@ -879,12 +950,28 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
 
+            // Cumulative cap — bounds runaway clean-EOF reopen loops that keep resetting the per-drop
+            // counter. The about-to-be-scheduled reconnect is the (cumulative + 1)th.
+            if (values.cumulativeReconnectAttempt + 1 > MAX_CUMULATIVE_RECONNECT_ATTEMPTS) {
+                actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
+                return
+            }
+
+            // Healthy-connection rule — a connection that stayed open ≥60s before dropping is not a
+            // flaky transport, so its drop is forgiven: schedule a reconnect but don't grow the
+            // per-drop budget. The cumulative counter still increments (via sseReconnecting) to
+            // bound pathological reopen loops.
+            const connectedAtMs = cache.sseConnectedAtMs as number | undefined
+            const wasHealthy = connectedAtMs !== undefined && Date.now() - connectedAtMs >= SSE_HEALTHY_CONNECTION_MS
+
             // Non-terminal → capped exponential backoff; attempts exhausted surface a retryable error.
-            const attempt = values.reconnectAttempt + 1
+            const attempt = wasHealthy ? values.reconnectAttempt : values.reconnectAttempt + 1
             if (attempt > MAX_SSE_RECONNECT_ATTEMPTS) {
                 actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
                 return
             }
+            // Backoff off the per-drop budget; a forgiven healthy drop (attempt 0) reconnects fast.
+            const delayMs = reconnectDelayMs(Math.max(attempt, 1))
             actions.sseReconnecting(attempt)
             // pauseOnPageHidden: false — the SSE connection survives tab hides, so a drop in a
             // hidden tab must also reconnect there; a paused timer would stall until refocus.
@@ -895,7 +982,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         // disconnected are re-delivered and the content-dedup drops the
                         // already-ingested ones, so the gap is filled losslessly.
                         actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: false })
-                    }, reconnectDelayMs(attempt))
+                    }, delayMs)
                     return () => clearTimeout(timer)
                 },
                 'reconnect-backoff',
@@ -999,6 +1086,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
 
+            // Crash/failure affordance: a failed run carrying an error_message otherwise just blanks
+            // the thinking indicator. Push a visible error item so the user sees why it stopped. The
+            // in-sandbox agent server writes "Agent server crashed: …" on a fatal exception — render
+            // that as a friendlier, retry-oriented `crash` variant; other failures show the raw line.
+            if (status === 'failed' && errorMessage) {
+                actions.pushErrorItem(errorMessage, errorMessage.startsWith(AGENT_CRASH_PREFIX) ? 'crash' : 'error')
+            }
+
             // TASK_RUN_TERMINATED telemetry. `duration_ms` is measured from the current turn's start
             // (run start for the first turn, the latest human message for a follow-up); absent if the
             // run terminated before either was seen.
@@ -1015,6 +1110,27 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 duration_ms: startedAt !== undefined ? Date.now() - startedAt : undefined,
             })
         },
+        handleStreamError: ({ errorTitle, errorMessage, retryable }) => {
+            // The composer-unlock is already wired off this action in maxThreadLogic; today it
+            // unlocks silently. Push a visible, retryable error line so the user knows the stream
+            // dropped — and capture the disconnect telemetry that mirrors the cloud client's
+            // CLOUD_STREAM_DISCONNECTED (the relay can't see a client-side reconnect-budget exhaustion).
+            actions.pushErrorItem(errorMessage ? `${errorTitle}: ${errorMessage}` : errorTitle)
+            const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            posthog.capture('sandbox_stream_disconnected', {
+                conversation_id: props.conversationId,
+                trace_id: values.traceId,
+                run_id: activeRun?.runId,
+                task_id: activeRun?.taskId,
+                error_title: errorTitle,
+                retryable,
+                reconnect_attempts: values.reconnectAttempt,
+                stream_error_attempts: 0,
+                cumulative_reconnect_attempts: values.cumulativeReconnectAttempt,
+                was_bootstrapping: cache.isBootstrapping === true,
+                execution_type: 'sandbox',
+            })
+        },
         closeSse: () => {
             cache.activeRun = undefined
             cache.disposables.dispose('reconnect-backoff')
@@ -1024,6 +1140,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.activeRun = undefined
             cache.turnStartedAtMs = undefined
             cache.ingestedEntryHashes = new Set<string>()
+            cache.isBootstrapping = false
+            cache.sseConnectedAtMs = undefined
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
         },
@@ -1076,6 +1194,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         cold_start: true,
                     })
                 }
+                // Provisioning is over once the agent has started — clear the disconnect-telemetry flag.
+                cache.isBootstrapping = false
                 actions.markRunStarted()
                 return
             }

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -74,6 +74,11 @@ export interface ThreadItem {
     toolCallId?: string
     /** For `error` items. */
     errorMessage?: string
+    /**
+     * For `error` items — distinguishes a friendlier agent-crash affordance (`crash`) from a
+     * raw error line (`error`, the default). Drives the copy/styling branch in the renderer.
+     */
+    variant?: 'error' | 'crash'
 }
 
 /**


### PR DESCRIPTION
## Problem

Three resilience/transparency gaps in the sandbox SSE stream: (1) an agent crash is invisible (the indicator just vanishes); (2) there's no disconnect telemetry; and (3) during the multi-second provisioning window the user sees nothing, because the progress notifications the workflow already emits are gated behind `isThinking` (which requires `run_started`). Implements the G7 plan.

## Changes

- **Crash affordance + telemetry:** terminal `failed` runs now push a visible thread error item (a friendlier "crash" variant when the message starts with "Agent server crashed"); a new `handleStreamError` listener pushes a retryable error item and captures `sandbox_stream_disconnected` with the reconnect counters + `was_bootstrapping` (via a new persistent `cache.isBootstrapping`, since the existing replay flag is always false by the time an async drop fires).
- **Provisioning transparency:** a `streamPhase` selector renders `currentProgress` before `run_started` with a fallback label — no new server data, just a render-gate fix.
- **Reconnect refinements (conservative cut):** cumulative cap (30) + healthy-connection grace (a connection open ≥60s isn't counted against the budget). Named `event: error` frames stay terminal (they carry their own `retryable` flag).

## How did you test this code?

Authored by an agent (Claude Code). Automated tests run on this branch:

- Jest `sandboxStreamLogic.test.ts` — 71 passed: crash variant + raw + no-message + replayed-from-history; disconnect telemetry with exact counter values + `was_bootstrapping` true/false; provisioning phase before/after `run_started`; healthy-connection grace (reconnect counter stays 0, cumulative grows, reopen still scheduled); cumulative cap fires on the (cap+1)th drop.
- `format` clean; `typescript:check` — the only error is a pre-existing stale typegen artifact (`AppShortcuts`), confirmed on the base branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review → fix). Conservative reconnect cut chosen (cumulative cap + healthy-connection only; no separate stream-error budget) — pure safety, no behavior regression. Provisioning line is standalone for now; shares a status surface with G6 (whichever lands first owns a shared component). Crash copy and the `sandbox_stream_disconnected` property shape may want product/dashboard review. Reviewer verdict: pass.
