### PR TITLE
feat(mcp-analytics): expose intent-clustering and intent-generation via MCP

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -70,6 +70,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'llm_skill', objectName: 'LLM skill', objectPlural: 'LLM skills' },
     { key: 'logs', objectName: 'Logs', objectPlural: 'logs' },
     { key: 'marketing_analytics', objectName: 'Marketing analytics', objectPlural: 'marketing analytics' },
+    { key: 'mcp_analytics', objectName: 'MCP analytics', objectPlural: 'MCP analytics' },
     { key: 'metrics', objectName: 'Metrics', objectPlural: 'metrics' },
     { key: 'notebook', objectName: 'Notebook', objectPlural: 'notebooks' },
     { key: 'organization', objectName: 'Organization', objectPlural: 'organizations', disabledWhenProjectScoped: true },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5533,6 +5533,7 @@ export type APIScopeObject =
     | 'llm_skill'
     | 'logs'
     | 'marketing_analytics'
+    | 'mcp_analytics'
     | 'metrics'
     | 'notebook'
     | 'organization'

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -71,6 +71,7 @@ APIScopeObject = Literal[
     "llm_skill",
     "logs",
     "marketing_analytics",
+    "mcp_analytics",
     "metrics",
     "notebook",
     "organization",

--- a/products/mcp_analytics/backend/presentation/views.py
+++ b/products/mcp_analytics/backend/presentation/views.py
@@ -15,7 +15,7 @@ from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.event_usage import report_user_action
 from posthog.models.user import User
-from posthog.permissions import SingleTenancyOrAdmin
+from posthog.permissions import PostHogFeatureFlagPermission, SingleTenancyOrAdmin
 
 from products.mcp_analytics.backend import logic
 from products.mcp_analytics.backend.facade import api, contracts, enums
@@ -139,8 +139,14 @@ class MCPFeedbackViewSet(BaseMCPAnalyticsSubmissionViewSet):
 
 class MCPSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     serializer_class = MCPSessionSerializer
-    permission_classes = [IsAuthenticated, SingleTenancyOrAdmin]
-    scope_object = "INTERNAL"
+    scope_object = "mcp_analytics"
+    # tool_calls is a detail GET (read); generate_intent is a POST that computes + persists the
+    # intent summary, so it maps to the write scope. The default read/write action lists don't
+    # cover custom @action names, so APIScopePermission would otherwise reject token access.
+    scope_object_read_actions = ["list", "retrieve", "tool_calls"]
+    scope_object_write_actions = ["generate_intent"]
+    posthog_feature_flag = "mcp-analytics"
+    permission_classes = [PostHogFeatureFlagPermission]
     pagination_class = MCPSessionPagination
 
     def dangerously_get_queryset(self) -> QuerySet:
@@ -227,8 +233,13 @@ class MCPSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
 class MCPIntentClusterViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     serializer_class = MCPIntentClusterSnapshotSerializer
-    permission_classes = [IsAuthenticated, SingleTenancyOrAdmin]
-    scope_object = "INTERNAL"
+    scope_object = "mcp_analytics"
+    # recompute is a POST that kicks off the async clustering task (a state change), so it maps to
+    # the write scope; the snapshot read stays on the read scope.
+    scope_object_read_actions = ["list", "retrieve"]
+    scope_object_write_actions = ["recompute"]
+    posthog_feature_flag = "mcp-analytics"
+    permission_classes = [PostHogFeatureFlagPermission]
     pagination_class = None
 
     def dangerously_get_queryset(self) -> QuerySet:

--- a/products/mcp_analytics/backend/tests/test_presentation.py
+++ b/products/mcp_analytics/backend/tests/test_presentation.py
@@ -134,7 +134,8 @@ class TestMCPAnalyticsPresentation(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
         assert response.json()["attr"] == field
 
     def test_intent_clusters_returns_empty_idle_when_no_snapshot(self) -> None:
-        response = self.client.get(f"/api/environments/{self.team.id}/mcp_analytics/intent_clusters/")
+        with patch("posthoganalytics.feature_enabled", return_value=True):
+            response = self.client.get(f"/api/environments/{self.team.id}/mcp_analytics/intent_clusters/")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -172,7 +173,8 @@ class TestMCPAnalyticsPresentation(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
             },
         )
 
-        response = self.client.get(f"/api/environments/{self.team.id}/mcp_analytics/intent_clusters/")
+        with patch("posthoganalytics.feature_enabled", return_value=True):
+            response = self.client.get(f"/api/environments/{self.team.id}/mcp_analytics/intent_clusters/")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
@@ -185,7 +187,10 @@ class TestMCPAnalyticsPresentation(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
         # Mock only the Celery dispatch so the synchronous COMPUTING write
         # still runs. The 202 body should reflect the new state, not the
         # stale pre-trigger state.
-        with patch("products.mcp_analytics.backend.tasks.tasks.compute_intent_clusters.delay") as mock_delay:
+        with (
+            patch("products.mcp_analytics.backend.tasks.tasks.compute_intent_clusters.delay") as mock_delay,
+            patch("posthoganalytics.feature_enabled", return_value=True),
+        ):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/mcp_analytics/intent_clusters/recompute/", {}, format="json"
             )
@@ -286,7 +291,8 @@ class TestMCPSessionIntentEndpoint(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
         session_id = "session-123"
         MCPSession.objects.create(team=self.team, session_id=session_id, intent="A persisted summary.")
 
-        response = self.client.post(self._url(session_id))
+        with patch("posthoganalytics.feature_enabled", return_value=True):
+            response = self.client.post(self._url(session_id))
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"session_id": session_id, "intent": "A persisted summary."}
@@ -295,6 +301,7 @@ class TestMCPSessionIntentEndpoint(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
         session_id = "session-fresh"
         # Mock the two primitives so the endpoint path runs without ClickHouse or a real LLM call.
         with (
+            patch("posthoganalytics.feature_enabled", return_value=True),
             patch.object(intent_generation, "fetch_session_intents", return_value=["check the funnel"]),
             patch.object(intent_generation, "summarize_intents", return_value="Generated summary."),
         ):
@@ -307,6 +314,7 @@ class TestMCPSessionIntentEndpoint(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
     def test_returns_503_when_generation_unavailable(self) -> None:
         session_id = "session-unavailable"
         with (
+            patch("posthoganalytics.feature_enabled", return_value=True),
             patch.object(intent_generation, "fetch_session_intents", return_value=["check the funnel"]),
             patch.object(
                 intent_generation,

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -14,82 +14,80 @@ tools:
         enabled: true
         scopes:
             - mcp_analytics:write
-        feature_flag: mcp-analytics
-        requires_ai_consent: true
         annotations:
             readOnly: false
             destructive: false
             idempotent: false
         title: Recompute intent clusters
         description: >
-            Trigger an asynchronous recompute of the intent-cluster snapshot: embed the project's recorded
-            agent intents and re-cluster them. Returns immediately with status 'computing'; poll
+            Trigger an asynchronous recompute of the intent-cluster snapshot: embed the project's recorded agent intents
+            and re-cluster them. Returns immediately with status 'computing'; poll
             mcp-analytics-intent-clusters-retrieve for progress (status becomes 'idle' or 'error').
+        requires_ai_consent: true
+        feature_flag: mcp-analytics
     mcp-analytics-intent-clusters-retrieve:
         operation: mcp_analytics_intent_clusters_retrieve
         enabled: true
         scopes:
             - mcp_analytics:read
-        feature_flag: mcp-analytics
         annotations:
             readOnly: true
             destructive: false
             idempotent: true
         title: Get intent cluster snapshot
         description: >
-            Return the most recent intent-clustering snapshot for the project: clusters of similar agent
-            intents, each with its tool distribution, error rate, routing entropy, and journey paths. Returns
-            an empty idle snapshot when no clustering run has happened yet — trigger one with
-            mcp-analytics-intent-clusters-recompute.
+            Return the most recent intent-clustering snapshot for the project: clusters of similar agent intents, each
+            with its tool distribution, error rate, routing entropy, and journey paths. Returns an empty idle snapshot
+            when no clustering run has happened yet — trigger one with mcp-analytics-intent-clusters-recompute.
+        feature_flag: mcp-analytics
     mcp-analytics-sessions-generate-intent:
         operation: mcp_analytics_sessions_generate_intent
         enabled: true
         scopes:
             - mcp_analytics:write
-        feature_flag: mcp-analytics
-        requires_ai_consent: true
         annotations:
             readOnly: false
             destructive: false
             idempotent: true
         title: Generate session intent summary
         description: >
-            Generate (or return the cached) LLM summary of the agent's goal for a session, derived from the
-            session's recorded intents. The first call summarises and persists the result; subsequent calls
-            return the stored summary.
+            Generate (or return the cached) LLM summary of the agent's goal for a session, derived from the session's
+            recorded intents. The first call summarises and persists the result; subsequent calls return the stored
+            summary.
+        requires_ai_consent: true
+        feature_flag: mcp-analytics
     mcp-analytics-sessions-list:
         operation: mcp_analytics_sessions_list
         enabled: true
         scopes:
             - mcp_analytics:read
-        feature_flag: mcp-analytics
         annotations:
             readOnly: true
             destructive: false
             idempotent: true
+        list: true
         title: List MCP sessions
         description: >
-            List MCP sessions for the current project, derived by grouping mcp_tool_call events by session.
-            Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the
-            acting user. Supports `search` (case-insensitive substring over session id, distinct id, client
-            name, and tools used) and `order_by`. Use it to find sessions worth drilling into with
-            mcp-analytics-sessions-tool-calls.
-        list: true
+            List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row
+            summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user.
+            Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and
+            `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.
+        feature_flag: mcp-analytics
     mcp-analytics-sessions-tool-calls:
         operation: mcp_analytics_sessions_tool_calls
         enabled: true
         scopes:
             - mcp_analytics:read
-        feature_flag: mcp-analytics
         annotations:
             readOnly: true
             destructive: false
             idempotent: true
         title: List tool calls in a session
         description: >
-            List every mcp_tool_call event in a session in chronological order, including tool name, stated
-            intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect
-            exactly what an agent did within one session.
+            List every mcp_tool_call event in a session in chronological order, including tool name, stated intent,
+            error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an
+            agent did within one session.
+        feature_flag: mcp-analytics
     mcp-feedback-list:
         operation: mcp_analytics_feedback_list
         enabled: false

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -11,19 +11,85 @@ ui_apps: {}
 tools:
     mcp-analytics-intent-clusters-recompute:
         operation: mcp_analytics_intent_clusters_recompute
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:write
+        feature_flag: mcp-analytics
+        requires_ai_consent: true
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Recompute intent clusters
+        description: >
+            Trigger an asynchronous recompute of the intent-cluster snapshot: embed the project's recorded
+            agent intents and re-cluster them. Returns immediately with status 'computing'; poll
+            mcp-analytics-intent-clusters-retrieve for progress (status becomes 'idle' or 'error').
     mcp-analytics-intent-clusters-retrieve:
         operation: mcp_analytics_intent_clusters_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:read
+        feature_flag: mcp-analytics
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get intent cluster snapshot
+        description: >
+            Return the most recent intent-clustering snapshot for the project: clusters of similar agent
+            intents, each with its tool distribution, error rate, routing entropy, and journey paths. Returns
+            an empty idle snapshot when no clustering run has happened yet — trigger one with
+            mcp-analytics-intent-clusters-recompute.
     mcp-analytics-sessions-generate-intent:
         operation: mcp_analytics_sessions_generate_intent
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:write
+        feature_flag: mcp-analytics
+        requires_ai_consent: true
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Generate session intent summary
+        description: >
+            Generate (or return the cached) LLM summary of the agent's goal for a session, derived from the
+            session's recorded intents. The first call summarises and persists the result; subsequent calls
+            return the stored summary.
     mcp-analytics-sessions-list:
         operation: mcp_analytics_sessions_list
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:read
+        feature_flag: mcp-analytics
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List MCP sessions
+        description: >
+            List MCP sessions for the current project, derived by grouping mcp_tool_call events by session.
+            Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the
+            acting user. Supports `search` (case-insensitive substring over session id, distinct id, client
+            name, and tools used) and `order_by`. Use it to find sessions worth drilling into with
+            mcp-analytics-sessions-tool-calls.
+        list: true
     mcp-analytics-sessions-tool-calls:
         operation: mcp_analytics_sessions_tool_calls
-        enabled: false
+        enabled: true
+        scopes:
+            - mcp_analytics:read
+        feature_flag: mcp-analytics
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List tool calls in a session
+        description: >
+            List every mcp_tool_call event in a session in chronological order, including tool name, stated
+            intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect
+            exactly what an agent did within one session.
     mcp-feedback-list:
         operation: mcp_analytics_feedback_list
         enabled: false

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -56,38 +56,15 @@ tools:
             summary.
         requires_ai_consent: true
         feature_flag: mcp-analytics
+    # Session listing and per-session tool calls are intentionally NOT exposed as tools — they are
+    # plain aggregations over mcp_tool_call events, fully served by execute-sql + the querying-posthog-data
+    # `models-mcp` reference. Only the three capabilities SQL can't express stay as tools (clustering + LLM intent).
     mcp-analytics-sessions-list:
         operation: mcp_analytics_sessions_list
-        enabled: true
-        scopes:
-            - mcp_analytics:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        list: true
-        title: List MCP sessions
-        description: >
-            List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row
-            summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user.
-            Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and
-            `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.
-        feature_flag: mcp-analytics
+        enabled: false
     mcp-analytics-sessions-tool-calls:
         operation: mcp_analytics_sessions_tool_calls
-        enabled: true
-        scopes:
-            - mcp_analytics:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: List tool calls in a session
-        description: >
-            List every mcp_tool_call event in a session in chronological order, including tool name, stated intent,
-            error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an
-            agent did within one session.
-        feature_flag: mcp-analytics
+        enabled: false
     mcp-feedback-list:
         operation: mcp_analytics_feedback_list
         enabled: false

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -56,9 +56,6 @@ tools:
             summary.
         requires_ai_consent: true
         feature_flag: mcp-analytics
-    # Session listing and per-session tool calls are intentionally NOT exposed as tools — they are
-    # plain aggregations over mcp_tool_call events, fully served by execute-sql + the querying-posthog-data
-    # `models-mcp` reference. Only the three capabilities SQL can't express stay as tools (clustering + LLM intent).
     mcp-analytics-sessions-list:
         operation: mcp_analytics_sessions_list
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4806,6 +4806,83 @@
         },
         "feature_flag": "marketing-analytics-mcp"
     },
+    "mcp-analytics-intent-clusters-recompute": {
+        "description": "Trigger an asynchronous recompute of the intent-cluster snapshot: embed the project's recorded agent intents and re-cluster them. Returns immediately with status 'computing'; poll mcp-analytics-intent-clusters-retrieve for progress (status becomes 'idle' or 'error').",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Recompute intent clusters",
+        "title": "Recompute intent clusters",
+        "required_scopes": ["mcp_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-intent-clusters-retrieve": {
+        "description": "Return the most recent intent-clustering snapshot for the project: clusters of similar agent intents, each with its tool distribution, error rate, routing entropy, and journey paths. Returns an empty idle snapshot when no clustering run has happened yet — trigger one with mcp-analytics-intent-clusters-recompute.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Get intent cluster snapshot",
+        "title": "Get intent cluster snapshot",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-generate-intent": {
+        "description": "Generate (or return the cached) LLM summary of the agent's goal for a session, derived from the session's recorded intents. The first call summarises and persists the result; subsequent calls return the stored summary.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Generate session intent summary",
+        "title": "Generate session intent summary",
+        "required_scopes": ["mcp_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-list": {
+        "description": "List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user. Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List MCP sessions",
+        "title": "List MCP sessions",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-tool-calls": {
+        "description": "List every mcp_tool_call event in a session in chronological order, including tool name, stated intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an agent did within one session.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List tool calls in a session",
+        "title": "List tool calls in a session",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
     "notebooks-create": {
         "description": "Create a new notebook. Provide a title and content. Content is a JSON object representing the notebook's rich text document structure (ProseMirror-based). Returns the created notebook with its short_id.\nEmbedded charts use `{type: \"ph-query\", attrs: {nodeId, query}}` nodes. The `query` object must be one of: (a) `{kind: \"DataVisualizationNode\", source: {kind: \"HogQLQuery\", query: \"SELECT ...\"}, display: \"ActionsBar\", chartSettings: {...}}` for SQL charts — do NOT wrap this in an InsightVizNode; (b) `{kind: \"InsightVizNode\", source: <TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery>}` for product-analytics insights; or (c) `{kind: \"SavedInsightNode\", shortId: \"...\"}` to embed a saved insight. The server rejects other shapes and auto-corrects the common `InsightVizNode` wrapping a SQL chart.",
         "category": "Notebooks",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4853,36 +4853,6 @@
         "requires_ai_consent": true,
         "feature_flag": "mcp-analytics"
     },
-    "mcp-analytics-sessions-list": {
-        "description": "List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user. Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "List MCP sessions",
-        "title": "List MCP sessions",
-        "required_scopes": ["mcp_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "mcp-analytics"
-    },
-    "mcp-analytics-sessions-tool-calls": {
-        "description": "List every mcp_tool_call event in a session in chronological order, including tool name, stated intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an agent did within one session.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "List tool calls in a session",
-        "title": "List tool calls in a session",
-        "required_scopes": ["mcp_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "mcp-analytics"
-    },
     "notebooks-create": {
         "description": "Create a new notebook. Provide a title and content. Content is a JSON object representing the notebook's rich text document structure (ProseMirror-based). Returns the created notebook with its short_id.\nEmbedded charts use `{type: \"ph-query\", attrs: {nodeId, query}}` nodes. The `query` object must be one of: (a) `{kind: \"DataVisualizationNode\", source: {kind: \"HogQLQuery\", query: \"SELECT ...\"}, display: \"ActionsBar\", chartSettings: {...}}` for SQL charts — do NOT wrap this in an InsightVizNode; (b) `{kind: \"InsightVizNode\", source: <TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery>}` for product-analytics insights; or (c) `{kind: \"SavedInsightNode\", shortId: \"...\"}` to embed a saved insight. The server rejects other shapes and auto-corrects the common `InsightVizNode` wrapping a SQL chart.",
         "category": "Notebooks",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5214,6 +5214,83 @@
         },
         "feature_flag": "marketing-analytics-mcp"
     },
+    "mcp-analytics-intent-clusters-recompute": {
+        "description": "Trigger an asynchronous recompute of the intent-cluster snapshot: embed the project's recorded agent intents and re-cluster them. Returns immediately with status 'computing'; poll mcp-analytics-intent-clusters-retrieve for progress (status becomes 'idle' or 'error').",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Recompute intent clusters",
+        "title": "Recompute intent clusters",
+        "required_scopes": ["mcp_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-intent-clusters-retrieve": {
+        "description": "Return the most recent intent-clustering snapshot for the project: clusters of similar agent intents, each with its tool distribution, error rate, routing entropy, and journey paths. Returns an empty idle snapshot when no clustering run has happened yet — trigger one with mcp-analytics-intent-clusters-recompute.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Get intent cluster snapshot",
+        "title": "Get intent cluster snapshot",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-generate-intent": {
+        "description": "Generate (or return the cached) LLM summary of the agent's goal for a session, derived from the session's recorded intents. The first call summarises and persists the result; subsequent calls return the stored summary.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Generate session intent summary",
+        "title": "Generate session intent summary",
+        "required_scopes": ["mcp_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-list": {
+        "description": "List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user. Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List MCP sessions",
+        "title": "List MCP sessions",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
+    "mcp-analytics-sessions-tool-calls": {
+        "description": "List every mcp_tool_call event in a session in chronological order, including tool name, stated intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an agent did within one session.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "List tool calls in a session",
+        "title": "List tool calls in a session",
+        "required_scopes": ["mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics"
+    },
     "notebook-edit": {
         "description": "Edit part of a notebook's content. Use this for any change inside a notebook — text, headings, attributes, whole paragraphs. Call `notebooks-retrieve` first to see what to target.\n\nMatching is by content. The tool finds `old_value` anywhere in the notebook and swaps it for `new_value` in place.\n\nOn success, returns the updated notebook with the new content and bumped version. On a 409 or 410 error, the notebook has changed since you loaded it — call `notebooks-retrieve` and re-apply your edit against the latest content.",
         "category": "Notebooks",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5261,36 +5261,6 @@
         "requires_ai_consent": true,
         "feature_flag": "mcp-analytics"
     },
-    "mcp-analytics-sessions-list": {
-        "description": "List MCP sessions for the current project, derived by grouping mcp_tool_call events by session. Each row summarises one session: tool-call count, tools used, start/end, duration, client, and the acting user. Supports `search` (case-insensitive substring over session id, distinct id, client name, and tools used) and `order_by`. Use it to find sessions worth drilling into with mcp-analytics-sessions-tool-calls.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "List MCP sessions",
-        "title": "List MCP sessions",
-        "required_scopes": ["mcp_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "mcp-analytics"
-    },
-    "mcp-analytics-sessions-tool-calls": {
-        "description": "List every mcp_tool_call event in a session in chronological order, including tool name, stated intent, error flag, error message, and duration. Use after mcp-analytics-sessions-list to inspect exactly what an agent did within one session.",
-        "category": "MCP analytics",
-        "feature": "mcp_analytics",
-        "summary": "List tool calls in a session",
-        "title": "List tool calls in a session",
-        "required_scopes": ["mcp_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        },
-        "feature_flag": "mcp-analytics"
-    },
     "notebook-edit": {
         "description": "Edit part of a notebook's content. Use this for any change inside a notebook — text, headings, attributes, whole paragraphs. Call `notebooks-retrieve` first to see what to target.\n\nMatching is by content. The tool finds `old_value` anywhere in the notebook and swaps it for `new_value` in place.\n\nOn success, returns the updated notebook with the new content and bumped version. On a 409 or 410 error, the notebook has changed since you loaded it — call `notebooks-retrieve` and re-apply your edit against the latest content.",
         "category": "Notebooks",

--- a/services/mcp/src/generated/mcp_analytics/api.ts
+++ b/services/mcp/src/generated/mcp_analytics/api.ts
@@ -1,0 +1,88 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 5 enabled ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Return the most recent intent cluster snapshot for the current project. Returns an empty IDLE snapshot when no clustering run has happened yet.
+ */
+export const McpAnalyticsIntentClustersRetrieveParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Trigger an asynchronous recompute of the intent cluster snapshot. The task runs in the background; poll the GET endpoint for progress (status transitions to 'idle' or 'error').
+ */
+export const McpAnalyticsIntentClustersRecomputeParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_session_id. Ordered by newest session start first by default.
+ */
+export const McpAnalyticsSessionsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const McpAnalyticsSessionsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .string()
+        .optional()
+        .describe(
+            "Sort column. Allowed: session_id, session_start, session_end, duration_seconds, tool_call_count, mcp_client_name, distinct_id. Prefix with '-' for descending. Defaults to '-session_start' (newest sessions first)."
+        ),
+    search: zod
+        .string()
+        .optional()
+        .describe(
+            'Case-insensitive substring filter matched against session_id, distinct_id, mcp_client_name, and tools_used.'
+        ),
+})
+
+/**
+ * Generate (or return the cached) LLM summary of the agent's goal for a session, derived from its recorded $mcp_intents. The first call summarises and persists the result; subsequent calls return the stored summary.
+ */
+export const McpAnalyticsSessionsGenerateIntentParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this mcp analytics submission.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * List all mcp_tool_call events that belong to a given $session_id, in chronological order.
+ */
+export const McpAnalyticsSessionsToolCallsParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this mcp analytics submission.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const McpAnalyticsSessionsToolCallsQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})

--- a/services/mcp/src/generated/mcp_analytics/api.ts
+++ b/services/mcp/src/generated/mcp_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 5 enabled ops
+ * PostHog API - MCP 3 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -31,34 +31,6 @@ export const McpAnalyticsIntentClustersRecomputeParams = /* @__PURE__ */ zod.obj
 })
 
 /**
- * List MCP sessions for the current project, derived by grouping mcp_tool_call events by $mcp_session_id. Ordered by newest session start first by default.
- */
-export const McpAnalyticsSessionsListParams = /* @__PURE__ */ zod.object({
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const McpAnalyticsSessionsListQueryParams = /* @__PURE__ */ zod.object({
-    limit: zod.number().optional().describe('Number of results to return per page.'),
-    offset: zod.number().optional().describe('The initial index from which to return the results.'),
-    order_by: zod
-        .string()
-        .optional()
-        .describe(
-            "Sort column. Allowed: session_id, session_start, session_end, duration_seconds, tool_call_count, mcp_client_name, distinct_id. Prefix with '-' for descending. Defaults to '-session_start' (newest sessions first)."
-        ),
-    search: zod
-        .string()
-        .optional()
-        .describe(
-            'Case-insensitive substring filter matched against session_id, distinct_id, mcp_client_name, and tools_used.'
-        ),
-})
-
-/**
  * Generate (or return the cached) LLM summary of the agent's goal for a session, derived from its recorded $mcp_intents. The first call summarises and persists the result; subsequent calls return the stored summary.
  */
 export const McpAnalyticsSessionsGenerateIntentParams = /* @__PURE__ */ zod.object({
@@ -68,21 +40,4 @@ export const McpAnalyticsSessionsGenerateIntentParams = /* @__PURE__ */ zod.obje
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
-})
-
-/**
- * List all mcp_tool_call events that belong to a given $session_id, in chronological order.
- */
-export const McpAnalyticsSessionsToolCallsParams = /* @__PURE__ */ zod.object({
-    id: zod.string().describe('A UUID string identifying this mcp analytics submission.'),
-    project_id: zod
-        .string()
-        .describe(
-            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
-        ),
-})
-
-export const McpAnalyticsSessionsToolCallsQueryParams = /* @__PURE__ */ zod.object({
-    limit: zod.number().optional().describe('Number of results to return per page.'),
-    offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })

--- a/services/mcp/src/lib/oauth-scopes.generated.ts
+++ b/services/mcp/src/lib/oauth-scopes.generated.ts
@@ -119,6 +119,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'logs:write',
     'marketing_analytics:read',
     'marketing_analytics:write',
+    'mcp_analytics:read',
+    'mcp_analytics:write',
     'notebook:read',
     'notebook:write',
     'organization:read',

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -29,6 +29,7 @@ import { GENERATED_TOOLS as health_issues } from './health_issues'
 import { GENERATED_TOOLS as integrations } from './integrations'
 import { GENERATED_TOOLS as logs } from './logs'
 import { GENERATED_TOOLS as marketing_analytics } from './marketing_analytics'
+import { GENERATED_TOOLS as mcp_analytics } from './mcp_analytics'
 import { GENERATED_TOOLS as notebooks } from './notebooks'
 import { GENERATED_TOOLS as persons } from './persons'
 import { GENERATED_TOOLS as platform_features } from './platform_features'
@@ -77,6 +78,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...integrations,
     ...logs,
     ...marketing_analytics,
+    ...mcp_analytics,
     ...notebooks,
     ...persons,
     ...platform_features,

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -18,7 +18,7 @@ const mcpAnalyticsIntentClustersRecompute = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<unknown>({
             method: 'POST',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/recompute/`,
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/recompute/`,
         })
         return result
     },
@@ -37,7 +37,7 @@ const mcpAnalyticsIntentClustersRetrieve = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.MCPIntentClusterSnapshot[]>({
             method: 'GET',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/`,
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/`,
         })
         return result
     },
@@ -55,7 +55,7 @@ const mcpAnalyticsSessionsGenerateIntent = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.MCPSessionIntent>({
             method: 'POST',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/generate_intent/`,
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/generate_intent/`,
         })
         return result
     },

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -2,13 +2,7 @@
 import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
-import {
-    McpAnalyticsSessionsGenerateIntentParams,
-    McpAnalyticsSessionsListQueryParams,
-    McpAnalyticsSessionsToolCallsParams,
-    McpAnalyticsSessionsToolCallsQueryParams,
-} from '@/generated/mcp_analytics/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { McpAnalyticsSessionsGenerateIntentParams } from '@/generated/mcp_analytics/api'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpAnalyticsIntentClustersRecomputeSchema = z.object({})
@@ -67,58 +61,8 @@ const mcpAnalyticsSessionsGenerateIntent = (): ToolBase<
     },
 })
 
-const McpAnalyticsSessionsListSchema = McpAnalyticsSessionsListQueryParams
-
-const mcpAnalyticsSessionsList = (): ToolBase<
-    typeof McpAnalyticsSessionsListSchema,
-    WithPostHogUrl<Schemas.PaginatedMCPSessionList>
-> => ({
-    name: 'mcp-analytics-sessions-list',
-    schema: McpAnalyticsSessionsListSchema,
-    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsListSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.PaginatedMCPSessionList>({
-            method: 'GET',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/`,
-            query: {
-                limit: params.limit,
-                offset: params.offset,
-                order_by: params.order_by,
-                search: params.search,
-            },
-        })
-        return await withPostHogUrl(context, result, '/mcp-analytics')
-    },
-})
-
-const McpAnalyticsSessionsToolCallsSchema = McpAnalyticsSessionsToolCallsParams.omit({ project_id: true }).extend(
-    McpAnalyticsSessionsToolCallsQueryParams.shape
-)
-
-const mcpAnalyticsSessionsToolCalls = (): ToolBase<
-    typeof McpAnalyticsSessionsToolCallsSchema,
-    Schemas.PaginatedMCPToolCallList
-> => ({
-    name: 'mcp-analytics-sessions-tool-calls',
-    schema: McpAnalyticsSessionsToolCallsSchema,
-    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsToolCallsSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.PaginatedMCPToolCallList>({
-            method: 'GET',
-            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/tool_calls/`,
-            query: {
-                limit: params.limit,
-                offset: params.offset,
-            },
-        })
-        return result
-    },
-})
-
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'mcp-analytics-intent-clusters-recompute': mcpAnalyticsIntentClustersRecompute,
     'mcp-analytics-intent-clusters-retrieve': mcpAnalyticsIntentClustersRetrieve,
     'mcp-analytics-sessions-generate-intent': mcpAnalyticsSessionsGenerateIntent,
-    'mcp-analytics-sessions-list': mcpAnalyticsSessionsList,
-    'mcp-analytics-sessions-tool-calls': mcpAnalyticsSessionsToolCalls,
 }

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -1,0 +1,124 @@
+// AUTO-GENERATED from products/mcp_analytics/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import {
+    McpAnalyticsSessionsGenerateIntentParams,
+    McpAnalyticsSessionsListQueryParams,
+    McpAnalyticsSessionsToolCallsParams,
+    McpAnalyticsSessionsToolCallsQueryParams,
+} from '@/generated/mcp_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const McpAnalyticsIntentClustersRecomputeSchema = z.object({})
+
+const mcpAnalyticsIntentClustersRecompute = (): ToolBase<
+    typeof McpAnalyticsIntentClustersRecomputeSchema,
+    unknown
+> => ({
+    name: 'mcp-analytics-intent-clusters-recompute',
+    schema: McpAnalyticsIntentClustersRecomputeSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsIntentClustersRecomputeSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/recompute/`,
+        })
+        return result
+    },
+})
+
+const McpAnalyticsIntentClustersRetrieveSchema = z.object({})
+
+const mcpAnalyticsIntentClustersRetrieve = (): ToolBase<
+    typeof McpAnalyticsIntentClustersRetrieveSchema,
+    Schemas.MCPIntentClusterSnapshot[]
+> => ({
+    name: 'mcp-analytics-intent-clusters-retrieve',
+    schema: McpAnalyticsIntentClustersRetrieveSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsIntentClustersRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.MCPIntentClusterSnapshot[]>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/intent_clusters/`,
+        })
+        return result
+    },
+})
+
+const McpAnalyticsSessionsGenerateIntentSchema = McpAnalyticsSessionsGenerateIntentParams.omit({ project_id: true })
+
+const mcpAnalyticsSessionsGenerateIntent = (): ToolBase<
+    typeof McpAnalyticsSessionsGenerateIntentSchema,
+    Schemas.MCPSessionIntent
+> => ({
+    name: 'mcp-analytics-sessions-generate-intent',
+    schema: McpAnalyticsSessionsGenerateIntentSchema,
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsGenerateIntentSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.MCPSessionIntent>({
+            method: 'POST',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/generate_intent/`,
+        })
+        return result
+    },
+})
+
+const McpAnalyticsSessionsListSchema = McpAnalyticsSessionsListQueryParams
+
+const mcpAnalyticsSessionsList = (): ToolBase<
+    typeof McpAnalyticsSessionsListSchema,
+    WithPostHogUrl<Schemas.PaginatedMCPSessionList>
+> => ({
+    name: 'mcp-analytics-sessions-list',
+    schema: McpAnalyticsSessionsListSchema,
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedMCPSessionList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                order_by: params.order_by,
+                search: params.search,
+            },
+        })
+        return await withPostHogUrl(context, result, '/mcp-analytics')
+    },
+})
+
+const McpAnalyticsSessionsToolCallsSchema = McpAnalyticsSessionsToolCallsParams.omit({ project_id: true }).extend(
+    McpAnalyticsSessionsToolCallsQueryParams.shape
+)
+
+const mcpAnalyticsSessionsToolCalls = (): ToolBase<
+    typeof McpAnalyticsSessionsToolCallsSchema,
+    Schemas.PaginatedMCPToolCallList
+> => ({
+    name: 'mcp-analytics-sessions-tool-calls',
+    schema: McpAnalyticsSessionsToolCallsSchema,
+    handler: async (context: Context, params: z.infer<typeof McpAnalyticsSessionsToolCallsSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedMCPToolCallList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/mcp_analytics/sessions/${encodeURIComponent(String(params.id))}/tool_calls/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'mcp-analytics-intent-clusters-recompute': mcpAnalyticsIntentClustersRecompute,
+    'mcp-analytics-intent-clusters-retrieve': mcpAnalyticsIntentClustersRetrieve,
+    'mcp-analytics-sessions-generate-intent': mcpAnalyticsSessionsGenerateIntent,
+    'mcp-analytics-sessions-list': mcpAnalyticsSessionsList,
+    'mcp-analytics-sessions-tool-calls': mcpAnalyticsSessionsToolCalls,
+}

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -749,9 +749,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'marketing-analytics-mcp',
                 'product-business-knowledge',
                 'field-notes',
+                'mcp-analytics',
             ])
         )
-        expect(flags).toHaveLength(17)
+        expect(flags).toHaveLength(18)
     })
 
     // Exercise the real predicate (toolPassesFlagGate) over hand-rolled entries


### PR DESCRIPTION
## Problem

The MCP analytics product's data was reachable only through its web UI, and the endpoints were locked to staff-only (`scope_object = "INTERNAL"` + `SingleTenancyOrAdmin`) — incompatible with MCP, where tools authenticate with the caller's own token. We want agents to reach the parts of this product that **can't** be expressed as a query: the embedding-based intent clustering and the LLM session-intent summary. Plain metrics and session listing are deliberately *not* tools — those are an `execute-sql` job (see the companion `models-mcp` querying-skill PR).

## Changes

**1. Auth model.** Adds a public `mcp_analytics` API scope (kept in sync across `posthog/scopes.py`, `frontend/src/types.ts`, `frontend/src/lib/scopes.tsx`). Flips the session and intent-cluster viewsets off the staff-only `INTERNAL` gate to `scope_object = "mcp_analytics"` + the existing `mcp-analytics` feature flag (`PostHogFeatureFlagPermission`), mirroring the `user_interviews` alpha. Custom actions are classified read/write so token auth resolves a scope. Data stays team-scoped; the flag is the rollout switch. Feedback / missing-capability viewsets stay `INTERNAL`.

**2. MCP tools — only what SQL can't do.** Three tools, gated by the `mcp-analytics` flag:

| Tool | Scope | Why it's a tool (not SQL) |
| --- | --- | --- |
| `mcp-analytics-intent-clusters-retrieve` | read | reads a precomputed embedding/DBSCAN snapshot — not derivable from events |
| `mcp-analytics-intent-clusters-recompute` | write | triggers the async clustering job (`requires_ai_consent`) |
| `mcp-analytics-sessions-generate-intent` | write | LLM summary of a session (`requires_ai_consent`) |

`sessions-list` and `sessions-tool-calls` are intentionally **not** exposed — they're plain aggregations over `mcp_tool_call` events, fully served by `execute-sql` + the `querying-posthog-data` `models-mcp` reference (companion PR). We did not build a tool-quality / metrics tool for the same reason: those are `query-trends` / `execute-sql` questions, and fixed-shape tools can't answer "last week / yesterday".

## How did you test this code?

I'm an agent. Checks I actually ran:

- `posthog/test/test_scopes.py` — 80/80 (new scope consistent across backend + frontend).
- MCP package `tsc --noEmit` passes; tool catalog / filtering / snapshot vitest pass.
- `hogli build:openapi` clean; the three tools generate with correct scopes + `feature_flag`, and `mcp_analytics:read`/`:write` appear in the generated OAuth metadata.
- **End-to-end against a local instance** with real `mcp_tool_call` data: confirmed the tools are flag-gated (hidden when off, exposed when on), authenticate via a scoped token, and return real data — `intent-clusters-retrieve` returned a populated multi-cluster snapshot.
- Did not run the Django endpoint tests locally (the test client loads the full URLconf, which imports a product whose sandbox needs Docker that isn't available here); they run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). We initially exposed five tools (the two session ones included) and a metrics matrix, then narrowed after reviewing how product_analytics exposes analytics: it ships only the generic `query-*` wrappers, not per-metric endpoints. Metric and session-listing questions are better served by `execute-sql` + the `models-mcp` skill, so this PR keeps only the three capabilities that genuinely aren't SQL-expressible. The auth pattern (public scope + feature-flag gating, dropping `SingleTenancyOrAdmin`) follows the `user_interviews` precedent.
