### PR TITLE
chore(ingestion): bump linked librdkafka from 2.10.1 to 2.12.0

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -11,7 +11,7 @@
 FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.91-node_24.13.0 AS nodejs-build
 
 # Compile and install system dependencies
-# Add Confluent's client repository for librdkafka 2.10.1
+# Add Confluent's client repository for librdkafka 2.12.0
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "wget" \
@@ -26,9 +26,9 @@ RUN apt-get update && \
     "g++" \
     "gcc" \
     "python3" \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "librdkafka-dev=2.10.1-1.cflt~deb12" \
+    "librdkafka1=2.12.0-1.cflt~deb12" \
+    "librdkafka++1=2.12.0-1.cflt~deb12" \
+    "librdkafka-dev=2.12.0-1.cflt~deb12" \
     # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
     # point releases out of the security archive, which breaks exact pins on uncached builds.
     "libssl-dev=3.0.*" \
@@ -50,7 +50,7 @@ COPY ./common/replay-shared/package.json ./common/replay-shared/
 COPY ./common/replay-headless/package.json ./common/replay-headless/
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
-# Use system librdkafka from Confluent (2.10.1) instead of bundled version
+# Use system librdkafka from Confluent (2.12.0) instead of bundled version
 ENV BUILD_LIBRDKAFKA=0
 
 # Compile and install Node.js dependencies
@@ -100,8 +100,8 @@ RUN apt-get update && \
     echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
+    "librdkafka1=2.12.0-1.cflt~deb12" \
+    "librdkafka++1=2.12.0-1.cflt~deb12" \
     # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
     # point releases out of the security archive, which breaks exact pins on uncached builds.
     "libssl3=3.0.*" \

--- a/Dockerfile.recording-rasterizer
+++ b/Dockerfile.recording-rasterizer
@@ -24,9 +24,9 @@ RUN apt-get update && \
     "g++" \
     "gcc" \
     "python3" \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "librdkafka-dev=2.10.1-1.cflt~deb12" \
+    "librdkafka1=2.12.0-1.cflt~deb12" \
+    "librdkafka++1=2.12.0-1.cflt~deb12" \
+    "librdkafka-dev=2.12.0-1.cflt~deb12" \
     # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
     # point releases out of the security archive, which breaks exact pins on uncached builds.
     "libssl-dev=3.0.*" \
@@ -106,8 +106,8 @@ RUN apt-get update && \
     echo "deb [signed-by=/etc/apt/keyrings/confluent-clients.gpg] https://packages.confluent.io/clients/deb/ bookworm main" > /etc/apt/sources.list.d/confluent-clients.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
-    "librdkafka1=2.10.1-1.cflt~deb12" \
-    "librdkafka++1=2.10.1-1.cflt~deb12" \
+    "librdkafka1=2.12.0-1.cflt~deb12" \
+    "librdkafka++1=2.12.0-1.cflt~deb12" \
     # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
     # point releases out of the security archive, which breaks exact pins on uncached builds.
     "libssl3=3.0.*" \


### PR DESCRIPTION
## Problem

The node and recording-rasterizer images link Confluent's system librdkafka (`BUILD_LIBRDKAFKA=0`), pinned at `2.10.1-1.cflt~deb12`. In librdkafka 2.10.1 the KIP-848 next-gen consumer group protocol (`group.protocol=consumer`) is only **Preview** — the upstream changelog states it *"should not be used in production environments."* It reaches **General Availability** in 2.12.0: *"Starting with librdkafka 2.12.0, the next generation consumer group rebalance protocol… is production-ready."*

This bump is the prerequisite for any production rollout of the KIP-848 consumer protocol, which removes the group-wide rebalance barrier that causes rebalance storms on large consumer groups during rollouts.

## Changes

Bump the linked Confluent librdkafka pin from `2.10.1-1.cflt~deb12` to `2.12.0-1.cflt~deb12` in `Dockerfile.node` and `Dockerfile.recording-rasterizer`, across both the build and runtime stages.

The classic consumer protocol path is unchanged, so this is a safe dependency bump on its own — no consumer config changes here, and KIP-848 stays opt-in via env var.

2.12.0 is the exact version node-rdkafka 3.6.1 already bundles, so the linked ABI matches what the binding was built against.

recording-rasterizer is bumped alongside node to avoid version drift between two images linking the same library; it does not use KIP-848.

## How did you test this code?

I'm an agent (Claude Code), working under José's direction. No runtime tests — this is a base-image dependency pin. Verified against Confluent's bookworm clients repo that `2.12.0-1.cflt~deb12` exists for all three packages (`librdkafka1`, `librdkafka++1`, `librdkafka-dev`), and confirmed the GA status from the upstream librdkafka 2.12.0 changelog. CI building both images is the real check; please confirm both image builds go green before merging.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

While validating whether the runtime supported KIP-848 for a related consumer-protocol change (PostHog/posthog#63469), found the images link system librdkafka 2.10.1 — not the 2.12.0 that node-rdkafka bundles — and that 2.10.1 has KIP-848 only at Preview maturity. This PR bumps the linked version to the GA release so prod enablement is unblocked.

- [ ] skip-inkeep-docs
