### PR TITLE
feat(observability): trace celery tasks and tag spans with team_id

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -19,6 +19,7 @@ from celery.signals import (
 )
 from django_structlog.celery import signals
 from django_structlog.celery.steps import DjangoStructLogInitStep
+from opentelemetry import trace
 from prometheus_client import Counter, Histogram, start_http_server
 
 # When PROMETHEUS_MULTIPROC_DIR is set (by bin/docker-worker-celery),
@@ -161,11 +162,44 @@ def on_celeryd_init(**kwargs) -> None:
     logger.info("prometheus_multiproc_cleanup_done", removed=removed)
 
 
+def _tag_celery_span_with_team_id(task_kwargs: dict | None) -> None:
+    """Tag the active Celery task span (created by CeleryInstrumentor) with team_id, read
+    best-effort from the task's keyword arguments. Coverage is partial by design: only tasks
+    invoked with an explicit ``team_id=`` keyword are tagged. No-op when the span isn't recording."""
+    try:
+        team_id = (task_kwargs or {}).get("team_id")
+        if not isinstance(team_id, int) or isinstance(team_id, bool):
+            return
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("team_id", team_id)
+    except Exception:
+        pass
+
+
+def _celery_team_id_prerun_receiver(task_id=None, task=None, args=None, kwargs=None, **_) -> None:
+    _tag_celery_span_with_team_id(kwargs)
+
+
 @worker_process_init.connect
 def on_worker_start(**kwargs) -> None:
     from posthoganalytics import setup
 
+    from posthog.otel_instrumentation import (
+        initialize_otel,  # noqa: PLC0415 — keep the OTel stack off the celery import path; only the worker child loads it
+    )
+
     setup()  # makes sure things like exception autocapture are initialised
+
+    # Initialize tracing in the forked worker child (not at import / pre-fork): the
+    # BatchSpanProcessor's export thread and gRPC channel do not survive fork(), so the
+    # provider must be created per child. This also enables CeleryInstrumentor, which starts
+    # a span per task. No-op when OTEL_SDK_DISABLED is set.
+    initialize_otel()
+    # Connect the team_id tagger AFTER initialize_otel (which instruments Celery) so Celery
+    # dispatches it after CeleryInstrumentor's own prerun receiver — the task span is the
+    # active span by then. Degrades to a no-op if that ordering ever changes.
+    task_prerun.connect(_celery_team_id_prerun_receiver, weak=False)
 
     port = int(os.getenv("CELERY_METRICS_PORT", "8001"))
     try:

--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -7,6 +7,7 @@ from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.aiokafka import AIOKafkaInstrumentor
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.instrumentation.kafka import KafkaInstrumentor
 from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
@@ -89,6 +90,7 @@ def initialize_otel():
         )
 
         instrument_django(provider)
+        instrument_celery(provider)
         instrument_redis(provider)
         instrument_psycopg(provider)
         instrument_kafka(provider)
@@ -117,6 +119,14 @@ def instrument_django(provider: trace.TracerProvider):
         logger.info("otel_instrumentation_attempt", instrumentor="DjangoInstrumentor", status="success")
     except Exception as e:
         logger.exception("otel_instrumentation_attempt", instrumentor="DjangoInstrumentor", status="error", exc_info=e)
+
+
+def instrument_celery(provider: trace.TracerProvider):
+    try:
+        CeleryInstrumentor().instrument(tracer_provider=provider)
+        logger.info("otel_instrumentation_attempt", instrumentor="CeleryInstrumentor", status="success")
+    except Exception as e:
+        logger.exception("otel_instrumentation_attempt", instrumentor="CeleryInstrumentor", status="error", exc_info=e)
 
 
 def instrument_redis(provider: trace.TracerProvider):

--- a/posthog/test/test_celery_span_team_id.py
+++ b/posthog/test/test_celery_span_team_id.py
@@ -1,0 +1,39 @@
+import pytest
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from posthog.celery import _tag_celery_span_with_team_id
+
+
+def _provider_with_exporter():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+@pytest.mark.parametrize(
+    "task_kwargs,expected",
+    [
+        ({"team_id": 4242}, 4242),
+        ({"team_id": 1, "other": "x"}, 1),
+        ({"other": "x"}, None),
+        ({"team_id": "4242"}, None),
+        ({"team_id": True}, None),
+        (None, None),
+    ],
+)
+def test_tag_celery_span_with_team_id(task_kwargs, expected):
+    provider, exporter = _provider_with_exporter()
+    with provider.get_tracer("test").start_as_current_span("run/some_task"):
+        _tag_celery_span_with_team_id(task_kwargs)
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == "run/some_task"]
+    assert len(spans) == 1
+    attributes = spans[0].attributes or {}
+    if expected is None:
+        assert "team_id" not in attributes
+    else:
+        assert attributes["team_id"] == expected

