### PR TITLE
fix(postgres): honor SSH tunnel TLS opt-out for CDC connections

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/cdc/slot_manager.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/slot_manager.py
@@ -28,7 +28,10 @@ def cdc_pg_connection(source: ExternalDataSource, connect_timeout: int = 15) -> 
 
     source_impl = PostgresSource()
     config = source_impl.parse_config(source.job_inputs or {})
-    require_ssl = source_requires_ssl(source)
+    # Pass `config` so the SSH-tunnel `require_tls` opt-out is honored, matching the main
+    # pipeline path. Without it SSL is forced on, and a database reached over an SSH tunnel
+    # that doesn't speak SSL fails with "server does not support SSL, but SSL was required".
+    require_ssl = source_requires_ssl(source, config)
 
     with source_impl.with_ssh_tunnel(config) as (host, port):
         conn = _connect_to_postgres(

--- a/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_slot_manager.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_slot_manager.py
@@ -1,11 +1,19 @@
+import datetime as dt
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from unittest import mock
 from unittest.mock import MagicMock
 
 import psycopg.errors
 
 from posthog.temporal.data_imports.sources.postgres.cdc.slot_manager import (
     add_table_to_publication,
+    cdc_pg_connection,
     remove_table_from_publication,
 )
+from posthog.temporal.data_imports.sources.postgres.postgres import SSL_REQUIRED_AFTER_DATE
 
 
 def _mock_conn(execute_side_effect=None):
@@ -65,3 +73,63 @@ class TestRemoveTableFromPublication:
 
         conn.rollback.assert_called_once()
         conn.commit.assert_not_called()
+
+
+class TestCdcPgConnectionSsl:
+    @pytest.mark.parametrize(
+        "is_new_source,ssh_tunnel_enabled,require_tls,expected_require_ssl",
+        [
+            (True, False, True, True),
+            (True, True, True, True),
+            (True, True, False, False),
+            (False, False, True, False),
+        ],
+    )
+    def test_honors_ssh_tunnel_tls_optout(self, is_new_source, ssh_tunnel_enabled, require_tls, expected_require_ssl):
+        # CDC must derive `require_ssl` from the full config like the main pipeline path, so an
+        # SSH-tunnel `require_tls` opt-out is honored. Otherwise SSL is forced on and a database
+        # reached over an SSH tunnel that doesn't speak SSL fails with "server does not support SSL".
+        from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
+
+        config = PostgresSource().parse_config(
+            {
+                "host": "db.example.com",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "public",
+            }
+        )
+        if ssh_tunnel_enabled:
+            config.ssh_tunnel = mock.MagicMock(enabled=True, require_tls=mock.MagicMock(enabled=require_tls))
+        else:
+            config.ssh_tunnel = None
+
+        created_at = (
+            SSL_REQUIRED_AFTER_DATE + dt.timedelta(days=1)
+            if is_new_source
+            else SSL_REQUIRED_AFTER_DATE - dt.timedelta(days=1)
+        )
+        source = SimpleNamespace(job_inputs={}, created_at=created_at)
+
+        @contextmanager
+        def fake_tunnel(self, config):
+            yield ("127.0.0.1", 44549)
+
+        with (
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.source.PostgresSource.parse_config",
+                return_value=config,
+            ),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.source.PostgresSource.with_ssh_tunnel",
+                fake_tunnel,
+            ),
+            mock.patch("posthog.temporal.data_imports.sources.postgres.postgres._connect_to_postgres") as mock_connect,
+        ):
+            with cdc_pg_connection(source):
+                pass
+
+        mock_connect.assert_called_once()
+        assert mock_connect.call_args.kwargs["require_ssl"] is expected_require_ssl

--- a/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_slot_manager.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_slot_manager.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from contextlib import contextmanager
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from unittest import mock
@@ -14,6 +15,8 @@ from posthog.temporal.data_imports.sources.postgres.cdc.slot_manager import (
     remove_table_from_publication,
 )
 from posthog.temporal.data_imports.sources.postgres.postgres import SSL_REQUIRED_AFTER_DATE
+
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 
 def _mock_conn(execute_side_effect=None):
@@ -128,7 +131,7 @@ class TestCdcPgConnectionSsl:
             ),
             mock.patch("posthog.temporal.data_imports.sources.postgres.postgres._connect_to_postgres") as mock_connect,
         ):
-            with cdc_pg_connection(source):
+            with cdc_pg_connection(cast(ExternalDataSource, source)):
                 pass
 
         mock_connect.assert_called_once()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OperationalError: connection failed: ... server does not support SSL, but SSL was required` originating in `_connect_to_postgres`, reached via `cdc_pg_connection` (the Postgres CDC slot/connection helper). The failing connection target was a local SSH-tunnel forward port.

When a user connects their Postgres source over an SSH tunnel, the tunnel already encrypts traffic, so the database often doesn't expose SSL directly. For exactly this case we offer a `require_tls` opt-out on the SSH tunnel, and `source_requires_ssl(source, config)` honors it — but only when the parsed config is passed in.

`cdc_pg_connection` called `source_requires_ssl(source)` **without** the config it had already parsed one line above. With the opt-out branch skipped, SSL was forced on (`sslmode=require`) for the CDC connection, so the connection to a no-SSL database over the tunnel failed every time. The user's main sync (which passes the config) worked, but CDC connections were broken.

This is a code bug, not a user/upstream error: the user correctly configured an SSH tunnel with TLS disabled, and one connection path inconsistently ignored that choice.

## Changes

- `cdc_pg_connection` now passes the parsed `config` to `source_requires_ssl`, matching every other connection path (main pipeline, direct query, API setup). This lets the SSH-tunnel `require_tls` opt-out take effect, so `sslmode` falls back to `prefer` when the user has opted out — instead of forcing `require` and failing against a database that doesn't speak SSL.

Genuine "I require SSL but my DB doesn't support it" cases are unaffected: when the opt-out is **not** set, `require_ssl` stays `True`, and `_connect_to_postgres` already maps that to a non-retryable `SSLRequiredError` with an actionable message.

## How did you test this code?

I'm an agent. I added an automated regression test and ran it; I did not perform manual testing.

- Added `TestCdcPgConnectionSsl::test_honors_ssh_tunnel_tls_optout` (parametrized) in `test_slot_manager.py`, asserting `cdc_pg_connection` passes the expected `require_ssl` to `_connect_to_postgres` across: new source / no tunnel (require), tunnel + TLS on (require), tunnel + TLS off (prefer), and pre-cutoff source (prefer).
- Verified the test **fails** without the fix (the tunnel-TLS-off case computed `require_ssl=True`) and **passes** with it.
- Ran the full `test_slot_manager.py` suite (8 passed) and `ruff check` / `ruff format` clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Postgres data-warehouse source. Investigated the stack trace (`cdc_pg_connection` → `_connect_to_postgres`), then compared all callers of `source_requires_ssl` and found the CDC path was the only one not passing the config. Considered treating it as a non-retryable error instead, but rejected that: the failure is caused by our own inconsistency, and the user had legitimately opted out of TLS, so the correct fix is to honor that opt-out rather than stop retrying. Kept the change to a single line plus a regression test.

Tools used: Claude Code with the PostHog error-tracking MCP (`query-error-tracking-issue`).
