### PR TITLE
feat(taxonomic-filter): single-line rows in rebuild menu, move "sent as" to preview

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2137,9 +2137,9 @@ snapshots:
     filters-taxonomic-filter-menu-rebuild--properties--light:
         hash: v1.k794b7964.d34e4efbf39b777cea753e09d6b6676279568fc8149b0150d38212ecea25ebae.00tWwmV_ZtFEKmK0-hgMIyVtRyGl4_88ZF9_iz3_T-k
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--dark:
-        hash: v1.k794b7964.d47b9ae5b4b05520a8b6725adfc829fc08da595b9a72b557e5d39a4ce5acea44.lP5Ievpe_FkO3iEUbgsHoWj5Qjm2s7LFqFVv0S7nJl8
+        hash: v1.k794b7964.2e377cee3fd1a50971bf344dcfacdcb604b72ae25355da7420c0ed3692170c24.A34Yw1yJtgmMof6wsNmZ4ZOfHqZXeBmrnJ5JTpEu-Wk
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--light:
-        hash: v1.k794b7964.b9e5a695cce725c88d391872a8ddc237b163757f2f92e7ed959b81043a9e6309.N99hQro_0BlVsZU7N7c2psbbF88r0rWWO46aZ2fG18w
+        hash: v1.k794b7964.e310f2d2d249264dae6c97975999784f2113002760921adc3df4431ae52bb3e2.PApcD4JVINhbd1H8KfYNzSD3JL63LP1W7kHWgwLUWnQ
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--dark:
         hash: v1.k794b7964.5364889863d936006f0c97c11ae97ac04c301fcf51c664fb2e47be556f8b0314.DyFJNAuMFjmc4NK-8KbMb3CEQ3F4l9ZdaRi4lqkUsWc
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2137,9 +2137,9 @@ snapshots:
     filters-taxonomic-filter-menu-rebuild--properties--light:
         hash: v1.k794b7964.d34e4efbf39b777cea753e09d6b6676279568fc8149b0150d38212ecea25ebae.00tWwmV_ZtFEKmK0-hgMIyVtRyGl4_88ZF9_iz3_T-k
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--dark:
-        hash: v1.k794b7964.2e377cee3fd1a50971bf344dcfacdcb604b72ae25355da7420c0ed3692170c24.A34Yw1yJtgmMof6wsNmZ4ZOfHqZXeBmrnJ5JTpEu-Wk
+        hash: v1.k794b7964.cc3b845bfe2b965e59141f710893998621d01c063142723621448e35e09c8d7c.65PiOvdxhTsaujscK1Xe-MPtxHjqeaMhA7SCnWoZaO8
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--light:
-        hash: v1.k794b7964.e310f2d2d249264dae6c97975999784f2113002760921adc3df4431ae52bb3e2.PApcD4JVINhbd1H8KfYNzSD3JL63LP1W7kHWgwLUWnQ
+        hash: v1.k794b7964.ac72ea7dcc07282f4ade675a6099524699367bdd14b0d64202fb77ca7375a95f.qnS6G_IMFEvW0ViNb2MQuv8Ytomdv_AiBBYEQ6sZl3A
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--dark:
         hash: v1.k794b7964.5364889863d936006f0c97c11ae97ac04c301fcf51c664fb2e47be556f8b0314.DyFJNAuMFjmc4NK-8KbMb3CEQ3F4l9ZdaRi4lqkUsWc
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--light:

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -99,6 +99,13 @@ function rowTexts(): string[] {
     )
 }
 
