### PR TITLE
feat(data-warehouse): promote Snapchat Ads source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -49,7 +50,7 @@ class SnapchatAdsSource(ResumableSource[SnapchatAdsSourceConfig, SnapchatResumeC
             name=SchemaExternalDataSourceType.SNAPCHAT_ADS,
             label="Snapchat Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Snapchat Ads. Ensure you have granted PostHog access to your Snapchat Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/snapchat-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/snapchat.png",
             docsUrl="https://posthog.com/docs/cdp/sources/snapchat-ads",
             fields=cast(


### PR DESCRIPTION
## Problem

The **Snapchat Ads** (`SnapchatAds`) data warehouse source has been running in **Beta**. It now clears the bar for general availability:

- **Adoption / longevity:** live for 3.6 months (GA needs 100+ teams *or* 3+ months live — the longevity threshold is met). Currently used by 17 teams.
- **Reliability:** 0.1% error rate over the last 7 days, well under the 2.5% GA threshold.

## Changes

Promote the source's release status from `beta` to `ga`:

- `posthog/temporal/data_imports/sources/snapchat_ads/source.py` — `releaseStatus="beta"` → `releaseStatus=ReleaseStatus.GA` (using the `ReleaseStatus` enum from `posthog.schema`, matching the convention used by other GA sources like TikTok Ads, Pinterest Ads, Meta Ads, and Google Ads).

This is a **status promotion only** — no changes to the connector's behavior, schemas, sync logic, or fields.

### Gating left untouched (intentional)

The frontend `NATIVE_SOURCE_FEATURE_FLAGS` map (`marketing-analytics/.../logic/utils.ts`) still gates `SnapchatAds` behind the `snapchat-ads-source` flag. I left this in place because the existing convention does **not** clearly couple flag removal to the GA stage — `PinterestAds` is already `ReleaseStatus.GA` in the backend yet retains its flag entry. Removing the gate is a separate rollout decision and out of scope for this status promotion.

## How did you test this code?

I'm an agent. Automated checks run:

- `ruff check` on the modified file — passes.
- Confirmed no test asserts the previous `"beta"` status (so no snapshot/test updates required).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Promotion requested by a human and carried out with Claude Code. Followed the `implementing-warehouse-sources` skill, which specifies using the `ReleaseStatus` enum rather than a bare string literal for `releaseStatus`. Scoped the change to the single backend source definition and verified other GA sources use the same enum pattern.
