### PR TITLE
fix(mailgun): skip un-queryable domains in fan-out instead of failing the sync

### DIFF
--- a/posthog/temporal/data_imports/sources/mailgun/mailgun.py
+++ b/posthog/temporal/data_imports/sources/mailgun/mailgun.py
@@ -209,6 +209,19 @@ def _fetch_page(url: str, api_key: str, logger: FilteringBoundLogger) -> dict[st
     return response.json()
 
 
+def _is_skippable_domain_error(config: MailgunEndpointConfig, domain: Optional[str], error: requests.HTTPError) -> bool:
+    """Whether a failed domain-scoped request should skip that domain instead of failing the sync.
+
+    The domain fan-out lists every domain on the account (`/v4/domains`), including ones that
+    can't be queried for events/suppressions — disabled, unverified, or sandbox-like domains.
+    Those reject the domain-scoped request with a 400, so one bad domain would otherwise abort
+    the whole fan-out and strand every other domain on the account."""
+    if not config.domain_scoped or domain is None:
+        return False
+    response = error.response
+    return response is not None and response.status_code == 400
+
+
 def get_domain_names(api_key: str, base_url: str, logger: FilteringBoundLogger) -> list[str]:
     config = MAILGUN_ENDPOINTS["domains"]
     names: list[str] = []
@@ -284,7 +297,21 @@ def get_rows(
                 resumable_source_manager.save_state(MailgunResumeConfig(pending_domains=pending_domains))
                 continue
 
-        data = _fetch_page(current_url, api_key, logger)
+        try:
+            data = _fetch_page(current_url, api_key, logger)
+        except requests.HTTPError as error:
+            if not _is_skippable_domain_error(config, current_domain, error):
+                raise
+            logger.warning(
+                f"Mailgun: skipping domain {current_domain} for {endpoint}; "
+                f"request returned {error.response.status_code if error.response is not None else '?'}. "
+                f"url={current_url}"
+            )
+            current_url = None
+            current_domain = None
+            resumable_source_manager.save_state(MailgunResumeConfig(pending_domains=pending_domains))
+            continue
+
         items = data.get("items") or []
 
         if items:

--- a/posthog/temporal/data_imports/sources/mailgun/tests/test_mailgun.py
+++ b/posthog/temporal/data_imports/sources/mailgun/tests/test_mailgun.py
@@ -6,6 +6,8 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 from unittest import mock
 
+import requests
+
 from posthog.temporal.data_imports.sources.mailgun.mailgun import (
     MAX_RETRY_AFTER_SECONDS,
     MailgunResumeConfig,
@@ -42,6 +44,15 @@ def _response(payload: dict[str, Any], status_code: int = 200) -> mock.MagicMock
     response.status_code = status_code
     response.ok = status_code < 400
     response.headers = {}
+    return response
+
+
+def _error_response(status_code: int, url: str) -> mock.MagicMock:
+    response = _response({}, status_code)
+    response.text = "Bad Request"
+    response.raise_for_status.side_effect = requests.HTTPError(
+        f"{status_code} Client Error: Bad Request for url: {url}", response=response
+    )
     return response
 
 
@@ -451,6 +462,52 @@ class TestGetRows:
         assert saved_states[0].current_domain == "a.com"
         assert saved_states[-1].next_url is None
         assert saved_states[-1].pending_domains == []
+
+    @mock.patch("posthog.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
+    def test_domain_scoped_400_skips_domain_and_continues_fan_out(self, mock_session):
+        # The account lists a domain that can't be queried for events (disabled / unverified):
+        # its 400 must skip the domain, not abort the whole fan-out, so b.com still imports.
+        domains_page = {"items": [{"name": "a.com"}, {"name": "b.com"}]}
+        a_bad = _error_response(400, f"{US_BASE}/v3/a.com/events")
+        b_events = _paging_page([{"id": "e2", "timestamp": 1700000100.5}], None)
+        mock_session.return_value.get.side_effect = [
+            _response(domains_page),
+            a_bad,
+            _response(b_events),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("key", "us", "events", mock.MagicMock(), manager))
+
+        rows = [row for batch in batches for row in batch]
+        assert [(row["id"], row["domain"]) for row in rows] == [("e2", "b.com")]
+        # The skipped domain leaves no in-flight chain behind, and the fan-out completes cleanly.
+        saved_states = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved_states[0].current_domain is None
+        assert saved_states[-1].next_url is None
+        assert saved_states[-1].pending_domains == []
+
+    @mock.patch("posthog.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
+    def test_account_level_400_still_raises(self, mock_session):
+        # A 400 on a non-domain-scoped endpoint means our request is wrong, not a bad domain —
+        # it must surface rather than be silently skipped.
+        mock_session.return_value.get.return_value = _error_response(400, f"{US_BASE}/v3/lists/pages")
+
+        manager = _make_manager()
+        with pytest.raises(requests.HTTPError, match="400 Client Error"):
+            list(get_rows("key", "us", "mailing_lists", mock.MagicMock(), manager))
+
+    @mock.patch("posthog.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
+    def test_domain_scoped_500_still_raises(self, mock_session):
+        # Server errors are transient and retryable — they must not be swallowed as a skip.
+        domains_page = {"items": [{"name": "a.com"}]}
+        server_error = _response({}, 500)
+        mock_session.return_value.get.side_effect = [_response(domains_page), *([server_error] * 10)]
+
+        manager = _make_manager()
+        with pytest.raises(MailgunRetryableError):
+            with mock.patch("tenacity.nap.time.sleep", return_value=None):
+                list(get_rows("key", "us", "events", mock.MagicMock(), manager))
 
     @mock.patch("posthog.temporal.data_imports.sources.mailgun.mailgun.make_tracked_session")
     def test_non_ok_response_raises(self, mock_session):


### PR DESCRIPTION
## Problem

The Mailgun data-warehouse source surfaced a recurring error in PostHog error tracking:

> `HTTPError: 400 Client Error: Bad Request for url: https://api.mailgun.net/v3/<domain>/events?limit=300&ascending=yes&end=...`

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ec3f2-d03d-7e93-92af-8da01bfe3dc0

The failure originates in `posthog/temporal/data_imports/sources/mailgun/mailgun.py` (`_fetch_page` → `response.raise_for_status()`), reached via the import pipeline → `get_rows` fan-out. The repeated occurrences seconds apart (each with a freshly-computed `end`) are Temporal activity retries hitting the same wall.

The events endpoint — and every other domain-scoped endpoint (bounces, complaints, unsubscribes, tags, templates) — fans out over **every** domain returned by `/v4/domains`. That listing includes domains that exist on the account but can't be queried for events/suppressions: disabled, unverified, or sandbox-like domains. Mailgun rejects the domain-scoped request for those with a `400 Bad Request`. Because the raised `HTTPError` propagated out of the fan-out loop, **one** un-queryable domain aborted the entire sync, so none of the account's other domains imported either, and the activity retried indefinitely without ever making progress.

## Changes

This is a fragility bug rather than a clean stop-retrying credential/config error, so the fix improves the code rather than extending `NonRetryableErrors`:

- When a **domain-scoped** request returns a client `400`, log a warning, skip that domain, and continue the fan-out so the remaining domains still import.
- The skip is scoped narrowly to avoid masking real bugs:
  - Only domain-scoped endpoints with a `current_domain` skip. A `400` on an account-level endpoint (the domains listing, mailing lists) still raises — that would indicate our request is malformed, not a bad domain.
  - `5xx`/`429`/transient errors are untouched and stay retryable.

Marking the whole error `NonRetryableError` was rejected: it would permanently fail the entire schema for one bad domain, so the good domains would never sync. Omitting `begin` on the initial sync was confirmed to be intentional and valid (existing test `test_events_url_without_begin_on_full_refresh`), so this is not a request-construction bug.

## How did you test this code?

I'm an agent. I added and ran automated tests only (no manual/live testing):

- `test_domain_scoped_400_skips_domain_and_continues_fan_out` — a `400` on the first domain's events is skipped and the second domain still imports; the fan-out completes cleanly.
- `test_account_level_400_still_raises` — a `400` on a non-domain-scoped endpoint still surfaces.
- `test_domain_scoped_500_still_raises` — server errors remain retryable and are not swallowed as a skip.

Full source test suite passes locally: `pytest posthog/temporal/data_imports/sources/mailgun/tests/` → 124 passed. `ruff check` and `ruff format` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's stack trace and a representative event via the PostHog error-tracking MCP tools to confirm the failure genuinely originates in the Mailgun source (`mailgun.py:207`, `_fetch_page`) rather than appearing only in serialized log context. Read the source and its tests to decide between extending `NonRetryableErrors` and fixing the code; chose a per-domain graceful skip because the fan-out crashing on a single un-queryable domain strands every other domain, which `NonRetryableErrors` would make worse. Kept the change tightly scoped (domain-scoped 400s only) and added regression tests at the same layer as the fix.
