### PR TITLE
feat(llma): add community skills marketplace backend and UI

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -257,6 +257,8 @@ def get_scoped_models() -> tuple[dict[str, set[str]], set[str], set[str], set[st
         "PromptSequence",
         "UserPromptState",
         # --- Global catalogs ---
+        "CommunitySkill",  # instance-global community skills catalog, synced from GitHub
+        "CommunitySkillFile",  # bundled files of a CommunitySkill (scoped via the catalog row)
         "HogFunctionTemplate",
         "MCPServer",
         # --- Special (has source_team + destination_team, not a plain team) ---

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3546,6 +3546,14 @@ export interface PatchedUserApi {
     readonly requires_credential_review?: boolean
 }
 
+export interface UserGithubLoginApi {
+    /**
+     * The user's resolved GitHub login, or null when no GitHub identity is linked.
+     * @nullable
+     */
+    github_login: string | null
+}
+
 export interface UserGitHubAccountApi {
     /**
      * GitHub account type for the installation (e.g. User or Organization).

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -75,6 +75,7 @@ import type {
     UserApi,
     UserGitHubLinkStartRequestApi,
     UserGitHubLinkStartResponseApi,
+    UserGithubLoginApi,
     UserPushTokenItemApi,
     UserPushTokenRegisterRequestApi,
     UserPushTokenUnregisterRequestApi,
@@ -3100,8 +3101,8 @@ export const getUsersGithubLoginRetrieveUrl = (uuid: string) => {
     return `/api/users/${uuid}/github_login/`
 }
 
-export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getUsersGithubLoginRetrieveUrl(uuid), {
+export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<UserGithubLoginApi> => {
+    return apiMutator<UserGithubLoginApi>(getUsersGithubLoginRetrieveUrl(uuid), {
         ...options,
         method: 'GET',
     })

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -336,6 +336,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-ai-observability
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-ai-observability
     LLM_ANALYTICS_SKILLS: 'llm-analytics-skills', // owner: #team-ai-observability
+    LLM_ANALYTICS_COMMUNITY_SKILLS: 'llm-analytics-community-skills', // owner: #team-ai-observability
     LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-ai-observability
     LLM_ANALYTICS_TAGS: 'llm-analytics-tags', // owner: #team-ai-observability
     LLM_ANALYTICS_TEXT_VIEW: 'llm-analytics-text-view', // owner: #team-ai-observability

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -138,6 +138,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     SessionGroupSummary: () => import('../../products/session_summaries/frontend/SessionGroupSummaryScene'),
     Skills: () => import('../../products/skills/frontend/LLMSkillsScene'),
     Skill: () => import('../../products/skills/frontend/LLMSkillScene'),
+    CommunitySkills: () => import('../../products/skills/frontend/CommunitySkillsScene'),
     TaskTracker: () => import('../../products/tasks/frontend/TaskTracker'),
     TaskDetail: () => import('../../products/tasks/frontend/TaskDetailScene'),
     SlackTaskContext: () => import('../../products/tasks/frontend/SlackTaskContextScene'),
@@ -263,6 +264,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/session-summaries': ['SessionGroupSummariesTable', 'sessionGroupSummariesTable'],
     '/session-summaries/:sessionGroupId': ['SessionGroupSummary', 'sessionGroupSummary'],
     '/skills': ['Skills', 'skills'],
+    '/community-skills': ['CommunitySkills', 'communitySkills'],
     '/skills/:name': ['Skill', 'skill'],
     '/tasks': ['TaskTracker', 'taskTracker'],
     '/tasks/:taskId': ['TaskDetail', 'taskDetail'],
@@ -747,6 +749,13 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'llm_prompts',
     },
     Skill: { projectBased: true, name: 'Skill', layout: 'app-container', iconType: 'llm_prompts' },
+    CommunitySkills: {
+        projectBased: true,
+        name: 'Community skills',
+        description: 'Discover and install agent skills shared by the PostHog community.',
+        layout: 'app-container',
+        iconType: 'llm_prompts',
+    },
     TaskTracker: {
         name: 'Tasks',
         projectBased: true,
@@ -1181,6 +1190,7 @@ export const productUrls = {
             version?: number
         }
     ): string => combineUrl(`/skills/${name}`, params).url,
+    communitySkills: (): string => '/community-skills',
     surveys: (tab?: SurveysTabs): string => `/surveys${tab ? `?tab=${tab}` : ''}`,
     survey: (id: string): string => `/surveys/${id}`,
     surveyFormBuilder: (id: string = 'new'): string => `/surveys/form/${id}`,
@@ -1997,7 +2007,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.skills(),
         flag: FEATURE_FLAGS.LLM_ANALYTICS_SKILLS,
         sceneKey: 'Skills',
-        sceneKeys: ['Skills', 'Skill'],
+        sceneKeys: ['Skills', 'Skill', 'CommunitySkills'],
     },
     {
         path: 'Support',

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -785,6 +785,13 @@ class ScenePersonalisationSerializer(serializers.ModelSerializer):
         )
 
 
+class UserGithubLoginSerializer(serializers.Serializer):
+    github_login = serializers.CharField(
+        allow_null=True,
+        help_text="The user's resolved GitHub login, or null when no GitHub identity is linked.",
+    )
+
+
 @extend_schema(extensions={"x-product": "core"})
 @extend_schema_view(
     retrieve=extend_schema(
@@ -890,6 +897,7 @@ class UserViewSet(
         report_user_deleted_account(user)
         super().perform_destroy(user)
 
+    @extend_schema(responses=UserGithubLoginSerializer)
     @action(methods=["GET"], detail=True, url_path="github_login")
     def github_login(self, request, **kwargs):
         user = self.get_object()

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -36,6 +36,13 @@ GITHUB_APP_PRIVATE_KEY = get_from_env("GITHUB_APP_PRIVATE_KEY", "")
 # which is separate from the private key used for App-as-App JWT signing.
 GITHUB_APP_CLIENT_SECRET = get_from_env("GITHUB_APP_CLIENT_SECRET", "")
 
+# Central GitHub App installation used to publish community skills as PRs to PostHog/community-skills.
+# Unlike the per-team GitHub integration (customers install the app on their own repos), this is a
+# single PostHog-owned installation on the community-skills repo. Leave empty to disable publishing.
+COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID = get_from_env("COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID", "")
+# Repository name only (no owner) — the owner is derived from the installation account.
+COMMUNITY_SKILLS_GITHUB_REPO = get_from_env("COMMUNITY_SKILLS_GITHUB_REPO", "community-skills")
+
 ZENDESK_ADMIN_EMAIL = get_from_env("ZENDESK_ADMIN_EMAIL", "")
 ZENDESK_API_TOKEN = get_from_env("ZENDESK_API_TOKEN", "")
 ZENDESK_SUBDOMAIN = get_from_env("ZENDESK_SUBDOMAIN", "posthoghelp")

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -67,6 +67,7 @@ from posthog.tasks.team_llm_gateway_policy import refresh_expiring_llm_gateway_p
 from posthog.tasks.team_metadata import cleanup_stale_expiry_tracking_task, refresh_expiring_team_metadata_cache_entries
 from posthog.utils import get_crontab, get_instance_region
 
+from products.ai_observability.backend.tasks import sync_community_skills
 from products.conversations.backend.tasks import flush_pending_email_replies, wake_snoozed_tickets
 from products.data_modeling.backend.tasks.cleanup_test_saved_queries import cleanup_expired_test_saved_queries
 from products.endpoints.backend.tasks import deactivate_stale_materializations
@@ -342,6 +343,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="4", minute="15"),
         send_ai_observability_usage_reports.s(),
         name="send llm analytics usage reports",
+    )
+
+    # Sync the community skills catalog from GitHub hourly
+    sender.add_periodic_task(
+        crontab(minute="20"),
+        sync_community_skills.s(),
+        name="sync community skills catalog",
     )
 
     # Send HogFunctions daily digest at 9:30 AM UTC (good for US and EU)

--- a/products/ai_observability/backend/api/__init__.py
+++ b/products/ai_observability/backend/api/__init__.py
@@ -1,6 +1,7 @@
 from .clustering import AIObservabilityClusteringRunViewSet
 from .clustering_config import ClusteringConfigViewSet
 from .clustering_job import ClusteringJobViewSet
+from .community_skills import CommunitySkillViewSet
 from .datasets import DatasetItemViewSet, DatasetViewSet
 from .evaluation_config import EvaluationConfigViewSet
 from .evaluation_reports import EvaluationReportViewSet
@@ -25,6 +26,7 @@ from .translate import AIObservabilityTranslateViewSet
 __all__ = [
     "ClusteringConfigViewSet",
     "ClusteringJobViewSet",
+    "CommunitySkillViewSet",
     "AIObservabilityClusteringRunViewSet",
     "LLMModelsViewSet",
     "LLMProxyViewSet",

--- a/products/ai_observability/backend/api/community_publish_services.py
+++ b/products/ai_observability/backend/api/community_publish_services.py
@@ -1,0 +1,259 @@
+"""Publish a team's LLMSkill to the PostHog/community-skills repo as a pull request.
+
+The heavy lifting (branch + commit + PR) reuses the existing `GitHubIntegration` that already
+powers the Tasks product. This module owns the pure rendering of an `LLMSkill` into the repo's
+`skills/<slug>/SKILL.md` layout; the GitHub side lives in `publish_skill_to_community`.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from django.conf import settings
+
+import yaml
+import structlog
+
+from posthog.models.integration import GitHubIntegration, Integration
+
+logger = structlog.get_logger(__name__)
+
+# Mirror the community-skills repo's slug rule (scripts/build_registry.py) so we never open a PR the
+# repo's own validation would reject.
+SLUG_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+MAX_SLUG_LENGTH = 64
+SKILLS_DIR = "skills"
+COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
+
+
+class CommunitySkillPublishError(Exception):
+    """Raised when a skill can't be rendered or published to the community repo."""
+
+
+class CommunitySkillPublishNotConfiguredError(CommunitySkillPublishError):
+    """Raised when the community-skills GitHub App installation isn't configured on this instance."""
+
+
+@dataclass(frozen=True)
+class RenderedFile:
+    """A single file to commit, at its path within the community-skills repo."""
+
+    path: str
+    content: str
+
+
+def _validate_slug(slug: str) -> str:
+    if not SLUG_PATTERN.match(slug) or "--" in slug or len(slug) > MAX_SLUG_LENGTH:
+        raise CommunitySkillPublishError(
+            f"'{slug}' is not a valid community skill slug (lowercase letters, numbers, single hyphens)."
+        )
+    return slug
+
+
+def render_skill_md(
+    *,
+    name: str,
+    description: str,
+    body: str,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> str:
+    """Render an LLMSkill's fields into community-skills `SKILL.md` content (frontmatter + body).
+
+    Output parses cleanly under the repo's `build_registry.py` frontmatter regex and field rules:
+    `name` and `description` are required; `trust_tier` defaults to `community` (maintainers set
+    `official`/`verified` on review); optional fields are omitted when empty.
+    """
+    if not name.strip():
+        raise CommunitySkillPublishError("Skill name is required to publish.")
+    if not description.strip():
+        raise CommunitySkillPublishError("Skill description is required to publish.")
+
+    frontmatter: dict[str, Any] = {
+        "name": name.strip(),
+        "description": description.strip(),
+        "trust_tier": "community",
+    }
+    if tags:
+        frontmatter["tags"] = list(tags)
+    if author_handle.strip():
+        frontmatter["author_handle"] = author_handle.strip()
+    if license.strip():
+        frontmatter["license"] = license.strip()
+    if compatibility.strip():
+        frontmatter["compatibility"] = compatibility.strip()
+    if allowed_tools:
+        frontmatter["allowed_tools"] = list(allowed_tools)
+
+    # sort_keys=False keeps the human-friendly field order above; default_flow_style=False emits
+    # block-style YAML (lists as `- item`) that the repo's yaml.safe_load round-trips.
+    rendered_frontmatter = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    return f"---\n{rendered_frontmatter}---\n\n{body.strip()}\n"
+
+
+def render_community_skill_files(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    body: str,
+    files: list[dict[str, str]] | None = None,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> list[RenderedFile]:
+    """Render the full set of files to commit for a skill: SKILL.md plus any bundled files.
+
+    Bundled files keep their skill-relative path under `skills/<slug>/` (e.g. a skill file at
+    `references/playbook.md` becomes `skills/<slug>/references/playbook.md`).
+    """
+    _validate_slug(slug)
+    skill_root = f"{SKILLS_DIR}/{slug}"
+
+    rendered: list[RenderedFile] = [
+        RenderedFile(
+            path=f"{skill_root}/SKILL.md",
+            content=render_skill_md(
+                name=name,
+                description=description,
+                body=body,
+                tags=tags,
+                allowed_tools=allowed_tools,
+                license=license,
+                compatibility=compatibility,
+                author_handle=author_handle,
+            ),
+        )
+    ]
+
+    for file in files or []:
+        rel_path = file["path"].lstrip("/")
+        # Confine writes to the skill directory — a bundled file must never escape skills/<slug>/.
+        if rel_path == "SKILL.md" or ".." in rel_path.split("/"):
+            raise CommunitySkillPublishError(f"Invalid bundled file path '{file['path']}'.")
+        rendered.append(RenderedFile(path=f"{skill_root}/{rel_path}", content=file["content"]))
+
+    return rendered
+
+
+def get_community_skills_publisher() -> GitHubIntegration | None:
+    """Build a GitHubIntegration bound to the central community-skills installation, or None.
+
+    Mints a fresh installation token via the GitHub App JWT (the same flow the per-team integration
+    uses) and wraps it in a transient, unsaved Integration — we never persist a teamless central row.
+    Returns None when the App or the community-skills installation isn't configured, so callers can
+    surface a clean "not configured" error instead of failing.
+    """
+    installation_id = settings.COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID
+    if not installation_id or not settings.GITHUB_APP_CLIENT_ID or not settings.GITHUB_APP_PRIVATE_KEY:
+        return None
+
+    info_response = GitHubIntegration.client_request(f"installations/{installation_id}")
+    token_response = GitHubIntegration.client_request(f"installations/{installation_id}/access_tokens", method="POST")
+    if info_response.status_code != 200 or token_response.status_code != 201:
+        logger.warning(
+            "community_skills_publisher_unavailable",
+            info_status=info_response.status_code,
+            token_status=token_response.status_code,
+        )
+        return None
+
+    account = info_response.json().get("account") or {}
+    token = token_response.json().get("token")
+    if not token or not account.get("login"):
+        return None
+
+    # Transient (never saved) Integration: the write helpers only read the access token + account
+    # name and don't trigger a refresh/save, so this avoids polluting the team-scoped Integration table.
+    integration = Integration(
+        team_id=None,
+        kind="github",
+        integration_id=str(installation_id),
+        config={"account": {"name": account["login"], "type": account.get("type")}},
+        sensitive_config={"access_token": token},
+    )
+    return GitHubIntegration(integration)
+
+
+def _community_pr_body(*, name: str, slug: str, author_handle: str) -> str:
+    # No PostHog user PII here — this PR is public. Attribution is only the GitHub handle the
+    # publisher explicitly provided for public sharing.
+    credit = f"Published by @{author_handle}" if author_handle else "Published from the PostHog skills marketplace"
+    return (
+        f"Adds the **{name}** community skill (`skills/{slug}/`).\n\n"
+        f"{credit} via the in-product *Publish to community* flow.\n\n"
+        "A maintainer should review the instructions for safety before merging; "
+        "set `trust_tier` on review. On merge, CI regenerates `registry.json` and PostHog syncs it."
+    )
+
+
+def publish_skill_to_community(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    body: str,
+    files: list[dict[str, str]] | None = None,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> dict[str, Any]:
+    """Open a PR in PostHog/community-skills adding (or updating) this skill. Returns the PR url/number.
+
+    Reuses the existing GitHubIntegration branch/commit/PR helpers. Raises CommunitySkillPublishError
+    when any GitHub step fails, or CommunitySkillPublishNotConfiguredError when publishing is disabled.
+    """
+    publisher = get_community_skills_publisher()
+    if publisher is None:
+        raise CommunitySkillPublishNotConfiguredError("Community skill publishing is not configured.")
+
+    rendered = render_community_skill_files(
+        slug=slug,
+        name=name,
+        description=description,
+        body=body,
+        files=files,
+        tags=tags,
+        allowed_tools=allowed_tools,
+        license=license,
+        compatibility=compatibility,
+        author_handle=author_handle,
+    )
+
+    repo = settings.COMMUNITY_SKILLS_GITHUB_REPO
+    base = COMMUNITY_SKILLS_PR_BASE_BRANCH
+    branch = f"community-skill/{slug}-{uuid.uuid4().hex[:8]}"
+
+    branch_result = publisher.create_branch(repo, branch, base)
+    if not branch_result.get("success"):
+        raise CommunitySkillPublishError(f"Failed to create branch: {branch_result.get('error')}")
+
+    for rendered_file in rendered:
+        commit_result = publisher.update_file(
+            repo, rendered_file.path, rendered_file.content, f"Add {rendered_file.path}", branch
+        )
+        if not commit_result.get("success"):
+            raise CommunitySkillPublishError(f"Failed to commit {rendered_file.path}: {commit_result.get('error')}")
+
+    pr_result = publisher.create_pull_request(
+        repo,
+        f"Add community skill: {name}",
+        _community_pr_body(name=name, slug=slug, author_handle=author_handle),
+        branch,
+        base,
+    )
+    if not pr_result.get("success"):
+        raise CommunitySkillPublishError(f"Failed to open pull request: {pr_result.get('error')}")
+
+    logger.info("community_skill_published", slug=slug, pr_number=pr_result.get("pr_number"))
+    return {"pr_url": pr_result["pr_url"], "pr_number": pr_result["pr_number"], "branch": branch}

--- a/products/ai_observability/backend/api/community_skill_serializers.py
+++ b/products/ai_observability/backend/api/community_skill_serializers.py
@@ -1,0 +1,163 @@
+from typing import Any
+
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from ..models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier
+
+ALLOWED_LIST_ORDERINGS = frozenset(
+    {
+        "name",
+        "-name",
+        "created_at",
+        "-created_at",
+        "published_at",
+        "-published_at",
+        "install_count",
+        "-install_count",
+        "vote_count",
+        "-vote_count",
+    }
+)
+
+
+class CommunitySkillFileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CommunitySkillFile
+        fields = ["path", "content", "content_type"]
+
+
+class CommunitySkillFileManifestSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CommunitySkillFile
+        fields = ["path", "content_type"]
+
+
+class CommunitySkillSerializer(serializers.ModelSerializer):
+    allowed_tools = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text="Tools the skill declares it may use. Surface these to the user before install.",
+    )
+    metadata = serializers.DictField(
+        required=False,
+        default=dict,
+        help_text="Arbitrary key-value metadata carried from the skill's frontmatter.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text="Free-form tags used for filtering and discovery.",
+    )
+    trust_tier = serializers.ChoiceField(
+        choices=CommunitySkillTrustTier.choices,
+        help_text="Moderation tier: 'official' (PostHog-authored), 'verified' (reviewed), or 'community'.",
+    )
+    files = serializers.SerializerMethodField(
+        help_text=(
+            "Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint."
+        ),
+    )
+    vote_count = serializers.SerializerMethodField(
+        help_text="Total number of upvotes this skill has received.",
+    )
+    has_voted = serializers.SerializerMethodField(
+        help_text="Whether the requesting user has upvoted this skill.",
+    )
+
+    class Meta:
+        model = CommunitySkill
+        fields = [
+            "id",
+            "slug",
+            "name",
+            "description",
+            "body",
+            "license",
+            "compatibility",
+            "allowed_tools",
+            "metadata",
+            "tags",
+            "trust_tier",
+            "author_handle",
+            "github_url",
+            "files",
+            "install_count",
+            "vote_count",
+            "has_voted",
+            "published_at",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "slug": {"help_text": "Stable identifier matching the skill's directory in the community-skills repo."},
+            "name": {"help_text": "Display name of the skill."},
+            "description": {"help_text": "What the skill does and when to use it."},
+            "body": {"help_text": "The SKILL.md instruction content (markdown)."},
+            "license": {"help_text": "License name or reference."},
+            "compatibility": {"help_text": "Environment requirements declared by the skill."},
+            "author_handle": {"help_text": "GitHub handle (or name) of the contributor who published the skill."},
+            "github_url": {"help_text": "Link to the skill's source directory on GitHub."},
+            "install_count": {"help_text": "Number of times this skill has been installed into a team."},
+            "published_at": {"help_text": "When the skill was first published to the community repo."},
+        }
+
+    @extend_schema_field(CommunitySkillFileManifestSerializer(many=True))
+    def get_files(self, instance: CommunitySkill) -> list[dict[str, Any]]:
+        return [dict(row) for row in instance.files.values("path", "content_type")]
+
+    def get_vote_count(self, instance: CommunitySkill) -> int:
+        # Provided by the viewset's annotated queryset; fall back to a count for unannotated instances.
+        annotated = getattr(instance, "vote_count", None)
+        return int(annotated) if annotated is not None else instance.votes.count()
+
+    def get_has_voted(self, instance: CommunitySkill) -> bool:
+        return bool(getattr(instance, "has_voted", False))
+
+
+class CommunitySkillListSerializer(CommunitySkillSerializer):
+    """List serializer that omits body and file manifest — progressive disclosure."""
+
+    class Meta(CommunitySkillSerializer.Meta):
+        fields = [f for f in CommunitySkillSerializer.Meta.fields if f not in ("body", "files")]
+        read_only_fields = fields
+
+
+class CommunitySkillListQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Substring filter applied to skill names, descriptions, and tags.",
+    )
+    tag = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Return only skills carrying this tag.",
+    )
+    trust_tier = serializers.ChoiceField(
+        choices=CommunitySkillTrustTier.choices,
+        required=False,
+        help_text="Filter to a single moderation tier.",
+    )
+    order_by = serializers.ChoiceField(
+        choices=sorted(ALLOWED_LIST_ORDERINGS),
+        required=False,
+        default="-install_count",
+        help_text="Sort key. Defaults to most-installed first.",
+    )
+
+
+class CommunitySkillInstallSerializer(serializers.Serializer):
+    new_name = serializers.CharField(
+        max_length=64,
+        required=False,
+        help_text="Name for the installed skill in your team. Defaults to the community skill's slug.",
+    )
+
+
+class CommunitySkillVoteResponseSerializer(serializers.Serializer):
+    vote_count = serializers.IntegerField(help_text="Total upvotes after applying the toggle.")
+    has_voted = serializers.BooleanField(help_text="Whether the requesting user is now an upvoter.")

--- a/products/ai_observability/backend/api/community_skill_services.py
+++ b/products/ai_observability/backend/api/community_skill_services.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import F
 from django.utils import timezone
 
@@ -88,8 +88,13 @@ def toggle_community_skill_vote(*, slug: str, user: User) -> tuple[int, bool]:
             existing.delete()
             has_voted = False
         else:
-            CommunitySkillVote.objects.create(skill=community_skill, user=user)
-            has_voted = True
+            try:
+                CommunitySkillVote.objects.create(skill=community_skill, user=user)
+                has_voted = True
+            except IntegrityError:
+                # A concurrent request created the vote first — converge on the "voted" state
+                # rather than surfacing the unique-constraint violation.
+                has_voted = True
         vote_count = CommunitySkillVote.objects.filter(skill=community_skill).count()
 
     return vote_count, has_voted
@@ -155,6 +160,14 @@ def sync_community_skills_from_github(registry_url: str = COMMUNITY_SKILLS_REGIS
     response.raise_for_status()
     payload = response.json()
     entries = payload.get("skills", [])
+
+    # Fail closed on malformed/empty payloads: a missing/empty `skills` key (bad generated
+    # registry, proxy error, rate-limit body) would otherwise soft-delete the entire catalog.
+    if not isinstance(entries, list):
+        raise ValueError("Registry payload 'skills' must be a list")
+    if not entries:
+        logger.warning("community_skills_sync_skipped_empty_registry")
+        return {"synced": 0, "skipped": 0, "removed": 0}
 
     synced = 0
     skipped = 0

--- a/products/ai_observability/backend/api/community_skill_services.py
+++ b/products/ai_observability/backend/api/community_skill_services.py
@@ -1,0 +1,175 @@
+from typing import Any
+
+from django.db import transaction
+from django.db.models import F
+from django.utils import timezone
+
+import requests
+import structlog
+
+from posthog.models import Team, User
+
+from ..models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
+from ..models.skills import LLMSkill
+from .skill_serializers import validate_skill_name_value
+from .skill_services import create_skill
+
+logger = structlog.get_logger(__name__)
+
+COMMUNITY_SKILLS_REPO = "PostHog/community-skills"
+COMMUNITY_SKILLS_BRANCH = "main"
+COMMUNITY_SKILLS_REGISTRY_URL = (
+    f"https://raw.githubusercontent.com/{COMMUNITY_SKILLS_REPO}/{COMMUNITY_SKILLS_BRANCH}/registry.json"
+)
+COMMUNITY_SKILLS_SYNC_TIMEOUT_SECONDS = 30
+
+
+class CommunitySkillNotFoundError(Exception):
+    pass
+
+
+def get_community_skill_by_slug(slug: str) -> CommunitySkill | None:
+    return CommunitySkill.objects.filter(slug=slug, deleted=False).first()
+
+
+def install_community_skill(
+    *,
+    team: Team,
+    user: User,
+    slug: str,
+    new_name: str | None = None,
+) -> LLMSkill:
+    """Copy a community skill into a team as a regular LLMSkill and bump its install counter.
+
+    Raises CommunitySkillNotFoundError if the slug is unknown, and
+    LLMSkillDuplicateNameConflictError if the target name already exists in the team.
+    """
+    community_skill = get_community_skill_by_slug(slug)
+    if community_skill is None:
+        raise CommunitySkillNotFoundError()
+
+    target_name = validate_skill_name_value(new_name or community_skill.slug)
+
+    files = [
+        {"path": f.path, "content": f.content, "content_type": f.content_type} for f in community_skill.files.all()
+    ]
+
+    installed = create_skill(
+        team,
+        user=user,
+        name=target_name,
+        description=community_skill.description,
+        body=community_skill.body,
+        license=community_skill.license,
+        compatibility=community_skill.compatibility,
+        allowed_tools=community_skill.allowed_tools,
+        # Stamp provenance so an installed skill can be traced back to its community source.
+        metadata={
+            **(community_skill.metadata or {}),
+            "community_skill_slug": community_skill.slug,
+            "community_skill_id": str(community_skill.id),
+        },
+        files=files or None,
+    )
+
+    CommunitySkill.objects.filter(pk=community_skill.pk).update(install_count=F("install_count") + 1)
+    return installed
+
+
+def toggle_community_skill_vote(*, slug: str, user: User) -> tuple[int, bool]:
+    """Add or remove the user's upvote. Returns (vote_count, has_voted) after the toggle."""
+    community_skill = get_community_skill_by_slug(slug)
+    if community_skill is None:
+        raise CommunitySkillNotFoundError()
+
+    with transaction.atomic():
+        existing = CommunitySkillVote.objects.filter(skill=community_skill, user=user).first()
+        if existing is not None:
+            existing.delete()
+            has_voted = False
+        else:
+            CommunitySkillVote.objects.create(skill=community_skill, user=user)
+            has_voted = True
+        vote_count = CommunitySkillVote.objects.filter(skill=community_skill).count()
+
+    return vote_count, has_voted
+
+
+def _upsert_community_skill(entry: dict[str, Any]) -> bool:
+    """Upsert a single registry entry. Returns True if the row was created or updated."""
+    slug = entry["slug"]
+    source_sha = entry.get("source_sha", "")
+
+    existing = CommunitySkill.objects.filter(slug=slug).first()
+    if existing is not None and existing.source_sha and existing.source_sha == source_sha and not existing.deleted:
+        return False
+
+    defaults: dict[str, Any] = {
+        "name": entry["name"],
+        "description": entry["description"],
+        "body": entry.get("body", ""),
+        "license": entry.get("license", ""),
+        "compatibility": entry.get("compatibility", ""),
+        "allowed_tools": entry.get("allowed_tools", []),
+        "metadata": entry.get("metadata", {}),
+        "tags": entry.get("tags", []),
+        "trust_tier": entry.get("trust_tier", "community"),
+        "author_handle": entry.get("author_handle", ""),
+        "github_url": entry.get("github_url", ""),
+        "source_sha": source_sha,
+        "deleted": False,
+    }
+    if entry.get("published_at"):
+        defaults["published_at"] = entry["published_at"]
+
+    with transaction.atomic():
+        skill, _ = CommunitySkill.objects.update_or_create(slug=slug, defaults=defaults)
+        if skill.published_at is None:
+            CommunitySkill.objects.filter(pk=skill.pk).update(published_at=timezone.now())
+
+        skill.files.all().delete()
+        files = entry.get("files", [])
+        if files:
+            CommunitySkillFile.objects.bulk_create(
+                [
+                    CommunitySkillFile(
+                        skill=skill,
+                        path=f["path"],
+                        content=f.get("content", ""),
+                        content_type=f.get("content_type", "text/plain"),
+                    )
+                    for f in files
+                ]
+            )
+    return True
+
+
+def sync_community_skills_from_github(registry_url: str = COMMUNITY_SKILLS_REGISTRY_URL) -> dict[str, int]:
+    """Pull the community-skills registry and reconcile the local read-model.
+
+    The registry.json is generated in the repo's CI and embeds each skill's content, so a
+    single fetch is enough. Skills missing from the registry are soft-deleted. Returns a
+    summary of {synced, skipped, removed} counts.
+    """
+    response = requests.get(registry_url, timeout=COMMUNITY_SKILLS_SYNC_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    payload = response.json()
+    entries = payload.get("skills", [])
+
+    synced = 0
+    skipped = 0
+    seen_slugs: set[str] = set()
+    for entry in entries:
+        slug = entry.get("slug")
+        if not slug:
+            continue
+        seen_slugs.add(slug)
+        if _upsert_community_skill(entry):
+            synced += 1
+        else:
+            skipped += 1
+
+    removed = CommunitySkill.objects.filter(deleted=False).exclude(slug__in=seen_slugs).update(deleted=True)
+
+    logger.info("community_skills_synced", synced=synced, skipped=skipped, removed=removed, total=len(entries))
+    return {"synced": synced, "skipped": skipped, "removed": removed}

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -7,6 +7,7 @@ import posthoganalytics
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -76,14 +77,14 @@ class CommunitySkillViewSet(
         # Deliberately bypasses team/parent filtering: CommunitySkill is a shared, instance-global
         # catalog with no team_id. Access is gated by the feature-flag permission above.
         user = cast(User, self.request.user)
-        return (
-            CommunitySkill.objects.filter(deleted=False)
-            .prefetch_related("files")
-            .annotate(
-                vote_count=Count("votes", distinct=True),
-                has_voted=Exists(CommunitySkillVote.objects.filter(skill=OuterRef("pk"), user=user)),
-            )
+        queryset = CommunitySkill.objects.filter(deleted=False).annotate(
+            vote_count=Count("votes", distinct=True),
+            has_voted=Exists(CommunitySkillVote.objects.filter(skill=OuterRef("pk"), user=user)),
         )
+        # Only the detail serializer renders the files manifest — skip the extra query on list.
+        if self.action != "list":
+            queryset = queryset.prefetch_related("files")
+        return queryset
 
     def get_serializer_class(self):
         if self.action == "list":
@@ -100,12 +101,14 @@ class CommunitySkillViewSet(
         queryset = self.get_queryset()
         search = params.validated_data.get("search", "").strip()
         if search:
+            # tags is a JSONField array — use `contains` for exact element membership, not a
+            # substring match against the serialized JSON.
             queryset = queryset.filter(
-                Q(name__icontains=search) | Q(description__icontains=search) | Q(tags__icontains=search)
+                Q(name__icontains=search) | Q(description__icontains=search) | Q(tags__contains=[search])
             )
         tag = params.validated_data.get("tag", "").strip()
         if tag:
-            queryset = queryset.filter(tags__icontains=tag)
+            queryset = queryset.filter(tags__contains=[tag])
         trust_tier = params.validated_data.get("trust_tier")
         if trust_tier:
             queryset = queryset.filter(trust_tier=trust_tier)
@@ -123,6 +126,15 @@ class CommunitySkillViewSet(
     @extend_schema(request=CommunitySkillInstallSerializer, responses={201: LLMSkillSerializer})
     @action(methods=["POST"], detail=True)
     def install(self, request: Request, slug: str = "", **kwargs) -> Response:
+        # Installing creates a durable LLMSkill in the team, so it must require the same write
+        # access as LLMSkillViewSet's create (resource-level "editor" on llm_skill). The viewset
+        # is scope_object="INTERNAL", so the shared AccessControlPermission only checks project
+        # membership — enforce skill-write access imperatively here. Catalog reads (list/retrieve)
+        # stay global and unaffected, and we avoid object-level AC checks against CommunitySkill
+        # (which has no team and is not an LLMSkill).
+        if not self.user_access_control.check_access_level_for_resource("llm_skill", "editor"):
+            raise PermissionDenied("You do not have permission to install skills in this project.")
+
         payload = CommunitySkillInstallSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
 

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -1,0 +1,172 @@
+from typing import Any, cast
+
+from django.db.models import Count, Exists, OuterRef, Q, QuerySet
+
+import structlog
+import posthoganalytics
+from drf_spectacular.utils import extend_schema
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+from posthog.models import User
+from posthog.permissions import get_organization_from_view
+from posthog.rate_limit import BurstRateThrottle, SustainedRateThrottle
+
+from ..models.community_skills import CommunitySkill, CommunitySkillVote
+from .community_skill_serializers import (
+    ALLOWED_LIST_ORDERINGS,
+    CommunitySkillInstallSerializer,
+    CommunitySkillListQuerySerializer,
+    CommunitySkillListSerializer,
+    CommunitySkillSerializer,
+    CommunitySkillVoteResponseSerializer,
+)
+from .community_skill_services import CommunitySkillNotFoundError, install_community_skill, toggle_community_skill_vote
+from .skill_serializers import LLMSkillSerializer
+from .skill_services import LLMSkillDuplicateNameConflictError
+
+logger = structlog.get_logger(__name__)
+
+COMMUNITY_SKILL_FEATURE_FLAG = "llm-analytics-community-skills"
+
+
+class CommunitySkillFeatureFlagPermission(BasePermission):
+    def has_permission(self, request, view) -> bool:
+        user = cast(User, request.user)
+        organization = get_organization_from_view(view)
+        org_id = str(organization.id)
+        distinct_id = user.distinct_id or str(user.uuid)
+
+        return bool(
+            posthoganalytics.feature_enabled(
+                COMMUNITY_SKILL_FEATURE_FLAG,
+                distinct_id,
+                groups={"organization": org_id},
+                group_properties={"organization": {"id": org_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+
+
+class CommunitySkillViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    # The community catalog is instance-global, so this endpoint is web-app only and not
+    # exposed for personal-API-key scoping. Team context comes from the URL for install/vote.
+    scope_object = "INTERNAL"
+    serializer_class = CommunitySkillSerializer
+    permission_classes = [CommunitySkillFeatureFlagPermission]
+    lookup_field = "slug"
+
+    def get_throttles(self):
+        if self.action in ("install", "vote"):
+            return [BurstRateThrottle(), SustainedRateThrottle()]
+        return super().get_throttles()
+
+    def dangerously_get_queryset(self) -> QuerySet[CommunitySkill]:
+        # Deliberately bypasses team/parent filtering: CommunitySkill is a shared, instance-global
+        # catalog with no team_id. Access is gated by the feature-flag permission above.
+        user = cast(User, self.request.user)
+        return (
+            CommunitySkill.objects.filter(deleted=False)
+            .prefetch_related("files")
+            .annotate(
+                vote_count=Count("votes", distinct=True),
+                has_voted=Exists(CommunitySkillVote.objects.filter(skill=OuterRef("pk"), user=user)),
+            )
+        )
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return CommunitySkillListSerializer
+        return super().get_serializer_class()
+
+    @extend_schema(
+        parameters=[CommunitySkillListQuerySerializer], responses={200: CommunitySkillListSerializer(many=True)}
+    )
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        params = CommunitySkillListQuerySerializer(data=request.query_params)
+        params.is_valid(raise_exception=True)
+
+        queryset = self.get_queryset()
+        search = params.validated_data.get("search", "").strip()
+        if search:
+            queryset = queryset.filter(
+                Q(name__icontains=search) | Q(description__icontains=search) | Q(tags__icontains=search)
+            )
+        tag = params.validated_data.get("tag", "").strip()
+        if tag:
+            queryset = queryset.filter(tags__icontains=tag)
+        trust_tier = params.validated_data.get("trust_tier")
+        if trust_tier:
+            queryset = queryset.filter(trust_tier=trust_tier)
+
+        order_by = params.validated_data.get("order_by", "-install_count")
+        queryset = queryset.order_by(order_by if order_by in ALLOWED_LIST_ORDERINGS else "-install_count", "-id")
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response({"count": len(serializer.data), "results": serializer.data})
+
+    @extend_schema(request=CommunitySkillInstallSerializer, responses={201: LLMSkillSerializer})
+    @action(methods=["POST"], detail=True)
+    def install(self, request: Request, slug: str = "", **kwargs) -> Response:
+        payload = CommunitySkillInstallSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        try:
+            installed = install_community_skill(
+                team=self.team,
+                user=cast(User, request.user),
+                slug=slug,
+                new_name=payload.validated_data.get("new_name"),
+            )
+        except CommunitySkillNotFoundError:
+            return Response(
+                {"detail": f"Community skill '{slug}' not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except LLMSkillDuplicateNameConflictError:
+            return Response(
+                {"attr": "new_name", "detail": "A skill with this name already exists in your project."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        report_user_action(
+            cast(User, request.user),
+            "community skill installed",
+            {
+                "community_skill_slug": slug,
+                "installed_skill_name": installed.name,
+            },
+            team=self.team,
+            request=request,
+        )
+        return Response(
+            cast(dict[str, Any], LLMSkillSerializer(installed, context=self.get_serializer_context()).data),
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(request=None, responses={200: CommunitySkillVoteResponseSerializer})
+    @action(methods=["POST"], detail=True)
+    def vote(self, request: Request, slug: str = "", **kwargs) -> Response:
+        try:
+            vote_count, has_voted = toggle_community_skill_vote(slug=slug, user=cast(User, request.user))
+        except CommunitySkillNotFoundError:
+            return Response(
+                {"detail": f"Community skill '{slug}' not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response({"vote_count": vote_count, "has_voted": has_voted})

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -16,7 +16,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.event_usage import report_user_action
 from posthog.models import User
 from posthog.permissions import get_organization_from_view
-from posthog.rate_limit import BurstRateThrottle, SustainedRateThrottle
+from posthog.rate_limit import PersonalApiKeyOrUserRateThrottle
 
 from ..models.community_skills import CommunitySkill, CommunitySkillVote
 from .community_skill_serializers import (
@@ -29,11 +29,26 @@ from .community_skill_serializers import (
 )
 from .community_skill_services import CommunitySkillNotFoundError, install_community_skill, toggle_community_skill_vote
 from .skill_serializers import LLMSkillSerializer
-from .skill_services import LLMSkillDuplicateNameConflictError
+from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimitError, LLMSkillFilePathConflictError
 
 logger = structlog.get_logger(__name__)
 
 COMMUNITY_SKILL_FEATURE_FLAG = "llm-analytics-community-skills"
+# Installing copies into a regular LLMSkill, whose UI and APIs are gated by this base flag — so the
+# marketplace also requires it, otherwise installed skills would be unreachable.
+BASE_SKILL_FEATURE_FLAG = "llm-analytics-skills"
+
+
+class CommunitySkillBurstThrottle(PersonalApiKeyOrUserRateThrottle):
+    # Web-aware burst throttle: this endpoint is session-authenticated, so the default
+    # PersonalApiKeyRateThrottle (personal-API-key only) would leave it unthrottled.
+    scope = "burst"
+    rate = "480/minute"
+
+
+class CommunitySkillSustainedThrottle(PersonalApiKeyOrUserRateThrottle):
+    scope = "sustained"
+    rate = "4800/hour"
 
 
 class CommunitySkillFeatureFlagPermission(BasePermission):
@@ -43,15 +58,18 @@ class CommunitySkillFeatureFlagPermission(BasePermission):
         org_id = str(organization.id)
         distinct_id = user.distinct_id or str(user.uuid)
 
-        return bool(
-            posthoganalytics.feature_enabled(
-                COMMUNITY_SKILL_FEATURE_FLAG,
-                distinct_id,
-                groups={"organization": org_id},
-                group_properties={"organization": {"id": org_id}},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
+        return all(
+            bool(
+                posthoganalytics.feature_enabled(
+                    flag,
+                    distinct_id,
+                    groups={"organization": org_id},
+                    group_properties={"organization": {"id": org_id}},
+                    only_evaluate_locally=False,
+                    send_feature_flag_events=False,
+                )
             )
+            for flag in (COMMUNITY_SKILL_FEATURE_FLAG, BASE_SKILL_FEATURE_FLAG)
         )
 
 
@@ -70,7 +88,7 @@ class CommunitySkillViewSet(
 
     def get_throttles(self):
         if self.action in ("install", "vote"):
-            return [BurstRateThrottle(), SustainedRateThrottle()]
+            return [CommunitySkillBurstThrottle(), CommunitySkillSustainedThrottle()]
         return super().get_throttles()
 
     def dangerously_get_queryset(self) -> QuerySet[CommunitySkill]:
@@ -153,6 +171,12 @@ class CommunitySkillViewSet(
         except LLMSkillDuplicateNameConflictError:
             return Response(
                 {"attr": "new_name", "detail": "A skill with this name already exists in your project."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except (LLMSkillFileLimitError, LLMSkillFilePathConflictError):
+            # The synced community payload violates the skill limits (too many files / bad paths).
+            return Response(
+                {"detail": "This community skill can't be installed because its bundled files are invalid."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/products/ai_observability/backend/api/skill_serializers.py
+++ b/products/ai_observability/backend/api/skill_serializers.py
@@ -544,3 +544,31 @@ class LLMSkillFileDeleteQuerySerializer(serializers.Serializer):
             "when another write has landed in the meantime."
         ),
     )
+
+
+class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
+    display_name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=200,
+        help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=64),
+        required=False,
+        help_text="Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].",
+    )
+    author_handle = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=100,
+        help_text="The publisher's GitHub username, used for public attribution on the listing and PR. Optional.",
+    )
+
+
+class CommunitySkillPublishResultSerializer(serializers.Serializer):
+    pr_url = serializers.URLField(
+        help_text="URL of the pull request opened in the community-skills repo for maintainer review."
+    )
+    pr_number = serializers.IntegerField(help_text="Number of the opened pull request.")
+    branch = serializers.CharField(help_text="Name of the branch created in the community-skills repo.")

--- a/products/ai_observability/backend/api/skills.py
+++ b/products/ai_observability/backend/api/skills.py
@@ -29,8 +29,14 @@ from posthog.rate_limit import BurstRateThrottle, SustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 
 from ..models.skills import LLMSkill, LLMSkillFile
+from .community_publish_services import (
+    CommunitySkillPublishError,
+    CommunitySkillPublishNotConfiguredError,
+    publish_skill_to_community,
+)
 from .metrics import llma_track_latency
 from .skill_serializers import (
+    CommunitySkillPublishResultSerializer,
     LLMSkillCreateSerializer,
     LLMSkillDuplicateSerializer,
     LLMSkillFetchQuerySerializer,
@@ -41,6 +47,7 @@ from .skill_serializers import (
     LLMSkillListQuerySerializer,
     LLMSkillListSerializer,
     LLMSkillPublishSerializer,
+    LLMSkillPublishToCommunitySerializer,
     LLMSkillResolveQuerySerializer,
     LLMSkillResolveResponseSerializer,
     LLMSkillSerializer,
@@ -163,7 +170,7 @@ class LLMSkillViewSet(
         return get_active_skill_queryset(self.team)
 
     def get_throttles(self):
-        if self.action in ["update_by_name", "get_by_name", "resolve_by_name"]:
+        if self.action in ["update_by_name", "get_by_name", "resolve_by_name", "publish_to_community"]:
             return [BurstRateThrottle(), SustainedRateThrottle()]
         return super().get_throttles()
 
@@ -561,6 +568,70 @@ class LLMSkillViewSet(
             request=request,
         )
         return Response(self._serialize_skill(new_skill), status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=LLMSkillPublishToCommunitySerializer, responses={201: CommunitySkillPublishResultSerializer})
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path=r"name/(?P<skill_name>[^/]+)/publish-community",
+        required_scopes=["llm_skill:write"],
+    )
+    @llma_track_latency("llma_skills_publish_community")
+    @monitor(feature=None, endpoint="llma_skills_publish_community", method="POST")
+    def publish_to_community(self, request: Request, skill_name: str = "", **kwargs) -> Response:
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
+        skill = get_skill_by_name_from_db(self.team, skill_name)
+        if skill is None:
+            return self._skill_not_found_response(skill_name)
+
+        payload = LLMSkillPublishToCommunitySerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        files = [{"path": f.path, "content": f.content, "content_type": f.content_type} for f in skill.files.all()]
+        metadata_tags = (skill.metadata or {}).get("tags")
+        tags = payload.validated_data.get("tags") or (metadata_tags if isinstance(metadata_tags, list) else [])
+        # The LLMSkill name is the kebab slug; default the community display name to a title-cased form.
+        display_name = payload.validated_data.get("display_name") or skill.name.replace("-", " ").title()
+
+        try:
+            result = publish_skill_to_community(
+                slug=skill.name,
+                name=display_name,
+                description=skill.description,
+                body=skill.body,
+                files=files or None,
+                tags=tags,
+                allowed_tools=skill.allowed_tools or [],
+                license=skill.license or "",
+                compatibility=skill.compatibility or "",
+                author_handle=payload.validated_data.get("author_handle", ""),
+            )
+        except CommunitySkillPublishNotConfiguredError:
+            return Response(
+                {"detail": "Publishing to the community is not available on this instance."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except CommunitySkillPublishError as err:
+            return Response({"detail": str(err)}, status=status.HTTP_502_BAD_GATEWAY)
+
+        props = {**_skill_analytics_props(skill), "community_pr_number": result["pr_number"]}
+        logger.info(
+            "llma_skill_published_to_community",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
+        report_user_action(
+            cast(User, request.user),
+            "llma skill published to community",
+            props,
+            team=self.team,
+            request=request,
+        )
+        return Response(result, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         parameters=[LLMSkillFetchQuerySerializer],

--- a/products/ai_observability/backend/api/test/test_community_publish_services.py
+++ b/products/ai_observability/backend/api/test/test_community_publish_services.py
@@ -1,0 +1,96 @@
+import re
+
+import yaml
+
+from products.ai_observability.backend.api.community_publish_services import (
+    CommunitySkillPublishError,
+    render_community_skill_files,
+    render_skill_md,
+)
+
+# Mirror of the community-skills repo's frontmatter parser (scripts/build_registry.py) so these
+# tests fail if we ever render a SKILL.md the repo's own CI would reject.
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+def _parse(content: str) -> tuple[dict, str]:
+    match = FRONTMATTER_RE.match(content)
+    assert match is not None, "rendered SKILL.md must start with a YAML frontmatter block"
+    return yaml.safe_load(match.group(1)) or {}, match.group(2).strip()
+
+
+class TestRenderSkillMd:
+    def test_renders_required_fields_and_body(self) -> None:
+        content = render_skill_md(
+            name="Make PR", description="Open a PR for the current branch.", body="# Make PR\n\nDo it."
+        )
+        frontmatter, body = _parse(content)
+        assert frontmatter["name"] == "Make PR"
+        assert frontmatter["description"] == "Open a PR for the current branch."
+        assert frontmatter["trust_tier"] == "community"
+        assert body == "# Make PR\n\nDo it."
+
+    def test_optional_fields_omitted_when_empty(self) -> None:
+        frontmatter, _ = _parse(render_skill_md(name="X", description="Y", body="Z"))
+        for omitted in ("tags", "author_handle", "license", "compatibility", "allowed_tools"):
+            assert omitted not in frontmatter
+
+    def test_optional_fields_included_when_set(self) -> None:
+        content = render_skill_md(
+            name="Make PR",
+            description="Open a PR.",
+            body="body",
+            tags=["github", "workflow"],
+            allowed_tools=["query", "docs-search"],
+            license="MIT",
+            compatibility="Requires gh",
+            author_handle="andymaguire",
+        )
+        frontmatter, _ = _parse(content)
+        assert frontmatter["tags"] == ["github", "workflow"]
+        assert frontmatter["allowed_tools"] == ["query", "docs-search"]
+        assert frontmatter["license"] == "MIT"
+        assert frontmatter["compatibility"] == "Requires gh"
+        assert frontmatter["author_handle"] == "andymaguire"
+
+    def test_requires_name_and_description(self) -> None:
+        for kwargs in ({"name": "  ", "description": "d"}, {"name": "n", "description": ""}):
+            try:
+                render_skill_md(body="b", **kwargs)
+            except CommunitySkillPublishError:
+                continue
+            raise AssertionError(f"expected CommunitySkillPublishError for {kwargs}")
+
+
+class TestRenderCommunitySkillFiles:
+    def test_skill_md_path_and_bundled_files(self) -> None:
+        rendered = render_community_skill_files(
+            slug="make-pr",
+            name="Make PR",
+            description="Open a PR.",
+            body="body",
+            files=[{"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}],
+        )
+        paths = {f.path for f in rendered}
+        assert paths == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
+
+    def test_rejects_bad_slug(self) -> None:
+        for bad in ["Make-PR", "make_pr", "-bad", "double--hyphen", "x" * 65]:
+            try:
+                render_community_skill_files(slug=bad, name="n", description="d", body="b")
+            except CommunitySkillPublishError:
+                continue
+            raise AssertionError(f"expected rejection for slug {bad!r}")
+
+    def test_rejects_path_traversal_in_bundled_file(self) -> None:
+        try:
+            render_community_skill_files(
+                slug="make-pr",
+                name="n",
+                description="d",
+                body="b",
+                files=[{"path": "../escape.md", "content": "x", "content_type": "text/plain"}],
+            )
+        except CommunitySkillPublishError:
+            return
+        raise AssertionError("expected rejection for path traversal")

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -159,3 +159,14 @@ class TestCommunitySkillSync(APIBaseTest):
 
         result = sync_community_skills_from_github()
         self.assertEqual(result, {"synced": 0, "skipped": 1, "removed": 0})
+
+    @patch("products.ai_observability.backend.api.community_skill_services.requests.get")
+    def test_sync_empty_registry_does_not_wipe_catalog(self, mock_get) -> None:
+        _create_community_skill(slug="keep-me")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {"skills": []}
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 0, "removed": 0})
+        self.assertFalse(CommunitySkill.objects.get(slug="keep-me").deleted)

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -1,0 +1,161 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
+from ...models.skills import LLMSkill
+from ..community_skill_services import sync_community_skills_from_github
+
+
+def _create_community_skill(
+    *,
+    slug: str = "web-analytics-triage",
+    name: str = "Web analytics triage",
+    trust_tier: str = "official",
+    install_count: int = 0,
+    deleted: bool = False,
+) -> CommunitySkill:
+    return CommunitySkill.objects.create(
+        slug=slug,
+        name=name,
+        description="Investigate a change in web traffic.",
+        body="# Triage\nDo the thing.",
+        trust_tier=trust_tier,
+        tags=["web-analytics"],
+        install_count=install_count,
+        deleted=deleted,
+    )
+
+
+@patch(
+    "products.ai_observability.backend.api.community_skills.posthoganalytics.feature_enabled",
+    return_value=True,
+)
+class TestCommunitySkillAPI(APIBaseTest):
+    def _url(self, path: str = "") -> str:
+        return f"/api/projects/{self.team.id}/community_skills/{path}"
+
+    def test_list_returns_published_skills_ordered_by_installs(self, _mock_flag) -> None:
+        _create_community_skill(slug="alpha", install_count=1)
+        _create_community_skill(slug="beta", install_count=5)
+
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual([s["slug"] for s in results], ["beta", "alpha"])
+        self.assertNotIn("body", results[0])  # list serializer omits body
+
+    def test_list_excludes_deleted(self, _mock_flag) -> None:
+        _create_community_skill(slug="visible")
+        _create_community_skill(slug="gone", deleted=True)
+
+        response = self.client.get(self._url())
+        self.assertEqual([s["slug"] for s in response.json()["results"]], ["visible"])
+
+    def test_filter_by_trust_tier(self, _mock_flag) -> None:
+        _create_community_skill(slug="official-one", trust_tier="official")
+        _create_community_skill(slug="community-one", trust_tier="community")
+
+        response = self.client.get(self._url(), {"trust_tier": "community"})
+        self.assertEqual([s["slug"] for s in response.json()["results"]], ["community-one"])
+
+    def test_retrieve_by_slug_includes_body(self, _mock_flag) -> None:
+        _create_community_skill(slug="web-analytics-triage")
+        response = self.client.get(self._url("web-analytics-triage/"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["body"], "# Triage\nDo the thing.")
+
+    def test_install_creates_team_skill_and_increments_count(self, _mock_flag) -> None:
+        skill = _create_community_skill(slug="web-analytics-triage")
+        CommunitySkillFile.objects.create(skill=skill, path="references/playbook.md", content="hints")
+
+        response = self.client.post(self._url("web-analytics-triage/install/"), {})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        installed = LLMSkill.objects.get(team=self.team, name="web-analytics-triage")
+        self.assertEqual(installed.body, "# Triage\nDo the thing.")
+        self.assertEqual(installed.metadata["community_skill_slug"], "web-analytics-triage")
+        self.assertEqual(installed.files.count(), 1)
+
+        skill.refresh_from_db()
+        self.assertEqual(skill.install_count, 1)
+
+    def test_install_with_custom_name(self, _mock_flag) -> None:
+        _create_community_skill(slug="web-analytics-triage")
+        response = self.client.post(self._url("web-analytics-triage/install/"), {"new_name": "my-triage"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertTrue(LLMSkill.objects.filter(team=self.team, name="my-triage").exists())
+
+    def test_install_name_conflict_returns_400(self, _mock_flag) -> None:
+        _create_community_skill(slug="web-analytics-triage")
+        LLMSkill.objects.create(team=self.team, name="web-analytics-triage", description="x", body="y")
+
+        response = self.client.post(self._url("web-analytics-triage/install/"), {})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_install_unknown_slug_returns_404(self, _mock_flag) -> None:
+        response = self.client.post(self._url("does-not-exist/install/"), {})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_vote_toggles_on_and_off(self, _mock_flag) -> None:
+        _create_community_skill(slug="web-analytics-triage")
+
+        first = self.client.post(self._url("web-analytics-triage/vote/"))
+        self.assertEqual(first.json(), {"vote_count": 1, "has_voted": True})
+
+        second = self.client.post(self._url("web-analytics-triage/vote/"))
+        self.assertEqual(second.json(), {"vote_count": 0, "has_voted": False})
+        self.assertFalse(CommunitySkillVote.objects.exists())
+
+
+class TestCommunitySkillSync(APIBaseTest):
+    @patch("products.ai_observability.backend.api.community_skill_services.requests.get")
+    def test_sync_upserts_and_soft_deletes_missing(self, mock_get) -> None:
+        _create_community_skill(slug="stale-skill", install_count=3)
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "version": 1,
+            "skills": [
+                {
+                    "slug": "fresh-skill",
+                    "name": "Fresh skill",
+                    "description": "New one",
+                    "body": "# Fresh",
+                    "trust_tier": "community",
+                    "source_sha": "abc123",
+                    "files": [{"path": "ref.md", "content": "x"}],
+                }
+            ],
+        }
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 1, "skipped": 0, "removed": 1})
+
+        fresh = CommunitySkill.objects.get(slug="fresh-skill")
+        self.assertEqual(fresh.files.count(), 1)
+        self.assertFalse(fresh.deleted)
+        self.assertIsNotNone(fresh.published_at)
+
+        self.assertTrue(CommunitySkill.objects.get(slug="stale-skill").deleted)
+
+    @patch("products.ai_observability.backend.api.community_skill_services.requests.get")
+    def test_sync_skips_unchanged_sha(self, mock_get) -> None:
+        existing = _create_community_skill(slug="web-analytics-triage")
+        CommunitySkill.objects.filter(pk=existing.pk).update(source_sha="same-sha")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "skills": [
+                {
+                    "slug": "web-analytics-triage",
+                    "name": "Web analytics triage",
+                    "description": "Investigate a change in web traffic.",
+                    "source_sha": "same-sha",
+                }
+            ],
+        }
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 1, "removed": 0})

--- a/products/ai_observability/backend/migrations/0005_communityskill.py
+++ b/products/ai_observability/backend/migrations/0005_communityskill.py
@@ -1,0 +1,131 @@
+import django.utils.timezone
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai_observability", "0004_parserrecipe"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CommunitySkill",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("slug", models.CharField(max_length=64, unique=True)),
+                ("name", models.CharField(max_length=64)),
+                ("description", models.CharField(max_length=4096)),
+                ("body", models.TextField()),
+                ("license", models.CharField(blank=True, default="", max_length=255)),
+                ("compatibility", models.CharField(blank=True, default="", max_length=500)),
+                ("allowed_tools", models.JSONField(blank=True, default=list)),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                ("tags", models.JSONField(blank=True, default=list)),
+                (
+                    "trust_tier",
+                    models.CharField(
+                        choices=[
+                            ("official", "Official"),
+                            ("verified", "Verified"),
+                            ("community", "Community"),
+                        ],
+                        default="community",
+                        max_length=20,
+                    ),
+                ),
+                ("author_handle", models.CharField(blank=True, default="", max_length=255)),
+                ("github_url", models.CharField(blank=True, default="", max_length=8201)),
+                ("source_sha", models.CharField(blank=True, default="", max_length=64)),
+                ("install_count", models.PositiveIntegerField(default=0)),
+                ("published_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("deleted", models.BooleanField(default=False)),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskill",
+            },
+        ),
+        migrations.CreateModel(
+            name="CommunitySkillFile",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("path", models.CharField(max_length=500)),
+                ("content", models.TextField()),
+                ("content_type", models.CharField(default="text/plain", max_length=100)),
+                (
+                    "skill",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="files",
+                        to="ai_observability.communityskill",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskillfile",
+            },
+        ),
+        migrations.CreateModel(
+            name="CommunitySkillVote",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "skill",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="votes",
+                        to="ai_observability.communityskill",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskillvote",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="communityskillfile",
+            constraint=models.UniqueConstraint(fields=("skill", "path"), name="unique_community_skill_file_path"),
+        ),
+        migrations.AddConstraint(
+            model_name="communityskillvote",
+            constraint=models.UniqueConstraint(fields=("skill", "user"), name="unique_community_skill_vote_per_user"),
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0004_parserrecipe
+0005_communityskill

--- a/products/ai_observability/backend/models/__init__.py
+++ b/products/ai_observability/backend/models/__init__.py
@@ -1,5 +1,6 @@
 from .clustering_config import ClusteringConfig
 from .clustering_job import ClusteringJob
+from .community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier, CommunitySkillVote
 from .datasets import Dataset, DatasetItem
 from .evaluation_config import EvaluationConfig
 from .evaluation_reports import EvaluationReport, EvaluationReportRun
@@ -18,6 +19,10 @@ from .trace_reviews import TraceReview, TraceReviewScore
 __all__ = [
     "ClusteringConfig",
     "ClusteringJob",
+    "CommunitySkill",
+    "CommunitySkillFile",
+    "CommunitySkillTrustTier",
+    "CommunitySkillVote",
     "Evaluation",
     "EvaluationConfig",
     "EvaluationReport",

--- a/products/ai_observability/backend/models/community_skills.py
+++ b/products/ai_observability/backend/models/community_skills.py
@@ -1,0 +1,89 @@
+from django.db import models
+from django.utils import timezone
+
+from posthog.models.utils import UUIDModel
+
+
+class CommunitySkillTrustTier(models.TextChoices):
+    OFFICIAL = "official", "Official"
+    VERIFIED = "verified", "Verified"
+    COMMUNITY = "community", "Community"
+
+
+class CommunitySkill(UUIDModel):
+    """Instance-global catalog of community-shared agent skills.
+
+    The source of truth for skill content is the PostHog/community-skills GitHub repo;
+    rows here are a synced read-model that powers in-app discovery, search, ranking, and
+    install. This model is deliberately NOT team-scoped — it is shared catalog data (the
+    same way DashboardTemplate GLOBAL templates are), so it has no team_id by design.
+    Installing a community skill copies it into a team as a regular LLMSkill.
+    """
+
+    class Meta:
+        db_table = "llm_analytics_communityskill"
+
+    # The repo directory name — the stable, human-readable identifier used in URLs.
+    slug = models.CharField(max_length=64, unique=True)
+
+    # Mirrors the Agent Skills spec fields carried by LLMSkill.
+    name = models.CharField(max_length=64)
+    description = models.CharField(max_length=4096)
+    body = models.TextField()
+    license = models.CharField(max_length=255, blank=True, default="")
+    compatibility = models.CharField(max_length=500, blank=True, default="")
+    allowed_tools = models.JSONField(blank=True, default=list)
+    metadata = models.JSONField(blank=True, default=dict)
+
+    # Marketplace fields.
+    tags = models.JSONField(blank=True, default=list)
+    trust_tier = models.CharField(
+        max_length=20,
+        choices=CommunitySkillTrustTier.choices,
+        default=CommunitySkillTrustTier.COMMUNITY,
+    )
+    author_handle = models.CharField(max_length=255, blank=True, default="")
+    github_url = models.CharField(max_length=8201, blank=True, default="")
+    # Commit SHA of the repo state this row was last synced from — lets the sync job skip unchanged skills.
+    source_sha = models.CharField(max_length=64, blank=True, default="")
+    # Denormalized install counter, incremented on each install. Strongest popularity signal.
+    install_count = models.PositiveIntegerField(default=0)
+
+    published_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+    # Soft-delete for skills removed from the repo, so install history and votes survive.
+    deleted = models.BooleanField(default=False)
+
+
+class CommunitySkillFile(UUIDModel):
+    class Meta:
+        db_table = "llm_analytics_communityskillfile"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["skill", "path"],
+                name="unique_community_skill_file_path",
+            ),
+        ]
+
+    skill = models.ForeignKey(CommunitySkill, on_delete=models.CASCADE, related_name="files")
+    path = models.CharField(max_length=500)
+    content = models.TextField()
+    content_type = models.CharField(max_length=100, default="text/plain")
+
+
+class CommunitySkillVote(UUIDModel):
+    """A single user's upvote of a community skill. User-scoped, not tenant data."""
+
+    class Meta:
+        db_table = "llm_analytics_communityskillvote"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["skill", "user"],
+                name="unique_community_skill_vote_per_user",
+            ),
+        ]
+
+    skill = models.ForeignKey(CommunitySkill, on_delete=models.CASCADE, related_name="votes")
+    user = models.ForeignKey("posthog.User", on_delete=models.CASCADE)
+    created_at = models.DateTimeField(default=timezone.now)

--- a/products/ai_observability/backend/routes.py
+++ b/products/ai_observability/backend/routes.py
@@ -29,6 +29,7 @@ from products.ai_observability.backend.api import (
     TaggerViewSet,
     TraceReviewViewSet,
 )
+from products.ai_observability.backend.api.community_skills import CommunitySkillViewSet
 from products.ai_observability.backend.api.skills import LLMSkillViewSet
 
 
@@ -43,6 +44,7 @@ def register_routes(routers: RouterRegistry) -> None:
         r"llm_analytics/parser_recipes", ParserRecipeViewSet, "project_llm_analytics_parser_recipes", ["team_id"]
     )
     routers.register_legacy_dual_route(r"llm_skills", LLMSkillViewSet, "project_llm_skills", ["team_id"])
+    routers.projects.register(r"community_skills", CommunitySkillViewSet, "project_community_skills", ["team_id"])
     routers.register_legacy_dual_route(r"datasets", DatasetViewSet, "environment_datasets", ["team_id"])
     routers.register_legacy_dual_route(r"dataset_items", DatasetItemViewSet, "environment_dataset_items", ["team_id"])
     routers.register_legacy_dual_route(r"evaluations", EvaluationViewSet, "project_evaluations", ["team_id"])

--- a/products/ai_observability/backend/tasks.py
+++ b/products/ai_observability/backend/tasks.py
@@ -1,0 +1,24 @@
+from celery import shared_task
+from structlog import get_logger
+
+from posthog.scoping_audit import skip_team_scope_audit
+
+from products.ai_observability.backend.api.community_skill_services import sync_community_skills_from_github
+
+logger = get_logger(__name__)
+
+
+@shared_task(ignore_result=True)
+@skip_team_scope_audit
+def sync_community_skills() -> None:
+    """Reconcile the local community-skills catalog with the PostHog/community-skills repo.
+
+    Operates on the instance-global CommunitySkill catalog (no team scope), so the team-scope
+    audit is intentionally skipped.
+    """
+    try:
+        result = sync_community_skills_from_github()
+    except Exception:
+        logger.exception("community_skills_sync_failed")
+        raise
+    logger.info("community_skills_sync_complete", **result)

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -138,6 +138,169 @@ export interface _ErrorResponseApi {
 }
 
 /**
+ * * `official` - Official
+ * * `verified` - Verified
+ * * `community` - Community
+ */
+export type TrustTierEnumApi = (typeof TrustTierEnumApi)[keyof typeof TrustTierEnumApi]
+
+export const TrustTierEnumApi = {
+    Official: 'official',
+    Verified: 'verified',
+    Community: 'community',
+} as const
+
+/**
+ * Arbitrary key-value metadata carried from the skill's frontmatter.
+ */
+export type CommunitySkillListApiMetadata = { [key: string]: unknown }
+
+/**
+ * List serializer that omits body and file manifest — progressive disclosure.
+ */
+export interface CommunitySkillListApi {
+    readonly id: string
+    /** Stable identifier matching the skill's directory in the community-skills repo. */
+    readonly slug: string
+    /** Display name of the skill. */
+    readonly name: string
+    /** What the skill does and when to use it. */
+    readonly description: string
+    /** License name or reference. */
+    readonly license: string
+    /** Environment requirements declared by the skill. */
+    readonly compatibility: string
+    /** Tools the skill declares it may use. Surface these to the user before install. */
+    allowed_tools?: string[]
+    /** Arbitrary key-value metadata carried from the skill's frontmatter. */
+    metadata?: CommunitySkillListApiMetadata
+    /** Free-form tags used for filtering and discovery. */
+    tags?: string[]
+    /** Moderation tier: 'official' (PostHog-authored), 'verified' (reviewed), or 'community'.
+     *
+     * * `official` - Official
+     * * `verified` - Verified
+     * * `community` - Community */
+    trust_tier: TrustTierEnumApi
+    /** GitHub handle (or name) of the contributor who published the skill. */
+    readonly author_handle: string
+    /** Link to the skill's source directory on GitHub. */
+    readonly github_url: string
+    /** Number of times this skill has been installed into a team. */
+    readonly install_count: number
+    /** Total number of upvotes this skill has received. */
+    readonly vote_count: number
+    /** Whether the requesting user has upvoted this skill. */
+    readonly has_voted: boolean
+    /**
+     * When the skill was first published to the community repo.
+     * @nullable
+     */
+    readonly published_at: string | null
+    readonly created_at: string
+    readonly updated_at: string
+}
+
+export interface PaginatedCommunitySkillListListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CommunitySkillListApi[]
+}
+
+/**
+ * Arbitrary key-value metadata carried from the skill's frontmatter.
+ */
+export type CommunitySkillApiMetadata = { [key: string]: unknown }
+
+export interface CommunitySkillFileManifestApi {
+    /** @maxLength 500 */
+    path: string
+    /** @maxLength 100 */
+    content_type?: string
+}
+
+export interface CommunitySkillApi {
+    readonly id: string
+    /** Stable identifier matching the skill's directory in the community-skills repo. */
+    readonly slug: string
+    /** Display name of the skill. */
+    readonly name: string
+    /** What the skill does and when to use it. */
+    readonly description: string
+    /** The SKILL.md instruction content (markdown). */
+    readonly body: string
+    /** License name or reference. */
+    readonly license: string
+    /** Environment requirements declared by the skill. */
+    readonly compatibility: string
+    /** Tools the skill declares it may use. Surface these to the user before install. */
+    allowed_tools?: string[]
+    /** Arbitrary key-value metadata carried from the skill's frontmatter. */
+    metadata?: CommunitySkillApiMetadata
+    /** Free-form tags used for filtering and discovery. */
+    tags?: string[]
+    /** Moderation tier: 'official' (PostHog-authored), 'verified' (reviewed), or 'community'.
+     *
+     * * `official` - Official
+     * * `verified` - Verified
+     * * `community` - Community */
+    trust_tier: TrustTierEnumApi
+    /** GitHub handle (or name) of the contributor who published the skill. */
+    readonly author_handle: string
+    /** Link to the skill's source directory on GitHub. */
+    readonly github_url: string
+    /** Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint. */
+    readonly files: readonly CommunitySkillFileManifestApi[]
+    /** Number of times this skill has been installed into a team. */
+    readonly install_count: number
+    /** Total number of upvotes this skill has received. */
+    readonly vote_count: number
+    /** Whether the requesting user has upvoted this skill. */
+    readonly has_voted: boolean
+    /**
+     * When the skill was first published to the community repo.
+     * @nullable
+     */
+    readonly published_at: string | null
+    readonly created_at: string
+    readonly updated_at: string
+}
+
+export interface CommunitySkillInstallApi {
+    /**
+     * Name for the installed skill in your team. Defaults to the community skill's slug.
+     * @maxLength 64
+     */
+    new_name?: string
+}
+
+/**
+ * Arbitrary key-value metadata.
+ */
+export type LLMSkillApiMetadata = { [key: string]: unknown }
+
+export interface LLMSkillFileManifestApi {
+    /** @maxLength 500 */
+    path: string
+    /** @maxLength 100 */
+    content_type?: string
+}
+
+export interface LLMSkillOutlineEntryApi {
+    /**
+     * Markdown heading level (1-6).
+     * @minimum 1
+     * @maximum 6
+     */
+    level: number
+    /** Heading text. */
+    text: string
+}
+
+/**
  * * `engineering` - Engineering
  * * `data` - Data
  * * `product` - Product Management
@@ -190,6 +353,56 @@ export interface UserBasicApi {
     /** @nullable */
     readonly hedgehog_config: UserBasicApiHedgehogConfig
     role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
+}
+
+export interface LLMSkillApi {
+    readonly id: string
+    /**
+     * Unique skill name. Lowercase letters, numbers, and hyphens only. Max 64 characters.
+     * @maxLength 64
+     */
+    name: string
+    /**
+     * What this skill does and when to use it. Max 4096 characters.
+     * @maxLength 4096
+     */
+    description: string
+    /** The SKILL.md instruction content (markdown). */
+    body: string
+    /**
+     * License name or reference to a bundled license file.
+     * @maxLength 255
+     */
+    license?: string
+    /**
+     * Environment requirements (intended product, system packages, network access, etc.).
+     * @maxLength 500
+     */
+    compatibility?: string
+    /** List of pre-approved tools the skill may use. */
+    allowed_tools?: string[]
+    /** Arbitrary key-value metadata. */
+    metadata?: LLMSkillApiMetadata
+    /** Bundled files manifest. Each entry is path + content_type only; fetch content via /llm_skills/name/{name}/files/{path}/. */
+    readonly files: readonly LLMSkillFileManifestApi[]
+    /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
+    readonly outline: readonly LLMSkillOutlineEntryApi[]
+    readonly version: number
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+    readonly deleted: boolean
+    readonly is_latest: boolean
+    readonly latest_version: number
+    readonly version_count: number
+    readonly first_version_created_at: string
+}
+
+export interface CommunitySkillVoteResponseApi {
+    /** Total upvotes after applying the toggle. */
+    vote_count: number
+    /** Whether the requesting user is now an upvoter. */
+    has_voted: boolean
 }
 
 export interface DatasetItemApi {
@@ -2001,17 +2214,6 @@ export interface LLMPromptResolveResponseApi {
     has_more: boolean
 }
 
-export interface LLMSkillOutlineEntryApi {
-    /**
-     * Markdown heading level (1-6).
-     * @minimum 1
-     * @maximum 6
-     */
-    level: number
-    /** Heading text. */
-    text: string
-}
-
 /**
  * Arbitrary key-value metadata.
  */
@@ -2137,61 +2339,6 @@ export interface LLMSkillCreateApi {
 /**
  * Arbitrary key-value metadata.
  */
-export type LLMSkillApiMetadata = { [key: string]: unknown }
-
-export interface LLMSkillFileManifestApi {
-    /** @maxLength 500 */
-    path: string
-    /** @maxLength 100 */
-    content_type?: string
-}
-
-export interface LLMSkillApi {
-    readonly id: string
-    /**
-     * Unique skill name. Lowercase letters, numbers, and hyphens only. Max 64 characters.
-     * @maxLength 64
-     */
-    name: string
-    /**
-     * What this skill does and when to use it. Max 4096 characters.
-     * @maxLength 4096
-     */
-    description: string
-    /** The SKILL.md instruction content (markdown). */
-    body: string
-    /**
-     * License name or reference to a bundled license file.
-     * @maxLength 255
-     */
-    license?: string
-    /**
-     * Environment requirements (intended product, system packages, network access, etc.).
-     * @maxLength 500
-     */
-    compatibility?: string
-    /** List of pre-approved tools the skill may use. */
-    allowed_tools?: string[]
-    /** Arbitrary key-value metadata. */
-    metadata?: LLMSkillApiMetadata
-    /** Bundled files manifest. Each entry is path + content_type only; fetch content via /llm_skills/name/{name}/files/{path}/. */
-    readonly files: readonly LLMSkillFileManifestApi[]
-    /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
-    readonly outline: readonly LLMSkillOutlineEntryApi[]
-    readonly version: number
-    readonly created_by: UserBasicApi
-    readonly created_at: string
-    readonly updated_at: string
-    readonly deleted: boolean
-    readonly is_latest: boolean
-    readonly latest_version: number
-    readonly version_count: number
-    readonly first_version_created_at: string
-}
-
-/**
- * Arbitrary key-value metadata.
- */
 export type PatchedLLMSkillPublishApiMetadata = { [key: string]: unknown }
 
 export interface LLMSkillEditOperationApi {
@@ -2298,6 +2445,33 @@ export interface LLMSkillFileApi {
     content: string
     /** @maxLength 100 */
     content_type?: string
+}
+
+export interface LLMSkillPublishToCommunityApi {
+    /**
+     * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+     * @maxLength 200
+     */
+    display_name?: string
+    /**
+     * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+     * @items.maxLength 64
+     */
+    tags?: string[]
+    /**
+     * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+     * @maxLength 100
+     */
+    author_handle?: string
+}
+
+export interface CommunitySkillPublishResultApi {
+    /** URL of the pull request opened in the community-skills repo for maintainer review. */
+    pr_url: string
+    /** Number of the opened pull request. */
+    pr_number: number
+    /** Name of the branch created in the community-skills repo. */
+    branch: string
 }
 
 export interface LLMSkillVersionSummaryApi {
@@ -2597,6 +2771,59 @@ export type LlmAnalyticsPersonalSpendListParams = {
      */
     refresh?: boolean
 }
+
+export type CommunitySkillsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * Sort key. Defaults to most-installed first.
+     *
+     * * `-created_at` - -created_at
+     * * `-install_count` - -install_count
+     * * `-name` - -name
+     * * `-published_at` - -published_at
+     * * `-vote_count` - -vote_count
+     * * `created_at` - created_at
+     * * `install_count` - install_count
+     * * `name` - name
+     * * `published_at` - published_at
+     * * `vote_count` - vote_count
+     * @minLength 1
+     */
+    order_by?: string
+    /**
+     * Substring filter applied to skill names, descriptions, and tags.
+     */
+    search?: string
+    /**
+     * Return only skills carrying this tag.
+     */
+    tag?: string
+    /**
+     * Filter to a single moderation tier.
+     *
+     * * `official` - Official
+     * * `verified` - Verified
+     * * `community` - Community
+     * @minLength 1
+     */
+    trust_tier?: CommunitySkillsListTrustTier
+}
+
+export type CommunitySkillsListTrustTier =
+    (typeof CommunitySkillsListTrustTier)[keyof typeof CommunitySkillsListTrustTier]
+
+export const CommunitySkillsListTrustTier = {
+    Official: 'official',
+    Verified: 'verified',
+    Community: 'community',
+} as const
 
 export type DatasetItemsListParams = {
     /**

--- a/products/ai_observability/frontend/generated/api.ts
+++ b/products/ai_observability/frontend/generated/api.ts
@@ -13,6 +13,11 @@ import type {
     BatchCheckResponseApi,
     ClusteringJobApi,
     ClusteringRunRequestApi,
+    CommunitySkillApi,
+    CommunitySkillInstallApi,
+    CommunitySkillPublishResultApi,
+    CommunitySkillVoteResponseApi,
+    CommunitySkillsListParams,
     DatasetApi,
     DatasetItemApi,
     DatasetItemsListParams,
@@ -38,6 +43,7 @@ import type {
     LLMSkillFileApi,
     LLMSkillFileCreateApi,
     LLMSkillFileRenameApi,
+    LLMSkillPublishToCommunityApi,
     LLMSkillResolveResponseApi,
     LlmAnalyticsClusteringConfigRetrieve200,
     LlmAnalyticsClusteringConfigSetEventFiltersCreate200,
@@ -65,6 +71,7 @@ import type {
     OfflineExperimentItemsRequestApi,
     OfflineExperimentItemsResponseApi,
     PaginatedClusteringJobListApi,
+    PaginatedCommunitySkillListListApi,
     PaginatedDatasetItemListApi,
     PaginatedDatasetListApi,
     PaginatedEvaluationListApi,
@@ -166,6 +173,81 @@ export const llmAnalyticsPersonalSpendList = async (
     return apiMutator<PersonalSpendAnalysisResponseApi[]>(getLlmAnalyticsPersonalSpendListUrl(params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getCommunitySkillsListUrl = (projectId: string, params?: CommunitySkillsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/community_skills/?${stringifiedParams}`
+        : `/api/projects/${projectId}/community_skills/`
+}
+
+export const communitySkillsList = async (
+    projectId: string,
+    params?: CommunitySkillsListParams,
+    options?: RequestInit
+): Promise<PaginatedCommunitySkillListListApi> => {
+    return apiMutator<PaginatedCommunitySkillListListApi>(getCommunitySkillsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCommunitySkillsRetrieveUrl = (projectId: string, slug: string) => {
+    return `/api/projects/${projectId}/community_skills/${slug}/`
+}
+
+export const communitySkillsRetrieve = async (
+    projectId: string,
+    slug: string,
+    options?: RequestInit
+): Promise<CommunitySkillApi> => {
+    return apiMutator<CommunitySkillApi>(getCommunitySkillsRetrieveUrl(projectId, slug), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCommunitySkillsInstallCreateUrl = (projectId: string, slug: string) => {
+    return `/api/projects/${projectId}/community_skills/${slug}/install/`
+}
+
+export const communitySkillsInstallCreate = async (
+    projectId: string,
+    slug: string,
+    communitySkillInstallApi?: CommunitySkillInstallApi,
+    options?: RequestInit
+): Promise<LLMSkillApi> => {
+    return apiMutator<LLMSkillApi>(getCommunitySkillsInstallCreateUrl(projectId, slug), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(communitySkillInstallApi),
+    })
+}
+
+export const getCommunitySkillsVoteCreateUrl = (projectId: string, slug: string) => {
+    return `/api/projects/${projectId}/community_skills/${slug}/vote/`
+}
+
+export const communitySkillsVoteCreate = async (
+    projectId: string,
+    slug: string,
+    options?: RequestInit
+): Promise<CommunitySkillVoteResponseApi> => {
+    return apiMutator<CommunitySkillVoteResponseApi>(getCommunitySkillsVoteCreateUrl(projectId, slug), {
+        ...options,
+        method: 'POST',
     })
 }
 
@@ -2278,6 +2360,24 @@ export const llmSkillsNameFilesDestroy = async (
     return apiMutator<LLMSkillApi>(getLlmSkillsNameFilesDestroyUrl(projectId, skillName, filePath, params), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getLlmSkillsNamePublishCommunityCreateUrl = (projectId: string, skillName: string) => {
+    return `/api/projects/${projectId}/llm_skills/name/${skillName}/publish-community/`
+}
+
+export const llmSkillsNamePublishCommunityCreate = async (
+    projectId: string,
+    skillName: string,
+    lLMSkillPublishToCommunityApi?: LLMSkillPublishToCommunityApi,
+    options?: RequestInit
+): Promise<CommunitySkillPublishResultApi> => {
+    return apiMutator<CommunitySkillPublishResultApi>(getLlmSkillsNamePublishCommunityCreateUrl(projectId, skillName), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(lLMSkillPublishToCommunityApi),
     })
 }
 

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -9,6 +9,16 @@
  */
 import * as zod from 'zod'
 
+export const communitySkillsInstallCreateBodyNewNameMax = 64
+
+export const CommunitySkillsInstallCreateBody = /* @__PURE__ */ zod.object({
+    new_name: zod
+        .string()
+        .max(communitySkillsInstallCreateBodyNewNameMax)
+        .optional()
+        .describe("Name for the installed skill in your team. Defaults to the community skill's slug."),
+})
+
 export const datasetItemsCreateBodyRefTraceIdMax = 255
 
 export const datasetItemsCreateBodyRefSourceIdMax = 255
@@ -1891,6 +1901,29 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Latest version you are editing from. If provided, the request fails with 409 when another write has landed in the meantime.'
         ),
+})
+
+export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 200
+
+export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
+
+export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax = 100
+
+export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.object({
+    display_name: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyDisplayNameMax)
+        .optional()
+        .describe('Human-friendly display name for the community listing. Defaults to a title-cased skill slug.'),
+    tags: zod
+        .array(zod.string().max(llmSkillsNamePublishCommunityCreateBodyTagsItemMax))
+        .optional()
+        .describe("Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage']."),
+    author_handle: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax)
+        .optional()
+        .describe("The publisher's GitHub username, used for public attribution on the listing and PR. Optional."),
 })
 
 export const taggersCreateBodyNameMax = 400

