### PR TITLE
feat(insights): show group info card on group key and id filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.test.tsx
@@ -21,7 +21,7 @@ describe('PropertyFilterButton', () => {
 
     it.each([
         {
-            description: 'a $group_key group filter (event/insight form)',
+            description: 'a $group_key group filter (the group identity)',
             item: {
                 key: '$group_key',
                 type: PropertyFilterType.Group,
@@ -29,10 +29,9 @@ describe('PropertyFilterButton', () => {
                 value: ['01953d33-82a2-0000-f577-8dcc2987f5ce'],
                 operator: PropertyOperator.Exact,
             },
-            expectRichTooltip: true,
         },
         {
-            description: 'an id group filter (groups-list form)',
+            description: 'an id group filter (a group property that often holds the key)',
             item: {
                 key: 'id',
                 type: PropertyFilterType.Group,
@@ -51,7 +50,7 @@ describe('PropertyFilterButton', () => {
         expect(document.querySelector('.PropertyFilterButton-content')).toBeInTheDocument()
         // Native title is suppressed; the formatted-card Tooltip is used instead.
         // (The inverse — group *property* keys not triggering the card — is
-        // covered by the isGroupIdentityFilterKey() unit tests.)
+        // covered by the isGroupCardFilterKey() unit tests.)
         expect(contentTitle()).toBeNull()
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.test.tsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { PropertyFilterButton } from './PropertyFilterButton'
+
+describe('PropertyFilterButton', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    // The content span carries a native `title` only when the rich group card
+    // tooltip is NOT used; a group-identity filter suppresses it and wraps the
+    // chip in the formatted-card Tooltip instead.
+    const contentTitle = (): string | null =>
+        document.querySelector('.PropertyFilterButton-content')?.getAttribute('title') ?? null
+
+    it.each([
+        {
+            description: 'a $group_key group filter (event/insight form)',
+            item: {
+                key: '$group_key',
+                type: PropertyFilterType.Group,
+                group_type_index: 0,
+                value: ['01953d33-82a2-0000-f577-8dcc2987f5ce'],
+                operator: PropertyOperator.Exact,
+            },
+            expectRichTooltip: true,
+        },
+        {
+            description: 'an id group filter (groups-list form)',
+            item: {
+                key: 'id',
+                type: PropertyFilterType.Group,
+                group_type_index: 0,
+                value: ['01953d33-82a2-0000-f577-8dcc2987f5ce'],
+                operator: PropertyOperator.Exact,
+            },
+        },
+    ])('suppresses the native title (uses the group card tooltip) for $description', ({ item }) => {
+        render(
+            <Provider>
+                <PropertyFilterButton item={item as AnyPropertyFilter} onClick={jest.fn()} />
+            </Provider>
+        )
+
+        expect(document.querySelector('.PropertyFilterButton-content')).toBeInTheDocument()
+        // Native title is suppressed; the formatted-card Tooltip is used instead.
+        // (The inverse — group *property* keys not triggering the card — is
+        // covered by the isGroupIdentityFilterKey() unit tests.)
+        expect(contentTitle()).toBeNull()
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -12,9 +12,9 @@ import { midEllipsis } from 'lib/utils'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { AnyPropertyFilter, GroupPropertyFilter, GroupTypeIndex, PropertyFilterType } from '~/types'
+import { AnyPropertyFilter, GroupPropertyFilter, GroupTypeIndex } from '~/types'
 
-import { formatPropertyLabel, propertyFilterTypeToPropertyDefinitionType } from '../utils'
+import { formatPropertyLabel, isGroupIdentityFilterKey, propertyFilterTypeToPropertyDefinitionType } from '../utils'
 import { GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
 
 export interface PropertyFilterButtonProps {
@@ -61,14 +61,13 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             : item.value !== null && item.value !== undefined
               ? [String(item.value)]
               : []
-        // When a single-group `$group_key` filter resolves to a real group we
-        // replace the bare "$group_key = <uuid>" tooltip with a formatted card so
-        // the user can confirm they picked the right group (e.g. after pasting a
-        // UUID). Restricted to a single value so hovering only ever looks up the
-        // one group under the mouse — never a fan-out across an "is one of" list.
+        // When a single-group identity filter resolves to a real group we replace
+        // the bare "<key> = <uuid>" tooltip with a formatted card so the user can
+        // confirm they picked the right group (e.g. after pasting a UUID).
+        // Restricted to a single value so hovering only ever looks up the one
+        // group under the mouse — never a fan-out across an "is one of" list.
         const isGroupKeyFilter =
-            item.type === PropertyFilterType.Group &&
-            item.key === '$group_key' &&
+            isGroupIdentityFilterKey(item.key, item.type) &&
             groupTypeIndex !== null &&
             groupTypeIndex !== undefined &&
             groupKeys.length === 1

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -66,7 +66,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
         // confirm they picked the right group (e.g. after pasting a UUID).
         // Restricted to a single value so hovering only ever looks up the one
         // group under the mouse — never a fan-out across an "is one of" list.
-        const isGroupKeyFilter =
+        const isGroupIdentityFilter =
             isGroupIdentityFilterKey(item.key, item.type) &&
             groupTypeIndex !== null &&
             groupTypeIndex !== undefined &&
@@ -90,7 +90,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
                 type={ButtonComponent === 'button' ? 'button' : undefined}
             >
                 <PropertyFilterIcon type={item.type} />
-                <span className="PropertyFilterButton-content" title={isGroupKeyFilter ? undefined : label}>
+                <span className="PropertyFilterButton-content" title={isGroupIdentityFilter ? undefined : label}>
                     {midEllipsis(label, 32)}
                 </span>
                 {closable && !disabledReason && (
@@ -114,7 +114,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             return <Tooltip title={disabledReason}>{button}</Tooltip>
         }
 
-        if (isGroupKeyFilter) {
+        if (isGroupIdentityFilter) {
             return (
                 <Tooltip
                     interactive

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -14,7 +14,7 @@ import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { AnyPropertyFilter, GroupPropertyFilter, GroupTypeIndex } from '~/types'
 
-import { formatPropertyLabel, isGroupIdentityFilterKey, propertyFilterTypeToPropertyDefinitionType } from '../utils'
+import { formatPropertyLabel, isGroupCardFilterKey, propertyFilterTypeToPropertyDefinitionType } from '../utils'
 import { GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
 
 export interface PropertyFilterButtonProps {
@@ -61,13 +61,14 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             : item.value !== null && item.value !== undefined
               ? [String(item.value)]
               : []
-        // When a single-group identity filter resolves to a real group we replace
+        // When a single-group filter's value resolves to a real group we replace
         // the bare "<key> = <uuid>" tooltip with a formatted card so the user can
-        // confirm they picked the right group (e.g. after pasting a UUID).
-        // Restricted to a single value so hovering only ever looks up the one
-        // group under the mouse — never a fan-out across an "is one of" list.
-        const isGroupIdentityFilter =
-            isGroupIdentityFilterKey(item.key, item.type) &&
+        // confirm they picked the right group (e.g. after pasting a UUID). This is
+        // display only and falls back to the label when the value isn't a real
+        // group key. Restricted to a single value so hovering only ever looks up
+        // the one group under the mouse — never a fan-out across an "is one of" list.
+        const showGroupCard =
+            isGroupCardFilterKey(item.key, item.type) &&
             groupTypeIndex !== null &&
             groupTypeIndex !== undefined &&
             groupKeys.length === 1
@@ -90,7 +91,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
                 type={ButtonComponent === 'button' ? 'button' : undefined}
             >
                 <PropertyFilterIcon type={item.type} />
-                <span className="PropertyFilterButton-content" title={isGroupIdentityFilter ? undefined : label}>
+                <span className="PropertyFilterButton-content" title={showGroupCard ? undefined : label}>
                     {midEllipsis(label, 32)}
                 </span>
                 {closable && !disabledReason && (
@@ -114,7 +115,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             return <Tooltip title={disabledReason}>{button}</Tooltip>
         }
 
-        if (isGroupIdentityFilter) {
+        if (showGroupCard) {
             return (
                 <Tooltip
                     interactive

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'kea'
 import { useMocks } from '~/mocks/jest'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { initKeaTests } from '~/test/init'
-import { PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
+import { GroupTypeIndex, PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
 
 import { PropertyValue } from './PropertyValue'
 
@@ -220,5 +220,28 @@ describe('PropertyValue', () => {
         await userEvent.type(input, '7a.8$')
 
         expect(input).toHaveValue('7.8')
+    })
+
+    it('renders a group `id` filter with the generic value editor, not the group-name picker', () => {
+        // Reverting the editor swap for `id` is the regression fix: a group property
+        // named `id` must keep its normal value input (GroupKeySelect, used only for
+        // the true `$group_key` identity, would replace it with a group search).
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="id"
+                    type={PropertyFilterType.Group}
+                    groupTypeIndex={0 as GroupTypeIndex}
+                    operator={PropertyOperator.Exact}
+                    onSet={jest.fn()}
+                    value={['org-abc-123']}
+                />
+            </Provider>
+        )
+
+        // GroupKeySelect's distinctive placeholder is absent — the generic editor is used.
+        expect(screen.queryByPlaceholderText('Search groups by name...')).not.toBeInTheDocument()
+        // The pasted id is shown as the value.
+        expect(screen.getByText('org-abc-123')).toBeInTheDocument()
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -18,7 +18,10 @@ import { GroupKeySelect } from 'lib/components/PropertyFilters/components/GroupK
 import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { propertyValueLogic } from 'lib/components/PropertyFilters/components/propertyValueLogic'
-import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
+import {
+    isGroupIdentityFilterKey,
+    propertyFilterTypeToPropertyDefinitionType,
+} from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
@@ -105,7 +108,7 @@ export function PropertyValue({
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
     const shouldRestrictToNumericInput = isNumericProperty && !isOperatorRegex(operator)
 
-    const isGroupKeyProperty = propertyKey === '$group_key' && groupTypeIndex != null
+    const isGroupKeyProperty = isGroupIdentityFilterKey(propertyKey, type) && groupTypeIndex != null
     const isDistinctIdProperty = propertyKey === 'distinct_id' && type === PropertyFilterType.Person
 
     // TODO: Add semver input validation when a semver operator is selected.

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -14,11 +14,12 @@ import { AssigneeSelect } from '@posthog/products-error-tracking/frontend/compon
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
 import { DistinctIdSelect } from 'lib/components/PropertyFilters/components/DistinctIdSelect'
+import { GroupKeyFilterTooltip } from 'lib/components/PropertyFilters/components/GroupKeyFilterTooltip'
 import { GroupKeySelect } from 'lib/components/PropertyFilters/components/GroupKeySelect'
 import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { propertyValueLogic } from 'lib/components/PropertyFilters/components/propertyValueLogic'
-import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
+import { isGroupCardFilterKey, propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
@@ -107,6 +108,20 @@ export function PropertyValue({
 
     const isGroupKeyProperty = propertyKey === '$group_key' && groupTypeIndex != null
     const isDistinctIdProperty = propertyKey === 'distinct_id' && type === PropertyFilterType.Person
+
+    // A group property like `id` often holds the group key. We don't swap the
+    // value editor (that would break filtering the property by an arbitrary
+    // value), but we do decorate the value with a read-only group-info card so
+    // the user can confirm a pasted id resolves to the right group. Display only
+    // — it falls back to the plain value when the lookup isn't a real group key.
+    const showGroupCardOnValue = isGroupCardFilterKey(propertyKey, type) && groupTypeIndex != null
+    const groupCardTooltip = (groupKey: string): JSX.Element => (
+        <GroupKeyFilterTooltip
+            groupTypeIndex={groupTypeIndex as GroupTypeIndex}
+            groupKey={groupKey}
+            fallbackLabel={groupKey}
+        />
+    )
 
     // TODO: Add semver input validation when a semver operator is selected.
     // This will require detecting isOperatorSemver(operator) and validating the input
@@ -473,24 +488,34 @@ export function PropertyValue({
                 status={validationError ? 'danger' : 'default'}
                 title={titleNode}
                 popoverClassName="max-w-200"
-                options={displayOptions.map(({ name: _name }, index) => {
-                    const name = toString(_name)
-                    return {
-                        key: name,
-                        label: name,
-                        value: isFlagDependencyProperty ? _name : undefined, // Preserve original type for flags
-                        labelComponent: (
-                            <span
-                                key={name}
-                                data-attr={'prop-val-' + index}
-                                className="ph-no-capture flex items-center gap-1.5"
-                                title={name}
-                            >
-                                {formatLabelContent(isFlagDependencyProperty ? _name : name)}
-                            </span>
-                        ),
-                    }
-                })}
+                options={[
+                    ...displayOptions.map(({ name: _name }, index) => {
+                        const name = toString(_name)
+                        return {
+                            key: name,
+                            label: name,
+                            value: isFlagDependencyProperty ? _name : undefined, // Preserve original type for flags
+                            tooltip: showGroupCardOnValue ? groupCardTooltip(name) : undefined,
+                            labelComponent: (
+                                <span
+                                    key={name}
+                                    data-attr={'prop-val-' + index}
+                                    className="ph-no-capture flex items-center gap-1.5"
+                                    title={name}
+                                >
+                                    {formatLabelContent(isFlagDependencyProperty ? _name : name)}
+                                </span>
+                            ),
+                        }
+                    }),
+                    // A pasted group id is a custom value absent from the suggestions, so add
+                    // an option for each selected value to carry the group-card tooltip on its snack.
+                    ...(showGroupCardOnValue
+                        ? formattedValues
+                              .filter((v) => !displayOptions.some((o) => toString(o.name) === v))
+                              .map((v) => ({ key: v, label: v, tooltip: groupCardTooltip(v) }))
+                        : []),
+                ]}
             />
             {showInlineValidationErrors && validationError && (
                 <div className="text-danger flex items-center gap-1 text-sm mt-1">

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -108,7 +108,7 @@ export function PropertyValue({
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
     const shouldRestrictToNumericInput = isNumericProperty && !isOperatorRegex(operator)
 
-    const isGroupKeyProperty = isGroupIdentityFilterKey(propertyKey, type) && groupTypeIndex != null
+    const isGroupIdentityProperty = isGroupIdentityFilterKey(propertyKey, type) && groupTypeIndex != null
     const isDistinctIdProperty = propertyKey === 'distinct_id' && type === PropertyFilterType.Person
 
     // TODO: Add semver input validation when a semver operator is selected.
@@ -144,7 +144,7 @@ export function PropertyValue({
     // preload values if preloadValues prop is set
     useEffect(() => {
         if (
-            !isGroupKeyProperty &&
+            !isGroupIdentityProperty &&
             !isDistinctIdProperty &&
             !isAssigneeProperty &&
             preloadValues &&
@@ -153,12 +153,19 @@ export function PropertyValue({
         ) {
             load('')
         }
-    }, [preloadValues, load, propertyOptions?.status, isGroupKeyProperty, isDistinctIdProperty, isAssigneeProperty])
+    }, [
+        preloadValues,
+        load,
+        propertyOptions?.status,
+        isGroupIdentityProperty,
+        isDistinctIdProperty,
+        isAssigneeProperty,
+    ])
 
     // load options when propertyKey changes, unless it's a date/time property (since those don't have options to load)
     useEffect(() => {
         if (
-            !isGroupKeyProperty &&
+            !isGroupIdentityProperty &&
             !isDistinctIdProperty &&
             !isAssigneeProperty &&
             !isDateTimeProperty &&
@@ -170,7 +177,7 @@ export function PropertyValue({
     }, [
         propertyKey,
         isDateTimeProperty,
-        isGroupKeyProperty,
+        isGroupIdentityProperty,
         isDistinctIdProperty,
         isAssigneeProperty,
         load,
@@ -284,7 +291,7 @@ export function PropertyValue({
         )
     }
 
-    if (isGroupKeyProperty && editable) {
+    if (isGroupIdentityProperty && editable) {
         return (
             <GroupKeySelect
                 value={value ?? null}
@@ -316,7 +323,7 @@ export function PropertyValue({
     )
 
     if (!editable) {
-        if (isGroupKeyProperty && groupKeyNames) {
+        if (isGroupIdentityProperty && groupKeyNames) {
             const rawValues = (value === null || value === undefined ? [] : Array.isArray(value) ? value : [value]).map(
                 String
             )

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -18,10 +18,7 @@ import { GroupKeySelect } from 'lib/components/PropertyFilters/components/GroupK
 import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
 import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 import { propertyValueLogic } from 'lib/components/PropertyFilters/components/propertyValueLogic'
-import {
-    isGroupIdentityFilterKey,
-    propertyFilterTypeToPropertyDefinitionType,
-} from 'lib/components/PropertyFilters/utils'
+import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
@@ -108,7 +105,7 @@ export function PropertyValue({
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
     const shouldRestrictToNumericInput = isNumericProperty && !isOperatorRegex(operator)
 
-    const isGroupIdentityProperty = isGroupIdentityFilterKey(propertyKey, type) && groupTypeIndex != null
+    const isGroupKeyProperty = propertyKey === '$group_key' && groupTypeIndex != null
     const isDistinctIdProperty = propertyKey === 'distinct_id' && type === PropertyFilterType.Person
 
     // TODO: Add semver input validation when a semver operator is selected.
@@ -144,7 +141,7 @@ export function PropertyValue({
     // preload values if preloadValues prop is set
     useEffect(() => {
         if (
-            !isGroupIdentityProperty &&
+            !isGroupKeyProperty &&
             !isDistinctIdProperty &&
             !isAssigneeProperty &&
             preloadValues &&
@@ -153,19 +150,12 @@ export function PropertyValue({
         ) {
             load('')
         }
-    }, [
-        preloadValues,
-        load,
-        propertyOptions?.status,
-        isGroupIdentityProperty,
-        isDistinctIdProperty,
-        isAssigneeProperty,
-    ])
+    }, [preloadValues, load, propertyOptions?.status, isGroupKeyProperty, isDistinctIdProperty, isAssigneeProperty])
 
     // load options when propertyKey changes, unless it's a date/time property (since those don't have options to load)
     useEffect(() => {
         if (
-            !isGroupIdentityProperty &&
+            !isGroupKeyProperty &&
             !isDistinctIdProperty &&
             !isAssigneeProperty &&
             !isDateTimeProperty &&
@@ -177,7 +167,7 @@ export function PropertyValue({
     }, [
         propertyKey,
         isDateTimeProperty,
-        isGroupIdentityProperty,
+        isGroupKeyProperty,
         isDistinctIdProperty,
         isAssigneeProperty,
         load,
@@ -291,7 +281,7 @@ export function PropertyValue({
         )
     }
 
-    if (isGroupIdentityProperty && editable) {
+    if (isGroupKeyProperty && editable) {
         return (
             <GroupKeySelect
                 value={value ?? null}
@@ -323,7 +313,7 @@ export function PropertyValue({
     )
 
     if (!editable) {
-        if (isGroupIdentityProperty && groupKeyNames) {
+        if (isGroupKeyProperty && groupKeyNames) {
             const rawValues = (value === null || value === undefined ? [] : Array.isArray(value) ? value : [value]).map(
                 String
             )

--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -3,7 +3,7 @@ import {
     convertPropertiesToPropertyGroup,
     convertPropertyGroupToProperties,
     createDefaultPropertyFilter,
-    isGroupIdentityFilterKey,
+    isGroupCardFilterKey,
     isValidPropertyFilter,
     normalizePropertyFilterValue,
     propertyFilterTypeToTaxonomicFilterType,
@@ -25,7 +25,7 @@ import {
 } from '../../../types'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
 
-describe('isGroupIdentityFilterKey()', () => {
+describe('isGroupCardFilterKey()', () => {
     it.each([
         { key: '$group_key', type: PropertyFilterType.Group, expected: true },
         { key: 'id', type: PropertyFilterType.Group, expected: true },
@@ -38,7 +38,7 @@ describe('isGroupIdentityFilterKey()', () => {
         { key: '$group_key', type: undefined, expected: false },
         { key: undefined, type: PropertyFilterType.Group, expected: false },
     ])('returns $expected for key=$key type=$type', ({ key, type, expected }) => {
-        expect(isGroupIdentityFilterKey(key, type)).toBe(expected)
+        expect(isGroupCardFilterKey(key, type)).toBe(expected)
     })
 })
 

--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -3,6 +3,7 @@ import {
     convertPropertiesToPropertyGroup,
     convertPropertyGroupToProperties,
     createDefaultPropertyFilter,
+    isGroupIdentityFilterKey,
     isValidPropertyFilter,
     normalizePropertyFilterValue,
     propertyFilterTypeToTaxonomicFilterType,
@@ -23,6 +24,25 @@ import {
     SessionPropertyFilter,
 } from '../../../types'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+
+describe('isGroupIdentityFilterKey()', () => {
+    it.each([
+        // A group is identified by its key under '$group_key' (event/insight filters)
+        // and 'id' (the groups-list query).
+        { key: '$group_key', type: PropertyFilterType.Group, expected: true },
+        { key: 'id', type: PropertyFilterType.Group, expected: true },
+        // 'id' is also the Cohort key — must not match there.
+        { key: 'id', type: PropertyFilterType.Cohort, expected: false },
+        // Group *property* filters use other keys.
+        { key: 'industry', type: PropertyFilterType.Group, expected: false },
+        // '$group_key' only makes sense for a Group-type filter.
+        { key: '$group_key', type: PropertyFilterType.Event, expected: false },
+        { key: '$group_key', type: undefined, expected: false },
+        { key: undefined, type: PropertyFilterType.Group, expected: false },
+    ])('returns $expected for key=$key type=$type', ({ key, type, expected }) => {
+        expect(isGroupIdentityFilterKey(key, type)).toBe(expected)
+    })
+})
 
 describe('isValidPropertyFilter()', () => {
     it('returns values correctly', () => {

--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -27,8 +27,6 @@ import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../TaxonomicFilt
 
 describe('isGroupIdentityFilterKey()', () => {
     it.each([
-        // A group is identified by its key under '$group_key' (event/insight filters)
-        // and 'id' (the groups-list query).
         { key: '$group_key', type: PropertyFilterType.Group, expected: true },
         { key: 'id', type: PropertyFilterType.Group, expected: true },
         // 'id' is also the Cohort key — must not match there.

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -227,6 +227,17 @@ export function isValidPropertyFilter(
 export function isCohortPropertyFilter(filter?: AnyFilterLike | null): filter is CohortPropertyFilter {
     return filter?.type === PropertyFilterType.Cohort
 }
+
+// A Group-type filter identifies one specific group by its key under two key
+// names: '$group_key' in event/insight property filters, and 'id' in the
+// groups-list query. ('id' is also the Cohort key, so the Group type gate
+// matters.) Group *property* filters (industry, name, ...) use other keys.
+export function isGroupIdentityFilterKey(
+    key: string | number | undefined,
+    type: PropertyFilterType | undefined
+): boolean {
+    return type === PropertyFilterType.Group && (key === '$group_key' || key === 'id')
+}
 export function isEventMetadataPropertyFilter(filter?: AnyFilterLike | null): filter is EventMetadataPropertyFilter {
     return filter?.type === PropertyFilterType.EventMetadata
 }

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -228,14 +228,15 @@ export function isCohortPropertyFilter(filter?: AnyFilterLike | null): filter is
     return filter?.type === PropertyFilterType.Cohort
 }
 
-// A Group-type filter identifies one specific group by its key under two key
-// names: '$group_key' in event/insight property filters, and 'id' in the
-// groups-list query. ('id' is also the Cohort key, so the Group type gate
-// matters.) Group *property* filters (industry, name, ...) use other keys.
-export function isGroupIdentityFilterKey(
-    key: string | number | undefined,
-    type: PropertyFilterType | undefined
-): boolean {
+// Filter keys whose value we offer a read-only group-info card for on hover.
+// '$group_key' is the group's true identity (always a group key). 'id' is a
+// group *property* that conventionally holds the group key (e.g. CRM-imported
+// groups), so a card is a useful confirmation there too — but it is display
+// only: the lookup falls back to the plain label when the value isn't a real
+// group key, and we deliberately do NOT swap the value editor for these (only
+// the true '$group_key' identity gets the group picker). 'id' is also the
+// Cohort key, so the Group type gate matters.
+export function isGroupCardFilterKey(key: string | number | undefined, type: PropertyFilterType | undefined): boolean {
     return type === PropertyFilterType.Group && (key === '$group_key' || key === 'id')
 }
 export function isEventMetadataPropertyFilter(filter?: AnyFilterLike | null): filter is EventMetadataPropertyFilter {


### PR DESCRIPTION
<img width="1000" height="625" alt="group-card-id-filter" src="https://github.com/user-attachments/assets/ee2d7fa5-6805-466e-8e42-e2b589d253e5" />


## Problem

When filtering by a group — by its identity (`$group_key`) or by an `id` property that holds the group key (e.g. pasting an organization id) — the filter only showed the raw UUID. There was no way to confirm you picked the right group without navigating away.

## Changes

Show a read-only group-info card (name, key, first seen — the same info as the group profile "Info" card) wherever a group filter's value resolves to a real group:

- on the collapsed filter **chip** (hover), and
- on the **value** in the editor — the selected-value snack and the dropdown options — so you see the group as you paste/select it.

**Display-only, by design** (this is the key review outcome): we do **not** swap the value editor to a group-name picker for `id` filters. `{type: group, key: id}` is a group *property* (`property_to_expr` evaluates it as `properties.id`; the groups table has no `id` column and identity is `$group_key`), so swapping the widget would break filtering that property by an arbitrary value. The card simply resolves the value as a group key and falls back to the plain value when it isn't one. Only the true `$group_key` identity uses the group picker (unchanged).

The card label is the group's `name` property, falling back to the key when there's no name.

## Demo

**Insight series picker — hovering a group `id` filter's value shows the card:**

_drop `group-card-insight-series-picker.gif` here_

## How did you test this code?

I'm an agent (PostHog Code). Automated tests plus live verification against the running app — no manual testing beyond what's listed.

- `isGroupCardFilterKey` unit tests — discriminates identity/`id` from cohort `id` and from group property keys.
- `PropertyFilterButton` test — `$group_key` and `id` group filters take the rich-card path (native title suppressed).
- `PropertyValue` test — an `id` group filter keeps the **generic** value editor (regression guard: no group-name-picker swap).
- Verified live in the insight series picker: both a `$group_key` and an `id` group filter show the card on the value snack, the dropdown option, and the chip.

Note: there is pre-existing flaky test isolation in the `PropertyFilters` jest suite (group-lookup tests resolving after teardown → occasional "Cannot log after tests are done"); it reproduces on master and each file passes in isolation. Not introduced here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). Paul reported that pasting a group/organization id didn't surface the group. Investigation (and a codex review) established that `key: id` is a group *property*, not the group identity — so an earlier attempt that swapped the value editor to a group picker was reverted to avoid regressing normal `id`-property filtering. The shipped approach is display-only: decorate the chip and the value snack/options with the group card, resolving the value as a group key with a graceful fallback. The card label uses the group `name` property.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
