### PR TITLE
feat(llma): display Vercel functionId as the span name

### DIFF
--- a/nodejs/src/ingestion/ai/otel/middleware/vercel-ai.test.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/vercel-ai.test.ts
@@ -279,6 +279,75 @@ describe('vercel-ai middleware', () => {
         })
     })
 
+    describe('functionId as $ai_span_name', () => {
+        it('overrides the generic name on a top-level wrapper span promoted to $ai_trace', () => {
+            const event = createEvent('$ai_span', {
+                'ai.operationId': 'ai.generateText',
+                'ai.telemetry.functionId': 'my-func',
+                $ai_span_name: 'ai.generateText',
+            })
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_trace')
+            expect(event.properties!['$ai_span_name']).toBe('my-func')
+        })
+
+        it('overrides the generic name on a $ai_trace event', () => {
+            const event = createEvent('$ai_trace', {
+                'ai.operationId': 'ai.generateText',
+                'ai.telemetry.functionId': 'my-func',
+                $ai_span_name: 'ai.generateText',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('my-func')
+        })
+
+        it('leaves $ai_span_name untouched when functionId is empty', () => {
+            const event = createEvent('$ai_trace', {
+                'ai.operationId': 'ai.generateText',
+                'ai.telemetry.functionId': '',
+                $ai_span_name: 'ai.generateText',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('ai.generateText')
+        })
+
+        it('leaves $ai_span_name untouched when no functionId is set', () => {
+            const event = createEvent('$ai_trace', {
+                'ai.operationId': 'ai.generateText',
+                $ai_span_name: 'ai.generateText',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('ai.generateText')
+        })
+
+        it('does not override $ai_span_name on a .doGenerate generation span', () => {
+            const event = createEvent('$ai_generation', {
+                'ai.operationId': 'ai.generateText.doGenerate',
+                'ai.telemetry.functionId': 'my-func',
+                $ai_span_name: 'ai.generateText.doGenerate',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('ai.generateText.doGenerate')
+        })
+
+        it('preserves the tool name on an ai.toolCall span carrying functionId', () => {
+            const event = createEvent('$ai_span', {
+                $ai_parent_id: 'parent-1',
+                'ai.operationId': 'ai.toolCall',
+                'ai.telemetry.functionId': 'my-func',
+                'ai.toolCall.name': 'get_weather',
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['$ai_span_name']).toBe('get_weather')
+        })
+    })
+
     describe('sets $ai_lib', () => {
         it.each(['$ai_generation', '$ai_span'])('sets $ai_lib on %s events', (eventType) => {
             const event = createEvent(eventType, { 'ai.operationId': 'ai.generateText.doGenerate' })

--- a/nodejs/src/ingestion/ai/otel/middleware/vercel-ai.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/vercel-ai.ts
@@ -163,6 +163,11 @@ function process(event: PluginEvent, next: () => void): void {
         props['functionId'] = functionId
     }
 
+    // The functionId represents the whole trace's purpose, so only override the span name for the top-level event
+    if (isTopLevel && typeof functionId === 'string' && functionId) {
+        props['$ai_span_name'] = functionId
+    }
+
     const posthogDistinctId = props['ai.telemetry.metadata.posthog_distinct_id']
     if (typeof posthogDistinctId === 'string' && posthogDistinctId) {
         if (props['posthog_distinct_id'] === undefined) {


### PR DESCRIPTION
## Problem

When a customer instruments the Vercel AI SDK via PostHog's OpenTelemetry path (`PostHogSpanProcessor` / `PostHogTraceExporter`) and sets `experimental_telemetry: { functionId: 'my-ai-function' }`, the trace/span still displays as the SDK's generic operation name (`ai.generateText`, `ai.streamText`, …). The traces list ends up a wall of identical `ai.generateText` rows.

## Changes

In the Vercel OTel middleware (`nodejs/src/ingestion/ai/otel/middleware/vercel-ai.ts`), after the standard attribute mapping, override `$ai_span_name` with `functionId` — but **only** on the top-level wrapper span (the one that becomes the `$ai_trace`), and only when `functionId` is a non-empty string.

## How did you test this code?

I'm an agent (PostHog Code). I added six focused unit tests in `vercel-ai.test.ts` and ran the suite — all 31 tests pass, including the existing regression guards (*ignores empty functionId telemetry*, *maps tool call attributes to state properties*, *strips Vercel-specific attributes*). New cases cover: top-level wrapper promoted to `$ai_trace`, a `$ai_trace` event, empty `functionId` (no-op), no `functionId` (no-op), a `.doGenerate` generation span (not overridden), and an `ai.toolCall` span (tool name preserved). Lint and typecheck are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Opus 4.8) at Carlos's direction. The change is intentionally narrow and defensive: a server-side ingestion mapping fix with no SDK release and no frontend change.

Key decision: scope the `$ai_span_name` override to top-level spans only. A naive "override whenever `functionId` is present" would rename `ai.toolCall` spans (e.g. `get_weather` → the functionId) and repeat the same label across every node in the trace tree. Verified that `$ai_span_name` is display-only — the trace tree is keyed on span/parent IDs, not names — and that `traces_query_runner.py` derives `trace_name` from the single `$ai_trace` event, so the only span we rename is exactly the one that surfaces in the traces list.

Out of scope: promoting arbitrary custom metadata (tracked separately in #52442), the Rust capture layer, and the `@posthog/ai` SDK.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