--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -1,0 +1,150 @@
+import { useActions, useValues } from 'kea'
+
+import { IconThumbsUp } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
+import { PaginationControl } from 'lib/lemon-ui/PaginationControl'
+import { usePagination } from 'lib/lemon-ui/PaginationControl/usePagination'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import type { CommunitySkillListApi } from 'products/ai_observability/frontend/generated/api.schemas'
+
+import { CommunitySkillTrustTier, communitySkillsLogic } from './communitySkillsLogic'
+
+export const scene: SceneExport = {
+    component: CommunitySkillsScene,
+    logic: communitySkillsLogic,
+    productKey: ProductKey.AI_OBSERVABILITY,
+}
+
+const TRUST_TIER_TAG: Record<CommunitySkillTrustTier, { label: string; type: LemonTagType }> = {
+    official: { label: 'Official', type: 'success' },
+    verified: { label: 'Verified', type: 'completion' },
+    community: { label: 'Community', type: 'default' },
+}
+
+function TrustTierBadge({ tier }: { tier: CommunitySkillTrustTier }): JSX.Element {
+    const config = TRUST_TIER_TAG[tier] ?? TRUST_TIER_TAG.community
+    return <LemonTag type={config.type}>{config.label}</LemonTag>
+}
+
+function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.Element {
+    const { installingSlugs } = useValues(communitySkillsLogic)
+    const { installSkill, toggleVote } = useActions(communitySkillsLogic)
+    const installing = !!installingSlugs[skill.slug]
+
+    return (
+        <div className="flex flex-col gap-2 border rounded p-4 bg-bg-light h-full">
+            <div className="flex items-start justify-between gap-2">
+                <h3 className="font-semibold m-0">{skill.name}</h3>
+                <TrustTierBadge tier={skill.trust_tier as CommunitySkillTrustTier} />
+            </div>
+            <p className="text-muted text-sm grow line-clamp-3">{skill.description}</p>
+            <div className="flex flex-wrap gap-1">
+                {(skill.tags ?? []).slice(0, 4).map((tag) => (
+                    <LemonTag key={tag} type="muted" size="small">
+                        {tag}
+                    </LemonTag>
+                ))}
+            </div>
+            <div className="flex items-center justify-between gap-2 pt-2 border-t">
+                <div className="flex items-center gap-3 text-muted text-xs">
+                    <span>{skill.install_count} installs</span>
+                    {skill.author_handle ? (
+                        <Link to={skill.github_url || undefined} target="_blank">
+                            @{skill.author_handle}
+                        </Link>
+                    ) : null}
+                </div>
+                <div className="flex items-center gap-2">
+                    <LemonButton
+                        size="small"
+                        type="tertiary"
+                        icon={<IconThumbsUp />}
+                        active={skill.has_voted}
+                        onClick={() => toggleVote(skill.slug)}
+                        tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
+                    >
+                        {skill.vote_count}
+                    </LemonButton>
+                    <LemonButton
+                        size="small"
+                        type="primary"
+                        loading={installing}
+                        disabledReason={installing ? 'Installing…' : undefined}
+                        onClick={() => installSkill(skill.slug)}
+                    >
+                        Install
+                    </LemonButton>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function CommunitySkillsScene(): JSX.Element {
+    const { displaySkills, filters, pagination, skillsLoading } = useValues(communitySkillsLogic)
+    const { setFilters } = useActions(communitySkillsLogic)
+    // Controlled pagination: page changes write the `page` URL param, which urlToAction turns into setFilters.
+    const paginationState = usePagination(displaySkills, pagination)
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Community skills"
+                description="Discover and install agent skills shared by the PostHog community."
+                resourceType={{ type: 'llm_analytics' }}
+            />
+
+            <div className="flex flex-wrap items-center gap-2">
+                <LemonInput
+                    type="search"
+                    placeholder="Search skills…"
+                    value={filters.search}
+                    onChange={(search) => setFilters({ search })}
+                    className="grow max-w-100"
+                />
+                <LemonSelect
+                    value={filters.trust_tier}
+                    onChange={(trust_tier) => setFilters({ trust_tier: trust_tier as CommunitySkillTrustTier | '' })}
+                    options={[
+                        { value: '', label: 'All tiers' },
+                        { value: 'official', label: 'Official' },
+                        { value: 'verified', label: 'Verified' },
+                        { value: 'community', label: 'Community' },
+                    ]}
+                />
+                <LemonSelect
+                    value={filters.order_by}
+                    onChange={(order_by) => setFilters({ order_by })}
+                    options={[
+                        { value: '-install_count', label: 'Most installed' },
+                        { value: '-vote_count', label: 'Top rated' },
+                        { value: '-published_at', label: 'Newest' },
+                        { value: 'name', label: 'Name (A–Z)' },
+                    ]}
+                />
+            </div>
+
+            {displaySkills.length === 0 && !skillsLoading ? (
+                <div className="text-muted text-center p-8">No community skills match your filters yet.</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {displaySkills.map((skill) => (
+                        <CommunitySkillCard key={skill.slug} skill={skill} />
+                    ))}
+                </div>
+            )}
+
+            <PaginationControl {...paginationState} nouns={['skill', 'skills']} />
+        </SceneContent>
+    )
+}

--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -37,9 +37,10 @@ function TrustTierBadge({ tier }: { tier: CommunitySkillTrustTier }): JSX.Elemen
 }
 
 function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.Element {
-    const { installingSlugs } = useValues(communitySkillsLogic)
+    const { installingSlugs, votingSlugs } = useValues(communitySkillsLogic)
     const { installSkill, toggleVote } = useActions(communitySkillsLogic)
     const installing = !!installingSlugs[skill.slug]
+    const voting = !!votingSlugs[skill.slug]
 
     return (
         <div className="flex flex-col gap-2 border rounded p-4 bg-bg-light h-full">
@@ -70,6 +71,8 @@ function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.El
                         type="tertiary"
                         icon={<IconThumbsUp />}
                         active={skill.has_voted}
+                        loading={voting}
+                        disabledReason={voting ? 'Saving your vote…' : undefined}
                         onClick={() => toggleVote(skill.slug)}
                         tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
                     >

--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconThumbsUp } from '@posthog/icons'
+import { IconGithub, IconThumbsUp } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -11,13 +11,12 @@ import { PaginationControl } from 'lib/lemon-ui/PaginationControl'
 import { usePagination } from 'lib/lemon-ui/PaginationControl/usePagination'
 import { SceneExport } from 'scenes/sceneTypes'
 
-import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import type { CommunitySkillListApi } from 'products/ai_observability/frontend/generated/api.schemas'
 
 import { CommunitySkillTrustTier, communitySkillsLogic } from './communitySkillsLogic'
+import { SkillsSceneShell } from './SkillsSceneShell'
 
 export const scene: SceneExport = {
     component: CommunitySkillsScene,
@@ -56,57 +55,59 @@ function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.El
                     </LemonTag>
                 ))}
             </div>
