### PR TITLE
refactor(charts): build SlopeChart on LineChart

### DIFF
--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -179,20 +179,12 @@ function LineChartInner<Meta = unknown>({
                 drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
             }
 
-            // Clip data drawing to the plot area so an overlay series with values outside
-            // the y-domain (e.g. a trendline projecting below 0) doesn't bleed into the
-            // axis-label gutter beneath the chart. A small pad on top/bottom keeps strokes
-            // at the domain edge from rendering at half-thickness — line strokes and point
-            // markers extend past the value's pixel center.
+            // Clip vertically only: keep out-of-domain values (e.g. a trendline below 0) out of the
+            // axis-label gutters, but span the full width so edge point markers/line caps render whole.
             const CLIP_PAD = 8
             ctx.save()
             ctx.beginPath()
-            ctx.rect(
-                dimensions.plotLeft,
-                dimensions.plotTop - CLIP_PAD,
-                dimensions.plotWidth,
-                dimensions.plotHeight + CLIP_PAD * 2
-            )
+            ctx.rect(0, dimensions.plotTop - CLIP_PAD, dimensions.width, dimensions.plotHeight + CLIP_PAD * 2)
             ctx.clip()
 
             for (const s of coloredSeries) {

--- a/packages/quill/packages/charts/src/charts/SlopeChart/SlopeChart.tsx
+++ b/packages/quill/packages/charts/src/charts/SlopeChart/SlopeChart.tsx
@@ -1,27 +1,19 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { ChartLegend } from '../../components/Legend/ChartLegend'
-import { drawAxes, drawHighlightPoint, drawLine, drawPoints } from '../../core/canvas-renderer'
-import type { DrawContext } from '../../core/canvas-renderer'
-import { Chart } from '../../core/Chart'
 import { ChartErrorBoundary } from '../../core/ChartErrorBoundary'
-import { createScales as createSlopeScales, yTickCountForHeight } from '../../core/scales'
-import type { ScaleSet } from '../../core/scales'
 import type {
     ChartConfig,
-    ChartDimensions,
-    ChartDrawArgs,
     ChartMargins,
-    ChartScales,
     ChartTheme,
-    CreateScalesFn,
+    LineChartConfig,
     PointClickData,
-    ResolvedSeries,
     Series,
     TooltipContext,
     ValueDomain,
 } from '../../core/types'
 import { FONT_FAMILY, measureLabelWidth } from '../../utils/text-measure'
+import { LineChart } from '../LineChart/LineChart'
 import {
     defaultDeltaFormatter,
     defaultValueFormatter,
@@ -35,11 +27,6 @@ import { SlopeSeriesLabels } from './SlopeSeriesLabels'
 import { SlopeValueLabels } from './SlopeValueLabels'
 
 export type { SlopeSeriesMeta } from './slope-data'
-
-// Brand for the private ChartScales._private slot used by SlopeChart, mirroring LineChart.
-interface SlopeChartPrivate {
-    __slopeChart: ScaleSet
-}
 
 const LABEL_FONT = `600 12px ${FONT_FAMILY}`
 const VALUE_GAP = 8
@@ -120,10 +107,8 @@ function SlopeChartInner<Meta = SlopeSeriesMeta>({
         deltaFormatter = defaultDeltaFormatter,
         endpointRadius = DEFAULT_ENDPOINT_RADIUS,
         valueDomain,
-        yScaleType = 'linear',
     } = config ?? {}
 
-    // Per-series start/end value labels can be toggled via `meta`; fall back to the chart default.
     const showsStart = useCallback(
         (s: Series<Meta>): boolean => slopeLabelVisible(s, 'start', showStartLabels),
         [showStartLabels]
@@ -133,8 +118,7 @@ function SlopeChartInner<Meta = SlopeSeriesMeta>({
         [showEndLabels]
     )
 
-    // Reserve left/right gutters sized to the actual label content so the absolutely-positioned
-    // value/name labels (which live in the margins, beyond the plot edges) aren't clipped.
+    // Reserve left/right gutters for the value/name labels, which sit in the margins beyond the plot.
     const { margins, nameOffsetX } = useMemo(() => {
         const startWidth = maxLabelWidth(series.filter(showsStart).map((s) => valueFormatter(slopeStart(s))))
         const endWidth = maxLabelWidth(series.filter(showsEnd).map((s) => valueFormatter(slopeEnd(s))))
@@ -158,91 +142,20 @@ function SlopeChartInner<Meta = SlopeSeriesMeta>({
         return { margins: { ...base, ...config?.margins }, nameOffsetX: offset }
     }, [series, showsStart, showsEnd, showSeriesLabels, valueFormatter, config?.margins])
 
-    // Slope charts encode the value through the start/end labels themselves, so the left value
-    // axis is hidden by default; the x-axis keeps the two column labels ("Before"/"After").
-    const chartConfig = useMemo<ChartConfig>(() => ({ hideYAxis: true, ...config, margins }), [config, margins])
-
-    const createScales: CreateScalesFn = useCallback(
-        (coloredSeries: ResolvedSeries[], scaleLabels: string[], dimensions: ChartDimensions): ChartScales => {
-            const d3Scales = createSlopeScales(coloredSeries, scaleLabels, dimensions, {
-                scaleType: yScaleType,
-                valueDomain,
-            })
-            const yTickCount = yTickCountForHeight(dimensions.plotHeight)
-            const slopePrivate: SlopeChartPrivate = { __slopeChart: d3Scales }
-            return {
-                x: (label: string) => d3Scales.x(label),
-                y: (value: number) => d3Scales.y(value),
-                yTicks: () => d3Scales.y.ticks?.(yTickCount) ?? [],
-                _private: slopePrivate,
-            }
-        },
-        [valueDomain, yScaleType]
+    // A slope is a two-point line — collapse each series to its endpoints, with a dot at each.
+    const slopeSeries = useMemo<Series<Meta>[]>(
+        () =>
+            series.map((s) => ({
+                ...s,
+                data: [slopeStart(s), slopeEnd(s)],
+                points: { ...s.points, radius: endpointRadius },
+            })),
+        [series, endpointRadius]
     )
 
-    const drawStatic = useCallback(
-        ({ ctx, dimensions, scales, series: coloredSeries, labels: drawLabels, theme: drawTheme }: ChartDrawArgs) => {
-            const d3Scales = (scales._private as SlopeChartPrivate | undefined)?.__slopeChart
-            if (!d3Scales || drawLabels.length < 2) {
-                return
-            }
-            const drawCtx: DrawContext = { ctx, dimensions, xScale: d3Scales.x, yScale: d3Scales.y, labels: drawLabels }
-
-            if (config?.showAxisLines) {
-                drawAxes(drawCtx, { axisColor: drawTheme.gridColor })
-            }
-
-            for (const s of coloredSeries) {
-                if (s.visibility?.excluded) {
-                    continue
-                }
-                // Collapse to the two endpoints so the shared line/point renderers map them to the
-                // start and end columns — a slope is a two-point line with a dot at each end.
-                const endpoints: ResolvedSeries = {
-                    ...s,
-                    data: [slopeStart(s), slopeEnd(s)],
-                    points: { radius: endpointRadius },
-                }
-                drawLine(drawCtx, endpoints)
-                drawPoints(drawCtx, endpoints)
-            }
-        },
-        [config?.showAxisLines, endpointRadius]
-    )
-
-    const drawHover = useCallback(
-        ({
-            ctx,
-            scales,
-            series: coloredSeries,
-            labels: drawLabels,
-            hoverIndex,
-            theme: drawTheme,
-        }: ChartDrawArgs): boolean => {
-            if (hoverIndex < 0 || drawLabels.length < 2) {
-                return false
-            }
-            const x = scales.x(drawLabels[hoverIndex])
-            if (x == null) {
-                return false
-            }
-            const background = drawTheme.backgroundColor ?? '#ffffff'
-            let drewAny = false
-            for (const s of coloredSeries) {
-                if (s.visibility?.excluded) {
-                    continue
-                }
-                const value = hoverIndex === 0 ? slopeStart(s) : slopeEnd(s)
-                const y = scales.y(value)
-                if (!isFinite(y)) {
-                    continue
-                }
-                drawHighlightPoint(ctx, x, y, s.color, background, endpointRadius)
-                drewAny = true
-            }
-            return drewAny
-        },
-        [endpointRadius]
+    const lineConfig = useMemo<LineChartConfig>(
+        () => ({ ...config, hideYAxis: config?.hideYAxis ?? true, showGrid: false, margins, valueDomain }),
+        [config, margins, valueDomain]
     )
 
     const legendItems = useMemo(() => slopeLegendItems(series, theme, deltaFormatter), [series, theme, deltaFormatter])
@@ -256,14 +169,11 @@ function SlopeChartInner<Meta = SlopeSeriesMeta>({
             gap={legend?.gap}
             legendDataAttr="hog-chart-slope-legend"
         >
-            <Chart
-                series={series}
+            <LineChart<Meta>
+                series={slopeSeries}
                 labels={labels}
-                config={chartConfig}
+                config={lineConfig}
                 theme={theme}
-                createScales={createScales}
-                drawStatic={drawStatic}
-                drawHover={drawHover}
                 tooltip={tooltip}
                 onPointClick={onPointClick}
                 className={className}
@@ -276,7 +186,7 @@ function SlopeChartInner<Meta = SlopeSeriesMeta>({
                 />
                 <SlopeSeriesLabels show={showSeriesLabels} offsetX={nameOffsetX} />
                 {children}
-            </Chart>
+            </LineChart>
         </ChartLegend>
     )
 }


### PR DESCRIPTION
## Problem

`SlopeChart` (#63442) is built directly on the core `Chart`, reimplementing `createScales`, `drawStatic`, and `drawHover`. But a slopegraph is just a two-point line chart with the axes and grid turned off — those three callbacks are near-copies of `LineChart`'s. This stacks the changes on top of #63442 to remove that duplication.

## Changes

**`SlopeChart` now renders a configured `<LineChart>`** instead of owning its own scale/draw plumbing:

- Collapses each series to its two endpoints (`data: [start, end]`, with `points.radius` for the dots) in a `useMemo`, then renders `<LineChart config={{ hideYAxis: true, showGrid: false, margins, valueDomain }}>`. `showAxisLines` and other base `ChartConfig` still pass through.
- The slope-specific parts are unchanged: the start/end value labels, end-anchored series-name labels (with largest-change-wins collision), the delta legend, and the gutter sizing. Those already read from chart context, so they don't care which wrapper draws the canvas.
- Deletes `SlopeChart`'s `createScales`, `drawStatic`, `drawHover`, and the private-scale brand (~90 lines).

**`LineChart` clip fix (no new config).** Its data clip was bounded horizontally at the plot edges. The x point-scale uses `padding(0)`, so the first/last category sits exactly on the plot edge — and the clip sliced any point marker there in half. That's precisely where a slope's endpoint dots live (and `LineChart`'s own first/last markers, e.g. its `radius: 3` stories). The clip's actual purpose is to keep out-of-domain values out of the top/bottom axis gutters, so it now spans the full width and clips vertically only.

The public `SlopeChart` API (props, config, exports) is unchanged.

## How did you test this code?

I'm an agent (Claude Code / PostHog Code). No manual testing — only automated checks, run locally:

- **Charts (jest, via the frontend config):** full charts suite passes — **46 suites / 1259 tests**, same as #63442's baseline, including the SlopeChart, LineChart, and PieChart (shared collision helper) suites.
- `tsc` on the changed source files: clean.
- `oxfmt --check` and `oxlint`: clean.

I did not run Storybook or view the canvas visually. Reviewer note: the full-width clip will likely shift a couple of existing **LineChart** visual snapshots (edge point markers now render whole rather than half-clipped) — an expected baseline regen, not a behavior bug.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code), directed by @aspicer. Stacked on @pauldambra's #63442. The human's read was that the chart looked like "a line chart with a few config options" and asked whether basing it on `LineChart` would simplify it.

Key decision: the one obstacle to delegating to `LineChart` was its clip slicing the endpoint dots at the plot edges. An earlier attempt added a `clipPadX` config knob to `LineChart`; that was rejected in favor of keeping changes minimal and config-free. Instead the clip was made full-width / vertical-only — which needs no new API and also fixes `LineChart`'s own edge markers being half-clipped.
