### PR TITLE
chore(slack-app): remove drained posthog-code workflow.deprecate_patch markers

### DIFF
--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
@@ -143,7 +143,6 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             repo_research_task_id: str | None = None
             repo_research_run_id: str | None = None
 
-            workflow.deprecate_patch("posthog-code-slack-user-github-2026-06")
             cascade = await _execute_posthog_code_activity(
                 cascade_posthog_code_repository_activity,
                 inputs,
@@ -160,7 +159,6 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                 # answer with no repo; coding asks surface the connect-personal-
                 # GitHub prompt instead of silently no-op'ing.
                 repository = None
-                workflow.deprecate_patch("posthog-code-classify-before-gate-2026-06")
                 needs_repo = await _execute_posthog_code_activity(
                     classify_posthog_code_task_needs_repo_activity,
                     event.get("text", ""),

--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention_command.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention_command.py
@@ -104,7 +104,6 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
             user_id=inputs.user_id,
         )
 
-        workflow.deprecate_patch("posthog-code-command-block-no-personal-github-2026-06")
         blocked = await workflow.execute_activity(
             block_posthog_code_task_if_no_personal_github_activity,
             args=[picker_inputs, channel, thread_ts, user_id],
@@ -114,7 +113,6 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
         if blocked:
             return
 
-        workflow.deprecate_patch("posthog-code-command-user-id-2026-06")
         await workflow.execute_activity(
             post_posthog_code_repo_picker_activity,
             args=[


### PR DESCRIPTION
## Problem

Four `workflow.deprecate_patch` markers added in #62165 (the second step of Temporal's `patched → deprecate_patch → remove` lifecycle) have outlived their purpose now that pre-patch histories have drained.

## Changes

Removes the four markers:

- `posthog_code_slack_mention.py` — `posthog-code-slack-user-github-2026-06`, `posthog-code-classify-before-gate-2026-06`
- `posthog_code_slack_mention_command.py` — `posthog-code-command-block-no-personal-github-2026-06`, `posthog-code-command-user-id-2026-06`

No behavior change — these always took the new path.

## How did you test this code?

Agent-authored, no manual testing. Pure deletion; CI covers regressions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta asked me to audit and remove deprecated patches in the PostHog code Slack workflows. Surfaced via grep, confirmed origin in #62165 (2026-06-08), proceeded with explicit approval. Tool: Claude Code.