-            <div className="flex items-center justify-between gap-2 pt-2 border-t">
-                <div className="flex items-center gap-3 text-muted text-xs">
-                    <span>{skill.install_count} installs</span>
-                    {skill.author_handle ? (
-                        <Link to={skill.github_url || undefined} target="_blank">
-                            @{skill.author_handle}
-                        </Link>
-                    ) : null}
-                </div>
-                <div className="flex items-center gap-2">
-                    <LemonButton
-                        size="small"
-                        type="tertiary"
-                        icon={<IconThumbsUp />}
-                        active={skill.has_voted}
-                        loading={voting}
-                        disabledReason={voting ? 'Saving your vote…' : undefined}
-                        onClick={() => toggleVote(skill.slug)}
-                        tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
-                    >
-                        {skill.vote_count}
-                    </LemonButton>
-                    <LemonButton
-                        size="small"
-                        type="primary"
-                        loading={installing}
-                        disabledReason={installing ? 'Installing…' : undefined}
-                        onClick={() => installSkill(skill.slug)}
-                    >
-                        Install
-                    </LemonButton>
-                </div>
+            <div className="flex items-center gap-3 text-muted text-xs">
+                <span>{skill.install_count} installs</span>
+                {skill.author_handle ? (
+                    // author_handle is the contributor's GitHub username (from the skill's PR/frontmatter).
+                    <Link to={`https://github.com/${skill.author_handle}`} target="_blank">
+                        @{skill.author_handle}
+                    </Link>
+                ) : null}
+                {skill.github_url ? (
+                    <Link to={skill.github_url} target="_blank" className="flex items-center gap-1">
+                        <IconGithub /> View on GitHub
+                    </Link>
+                ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t">
+                <LemonButton
+                    size="small"
+                    type="tertiary"
+                    icon={<IconThumbsUp />}
+                    active={skill.has_voted}
+                    loading={voting}
+                    disabledReason={voting ? 'Saving your vote…' : undefined}
+                    onClick={() => toggleVote(skill.slug)}
+                    tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
+                >
+                    {skill.vote_count}
+                </LemonButton>
+                <LemonButton
+                    size="small"
+                    type="primary"
+                    loading={installing}
+                    disabledReason={installing ? 'Installing…' : undefined}
+                    onClick={() => installSkill(skill.slug)}
+                >
+                    Install
+                </LemonButton>
             </div>
         </div>
     )
 }
 
 export function CommunitySkillsScene(): JSX.Element {
+    return <SkillsSceneShell activeTab="community" content={<CommunitySkillsContent />} />
+}
+
+function CommunitySkillsContent(): JSX.Element {
     const { displaySkills, filters, pagination, skillsLoading } = useValues(communitySkillsLogic)
     const { setFilters } = useActions(communitySkillsLogic)
     // Controlled pagination: page changes write the `page` URL param, which urlToAction turns into setFilters.
     const paginationState = usePagination(displaySkills, pagination)
 
     return (
-        <SceneContent>
-            <SceneTitleSection
-                name="Community skills"
-                description="Discover and install agent skills shared by the PostHog community."
-                resourceType={{ type: 'llm_analytics' }}
-            />
-
+        <div className="flex flex-col gap-4">
             <div className="flex flex-wrap items-center gap-2">
                 <LemonInput
                     type="search"
@@ -148,6 +149,6 @@ export function CommunitySkillsScene(): JSX.Element {
             )}
 
             <PaginationControl {...paginationState} nouns={['skill', 'skills']} />
-        </SceneContent>
+        </div>
     )
 }

