### PR TITLE
feat(ingestion): support KIP-848 consumer group protocol

### DIFF
--- a/nodejs/src/kafka/config.test.ts
+++ b/nodejs/src/kafka/config.test.ts
@@ -1,4 +1,6 @@
-import { getKafkaConfigFromEnv } from './config'
+import { ConsumerGlobalConfig } from 'node-rdkafka'
+
+import { getKafkaConfigFromEnv, stripClassicProtocolConfig } from './config'
 
 describe('getKafkaConfigFromEnv', () => {
     const OLD_ENV = process.env
@@ -56,5 +58,46 @@ describe('getKafkaConfigFromEnv', () => {
               "valid.setting": "value",
             }
         `)
+    })
+})
+
+describe('stripClassicProtocolConfig', () => {
+    it('leaves config untouched for the classic protocol', () => {
+        const config: ConsumerGlobalConfig = {
+            'group.id': 'test-group',
+            'session.timeout.ms': 30_000,
+            'partition.assignment.strategy': 'cooperative-sticky',
+        }
+
+        expect(stripClassicProtocolConfig(config)).toEqual(config)
+    })
+
+    it('strips classic-only keys when group.protocol is consumer', () => {
+        const config: ConsumerGlobalConfig = {
+            'group.id': 'test-group',
+            'group.protocol': 'consumer',
+            'session.timeout.ms': 30_000,
+            'heartbeat.interval.ms': 3_000,
+            'partition.assignment.strategy': 'cooperative-sticky',
+            'group.protocol.type': 'consumer',
+            'max.poll.interval.ms': 300_000,
+        }
+
+        expect(stripClassicProtocolConfig(config)).toEqual({
+            'group.id': 'test-group',
+            'group.protocol': 'consumer',
+            'max.poll.interval.ms': 300_000,
+        })
+    })
+
+    it('does not mutate the input config', () => {
+        const config: ConsumerGlobalConfig = {
+            'group.protocol': 'consumer',
+            'session.timeout.ms': 30_000,
+        }
+
+        stripClassicProtocolConfig(config)
+
+        expect(config['session.timeout.ms']).toBe(30_000)
     })
 })

--- a/nodejs/src/kafka/config.ts
+++ b/nodejs/src/kafka/config.ts
@@ -1,4 +1,4 @@
-import { GlobalConfig } from 'node-rdkafka'
+import { ConsumerGlobalConfig, GlobalConfig } from 'node-rdkafka'
 
 import { defaultConfig } from '../config/config'
 
@@ -71,4 +71,25 @@ export const getKafkaConfigFromEnv = (target: KafkaConfigTarget): GlobalConfig =
     // That said we also want to be able to add defaults on the global config object
     // So what we do is we first find all values from the default config object and then in addition we add the env ones.
     return parseEnvToRdkafkaConfig(`KAFKA_${target}_`, { skipKeysInDefaultConfig: true })
+}
+
+/**
+ * With the KIP-848 protocol (`group.protocol=consumer`, e.g. via
+ * KAFKA_CONSUMER_GROUP_PROTOCOL=consumer) group session and assignment
+ * settings are broker-side: librdkafka rejects the whole config at startup if
+ * any classic-only key is explicitly set. Strip them after merging so the
+ * hardcoded classic defaults don't break consumers opted into the new
+ * protocol. Use `group.remote.assignor` instead of
+ * `partition.assignment.strategy` to pick the server-side assignor.
+ */
+export function stripClassicProtocolConfig(config: ConsumerGlobalConfig): ConsumerGlobalConfig {
+    if (config['group.protocol'] !== 'consumer') {
+        return config
+    }
+    const stripped = { ...config }
+    delete stripped['session.timeout.ms']
+    delete stripped['heartbeat.interval.ms']
+    delete stripped['partition.assignment.strategy']
+    delete stripped['group.protocol.type']
+    return stripped
 }

--- a/nodejs/src/kafka/consumer/consumer-v1.ts
+++ b/nodejs/src/kafka/consumer/consumer-v1.ts
@@ -35,7 +35,7 @@ import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
 import { promisifyCallback } from '../../utils/utils'
 import { ensureTopicExists } from '../admin'
-import { getKafkaConfigFromEnv } from '../config'
+import { getKafkaConfigFromEnv, stripClassicProtocolConfig } from '../config'
 import { parseBrokerStatistics, trackBrokerMetrics } from '../kafka-client-metrics'
 import {
     consumedBatchBackgroundDuration,
@@ -176,7 +176,7 @@ export class KafkaConsumer {
             ? this.rebalanceCallback.bind(this)
             : true
 
-        this.consumerConfig = {
+        this.consumerConfig = stripClassicProtocolConfig({
             'client.id': hostname(),
             'security.protocol': 'plaintext',
             'metadata.broker.list': 'kafka:9092', // Overridden with KAFKA_CONSUMER_METADATA_BROKER_LIST
@@ -209,7 +209,7 @@ export class KafkaConsumer {
             'enable.auto.commit': this.config.autoCommit,
             rebalance_cb: rebalancecb,
             offset_commit_cb: true,
-        }
+        })
 
         this.rdKafkaConsumer = this.createConsumer()
     }

--- a/nodejs/src/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/kafka/consumer/consumer-v2.ts
@@ -20,7 +20,7 @@ import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
 import { promisifyCallback } from '../../utils/utils'
 import { ensureTopicExists } from '../admin'
-import { getKafkaConfigFromEnv } from '../config'
+import { getKafkaConfigFromEnv, stripClassicProtocolConfig } from '../config'
 import { parseBrokerStatistics, trackBrokerMetrics } from '../kafka-client-metrics'
 import {
     consumedBatchBackgroundDuration,
@@ -127,7 +127,7 @@ export class KafkaConsumerV2 {
         this.loopStallThresholdMs = defaultConfig.CONSUMER_LOOP_STALL_THRESHOLD_MS || LOOP_STALL_THRESHOLD_MS_DEFAULT
         this.logStatsLevel = defaultConfig.CONSUMER_LOG_STATS_LEVEL
 
-        this.rdKafkaConfig = {
+        this.rdKafkaConfig = stripClassicProtocolConfig({
             'client.id': hostname(),
             'security.protocol': 'plaintext',
             'metadata.broker.list': 'kafka:9092',
@@ -157,7 +157,7 @@ export class KafkaConsumerV2 {
             'enable.auto.commit': this.config.autoCommit,
             rebalance_cb: this.rebalanceCallback.bind(this),
             offset_commit_cb: true,
-        }
+        })
 
         this.rdKafkaConsumer = this.createConsumer()
     }


### PR DESCRIPTION
## Problem

The analytics ingestion consumer groups run ~500 members on the classic Kafka consumer group protocol (cooperative-sticky is only a client-side assignor — it does not change the membership protocol). Every member join/leave triggers a group-wide JoinGroup/SyncGroup round through the coordinator, with a synchronization barrier that scales with group size. During an hourly rolling deploy the group is rebuilt from scratch (hundreds of leaves + joins), so it sits in near-continuous rebalance: committed-offset throughput collapses and lag spikes while the fleet churns.

KIP-848 (the next-gen `consumer` group protocol, GA in Kafka 4.0 and production-ready in librdkafka 2.11+) removes the barrier: the broker computes assignments and reconciles each member incrementally through its own heartbeat, so a membership change only moves the affected partitions and never stalls the rest of the group.

## Changes

Add opt-in support for `group.protocol=consumer`, selectable per deployment via `KAFKA_CONSUMER_GROUP_PROTOCOL` (and `KAFKA_CONSUMER_GROUP_REMOTE_ASSIGNOR` for the server-side assignor).

librdkafka rejects the entire consumer config at startup if any classic-only key is set alongside `group.protocol=consumer`. Both consumers hardcode several such keys (`session.timeout.ms`, `partition.assignment.strategy`) in their non-overridable config block, so a new `stripClassicProtocolConfig()` helper removes the classic-only keys (`session.timeout.ms`, `heartbeat.interval.ms`, `partition.assignment.strategy`, `group.protocol.type`) after the config is merged, but only when the new protocol is selected. `max.poll.interval.ms` is kept — it remains a client-side concern under KIP-848. The classic path is byte-for-byte unchanged.

Applies to both `consumer-v1` and `consumer-v2`. No default behavior change: without the env var, consumers stay on the classic protocol.

## How did you test this code?

I'm an agent (Claude Code), working under José's direction. Automated only — added unit tests for `stripClassicProtocolConfig` (classic config untouched, the four classic-only keys stripped under `group.protocol=consumer`, input not mutated) and ran `pnpm test src/kafka/config.test.ts` green. No manual broker testing yet; the companion charts PR enables this on the dev ingestion-analytics-main lane to validate against a live cluster.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a deploy-correlated rebalance storm on `ingestion-analytics-main` (prod-us) via Grafana: every ~hourly rollout dropped consumption from ~4.5M to ~1.5M events/min for several minutes and pegged the KEDA HPA at maxReplicas, with no pod restarts — i.e. protocol-level rebalance cost, not crashes. Considered three directions: enabling the V2 consumer (cuts duplicate work on revocation but not rebalance count), the in-repo `kafka-assigner` service (etcd-coordinated, k8s-aware, but MVP-stage with no Node client), and KIP-848. Chose KIP-848 as the lowest-lift fix that removes the sync barrier outright, since the brokers are on Kafka 4.1 and node-rdkafka 3.6.1 bundles librdkafka 2.12.

Companion: PostHog/charts enables this on dev ingestion-analytics-main. Merge order matters — this must ship to the dev image before the charts change rolls out, or opted-in pods crash at startup on the rejected config.

- [ ] skip-inkeep-docs