--- a/posthog/test/test_otel_instrumentation.py
+++ b/posthog/test/test_otel_instrumentation.py
@@ -38,6 +38,7 @@ class TestOtelInstrumentation(BaseTest):
 
         super().tearDown()
 
+    @mock.patch("posthog.otel_instrumentation.CeleryInstrumentor")
     @mock.patch("posthog.otel_instrumentation.AIOKafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.KafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.PsycopgInstrumentor")
@@ -71,6 +72,7 @@ class TestOtelInstrumentation(BaseTest):
         mock_psycopg_instrumentor_cls,
         mock_kafka_instrumentor_cls,
         mock_aio_kafka_instrumentor_cls,
+        mock_celery_instrumentor_cls,
     ):
         # Arrange
         mock_resource_instance = mock.Mock()
@@ -114,6 +116,12 @@ class TestOtelInstrumentation(BaseTest):
 
         mock_django_instrumentor_cls.assert_called_once_with()
         mock_django_instrumentor_instance.instrument.assert_called_once()
+
+        # Assert CeleryInstrumentor call
+        mock_celery_instrumentor_cls.assert_called_once_with()
+        mock_celery_instrumentor_cls.return_value.instrument.assert_called_once_with(
+            tracer_provider=mock_provider_instance
+        )
 
         instrument_call_args = mock_django_instrumentor_instance.instrument.call_args
         self.assertEqual(instrument_call_args[1]["tracer_provider"], mock_provider_instance)
@@ -166,6 +174,7 @@ class TestOtelInstrumentation(BaseTest):
         self.assertEqual(django_otel_lib_logger.level, logging.DEBUG)  # Always set to DEBUG
         self.assertTrue(django_otel_lib_logger.propagate)
 
+    @mock.patch("posthog.otel_instrumentation.CeleryInstrumentor")
     @mock.patch("posthog.otel_instrumentation.AIOKafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.KafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.PsycopgInstrumentor")
@@ -181,12 +190,14 @@ class TestOtelInstrumentation(BaseTest):
         mock_psycopg_instrumentor_cls,
         mock_kafka_instrumentor_cls,
         mock_aio_kafka_instrumentor_cls,
+        mock_celery_instrumentor_cls,
     ):
         # Act
         initialize_otel()
 
         # Assert
         mock_django_instrumentor_cls.return_value.instrument.assert_not_called()
+        mock_celery_instrumentor_cls.return_value.instrument.assert_not_called()
         mock_redis_instrumentor_cls.return_value.instrument.assert_not_called()
         mock_psycopg_instrumentor_cls.return_value.instrument.assert_not_called()
         mock_kafka_instrumentor_cls.return_value.instrument.assert_not_called()
@@ -251,6 +262,7 @@ class TestOtelInstrumentation(BaseTest):
 
         mock_span.set_attribute.assert_not_called()
 
+    @mock.patch("posthog.otel_instrumentation.CeleryInstrumentor")
     @mock.patch("posthog.otel_instrumentation.AIOKafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.KafkaInstrumentor")
     @mock.patch("posthog.otel_instrumentation.PsycopgInstrumentor")
@@ -286,6 +298,7 @@ class TestOtelInstrumentation(BaseTest):
         mock_psycopg_instrumentor_cls,
         mock_kafka_instrumentor_cls,
         mock_aio_kafka_instrumentor_cls,