--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -55,42 +55,44 @@ function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.El
                     </LemonTag>
                 ))}
             </div>
-            <div className="flex items-center gap-3 text-muted text-xs">
-                <span>{skill.install_count} installs</span>
-                {skill.author_handle ? (
-                    // author_handle is the contributor's GitHub username (from the skill's PR/frontmatter).
-                    <Link to={`https://github.com/${skill.author_handle}`} target="_blank">
-                        @{skill.author_handle}
-                    </Link>
-                ) : null}
-                {skill.github_url ? (
-                    <Link to={skill.github_url} target="_blank" className="flex items-center gap-1">
-                        <IconGithub /> View on GitHub
-                    </Link>
-                ) : null}
-            </div>
-            <div className="flex items-center justify-end gap-2 pt-2 border-t">
-                <LemonButton
-                    size="small"
-                    type="tertiary"
-                    icon={<IconThumbsUp />}
-                    active={skill.has_voted}
-                    loading={voting}
-                    disabledReason={voting ? 'Saving your vote…' : undefined}
-                    onClick={() => toggleVote(skill.slug)}
-                    tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
-                >
-                    {skill.vote_count}
-                </LemonButton>
-                <LemonButton
-                    size="small"
-                    type="primary"
-                    loading={installing}
-                    disabledReason={installing ? 'Installing…' : undefined}
-                    onClick={() => installSkill(skill.slug)}
-                >
-                    Install
-                </LemonButton>
+            <div className="flex items-center justify-between gap-2 pt-2 border-t">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted text-xs">
+                    <span>{skill.install_count} installs</span>
+                    {skill.author_handle ? (
+                        // author_handle is the contributor's GitHub username (from the skill's PR/frontmatter).
+                        <Link to={`https://github.com/${skill.author_handle}`} target="_blank">
+                            @{skill.author_handle}
+                        </Link>
+                    ) : null}
+                    {skill.github_url ? (
+                        <Link to={skill.github_url} target="_blank" className="flex items-center gap-1">
+                            <IconGithub /> View on GitHub
+                        </Link>
+                    ) : null}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                    <LemonButton
+                        size="small"
+                        type="tertiary"
+                        icon={<IconThumbsUp />}
+                        active={skill.has_voted}
+                        loading={voting}
+                        disabledReason={voting ? 'Saving your vote…' : undefined}
+                        onClick={() => toggleVote(skill.slug)}
+                        tooltip={skill.has_voted ? 'Remove your vote' : 'Upvote this skill'}
+                    >
+                        {skill.vote_count}
+                    </LemonButton>
+                    <LemonButton
+                        size="small"
+                        type="primary"
+                        loading={installing}
+                        disabledReason={installing ? 'Installing…' : undefined}
+                        onClick={() => installSkill(skill.slug)}
+                    >
+                        Install
+                    </LemonButton>
+                </div>
             </div>
         </div>
     )

