### PR TITLE
fix(llma): keep eval-clustering embedding rendering low cardinality

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_clustering/data.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/data.py
@@ -4,7 +4,7 @@ Two queries:
 
 - ``fetch_evaluation_embeddings`` — pulls accumulated eval embeddings for a job
   via ``endsWith(rendering, '_{job_id}')``, matching the Stage A rendering
-  convention ``{team_id}_{run_ts}_{job_id}``.
+  convention ``eval_{job_id}``.
 - ``fetch_evaluation_metadata`` — joins the sampled $ai_evaluation rows to their
   target $ai_generation (via $ai_target_event_id) to surface both
   eval-specific metadata (name/result/runtime/reasoning/judge_cost) and
@@ -90,10 +90,9 @@ def fetch_evaluation_embeddings(
 ) -> tuple[list[str], dict[str, list[float]]]:
     """Read up to max_samples eval embeddings accumulated by Stage A for this job.
 
-    Stage A writes a new row every hour tagged with
-    ``rendering = {team_id}_{run_ts}_{job_id}``; we match by suffix since only the
-    job id is stable across runs. Random-order sampling keeps the read size bounded
-    when a job has accumulated far more than ``max_samples`` over time.
+    Stage A tags rows with ``rendering = eval_{job_id}``; we match by suffix so rows
+    from the older ``{team_id}_{run_ts}_{job_id}`` format keep resolving. Random-order
+    sampling bounds the read when a job has accumulated more than ``max_samples``.
 
     ``window_start``/``window_end`` must align with the Stage B metadata lookup
     window — otherwise the random sample can return older eval ids that the

--- a/posthog/temporal/ai_observability/evaluation_clustering/models.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/models.py
@@ -16,7 +16,6 @@ class SamplerActivityInputs:
     team_id: int
     job_id: str
     job_name: str
-    run_ts: str  # ISO timestamp tag used in the embedding `rendering` value
     window_start: str  # ISO
     window_end: str  # ISO
     max_samples: int

--- a/posthog/temporal/ai_observability/evaluation_clustering/sampling.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/sampling.py
@@ -163,9 +163,10 @@ def _sample_and_embed_sync(inputs: SamplerActivityInputs) -> SamplerActivityResu
         )
         return SamplerActivityResult(team_id=team.id, job_id=inputs.job_id, sampled=0, embedded=0)
 
-    # Keep the rendering format identical to trace/generation clustering so Stage B can
-    # read eval embeddings with the same endsWith(rendering, '_{job_id}') pattern.
-    rendering = f"{team.id}_{inputs.run_ts}_{inputs.job_id}"
+    # `rendering` is LowCardinality and in the sorting key, so keep it low cardinality:
+    # one stable value per job, not a fresh one per run. Stage B scopes by the
+    # '_{job_id}' suffix, which also matches rows written in the older format.
+    rendering = f"eval_{inputs.job_id}"
     # Use the small (1536-dim) model — see AI_OBSERVABILITY_EVALUATION_EMBEDDING_MODEL in constants.py.
     # The lazy import keeps EmbeddingModelName out of the module top-level (avoids pulling
     # posthog.schema into the workflow-side graph via the activity module).

--- a/posthog/temporal/ai_observability/evaluation_clustering/tests/test_sampling.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/tests/test_sampling.py
@@ -105,7 +105,6 @@ class TestSampleAndEmbedForJobActivity:
             team_id=mock_team.id,
             job_id="job-abc",
             job_name="Eval Clustering Job",
-            run_ts="2026-04-15T12:00:00Z",
             window_start="2026-04-15T10:30:00Z",
             window_end="2026-04-15T11:30:00Z",
             max_samples=250,
@@ -135,8 +134,8 @@ class TestSampleAndEmbedForJobActivity:
         assert result.team_id == mock_team.id
         assert result.job_id == "job-abc"
 
-        # Every call used the eval document type and the team-scoped rendering suffix
-        expected_rendering = f"{mock_team.id}_2026-04-15T12:00:00Z_job-abc"
+        # Every call used the eval document type and the low-cardinality job rendering
+        expected_rendering = "eval_job-abc"
         calls = mock_embedder.embed_document.call_args_list
         assert len(calls) == 3
         for call in calls:
@@ -162,7 +161,6 @@ class TestSampleAndEmbedForJobActivity:
             team_id=mock_team.id,
             job_id="job-abc",
             job_name="",
-            run_ts="2026-04-15T12:00:00Z",
             window_start="2026-04-15T10:30:00Z",
             window_end="2026-04-15T11:30:00Z",
             max_samples=250,
@@ -194,7 +192,6 @@ class TestSampleAndEmbedForJobActivity:
             team_id=mock_team.id,
             job_id="job-abc",
             job_name="",
-            run_ts="2026-04-15T12:00:00Z",
             window_start="2026-04-15T10:30:00Z",
             window_end="2026-04-15T11:30:00Z",
             max_samples=250,

--- a/posthog/temporal/ai_observability/evaluation_clustering/tests/test_workflow.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/tests/test_workflow.py
@@ -78,7 +78,7 @@ async def _run_sampler_with_mock_activity(
     """Run AIObservabilityEvaluationSamplerWorkflow end-to-end with the sample activity mocked out.
 
     Returns the SamplerActivityInputs that the workflow dispatched, so callers can assert