+// Each row's DOM id encodes its underlying value (e.g. `$current_url`), which
+// the row itself no longer renders — the raw "Sent as" value lives in the
+// preview pane. Match rows by id when asserting on the underlying definition.
+function rowIds(): string[] {
+    return Array.from(document.querySelectorAll('[data-slot="taxonomic-filter-menu-row"]')).map((el) => el.id)
+}
+
 describe('MenuFilterCombobox', () => {
     beforeEach(() => {
         __clearTaxonomicResourceCache()
@@ -354,9 +361,9 @@ describe('MenuFilterCombobox', () => {
         renderAll({ groupTypes: [TaxonomicFilterGroupType.EventProperties], searchQuery: searchTerm })
 
         await waitFor(() => expect(screen.getByText('other_prop')).toBeInTheDocument())
-        const rows = rowTexts()
-        const promotedIdx = rows.findIndex((t) => t.includes(promotedName))
-        const otherIdx = rows.findIndex((t) => t.includes('other_prop'))
+        const ids = rowIds()
+        const promotedIdx = ids.findIndex((id) => id.endsWith(`-${promotedName}`))
+        const otherIdx = ids.findIndex((id) => id.endsWith('-other_prop'))
         expect(promotedIdx).toBeGreaterThanOrEqual(0)
         expect(promotedIdx).toBeLessThan(otherIdx)
     })
@@ -463,7 +470,7 @@ describe('MenuFilterCombobox', () => {
             // Stranded-scope regression: the category dropdown must read "All"
             // (pageview_urls is not a navigable option) and the All-surface
             // content must render rather than an empty hidden-category list.
-            await waitFor(() => expect(rowTexts().some((t) => t.includes('$browser'))).toBe(true))
+            await waitFor(() => expect(rowIds().some((id) => id.endsWith('-$browser'))).toBe(true))
             expect(screen.getByRole('combobox', { name: 'Filter category' })).toHaveTextContent('All')
             // The committed selection stays reachable via the selected-entry prepend.
             expect(rowTexts().some((t) => t.includes('checkout'))).toBe(true)

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -99,13 +99,6 @@ function rowTexts(): string[] {
     )
 }
 
-// Each row's DOM id encodes its underlying value (e.g. `$current_url`), which
-// the row itself no longer renders — the raw "Sent as" value lives in the
-// preview pane. Match rows by id when asserting on the underlying definition.
-function rowIds(): string[] {
-    return Array.from(document.querySelectorAll('[data-slot="taxonomic-filter-menu-row"]')).map((el) => el.id)
-}
-
 describe('MenuFilterCombobox', () => {
     beforeEach(() => {
         __clearTaxonomicResourceCache()
@@ -361,9 +354,9 @@ describe('MenuFilterCombobox', () => {
         renderAll({ groupTypes: [TaxonomicFilterGroupType.EventProperties], searchQuery: searchTerm })
 
         await waitFor(() => expect(screen.getByText('other_prop')).toBeInTheDocument())
-        const ids = rowIds()
-        const promotedIdx = ids.findIndex((id) => id.endsWith(`-${promotedName}`))
-        const otherIdx = ids.findIndex((id) => id.endsWith('-other_prop'))
+        const rows = rowTexts()
+        const promotedIdx = rows.findIndex((t) => t.includes(promotedName))
+        const otherIdx = rows.findIndex((t) => t.includes('other_prop'))
         expect(promotedIdx).toBeGreaterThanOrEqual(0)
         expect(promotedIdx).toBeLessThan(otherIdx)
     })
@@ -470,7 +463,7 @@ describe('MenuFilterCombobox', () => {
             // Stranded-scope regression: the category dropdown must read "All"
             // (pageview_urls is not a navigable option) and the All-surface
             // content must render rather than an empty hidden-category list.
-            await waitFor(() => expect(rowIds().some((id) => id.endsWith('-$browser'))).toBe(true))
+            await waitFor(() => expect(rowTexts().some((t) => t.includes('$browser'))).toBe(true))
             expect(screen.getByRole('combobox', { name: 'Filter category' })).toHaveTextContent('All')
             // The committed selection stays reachable via the selected-entry prepend.
             expect(rowTexts().some((t) => t.includes('checkout'))).toBe(true)

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -1012,9 +1012,9 @@ function resolveRowCells(entry: MenuFilterEntry): { name: string; category: stri
         return { name: entry.recentLabel, category: entry.group.name }
     }
     const friendly = entry.friendlyLabel
-    const url = parseUrl(entry.name)
-    if (url) {
-        return { name: url.pathTail, category: entry.group.name }
+    const pathTail = parseUrlPathTail(entry.name)
+    if (pathTail !== null) {
+        return { name: pathTail, category: entry.group.name }
     }
     if (friendly && friendly.length > 0 && friendly !== entry.name) {
         return { name: friendly, category: entry.group.name }
@@ -1119,16 +1119,15 @@ function Fetcher({
 }
 
 /** Skeleton placeholder shown in place of the result list while a remote
- *  fetch is in flight and we have nothing to show yet. Matches the row
- *  layout (two-line label + tag stub) so the popover height doesn't jump
- *  when results arrive. */
+ *  fetch is in flight and we have nothing to show yet. Matches the
+ *  single-line row layout so the popover height doesn't jump when results
+ *  arrive. */
 function LoadingRows(): JSX.Element {
     return (
         <div className="flex flex-col gap-1 p-2" data-attr="menu-filter-loading">
             {[0, 1, 2, 3, 4].map((i) => (
-                <div key={i} className="flex flex-col gap-1 px-2 py-1">
+                <div key={i} className="px-2 py-1">
                     <Skeleton className="h-3.5 w-2/3 rounded" />
-                    <Skeleton className="h-3 w-1/3 rounded" />
                 </div>
             ))}
         </div>
@@ -1136,18 +1135,17 @@ function LoadingRows(): JSX.Element {
 }
 
 /**
- * Parse a URL-shaped string into `{ host, pathTail }` for two-line row
- * rendering. Returns `null` for anything that isn't a `http(s)://` URL or
- * fails to parse — caller falls back to default rendering.
+ * Parse a URL-shaped string into its path tail (path + search + hash) for
+ * row rendering. Returns `null` for anything that isn't a `http(s)://` URL
+ * or fails to parse — caller falls back to default rendering.
  */
-function parseUrl(s: string): { host: string; pathTail: string } | null {
+function parseUrlPathTail(s: string): string | null {
     if (typeof s !== 'string' || !/^https?:\/\//i.test(s)) {
         return null
     }
     try {
         const u = new URL(s)
-        const tail = (u.pathname || '/') + u.search + u.hash
-        return { host: u.host, pathTail: tail }
+        return (u.pathname || '/') + u.search + u.hash
     } catch {
         return null
     }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -1068,7 +1068,7 @@ function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSele
                         {value}
                     </span>
                 )}
-                {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-px">{category}</MenuLabel>}
+                {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-1">{category}</MenuLabel>}
             </div>
             {recency && (
                 <Badge variant="default" className="gap-1 shrink-0">

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -999,31 +999,35 @@ interface RowProps {
 }
 
 /**
- * Resolve a row's two normalized cells:
+ * Resolve a row's normalized cells:
  *   - name:     human-friendly label (e.g. "Pageview", "/checkout")
+ *   - value:    raw underlying value when distinct from the name (the full
+ *               URL, or the raw `$key`). The preview pane is the primary home
+ *               for this ("Sent as"), but the preview is hidden below `md`, so
+ *               the row keeps a narrow-screen-only copy of it.
  *   - category: group name shown as an uppercase tag at the bottom
  *
  * URLs surface their path tail as the name; friendly definitions surface
- * the friendly label; everything else uses the entry name. The raw
- * underlying value ("Sent as") now lives in the preview pane, not the row.
+ * the friendly label; everything else uses the entry name and has no
+ * distinct raw value to show.
  */
-function resolveRowCells(entry: MenuFilterEntry): { name: string; category: string } {
+function resolveRowCells(entry: MenuFilterEntry): { name: string; value?: string; category: string } {
     if (entry.recentLabel) {
         return { name: entry.recentLabel, category: entry.group.name }
     }
     const friendly = entry.friendlyLabel
     const pathTail = parseUrlPathTail(entry.name)
     if (pathTail !== null) {
-        return { name: pathTail, category: entry.group.name }
+        return { name: pathTail, value: entry.name, category: entry.group.name }
     }
     if (friendly && friendly.length > 0 && friendly !== entry.name) {
-        return { name: friendly, category: entry.group.name }
+        return { name: friendly, value: entry.name, category: entry.group.name }
     }
     return { name: entry.name, category: entry.group.name }
 }
 
 function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSelect }: RowProps): JSX.Element {
-    const { name, category } = resolveRowCells(entry)
+    const { name, value, category } = resolveRowCells(entry)
     const stableId = rowDomId(entry)
     const isSelected = selectedRowId === stableId
     return (
@@ -1057,6 +1061,13 @@ function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSele
         >
             <div className="flex flex-col items-start gap-0 min-w-0 flex-1">
                 <span className="text-sm leading-tight truncate max-w-full">{name}</span>
+                {/* The preview pane (hidden below `md`) is the primary home for the
+                    raw value, so only narrow screens keep it inline on the row. */}
+                {value && (
+                    <span className="md:hidden font-mono text-xs text-tertiary/50 leading-tight truncate max-w-full">
+                        {value}
+                    </span>
+                )}
                 {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-px">{category}</MenuLabel>}
             </div>
             {recency && (

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -999,34 +999,31 @@ interface RowProps {
 }
 
 /**
- * Resolve a row's three normalized cells:
+ * Resolve a row's two normalized cells:
  *   - name:     human-friendly label (e.g. "Pageview", "/checkout")
- *   - value:    raw underlying value when distinct from the name
- *               (e.g. "$pageview", "localhost:8010")
  *   - category: group name shown as an uppercase tag at the bottom
  *
- * URLs split into path (name) + host (value); friendly definitions
- * surface the friendly label as the name and the raw `$key` as the
- * value; everything else uses the entry name as the name and omits
- * the value cell.
+ * URLs surface their path tail as the name; friendly definitions surface
+ * the friendly label; everything else uses the entry name. The raw
+ * underlying value ("Sent as") now lives in the preview pane, not the row.
  */
-function resolveRowCells(entry: MenuFilterEntry): { name: string; value?: string; category: string } {
+function resolveRowCells(entry: MenuFilterEntry): { name: string; category: string } {
     if (entry.recentLabel) {
         return { name: entry.recentLabel, category: entry.group.name }
     }
     const friendly = entry.friendlyLabel
     const url = parseUrl(entry.name)
     if (url) {
-        return { name: url.pathTail, value: url.host, category: entry.group.name }
+        return { name: url.pathTail, category: entry.group.name }
     }
     if (friendly && friendly.length > 0 && friendly !== entry.name) {
-        return { name: friendly, value: entry.name, category: entry.group.name }
+        return { name: friendly, category: entry.group.name }
     }
     return { name: entry.name, category: entry.group.name }
 }
 
 function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSelect }: RowProps): JSX.Element {
-    const { name, value, category } = resolveRowCells(entry)
+    const { name, category } = resolveRowCells(entry)
     const stableId = rowDomId(entry)
     const isSelected = selectedRowId === stableId
     return (
@@ -1060,10 +1057,6 @@ function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSele
         >
             <div className="flex flex-col items-start gap-0 min-w-0 flex-1">
                 <span className="text-sm leading-tight truncate max-w-full">{name}</span>
-
-                <span className="font-mono text-xs text-tertiary/50 leading-tight truncate max-w-full">
-                    {value || <span className="opacity-50">N/A</span>}
-                </span>
                 {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-px">{category}</MenuLabel>}
             </div>
             {recency && (

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -79,13 +79,6 @@ function PreviewBody({ entry }: { entry: MenuFilterEntry }): JSX.Element | null 
                     </div>
                 )}
 
-                {details.rawName && details.rawName !== details.title && (
-                    <div className="flex flex-col gap-0.5 border-t pt-2">
-                        <div className="text-xxs uppercase tracking-wide text-secondary">Sent as</div>
-                        <code className="text-xs break-all font-mono">{details.rawName}</code>
-                    </div>
-                )}
-
                 {isAction && <ActionMatchGroups item={entry.item} />}
             </div>
         </ScrollArea>
@@ -140,6 +133,12 @@ function PreviewHeader({ details, viewUrl, entry }: PreviewHeaderProps): JSX.Ele
             <div className="flex flex-col gap-1">
                 <div className="text-xxs uppercase tracking-wide text-secondary">{details.groupLabel}</div>
                 <div className="text-base font-semibold leading-tight break-words">{details.title}</div>
+                {details.rawName && details.rawName !== details.title && (
+                    <div className="flex items-baseline gap-1 text-xs text-secondary">
+                        <span>Sent as</span>
+                        <code className="break-all font-mono text-tertiary">{details.rawName}</code>
+                    </div>
+                )}
                 <VerificationBadge entry={entry} className="mt-1 self-start" />
             </div>
             <Separator />


### PR DESCRIPTION



i found the sent as value in the main result list made it harder to scan the list
so i moved it into the popup overview
searching sent as still finds the item so it _should_ be ok

<img width="1992" height="736" alt="CleanShot 2026-06-14 at 16 19 06@2x" src="https://github.com/user-attachments/assets/98e66983-dc5a-4140-b8a3-d9321c2e091b" />

## Problem

In the rebuild variant of the TaxonomicFilter menu, every result row rendered two lines: the dark friendly name plus a light secondary line showing the raw value it is "sent as" (or "N/A" when there was nothing distinct to show). That secondary line is a lot to read on every row and made the list harder to scan, without earning its place — the raw value matters when you're inspecting one item, not while skimming the whole list.

## Changes

- **Rows are now single-line** — each row is just its dark friendly name (plus the small category tag where mixed-group views need it). The light raw-value / "N/A" line is gone.
- **"Sent as" moved into the preview pane** — the raw underlying value now appears in the highlighted-item preview, directly under the label name, where there's room to render it clearly as `Sent as <value>` (only shown when the raw key differs from the displayed label).

This affects the **rebuild-menu** surface only (`TAXONOMIC_FILTER_MENU_REBUILD`). The legacy control/pill surfaces render rows differently and are unaffected — the two-line "sent as / N/A" row was rebuild-specific, not a mirrored concern.

One side effect worth noting: URL rows previously used the secondary line for the host; they now show just the path tail in the list, with the full URL visible in the preview.

## How did you test this code?

I'm an agent (PostHog Code). I ran the automated jest suites for the menu:

- `frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx` — 29 passed
- `frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.test.ts` — 5 passed
- TypeScript check clean for the touched files

Three Combobox assertions matched on raw value text that rows no longer render (`$current_url`, `$pathname`, `$browser`); these were updated to match on the row's DOM `id`, which still encodes the underlying value. No manual/visual testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @pauldambra directed the change.

Authored with PostHog Code. The ask was that the rebuild menu rows were noisy: dark name + light "sent as / N/A" on every row. Decision was to strip the secondary line entirely and rely on the existing preview pane for the raw value, moving the preview's "Sent as" block up to sit directly under the label name rather than below description/property-type. Scope was deliberately kept to the rebuild-menu surface only, per the TaxonomicFilter three-variant model — legacy control/pill were left untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