--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -290,7 +290,7 @@ export function LLMSkillsScene(): JSX.Element {
 
 function YourSkillsContent(): JSX.Element {
     const { setFilters, deleteSkill, duplicateSkill, publishToCommunity } = useActions(llmSkillsLogic)
-    const { skills, skillsLoading, sorting, pagination, filters, skillCountLabel, groupedSkills } =
+    const { skills, skillsLoading, sorting, pagination, filters, skillCountLabel, groupedSkills, githubLogin } =
         useValues(llmSkillsLogic)
     const { searchParams } = useValues(router)
     const skillUrl = (name: string): string => combineUrl(urls.skill(name), searchParams).url
@@ -303,7 +303,9 @@ function YourSkillsContent(): JSX.Element {
             initialValues: {
                 display_name: skill.name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
                 tags: '',
-                author_handle: '',
+                // Prefill with the user's resolved GitHub handle when we have one; the field stays
+                // editable so users without a linked GitHub identity can still type one (free-text fallback).
+                author_handle: githubLogin ?? '',
             },
             content: (
                 <div className="flex flex-col gap-2">

--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -15,8 +15,6 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { LemonDialog } from '~/lib/lemon-ui/LemonDialog'
 import { LemonField } from '~/lib/lemon-ui/LemonField'
 import { LemonInput } from '~/lib/lemon-ui/LemonInput'
@@ -30,6 +28,7 @@ import type { LLMSkillListApi } from 'products/ai_observability/frontend/generat
 import { SKILLS_GROUP_LIMIT, SKILLS_PER_PAGE, SkillGroupNode, SkillGroupTree, llmSkillsLogic } from './llmSkillsLogic'
 import { SKILL_NAME_MAX_LENGTH, validateSkillName } from './skillConstants'
 import { openArchiveSkillDialog } from './skillSceneComponents'
+import { SkillsSceneShell } from './SkillsSceneShell'
 
 export const scene: SceneExport = {
     component: LLMSkillsScene,
@@ -40,7 +39,8 @@ export const scene: SceneExport = {
 function buildSkillColumns(
     skillUrl: (name: string) => string,
     duplicateSkill: (name: string, newName: string) => void,
-    deleteSkill: (name: string) => void
+    deleteSkill: (name: string) => void,
+    publishToCommunity: (skill: LLMSkillListApi) => void
 ): LemonTableColumns<LLMSkillListApi> {
     return [
         {
@@ -136,6 +136,19 @@ function buildSkillColumns(
                                         fullWidth
                                     >
                                         Duplicate
+                                    </LemonButton>
+                                </AccessControlAction>
+
+                                <AccessControlAction
+                                    resourceType={AccessControlResourceType.LlmAnalytics}
+                                    minAccessLevel={AccessControlLevel.Editor}
+                                >
+                                    <LemonButton
+                                        onClick={() => publishToCommunity(skill)}
+                                        data-attr="llma-skill-dropdown-publish-community"
+                                        fullWidth
+                                    >
+                                        Publish to community
                                     </LemonButton>
                                 </AccessControlAction>
 
@@ -256,123 +269,172 @@ function GroupedSkillsView({
 }
 
 export function LLMSkillsScene(): JSX.Element {
-    const { setFilters, deleteSkill, duplicateSkill } = useActions(llmSkillsLogic)
+    const { searchParams } = useValues(router)
+    const actions = (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.LlmAnalytics}
+            minAccessLevel={AccessControlLevel.Editor}
+        >
+            <LemonButton
+                type="primary"
+                to={combineUrl(urls.skill('new'), searchParams).url}
+                icon={<IconPlusSmall />}
+                data-attr="new-skill-button"
+            >
+                New skill
+            </LemonButton>
+        </AccessControlAction>
+    )
+    return <SkillsSceneShell activeTab="your" actions={actions} content={<YourSkillsContent />} />
+}
+
+function YourSkillsContent(): JSX.Element {
+    const { setFilters, deleteSkill, duplicateSkill, publishToCommunity } = useActions(llmSkillsLogic)
     const { skills, skillsLoading, sorting, pagination, filters, skillCountLabel, groupedSkills } =
         useValues(llmSkillsLogic)
     const { searchParams } = useValues(router)
     const skillUrl = (name: string): string => combineUrl(urls.skill(name), searchParams).url
 
+    const openPublishDialog = (skill: LLMSkillListApi): void => {
+        LemonDialog.openForm({
+            title: 'Publish to community',
+            description:
+                'Open a pull request adding this skill to the PostHog community catalog. A maintainer reviews it before it goes live.',
+            initialValues: {
+                display_name: skill.name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                tags: '',
+                author_handle: '',
+            },
+            content: (
+                <div className="flex flex-col gap-2">
+                    <LemonField name="display_name" label="Display name">
+                        <LemonInput data-attr="llma-publish-display-name" autoFocus />
+                    </LemonField>
+                    <LemonField name="tags" label="Tags (comma-separated)">
+                        <LemonInput data-attr="llma-publish-tags" placeholder="web-analytics, triage" />
+                    </LemonField>
+                    <LemonField name="author_handle" label="Your GitHub handle (optional)">
+                        <LemonInput data-attr="llma-publish-author-handle" placeholder="octocat" />
+                    </LemonField>
+                </div>
+            ),
+            onSubmit: ({ display_name, tags, author_handle }) =>
+                publishToCommunity(skill.name, {
+                    display_name: display_name?.trim() || undefined,
+                    tags: tags
+                        ? tags
+                              .split(',')
+                              .map((t: string) => t.trim())
+                              .filter(Boolean)
+                        : undefined,
+                    author_handle: author_handle?.trim() || undefined,
+                }),
+        })
+    }
+
     // Memoize columns so the array reference doesn't change every render — otherwise every
     // nested LemonTable inside the grouped tree reconciles on each parent re-render.
     const columns = useMemo(
-        () => buildSkillColumns(skillUrl, duplicateSkill, deleteSkill),
+        () => buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, openPublishDialog),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [searchParams, duplicateSkill, deleteSkill]
+        [searchParams, duplicateSkill, deleteSkill, publishToCommunity]
     )
 
     const showGroupedView = filters.group_by_prefix && groupedSkills && !skillsLoading
     const showGroupedLoadingSkeleton = filters.group_by_prefix && skillsLoading
     const truncated = filters.group_by_prefix && skills.count > skills.results.length
 
+    // Discovery nudge: an empty project is the moment to point people at the community catalog.
+    const showCommunityCallout = skills.count === 0 && !skillsLoading && !filters.search
+
     return (
-        <SceneContent>
-            <SceneTitleSection
-                name="Skills"
-                description="Manage versioned agent skills that any MCP-connected agent can discover and use."
-                resourceType={{ type: 'llm_analytics' }}
-                actions={
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.LlmAnalytics}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
-                        <LemonButton
-                            type="primary"
-                            to={skillUrl('new')}
-                            icon={<IconPlusSmall />}
-                            data-attr="new-skill-button"
-                        >
-                            New skill
+        <div className="space-y-4">
+            {showCommunityCallout && (
+                <LemonBanner type="info" className="mb-0">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <span>
+                            New here? Browse skills shared by the PostHog community and install one to get started.
+                        </span>
+                        <LemonButton type="secondary" size="small" to={urls.communitySkills()}>
+                            Browse community
                         </LemonButton>
-                    </AccessControlAction>
-                }
-            />
-
-            <div className="space-y-4">
-                <div className="flex gap-x-4 gap-y-2 items-center flex-wrap">
-                    <LemonInput
-                        type="search"
-                        placeholder="Search skills..."
-                        value={filters.search}
-                        data-attr="skills-search-input"
-                        onChange={(value) => setFilters({ search: value })}
-                        className="max-w-md"
-                    />
-                    <LemonSwitch
-                        label="Group by prefix"
-                        checked={filters.group_by_prefix}
-                        onChange={(checked) => setFilters({ group_by_prefix: checked })}
-                        bordered
-                        size="small"
-                        data-attr="skills-group-by-prefix-toggle"
-                    />
-                    <div className="text-muted-alt">{skillCountLabel}</div>
-                    <div className="flex-1" />
-                    <span>
-                        <b>Created by</b>
-                    </span>
-                    <MemberSelect
-                        defaultLabel="Any user"
-                        value={filters.created_by_id ?? null}
-                        size="xsmall"
-                        onChange={(user) => setFilters({ created_by_id: user?.id, page: 1 })}
-                    />
-                </div>
-
-                {filters.group_by_prefix ? (
-                    <>
-                        {truncated && (
-                            <LemonBanner type="warning">
-                                Showing the first {skills.results.length} of {skills.count} skills. The grouped view is
-                                capped at {SKILLS_GROUP_LIMIT} skills — use search or turn off grouping to see the rest.
-                            </LemonBanner>
-                        )}
-                        {showGroupedLoadingSkeleton ? (
-                            <LemonTable
-                                loading
-                                columns={columns}
-                                dataSource={[]}
-                                rowKey="id"
-                                loadingSkeletonRows={SKILLS_PER_PAGE}
-                                nouns={['skill', 'skills']}
-                            />
-                        ) : (
-                            showGroupedView && <GroupedSkillsView tree={groupedSkills!} columns={columns} />
-                        )}
-                    </>
-                ) : (
-                    <LemonTable
-                        loading={skillsLoading}
-                        columns={columns}
-                        // Drop the cached results while a reload is in flight if they exceed the
-                        // expected page size — otherwise toggling out of grouped mode flashes the
-                        // full 500-item payload through the controlled-paginated flat table.
-                        dataSource={skillsLoading && skills.results.length > SKILLS_PER_PAGE ? [] : skills.results}
-                        pagination={pagination}
-                        noSortingCancellation
-                        sorting={sorting}
-                        onSort={(newSorting) =>
-                            setFilters({
-                                order_by: newSorting
-                                    ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
-                                    : undefined,
-                            })
-                        }
-                        rowKey="id"
-                        loadingSkeletonRows={SKILLS_PER_PAGE}
-                        nouns={['skill', 'skills']}
-                    />
-                )}
+                    </div>
+                </LemonBanner>
+            )}
+            <div className="flex gap-x-4 gap-y-2 items-center flex-wrap">
+                <LemonInput
+                    type="search"
+                    placeholder="Search skills..."
+                    value={filters.search}
+                    data-attr="skills-search-input"
+                    onChange={(value) => setFilters({ search: value })}
+                    className="max-w-md"
+                />
+                <LemonSwitch
+                    label="Group by prefix"
+                    checked={filters.group_by_prefix}
+                    onChange={(checked) => setFilters({ group_by_prefix: checked })}
+                    bordered
+                    size="small"
+                    data-attr="skills-group-by-prefix-toggle"
+                />
+                <div className="text-muted-alt">{skillCountLabel}</div>
+                <div className="flex-1" />
+                <span>
+                    <b>Created by</b>
+                </span>
+                <MemberSelect
+                    defaultLabel="Any user"
+                    value={filters.created_by_id ?? null}
+                    size="xsmall"
+                    onChange={(user) => setFilters({ created_by_id: user?.id, page: 1 })}
+                />
             </div>
-        </SceneContent>
+
+            {filters.group_by_prefix ? (
+                <>
+                    {truncated && (
+                        <LemonBanner type="warning">
+                            Showing the first {skills.results.length} of {skills.count} skills. The grouped view is
+                            capped at {SKILLS_GROUP_LIMIT} skills — use search or turn off grouping to see the rest.
+                        </LemonBanner>
+                    )}
+                    {showGroupedLoadingSkeleton ? (
+                        <LemonTable
+                            loading
+                            columns={columns}
+                            dataSource={[]}
+                            rowKey="id"
+                            loadingSkeletonRows={SKILLS_PER_PAGE}
+                            nouns={['skill', 'skills']}
+                        />
+                    ) : (
+                        showGroupedView && <GroupedSkillsView tree={groupedSkills!} columns={columns} />
+                    )}
+                </>
+            ) : (
+                <LemonTable
+                    loading={skillsLoading}
+                    columns={columns}
+                    // Drop the cached results while a reload is in flight if they exceed the
+                    // expected page size — otherwise toggling out of grouped mode flashes the
+                    // full 500-item payload through the controlled-paginated flat table.
+                    dataSource={skillsLoading && skills.results.length > SKILLS_PER_PAGE ? [] : skills.results}
+                    pagination={pagination}
+                    noSortingCancellation
+                    sorting={sorting}
+                    onSort={(newSorting) =>
+                        setFilters({
+                            order_by: newSorting
+                                ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                                : undefined,
+                        })
+                    }
+                    rowKey="id"
+                    loadingSkeletonRows={SKILLS_PER_PAGE}
+                    nouns={['skill', 'skills']}
+                />
+            )}
+        </div>
     )
 }

--- a/products/skills/frontend/SkillsSceneShell.tsx
+++ b/products/skills/frontend/SkillsSceneShell.tsx
@@ -1,0 +1,56 @@
+import { LemonTab, LemonTabs } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+export type SkillsTab = 'your' | 'community'
+
+const TAB_DESCRIPTIONS: Record<SkillsTab, string> = {
+    your: 'Manage versioned agent skills that any MCP-connected agent can discover and use.',
+    community: 'Discover and install agent skills shared by the PostHog community.',
+}
+
+/**
+ * Shared shell for the two Skills tabs ("Your skills" and "Community"). Each scene renders this
+ * with only its own tab's content; the inactive tab navigates via its `link`, so its content is
+ * never mounted here. This keeps the two scenes' logics (and URL contracts) independent while
+ * presenting them as one tabbed surface.
+ */
+export function SkillsSceneShell({
+    activeTab,
+    actions,
+    content,
+}: {
+    activeTab: SkillsTab
+    actions?: JSX.Element
+    content: JSX.Element
+}): JSX.Element {
+    const tabs: LemonTab<SkillsTab>[] = [
+        {
+            key: 'your',
+            label: 'Your skills',
+            link: urls.skills(),
+            content: activeTab === 'your' ? content : <></>,
+        },
+        {
+            key: 'community',
+            label: 'Community',
+            link: urls.communitySkills(),
+            content: activeTab === 'community' ? content : <></>,
+        },
+    ]
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Skills"
+                description={TAB_DESCRIPTIONS[activeTab]}
+                resourceType={{ type: 'llm_analytics' }}
+                actions={actions}
+            />
+            <LemonTabs activeKey={activeTab} data-attr="skills-tabs" tabs={tabs} sceneInset />
+        </SceneContent>
+    )
+}

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -74,6 +74,7 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             slug,
             voteResult,
         }),
+        toggleVoteFailure: (slug: string) => ({ slug }),
     }),
 
     reducers({
@@ -103,6 +104,14 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
                 installSkillFailure: (state, { slug }) => ({ ...state, [slug]: false }),
             },
         ],
+        votingSlugs: [
+            {} as Record<string, boolean>,
+            {
+                toggleVote: (state, { slug }) => ({ ...state, [slug]: true }),
+                toggleVoteSuccess: (state, { slug }) => ({ ...state, [slug]: false }),
+                toggleVoteFailure: (state, { slug }) => ({ ...state, [slug]: false }),
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -110,9 +119,9 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             { results: [], count: 0 } as PaginatedCommunitySkillListListApi,
             {
                 loadSkills: async ({ debounce }, breakpoint) => {
-                    if (debounce && values.skills.results.length > 0) {
-                        await breakpoint(300)
-                    }
+                    // Always breakpoint so a slower in-flight request can't overwrite newer results;
+                    // the delay only debounces rapid filter/search changes.
+                    await breakpoint(debounce ? 300 : 0)
                     const { filters } = values
                     return await communitySkillsList(String(ApiConfig.getCurrentTeamId()), {
                         search: filters.search,
@@ -187,6 +196,7 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             } catch (e) {
                 console.error('Failed to vote on community skill', e)
                 lemonToast.error('Failed to register your vote')
+                actions.toggleVoteFailure(slug)
             }
         },
     })),

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -1,0 +1,217 @@
+import { actions, afterMount, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router, urlToAction } from 'kea-router'
+
+import { ApiConfig } from '~/lib/api'
+import { lemonToast } from '~/lib/lemon-ui/LemonToast/LemonToast'
+import { PaginationManual } from '~/lib/lemon-ui/PaginationControl'
+import { trackedActionToUrl } from '~/lib/logic/scenes/trackedActionToUrl'
+import { objectsEqual } from '~/lib/utils'
+import { urls } from '~/scenes/urls'
+
+import {
+    communitySkillsInstallCreate,
+    communitySkillsList,
+    communitySkillsVoteCreate,
+} from 'products/ai_observability/frontend/generated/api'
+import type {
+    CommunitySkillListApi,
+    PaginatedCommunitySkillListListApi,
+} from 'products/ai_observability/frontend/generated/api.schemas'
+
+import type { communitySkillsLogicType } from './communitySkillsLogicType'
+
+export const COMMUNITY_SKILLS_PER_PAGE = 30
+
+export type CommunitySkillTrustTier = 'official' | 'verified' | 'community'
+
+export interface CommunitySkillFilters {
+    page: number
+    search: string
+    order_by: string
+    tag: string
+    trust_tier: CommunitySkillTrustTier | ''
+}
+
+function cleanFilters(values: Partial<CommunitySkillFilters>): CommunitySkillFilters {
+    return {
+        page: parseInt(String(values.page)) || 1,
+        search: String(values.search || ''),
+        order_by: values.order_by || '-install_count',
+        tag: String(values.tag || ''),
+        trust_tier: (values.trust_tier as CommunitySkillTrustTier) || '',
+    }
+}
+
+function cleanFilterUrlParams(filters: CommunitySkillFilters): Record<string, unknown> {
+    return {
+        page: filters.page === 1 ? undefined : filters.page,
+        search: filters.search || undefined,
+        order_by: filters.order_by === '-install_count' ? undefined : filters.order_by,
+        tag: filters.tag || undefined,
+        trust_tier: filters.trust_tier || undefined,
+    }
+}
+
+export type CommunitySkillsLogicProps = Record<string, never>
+
+export const communitySkillsLogic = kea<communitySkillsLogicType>([
+    path(['scenes', 'skills', 'communitySkillsLogic']),
+    props({} as CommunitySkillsLogicProps),
+
+    actions({
+        setFilters: (filters: Partial<CommunitySkillFilters>, merge: boolean = true, debounce: boolean = true) => ({
+            filters,
+            merge,
+            debounce,
+        }),
+        loadSkills: (debounce: boolean = true) => ({ debounce }),
+        installSkill: (slug: string, newName?: string) => ({ slug, newName }),
+        installSkillSuccess: (slug: string) => ({ slug }),
+        installSkillFailure: (slug: string) => ({ slug }),
+        toggleVote: (slug: string) => ({ slug }),
+        toggleVoteSuccess: (slug: string, voteResult: { has_voted: boolean; vote_count: number }) => ({
+            slug,
+            voteResult,
+        }),
+    }),
+
+    reducers({
+        rawFilters: [
+            null as Partial<CommunitySkillFilters> | null,
+            {
+                setFilters: (state, { filters, merge }) =>
+                    cleanFilters({
+                        ...(merge ? state || {} : {}),
+                        ...filters,
+                        ...('page' in filters ? {} : { page: 1 }),
+                    }),
+            },
+        ],
+        // Optimistic per-slug vote state keyed by slug, merged over the server values for snappy UI.
+        voteOverrides: [
+            {} as Record<string, { has_voted: boolean; vote_count: number }>,
+            {
+                toggleVoteSuccess: (state, { slug, voteResult }) => ({ ...state, [slug]: voteResult }),
+            },
+        ],
+        installingSlugs: [
+            {} as Record<string, boolean>,
+            {
+                installSkill: (state, { slug }) => ({ ...state, [slug]: true }),
+                installSkillSuccess: (state, { slug }) => ({ ...state, [slug]: false }),
+                installSkillFailure: (state, { slug }) => ({ ...state, [slug]: false }),
+            },
+        ],
+    }),
+
+    loaders(({ values }) => ({
+        skills: [
+            { results: [], count: 0 } as PaginatedCommunitySkillListListApi,
+            {
+                loadSkills: async ({ debounce }, breakpoint) => {
+                    if (debounce && values.skills.results.length > 0) {
+                        await breakpoint(300)
+                    }
+                    const { filters } = values
+                    return await communitySkillsList(String(ApiConfig.getCurrentTeamId()), {
+                        search: filters.search,
+                        order_by: filters.order_by,
+                        tag: filters.tag,
+                        trust_tier: filters.trust_tier || undefined,
+                        offset: Math.max(0, (filters.page - 1) * COMMUNITY_SKILLS_PER_PAGE),
+                        limit: COMMUNITY_SKILLS_PER_PAGE,
+                    })
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        filters: [
+            (s) => [s.rawFilters],
+            (rawFilters: Partial<CommunitySkillFilters> | null): CommunitySkillFilters =>
+                cleanFilters(rawFilters || {}),
+        ],
+        count: [(s) => [s.skills], (skills: PaginatedCommunitySkillListListApi) => skills.count],
+        // Server results with optimistic vote overrides applied.
+        displaySkills: [
+            (s) => [s.skills, s.voteOverrides],
+            (
+                skills: PaginatedCommunitySkillListListApi,
+                voteOverrides: Record<string, { has_voted: boolean; vote_count: number }>
+            ): CommunitySkillListApi[] =>
+                skills.results.map((skill) => {
+                    const override = voteOverrides[skill.slug]
+                    return override ? { ...skill, ...override } : skill
+                }),
+        ],
+        pagination: [
+            (s) => [s.filters, s.count],
+            (filters: CommunitySkillFilters, count: number): PaginationManual => ({
+                controlled: true,
+                pageSize: COMMUNITY_SKILLS_PER_PAGE,
+                currentPage: filters.page,
+                entryCount: count,
+            }),
+        ],
+    }),
+
+    listeners(({ actions, asyncActions, values, selectors }) => ({
+        setFilters: async ({ debounce }, _, __, previousState) => {
+            const oldFilters = selectors.filters(previousState)
+            if (!objectsEqual(oldFilters, values.filters)) {
+                await asyncActions.loadSkills(debounce)
+            }
+        },
+
+        installSkill: async ({ slug, newName }) => {
+            try {
+                await communitySkillsInstallCreate(String(ApiConfig.getCurrentTeamId()), slug, {
+                    new_name: newName,
+                })
+                lemonToast.success(`Installed "${newName || slug}" into your project.`)
+                actions.installSkillSuccess(slug)
+                router.actions.push(urls.skill(newName || slug))
+            } catch (e) {
+                console.error('Failed to install community skill', e)
+                lemonToast.error('Failed to install skill — a skill with that name may already exist.')
+                actions.installSkillFailure(slug)
+            }
+        },
+
+        toggleVote: async ({ slug }) => {
+            try {
+                const result = await communitySkillsVoteCreate(String(ApiConfig.getCurrentTeamId()), slug)
+                actions.toggleVoteSuccess(slug, result)
+            } catch (e) {
+                console.error('Failed to vote on community skill', e)
+                lemonToast.error('Failed to register your vote')
+            }
+        },
+    })),
+
+    trackedActionToUrl(({ values }) => {
+        const changeUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] | void => {
+            const nextValues = cleanFilterUrlParams(values.filters)
+            const urlValues = cleanFilters(router.values.searchParams)
+            if (!objectsEqual(values.filters, urlValues)) {
+                return [urls.communitySkills(), nextValues, {}, { replace: true }]
+            }
+        }
+        return { setFilters: changeUrl }
+    }),
+
+    urlToAction(({ actions, values }) => ({
+        [urls.communitySkills()]: (_, searchParams) => {
+            const newFilters = cleanFilters(searchParams)
+            if (!objectsEqual(values.filters, newFilters)) {
+                actions.setFilters(newFilters, false)
+            }
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadSkills()
+    }),
+])

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -2,6 +2,7 @@ import { actions, afterMount, kea, listeners, path, props, reducers, selectors }
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 
+import { usersGithubLoginRetrieve } from '~/generated/core/api'
 import { ApiConfig } from '~/lib/api'
 import { Sorting } from '~/lib/lemon-ui/LemonTable'
 import { lemonToast } from '~/lib/lemon-ui/LemonToast/LemonToast'
@@ -227,6 +228,20 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                 },
             },
         ],
+        // Resolved GitHub handle for the current user — used to prefill the publish dialog's
+        // author_handle so the common case (GitHub-SSO'd users) is correct by default. Null when
+        // no GitHub identity is linked; the dialog field then falls back to free text.
+        githubLogin: [
+            null as string | null,
+            {
+                loadGithubLogin: async () => {
+                    // `@me` resolves to the current user server-side, so this doesn't race userLogic
+                    // loading the user object first.
+                    const response = await usersGithubLoginRetrieve('@me')
+                    return response.github_login ?? null
+                },
+            },
+        ],
     })),
 
     selectors({
@@ -394,5 +409,6 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
 
     afterMount(({ actions }) => {
         actions.loadSkills()
+        actions.loadGithubLogin()
     }),
 ])

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -15,6 +15,7 @@ import {
     llmSkillsList,
     llmSkillsNameArchiveCreate,
     llmSkillsNameDuplicateCreate,
+    llmSkillsNamePublishCommunityCreate,
 } from 'products/ai_observability/frontend/generated/api'
 import type {
     LLMSkillListApi,
@@ -155,6 +156,12 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
         loadSkills: (debounce: boolean = true) => ({ debounce }),
         deleteSkill: (skillName: string) => ({ skillName }),
         duplicateSkill: (skillName: string, newName: string) => ({ skillName, newName }),
+        publishToCommunity: (
+            skillName: string,
+            options: { display_name?: string; tags?: string[]; author_handle?: string }
+        ) => ({ skillName, options }),
+        publishToCommunitySuccess: (skillName: string) => ({ skillName }),
+        publishToCommunityFailure: (skillName: string) => ({ skillName }),
     }),
 
     reducers({
@@ -167,6 +174,15 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                         ...filters,
                         ...('page' in filters ? {} : { page: 1 }),
                     }),
+            },
+        ],
+        // Per-skill publish-in-flight state so the trigger can guard against double-submission.
+        publishingSkills: [
+            {} as Record<string, boolean>,
+            {
+                publishToCommunity: (state, { skillName }) => ({ ...state, [skillName]: true }),
+                publishToCommunitySuccess: (state, { skillName }) => ({ ...state, [skillName]: false }),
+                publishToCommunityFailure: (state, { skillName }) => ({ ...state, [skillName]: false }),
             },
         ],
     }),
