### PR TITLE
feat(posthog-ai): responsive Max layout for mobile

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -133,12 +133,19 @@ export function SidePanel({ className }: { className?: string }): JSX.Element | 
         }
     }, [sidePanelOpen, selectedTab, sidePanelOpenAndAvailable, enabledTabs, openSidePanel])
 
-    const { windowSize } = useWindowSize()
+    const { windowSize, isWindowLessThan } = useWindowSize()
+
+    // On small screens the panel becomes a full-width overlay instead of a column squeezing the app.
+    // `lg` (992) matches the existing `lg:hidden` click-outside overlay below and agrees across the CSS
+    // and JS breakpoint systems.
+    const isMobile = isWindowLessThan('lg')
 
     const rawSidePanelWidth = !visibleTabs.length
         ? 0
         : sidePanelOpenAndAvailable
-          ? Math.max(desiredSize ?? DEFAULT_WIDTH, SIDE_PANEL_MIN_WIDTH_COMPACT)
+          ? isMobile
+              ? (windowSize.width ?? DEFAULT_WIDTH)
+              : Math.max(desiredSize ?? DEFAULT_WIDTH, SIDE_PANEL_MIN_WIDTH_COMPACT)
           : 0
 
     const sidePanelWidth = windowSize.width != null ? Math.min(rawSidePanelWidth, windowSize.width) : rawSidePanelWidth
@@ -175,13 +182,16 @@ export function SidePanel({ className }: { className?: string }): JSX.Element | 
         >
             {sidePanelOpenAndAvailable && (
                 <>
-                    <Resizer
-                        {...resizerLogicProps}
-                        className={cn('top-[calc(var(--scene-layout-header-height)+8px)] left-[-1px] bottom-4', {
-                            'left-0': sidePanelOpenAndAvailable,
-                            'top-0 h-full': sidePanelOpenAndAvailable,
-                        })}
-                    />
+                    {/* A full-screen overlay has nothing to resize against, so hide the resizer on mobile */}
+                    {!isMobile && (
+                        <Resizer
+                            {...resizerLogicProps}
+                            className={cn('top-[calc(var(--scene-layout-header-height)+8px)] left-[-1px] bottom-4', {
+                                'left-0': sidePanelOpenAndAvailable,
+                                'top-0 h-full': sidePanelOpenAndAvailable,
+                            })}
+                        />
+                    )}
                     {/* Overlay for mobile to click outside to close the side panel */}
                     <div onClick={() => closeSidePanel()} className="lg:hidden fixed inset-0 -z-1" />
                 </>

--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -3573,3 +3573,38 @@ export const ThreadWithSliderForm: Story = {
         },
     },
 }
