### PR TITLE
feat(data-warehouse): promote Google Search Console source to beta

### DIFF
--- a/posthog/temporal/data_imports/sources/google_search_console/source.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/source.py
@@ -4,6 +4,7 @@ import requests
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -144,7 +145,7 @@ class GoogleSearchConsoleSource(
                 "Connect a verified Google Search Console property to sync daily Search Analytics performance data "
                 "(clicks, impressions, CTR, average position). Requires a Google account with read access to the property."
             ),
-            releaseStatus="alpha",
+            releaseStatus=ReleaseStatus.BETA,
             featureFlag="dwh-google-search-console",
             iconPath="/static/services/google-search-console.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/google-search-console",

--- a/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
@@ -29,7 +29,7 @@ def test_get_source_config_fields():
     assert field_names == {"google_search_console_integration_id", "site_url"}
     assert cfg.label == "Google Search Console"
     assert cfg.featureFlag == "dwh-google-search-console"
-    assert cfg.releaseStatus == "alpha"
+    assert cfg.releaseStatus == "beta"
 
 
 def test_get_schemas_returns_all_schemas_with_date_incremental():


### PR DESCRIPTION
## Problem

The Google Search Console data warehouse source has been running as **Alpha**. Its current adoption and reliability now clear the bar for **Beta**:

- **Teams using it (7d):** 68 (threshold ≥ 30)
- **Error rate (7d):** 0.1% (threshold < 5.0%)

## Changes

- Set `releaseStatus` on the `GoogleSearchConsole` source config from `alpha` to `ReleaseStatus.BETA`.
- Converted the value from a bare string literal to the `ReleaseStatus` enum, matching the source-config convention (the skill mandates the enum over a string).
- Updated the source-config test assertion to expect `beta`.

This is a status promotion only — no changes to connector behavior, schemas, or sync logic. The `dwh-google-search-console` feature-flag gate is intentionally left untouched, since beta sources commonly retain a controlled-rollout flag and existing conventions don't call for removing it as part of a stage bump.

## How did you test this code?

I'm an agent. I ran the affected automated test:

```
pytest posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py::test_get_source_config_fields
```

It passes with the updated `beta` assertion. No manual testing performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Claude Code to promote the Google Search Console warehouse source from Alpha to Beta. I read the `implementing-warehouse-sources` skill to confirm where release status lives and the convention to use the `ReleaseStatus` enum, located the source definition at `posthog/temporal/data_imports/sources/google_search_console/source.py`, and made the minimal status change plus the corresponding test update. I deliberately left the `featureFlag` gate in place since the skill treats `releaseStatus` as a soft label independent of gating and nothing in the conventions tied the two together.