### PR TITLE
fix(llma): drop per-run timestamp from trace/generation batch_run_id

### DIFF
--- a/posthog/temporal/ai_observability/trace_clustering/data.py
+++ b/posthog/temporal/ai_observability/trace_clustering/data.py
@@ -45,7 +45,8 @@ def fetch_item_embeddings_for_clustering(
     """Query item IDs and embeddings from document_embeddings table.
 
     Two paths:
-    - job_id present: filter by rendering suffix (batch_run_id = {team}_{ts}_{job_id})
+    - job_id present: filter by rendering suffix (batch_run_id = {team}_{job_id}; older
+      rows use {team}_{ts}_{job_id} and still resolve via the suffix match)
     - no job_id: return all embeddings for the document type (legacy/unfiltered)
     """
     document_type = (
@@ -137,7 +138,7 @@ def fetch_item_embeddings_for_clustering(
 
         # Only store as batch_run_id if it's not a legacy rendering constant
         # Legacy embeddings have rendering like "llma_trace_detailed"
-        # New embeddings have rendering = batch_run_id (e.g., "1_2025-12-13T...")
+        # New embeddings have rendering = batch_run_id (e.g., "1_<job_id>")
         rendering_value = row[2]
         if rendering_value and rendering_value not in legacy_rendering_values:
             batch_run_ids_map[item_id] = rendering_value

--- a/posthog/temporal/ai_observability/trace_summarization/workflow.py
+++ b/posthog/temporal/ai_observability/trace_summarization/workflow.py
@@ -177,7 +177,10 @@ class BatchTraceSummarizationWorkflow(PostHogWorkflow):
             BatchSummarizationResult containing metrics and results
         """
         start_time = temporalio.workflow.now()
-        batch_run_id = f"{inputs.team_id}_{start_time.isoformat()}"
+        # `batch_run_id` is written to the LowCardinality `rendering` column (and the
+        # matching $ai_batch_run_id summary property), so keep it low cardinality: one
+        # stable value per (team, job), not a fresh one per run.
+        batch_run_id = f"{inputs.team_id}"
         if inputs.job_id:
             batch_run_id = f"{batch_run_id}_{inputs.job_id}"
         metrics = BatchSummarizationMetrics()


### PR DESCRIPTION
## Problem

Companion to the eval-clustering fix (#63455). Same root cause, the larger contributor.

Trace and generation clustering tag each summary embedding with `rendering = batch_run_id = f"{team_id}_{start_time.isoformat()}_{job_id}"`. Because the timestamp is stamped per run, every hourly summarization run mints a brand-new `rendering` value, per job, forever. `rendering` is a `LowCardinality(String)` column **and** part of the `document_embeddings` `ReplacingMergeTree` sorting key, with a 3-month TTL — so unbounded growth there bloats the LowCardinality dictionary (this is what blew up the `embedding-worker` `/metrics` and tripped the critical `VMAgentScrapeExceedsMaxSize` alert) and hurts the table's sort/compression.

## Changes

Drop the per-run timestamp from `batch_run_id`, so it becomes one stable value per `(team, job)`: `f"{team_id}_{job_id}"`.

Crucially the timestamp is dropped at the single point both downstream values derive from (`batch_run_id` in `trace_summarization/workflow.py`). Both the embedding's `rendering` tag **and** the summary event's `$ai_batch_run_id` property come from that variable, so they stay equal and the existing embedding↔summary pairing in `trace_clustering/data.py` (`rendering == $ai_batch_run_id`) keeps working with **no change to the matching code**.

- Cardinality on this path drops from "one value per job *per run*, unbounded over the 3-month TTL" to "one value per `(team, job)`, stable".
- Backward-compatible: the read filter is a suffix match (`endsWith(rendering, '_{job_id}')`), so rows already written in the old `{team}_{ts}_{job_id}` format keep resolving.
- `batch_run_id` is fully self-contained in the summarization→clustering pipeline (no frontend consumer, no idempotency or timestamp parsing) — verified across the repo.

**Behavioral note:** with the timestamp gone, all runs of a job share one `batch_run_id`. A trace re-summarized across runs now collapses to the latest embedding (ReplacingMergeTree dedup on the sorting key), and summary pairing matches at job granularity rather than exact run. This is low-stakes: summary *mode* is already separated via `document_type` (`llm-trace-summary-detailed`), not `rendering`. Making the pairing deterministic (e.g. keying on `$ai_clustering_job_id` + latest timestamp) is possible follow-up hardening but isn't needed for this fix.

A longer-term option is to return `rendering` to its intended low-cardinality meaning (the render mode, per its column comment) and scope embeddings to a job via a dedicated column — that's a schema change for the AIO team to weigh separately.

## How did you test this code?

I'm an agent (Claude Code, driven by Andy). Automated only:

- `posthog/temporal/ai_observability/trace_summarization/tests/test_workflow.py`
- `posthog/temporal/ai_observability/trace_clustering/tests/test_data.py`

23 tests pass. Confirmed no test couples to the old `{team}_{ts}_{job_id}` format (the `data.py` matching tests use synthetic `batch_run_id` values). `ruff` and the pre-commit typecheck pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to an on-call incident where the `embedding-worker` `/metrics` payload exploded from high-cardinality `rendering` values. Tool: Claude Code.

After shipping the eval-clustering fix, Andy asked to investigate trace/generation, which is trickier because the full `rendering` value there is load-bearing (cross-referenced against `$ai_batch_run_id` on summary events). The investigation found both values derive from one `batch_run_id` variable, so dropping the timestamp at that single source keeps them consistent and the existing matching untouched — the minimal safe fix. Verified `batch_run_id` has no other consumers and that mode disambiguation lives in `document_type`, not `rendering`.