@@ -280,7 +296,7 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
         ],
     }),
 
-    listeners(({ asyncActions, values, selectors }) => ({
+    listeners(({ actions, asyncActions, values, selectors }) => ({
         setFilters: async ({ debounce }, _, __, previousState) => {
             const oldFilters = selectors.filters(previousState)
             const { filters } = values
@@ -311,6 +327,36 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
             } catch (e) {
                 console.error('Failed to duplicate skill', e)
                 lemonToast.error('Failed to duplicate skill')
+            }
+        },
+
+        publishToCommunity: async ({ skillName, options }) => {
+            try {
+                const result = await llmSkillsNamePublishCommunityCreate(
+                    String(ApiConfig.getCurrentTeamId()),
+                    skillName,
+                    {
+                        display_name: options.display_name,
+                        tags: options.tags,
+                        author_handle: options.author_handle,
+                    }
+                )
+                lemonToast.success(
+                    `Opened a community pull request for "${skillName}" — a maintainer will review it.`,
+                    {
+                        button: { label: 'View PR', action: () => window.open(result.pr_url, '_blank', 'noopener') },
+                    }
+                )
+                actions.publishToCommunitySuccess(skillName)
+            } catch (e: any) {
+                console.error('Failed to publish skill to community', e)
+                const detail = e?.data?.detail || e?.detail
+                lemonToast.error(
+                    e?.status === 503
+                        ? 'Publishing to the community is not available on this instance yet.'
+                        : detail || 'Failed to publish skill to the community'
+                )
+                actions.publishToCommunityFailure(skillName)
             }
         },
     })),

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -25,9 +25,19 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             iconType: 'llm_prompts',
         },
+        CommunitySkills: {
+            import: () => import('./frontend/CommunitySkillsScene'),
+            projectBased: true,
+            name: 'Community skills',
+            description: 'Discover and install agent skills shared by the PostHog community.',
+            layout: 'app-container',
+            iconType: 'llm_prompts',
+        },
     },
     routes: {
         '/skills': ['Skills', 'skills'],
+        // Registered before '/skills/:name' so the literal path wins over the slug matcher.
+        '/community-skills': ['CommunitySkills', 'communitySkills'],
         '/skills/:name': ['Skill', 'skill'],
     },
     redirects: {
@@ -44,6 +54,7 @@ export const manifest: ProductManifest = {
         skills: (): string => '/skills',
         skill: (name: string, params?: { file?: string; version?: number }): string =>
             combineUrl(`/skills/${name}`, params).url,
+        communitySkills: (): string => '/community-skills',
     },
     fileSystemTypes: {},
     treeItemsNew: [],
@@ -58,6 +69,17 @@ export const manifest: ProductManifest = {
             href: urls.skills(),
             flag: FEATURE_FLAGS.LLM_ANALYTICS_SKILLS,
             sceneKey: 'Skills',
+        },
+        {
+            path: 'Community skills',
+            intents: [ProductKey.LLM_PROMPTS],
+            category: ProductItemCategory.TOOLS,
+            type: 'community_skills',
+            iconType: 'llm_prompts' as FileSystemIconType,
+            iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
+            href: urls.communitySkills(),
+            flag: FEATURE_FLAGS.LLM_ANALYTICS_COMMUNITY_SKILLS,
+            sceneKey: 'CommunitySkills',
         },
     ],
 }

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -69,17 +69,9 @@ export const manifest: ProductManifest = {
             href: urls.skills(),
             flag: FEATURE_FLAGS.LLM_ANALYTICS_SKILLS,
             sceneKey: 'Skills',
-        },
-        {
-            path: 'Community skills',
-            intents: [ProductKey.LLM_PROMPTS],
-            category: ProductItemCategory.TOOLS,
-            type: 'community_skills',
-            iconType: 'llm_prompts' as FileSystemIconType,
-            iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
-            href: urls.communitySkills(),
-            flag: FEATURE_FLAGS.LLM_ANALYTICS_COMMUNITY_SKILLS,
-            sceneKey: 'CommunitySkills',
+            // Community is a tab within the Skills scene, not a separate nav item — keep the
+            // Skills item highlighted on the skill detail and community routes.
+            sceneKeys: ['Skills', 'Skill', 'CommunitySkills'],
         },
     ],
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43271,6 +43271,14 @@ export namespace Schemas {
       connect_flow: string;
     }
 
