### PR TITLE
fix(taxonomic-filter): plain resting icon for rebuild input trigger

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2137,9 +2137,9 @@ snapshots:
     filters-taxonomic-filter-menu-rebuild--properties--light:
         hash: v1.k794b7964.d34e4efbf39b777cea753e09d6b6676279568fc8149b0150d38212ecea25ebae.00tWwmV_ZtFEKmK0-hgMIyVtRyGl4_88ZF9_iz3_T-k
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--dark:
-        hash: v1.k794b7964.cc3b845bfe2b965e59141f710893998621d01c063142723621448e35e09c8d7c.65PiOvdxhTsaujscK1Xe-MPtxHjqeaMhA7SCnWoZaO8
+        hash: v1.k794b7964.ea50a7beff34bc4e953b625a4edf12bca69b6849c5b1a78f11002c973f6b3c90.IFWFrwM8maHSl4zUuOyeaBoEMTiP3NCiAag1ydXra7k
     filters-taxonomic-filter-menu-rebuild--recents-bare-key-expansion--light:
-        hash: v1.k794b7964.ac72ea7dcc07282f4ade675a6099524699367bdd14b0d64202fb77ca7375a95f.qnS6G_IMFEvW0ViNb2MQuv8Ytomdv_AiBBYEQ6sZl3A
+        hash: v1.k794b7964.1ed0f75c3a0480005dea3df32256890a335aac22a66cf4a4baed82dc6fc25854.Zdi4U-3WRmlIToDecZBZVqjap7rYrCGHzuwQP-brtkY
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--dark:
         hash: v1.k794b7964.5364889863d936006f0c97c11ae97ac04c301fcf51c664fb2e47be556f8b0314.DyFJNAuMFjmc4NK-8KbMb3CEQ3F4l9ZdaRi4lqkUsWc
     filters-taxonomic-filter-menu-rebuild--series-plus-data-warehouse--light:

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -22,7 +22,6 @@ import { useValues } from 'kea'
 import { ReactElement, useMemo, useState } from 'react'
 
 import { IconChevronDown, IconFilter } from '@posthog/icons'
-import { InputGroupButton } from '@posthog/quill'
 
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
 import { MenuFilterEntry, TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
@@ -169,21 +168,22 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             {useInputTrigger ? (
                 <MenuInputTrigger
                     iconButton={
-                        <InputGroupButton
-                            variant="outline"
-                            size="icon-sm"
+                        // Matches the armed menu's `inputTriggerIcon` (a plain
+                        // tertiary LemonButton) so the resting placeholder and the
+                        // live trigger look identical — no visual jump on first click.
+                        <LemonButton
+                            size="small"
+                            icon={<IconFilter />}
                             aria-label="Open filter menu"
                             data-attr="taxonomic-popover-menu-trigger"
                             // Stop the click bubbling to the LemonInput wrapper, whose
                             // onClick focuses the input, whose onFocus arms the combobox.
                             // Without this the icon would open the combobox, not the menu.
-                            onClick={(e: React.MouseEvent) => {
+                            onClick={(e) => {
                                 e.stopPropagation()
                                 arm('menu')
                             }}
-                        >
-                            <IconFilter />
-                        </InputGroupButton>
+                        />
                     }
                     fullWidth={!!triggerButtonProps?.fullWidth}
                     placeholder={typeof placeholder === 'string' ? placeholder : 'Add filter'}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopoverMenu.tsx
@@ -168,9 +168,8 @@ export function TaxonomicPopoverMenu<ValueType extends TaxonomicFilterValue = Ta
             {useInputTrigger ? (
                 <MenuInputTrigger
                     iconButton={
-                        // Matches the armed menu's `inputTriggerIcon` (a plain
-                        // tertiary LemonButton) so the resting placeholder and the
-                        // live trigger look identical — no visual jump on first click.
+                        // Keep the resting placeholder visually identical to the armed trigger.
+                        // data-attr differs from the armed trigger's — intentional for analytics.
                         <LemonButton
                             size="small"
                             icon={<IconFilter />}


### PR DESCRIPTION
## Problem

In the rebuilt taxonomic menu (behind `TAXONOMIC_FILTER_MENU_REBUILD`), the "Add filter" input trigger — e.g. the inline `where → Add filter` row on an insight series — changed appearance the moment it was clicked. At rest its filter icon sat inside a boxed button (fill + border); after the first interaction the same icon became a plain borderless icon. That box-to-plain jump looked like a glitch.

## Changes

The icon was rendered by two different components depending on whether the lazily-mounted menu had been "armed":

- **resting placeholder** used quill's `InputGroupButton variant="outline"` (carries a background fill + 1px border)
- **armed menu** used a plain tertiary `LemonButton`

This makes the resting placeholder render the same plain `LemonButton` the armed menu already uses, so the two states are visually identical and there's no jump on first click. Click behaviour (arming the menu, `stopPropagation`) is unchanged.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** add automated tests for this purely-cosmetic swap.

Manual verification I actually performed: ran the dev stack and, with `TAXONOMIC_FILTER_MENU_REBUILD` enabled, opened the inline series property filter and inspected the resting trigger's prefix icon in the live DOM. Before: `quill-button--variant-outline` with a non-transparent background and a 1px border. After: `LemonButton--tertiary` with `background: rgba(0,0,0,0)`, `border: 0`, `box-shadow: none` — matching the armed/open state, and confirmed visually that the icon no longer changes on first click.

`pnpm --filter=@posthog/frontend format` passes clean on the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul reported the before/after styling difference on the insight-series filter trigger and preferred the post-click (plain) look. Using PostHog Code with the `modifying-taxonomic-filter` skill, I traced the discrepancy to two distinct icon components across the lazy-placeholder vs armed states (confirmed via live DOM inspection rather than guessing — the same `iconButton` prop flows to both paths, so the difference was the component, not context), then unified them on the plain `LemonButton`. Scope is limited to the rebuild-menu surface; no telemetry, ordering, or promotion logic was touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
