### PR TITLE
chore: add trailing whitespace to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+


### PR DESCRIPTION
## Problem

Low-risk change to exercise the PR flow.

## Changes

Adds a single trailing newline to the end of `README.md`. No functional or content changes.

## How did you test this code?

I'm an agent. No tests were run — the change is whitespace-only in a Markdown file. `git diff` confirms the only change is one added blank line at the end of `README.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the user's request to add some whitespace to the README. The change is intentionally minimal: a single trailing newline appended to `README.md`.