-    against the derived window, run_ts, and forwarded fields without touching ClickHouse.
+    against the derived window and forwarded fields without touching ClickHouse.
     """
     captured: dict[str, SamplerActivityInputs] = {}
 
@@ -125,20 +125,18 @@ class TestSamplerWorkflowWindowMath:
             window_end   = workflow.now() - SAMPLER_WINDOW_OFFSET_MINUTES
             window_start = window_end     - SAMPLER_WINDOW_MINUTES
 
-        Pins on workflow.run_ts (stamped from the same workflow.now() call) so the
-        assertion is independent of wall-clock time, and asserts against the offset
-        and window constants directly so a future accidental swap is caught.
+        Asserts the start↔end span against the window constant so the wiring is
+        verified independent of wall-clock time (the offset math is pinned by
+        TestWindowMathFormula).
         """
         inputs = SamplerWorkflowInputs(team_id=7, job_id="j-derived", job_name="derived window")
 
         activity_inputs = await _run_sampler_with_mock_activity(inputs)
 
-        run_ts = _parse_z(activity_inputs.run_ts)
         window_end = _parse_z(activity_inputs.window_end)
         window_start = _parse_z(activity_inputs.window_start)
 
-        assert window_end == run_ts - timedelta(minutes=SAMPLER_WINDOW_OFFSET_MINUTES)
-        assert window_start == window_end - timedelta(minutes=SAMPLER_WINDOW_MINUTES)
+        assert window_end - window_start == timedelta(minutes=SAMPLER_WINDOW_MINUTES)
 
     @pytest.mark.asyncio
     async def test_honours_explicit_window_override(self):

--- a/posthog/temporal/ai_observability/evaluation_clustering/workflow.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/workflow.py
@@ -63,7 +63,6 @@ class AIObservabilityEvaluationSamplerWorkflow(PostHogWorkflow):
             window_end = window_end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         max_samples = inputs.max_samples or SAMPLER_MAX_SAMPLES_PER_JOB
-        run_ts = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         result = await workflow.execute_activity(
             sample_and_embed_for_job_activity,
@@ -71,7 +70,6 @@ class AIObservabilityEvaluationSamplerWorkflow(PostHogWorkflow):
                 team_id=inputs.team_id,
                 job_id=inputs.job_id,
                 job_name=inputs.job_name,
-                run_ts=run_ts,
                 window_start=window_start,
                 window_end=window_end,
                 max_samples=max_samples,


### PR DESCRIPTION
## Problem

The `embedding-worker` `/metrics` endpoint exploded to ~400MB, tripping a critical `VMAgentScrapeExceedsMaxSize` alert (vmagent dropping metrics past `promscrape.maxScrapeSize`). Root cause: an explosion of distinct values on the `rendering` dimension.

Stage A of eval clustering wrote embeddings with `rendering = f"{team.id}_{run_ts}_{job_id}"`. Because `run_ts` is stamped per hourly run, this minted a brand-new `rendering` value every run, per job, forever. `rendering` is a `LowCardinality(String)` column **and** part of the `document_embeddings` sorting key, so unbounded growth there is doubly harmful — it bloats the LowCardinality dictionary (the metrics blowup) and degrades the table's sort/compression.

## Changes

`rendering` now carries a single stable value per job: `eval_{job_id}`.

- Stage B already scopes a job's embeddings via `endsWith(rendering, '_{job_id}')` — it never parsed the `team_id`/`run_ts` prefix. The new value keeps that suffix match working, and because the match is suffix-based it stays backward-compatible with rows already written in the old `{team_id}_{run_ts}_{job_id}` format.
- Team scoping is already enforced by the team-scoped HogQL query, so dropping `team_id` from the string is safe.
- Removed the now-dead `run_ts` plumbing (`SamplerActivityInputs` field + workflow construction).

Cardinality on this path drops from "one value per job per hour, unbounded" to "one value per job, stable".

Note: trace and generation clustering use the same `{team}_{ts}_{job_id}` format, but there the full value is load-bearing (it is cross-referenced against `$ai_batch_run_id` on summary events to match an embedding to its summary). That needs a separate, coordinated change and is **not** in scope here.

## How did you test this code?

I'm an agent (Claude Code, driven by Andy). Automated only — ran the eval clustering unit suites locally:

- `posthog/temporal/ai_observability/evaluation_clustering/tests/test_sampling.py`
- `posthog/temporal/ai_observability/evaluation_clustering/tests/test_workflow.py`

All 23 tests pass. Updated the sampling test's `rendering` assertion to `eval_job-abc` and reworked the workflow window test to assert the start↔end span (the absolute offset math is already pinned by `TestWindowMathFormula`). `ruff check`/`format` and the pre-commit typecheck pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triggered from an on-call incident thread where Andy was pinged as the author of the offending line. Tool: Claude Code.

Investigation traced the metrics blowup to the high-cardinality `rendering` value, then confirmed via the Stage B read path (`evaluation_clustering/data.py`) that only the `_{job_id}` suffix is ever consumed for eval clustering — so the `team_id`/`run_ts` prefix could be dropped without breaking the read, and old rows still resolve thanks to the suffix match. Trace/generation clustering was checked and deliberately left alone because its full `rendering` value doubles as a cross-reference key on summary events.
