### PR TITLE
fix(sharing): gate session recording sharing on editor access

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -1,10 +1,12 @@
 import json
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any, Optional, cast
 from urllib.parse import urlparse, urlunparse
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Q
+from django.db.models import Model, Q
 from django.shortcuts import render
 from django.utils.timezone import now
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -38,6 +40,7 @@ from posthog.models.activity_logging.activity_log import Change, Detail, log_act
 from posthog.models.resource_transfer.visitors.insight import InsightVisitor
 from posthog.models.user import User
 from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
+from posthog.scopes import APIScopeObject
 from posthog.security.url_validation import is_url_allowed
 from posthog.session_recordings.session_recording_api import SessionRecordingSerializer
 from posthog.user_permissions import UserPermissions
@@ -143,6 +146,66 @@ def _log_share_password_attempt(
     )
 
 
+# A check raises PermissionDenied when the requesting user may not edit sharing for the given target.
+SharingResourceEditCheck = Callable[["SharingConfigurationViewSet", UserAccessControl, Model], None]
+
+
+def _require_resource_editor(resource: APIScopeObject, denied_message: str) -> SharingResourceEditCheck:
+    def check(_view: "SharingConfigurationViewSet", user_access_control: UserAccessControl, target: Model) -> None:
+        access_level = user_access_control.get_user_access_level(target)
+        if not access_level or not access_level_satisfied_for_resource(resource, access_level, "editor"):
+            raise PermissionDenied(denied_message)
+
+    return check
+
+
+def _require_dashboard_editor(
+    view: "SharingConfigurationViewSet", user_access_control: UserAccessControl, dashboard: Model
+) -> None:
+    dashboard = cast(Dashboard, dashboard)
+    # Legacy check: remove once all users are on the new access control
+    if dashboard.restriction_level > Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
+        if not view.user_permissions.dashboard(dashboard).can_edit:
+            raise PermissionDenied("You don't have edit permissions for this dashboard.")
+        return
+
+    access_level = user_access_control.get_user_access_level(dashboard)
+    if not access_level or not access_level_satisfied_for_resource("dashboard", access_level, "editor"):
+        raise PermissionDenied("You don't have edit permissions for this dashboard.")
+
+
+# Maps every shareable FK on SharingConfiguration to the editor-permission check that gates writes for it.
+# A ``None`` value means the resource is created server-side and is not writable through this viewset; if such
+# a config ever reaches the gate we fail closed rather than fall through to "allowed". The relationship is
+# enforced against the model below, so a newly added shareable resource cannot ship without a decision here.
+SHARING_RESOURCE_EDIT_CHECKS: dict[str, SharingResourceEditCheck | None] = {
+    "dashboard": _require_dashboard_editor,
+    "insight": _require_resource_editor("insight", "You don't have edit permissions for this insight."),
+    "recording": _require_resource_editor("session_recording", "You don't have edit permissions for this recording."),
+    "notebook": _require_resource_editor("notebook", "You don't have edit permissions for this notebook."),
+    # Materialized by the user-interviews link-generation flow, never via SharingConfigurationViewSet.
+    "interviewee_context": None,
+}
+
+
+def _assert_every_shareable_resource_is_gated() -> None:
+    model_fields = SharingConfiguration.shareable_resource_fields()
+    registered = set(SHARING_RESOURCE_EDIT_CHECKS)
+    missing = model_fields - registered
+    unexpected = registered - model_fields
+    if missing or unexpected:
+        raise ImproperlyConfigured(
+            "SHARING_RESOURCE_EDIT_CHECKS is out of sync with SharingConfiguration's shareable FK fields. "
+            f"Missing a sharing edit check for: {sorted(missing)}. "
+            f"Edit check registered for a non-existent field: {sorted(unexpected)}. "
+            "Every shareable resource needs an explicit editor-permission check (or None when it is not "
+            "editable through SharingConfigurationViewSet)."
+        )
+
+
+_assert_every_shareable_resource_is_gated()
+
+
 # NOTE: We can't use a standard permission system as we are using Detail view on a non-detail route
 def check_can_edit_sharing_configuration(
     view: "SharingConfigurationViewSet", request: Request, sharing: SharingConfiguration
@@ -160,25 +223,13 @@ def check_can_edit_sharing_configuration(
 
     user_access_control = UserAccessControl(cast(User, request.user), team=view.team)
 
-    if sharing.dashboard:
-        # Legacy check: remove once all users are on the new access control
-        if sharing.dashboard.restriction_level > Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
-            if not view.user_permissions.dashboard(sharing.dashboard).can_edit:
-                raise PermissionDenied("You don't have edit permissions for this dashboard.")
-        else:
-            access_level = user_access_control.get_user_access_level(sharing.dashboard)
-            if not access_level or not access_level_satisfied_for_resource("dashboard", access_level, "editor"):
-                raise PermissionDenied("You don't have edit permissions for this dashboard.")
-
-    if sharing.insight:
-        access_level = user_access_control.get_user_access_level(sharing.insight)
-        if not access_level or not access_level_satisfied_for_resource("insight", access_level, "editor"):
-            raise PermissionDenied("You don't have edit permissions for this insight.")
-
-    if sharing.notebook:
-        access_level = user_access_control.get_user_access_level(sharing.notebook)
-        if not access_level or not access_level_satisfied_for_resource("notebook", access_level, "editor"):
-            raise PermissionDenied("You don't have edit permissions for this notebook.")
+    for field_name, edit_check in SHARING_RESOURCE_EDIT_CHECKS.items():
+        target = getattr(sharing, field_name)
+        if target is None:
+            continue
+        if edit_check is None:
+            raise PermissionDenied("This resource cannot be shared through this endpoint.")
+        edit_check(view, user_access_control, target)
 
     return True
 

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1630,5 +1630,7 @@ class TestSharingResourceEditChecks(APIBaseTest):
         request.user = self.user
         view = Mock(team=self.team)
 
-        with self.assertRaises(PermissionDenied):
+        with self.assertRaises(PermissionDenied) as caught:
             check_can_edit_sharing_configuration(view, request, sharing)
+
+        assert "cannot be shared through this endpoint" in str(caught.exception)

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -7,14 +7,22 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, Mock, patch
 
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.timezone import now
 
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 
-from posthog.api.sharing import _log_share_password_attempt, shared_url_as_png
+from posthog.api.sharing import (
+    SHARING_RESOURCE_EDIT_CHECKS,
+    _assert_every_shareable_resource_is_gated,
+    _log_share_password_attempt,
+    check_can_edit_sharing_configuration,
+    shared_url_as_png,
+)
 from posthog.constants import AvailableFeature
 from posthog.models import ActivityLog
 from posthog.models.filters.filter import Filter
@@ -1587,3 +1595,40 @@ class TestSharedCohortInlining(APIBaseTest):
         assert widget_data["widget_type"] == "error_tracking_list"
         assert widget_data["config"]["limit"] == 10
         assert "created_by" not in widget_data
+
+
+class TestSharingResourceEditChecks(APIBaseTest):
+    def test_every_shareable_resource_has_an_edit_check(self):
+        assert set(SHARING_RESOURCE_EDIT_CHECKS) == SharingConfiguration.shareable_resource_fields()
+
+    @parameterized.expand(
+        [
+            ("a shareable resource has no registered edit check", "recording", None),
+            ("the registry references a non-existent field", None, "made_up_resource"),
+        ]
+    )
+    def test_assertion_rejects_a_registry_out_of_sync_with_the_model(self, _name, drop_key, add_key):
+        mutated = dict(SHARING_RESOURCE_EDIT_CHECKS)
+        if drop_key:
+            mutated.pop(drop_key)
+        if add_key:
+            mutated[add_key] = None
+
+        with patch.dict("posthog.api.sharing.SHARING_RESOURCE_EDIT_CHECKS", mutated, clear=True):
+            with self.assertRaises(ImproperlyConfigured):
+                _assert_every_shareable_resource_is_gated()
+
+    @patch("posthog.api.sharing.UserAccessControl")
+    def test_gate_fails_closed_for_a_resource_with_no_edit_check(self, _mock_user_access_control):
+        sharing = Mock(spec=SharingConfiguration)
+        for field_name in SharingConfiguration.shareable_resource_fields():
+            setattr(sharing, field_name, None)
+        sharing.interviewee_context = Mock()
+        sharing.team = self.team
+
+        request = Mock(method="PATCH", data={})
+        request.user = self.user
+        view = Mock(team=self.team)
+
+        with self.assertRaises(PermissionDenied):
+            check_can_edit_sharing_configuration(view, request, sharing)

--- a/posthog/models/sharing_configuration.py
+++ b/posthog/models/sharing_configuration.py
@@ -70,6 +70,17 @@ class SharingConfiguration(models.Model):
     password_required = models.BooleanField(default=False)
 
     @classmethod
+    def shareable_resource_fields(cls) -> frozenset[str]:
+        """The FK fields that point at a shareable resource - every relation except the team tenant FK.
+
+        The sharing API cross-checks this against its per-resource edit-permission registry at import
+        time, so a newly added shareable resource cannot ship without an explicit access-control decision.
+        """
+        return frozenset(
+            field.name for field in cls._meta.fields if field.is_relation and field.many_to_one and field.name != "team"
+        )
+
+    @classmethod
     def _resource_lookup(
         cls,
         *,

--- a/posthog/session_recordings/test/test_session_recordings_sharing.py
+++ b/posthog/session_recordings/test/test_session_recordings_sharing.py
@@ -9,10 +9,18 @@ from rest_framework import status
 
 from posthog.api.test.test_team import create_team
 from posthog.clickhouse.client import sync_execute
+from posthog.constants import AvailableFeature
 from posthog.models import Person, SessionRecording
+from posthog.models.organization import OrganizationMembership
+from posthog.models.user import User
 from posthog.models.utils import uuid7
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+
+try:
+    from ee.models.rbac.access_control import AccessControl
+except ImportError:
+    pass
 
 
 class TestSessionRecordingsSharing(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest):
@@ -130,3 +138,58 @@ class TestSessionRecordingsSharing(APIBaseTest, ClickhouseTestMixin, QueryMatchi
             f"/api/projects/{self.team.id}/session_recordings/{self.session_id}/snapshots?sharing_access_token={token}"
         )
         assert response.status_code == status.HTTP_200_OK, response.json()
+
+
+class TestSessionRecordingsSharingAccessControl(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest):
+    def setUp(self):
+        super().setUp()
+
+        sync_execute("TRUNCATE TABLE sharded_session_replay_events")
+        SessionRecording.objects.all().delete()
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        self.member_user = User.objects.create_and_join(self.organization, "member@posthog.com", "testtest")
+
+        with freeze_time("2023-01-01T12:00:00Z"):
+            self.session_id = str(uuid7())
+            produce_replay_summary(
+                team_id=self.team.pk,
+                session_id=self.session_id,
+                distinct_id="user",
+                first_timestamp=now() - relativedelta(days=1),
+                last_timestamp=now() - relativedelta(days=1),
+                ensure_analytics_event_in_session=False,
+            )
+
+    def _grant_recording_access(self, access_level: str) -> None:
+        membership = OrganizationMembership.objects.get(user=self.member_user, organization=self.organization)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="session_recording",
+            resource_id=None,
+            access_level=access_level,
+            organization_member=membership,
+        )
+
+    @parameterized.expand(
+        [
+            ("viewer", status.HTTP_403_FORBIDDEN),
+            ("editor", status.HTTP_200_OK),
+        ]
+    )
+    @freeze_time("2023-01-01T12:00:00Z")
+    def test_enable_sharing_requires_editor_access(self, access_level: str, expected_status: int) -> None:
+        self._grant_recording_access(access_level)
+        self.client.force_login(self.member_user)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/session_recordings/{self.session_id}/sharing",
+            {"enabled": True},
+        )
+
+        assert response.status_code == expected_status, response.json()

--- a/posthog/session_recordings/test/test_session_recordings_sharing.py
+++ b/posthog/session_recordings/test/test_session_recordings_sharing.py
@@ -1,3 +1,4 @@
+import pytest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
@@ -140,6 +141,7 @@ class TestSessionRecordingsSharing(APIBaseTest, ClickhouseTestMixin, QueryMatchi
         assert response.status_code == status.HTTP_200_OK, response.json()
 
 
+@pytest.mark.ee
 class TestSessionRecordingsSharingAccessControl(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest):
     def setUp(self):
         super().setUp()

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -4,6 +4,7 @@ import hmac
 import json
 import hashlib
 import datetime
+from types import SimpleNamespace
 from typing import Any
 
 import unittest
@@ -17,7 +18,9 @@ from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 
+from posthog.api.sharing import check_can_edit_sharing_configuration
 from posthog.api.test.test_sharing import mock_exporter_template
 from posthog.models.sharing_configuration import SharingConfiguration
 
@@ -1384,3 +1387,27 @@ class TestSharingConfigurationCanAccess(APIBaseTest):
         )
         share = SharingConfiguration.objects.create(team=self.team, interviewee_context=ic, enabled=True)
         self.assertTrue(share.can_access_object(ic))
+
+    def test_interviewee_context_config_fails_closed_through_sharing_gate(self):
+        topic = UserInterviewTopic.objects.create(
+            team=self.team,
+            created_by=self.user,
+            interviewee_emails=["alex@example.com"],
+            topic="t",
+        )
+        ic = IntervieweeContext.objects.create(
+            team=self.team,
+            topic=topic,
+            interviewee_identifier="alex@example.com",
+            agent_context="",
+            created_by=self.user,
+        )
+        share = SharingConfiguration.objects.create(team=self.team, interviewee_context=ic, enabled=True)
+
+        request = SimpleNamespace(method="PATCH", data={"enabled": True}, user=self.user)
+        view = SimpleNamespace(team=self.team)
+
+        with self.assertRaises(PermissionDenied) as caught:
+            check_can_edit_sharing_configuration(view, request, share)
+
+        assert "cannot be shared through this endpoint" in str(caught.exception)

--- a/products/user_interviews/backend/test_interview_sharing.py
+++ b/products/user_interviews/backend/test_interview_sharing.py
@@ -4,13 +4,12 @@ import hmac
 import json
 import hashlib
 import datetime
-from types import SimpleNamespace
 from typing import Any
 
 import unittest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.template.loader import get_template
 from django.test import override_settings
@@ -1404,8 +1403,9 @@ class TestSharingConfigurationCanAccess(APIBaseTest):
         )
         share = SharingConfiguration.objects.create(team=self.team, interviewee_context=ic, enabled=True)
 
