### PR TITLE
fix(tasks): salvage dropped-finalization turns past trailing relay logs

### DIFF
--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -46,6 +46,19 @@ STALE_TURN_SALVAGE_SECONDS = 300
 # "Activity task failed" wrapper.
 AGENT_ERROR_METHOD = "_posthog/error"
 
+# Observability side-channels the relay interleaves into the turn log asynchronously
+# (agentsh network-audit dumps and sandbox credential refreshes ride on `_posthog/console`,
+# sandbox stdout/stderr on `_posthog/sandbox_output`, setup steps on `_posthog/progress`).
+# They carry no turn-state and routinely land *after* the agent's closing usage_update, so the
+# dropped-finalization tail check skips them rather than treating one as the decisive tail.
+TRANSIENT_SIDE_CHANNEL_METHODS = frozenset(
+    {
+        "_posthog/console",
+        "_posthog/progress",
+        "_posthog/sandbox_output",
+    }
+)
+
 
 @dataclass(frozen=True)
 class AgentError:
@@ -581,12 +594,19 @@ def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | 
 
 
 def _ended_on_pending_finalization(full_log: str | None) -> bool:
-    """True when the log's last notification is a usage_update carrying an explicit null cost —
-    the sandbox ran turn accounting but the closing end_turn was dropped. The cost key must be
-    present and null: older usage_update lines omit it entirely and are not this fingerprint.
-    Any other trailing notification (an end_turn/result, a `_posthog/error`, a mid-turn update)
-    is decisive that this is not the dropped-finalization case, so we don't salvage and let the
-    normal completion / terminal-status drain handle it."""
+    """True when the agent's last turn-relevant notification is a usage_update carrying an explicit
+    null cost — the sandbox ran turn accounting but the closing end_turn was dropped. The cost key
+    must be present and null: older usage_update lines omit it entirely and are not this fingerprint.
+    Any other trailing turn-relevant notification (an end_turn/result, a `_posthog/error`, a mid-turn
+    update) is decisive that this is not the dropped-finalization case, so we don't salvage and let
+    the normal completion / terminal-status drain handle it.
+
+    Observability side-channels (`TRANSIENT_SIDE_CHANNEL_METHODS`) are skipped while walking back:
+    the relay appends agentsh network-audit events and credential-refresh notices to the turn log
+    asynchronously, so one routinely lands after the closing usage_update. Treating such a line as
+    the decisive tail (the prior behavior) masked the fingerprint and made the salvage decline a
+    turn that had genuinely finished — the dominant cause of scout runs hanging out to the poll
+    timeout and being marked failed."""
     if not full_log:
         return False
     for line in reversed(full_log.strip().split("\n")):
@@ -598,6 +618,8 @@ def _ended_on_pending_finalization(full_log: str | None) -> bool:
         except json.JSONDecodeError:
             continue
         if not isinstance(notification, dict):
+            continue
+        if notification.get("method") in TRANSIENT_SIDE_CHANNEL_METHODS:
             continue
         params = notification.get("params")
         update = params.get("update") if isinstance(params, dict) else None

--- a/products/tasks/backend/tests/agent_log_fixtures.py
+++ b/products/tasks/backend/tests/agent_log_fixtures.py
@@ -105,6 +105,13 @@ def _usage_update_line(used: int = 1000, cost: float | None = None) -> str:
     )
 
 
