### PR TITLE
feat(experiments): custom tooltip for variant timeseries chart

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -1,7 +1,10 @@
+import { Chart, ChartType, TooltipModel } from 'lib/Chart'
 import { useChart } from 'lib/hooks/useChart'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 
 import { ProcessedChartData } from '../../experimentTimeseriesLogic'
 import { useChartColors } from '../shared/colors'
+import { VariantTimeseriesTooltip } from './VariantTimeseriesTooltip'
 
 interface VariantTimeseriesChartProps {
     chartData: ProcessedChartData
@@ -13,6 +16,7 @@ export function VariantTimeseriesChart({
     isRatioMetric = false,
 }: VariantTimeseriesChartProps): JSX.Element {
     const colors = useChartColors()
+    const { getTooltip, showTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
 
     const { canvasRef } = useChart({
         getConfig: () => {
@@ -20,7 +24,7 @@ export function VariantTimeseriesChart({
                 return null
             }
 
-            const { labels, datasets, processedData } = data
+            const { labels, datasets, processedData, computedAt } = data
 
             return {
                 type: 'line' as const,
@@ -85,57 +89,46 @@ export function VariantTimeseriesChart({
                             display: false,
                         },
                         tooltip: {
-                            callbacks: {
-                                label: function (context) {
-                                    const value = context.parsed.y
-                                    if (value === null) {
-                                        return ''
-                                    }
-                                    const formattedValue = `${(value * 100).toFixed(2)}%`
-                                    return `${context.dataset.label}: ${formattedValue}`
-                                },
-                                labelPointStyle: function () {
-                                    return {
-                                        pointStyle: 'circle',
-                                        rotation: 0,
-                                    }
-                                },
-                                afterBody: function (context) {
-                                    if (context.length > 0) {
-                                        const dataIndex = context[0].dataIndex
-                                        const dataPoint = processedData[dataIndex]
-                                        const lines = []
+                            enabled: false,
+                            external: ({ chart, tooltip }: { chart: Chart; tooltip: TooltipModel<ChartType> }) => {
+                                const canvas = chart.canvas
+                                if (!canvas) {
+                                    return
+                                }
 
-                                        if (dataPoint && !dataPoint.hasRealData) {
-                                            lines.push('⚠️ Data pending - showing last known value')
-                                        }
+                                const [tooltipRoot, tooltipEl] = getTooltip()
 
-                                        if (dataPoint) {
-                                            if (isRatioMetric) {
-                                                if (dataPoint.denominator_sum) {
-                                                    lines.push(
-                                                        `Denominator: ${dataPoint.denominator_sum.toLocaleString()}`
-                                                    )
-                                                }
-                                            } else {
-                                                if (dataPoint.number_of_samples) {
-                                                    lines.push(
-                                                        `Exposures: ${dataPoint.number_of_samples.toLocaleString()}`
-                                                    )
-                                                }
-                                            }
-                                        }
-                                        if (dataPoint && dataPoint.significant !== undefined) {
-                                            lines.push(`Significant: ${dataPoint.significant ? 'Yes' : 'No'}`)
-                                        }
-                                        return lines
-                                    }
-                                    return []
-                                },
+                                if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
+                                    hideTooltip()
+                                    return
+                                }
+
+                                const dataIndex = tooltip.dataPoints[0].dataIndex
+                                const dataPoint = processedData[dataIndex]
+                                if (!dataPoint) {
+                                    hideTooltip()
+                                    return
+                                }
+
+                                showTooltip()
+                                tooltipRoot.render(
+                                    <VariantTimeseriesTooltip
+                                        date={dataPoint.date}
+                                        delta={dataPoint.value}
+                                        lowerBound={dataPoint.lower_bound}
+                                        upperBound={dataPoint.upper_bound}
+                                        isRatioMetric={isRatioMetric}
+                                        exposures={dataPoint.number_of_samples}
+                                        denominator={dataPoint.denominator_sum}
+                                        significant={dataPoint.significant}
+                                        hasRealData={dataPoint.hasRealData}
+                                        computedAt={computedAt}
+                                    />
+                                )
+
+                                const bounds = canvas.getBoundingClientRect()
+                                positionTooltip(tooltipEl, bounds, tooltip.caretX, 0, false)
                             },
-                            usePointStyle: true,
-                            boxWidth: 16,
-                            boxHeight: 1,
                         },
                         crosshair: false,
                     },

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesTooltip.tsx
@@ -1,0 +1,149 @@
+import { useValues } from 'kea'
+
+import { IconCalendar, IconClock, IconHome, IconLaptop } from '@posthog/icons'
+
+import { dayjs } from 'lib/dayjs'
+import { IconWeb } from 'lib/lemon-ui/icons'
+import { shortTimeZone } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+
+const DATE_FORMAT = 'MMM D, YYYY'
+const DATETIME_FORMAT = 'MMM D, YYYY h:mm A'
+
+const formatPercent = (value: number | null): string => (value === null ? '—' : `${(value * 100).toFixed(2)}%`)
+
+export interface VariantTimeseriesTooltipProps {
+    date: string
+    delta: number | null
+    lowerBound: number | null
+    upperBound: number | null
+    isRatioMetric: boolean
+    exposures?: number
+    denominator?: number
+    significant?: boolean
+    hasRealData: boolean
+    /** When the timeseries was computed (ISO string), or null if unknown. */
+    computedAt: string | null
+}
+
+function TooltipRow({ label, value }: { label: string; value: React.ReactNode }): JSX.Element {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="text-secondary">{label}</span>
+            <span className="font-medium tabular-nums">{value}</span>
+        </div>
+    )
+}
+
+function CalculatedAtRow({
+    icon,
+    label,
+    caption,
+    value,
+}: {
+    icon: React.ReactNode
+    label: string
+    caption?: string
+    value: string
+}): JSX.Element {
+    return (
+        <div className="flex items-center gap-1.5">
+            <span className="text-secondary text-base shrink-0">{icon}</span>
+            <span className="text-secondary">{label}</span>
+            {caption && <span className="text-secondary text-[0.6875rem]">{caption}</span>}
+            <span className="ml-auto font-medium tabular-nums">{value}</span>
+        </div>
+    )
+}
+
+/**
+ * Standalone, fully formattable tooltip for the variant timeseries chart.
+ * Rendered into the shared insight-tooltip DOM via the chart's `external` callback.
+ */
+export function VariantTimeseriesTooltip({
+    date,
+    delta,
+    lowerBound,
+    upperBound,
+    isRatioMetric,
+    exposures,
+    denominator,
+    significant,
+    hasRealData,
+    computedAt,
+}: VariantTimeseriesTooltipProps): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    const computed = computedAt ? dayjs(computedAt) : null
+    const projectTimezone = currentTeam?.timezone
+    const computedDate = computed?.toDate()
+
+    return (
+        <div className="bg-surface-primary border border-primary rounded shadow-md text-[0.8125rem] min-w-[15rem] overflow-hidden">
+            <div className="px-3 py-2 border-b border-primary font-semibold flex items-center gap-1.5">
+                <IconCalendar className="text-secondary text-base" />
+                {dayjs(date).format(DATE_FORMAT)}
+            </div>
+
+            <div className="px-3 py-2 flex flex-col gap-1">
+                <TooltipRow label="Delta" value={formatPercent(delta)} />
+                <TooltipRow
+                    label="Confidence interval"
+                    value={`${formatPercent(lowerBound)} → ${formatPercent(upperBound)}`}
+                />
+                {isRatioMetric
+                    ? denominator !== undefined && (
+                          <TooltipRow label="Denominator" value={denominator.toLocaleString()} />
+                      )
+                    : exposures !== undefined && <TooltipRow label="Exposures" value={exposures.toLocaleString()} />}
+                {significant !== undefined && (
+                    <TooltipRow
+                        label="Significant"
+                        value={
+                            <span className={significant ? 'text-success' : 'text-secondary'}>
+                                {significant ? 'Yes' : 'No'}
+                            </span>
+                        }
+                    />
+                )}
+            </div>
+
+            {!hasRealData && (
+                <div className="px-3 py-1.5 border-t border-primary text-warning text-xs flex items-center gap-1.5">
+                    <IconClock className="text-base shrink-0" />
+                    Data pending — showing last known value
+                </div>
+            )}
+
+            {computed && (
+                <div className="px-3 py-2 border-t border-primary bg-surface-secondary flex flex-col gap-1 text-xs">
+                    <div className="text-secondary uppercase tracking-wide text-[0.6875rem] font-semibold mb-0.5">
+                        Calculated at
+                    </div>
+                    {projectTimezone && (
+                        <CalculatedAtRow
+                            icon={<IconHome />}
+                            label="Project"
+                            caption={shortTimeZone(projectTimezone, computedDate) ?? projectTimezone}
+                            value={computed.tz(projectTimezone).format(DATETIME_FORMAT)}
+                        />
+                    )}
+                    <CalculatedAtRow
+                        icon={<IconLaptop />}
+                        label="Your device"
+                        caption={shortTimeZone(undefined, computedDate) ?? ''}
+                        value={computed.format(DATETIME_FORMAT)}
+                    />
+                    {projectTimezone !== 'UTC' && (
+                        <CalculatedAtRow
+                            icon={<IconWeb />}
+                            label="UTC"
+                            caption="UTC"
+                            value={computed.tz('UTC').format(DATETIME_FORMAT)}
+                        />
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -48,6 +48,8 @@ export interface ProcessedChartData {
     labels: string[]
     datasets: ChartDataset[]
     processedData: ProcessedTimeseriesDataPoint[]
+    /** When the timeseries was last computed (ISO string), shared across all data points. */
+    computedAt: string | null
 }
 
 export interface ExperimentTimeseriesLogicProps {
@@ -249,9 +251,10 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
 
         // Generate Chart.js-ready datasets
         chartData: [
-            (s, props) => [s.processedVariantData, props.experiment, props.metric],
+            (s, props) => [s.processedVariantData, s.timeseries, props.experiment, props.metric],
             (
                 processedVariantData: (variantKey: string) => ProcessedTimeseriesDataPoint[],
+                timeseries: ExperimentMetricTimeseries | null,
                 experiment: Experiment,
                 metric: ExperimentMetric | undefined
             ): ((variantKey: string) => ProcessedChartData | null) => {
@@ -400,6 +403,7 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                         labels,
                         datasets,
                         processedData: trimmedData,
+                        computedAt: timeseries?.computed_at ?? null,
                     }
                 }
             },


### PR DESCRIPTION
## Problem

The variant timeseries chart used Chart.js's default black-and-white tooltip, which can't be styled or formatted, and it didn't surface when the data was computed.

## Changes

- New standalone `VariantTimeseriesTooltip` React component with a white surface, border, and shadow — fully formattable.
- Renders the chart tooltip via Chart.js `external` + the shared insight-tooltip infrastructure (`useInsightTooltip`).
- Adds a "Calculated at" section showing the computation time in project, device, and UTC timezones with their abbreviations, modeled on the `TZLabel`/"Last refreshed" popover.
- Threads the timeseries `computed_at` through `ProcessedChartData`.

<img width="995" height="432" alt="image" src="https://github.com/user-attachments/assets/c37f69a7-fdce-475f-81f8-0c3f0c254489" />

## How did you test this code?
Manually

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The "Calculated at" section renders the timezone rows statically inline rather than nesting `TZLabel`'s own hover popover, since the chart tooltip is non-interactive (pointer-events disabled, follows the cursor).