-        request = SimpleNamespace(method="PATCH", data={"enabled": True}, user=self.user)
-        view = SimpleNamespace(team=self.team)
+        request = Mock(method="PATCH", data={"enabled": True})
+        request.user = self.user
+        view = Mock(team=self.team)
 
         with self.assertRaises(PermissionDenied) as caught:
             check_can_edit_sharing_configuration(view, request, share)


### PR DESCRIPTION
## Problem

`check_can_edit_sharing_configuration` is the single authorization gate for every write action on `SharingConfigurationViewSet` (`update`/`partial_update`, `refresh`, `create_password`, `delete_password`). It had explicit editor-level checks for `dashboard`, `insight`, and `notebook`, but no branch for `recording` — so a session-recording sharing config fell through to a default `return True`.

The effect: a member with only **viewer** access to session recordings (via advanced access control) could publicly expose any recording in the team by enabling sharing, rotate its token, or strip password protection — none of which they can do for an insight or dashboard. This is a broken object-level authorization gap (CWE-862). The org-wide `allow_publicly_shared_resources` toggle still applied, so orgs that globally disabled public sharing were unaffected.

While fixing it, the same fallthrough turned out to hide a second un-gated resource: `interviewee_context`. It's safe today only because the viewset's context resolver has no route that can target it — an implicit, undocumented assumption rather than an enforced one.

