### PR TITLE
feat(mcp-analytics): add SQL reference for mcp_tool_call data

### DIFF
--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -50,6 +50,7 @@ Schema reference for PostHog's core system models, organized by domain:
 - [AI observability events (`posthog.ai_events`)](./references/models-ai-observability-events.md)
 - [AI observability reviews](./references/models-ai-observability-reviews.md)
 - [Logs (`logs` data plane + saved views and alerts)](./references/models-logs.md)
+- [MCP analytics (`mcp_tool_call` events)](./references/models-mcp.md)
 - [Metrics (`posthog.metrics`)](./references/models-metrics.md)
 - [Notebooks](./references/models-notebooks.md)
 - [Session Recording Playlists](./references/models-session-recording-playlists.md)

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
@@ -1,0 +1,145 @@
+# MCP analytics (`mcp_tool_call` events)
+
+PostHog's own MCP server emits a `mcp_tool_call` event on the shared `events` table every time an agent invokes a tool. There is **no dedicated ClickHouse table** — all fields live as `$mcp_*` properties on `events`, queried directly with `posthog:execute-sql`. This is the data behind the MCP analytics dashboard, tool-quality, and tool-detail screens; every metric on those screens is reproducible as HogQL over this event.
+
+**HogQL is the primary path here.** Session listing, per-session tool calls, tool-level metrics (error rate, latency, adoption), harness breakdowns, time series, and co-occurrence are all just aggregations over this event — query them with `execute-sql`. The only typed tools are for things SQL can't express: `posthog:mcp-analytics-intent-clusters-retrieve` / `...-recompute` (embedding-based intent clustering) and `posthog:mcp-analytics-sessions-generate-intent` (LLM session summary).
+
+## Key properties
+
+| Property                   | Meaning                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `$mcp_tool_name`           | Registered tool name.                                                                                                                    |
+| `$mcp_exec_tool_call_name` | Inner tool name when the call went through the new-SDK single-exec wrapper. See effective-tool-name note below.                          |
+| `$mcp_is_error`            | Whether the call failed. Always read via `toBool(properties.$mcp_is_error)`.                                                             |
+| `$mcp_error_message`       | Error text when `$mcp_is_error` is true.                                                                                                 |
+| `$mcp_duration_ms`         | Wall-clock duration; cast with `toFloat(...)`.                                                                                           |
+| `$mcp_session_id`          | Session/conversation id — the grouping key for a single agent run.                                                                       |
+| `$mcp_intent`              | The agent's stated intent for the call, when supplied.                                                                                   |
+| `$mcp_client_name`         | Raw client string (e.g. `claude-code/1.2.3`). The dashboard buckets these into harnesses in the frontend; there is no `category` column. |
+| `$mcp_tool_category`       | Tool category, when tagged.                                                                                                              |
+| `$mcp_tool_description`    | Tool description as seen by the agent (revisions over time).                                                                             |
+
+**Effective tool name.** New-SDK events wrap the real tool in a single-exec call, so to filter/group by the tool the agent actually invoked, use:
+
+```sql
+coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))
+```
+
+**Failures with detail.** `mcp_tool_call` carries `$mcp_is_error` + `$mcp_error_message`; richer stack/exception data is on `$exception` events (`$exception_message`), correlated by `$mcp_session_id` / `$session_id` and timestamp.
+
+## Example queries
+
+**Error rate of one tool:**
+
+```sql
+SELECT
+    count() AS total_calls,
+    countIf(toBool(properties.$mcp_is_error)) AS errors,
+    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct
+FROM events
+WHERE event = 'mcp_tool_call'
+    -- effective tool name: new-SDK events put the real tool in $mcp_exec_tool_call_name
+    AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) = '<tool-name>'
+    AND timestamp >= now() - INTERVAL 7 DAY
+```
+
+**Tool-quality matrix** (error rate + latency percentiles + reach, one row per tool):
+
+```sql
+SELECT
+    -- effective tool name: new-SDK events put the real tool in $mcp_exec_tool_call_name,
+    -- so grouping on raw $mcp_tool_name would collapse them under the single-exec wrapper
+    coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) AS tool,
+    count() AS total_calls,
+    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct,
+    round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50_ms,
+    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_ms,
+    uniq(distinct_id) AS users,
+    countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions
+FROM events
+WHERE event = 'mcp_tool_call'
+    AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) != ''
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY tool
+ORDER BY total_calls DESC
+```
+
+**Daily activity** (success/error split for a time series):
+
+```sql
+SELECT toDate(timestamp) AS day,
+    countIf(NOT toBool(properties.$mcp_is_error)) AS successes,
+    countIf(toBool(properties.$mcp_is_error)) AS errors
+FROM events
+WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day
+```
+
+### Harness (client) bucketing
+
+`$mcp_client_name` is the raw client string the MCP client sends (`claude-code/1.2.3`, `Anthropic/ClaudeAI`, `windsurf`, sometimes with a `(via mcp-remote …)` suffix). A bare `GROUP BY properties.$mcp_client_name` therefore fragments a single harness across version/variant strings. To group by harness, normalize the raw client name in an inner subquery, then bucket it with `multiIf`. This mapping mirrors `HARNESS_CATEGORIES` / `categorizeHarness()` in `products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts` — keep the two in sync until a materialized `$mcp_harness` property exists. (HogQL has no `WITH <expr> AS alias`, so the normalized name `h` is computed in a subquery, not a CTE.)
+
+**Share of users by harness** (answers "what % of my users are on Claude Code"):
+
+```sql
+SELECT
+    harness,
+    uniq(distinct_id) AS users,
+    round(uniq(distinct_id) * 100.0 / (
+        SELECT uniq(distinct_id) FROM events
+        WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+    ), 1) AS pct_of_users
+FROM (
+    SELECT
+        distinct_id,
+        multiIf(
+            startsWith(h, 'claude-code'), 'Claude Code',
+            h IN ('claude-ai', 'anthropic/claudeai'), 'Claude.ai',
+            h = 'anthropic/api', 'Anthropic API',
+            startsWith(h, 'codex') OR startsWith(h, 'openai-mcp'), 'OpenAI Codex',
+            startsWith(h, 'cursor'), 'Cursor',
+            startsWith(h, 'visual studio code'), 'VS Code',
+            h = 'windsurf', 'Windsurf',
+            startsWith(h, 'replit'), 'Replit',
+            startsWith(h, 'lovable'), 'Lovable',
+            h = 'manus', 'Manus',
+            h = 'coderabbit', 'CodeRabbit',
+            startsWith(h, 'notion'), 'Notion',
+            h = 'poke', 'Poke',
+            h = 'opencode', 'opencode',
+            startsWith(h, 'kiro'), 'Kiro',
+            startsWith(h, 'desktop-commander'), 'Desktop Commander',
+            'Other'
+        ) AS harness
+    FROM (
+        SELECT
+            distinct_id,
+            lower(trim(replaceRegexpOne(toString(properties.$mcp_client_name), '\\s*\\(via mcp-remote[^)]*\\)\\s*', ''))) AS h
+        FROM events
+        WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+    )
+)
+GROUP BY harness
+ORDER BY users DESC
+```
+
+The `multiIf` above is the canonical bucket list. The denominator is total distinct users, so per-harness shares can sum past 100% (one user may use several harnesses). Swap the outer aggregate for other harness cuts — `count()` for call volume, `quantile(0.95)(toFloat(properties.$mcp_duration_ms))` for latency. For `query-trends`, pass the inner `multiIf(...)` over the normalized client name as a **HogQL breakdown** to get the same buckets in a trends series.
+
+**Tool co-occurrence** (which tool tends to run right before a given tool, within a session):
+
+```sql
+SELECT prev_tool AS tool, count() AS co_occurrences
+FROM (
+    SELECT properties.$mcp_session_id AS conv_id,
+        coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) AS tool,
+        lagInFrame(coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)))
+            OVER (PARTITION BY properties.$mcp_session_id ORDER BY timestamp
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_tool
+    FROM events
+    WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 7 DAY
+)
+WHERE tool = '<tool-name>' AND prev_tool != '' AND prev_tool != tool
+GROUP BY prev_tool ORDER BY co_occurrences DESC LIMIT 5
+```
+
+Swap `lagInFrame` for `leadInFrame` to get the tool that runs _after_.