+        mock_celery_instrumentor_cls,
     ):
         # Arrange
         mock_resource_instance = mock.Mock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ dependencies = [
     "opentelemetry-instrumentation-aiokafka==0.54b1",
     "opentelemetry-instrumentation-aiohttp-client==0.54b1",
     "opentelemetry-instrumentation-asgi==0.54b1",
+    "opentelemetry-instrumentation-celery==0.54b1",
     "opentelemetry-instrumentation-django==0.54b1",
     "opentelemetry-instrumentation-kafka-python==0.54b1",
     "opentelemetry-instrumentation-psycopg==0.54b1",

--- a/uv.lock
+++ b/uv.lock
@@ -4888,6 +4888,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/71/4ac353874e0f7ca93591e1a74b7a290dec2027733bbb31bd76da3a74f97f/opentelemetry_instrumentation_celery-0.54b1.tar.gz", hash = "sha256:f2bd019afe9286214083ae2db95ed24adf9a0aa2e943177462d64ceb8380d78e", size = 14778, upload-time = "2025-05-16T19:03:37.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/be/90e2b7d26915639cfcdf6e200b309c9d64027ff752c56145bc149cd67d68/opentelemetry_instrumentation_celery-0.54b1-py3-none-any.whl", hash = "sha256:892ec6bf829a0d60cf3bffd1a8bb6fd8055f1194167b4e132e33321de8e05c24", size = 13809, upload-time = "2025-05-16T19:02:33.046Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-dbapi"
 version = "0.54b1"
 source = { registry = "https://pypi.org/simple" }
@@ -5534,6 +5548,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-instrumentation-aiokafka" },
     { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-instrumentation-celery" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-kafka-python" },
     { name = "opentelemetry-instrumentation-psycopg" },
@@ -5804,6 +5819,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-aiohttp-client", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-aiokafka", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-asgi", specifier = "==0.54b1" },
+    { name = "opentelemetry-instrumentation-celery", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-django", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-kafka-python", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-psycopg", specifier = "==0.54b1" },


### PR DESCRIPTION
## Problem

Celery task execution is invisible in APM. Unlike the web tier (`DjangoInstrumentor`) and Temporal workers (OTel plugin), **Celery workers have no OpenTelemetry tracer provider at all** — `initialize_otel()` is only called from `wsgi.py` / `asgi.py`, never in the worker bootstrap, and there's no `CeleryInstrumentor`. So every `tracer.start_as_current_span(...)` that runs inside a Celery task today is a silent no-op, and no Celery service appears in APM. (This also means async query processing, which runs on Celery via `process_query_task`, emits no traces.)

So before we can tag Celery task spans with a team, there has to *be* a span. This PR stands up Celery tracing and then tags it.

## Changes

1. **Dependency:** add `opentelemetry-instrumentation-celery` (pinned to `0.54b1`, matching the other OTel instrumentation packages).
2. **Instrument Celery** in the shared `initialize_otel()` via a new `instrument_celery()`. Enabling it in the web tier too means the producer side is instrumented, so a task enqueued during a web request propagates trace context into the task.
3. **Initialize OTel in the worker child**, from the existing `worker_process_init` handler (`on_worker_start`). This is deliberately **post-fork**: Celery prefork means the `BatchSpanProcessor`'s background export thread and the OTLP gRPC channel must be created per child — initializing pre-fork would leave children with a dead exporter that silently drops spans. No-op when `OTEL_SDK_DISABLED` is set.
4. **Tag `team_id` on the task span**, best-effort, from the task's `team_id` keyword argument. The tagger is connected as a `task_prerun` receiver *after* instrumentation so it runs after `CeleryInstrumentor`'s own prerun receiver (when the task span is the active span); it degrades to a no-op if that ordering ever changes.

`team_id` is the same attribute key used by the Django request span, the Temporal spans, and `create_hogql_database`.

This is the third of three PRs for trace attribution (after the query-endpoint spans and the Django+Temporal root spans). Celery was split out precisely because it's instrument-from-scratch rather than a tagging tweak.

### Known limitations (called out for review)

- **Coverage is partial.** Celery task signatures aren't uniform the way Temporal input dataclasses are — many tasks take `team_id` positionally, take an object id and resolve the team later, or are team-agnostic (cleanup/system jobs). Tagging only reads the `team_id` *keyword*, to keep false-positives at zero. Positional/derived team ids can be added later, per-task, if wanted.
- **Service name.** Worker deployments should set `OTEL_SERVICE_NAME` (e.g. `posthog-celery-worker`) so worker spans get a distinct service; otherwise they fall under the default name.
- **Runtime behavior is unverified locally.** See testing notes.

## How did you test this code?

Authored by an agent (Claude Code). Automated tests:

- **`posthog/test/test_celery_span_team_id.py`** (new): parametrized unit tests for the tagging helper — asserts the active span gets `team_id` from the task kwargs, and is left untagged when `team_id` is absent, non-int, or boolean. Verified red-green locally (the positive cases fail with `KeyError` when the helper is neutered). All 6 pass.
- **`posthog/test/test_otel_instrumentation.py`** (updated): mocks `CeleryInstrumentor` alongside the existing instrumentors and asserts it's instrumented with the provider when enabled and not when disabled.

What is **not** verified locally and needs validation on a real deploy / staging worker (the sandbox has no Postgres and no running Celery worker, and I can't fork a worker to observe span export):

- that worker spans actually export post-fork,
- that `CeleryInstrumentor` and our `task_prerun` receiver fire in the expected order so the task span is active when we tag it.

`ruff` and `mypy` pass on the changed source files; `test_otel_instrumentation.py` itself needs Postgres so it's verified by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie via a Claude Code session, as the third in a sequence (query-endpoint spans → Django+Temporal root spans → Celery). Investigation (code + live APM) established that Celery is categorically different from the other two: no tracer provider in workers, no instrumentor, zero Celery services in APM — so there was no span to tag.

Key decisions: use `CeleryInstrumentor` (the `DjangoInstrumentor` equivalent) rather than hand-rolling a task span, for trace-context propagation from the enqueue side; initialize strictly post-fork to avoid the classic dead-exporter failure; tag `team_id` from kwargs only (zero false-positive) and accept partial coverage for v1; connect the tagger after instrumentation to land on the active task span, with a safe no-op fallback. The fork-safety and signal-ordering aspects can't be exercised in the local sandbox and are flagged for deploy validation — hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