## Changes

Replaced the per-resource `if` chain with a structure that makes the relationship between "shareable thing" and "required access check" explicit and enforced, so a future resource can't silently inherit the gap:

- The model owns the list of shareable things: `SharingConfiguration.shareable_resource_fields()` introspects its own FKs (everything except the `team` tenant FK).
- The API owns the policy per thing: `SHARING_RESOURCE_EDIT_CHECKS` maps each field to its editor-permission check. `None` is a deliberate, visible declaration that a resource is created server-side and is not writable through this viewset (that's `interviewee_context`).
- An import-time assertion binds the two: `_assert_every_shareable_resource_is_gated()` raises `ImproperlyConfigured` at module load if the registry and the model's FK set disagree. The app won't import until a newly added shareable resource has an explicit decision.
- The gate is now fail-closed: a target whose policy is `None` raises `PermissionDenied` instead of the old silent allow.

`recording` is gated against the `session_recording` editor access level, matching the existing insight/notebook pattern.

## How did you test this code?

I'm an agent (PostHog Code). I added and ran automated tests; I did not perform manual testing.

- `TestSessionRecordingsSharingAccessControl` — parameterized: a viewer-level member gets `403` and an editor-level member gets `200` when enabling recording sharing.
- `TestSharingResourceEditChecks` — the registry matches the model's shareable fields; the import-time assertion rejects an out-of-sync registry (missing field and phantom field, parameterized); the gate fails closed for a resource with a `None` policy.

Two pre-existing local failures in `test_sharing.py` (`test_should_not_get_deleted_item`, `test_refresh_token_grace_period`) are unrelated to this change — they require the built `exporter.html` frontend asset and fail identically on clean master. Everything else in the suite passes.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). Started from a reported authorization-gap finding on the recordings branch, verified it against the access-control registry (`model_to_resource` maps `SessionRecording` -> `session_recording`, a real access-controlled resource with viewer/editor levels), then fixed it. Rather than only adding the missing `if`, I generalized the gate into a model-owned field list plus an API-owned policy registry with an import-time consistency assertion, after discovering `interviewee_context` was a second un-gated resource relying on routing rather than an explicit check. Left `_lock_resource_for_rotation`'s parallel field-name tuple untouched as out of scope: a drift there degrades gracefully (a missed row lock during token rotation) rather than opening a hole.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