+
+export const ThreadNarrowViewport: Story = {
+    render: () => {
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const { askMax } = useActions(
+            maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, panelId: 'storybook' })
+        )
+        const { dataProcessingAccepted } = useValues(maxGlobalLogic)
+
+        useEffect(() => {
+            if (dataProcessingAccepted) {
+                setTimeout(() => {
+                    setConversationId(CONVERSATION_ID)
+                    askMax(humanMessage.content)
+                }, 0)
+            }
+        }, [dataProcessingAccepted, setConversationId, askMax])
+
+        if (!dataProcessingAccepted) {
+            return <></>
+        }
+
+        // Constrain the rendered width to phone size so the responsive chat column and composer
+        // are snapshotted at a narrow viewport.
+        return <Template className="max-w-[375px]" />
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: 'mobile2',
+        },
+        testOptions: {
+            waitForLoadersToDisappear: false,
+        },
+    },
+}

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -52,7 +52,7 @@ export function Max({ tabId }: { tabId?: string }): JSX.Element {
     const { conversationId: sidepanelConversationId } = useValues(maxLogic({ panelId: SIDE_PANEL_PANEL_ID }))
     if (sidePanelOpen && selectedTab === SidePanelTab.Max && sidepanelConversationId === tabConversationId) {
         return (
-            <SceneContent className="px-4 py-4 min-h-[calc(100vh-var(--scene-layout-header-height)-120px)]">
+            <SceneContent className="px-2 md:px-4 py-4 min-h-[calc(100vh-var(--scene-layout-header-height)-120px)]">
                 <SceneTitleSection name={null} resourceType={{ type: 'chat' }} />
                 <div className="flex flex-col items-center justify-center w-full grow">
                     <IconSidePanel className="text-3xl text-muted mb-2" />
@@ -119,7 +119,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
                     // This makes the transition from one view into another just that bit smoother visually.
                     <div
                         className={cn(
-                            '@container/max-welcome relative flex flex-col gap-4 px-4 pb-7 grow',
+                            '@container/max-welcome relative flex flex-col gap-4 px-2 md:px-4 pb-7 grow',
                             !sidePanel && 'min-h-[calc(100vh-var(--scene-layout-header-height)-120px)]',
                             sidePanel && 'px-0'
                         )}
@@ -226,7 +226,7 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
             </SidePanelContentContainer>
         </>
     ) : (
-        <SceneContent className="pt-4 px-4 min-h-[calc(100vh-var(--scene-layout-header-height))]">
+        <SceneContent className="pt-4 px-2 md:px-4 min-h-[calc(100vh-var(--scene-layout-header-height))]">
             <SceneTitleSection
                 name={null}
                 resourceType={{ type: 'chat' }}

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -76,7 +76,7 @@ import { DangerousOperationApprovalCard } from './DangerousOperationApprovalCard
 import { FeedbackPrompt } from './FeedbackPrompt'
 import { maxMessageRatingsLogic } from './logics/maxMessageRatingsLogic'
 import { MarkdownMessage } from './MarkdownMessage'
-import { EnhancedToolCall, ToolRegistration, getToolDefinitionFromToolCall } from './max-constants'
+import { EnhancedToolCall, MAX_CHAT_COLUMN, ToolRegistration, getToolDefinitionFromToolCall } from './max-constants'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { ThreadMessage, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
@@ -254,10 +254,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
         }
         return (
             <div
-                className={cn(
-                    '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
-                    className
-                )}
+                className={cn('@container/thread flex flex-col items-stretch gap-1.5 grow', MAX_CHAT_COLUMN, className)}
             >
                 {/* Same key maxThreadLogic's connect() uses, so both resolve the same instance */}
                 <BindLogic logic={sandboxStreamLogic} props={{ conversationId: sandboxConversationKey }}>
@@ -268,12 +265,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
     }
 
     return (
-        <div
-            className={cn(
-                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
-                className
-            )}
-        >
+        <div className={cn('@container/thread flex flex-col items-stretch gap-1.5 grow', MAX_CHAT_COLUMN, className)}>
             {(conversationLoading || messagesLoading) && threadGrouped.length === 0 ? (
                 <>
                     <MessageGroupSkeleton groupType="human" />

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -45,7 +45,7 @@ export function ChatHeader({
             <div className="flex items-center gap-2 pl-2 text-sm font-medium truncate min-w-0 flex-1">
                 {children}
                 {chatTitle === null ? null : isTitleLoading ? (
-                    <div className="w-100">
+                    <div className="w-full max-w-100">
                         <SceneName name="New chat" isLoading />
                     </div>
                 ) : (
@@ -168,7 +168,7 @@ function ChatArea({ threadVisible, conversation, onStartNewConversation }: ChatA
 
             {/* Input - always in flow, mt-auto pushes to bottom when messages exist */}
             <div
-                className={`w-full max-w-3xl mx-auto px-4 transition-all duration-300 ease-out z-50 ${
+                className={`w-full max-w-3xl mx-auto px-2 md:px-4 transition-all duration-300 ease-out z-50 ${
                     hasMessages ? 'sticky bottom-0 bg-primary py-2 max-w-none' : 'pb-4'
                 }`}
             >

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -19,6 +19,7 @@ import { ConversationQueueMessage } from '~/types'
 
 import { ContextDisplay } from '../Context'
 import { handsFreeLogic } from '../handsFreeLogic'
+import { MAX_CHAT_COLUMN } from '../max-constants'
 import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
@@ -229,7 +230,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         <div
             className={cn(
                 'w-full px-3',
-                (isSticky || isThreadVisible) && 'sticky bottom-0 z-10 max-w-180 self-center',
+                (isSticky || isThreadVisible) && cn('sticky bottom-0 z-10', MAX_CHAT_COLUMN),
                 // containerClassName last so callers can override (e.g. sidePanel's px-0).
                 containerClassName
             )}

--- a/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SidebarQuestionInput.tsx
@@ -10,6 +10,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { useAnimatedPresence } from 'lib/hooks/useAnimatedPresence'
 import { cn } from 'lib/utils/css-classes'
 
+import { MAX_CHAT_COLUMN } from '../max-constants'
 import { SuggestionGroup, maxLogic } from '../maxLogic'
 import { maxThreadLogic } from '../maxThreadLogic'
 import { InputFormArea, SandboxModeBadge } from './InputFormArea'
@@ -67,7 +68,7 @@ export function SidebarQuestionInput({
     // Show form area directly when there's a pending form/approval (even if showInput is false)
     if (activeMultiQuestionForm || hasApprovalToShow || hasSandboxPermissionToShow) {
         return (
-            <div className="w-full max-w-180 self-center px-3 mx-auto bg-[var(--scene-layout-background)]/50 backdrop-blur-sm">
+            <div className={cn(MAX_CHAT_COLUMN, 'px-3 bg-[var(--scene-layout-background)]/50 backdrop-blur-sm')}>
                 <div className="border border-primary rounded-lg bg-surface-primary">
                     <InputFormArea />
                 </div>

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -45,6 +45,13 @@ export interface DisplayFormatterContext {
     registeredToolMap: Record<string, ToolRegistration>
 }
 
+/**
+ * Shared class fragment for the centered chat column. Keeps the thread body and composer in lockstep
+ * so they read as a single chat surface. `max-w-180` is a max, not a fixed width, so the column
+ * collapses to the full available width on narrow viewports.
+ */
+export const MAX_CHAT_COLUMN = 'w-full max-w-180 self-center mx-auto'
+
 /** Static tool definition for display purposes. */
 export interface ToolDefinition<N extends string = string> {
     /** A user-friendly display name for the tool. Must be a verb phrase, like "Create surveys" or "Search docs" */


### PR DESCRIPTION
## Problem

The Max (PostHog AI) chat UI is desktop-only: a fixed-width centered column with zero viewport breakpoints, and in the right-hand side panel it either eats the viewport or squeezes the app to a sliver on a phone. Implements the G9 plan (lowest-priority polish; CSS/layout only).

## Changes

- **Side panel → full-width overlay on small screens** (the biggest lever): extends the existing `useWindowSize` to branch at `< lg` (matching the existing `lg:hidden` click-outside overlay), setting the panel to full viewport width and hiding the resizer.
- **Fluid chat column:** unified the four `max-w-180` sites behind one shared `MAX_CHAT_COLUMN` fragment and added responsive wrapper padding (`px-2 md:px-4`).
- Standardized on `md`/`lg` breakpoints only (avoids the `sm` 526-vs-576 mismatch between the JS constant and the CSS config); left the `min-w-0`/`truncate`/flex overflow guards untouched.
- Added a narrow-viewport Storybook story for visual-regression coverage.

## How did you test this code?

Authored by an agent (Claude Code). Automated checks run on this branch:

- `format` clean; `typescript:check` — 0 errors in any of the 8 changed files (the 2 remaining errors are a pre-existing stale typegen artifact, confirmed on the base branch).
- No dedicated unit tests (the scene's tests are behavioral, not layout). **Snapshot/visual-regression review is manual** — this CSS churn will produce many Storybook diffs that a reviewer must intentionally review; I did **not** regenerate snapshots.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review). Scoped to "don't break on small screens" rather than a mobile-first rebuild. Deferred per plan: reconciling the full-page `max-w-3xl` vs side-panel `max-w-180` width (design-dependent) and the floating Max input. This is intentionally the **last** of the migration plan series to land — it touches the broadest component set and carries the most snapshot churn, so it should merge after the sibling restyles (G2/G5/G6/G7) to avoid re-baselining. Reviewer verdict: pass.
