### PR TITLE
feat(observability): tag django and temporal spans with team_id

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from django.db.models.query import QuerySet
 
+from opentelemetry import trace
 from rest_framework.exceptions import AuthenticationFailed, NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
@@ -247,6 +248,12 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
                 # touches a scoped model will get TeamScopeError, which is the
                 # correct fail-closed behavior.
                 return
+            # Tag the request (root) span as soon as the team is resolved, so the whole
+            # trace is attributable to a team. DjangoInstrumentor's request span is the
+            # current span here (no manual span has opened yet); a no-op when tracing is off.
+            request_span = trace.get_current_span()
+            if request_span.is_recording():
+                request_span.set_attribute("team_id", team_id)
             # Compute canonical team_id. self.team is a @cached_property
             # (line ~297) usually loaded by the permission checks above, so
             # this is free. Reading via __dict__ rather than attribute access

--- a/posthog/api/test/test_routing.py
+++ b/posthog/api/test/test_routing.py
@@ -12,6 +12,9 @@ from django.test import override_settings
 from django.urls import include, path
 from django.utils import timezone
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -73,6 +76,37 @@ scoped_test_organizations_router.register(
 urlpatterns = [
     path("api/", include(test_router.urls)),
 ]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class TestTeamAndOrgViewSetMixinSpanTagging(APIBaseTest):
+    """The request (root) span should be tagged with team_id for team/project views."""
+
+    def _recording_tracer(self):
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        return provider.get_tracer("test"), exporter
+
+    def _root_span(self, exporter):
+        spans = [s for s in exporter.get_finished_spans() if s.name == "test-request-root"]
+        self.assertEqual(len(spans), 1)
+        return spans[0]
+
+    def test_team_view_tags_request_span_with_team_id(self):
+        tracer, exporter = self._recording_tracer()
+        with tracer.start_as_current_span("test-request-root"):
+            response = self.client.get(f"/api/environments/{self.team.id}/foos/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._root_span(exporter).attributes["team_id"], self.team.id)
+
+    def test_organization_view_does_not_tag_team_id(self):
+        # Org-scoped views have no single team, so the stamp must not fire.
+        tracer, exporter = self._recording_tracer()
+        with tracer.start_as_current_span("test-request-root"):
+            response = self.client.get(f"/api/organizations/{self.organization.id}/foos/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("team_id", self._root_span(exporter).attributes or {})
 
 
 @override_settings(ROOT_URLCONF=__name__)  # Use `urlpatterns` from this file and not from `posthog.urls`

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -2,6 +2,7 @@ from dataclasses import is_dataclass
 from typing import Any, Optional
 
 import temporalio.exceptions
+from opentelemetry import trace
 from posthoganalytics import api_key, capture_exception
 from temporalio import activity, workflow
 from temporalio.worker import (
@@ -17,6 +18,26 @@ from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 from posthog.temporal.common.logger import get_write_only_logger
 
 logger = get_write_only_logger()
+
+
+def _tag_team_id_on_current_span(input: ExecuteActivityInput | ExecuteWorkflowInput) -> None:
+    """Tag the active span (the Temporal RunActivity/RunWorkflow span, when OTel tracing is
+    enabled on the worker) with team_id read from the activity/workflow input.
+
+    team_id is named consistently across PostHog's Temporal input dataclasses, so a reflective
+    read covers nearly all of them without per-workflow opt-in. Best-effort: span bookkeeping
+    must never break execution, and set_attribute is a non-IO no-op when the span isn't recording."""
+    try:
+        if not (len(input.args) == 1 and is_dataclass(input.args[0])):
+            return
+        team_id = getattr(input.args[0], "team_id", None)
+        if not isinstance(team_id, int) or isinstance(team_id, bool):
+            return
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("team_id", team_id)
+    except Exception:
+        pass
 
 
 async def _add_inputs_to_capture_kwargs(
@@ -40,6 +61,7 @@ async def _add_inputs_to_capture_kwargs(
 
 class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
+        _tag_team_id_on_current_span(input)
         try:
             return await super().execute_activity(input)
         except Exception as e:
@@ -69,6 +91,7 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
 
 class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        _tag_team_id_on_current_span(input)
         try:
             return await super().execute_workflow(input)
         except Exception as e:
@@ -100,7 +123,8 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
 
 
 class PostHogClientInterceptor(Interceptor):
-    """PostHog Interceptor class which will report workflow & activity exceptions to PostHog"""
+    """PostHog Interceptor: reports workflow & activity exceptions to PostHog and tags the
+    Temporal span of each execution with team_id (read reflectively from the input)."""
 
     task_queue = ALL_TASK_QUEUES
 

--- a/posthog/temporal/tests/common/test_posthog_client_team_id.py
+++ b/posthog/temporal/tests/common/test_posthog_client_team_id.py
@@ -38,50 +38,39 @@ def _span_named(exporter: InMemorySpanExporter, name: str):
 
 
 @pytest.mark.asyncio
-class TestPostHogClientActivityTeamIdTagging:
-    async def test_tags_team_id_on_current_span(self):
+@pytest.mark.parametrize(
+    "interceptor_cls,input_spec,execute_method,span_name",
+    [
+        (_PostHogClientActivityInboundInterceptor, ExecuteActivityInput, "execute_activity", "RunActivity"),
+        (_PostHogClientWorkflowInterceptor, ExecuteWorkflowInput, "execute_workflow", "RunWorkflow"),
+    ],
+)
+class TestPostHogClientTeamIdTagging:
+    async def test_tags_team_id_on_current_span(self, interceptor_cls, input_spec, execute_method, span_name):
         provider, exporter = _provider_with_exporter()
         next_interceptor = AsyncMock()
-        next_interceptor.execute_activity.return_value = "result"
-        interceptor = _PostHogClientActivityInboundInterceptor(next_interceptor)
+        getattr(next_interceptor, execute_method).return_value = "result"
+        interceptor = interceptor_cls(next_interceptor)
 
-        mock_input = MagicMock(spec=ExecuteActivityInput)
+        mock_input = MagicMock(spec=input_spec)
         mock_input.args = [_InputWithTeam(team_id=4242)]
 
-        with provider.get_tracer("test").start_as_current_span("RunActivity"):
-            result = await interceptor.execute_activity(mock_input)
+        with provider.get_tracer("test").start_as_current_span(span_name):
+            result = await getattr(interceptor, execute_method)(mock_input)
 
         assert result == "result"
-        assert _span_named(exporter, "RunActivity").attributes["team_id"] == 4242
+        assert _span_named(exporter, span_name).attributes["team_id"] == 4242
 
-    async def test_no_team_id_when_input_lacks_field(self):
+    async def test_no_team_id_when_input_lacks_field(self, interceptor_cls, input_spec, execute_method, span_name):
         provider, exporter = _provider_with_exporter()
         next_interceptor = AsyncMock()
-        next_interceptor.execute_activity.return_value = "result"
-        interceptor = _PostHogClientActivityInboundInterceptor(next_interceptor)
+        getattr(next_interceptor, execute_method).return_value = "result"
+        interceptor = interceptor_cls(next_interceptor)
 
-        mock_input = MagicMock(spec=ExecuteActivityInput)
+        mock_input = MagicMock(spec=input_spec)
         mock_input.args = [_InputWithoutTeam(something_else="x")]
 
-        with provider.get_tracer("test").start_as_current_span("RunActivity"):
-            await interceptor.execute_activity(mock_input)
+        with provider.get_tracer("test").start_as_current_span(span_name):
+            await getattr(interceptor, execute_method)(mock_input)
 
-        assert "team_id" not in (_span_named(exporter, "RunActivity").attributes or {})
-
-
-@pytest.mark.asyncio
-class TestPostHogClientWorkflowTeamIdTagging:
-    async def test_tags_team_id_on_current_span(self):
-        provider, exporter = _provider_with_exporter()
-        next_interceptor = AsyncMock()
-        next_interceptor.execute_workflow.return_value = "result"
-        interceptor = _PostHogClientWorkflowInterceptor(next_interceptor)
-
-        mock_input = MagicMock(spec=ExecuteWorkflowInput)
-        mock_input.args = [_InputWithTeam(team_id=7)]
-
-        with provider.get_tracer("test").start_as_current_span("RunWorkflow"):
-            result = await interceptor.execute_workflow(mock_input)
-
-        assert result == "result"
-        assert _span_named(exporter, "RunWorkflow").attributes["team_id"] == 7
+        assert "team_id" not in (_span_named(exporter, span_name).attributes or {})

--- a/posthog/temporal/tests/common/test_posthog_client_team_id.py
+++ b/posthog/temporal/tests/common/test_posthog_client_team_id.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from temporalio.worker import ExecuteActivityInput, ExecuteWorkflowInput
+
+from posthog.temporal.common.posthog_client import (
+    _PostHogClientActivityInboundInterceptor,
+    _PostHogClientWorkflowInterceptor,
+)
+
+
+@dataclass
+class _InputWithTeam:
+    team_id: int
+
+
+@dataclass
+class _InputWithoutTeam:
+    something_else: str
+
+
+def _provider_with_exporter() -> tuple[TracerProvider, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def _span_named(exporter: InMemorySpanExporter, name: str):
+    spans = [s for s in exporter.get_finished_spans() if s.name == name]
+    assert len(spans) == 1
+    return spans[0]
+
+
+@pytest.mark.asyncio
+class TestPostHogClientActivityTeamIdTagging:
+    async def test_tags_team_id_on_current_span(self):
+        provider, exporter = _provider_with_exporter()
+        next_interceptor = AsyncMock()
+        next_interceptor.execute_activity.return_value = "result"
+        interceptor = _PostHogClientActivityInboundInterceptor(next_interceptor)
+
+        mock_input = MagicMock(spec=ExecuteActivityInput)
+        mock_input.args = [_InputWithTeam(team_id=4242)]
+
+        with provider.get_tracer("test").start_as_current_span("RunActivity"):
+            result = await interceptor.execute_activity(mock_input)
+
+        assert result == "result"
+        assert _span_named(exporter, "RunActivity").attributes["team_id"] == 4242
+
+    async def test_no_team_id_when_input_lacks_field(self):
+        provider, exporter = _provider_with_exporter()
+        next_interceptor = AsyncMock()
+        next_interceptor.execute_activity.return_value = "result"
+        interceptor = _PostHogClientActivityInboundInterceptor(next_interceptor)
+
+        mock_input = MagicMock(spec=ExecuteActivityInput)
+        mock_input.args = [_InputWithoutTeam(something_else="x")]
+
+        with provider.get_tracer("test").start_as_current_span("RunActivity"):
+            await interceptor.execute_activity(mock_input)
+
+        assert "team_id" not in (_span_named(exporter, "RunActivity").attributes or {})
+
+
+@pytest.mark.asyncio
+class TestPostHogClientWorkflowTeamIdTagging:
+    async def test_tags_team_id_on_current_span(self):
+        provider, exporter = _provider_with_exporter()
+        next_interceptor = AsyncMock()
+        next_interceptor.execute_workflow.return_value = "result"
+        interceptor = _PostHogClientWorkflowInterceptor(next_interceptor)
+
+        mock_input = MagicMock(spec=ExecuteWorkflowInput)
+        mock_input.args = [_InputWithTeam(team_id=7)]
+
+        with provider.get_tracer("test").start_as_current_span("RunWorkflow"):
+            result = await interceptor.execute_workflow(mock_input)
+
+        assert result == "result"
+        assert _span_named(exporter, "RunWorkflow").attributes["team_id"] == 7


### PR DESCRIPTION
## Problem

Traces are hard to attribute to a team. `create_hogql_database` and ClickHouse client spans carry a team_id, but the spans closer to the root of a trace don't:

- **Django requests:** the `DjangoInstrumentor` request span (the trace root for web traffic) has no team_id.
- **Temporal jobs:** the `RunActivity` / `RunWorkflow` spans carry `temporalRunID` / `temporalWorkflowID` but no team_id (verified against live APM — `temporal-worker-batch-exports` spans show the temporal IDs and nothing team-related).

So filtering a trace by team means digging into descendant spans instead of the entry span you actually land on.

## Changes

Tag `team_id` once, as close to the root as possible, in the single chokepoint each subsystem already funnels through. No behavior change — both are no-ops when the span isn't recording.

- **Django:** in `TeamAndOrgViewSetMixin.initial()`, stamp the current (request) span with `team_id` as soon as the team is resolved. This is the one place ~all authenticated team/project-scoped REST traffic passes through, and at that point the `DjangoInstrumentor` request span is the active span (no manual span has opened yet). Org-scoped views have no single team, so the stamp is correctly skipped.
- **Temporal:** the existing `PostHogClientInterceptor` already runs on `ALL_TASK_QUEUES` and reflects over `input.args[0]`. It now also reads `team_id` off the activity/workflow input and tags the active Temporal span (the `RunActivity`/`RunWorkflow` span created by the OTel plugin). `team_id` is named consistently across PostHog's Temporal input dataclasses, so reflective extraction covers nearly all of them without per-workflow opt-in. Workers use `UnsandboxedWorkflowRunner`, and `set_attribute` is a deterministic, non-IO call, so tagging the workflow span is replay-safe.

The attribute key is plain `team_id`, matching `create_hogql_database` and the other hand-instrumented endpoints.

This is the second of three PRs covering the trace-attribution surfaces (the first tagged the query endpoint / HogQL executor spans). Celery is intentionally left out — it has no tracer provider in its workers today, so it needs tracing stood up from scratch rather than a tagging tweak, and will follow in its own PR.

## How did you test this code?

Authored by an agent (Claude Code); no manual testing was performed. Automated tests added and run:

- **Temporal** (`posthog/temporal/tests/common/test_posthog_client_team_id.py`): asserts the activity and workflow interceptors tag the active span with `team_id` from the input, and don't when the input lacks a `team_id` field. Verified red-green locally — the positive cases fail with `KeyError` on `team_id` when the tagging helper is neutered. All 3 pass.
- **Django** (`posthog/api/test/test_routing.py::TestTeamAndOrgViewSetMixinSpanTagging`): asserts a team-scoped request tags the request span with `team_id`, and an org-scoped request does not. Uses an in-memory span exporter, mirroring the existing `test_auth_spans.py` pattern. This test needs Postgres, which wasn't available in the local sandbox, so it's verified by CI.

`ruff` and `mypy` pass on the changed source files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie via a Claude Code session. The work started from "make `create_hogql_database` emit a team-tagged span" and zoomed out to "tag as many spans as possible at the root, as soon as the team is resolved." Investigation (code reading + live APM queries) established that team resolution is uniform for authenticated REST traffic (one mixin chokepoint) but bespoke for ingestion/public endpoints, and that Temporal already emits root spans via the OTel plugin while Celery emits none.

Key decisions: tag at the entry/root span of each subsystem rather than every span (attributes aren't inherited, but filtering the root and viewing the whole trace is the practical workflow); fold the Temporal tagging into the existing `PostHogClientInterceptor` to avoid a second reflection pass and interceptor; include the workflow side because the unsandboxed runner plus a non-IO `set_attribute` make it replay-safe. The `SpanProcessor`-on-every-span approach was considered and deferred as a possible follow-up if per-child-span filtering is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
