### PR TITLE
feat(taxonomic-filter): replay-style input trigger for the rebuild menu

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -59,6 +59,12 @@ export interface PropertyFiltersProps {
     addFilterDocLink?: string
     operatorAllowlist?: OperatorValueSelectProps['operatorAllowlist']
     hogQLGlobals?: Record<string, any>
+    /**
+     * `'input'` renders the replay-style input-box add-filter trigger; `'button'`
+     * (the default) renders a button. Only has an effect on the rebuild menu
+     * (`TAXONOMIC_FILTER_MENU_REBUILD`).
+     */
+    triggerVariant?: 'button' | 'input'
 }
 
 export function PropertyFilters({
@@ -97,6 +103,7 @@ export function PropertyFilters({
     addFilterDocLink,
     operatorAllowlist,
     hogQLGlobals,
+    triggerVariant = 'button',
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
@@ -167,6 +174,7 @@ export function PropertyFilters({
                                             editable={editable}
                                             operatorAllowlist={operatorAllowlist}
                                             hogQLGlobals={hogQLGlobals}
+                                            triggerVariant={triggerVariant}
                                         />
                                     )}
                                     errorMessage={errorMessages && errorMessages[index]}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.triggerVariant.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.triggerVariant.test.tsx
@@ -1,0 +1,97 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { initKeaTests } from '~/test/init'
+import { mockGetEventDefinitions, mockGetPropertyDefinitions } from '~/test/mocks'
+
+import { TaxonomicFilterGroupType } from '../../TaxonomicFilter/types'
+import { PropertyFilters } from '../PropertyFilters'
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('TaxonomicPropertyFilter triggerVariant (rebuild menu)', () => {
+    let unmountFeatureFlagLogic: (() => void) | null = null
+
+    beforeEach(() => {
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+        propertyDefinitionsModel.mount()
+        localStorage.clear()
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                '/api/projects/:team/actions': { results: [] },
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        unmountFeatureFlagLogic = featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD], {
+            [FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD]: true,
+        })
+    })
+
+    afterEach(() => {
+        featureFlagLogic.actions.setFeatureFlags([], {})
+        unmountFeatureFlagLogic?.()
+        unmountFeatureFlagLogic = null
+        cleanup()
+    })
+
+    function renderWith(triggerVariant?: 'button' | 'input'): void {
+        render(
+            <Provider>
+                <PropertyFilters
+                    pageKey="input-trigger-test"
+                    propertyFilters={[]}
+                    onChange={jest.fn()}
+                    disablePopover
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                    triggerVariant={triggerVariant}
+                />
+            </Provider>
+        )
+    }
+
+    it.each([
+        { name: 'renders the button trigger by default', triggerVariant: undefined, expectInput: false },
+        {
+            name: 'renders the button trigger for triggerVariant="button"',
+            triggerVariant: 'button',
+            expectInput: false,
+        },
+        {
+            name: 'renders the input-box trigger for triggerVariant="input"',
+            triggerVariant: 'input',
+            expectInput: true,
+        },
+    ] as const)('$name', async ({ triggerVariant, expectInput }) => {
+        renderWith(triggerVariant)
+
+        if (expectInput) {
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-filter-menu-input')).toBeInTheDocument()
+            })
+        } else {
+            await waitFor(() => {
+                expect(screen.getByTestId('taxonomic-popover-menu-trigger')).toBeInTheDocument()
+            })
+            expect(screen.queryByTestId('taxonomic-filter-menu-input')).not.toBeInTheDocument()
+        }
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -87,6 +87,7 @@ export function TaxonomicPropertyFilter({
     operatorAllowlist,
     endpointFilters,
     hogQLGlobals,
+    triggerVariant = 'button',
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
     const baseGroupTypes = taxonomicGroupTypes || DEFAULT_TAXONOMIC_GROUP_TYPES
@@ -325,13 +326,13 @@ export function TaxonomicPropertyFilter({
             endpointFilters={endpointFilters}
             hogQLGlobals={hogQLGlobals}
             enableKeywordShortcuts
-            triggerVariant="input"
+            triggerVariant={triggerVariant}
             triggerButtonProps={{
                 type: 'secondary',
                 size,
                 truncate: true,
                 sideIcon: null,
-                fullWidth: true,
+                fullWidth: triggerVariant === 'input',
                 icon: !valuePresent ? <IconPlusSmall /> : undefined,
             }}
         />

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -325,11 +325,13 @@ export function TaxonomicPropertyFilter({
             endpointFilters={endpointFilters}
             hogQLGlobals={hogQLGlobals}
             enableKeywordShortcuts
+            triggerVariant="input"
             triggerButtonProps={{
                 type: 'secondary',
                 size,
                 truncate: true,
                 sideIcon: null,
+                fullWidth: true,
                 icon: !valuePresent ? <IconPlusSmall /> : undefined,
             }}
         />

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -68,4 +68,10 @@ export interface PropertyFilterInternalProps {
     addFilterDocLink?: string
     endpointFilters?: Record<string, any>
     hogQLGlobals?: Record<string, any>
+    /**
+     * `'input'` renders the replay-style input-box add-filter trigger; `'button'`
+     * (the default) renders a button. Only has an effect on the rebuild menu
+     * (`TAXONOMIC_FILTER_MENU_REBUILD`).
+     */
+    triggerVariant?: 'button' | 'input'
 }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -13,7 +13,7 @@
 import { Autocomplete } from '@base-ui/react/autocomplete'
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { ReactElement, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MutableRefObject, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconCheck, IconChevronRight, IconClock, IconPinFilled } from '@posthog/icons'
 import {
@@ -136,8 +136,9 @@ export interface MenuFilterComboboxProps {
     title?: string
     /** Currently-committed selection — rendered with a checkmark + scrolled into view. */
     selectedEntry?: MenuFilterEntry | null
-    /** Shared ref to the search input so the popover can target it for focus. */
-    inputRef?: RefObject<HTMLInputElement | null>
+    /** Shared ref to the search input so the popover can target it for focus.
+     *  Mutable because the adapter assigns the input element onto it. */
+    inputRef?: MutableRefObject<HTMLInputElement | null>
     /**
      * Filter-icon menu button shown as the field's prefix in input-trigger
      * mode (where the field is a `LemonInput` in the trigger row). Omitted in
@@ -1026,7 +1027,7 @@ interface AutocompleteLemonInputProps {
     onValueChange: (value: string) => void
     /** Set alongside base-ui's own ref, so callers (popover `initialFocus`,
      *  category-select refocus) can reach the input element. */
-    sharedInputRef?: RefObject<HTMLInputElement | null>
+    sharedInputRef?: MutableRefObject<HTMLInputElement | null>
     prefix?: ReactElement
     suffix?: ReactElement
     placeholder?: string
@@ -1084,7 +1085,7 @@ function AutocompleteLemonInput({
                         ;(ref as React.MutableRefObject<HTMLInputElement | null>).current = el
                     }
                     if (sharedInputRef) {
-                        ;(sharedInputRef as React.MutableRefObject<HTMLInputElement | null>).current = el
+                        sharedInputRef.current = el
                     }
                 }
                 return (

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -1047,7 +1047,8 @@ interface AutocompleteLemonInputProps {
  * so we strip the props we drive ourselves and pass the rest through. Keeping the
  * adapter in one named place (rather than inline in the combobox render) means a
  * base-ui upgrade that changes how it drives the input has exactly one site to
- * update. Validated against `@base-ui/react` 1.5.
+ * update — the typed destructure below and the input-trigger tests are what guard
+ * the contract.
  */
 function AutocompleteLemonInput({
     value,

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -13,7 +13,7 @@
 import { Autocomplete } from '@base-ui/react/autocomplete'
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ReactElement, RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconCheck, IconChevronRight, IconClock, IconPinFilled } from '@posthog/icons'
 import {
@@ -35,6 +35,7 @@ import {
     Skeleton,
 } from '@posthog/quill'
 
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { surveyQuestionLabelsLogic } from 'scenes/surveys/surveyQuestionLabelsLogic'
 
@@ -135,6 +136,14 @@ export interface MenuFilterComboboxProps {
     title?: string
     /** Currently-committed selection — rendered with a checkmark + scrolled into view. */
     selectedEntry?: MenuFilterEntry | null
+    /** Shared ref to the search input so the popover can target it for focus. */
+    inputRef?: RefObject<HTMLInputElement | null>
+    /**
+     * Filter-icon menu button shown as the field's prefix in input-trigger
+     * mode (where the field is a `LemonInput` in the trigger row). Omitted in
+     * the popover/button mode, which renders the field as a quill input.
+     */
+    iconButton?: ReactElement
 }
 
 export function MenuFilterCombobox({
@@ -147,6 +156,8 @@ export function MenuFilterCombobox({
     onBack,
     title,
     selectedEntry,
+    inputRef: externalInputRef,
+    iconButton,
 }: MenuFilterComboboxProps): JSX.Element {
     // Sync our local query to the orchestrator's so remote-endpoint groups
     // (Pageview URLs, Screens, etc.) actually fetch — `useGroupList` reads
@@ -192,7 +203,8 @@ export function MenuFilterCombobox({
     // `filtered` (selected entry promoted to index 0) keeps the
     // highlight on the same row.
     const [highlightedEntry, setHighlightedEntry] = useState<MenuFilterEntry | null>(selectedEntry ?? null)
-    const inputRef = useRef<HTMLInputElement | null>(null)
+    const localInputRef = useRef<HTMLInputElement | null>(null)
+    const inputRef = externalInputRef ?? localInputRef
 
     // Stale events (event definitions not ingested within the staleness window)
     // are hidden by default to match the legacy picker. The opt-in is per-search:
@@ -791,6 +803,140 @@ export function MenuFilterCombobox({
         }
     }
 
+    // Category dropdown — picks the active scope; replaces the old flex-wrapped
+    // chip row. Only shown when there's more than the implicit "All" category.
+    const categorySelect =
+        showChips && categoryOptions.length > 1 ? (
+            <Select<DrillCategory>
+                value={activeChip}
+                onValueChange={(value) => {
+                    posthog.capture('taxonomic filter menu category changed', {
+                        fromChip: activeChip,
+                        toChip: value ?? 'all',
+                        via: 'dropdown',
+                    })
+                    setActiveChip(value ?? 'all')
+                    inputRef.current?.focus()
+                }}
+                itemToStringLabel={(value) => categoryOptions.find((o) => o.value === value)?.label ?? 'All'}
+            >
+                <SelectTrigger
+                    size="sm"
+                    aria-label="Filter category"
+                    data-attr="menu-filter-category"
+                    className="mr-0.5"
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                {/* Fit the list to its items: at least as wide as the trigger,
+                    grow to the longest option, capped at the available viewport
+                    width so it never overflows. */}
+                <SelectContent
+                    align="end"
+                    alignItemWithTrigger={false}
+                    className="w-max min-w-(--anchor-width) max-w-(--available-width)"
+                >
+                    <SelectGroup>
+                        {categoryOptions.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>
+                                {o.label}
+                            </SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SelectContent>
+            </Select>
+        ) : null
+
+    // The search field — a full-width row between the header and the
+    // list/preview, so the menu chrome wraps it (header above, results below).
+    // In input-trigger mode it's a LemonInput matching the surrounding scene's
+    // UI, with base-ui driving the inner input via `render`, the filter-icon
+    // button as its prefix and the category dropdown as its suffix. The button
+    // trigger keeps the quill input bar.
+    const searchField = iconButton ? (
+        <Autocomplete.Input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            render={(autoProps) => {
+                // base-ui hands us the input's controlled props (role,
+                // aria-activedescendant, keyboard nav, ref…). Route them to
+                // LemonInput's inner input; value/onChange round-trip through
+                // `searchQuery` so we don't fight LemonInput's string onChange.
+                const {
+                    ref,
+                    value: _baseValue,
+                    onChange: _baseOnChange,
+                    className: _baseClassName,
+                    onKeyDown: baseOnKeyDown,
+                    ...rest
+                } = autoProps as Record<string, unknown> & { ref?: React.Ref<HTMLInputElement> }
+                // Feed both base-ui's ref (focus/aria) and the shared
+                // `inputRef` (popover `initialFocus`, category-select refocus).
+                const setFieldRef = (el: HTMLInputElement | null): void => {
+                    if (typeof ref === 'function') {
+                        ref(el)
+                    } else if (ref) {
+                        ;(ref as React.MutableRefObject<HTMLInputElement | null>).current = el
+                    }
+                    ;(inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el
+                }
+                return (
+                    <LemonInput
+                        // eslint-disable-next-line react/no-unknown-property
+                        {...(rest as Record<string, unknown>)}
+                        inputRef={setFieldRef}
+                        size="small"
+                        fullWidth
+                        prefix={iconButton}
+                        suffix={categorySelect ?? undefined}
+                        data-attr="menu-filter-search"
+                        placeholder={activePlaceholder}
+                        value={searchQuery}
+                        onChange={(next) => setSearchQuery(next)}
+                        onKeyDown={(e) => {
+                            handleInputKeyDown(e)
+                            if (!e.defaultPrevented) {
+                                ;(baseOnKeyDown as ((e: React.KeyboardEvent<HTMLInputElement>) => void) | undefined)?.(
+                                    e
+                                )
+                            }
+                        }}
+                        onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                            pastedCharsRef.current += e.clipboardData.getData('text').length
+                        }}
+                    />
+                )
+            }}
+        />
+    ) : (
+        <>
+            <Autocomplete.Input
+                render={
+                    <InputGroupInput
+                        ref={inputRef}
+                        autoFocus
+                        data-attr="menu-filter-search"
+                        placeholder={activePlaceholder}
+                        onKeyDown={handleInputKeyDown}
+                        onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
+                            pastedCharsRef.current += e.clipboardData.getData('text').length
+                        }}
+                    />
+                }
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            {categorySelect && <InputGroupAddon align="inline-end">{categorySelect}</InputGroupAddon>}
+        </>
+    )
+
+    // Full-width input row, sitting between the header and the list/preview
+    // columns. The LemonInput (input-trigger) is full width on its own; the
+    // quill input needs the InputGroup wrapper.
+    const searchFieldRow = (
+        <div className="p-2 border-b">{iconButton ? searchField : <InputGroup>{searchField}</InputGroup>}</div>
+    )
+
     return (
         <div className="flex flex-col flex-1 min-h-0">
             <MenuFilterHeader
@@ -816,80 +962,12 @@ export function MenuFilterCombobox({
                 itemToStringValue={(entry: MenuFilterEntry) => entry.name}
                 onItemHighlighted={(entry) => setHighlightedEntry((entry as MenuFilterEntry | undefined) ?? null)}
             >
+                {searchFieldRow}
                 {/* Flex layout: list flexes, separator is 1px, preview is a
                     fixed 300px column. `shrink-0` on the preview keeps it
                     stable when the popover (or list contents) change width. */}
                 <div className="flex flex-1 min-h-0">
                     <div className="flex flex-col flex-1 min-w-0 min-h-0">
-                        <div className="p-2 border-b">
-                            <InputGroup>
-                                <Autocomplete.Input
-                                    render={
-                                        <InputGroupInput
-                                            ref={inputRef}
-                                            autoFocus
-                                            data-attr="menu-filter-search"
-                                            placeholder={activePlaceholder}
-                                            onKeyDown={handleInputKeyDown}
-                                            onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                                                pastedCharsRef.current += e.clipboardData.getData('text').length
-                                            }}
-                                        />
-                                    }
-                                    value={searchQuery}
-                                    onChange={(e) => setSearchQuery(e.target.value)}
-                                />
-                                {/* Category dropdown — trailing addon. Picks
-                                    the active scope; replaces the old
-                                    flex-wrapped chip row. Only shown when
-                                    there's more than the implicit "All"
-                                    category to choose between. */}
-                                {showChips && categoryOptions.length > 1 && (
-                                    <InputGroupAddon align="inline-end">
-                                        <Select<DrillCategory>
-                                            value={activeChip}
-                                            onValueChange={(value) => {
-                                                posthog.capture('taxonomic filter menu category changed', {
-                                                    fromChip: activeChip,
-                                                    toChip: value ?? 'all',
-                                                    via: 'dropdown',
-                                                })
-                                                setActiveChip(value ?? 'all')
-                                                inputRef.current?.focus()
-                                            }}
-                                            itemToStringLabel={(value) =>
-                                                categoryOptions.find((o) => o.value === value)?.label ?? 'All'
-                                            }
-                                        >
-                                            <SelectTrigger
-                                                size="sm"
-                                                aria-label="Filter category"
-                                                data-attr="menu-filter-category"
-                                                className="mr-0.5"
-                                            >
-                                                <SelectValue />
-                                            </SelectTrigger>
-                                            {/* Fit the list to its items: at least as wide as the
-                                                trigger, grow to the longest option, capped at the
-                                                available viewport width so it never overflows. */}
-                                            <SelectContent
-                                                align="end"
-                                                alignItemWithTrigger={false}
-                                                className="w-max min-w-(--anchor-width) max-w-(--available-width)"
-                                            >
-                                                <SelectGroup>
-                                                    {categoryOptions.map((o) => (
-                                                        <SelectItem key={o.value} value={o.value}>
-                                                            {o.label}
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectGroup>
-                                            </SelectContent>
-                                        </Select>
-                                    </InputGroupAddon>
-                                )}
-                            </InputGroup>
-                        </div>
                         {!drillItems &&
                             targetGroups.map((g) => (
                                 <Fetcher

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -854,58 +854,17 @@ export function MenuFilterCombobox({
     // button as its prefix and the category dropdown as its suffix. The button
     // trigger keeps the quill input bar.
     const searchField = iconButton ? (
-        <Autocomplete.Input
+        <AutocompleteLemonInput
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            render={(autoProps) => {
-                // base-ui hands us the input's controlled props (role,
-                // aria-activedescendant, keyboard nav, ref…). Route them to
-                // LemonInput's inner input; value/onChange round-trip through
-                // `searchQuery` so we don't fight LemonInput's string onChange.
-                const {
-                    ref,
-                    value: _baseValue,
-                    onChange: _baseOnChange,
-                    className: _baseClassName,
-                    onKeyDown: baseOnKeyDown,
-                    ...rest
-                } = autoProps as Record<string, unknown> & { ref?: React.Ref<HTMLInputElement> }
-                // Feed both base-ui's ref (focus/aria) and the shared
-                // `inputRef` (popover `initialFocus`, category-select refocus).
-                const setFieldRef = (el: HTMLInputElement | null): void => {
-                    if (typeof ref === 'function') {
-                        ref(el)
-                    } else if (ref) {
-                        ;(ref as React.MutableRefObject<HTMLInputElement | null>).current = el
-                    }
-                    ;(inputRef as React.MutableRefObject<HTMLInputElement | null>).current = el
-                }
-                return (
-                    <LemonInput
-                        // eslint-disable-next-line react/no-unknown-property
-                        {...(rest as Record<string, unknown>)}
-                        inputRef={setFieldRef}
-                        size="small"
-                        fullWidth
-                        prefix={iconButton}
-                        suffix={categorySelect ?? undefined}
-                        data-attr="menu-filter-search"
-                        placeholder={activePlaceholder}
-                        value={searchQuery}
-                        onChange={(next) => setSearchQuery(next)}
-                        onKeyDown={(e) => {
-                            handleInputKeyDown(e)
-                            if (!e.defaultPrevented) {
-                                ;(baseOnKeyDown as ((e: React.KeyboardEvent<HTMLInputElement>) => void) | undefined)?.(
-                                    e
-                                )
-                            }
-                        }}
-                        onPaste={(e: React.ClipboardEvent<HTMLInputElement>) => {
-                            pastedCharsRef.current += e.clipboardData.getData('text').length
-                        }}
-                    />
-                )
+            onValueChange={setSearchQuery}
+            sharedInputRef={inputRef}
+            prefix={iconButton}
+            suffix={categorySelect ?? undefined}
+            placeholder={activePlaceholder}
+            data-attr="menu-filter-search"
+            onKeyDown={handleInputKeyDown}
+            onPaste={(e) => {
+                pastedCharsRef.current += e.clipboardData.getData('text').length
             }}
         />
     ) : (
@@ -1059,6 +1018,101 @@ export function MenuFilterCombobox({
                 </div>
             </Autocomplete.Root>
         </div>
+    )
+}
+
+interface AutocompleteLemonInputProps {
+    value: string
+    onValueChange: (value: string) => void
+    /** Set alongside base-ui's own ref, so callers (popover `initialFocus`,
+     *  category-select refocus) can reach the input element. */
+    sharedInputRef?: RefObject<HTMLInputElement | null>
+    prefix?: ReactElement
+    suffix?: ReactElement
+    placeholder?: string
+    'data-attr'?: string
+    /** Runs before base-ui's own keydown handler; base-ui's runs only when this
+     *  one didn't `preventDefault` (so Esc/Enter/Tab can take precedence over the
+     *  autocomplete's arrow-key navigation). */
+    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+    onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void
+}
+
+/**
+ * The single place that bridges base-ui's `Autocomplete.Input` onto a
+ * `LemonInput`. base-ui drives a controlled `<input>` through its `render` prop —
+ * value/onChange/ref/keyboard plus the combobox a11y attrs (`role`,
+ * `aria-activedescendant`, `aria-expanded`, …). `LemonInput`'s typed props don't
+ * include those a11y attrs but its inner `<input>` forwards unrecognised props,
+ * so we strip the props we drive ourselves and pass the rest through. Keeping the
+ * adapter in one named place (rather than inline in the combobox render) means a
+ * base-ui upgrade that changes how it drives the input has exactly one site to
+ * update. Validated against `@base-ui/react` 1.5.
+ */
+function AutocompleteLemonInput({
+    value,
+    onValueChange,
+    sharedInputRef,
+    prefix,
+    suffix,
+    placeholder,
+    onKeyDown,
+    onPaste,
+    'data-attr': dataAttr,
+}: AutocompleteLemonInputProps): JSX.Element {
+    return (
+        <Autocomplete.Input
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            render={(autoProps) => {
+                // Type the incoming contract as input attributes (not `any`), then
+                // peel off the props we own — base-ui's value/onChange/className,
+                // its ref (merged below), and its keydown (composed below).
+                const {
+                    ref,
+                    value: _baseValue,
+                    onChange: _baseOnChange,
+                    className: _baseClassName,
+                    onKeyDown: baseOnKeyDown,
+                    ...baseInputAttrs
+                } = autoProps as React.InputHTMLAttributes<HTMLInputElement> & { ref?: React.Ref<HTMLInputElement> }
+                const setRef = (el: HTMLInputElement | null): void => {
+                    if (typeof ref === 'function') {
+                        ref(el)
+                    } else if (ref) {
+                        ;(ref as React.MutableRefObject<HTMLInputElement | null>).current = el
+                    }
+                    if (sharedInputRef) {
+                        ;(sharedInputRef as React.MutableRefObject<HTMLInputElement | null>).current = el
+                    }
+                }
+                return (
+                    <LemonInput
+                        // The remaining base-ui attrs (role, aria-activedescendant…)
+                        // are valid `<input>` attributes LemonInput forwards but
+                        // doesn't type — the one boundary cast the bridge needs.
+                        // eslint-disable-next-line react/no-unknown-property
+                        {...(baseInputAttrs as Record<string, unknown>)}
+                        inputRef={setRef}
+                        size="small"
+                        fullWidth
+                        prefix={prefix}
+                        suffix={suffix}
+                        data-attr={dataAttr}
+                        placeholder={placeholder}
+                        value={value}
+                        onChange={(next) => onValueChange(next)}
+                        onKeyDown={(e) => {
+                            onKeyDown?.(e)
+                            if (!e.defaultPrevented) {
+                                baseOnKeyDown?.(e)
+                            }
+                        }}
+                        onPaste={onPaste}
+                    />
+                )
+            }}
+        />
     )
 }
 

--- a/frontend/src/lib/components/TaxonomicFilter/menu/InputTrigger.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/InputTrigger.tsx
@@ -36,7 +36,15 @@ export function MenuInputTrigger({
 }: MenuInputTriggerProps): JSX.Element {
     if (spacerOnly) {
         return (
-            <LemonInput fullWidth={fullWidth} size="small" disabled placeholder={placeholder} className="invisible" />
+            <div aria-hidden="true">
+                <LemonInput
+                    fullWidth={fullWidth}
+                    size="small"
+                    disabled
+                    placeholder={placeholder}
+                    className="invisible"
+                />
+            </div>
         )
     }
     return (

--- a/frontend/src/lib/components/TaxonomicFilter/menu/InputTrigger.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/InputTrigger.tsx
@@ -1,0 +1,54 @@
+import { ReactElement } from 'react'
+
+/**
+ * Replay-style trigger for the rebuilt taxonomic menu: a LemonInput search box
+ * with a leading filter-icon button. Focusing/typing in the box opens the
+ * combobox; clicking the icon opens the dropdown menu.
+ *
+ * LemonInput (not quill) so the trigger matches the surrounding scene's UI. The
+ * combobox internals stay quill; when it opens, the popover panel renders its
+ * own live search field (header above, list below) positioned over this row, so
+ * here we render an invisible same-height spacer to hold the anchor in place
+ * and avoid a layout shift behind the panel.
+ */
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+
+export interface MenuInputTriggerProps {
+    iconButton: ReactElement
+    placeholder?: string
+    value?: string
+    onChange?: (value: string) => void
+    onFocus?: () => void
+    fullWidth?: boolean
+    /** While the combobox panel is open it owns the visible field; the row
+     *  holds an invisible spacer so the trigger anchor and layout don't shift. */
+    spacerOnly?: boolean
+}
+
+export function MenuInputTrigger({
+    iconButton,
+    placeholder,
+    value,
+    onChange,
+    onFocus,
+    fullWidth = true,
+    spacerOnly = false,
+}: MenuInputTriggerProps): JSX.Element {
+    if (spacerOnly) {
+        return (
+            <LemonInput fullWidth={fullWidth} size="small" disabled placeholder={placeholder} className="invisible" />
+        )
+    }
+    return (
+        <LemonInput
+            fullWidth={fullWidth}
+            size="small"
+            prefix={iconButton}
+            data-attr="taxonomic-filter-menu-input"
+            placeholder={placeholder}
+            value={value}
+            onChange={onChange}
+            onFocus={onFocus}
+        />
+    )
+}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.inputTrigger.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.inputTrigger.test.tsx
@@ -93,6 +93,9 @@ describe('TaxonomicFilterMenu input trigger', () => {
         // Typing in the box replaces "New filter…", so it must not be offered.
         expect(screen.queryByTestId('taxonomic-filter-menu-new')).not.toBeInTheDocument()
         expect(screen.queryByText('New filter…')).not.toBeInTheDocument()
+        // The icon opens the menu, NOT the combobox — guards the `stopPropagation`
+        // that keeps the click from bubbling to the input's focus handler.
+        expect(screen.queryByTestId('menu-filter-search')).not.toBeInTheDocument()
     })
 
     it('opens the combobox search panel when the input is focused', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.inputTrigger.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.inputTrigger.test.tsx
@@ -1,0 +1,128 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { performQuery } from '~/queries/query'
+import { initKeaTests } from '~/test/init'
+
+import { TaxonomicFilterHeadless } from '../headless'
+import { __clearTaxonomicResourceCache } from '../hooks/useTaxonomicResource'
+import { TaxonomicFilterGroupType } from '../types'
+import { TaxonomicFilterMenu } from './TaxonomicFilterMenu'
+
+jest.mock('~/queries/query', () => ({
+    performQuery: jest.fn(),
+}))
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+jest.mock('lib/api', () => {
+    const emptyPaginated = (): Promise<{ results: any[]; count: number; next: null }> =>
+        Promise.resolve({ results: [], count: 0, next: null })
+    return {
+        __esModule: true,
+        default: {
+            get: jest.fn().mockImplementation(emptyPaginated),
+            actions: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dataWarehouseSavedQueries: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dataWarehouseTables: { list: jest.fn().mockImplementation(emptyPaginated) },
+            queryTabState: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dashboards: { list: jest.fn().mockImplementation(emptyPaginated) },
+            cohorts: { listPaginated: jest.fn().mockImplementation(emptyPaginated) },
+        },
+    }
+})
+
+const apiGet = jest.requireMock('lib/api').default.get as jest.MockedFunction<any>
+
+const GROUP_TYPES = [
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.PersonProperties,
+    TaxonomicFilterGroupType.HogQLExpression,
+]
+
+function renderInputTriggerMenu(): ReturnType<typeof render> {
+    return render(
+        <Provider>
+            <TaxonomicFilterHeadless.Root taxonomicGroupTypes={GROUP_TYPES} onChange={jest.fn()}>
+                <TaxonomicFilterMenu triggerVariant="input" />
+            </TaxonomicFilterHeadless.Root>
+        </Provider>
+    )
+}
+
+describe('TaxonomicFilterMenu input trigger', () => {
+    beforeEach(() => {
+        __clearTaxonomicResourceCache()
+        apiGet.mockReset()
+        apiGet.mockResolvedValue({ results: [], count: 0, next: null })
+        ;(performQuery as jest.Mock).mockResolvedValue({ tables: {}, joins: [] })
+        useMocks({})
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => cleanup())
+
+    it('renders a text input and a filter-icon menu button instead of a single button', () => {
+        renderInputTriggerMenu()
+
+        expect(screen.getByTestId('taxonomic-filter-menu-input')).toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Open filter menu' })).toBeInTheDocument()
+    })
+
+    it('opens the dropdown menu (without a redundant "New filter…" item) when the filter icon is clicked', async () => {
+        renderInputTriggerMenu()
+
+        await userEvent.click(screen.getByRole('button', { name: 'Open filter menu' }))
+
+        // The menu opens — its always-present "HogQL expression" entry confirms it.
+        await waitFor(() => {
+            expect(screen.getByTestId('taxonomic-filter-menu-hogql')).toBeInTheDocument()
+        })
+        // Typing in the box replaces "New filter…", so it must not be offered.
+        expect(screen.queryByTestId('taxonomic-filter-menu-new')).not.toBeInTheDocument()
+        expect(screen.queryByText('New filter…')).not.toBeInTheDocument()
+    })
+
+    it('opens the combobox search panel when the input is focused', async () => {
+        renderInputTriggerMenu()
+
+        await userEvent.click(screen.getByTestId('taxonomic-filter-menu-input'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('menu-filter-search')).toBeInTheDocument()
+        })
+        // The dropdown menu must not also be open — focusing the input is the
+        // combobox path, not the menu path.
+        expect(screen.queryByTestId('taxonomic-filter-menu-hogql')).not.toBeInTheDocument()
+    })
+
+    it('keeps a single search input — the combobox chrome opens around the trigger box, not a second mirrored input', async () => {
+        renderInputTriggerMenu()
+
+        await userEvent.click(screen.getByTestId('taxonomic-filter-menu-input'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('menu-filter-search')).toBeInTheDocument()
+        })
+        // The placeholder trigger input is replaced by the search field, not
+        // mirrored alongside it — so there's a single live input, not two.
+        expect(screen.queryByTestId('taxonomic-filter-menu-input')).not.toBeInTheDocument()
+        // The search field renders in the trigger row beside the filter-icon
+        // button (chrome opens around it), not adrift in the popover.
+        const iconButton = screen.getByRole('button', { name: 'Open filter menu' })
+        const searchInput = screen.getByTestId('menu-filter-search')
+        expect(iconButton.closest('.LemonInput')).toContainElement(searchInput)
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -25,7 +25,7 @@ import { useValues } from 'kea'
 import posthog from 'posthog-js'
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconChevronRight } from '@posthog/icons'
+import { IconChevronRight, IconFilter } from '@posthog/icons'
 import {
     Button,
     cn,
@@ -40,6 +40,7 @@ import {
 } from '@posthog/quill'
 
 import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { isDefinitionStale } from 'lib/utils/definitions'
 
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
@@ -53,6 +54,7 @@ import { filterPinnedForContext, filterRecentsForContext } from '../utils/sugges
 import { MenuFilterCombobox } from './Combobox'
 import { MenuFilterDwhConfig } from './DwhFlow'
 import { MenuFilterHogQLEditor } from './HogQLEditor'
+import { MenuInputTrigger } from './InputTrigger'
 import { taxonomicTriggerWrapperClassName } from './triggerLayout'
 import {
     CommitFn,
@@ -106,6 +108,22 @@ export interface TaxonomicFilterMenuProps {
      * callers don't need to add another positioned ancestor of their own.
      */
     triggerAccessory?: import('react').ReactNode
+    /**
+     * Trigger presentation. `'button'` (default) is the single dropdown
+     * button. `'input'` renders a replay-style search box with a leading
+     * filter-icon button: focusing/typing in the box opens the combobox,
+     * clicking the icon opens the dropdown menu. Only takes effect while
+     * nothing is `selected` (the add-filter case) — an existing selection
+     * still renders the button so its label is visible.
+     */
+    triggerVariant?: 'button' | 'input'
+    /**
+     * Where `defaultOpen` lands. Defaults to `resolveOpenState()` (menu when
+     * nothing is selected). The input trigger uses this so an open driven by
+     * the search box arrives directly on the combobox while one driven by the
+     * filter icon arrives on the dropdown menu.
+     */
+    defaultOpenState?: 'menu' | 'combobox'
 }
 
 export interface TriggerState {
@@ -122,6 +140,18 @@ type MenuOption = 'new' | 'recent' | 'pinned' | 'dwh' | 'hogql'
 // first trigger click). Heuristic only — shared across all triggers.
 let lastMenuClosedAtMs: number | null = null
 const QUICK_REOPEN_MS = 3000
+
+/** Distance from the input-trigger panel's top to its search field: the
+ *  `MenuFilterHeader` (px-3 py-2 + sm button + border ≈ 41px) plus the input
+ *  row's top padding (p-2 = 8px). Used to shift the panel up so the field lands
+ *  over the trigger row. */
+const INPUT_TRIGGER_PANEL_HEADER_OFFSET = 49
+
+/** The input-trigger panel's search field is inset from the panel's left edge
+ *  by its border + the input row's left padding. Shift the panel left by this
+ *  much so the field's box lands over the trigger box — the input appears not
+ *  to move horizontally, only widen. */
+const INPUT_TRIGGER_PANEL_LEFT_INSET = 9
 
 /** Mirrors legacy `taxonomicFilterLogic`: staleness only applies to event /
  *  custom-event definitions that carry `last_seen_at`; `undefined` for every
@@ -150,8 +180,10 @@ export function TaxonomicFilterMenu({
     fullWidthTrigger = false,
     defaultOpen = false,
     triggerAccessory,
+    triggerVariant = 'button',
+    defaultOpenState,
 }: TaxonomicFilterMenuProps): JSX.Element {
-    const { groups, selectItem, inputProps, searchQuery, selectingKeyOnly, excludedOperators } =
+    const { groups, selectItem, inputProps, searchQuery, setSearchQuery, selectingKeyOnly, excludedOperators } =
         useTaxonomicFilterContext()
     const [state, setState] = useState<MenuFilterState>({ kind: 'closed' })
 
@@ -263,7 +295,13 @@ export function TaxonomicFilterMenu({
     // Runs once — opening is a one-shot mount concern, not reactive.
     useEffect(() => {
         if (defaultOpen) {
-            setState(resolveOpenState())
+            setState(
+                defaultOpenState === 'combobox'
+                    ? { kind: 'combobox', drillTo: 'all' }
+                    : defaultOpenState === 'menu'
+                      ? { kind: 'menu' }
+                      : resolveOpenState()
+            )
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
@@ -372,6 +410,18 @@ export function TaxonomicFilterMenu({
     const triggerEl: ReactElement =
         typeof trigger === 'function' ? trigger(triggerState) : (trigger ?? <Button variant="outline">{label}</Button>)
 
+    // Replay-style input trigger — only while nothing is selected, so an
+    // existing selection keeps showing its label in the button. The icon is
+    // the dropdown-menu anchor; the input opens (and seeds) the combobox.
+    const useInputTrigger = triggerVariant === 'input' && !selected
+    const inputTriggerPlaceholder = triggerLabel || inputProps.placeholder || 'Add filter'
+
+    // When the input-trigger combobox is open, the popover panel renders the
+    // live search field (header above it, results below) and is shifted up so
+    // that field lands over the trigger row — the chrome wraps the input. The
+    // shared ref lets the popover focus that field on open.
+    const comboboxInputRef = useRef<HTMLInputElement | null>(null)
+
     // -- Popover open derives from state. The dropdown menu is a separate
     // overlay (DropdownMenu); the popover is open for any non-menu,
     // non-closed kind.
@@ -383,6 +433,31 @@ export function TaxonomicFilterMenu({
     // the dialog returns to `dwh-pick` and the popover re-opens at the
     // table list.
     const popoverOpen = state.kind === 'combobox' || state.kind === 'dwh-pick' || state.kind === 'hogql-edit'
+
+    // The combobox (the only popover state that renders a search field) is what
+    // hosts the portaled input. In those states the trigger box yields its
+    // input slot; otherwise it shows its own plain input.
+    const externalInput = useInputTrigger && (state.kind === 'combobox' || state.kind === 'dwh-pick')
+
+    // Filter-icon menu anchor, styled to match the scene (LemonButton). Lives
+    // as the field's prefix — in the resting trigger box, and in the combobox's
+    // portaled field while open — so it stays put as the menu opens around it.
+    const inputTriggerIcon = (
+        <DropdownMenuTrigger
+            render={
+                <LemonButton
+                    size="small"
+                    icon={<IconFilter />}
+                    aria-label="Open filter menu"
+                    data-attr="taxonomic-filter-menu-trigger"
+                    // Stop the click bubbling to the LemonInput wrapper, whose
+                    // onClick focuses the input — that would open the combobox
+                    // instead of the icon's dropdown menu.
+                    onClick={(e) => e.stopPropagation()}
+                />
+            }
+        />
+    )
 
     // Manual outside-click handling. base-ui Popover's automatic dismiss
     // can't reliably distinguish a click on the visible trigger (the
@@ -522,7 +597,28 @@ export function TaxonomicFilterMenu({
                 }}
             >
                 <span ref={triggerWrapRef} className={taxonomicTriggerWrapperClassName(fullWidthTrigger)}>
-                    <DropdownMenuTrigger render={triggerEl} data-attr="taxonomic-filter-menu-trigger" />
+                    {useInputTrigger ? (
+                        <MenuInputTrigger
+                            iconButton={inputTriggerIcon}
+                            fullWidth={fullWidthTrigger}
+                            placeholder={inputTriggerPlaceholder}
+                            value={searchQuery}
+                            spacerOnly={externalInput}
+                            onChange={(next) => {
+                                setSearchQuery(next)
+                                if (state.kind !== 'combobox') {
+                                    openCombobox('all')
+                                }
+                            }}
+                            onFocus={() => {
+                                if (state.kind === 'closed') {
+                                    openCombobox('all')
+                                }
+                            }}
+                        />
+                    ) : (
+                        <DropdownMenuTrigger render={triggerEl} data-attr="taxonomic-filter-menu-trigger" />
+                    )}
                     <PopoverTrigger
                         render={<span aria-hidden tabIndex={-1} className="absolute inset-0 pointer-events-none" />}
                     />
@@ -531,8 +627,30 @@ export function TaxonomicFilterMenu({
                 <PopoverContent
                     align="start"
                     side="bottom"
-                    sideOffset={4}
-                    container={popoverContainer}
+                    // Input trigger: shift the panel up by (trigger height +
+                    // header + input-row padding) so the panel's search field
+                    // lands over the trigger row — header pops above, results
+                    // below, the input appears to stay put and just widen. Keep
+                    // the side fixed so it can't flip away from that alignment.
+                    // Button trigger: a normal dropdown below the button.
+                    sideOffset={
+                        externalInput ? ({ anchor }) => -(anchor.height + INPUT_TRIGGER_PANEL_HEADER_OFFSET) : 4
+                    }
+                    // Pull the panel left so its inset search field aligns with
+                    // the trigger box horizontally (input appears not to move).
+                    alignOffset={externalInput ? -INPUT_TRIGGER_PANEL_LEFT_INSET : 0}
+                    // Input trigger: pin both axes so the field stays over the
+                    // trigger (no collision shift can break the alignment).
+                    // Button trigger: keep it on the vertical axis, never beside.
+                    collisionAvoidance={
+                        externalInput
+                            ? { side: 'none', align: 'none' }
+                            : { side: 'flip', align: 'shift', fallbackAxisSide: 'none' }
+                    }
+                    container={popoverContainer ?? undefined}
+                    // Focus the panel's search field on open (it's outside the
+                    // popover's default focusable flow until rendered).
+                    initialFocus={externalInput ? comboboxInputRef : undefined}
                     className={cn(
                         'p-0 gap-0 overflow-hidden flex flex-col w-[calc(100%_-_2rem)] @[720px]/main-content-container:w-[720px] h-[400px]'
                     )}
@@ -559,6 +677,8 @@ export function TaxonomicFilterMenu({
                             selectedEntry={selected ?? null}
                             onCommit={handleCommit}
                             onBack={openMenu}
+                            inputRef={comboboxInputRef}
+                            iconButton={useInputTrigger ? inputTriggerIcon : undefined}
                         />
                     )}
                     {(state.kind === 'dwh-pick' || state.kind === 'dwh-config') && (
@@ -576,6 +696,8 @@ export function TaxonomicFilterMenu({
                             }
                             onCommit={(entry) => openDwhConfig(entry.item, entry.group, 'dwh-pick')}
                             onBack={openMenu}
+                            inputRef={comboboxInputRef}
+                            iconButton={useInputTrigger ? inputTriggerIcon : undefined}
                         />
                     )}
                     {state.kind === 'hogql-edit' && (
@@ -612,16 +734,20 @@ export function TaxonomicFilterMenu({
                 />
             )}
             <DropdownMenuContent align="start" className="min-w-[240px]">
-                <DropdownMenuItem
-                    onClick={() => selectMenuOption('new', () => openCombobox('all'))}
-                    data-attr="taxonomic-filter-menu-new"
-                >
-                    New filter…
-                    <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
-                </DropdownMenuItem>
+                {/* The input-trigger box already does "type to make a new filter",
+                    so the explicit "New filter…" row would be redundant there. */}
+                {!useInputTrigger && (
+                    <DropdownMenuItem
+                        onClick={() => selectMenuOption('new', () => openCombobox('all'))}
+                        data-attr="taxonomic-filter-menu-new"
+                    >
+                        New filter…
+                        <IconChevronRight className="ml-auto size-3.5 text-tertiary" />
+                    </DropdownMenuItem>
+                )}
                 {recentEntries.length > 0 && (
                     <>
-                        <DropdownMenuSeparator />
+                        {!useInputTrigger && <DropdownMenuSeparator />}
                         <DropdownMenuItem onClick={() => selectMenuOption('recent', () => openCombobox('recent'))}>
                             Recent
                             <IconChevronRight className="ml-auto size-3.5 text-tertiary" />

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -141,17 +141,25 @@ type MenuOption = 'new' | 'recent' | 'pinned' | 'dwh' | 'hogql'
 let lastMenuClosedAtMs: number | null = null
 const QUICK_REOPEN_MS = 3000
 
-/** Distance from the input-trigger panel's top to its search field: the
- *  `MenuFilterHeader` (px-3 py-2 + sm button + border ≈ 41px) plus the input
- *  row's top padding (p-2 = 8px). Used to shift the panel up so the field lands
- *  over the trigger row. */
-const INPUT_TRIGGER_PANEL_HEADER_OFFSET = 49
+// The input-trigger panel is shifted up + left so its search field lands over
+// the trigger row (the input appears to stay put and only widen). The shift
+// equals the field's offset from the panel's top-left, summed from the pieces
+// that produce it — kept as named parts so a change to `MenuFilterHeader`'s
+// spacing or the input row's padding is visibly the thing to keep in sync here.
+const MENU_HEADER_PADDING_Y_PX = 16 // MenuFilterHeader `py-2` (top + bottom)
+const MENU_HEADER_BUTTON_HEIGHT_PX = 24 // "Go back" Button `size="sm"` (h-6)
+const MENU_HEADER_BORDER_PX = 1 // MenuFilterHeader `border-b`
+const SEARCH_ROW_PADDING_PX = 8 // search-field row `p-2` (one side)
+const PANEL_BORDER_PX = 1 // PopoverContent border
 
-/** The input-trigger panel's search field is inset from the panel's left edge
- *  by its border + the input row's left padding. Shift the panel left by this
- *  much so the field's box lands over the trigger box — the input appears not
- *  to move horizontally, only widen. */
-const INPUT_TRIGGER_PANEL_LEFT_INSET = 9
+/** Panel-top → search-field-top: the header (padding + button + border) plus the
+ *  search row's top padding. */
+const INPUT_TRIGGER_PANEL_HEADER_OFFSET =
+    MENU_HEADER_PADDING_Y_PX + MENU_HEADER_BUTTON_HEIGHT_PX + MENU_HEADER_BORDER_PX + SEARCH_ROW_PADDING_PX
+
+/** Panel-left → search-field-left: the panel border plus the search row's left
+ *  padding. */
+const INPUT_TRIGGER_PANEL_LEFT_INSET = PANEL_BORDER_PX + SEARCH_ROW_PADDING_PX
 
 /** Mirrors legacy `taxonomicFilterLogic`: staleness only applies to event /
  *  custom-event definitions that carry `last_seen_at`; `undefined` for every
@@ -434,10 +442,12 @@ export function TaxonomicFilterMenu({
     // table list.
     const popoverOpen = state.kind === 'combobox' || state.kind === 'dwh-pick' || state.kind === 'hogql-edit'
 
-    // The combobox (the only popover state that renders a search field) is what
-    // hosts the portaled input. In those states the trigger box yields its
-    // input slot; otherwise it shows its own plain input.
-    const externalInput = useInputTrigger && (state.kind === 'combobox' || state.kind === 'dwh-pick')
+    // `combobox` and `dwh-pick` render a search-field row, so in input-trigger
+    // mode the panel is shifted to overlay that field on the trigger box (and the
+    // trigger yields to an invisible spacer). `hogql-edit` is intentionally
+    // excluded: the code editor has no search-field row to align to, so it opens
+    // as a normal dropdown below the trigger.
+    const comboboxOverlaysTrigger = useInputTrigger && (state.kind === 'combobox' || state.kind === 'dwh-pick')
 
     // Filter-icon menu anchor, styled to match the scene (LemonButton). Lives
     // as the field's prefix — in the resting trigger box, and in the combobox's
@@ -603,7 +613,7 @@ export function TaxonomicFilterMenu({
                             fullWidth={fullWidthTrigger}
                             placeholder={inputTriggerPlaceholder}
                             value={searchQuery}
-                            spacerOnly={externalInput}
+                            spacerOnly={comboboxOverlaysTrigger}
                             onChange={(next) => {
                                 setSearchQuery(next)
                                 if (state.kind !== 'combobox') {
@@ -634,23 +644,25 @@ export function TaxonomicFilterMenu({
                     // the side fixed so it can't flip away from that alignment.
                     // Button trigger: a normal dropdown below the button.
                     sideOffset={
-                        externalInput ? ({ anchor }) => -(anchor.height + INPUT_TRIGGER_PANEL_HEADER_OFFSET) : 4
+                        comboboxOverlaysTrigger
+                            ? ({ anchor }) => -(anchor.height + INPUT_TRIGGER_PANEL_HEADER_OFFSET)
+                            : 4
                     }
                     // Pull the panel left so its inset search field aligns with
                     // the trigger box horizontally (input appears not to move).
-                    alignOffset={externalInput ? -INPUT_TRIGGER_PANEL_LEFT_INSET : 0}
+                    alignOffset={comboboxOverlaysTrigger ? -INPUT_TRIGGER_PANEL_LEFT_INSET : 0}
                     // Input trigger: pin both axes so the field stays over the
                     // trigger (no collision shift can break the alignment).
                     // Button trigger: keep it on the vertical axis, never beside.
                     collisionAvoidance={
-                        externalInput
+                        comboboxOverlaysTrigger
                             ? { side: 'none', align: 'none' }
                             : { side: 'flip', align: 'shift', fallbackAxisSide: 'none' }
                     }
                     container={popoverContainer ?? undefined}
                     // Focus the panel's search field on open (it's outside the
                     // popover's default focusable flow until rendered).
-                    initialFocus={externalInput ? comboboxInputRef : undefined}
+                    initialFocus={comboboxOverlaysTrigger ? comboboxInputRef : undefined}
                     className={cn(
                         'p-0 gap-0 overflow-hidden flex flex-col w-[calc(100%_-_2rem)] @[720px]/main-content-container:w-[720px] h-[400px]'
                     )}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -651,12 +651,15 @@ export function TaxonomicFilterMenu({
                     // Pull the panel left so its inset search field aligns with
                     // the trigger box horizontally (input appears not to move).
                     alignOffset={comboboxOverlaysTrigger ? -INPUT_TRIGGER_PANEL_LEFT_INSET : 0}
-                    // Input trigger: pin both axes so the field stays over the
-                    // trigger (no collision shift can break the alignment).
+                    // Input trigger: pin the vertical axis so the field stays over
+                    // the trigger row, but allow horizontal `shift` so the wide
+                    // panel slides left to stay on-screen when the trigger sits near
+                    // the right edge (e.g. web-analytics filters) — losing a few px
+                    // of horizontal alignment there beats clipping off-screen.
                     // Button trigger: keep it on the vertical axis, never beside.
                     collisionAvoidance={
                         comboboxOverlaysTrigger
-                            ? { side: 'none', align: 'none' }
+                            ? { side: 'none', align: 'shift' }
                             : { side: 'flip', align: 'shift', fallbackAxisSide: 'none' }
                     }
                     container={popoverContainer ?? undefined}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -152,12 +152,12 @@ const MENU_HEADER_BORDER_PX = 1 // MenuFilterHeader `border-b`
 const SEARCH_ROW_PADDING_PX = 8 // search-field row `p-2` (one side)
 const PANEL_BORDER_PX = 1 // PopoverContent border
 
-/** Panel-top → search-field-top: the header (padding + button + border) plus the
+/** Panel-top to search-field-top: the header (padding + button + border) plus the
  *  search row's top padding. */
 const INPUT_TRIGGER_PANEL_HEADER_OFFSET =
     MENU_HEADER_PADDING_Y_PX + MENU_HEADER_BUTTON_HEIGHT_PX + MENU_HEADER_BORDER_PX + SEARCH_ROW_PADDING_PX
 
-/** Panel-left → search-field-left: the panel border plus the search row's left
+/** Panel-left to search-field-left: the panel border plus the search row's left
  *  padding. */
 const INPUT_TRIGGER_PANEL_LEFT_INSET = PANEL_BORDER_PX + SEARCH_ROW_PADDING_PX
 

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.inputTrigger.test.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.inputTrigger.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { __clearTaxonomicResourceCache } from 'lib/components/TaxonomicFilter/hooks/useTaxonomicResource'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { performQuery } from '~/queries/query'
+import { initKeaTests } from '~/test/init'
+
+import { TaxonomicPopoverMenu } from './TaxonomicPopoverMenu'
+
+jest.mock('~/queries/query', () => ({
+    performQuery: jest.fn(),
+}))
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+jest.mock('lib/api', () => {
+    const emptyPaginated = (): Promise<{ results: any[]; count: number; next: null }> =>
+        Promise.resolve({ results: [], count: 0, next: null })
+    return {
+        __esModule: true,
+        default: {
+            get: jest.fn().mockImplementation(emptyPaginated),
+            actions: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dataWarehouseSavedQueries: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dataWarehouseTables: { list: jest.fn().mockImplementation(emptyPaginated) },
+            queryTabState: { list: jest.fn().mockImplementation(emptyPaginated) },
+            dashboards: { list: jest.fn().mockImplementation(emptyPaginated) },
+            cohorts: { listPaginated: jest.fn().mockImplementation(emptyPaginated) },
+        },
+    }
+})
+
+const apiGet = jest.requireMock('lib/api').default.get as jest.MockedFunction<any>
+
+function renderInputTriggerPopoverMenu(): ReturnType<typeof render> {
+    return render(
+        <Provider>
+            <TaxonomicPopoverMenu
+                groupType={TaxonomicFilterGroupType.EventProperties}
+                groupTypes={[TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.HogQLExpression]}
+                triggerVariant="input"
+                onChange={jest.fn()}
+            />
+        </Provider>
+    )
+}
+
+describe('TaxonomicPopoverMenu input trigger (lazy placeholder)', () => {
+    beforeEach(() => {
+        __clearTaxonomicResourceCache()
+        apiGet.mockReset()
+        apiGet.mockResolvedValue({ results: [], count: 0, next: null })
+        ;(performQuery as jest.Mock).mockResolvedValue({ tables: {}, joins: [] })
+        useMocks({})
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => cleanup())
+
+    it('renders the placeholder input + filter-icon button before arming', () => {
+        renderInputTriggerPopoverMenu()
+
+        expect(screen.getByTestId('taxonomic-filter-menu-input')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Open filter menu' })).toBeInTheDocument()
+    })
+
+    it('arms to the dropdown menu (not the combobox) when the filter icon is clicked from the resting trigger', async () => {
+        renderInputTriggerPopoverMenu()
+
+        await userEvent.click(screen.getByRole('button', { name: 'Open filter menu' }))
+
+        // The icon arms straight to the menu — its "HogQL expression" entry confirms it.
+        await waitFor(() => {
+            expect(screen.getByTestId('taxonomic-filter-menu-hogql')).toBeInTheDocument()
+        })
+        // It must NOT open the combobox: the icon click must not bubble to the
+        // input's focus handler, which would arm the combobox instead.
+        expect(screen.queryByTestId('menu-filter-search')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -175,7 +175,7 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                             aria-label="Open filter menu"
                             data-attr="taxonomic-popover-menu-trigger"
                             // Stop the click bubbling to the LemonInput wrapper, whose
-                            // onClick focuses the input → onFocus arms the combobox.
+                            // onClick focuses the input, whose onFocus arms the combobox.
                             // Without this the icon would open the combobox, not the menu.
                             onClick={(e) => {
                                 e.stopPropagation()

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -177,7 +177,7 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                             // Stop the click bubbling to the LemonInput wrapper, whose
                             // onClick focuses the input, whose onFocus arms the combobox.
                             // Without this the icon would open the combobox, not the menu.
-                            onClick={(e) => {
+                            onClick={(e: React.MouseEvent) => {
                                 e.stopPropagation()
                                 arm('menu')
                             }}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -21,10 +21,12 @@
 import { useValues } from 'kea'
 import { ReactElement, useMemo, useState } from 'react'
 
-import { IconChevronDown } from '@posthog/icons'
+import { IconChevronDown, IconFilter } from '@posthog/icons'
+import { InputGroupButton } from '@posthog/quill'
 
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
 import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
+import { MenuInputTrigger } from 'lib/components/TaxonomicFilter/menu/InputTrigger'
 import { taxonomicTriggerWrapperClassName } from 'lib/components/TaxonomicFilter/menu/triggerLayout'
 import {
     AllowedProperties,
@@ -92,6 +94,12 @@ export interface TaxonomicPopoverMenuProps<ValueType extends TaxonomicFilterValu
     /** Trigger button styling, forwarded so the rebuilt menu's trigger
      *  matches the legacy `TaxonomicPopover` button at the call site. */
     triggerButtonProps?: TriggerButtonProps
+    /**
+     * `'input'` renders a replay-style search box + filter-icon trigger
+     * instead of a single button, while no value is selected. Focusing the
+     * box opens the combobox; clicking the icon opens the dropdown menu.
+     */
+    triggerVariant?: 'button' | 'input'
 }
 
 /**
@@ -139,22 +147,52 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
     // placeholder button. Mounting the orchestrator for pickers the user
     // never opens would multiply mount cost across every call site on a page.
     const [armed, setArmed] = useState(false)
+    // Which panel the first interaction should land on once armed. The input
+    // variant has two entry points (search box → combobox, icon → menu); the
+    // button variant always resolves its own open state, so this is ignored.
+    const [armOpenTo, setArmOpenTo] = useState<'menu' | 'combobox'>('combobox')
+
+    const { value, renderValue, placeholder = 'Select', placeholderClass, triggerButtonProps, triggerVariant } = props
+    const useInputTrigger = triggerVariant === 'input' && (value == null || value === '')
 
     if (armed) {
-        return <ArmedTaxonomicPopoverMenu {...props} />
+        return <ArmedTaxonomicPopoverMenu {...props} defaultOpenState={useInputTrigger ? armOpenTo : undefined} />
     }
 
-    const { value, renderValue, placeholder = 'Select', placeholderClass, triggerButtonProps } = props
+    const arm = (to: 'menu' | 'combobox'): void => {
+        setArmOpenTo(to)
+        setArmed(true)
+    }
+
     return (
         <span className={taxonomicTriggerWrapperClassName(triggerButtonProps?.fullWidth)}>
-            {buildTriggerButton({
-                value,
-                renderValue,
-                placeholder,
-                placeholderClass,
-                triggerButtonProps,
-                onClick: () => setArmed(true),
-            })}
+            {useInputTrigger ? (
+                <MenuInputTrigger
+                    iconButton={
+                        <InputGroupButton
+                            variant="outline"
+                            size="icon-sm"
+                            aria-label="Open filter menu"
+                            data-attr="taxonomic-popover-menu-trigger"
+                            onClick={() => arm('menu')}
+                        >
+                            <IconFilter />
+                        </InputGroupButton>
+                    }
+                    fullWidth={!!triggerButtonProps?.fullWidth}
+                    placeholder={typeof placeholder === 'string' ? placeholder : 'Add filter'}
+                    onFocus={() => arm('combobox')}
+                />
+            ) : (
+                buildTriggerButton({
+                    value,
+                    renderValue,
+                    placeholder,
+                    placeholderClass,
+                    triggerButtonProps,
+                    onClick: () => setArmed(true),
+                })
+            )}
             <TaxonomicMenuToggle />
         </span>
     )
@@ -185,7 +223,9 @@ function ArmedTaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Taxo
     suggestedFiltersLabel,
     enableKeywordShortcuts,
     triggerButtonProps,
-}: TaxonomicPopoverMenuProps<ValueType>): JSX.Element {
+    triggerVariant,
+    defaultOpenState,
+}: TaxonomicPopoverMenuProps<ValueType> & { defaultOpenState?: 'menu' | 'combobox' }): JSX.Element {
     // Data warehouse tables carry their column schema (`fields`) in
     // `databaseTableListLogic`, not in the bare popover value — needed so
     // the DWH config form can render its column dropdowns / preview. Read
@@ -274,9 +314,13 @@ function ArmedTaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Taxo
                 dataWarehousePopoverFields={dataWarehousePopoverFields}
                 fullWidthTrigger={!!triggerButtonProps?.fullWidth}
                 triggerAccessory={<TaxonomicMenuToggle />}
+                triggerVariant={triggerVariant}
                 // Open immediately — this component is mounted in response
-                // to the user's first trigger click (see `TaxonomicPopoverMenu`).
+                // to the user's first trigger interaction (see `TaxonomicPopoverMenu`).
+                // `defaultOpenState` routes that open to the panel matching the
+                // interaction: the search box → combobox, the filter icon → menu.
                 defaultOpen
+                defaultOpenState={defaultOpenState}
                 trigger={({ open }) =>
                     buildTriggerButton({ value, renderValue, placeholder, placeholderClass, triggerButtonProps, open })
                 }

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -174,7 +174,13 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
                             size="icon-sm"
                             aria-label="Open filter menu"
                             data-attr="taxonomic-popover-menu-trigger"
-                            onClick={() => arm('menu')}
+                            // Stop the click bubbling to the LemonInput wrapper, whose
+                            // onClick focuses the input → onFocus arms the combobox.
+                            // Without this the icon would open the combobox, not the menu.
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                arm('menu')
+                            }}
                         >
                             <IconFilter />
                         </InputGroupButton>

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -700,6 +700,7 @@ export function ActionFilterRow({
                         excludedProperties={excludedProperties}
                         hogQLGlobals={hogQLGlobals}
                         operatorAllowlist={operatorAllowlist}
+                        triggerVariant="input"
                     />
                     <SaveAsActionBanner filter={filter} />
                 </div>

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -577,6 +577,8 @@ Icon-only trigger — only the chevron toggles, so the label can be its own butt
 </Popover>
 ```
 
+`PopoverContent` forwards `collisionAvoidance` to the positioner. Pass `fallbackAxisSide: 'none'` to keep a tall panel on its requested axis (e.g. below the trigger, flipping above only if it won't fit) instead of jumping beside the trigger when vertical space is tight: `collisionAvoidance={{ side: 'flip', align: 'shift', fallbackAxisSide: 'none' }}`.
+
 ### Tooltip
 
 ```tsx

--- a/packages/quill/packages/primitives/src/popover.tsx
+++ b/packages/quill/packages/primitives/src/popover.tsx
@@ -18,10 +18,11 @@ function PopoverContent({
     alignOffset = 0,
     side = 'bottom',
     sideOffset = 4,
+    collisionAvoidance,
     container,
     ...props
 }: PopoverPrimitive.Popup.Props &
-    Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'> &
+    Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset' | 'collisionAvoidance'> &
     Pick<PopoverPrimitive.Portal.Props, 'container'>): React.ReactElement {
     /*
      * `container` opt-in lets consumers mount the popover inside a
@@ -41,6 +42,7 @@ function PopoverContent({
                 alignOffset={alignOffset}
                 side={side}
                 sideOffset={sideOffset}
+                collisionAvoidance={collisionAvoidance}
                 className="isolate"
             >
                 <PopoverPrimitive.Popup


### PR DESCRIPTION
<img width="900" height="568" alt="taxonomic-pill-variant" src="https://github.com/user-attachments/assets/eb7c815c-aae4-4909-8479-6580f6f2cecf" />
<img width="900" height="568" alt="taxonomic-rebuild-variant" src="https://github.com/user-attachments/assets/5ff343e2-561b-4172-b70d-058e36990c14" />


## Problem

In the rebuild taxonomic menu (`TAXONOMIC_FILTER_MENU_REBUILD`), the empty "Add filter" property-filter case was a plain button. We want to try a replay-style input box that lets you start typing to search immediately, while still exposing the dropdown menu (recents / HogQL) via an icon — and have the menu chrome feel like it opens *around* the input rather than as a detached panel.

## Changes

Scoped to the **rebuild-menu** variant only — the legacy `control`/`pill` arms are untouched.

**Opt-in, one surface this pass.** The input trigger is gated behind an explicit `triggerVariant: 'button' | 'input'` prop (default `'button'`) on `PropertyFilters` / `TaxonomicPropertyFilter`. Only the **insight-series add-filter** call site (`ActionFilterRow`) opts in with `triggerVariant="input"`. Every other `PropertyFilters` consumer behind the flag (web analytics, feature flags, surveys, etc.) keeps the existing button + dropdown — an earlier revision rendered the input everywhere and mispositioned the panel on narrow/right-edge and form surfaces.

The input experience itself:

- The empty property-filter trigger renders a **`LemonInput`** search box with a leading filter-icon button (styled to match the surrounding scene per the quill/Lemon convention).
- **Focus/type** opens the combobox; the panel **wraps the input in place** — header pops above, results + preview below — so the field appears to stay put and only widen as the chrome opens around it. The positioner is shifted up/left so the panel's field lands over the trigger box (measured: the field moves ~0px horizontally, ~1px vertically between closed and open).
- **Clicking the filter icon** opens the dropdown menu (Recent / HogQL), with no redundant "New filter…" row since typing serves that purpose.
- The combobox's search field is driven through base-ui's `Autocomplete` `render` prop so a `LemonInput` can host the live input — there's a single field, not a mirrored second input.
- **Quill primitive:** `PopoverContent` now forwards `collisionAvoidance` to its positioner (additive, optional). The menu uses `fallbackAxisSide: 'none'` / pinned axis so the panel never flips *beside* the trigger. Documented in `packages/primitives/AGENTS.md`.

## How did you test this code?

I'm an agent. Automated tests I ran (all green):

- New `TaxonomicPropertyFilter.triggerVariant.test.tsx` — parameterized over `undefined` / `'button'` / `'input'`: confirms the rebuild menu renders the button trigger by default and the input-box trigger only when opted in.
- `frontend/src/lib/components/TaxonomicFilter/menu/` — input + icon render, icon opens the menu without "New filter…", input focus opens the combobox, single search field (no mirrored input).
- `TaxonomicPropertyFilter.selectingKeyOnly.test.tsx` and `Combobox.test.tsx` still pass.

Manual verification against the live app (flag on): the insight-series series filter shows the input box and opens the wrapping combobox; web analytics and the other surfaces show the plain button + dropdown with no overflow. Full local typecheck OOMs in this environment (CI covers it); I confirmed no type errors in the touched files.

## Docs update

No user-facing docs needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code over an iterative session. Key decisions:

- **Opt-in over global:** the change was originally applied to all ~30 `PropertyFilters` call sites via the shared `TaxonomicPropertyFilter`. Live verification across distinct layout contexts surfaced panel-positioning problems on narrow/right-edge (web analytics) and form (feature flags, surveys) surfaces, so the trigger is now opt-in via `triggerVariant` and enabled only on the insight-series call site for this pass.
- **One field, not two:** an early version portaled the combobox's input into the trigger row; the reviewer wanted the chrome to wrap the input instead, so the input now lives in the panel and the panel is shifted so its field overlays the trigger (header above, body below). The closed-state trigger holds an invisible same-height spacer to keep the anchor/layout stable.
- **LemonInput via base-ui `render`:** `LemonInput` can't be base-ui's controlled input directly (it wraps + transforms `value`/`onChange`), so the function form of `render` routes base-ui's input props (role, `aria-activedescendant`, keyboard nav, ref) to LemonInput's inner input while `value`/`onChange` round-trip through the orchestrator's `searchQuery`.

**Follow-up (separate PR):** a Storybook story that mounts every taxonomic-filter surface/presentation (legacy-control, legacy-pill, rebuild button, rebuild input) side by side, so the variants can be eyeballed together before widening the input trigger to more surfaces.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