+    export interface UserGithubLogin {
+      /**
+         * The user's resolved GitHub login, or null when no GitHub identity is linked.
+         * @nullable
+         */
+      github_login: string | null;
+    }
+
     /**
      * * `transcript` - transcript
      * * `summary` - summary

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11498,6 +11498,154 @@ export namespace Schemas {
       source_comment?: string | null;
     }
 
+    /**
+     * Arbitrary key-value metadata carried from the skill's frontmatter.
+     */
+    export type CommunitySkillMetadata = { [key: string]: unknown };
+
+    /**
+     * * `official` - Official
+     * * `verified` - Verified
+     * * `community` - Community
+     */
+    export type TrustTierEnum = typeof TrustTierEnum[keyof typeof TrustTierEnum];
+
+
+    export const TrustTierEnum = {
+      Official: 'official',
+      Verified: 'verified',
+      Community: 'community',
+    } as const;
+
+    export interface CommunitySkillFileManifest {
+      /** @maxLength 500 */
+      path: string;
+      /** @maxLength 100 */
+      content_type?: string;
+    }
+
+    export interface CommunitySkill {
+      readonly id: string;
+      /** Stable identifier matching the skill's directory in the community-skills repo. */
+      readonly slug: string;
+      /** Display name of the skill. */
+      readonly name: string;
+      /** What the skill does and when to use it. */
+      readonly description: string;
+      /** The SKILL.md instruction content (markdown). */
+      readonly body: string;
+      /** License name or reference. */
+      readonly license: string;
+      /** Environment requirements declared by the skill. */
+      readonly compatibility: string;
+      /** Tools the skill declares it may use. Surface these to the user before install. */
+      allowed_tools?: string[];
+      /** Arbitrary key-value metadata carried from the skill's frontmatter. */
+      metadata?: CommunitySkillMetadata;
+      /** Free-form tags used for filtering and discovery. */
+      tags?: string[];
+      /** Moderation tier: 'official' (PostHog-authored), 'verified' (reviewed), or 'community'.
+       *
+       * * `official` - Official
+       * * `verified` - Verified
+       * * `community` - Community */
+      trust_tier: TrustTierEnum;
+      /** GitHub handle (or name) of the contributor who published the skill. */
+      readonly author_handle: string;
+      /** Link to the skill's source directory on GitHub. */
+      readonly github_url: string;
+      /** Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint. */
+      readonly files: readonly CommunitySkillFileManifest[];
+      /** Number of times this skill has been installed into a team. */
+      readonly install_count: number;
+      /** Total number of upvotes this skill has received. */
+      readonly vote_count: number;
+      /** Whether the requesting user has upvoted this skill. */
+      readonly has_voted: boolean;
+      /**
+         * When the skill was first published to the community repo.
+         * @nullable
+         */
+      readonly published_at: string | null;
+      readonly created_at: string;
+      readonly updated_at: string;
+    }
+
+    export interface CommunitySkillInstall {
+      /**
+         * Name for the installed skill in your team. Defaults to the community skill's slug.
+         * @maxLength 64
+         */
+      new_name?: string;
+    }
+
+    /**
+     * Arbitrary key-value metadata carried from the skill's frontmatter.
+     */
+    export type CommunitySkillListMetadata = { [key: string]: unknown };
+
+    /**
+     * List serializer that omits body and file manifest — progressive disclosure.
+     */
+    export interface CommunitySkillList {
+      readonly id: string;
+      /** Stable identifier matching the skill's directory in the community-skills repo. */
+      readonly slug: string;
+      /** Display name of the skill. */
+      readonly name: string;
+      /** What the skill does and when to use it. */
+      readonly description: string;
+      /** License name or reference. */
+      readonly license: string;
+      /** Environment requirements declared by the skill. */
+      readonly compatibility: string;
+      /** Tools the skill declares it may use. Surface these to the user before install. */
+      allowed_tools?: string[];
+      /** Arbitrary key-value metadata carried from the skill's frontmatter. */
+      metadata?: CommunitySkillListMetadata;
+      /** Free-form tags used for filtering and discovery. */
+      tags?: string[];
+      /** Moderation tier: 'official' (PostHog-authored), 'verified' (reviewed), or 'community'.
+       *
+       * * `official` - Official
+       * * `verified` - Verified
+       * * `community` - Community */
+      trust_tier: TrustTierEnum;
+      /** GitHub handle (or name) of the contributor who published the skill. */
+      readonly author_handle: string;
+      /** Link to the skill's source directory on GitHub. */
+      readonly github_url: string;
+      /** Number of times this skill has been installed into a team. */
+      readonly install_count: number;
+      /** Total number of upvotes this skill has received. */
+      readonly vote_count: number;
+      /** Whether the requesting user has upvoted this skill. */
+      readonly has_voted: boolean;
+      /**
+         * When the skill was first published to the community repo.
+         * @nullable
+         */
+      readonly published_at: string | null;
+      readonly created_at: string;
+      readonly updated_at: string;
+    }
+
+    export interface CommunitySkillPublishResult {
+      /** URL of the pull request opened in the community-skills repo for maintainer review. */
+      pr_url: string;
+      /** Number of the opened pull request. */
+      pr_number: number;
+      /** Name of the branch created in the community-skills repo. */
+      branch: string;
+    }
+
+    export interface CommunitySkillVoteResponse {
+      /** Total upvotes after applying the toggle. */
+      vote_count: number;
+      /** Whether the requesting user is now an upvoter. */
+      has_voted: boolean;
+    }
+
     export interface CompareItem {
       label: string;
       value: string;
@@ -22641,6 +22789,24 @@ export namespace Schemas {
       readonly first_version_created_at: string;
     }
 
+    export interface LLMSkillPublishToCommunity {
+      /**
+         * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+         * @maxLength 200
+         */
+      display_name?: string;
+      /**
+         * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+         * @items.maxLength 64
+         */
+      tags?: string[];
+      /**
+         * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+         * @maxLength 100
+         */
+      author_handle?: string;
+    }
+
     export interface LLMSkillVersionSummary {
       readonly id: string;
       readonly version: number;
@@ -25106,6 +25272,15 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: Comment[];
+    }
+
+    export interface PaginatedCommunitySkillListList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: CommunitySkillList[];
     }
 
     export interface PaginatedConversationMinimalList {
@@ -49631,6 +49806,59 @@ export namespace Schemas {
       Any: 'any',
       Comment: 'comment',
       Task: 'task',
+    } as const;
+
+    export type CommunitySkillsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    /**
+     * Sort key. Defaults to most-installed first.
+     *
+     * * `-created_at` - -created_at
+     * * `-install_count` - -install_count
+     * * `-name` - -name
+     * * `-published_at` - -published_at
+     * * `-vote_count` - -vote_count
+     * * `created_at` - created_at
+     * * `install_count` - install_count
+     * * `name` - name
+     * * `published_at` - published_at
+     * * `vote_count` - vote_count
+     * @minLength 1
+     */
+    order_by?: string;
+    /**
+     * Substring filter applied to skill names, descriptions, and tags.
+     */
+    search?: string;
+    /**
+     * Return only skills carrying this tag.
+     */
+    tag?: string;
+    /**
+     * Filter to a single moderation tier.
+     *
+     * * `official` - Official
+     * * `verified` - Verified
+     * * `community` - Community
+     * @minLength 1
+     */
+    trust_tier?: CommunitySkillsListTrustTier;
+    };
+
+    export type CommunitySkillsListTrustTier = typeof CommunitySkillsListTrustTier[keyof typeof CommunitySkillsListTrustTier];
+
+
+    export const CommunitySkillsListTrustTier = {
+      Official: 'official',
+      Verified: 'verified',
+      Community: 'community',
     } as const;
 
     export type ConversationsTicketsListParams = {


### PR DESCRIPTION
## Problem

PostHog users build useful agent skills (the versioned `LLMSkill` instruction packs that any MCP-connected agent can discover and use), but there's no way to share them with other users or discover skills others have found valuable. We want a community marketplace — think Grafana community plugins, but for PostHog agent skills — where users can browse, search, install, and vote on skills shared by the community.

## Changes

This is the in-product slice of the design. Content lives in a separate **`PostHog/community-skills`** GitHub repo (source of truth); PostHog ingests it into a DB read-model that powers in-app discovery. Installing a community skill copies it into your project as a regular `LLMSkill`, so it immediately works with everything already built (the `/skills` editor, versioning, MCP `llma-skill-*` tools).

**Backend** (`products/ai_observability/backend`)
- `CommunitySkill` / `CommunitySkillFile` / `CommunitySkillVote` models. The catalog is **instance-global** (no `team_id`) by design — shared catalog data like `DashboardTemplate` GLOBAL templates; votes are user-scoped.
- `CommunitySkillViewSet` (gated behind `llm-analytics-community-skills`): list/retrieve plus `install` (reuses the existing `create_skill` service to copy into the team and bumps an install counter) and `vote` (toggle) actions.
- Hourly Celery task `sync_community_skills` reconciles the catalog from the repo's generated `registry.json` (mirrors the `DashboardTemplate` ← `templates-repository` precedent); skills dropped from the repo are soft-deleted.

**Frontend** (`products/skills`)
- A **Community** marketplace tab at `/community-skills`: card grid with search, trust-tier filter, sort (Most installed / Top rated / Newest / Name), one-click install, and an optimistic upvote button. Business logic lives in `communitySkillsLogic.ts`.

**Companion repo:** the `PostHog/community-skills` scaffold (SKILL.md spec, `registry.json` builder, validation + safety-scan CI, CODEOWNERS, MIT license, worked example) was authored separately and will be pushed to that repo.

### Ranking & trust
Discovery ranks on installs, votes, and (next phase) real usage via dogfooded PostHog analytics. Skills carry a trust tier (`official` / `verified` / `community`) surfaced as a badge — skills are agent instructions, so PR review in the content repo is the moderation gate and `allowed_tools` is surfaced at install time.

## How did you test this code?

I'm an agent (Claude Code). Automated only:
- Added `products/ai_observability/backend/api/test/test_community_skills.py` covering list/filter/retrieve, install (success, custom name, name conflict, unknown slug), vote toggle, and the sync service (upsert + soft-delete + unchanged-SHA skip).
- Ran `ruff check` and `ruff format` over all new/changed backend files (clean).

⚠️ **Not run here (no Django/Node toolchain in this environment) — required before merge:**
- `hogli build:openapi` to generate the frontend API client + types (`communitySkillsList`, `CommunitySkillListApi`, etc.). The frontend imports these and **will not type-check until codegen runs.**
- `kea-typegen` to generate `communitySkillsLogicType`.
- The backend migration `0005_communityskill` was hand-written from the established format; confirm with `makemigrations --check` after syncing the env.
- Backend test suite has not been executed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @andymaguire.

Authored with Claude Code. We researched the existing PostHog skills primitives and Grafana's community-plugin model, then chose: in-product `LLMSkill`-based skills (not Claude Code `.agents/skills`), and GitHub-as-source-of-truth with a synced DB read-model (over a DB-authoritative design). The marketplace deliberately reuses existing infra — `create_skill` for install, the `DashboardTemplate` sync precedent, and the `/skills` product surface — rather than adding parallel systems.

Open design decisions left for review: trust-tier moderation policy, and whether to fold the Community view into the existing Skills scene as a tab vs. the separate route used here. This PR is intentionally a **draft** pending the codegen steps above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRdPDYS9rf4MfbtReSyBLE)_