### PR DESCRIPTION
## Problem

MCP analytics' Dashboard, Tool quality, and Tool detail screens compute their metrics (error rate, latency percentiles, harness breakdown, daily activity, tool co-occurrence) from HogQL queries that run entirely in the frontend — there's no backend API or typed MCP tool behind them. As a result, an MCP agent had no documented way to reach that data, even though it all lives on the shared `events` table as `mcp_tool_call` events.

## Changes

Adds a `querying-posthog-data` skill reference, `models-mcp.md`, and registers it under Data Schema. It documents:

- the `$mcp_*` properties on the `mcp_tool_call` event,
- the effective-tool-name expression for new-SDK (single-exec-wrapped) calls, applied consistently across every tool-level query,
- harness bucketing — normalizing the raw `$mcp_client_name` into named harnesses (Claude Code, Cursor, …) via a `multiIf` that mirrors the frontend mapping,
- worked HogQL examples for each dashboard/tool-quality metric — error rate of a tool, the tool-quality matrix, daily activity, share of users by harness, and tool co-occurrence via window functions.

This lets an agent reproduce the full metric surface via the existing `execute-sql` tool, with no ClickHouse migration. The data lives on `events`, not a dedicated table, so no schema change is involved. This is a docs-only change — no production code paths are touched.

A typed-tool / system-table layer on top (the pattern AI observability uses) is a possible follow-up; this is the lightweight first step.

## How did you test this code?

I'm an agent. Checks I actually ran:

- **End-to-end via `execute-sql`** against a dev project with real `mcp_tool_call` data: the documented queries return correct results. The tool-quality matrix returns per-tool error rate / p95 / reach matching a direct ClickHouse run of the same logic (top tool by error rate: `experiment_get`, 32.8%), and the harness query runs as written.
- The effective-tool-name expression is applied consistently across every tool-level query (error rate, tool-quality matrix, co-occurrence), so new-SDK single-exec calls aren't missed or collapsed under the wrapper.
- Docs-only change — no production code paths touched, so no unit tests apply.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). The user is building out MCP access to the MCP-analytics product. We considered two ways to expose the dashboard/tool-quality metric surface to agents: (1) a typed `mcp_tool_calls` HogQL system table, which the `ai_events` precedent showed requires a real ClickHouse view created by a migration; and (2) this lighter "doc route" — teach agents to query the existing `mcp_tool_call` events via `execute-sql` using a reference doc, which every product's `models-*.md` already establishes as the standard SQL-access pattern. We shipped the doc route first as a standalone change; the typed-tool layer is tracked separately. Review feedback (effective-tool-name in the error-rate and tool-quality queries) has been addressed.
