### PR TITLE
perf(file-system): index LOWER(path) for project tree listing

### DIFF
--- a/posthog/migrations/1220_filesystem_lower_path_index.py
+++ b/posthog/migrations/1220_filesystem_lower_path_index.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+from django.db.models.expressions import F
+from django.db.models.functions import Lower
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1219_filesystemfoldercontextgeneration"),
+    ]
+
+    operations = [
+        # Add a functional index on LOWER(path) so the default tree-listing
+        # `ORDER BY LOWER(path)` is served by an index instead of a full filesort.
+        # Built CONCURRENTLY (non-blocking); SeparateDatabaseAndState keeps Django's
+        # index state in sync. The helper disables lock_timeout, recovers from invalid
+        # leftover indexes, and emits IF NOT EXISTS so deploy-time retries are safe.
+        # It is reversible on its own (reverse = DROP INDEX CONCURRENTLY).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="filesystem",
+                    index=models.Index(F("team_id"), F("surface"), Lower("path"), name="posthog_fs_team_s_lpath"),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="posthog_fs_team_s_lpath",
+                    table_name="posthog_filesystem",
+                    columns="(team_id, surface, lower(path))",
+                ),
+            ],
+        ),
+    ]

--- a/posthog/models/file_system/file_system.py
+++ b/posthog/models/file_system/file_system.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.db import models
 from django.db.models import Q
 from django.db.models.expressions import F
+from django.db.models.functions import Lower
 from django.utils import timezone
 
 from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
@@ -39,6 +40,11 @@ class FileSystem(models.Model):
         indexes = [
             models.Index(fields=["team"]),
             models.Index(F("team_id"), F("surface"), F("path"), name="posthog_fs_team_s_path"),
+            # Functional index matching the default tree-listing `ORDER BY LOWER(path)`
+            # in FileSystemViewSet.safely_get_queryset. The raw-`path` index above can't
+            # satisfy a case-insensitive sort, so listing a large tree falls back to a full
+            # filesort and times out (504) once the tree grows past a few thousand rows.
+            models.Index(F("team_id"), F("surface"), Lower("path"), name="posthog_fs_team_s_lpath"),
             models.Index(F("team_id"), F("surface"), F("depth"), name="posthog_fs_team_s_depth"),
             models.Index(F("team_id"), F("surface"), F("type"), F("ref"), name="posthog_fs_team_s_typeref"),
         ]


### PR DESCRIPTION
## Problem

Client-side `504 (Non-OK response)` errors from `GET /api/environments/:id/file_system` (and `…/file_system/log_view`) have climbed sharply since early May — the project-tree listing is gateway-timing-out for a broad set of users, worst for projects with large trees.

Two things compounded:

1. **Exposure.** The project-tree ("AI-first") navigation became the default for all users when the `AI_FIRST` flag was removed (#56598, May 7). The tree now loads for essentially every active app session, so a query that was previously only run for flag-enabled users now runs for everyone — which is when the 504s began climbing week over week.
2. **Query cost.** The default tree listing in `FileSystemViewSet.safely_get_queryset` orders by `LOWER(path)`, but the only path index (`posthog_fs_team_s_path`) is on the raw `path` column. Postgres can't use a raw-column B-tree to satisfy a case-insensitive sort, so the listing falls back to a full filesort that scales O(N log N) with tree size and crosses the gateway timeout once a tree grows past a few thousand rows.

This PR addresses (2), the durable query-cost fix.

## Changes

- Add a functional composite index `posthog_fs_team_s_lpath` on `(team_id, surface, LOWER(path))` to `FileSystem`, matching the default listing's `ORDER BY LOWER(path)`.
- Migration `1220` builds it `CONCURRENTLY` (non-blocking), wrapped in `SeparateDatabaseAndState` and using the `CreateIndexConcurrently` helper, exactly mirroring the existing surface-index migration `1198`.

## How did you test this code?

I'm an agent (PostHog Slack app). I could **not** run `manage.py`/tests or `EXPLAIN ANALYZE` in this environment — no Python runtime available. Validation done:

- Confirmed the migration structure, helper import, dependency chain (`1219`), and index-name uniqueness mirror the in-repo `1198` template.
- Verified the new index expression matches the exact `ORDER BY LOWER(path)` produced by `safely_get_queryset`.

Reviewer follow-ups before merge:
- Run `manage.py makemigrations --check` and `sqlmigrate posthog 1220` to confirm no state drift and correct concurrent SQL.
- `EXPLAIN (ANALYZE, BUFFERS)` a default tree listing on a large-tree project to confirm the new index replaces the filesort.

Note: the `surface IS NULL OR surface = 'web'` OR-condition (#61047) and the per-row RBAC `EXISTS` annotations are additional, separate costs on this query — out of scope here but worth a follow-up if 504s persist after this index lands.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from an error-tracking exception subscription flagging rising 504s. Traced the volume to the `file_system` tree endpoints, established the inflection (week of May 11) against a baseline, and correlated it with the `AI_FIRST` flag removal (#56598) that made the tree the default UI. Read the endpoint/queryset and model to identify the unindexed `ORDER BY LOWER(path)` as the dominant scaling cost. Chose an additive functional index (lowest-risk, behavior-preserving) over riskier options like backfilling `surface` or reordering on raw `path` (would change sort order). Tool: PostHog Slack app (Claude Code).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C05G937QY1Z/p1781506679121539?thread_ts=1781506679.121539&cid=C05G937QY1Z)*