+def _console_line(message: str = "agentsh network events", method: str = "_posthog/console") -> str:
+    # An observability side-channel the relay interleaves into the turn log (agentsh network audit,
+    # sandbox credential refresh, stdout). It carries no turn-state and can land AFTER the agent's
+    # closing usage_update — the dropped-finalization tail check must skip it, not stop on it.
+    return json.dumps({"notification": {"method": method, "params": {"level": "debug", "message": message}}})
+
+
 def _cost_less_usage_update_line(used: int = 1000) -> str:
     # Older sandbox builds omit cost entirely — must NOT read as the null-cost fingerprint.
     return json.dumps(

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -27,6 +27,7 @@ from products.tasks.backend.tests.agent_log_fixtures import (
     _agent_error_line,
     _agent_message_chunk_line,
     _agent_message_line,
+    _console_line,
     _cost_less_usage_update_line,
     _end_turn_line,
     _tool_call_line,
@@ -192,6 +193,55 @@ class TestPollForTurnStaleSalvage:
 
         assert last_message == "close-out summary"
         assert total_lines == len(done)
+
+    @parameterized.expand(
+        [
+            ("single_network_audit", [_console_line("agentsh network events")]),
+            (
+                "audit_then_credential_refresh",
+                [_console_line("agentsh network events"), _console_line("Refreshed sandbox credentials: github")],
+            ),
+            ("sandbox_output", [_console_line("npm install ...", method="_posthog/sandbox_output")]),
+            ("setup_progress", [_console_line("cloning repo", method="_posthog/progress")]),
+        ]
+    )
+    async def test_salvages_dropped_finalization_despite_trailing_console_lines(self, _name, trailing):
+        # The prod failure shape: the agent emits its close-out + null-cost usage_update, then the relay
+        # appends observability side-channels (agentsh network audit, credential refresh, stdout, setup
+        # progress) AFTER the fingerprint while the turn hangs. The tail check must skip those and still
+        # recognize the dropped finalization — otherwise the run hangs to the poll timeout and fails.
+        log = "\n".join([_agent_message_line("close-out summary"), _usage_update_line(165000), *trailing])
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            last_message, _, total_lines, _ = await poll_for_turn(fake, skip_lines=0)
+
+        assert last_message == "close-out summary"
+        assert total_lines == 2 + len(trailing)
+
+    @pytest.mark.asyncio
+    async def test_does_not_salvage_when_console_lines_follow_a_live_tail(self):
+        # Trailing console noise must NOT manufacture a salvage when the agent's own tail isn't the
+        # finalization fingerprint: here the last turn-relevant line is a bare agent_message (no
+        # usage_update), so skipping the console lines still finds no fingerprint and the run times out.
+        log = "\n".join([_agent_message_line("still working"), _console_line("agentsh network events")])
+        fake = FakeTaskRun()
+        with (
+            patch("posthog.storage.object_storage.read", return_value=log),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("products.tasks.backend.services.custom_prompt_internals.POLL_INTERVAL_SECONDS", 10),
+            patch("products.tasks.backend.services.custom_prompt_internals.MAX_POLL_SECONDS", 30),
+            patch("products.tasks.backend.services.custom_prompt_internals.STALE_TURN_SALVAGE_SECONDS", 15),
+            patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake),
+        ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await poll_for_turn(fake, skip_lines=0)
 
     @pytest.mark.asyncio
     async def test_max_poll_seconds_overrides_module_budget(self):


### PR DESCRIPTION
## Problem

Signals scout runs routinely "do their work, then hang and time out as failed." Investigating a live failed run (project 2, AI-observability scout) confirmed it's a **dropped close-out**, not broken scout logic: the agent finished all its work and emitted its full close-out message ~2m43s into the run, then the turn went silent and was hard-killed ~28 minutes later with `custom_prompt - poll_for_turn: timed out after 1800s`. About half of each tick's runs die this way; the fleet has been working around it by "staying surgical."

`poll_for_turn` already has a salvage path (`_salvage_dropped_finalization`) built for exactly this — final message present, closing `end_turn` dropped, log goes quiet. But it was **declining** these turns. Its tail detector `_ended_on_pending_finalization` required the **last line** of the S3 turn log to be the null-cost `usage_update` fingerprint. In practice the relay appends observability side-channels — agentsh network-audit dumps and sandbox credential refreshes (both `_posthog/console`), sandbox stdout (`_posthog/sandbox_output`), setup progress (`_posthog/progress`) — to the same turn log **asynchronously**, so one routinely lands *after* the agent's closing `usage_update`. That trailing line masked the fingerprint, the salvage declined, and the run hung out to the poll budget and was marked failed.

The session-logs endpoint reads the identical S3 object (`object_storage.read(task_run.log_url)`) that the salvage reads, which is how the trailing `_posthog/console` lines were confirmed to be in the salvage's actual input.

## Changes

- `_ended_on_pending_finalization` now **skips transient relay side-channel notifications** (`_posthog/console`, `_posthog/sandbox_output`, `_posthog/progress`, collected in a new `TRANSIENT_SIDE_CHANNEL_METHODS` constant) while walking the tail, so it classifies on the agent's own last turn-relevant line. A trailing `_posthog/error` stays decisive (an errored turn is still not salvaged), and a non-fingerprint agent tail still declines — only the orthogonal infra noise is ignored.
- Added a `_console_line` test fixture and regression tests covering a finalization fingerprint followed by network-audit / credential-refresh / stdout / progress lines (must salvage), plus a guard that trailing console noise after a *live* (non-fingerprint) tail still declines.

This is the second half of a pair: a separate change lowers the scout's poll budget to 900s so the salvage window fits inside the Temporal activity timeout (so salvage actually *runs* instead of being pre-empted by `Activity task timed out`). That change is necessary but not sufficient on its own — without this fix the salvage runs and still declines. Together they let a hung-but-finished scout run complete.

A known secondary effect is left as a follow-up: the relay's periodic side-channel lines also reset the poll loop's staleness clock, which can delay the salvage attempt; the observed gaps are large enough that salvage still fires, so this PR targets the dominant decline cause.

## How did you test this code?

I'm an agent (Claude Code, directed by the PR assignee). I did not perform manual testing. Automated tests I actually ran:

- `hogli test products/tasks/backend/tests/test_multi_turn_session.py::TestPollForTurnStaleSalvage` — 25 passed, including the 5 new cases.
- `hogli test products/tasks/backend/tests/test_multi_turn_session.py` — 54 passed; the only 6 errors are environmental (local Postgres not running, so the DB-fixture classes can't set up) and are unrelated to this change, which is pure log-parsing logic.
- `ruff check`/`ruff format` clean; pre-commit lint + format + type check passed on commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused with Claude Code from a live failed scout run: pulled the run's session log, established the agent finished and emitted its close-out before going silent, then traced the failure through `poll_for_turn` → `_salvage_dropped_finalization` → `_ended_on_pending_finalization` and proved (via the session-logs endpoint reading the same S3 object) that trailing `_posthog/console` relay lines were defeating the tail check.

Considered a broader "skip every `_posthog/*` except `_posthog/error`" rule but chose an explicit allowlist of the three unambiguous observability side-channels — it's the minimal, provably-correct change and keeps every decisive case (agent error, live mid-turn tail, populated-cost tail) behaving exactly as before.
