### PR TITLE
fix: seed slack ticket from thread parent on bot mention

### DIFF
--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -175,6 +175,37 @@ class TestSlackMessageRouting(BaseTest):
         assert kwargs["is_thread_reply"] is True
         assert kwargs["slack_user_id"] == "U_MENTIONER"
 
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_mention_in_thread_falls_back_to_mention_when_parent_unavailable(
+        self, mock_create_or_update, mock_get_client, mock_backfill
+    ):
+        # Parent fetch returns nothing (e.g. message deleted or API hiccup) -> fall
+        # back to seeding the ticket from the mention itself rather than dropping it.
+        mock_get_client.return_value.conversations_history.return_value = {"messages": []}
+
+        handle_support_mention(
+            {
+                "type": "app_mention",
+                "channel": "C_ANY",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U_MENTIONER",
+                "text": "<@U_BOT> please help here",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_backfill.assert_not_called()
+        mock_create_or_update.assert_called_once()
+        kwargs = mock_create_or_update.call_args.kwargs
+        assert kwargs["slack_user_id"] == "U_MENTIONER"
+        assert kwargs["text"] == "<@U_BOT> please help here"
+        assert kwargs["is_thread_reply"] is False
+        assert kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
+
     @patch("products.conversations.backend.slack.get_slack_client")
     @patch("products.conversations.backend.slack.create_or_update_slack_ticket")
     def test_emoji_reaction_passes_channel_detail(self, mock_create_or_update, mock_get_client):

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -106,6 +106,75 @@ class TestSlackMessageRouting(BaseTest):
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
 
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_mention_in_thread_seeds_ticket_from_parent_message(
+        self, mock_create_or_update, mock_get_client, mock_backfill
+    ):
+        mock_get_client.return_value.conversations_history.return_value = {
+            "messages": [{"user": "U_OP", "text": "Initial message that started the thread"}]
+        }
+        mock_create_or_update.return_value = object()
+
+        handle_support_mention(
+            {
+                "type": "app_mention",
+                "channel": "C_ANY",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U_MENTIONER",
+                "text": "<@U_BOT> please help here",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.conversations_history.assert_called_once()
+        mock_create_or_update.assert_called_once()
+        kwargs = mock_create_or_update.call_args.kwargs
+        assert kwargs["slack_user_id"] == "U_OP"
+        assert kwargs["text"] == "Initial message that started the thread"
+        assert kwargs["thread_ts"] == "1700000000.000100"
+        assert kwargs["is_thread_reply"] is False
+        assert kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
+        mock_backfill.assert_called_once()
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_mention_in_thread_with_existing_ticket_adds_reply(
+        self, mock_create_or_update, mock_get_client, mock_backfill
+    ):
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id="C_ANY",
+            slack_thread_ts="1700000000.000100",
+        )
+
+        handle_support_mention(
+            {
+                "type": "app_mention",
+                "channel": "C_ANY",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U_MENTIONER",
+                "text": "<@U_BOT> bumping this",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.conversations_history.assert_not_called()
+        mock_backfill.assert_not_called()
+        mock_create_or_update.assert_called_once()
+        kwargs = mock_create_or_update.call_args.kwargs
+        assert kwargs["is_thread_reply"] is True
+        assert kwargs["slack_user_id"] == "U_MENTIONER"
+
     @patch("products.conversations.backend.slack.get_slack_client")
     @patch("products.conversations.backend.slack.create_or_update_slack_ticket")
     def test_emoji_reaction_passes_channel_detail(self, mock_create_or_update, mock_get_client):

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -106,16 +106,68 @@ class TestSlackMessageRouting(BaseTest):
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
 
+    @parameterized.expand(
+        [
+            # No ticket yet: seed from the thread's parent message and backfill replies.
+            (
+                "seeds_from_parent",
+                False,
+                [{"user": "U_OP", "text": "Initial message that started the thread"}],
+                True,
+                "U_OP",
+                "Initial message that started the thread",
+                False,
+            ),
+            # Ticket already tracked: just append the mention as a reply, no parent fetch.
+            (
+                "existing_ticket_adds_reply",
+                True,
+                None,
+                False,
+                "U_MENTIONER",
+                "<@U_BOT> please help here",
+                True,
+            ),
+            # Parent unavailable (deleted / API hiccup): fall back to the mention itself.
+            (
+                "parent_unavailable_falls_back",
+                False,
+                [],
+                False,
+                "U_MENTIONER",
+                "<@U_BOT> please help here",
+                False,
+            ),
+        ]
+    )
     @patch(f"{MODULE}._backfill_thread_replies")
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
-    def test_mention_in_thread_seeds_ticket_from_parent_message(
-        self, mock_create_or_update, mock_get_client, mock_backfill
+    def test_thread_reply_mention(
+        self,
+        _name,
+        ticket_exists,
+        history_messages,
+        expect_backfill,
+        expected_user,
+        expected_text,
+        expected_is_thread_reply,
+        mock_create_or_update,
+        mock_get_client,
+        mock_backfill,
     ):
-        mock_get_client.return_value.conversations_history.return_value = {
-            "messages": [{"user": "U_OP", "text": "Initial message that started the thread"}]
-        }
-        mock_create_or_update.return_value = object()
+        if ticket_exists:
+            Ticket.objects.create_with_number(
+                team=self.team,
+                channel_source=Channel.SLACK,
+                widget_session_id="",
+                distinct_id="",
+                slack_channel_id="C_ANY",
+                slack_thread_ts="1700000000.000100",
+            )
+        else:
+            mock_get_client.return_value.conversations_history.return_value = {"messages": history_messages}
+            mock_create_or_update.return_value = object()
 
         handle_support_mention(
             {
@@ -130,80 +182,18 @@ class TestSlackMessageRouting(BaseTest):
             "T123",
         )
 
-        mock_get_client.return_value.conversations_history.assert_called_once()
+        if ticket_exists:
+            mock_get_client.return_value.conversations_history.assert_not_called()
+        else:
+            mock_get_client.return_value.conversations_history.assert_called_once()
+
+        assert mock_backfill.call_count == (1 if expect_backfill else 0)
         mock_create_or_update.assert_called_once()
         kwargs = mock_create_or_update.call_args.kwargs
-        assert kwargs["slack_user_id"] == "U_OP"
-        assert kwargs["text"] == "Initial message that started the thread"
+        assert kwargs["slack_user_id"] == expected_user
+        assert kwargs["text"] == expected_text
         assert kwargs["thread_ts"] == "1700000000.000100"
-        assert kwargs["is_thread_reply"] is False
-        assert kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
-        mock_backfill.assert_called_once()
-
-    @patch(f"{MODULE}._backfill_thread_replies")
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.create_or_update_slack_ticket")
-    def test_mention_in_thread_with_existing_ticket_adds_reply(
-        self, mock_create_or_update, mock_get_client, mock_backfill
-    ):
-        Ticket.objects.create_with_number(
-            team=self.team,
-            channel_source=Channel.SLACK,
-            widget_session_id="",
-            distinct_id="",
-            slack_channel_id="C_ANY",
-            slack_thread_ts="1700000000.000100",
-        )
-
-        handle_support_mention(
-            {
-                "type": "app_mention",
-                "channel": "C_ANY",
-                "thread_ts": "1700000000.000100",
-                "ts": "1700000000.000200",
-                "user": "U_MENTIONER",
-                "text": "<@U_BOT> bumping this",
-            },
-            self.team,
-            "T123",
-        )
-
-        mock_get_client.return_value.conversations_history.assert_not_called()
-        mock_backfill.assert_not_called()
-        mock_create_or_update.assert_called_once()
-        kwargs = mock_create_or_update.call_args.kwargs
-        assert kwargs["is_thread_reply"] is True
-        assert kwargs["slack_user_id"] == "U_MENTIONER"
-
-    @patch(f"{MODULE}._backfill_thread_replies")
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.create_or_update_slack_ticket")
-    def test_mention_in_thread_falls_back_to_mention_when_parent_unavailable(
-        self, mock_create_or_update, mock_get_client, mock_backfill
-    ):
-        # Parent fetch returns nothing (e.g. message deleted or API hiccup) -> fall
-        # back to seeding the ticket from the mention itself rather than dropping it.
-        mock_get_client.return_value.conversations_history.return_value = {"messages": []}
-
-        handle_support_mention(
-            {
-                "type": "app_mention",
-                "channel": "C_ANY",
-                "thread_ts": "1700000000.000100",
-                "ts": "1700000000.000200",
-                "user": "U_MENTIONER",
-                "text": "<@U_BOT> please help here",
-            },
-            self.team,
-            "T123",
-        )
-
-        mock_backfill.assert_not_called()
-        mock_create_or_update.assert_called_once()
-        kwargs = mock_create_or_update.call_args.kwargs
-        assert kwargs["slack_user_id"] == "U_MENTIONER"
-        assert kwargs["text"] == "<@U_BOT> please help here"
-        assert kwargs["is_thread_reply"] is False
+        assert kwargs["is_thread_reply"] is expected_is_thread_reply
         assert kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
 
     @patch("products.conversations.backend.slack.get_slack_client")

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -648,7 +648,10 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
     """
     Handle a Slack 'app_mention' event to create a support ticket.
 
-    The mention message becomes the first message of the ticket.
+    For a top-level mention, the mention message becomes the ticket's first message.
+    For a mention posted as a thread reply on an untracked thread, the ticket is
+    seeded from the message that started the thread (not the mention itself), then
+    the in-between replies are backfilled.
     """
     channel = event.get("channel")
     slack_user_id = event.get("user")
@@ -659,8 +662,9 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
         return
 
     message_ts = event.get("ts")
+    event_thread_ts = event.get("thread_ts")
     # Use thread_ts if in a thread, otherwise the message ts
-    thread_ts = event.get("thread_ts") or message_ts
+    thread_ts = event_thread_ts or message_ts
     if not thread_ts:
         return
 
@@ -681,7 +685,7 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
     # the thread — not the @mention reply — should seed the ticket. Fetch the parent
     # message and create the ticket from it, then backfill the in-between replies
     # (including the mention itself).
-    is_thread_reply_mention = bool(event.get("thread_ts")) and event.get("thread_ts") != message_ts
+    is_thread_reply_mention = bool(event_thread_ts) and event_thread_ts != message_ts
     if not existing and is_thread_reply_mention:
         client = get_slack_client(team)
         try:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -658,8 +658,9 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
     if not channel or not slack_user_id:
         return
 
+    message_ts = event.get("ts")
     # Use thread_ts if in a thread, otherwise the message ts
-    thread_ts = event.get("thread_ts") or event.get("ts")
+    thread_ts = event.get("thread_ts") or message_ts
     if not thread_ts:
         return
 
@@ -675,6 +676,49 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
         slack_channel_id=channel,
         slack_thread_ts=thread_ts,
     ).exists()
+
+    # When the mention is a reply on an untracked thread, the message that started
+    # the thread — not the @mention reply — should seed the ticket. Fetch the parent
+    # message and create the ticket from it, then backfill the in-between replies
+    # (including the mention itself).
+    is_thread_reply_mention = bool(event.get("thread_ts")) and event.get("thread_ts") != message_ts
+    if not existing and is_thread_reply_mention:
+        client = get_slack_client(team)
+        try:
+            result = client.conversations_history(
+                channel=channel,
+                latest=thread_ts,
+                inclusive=True,
+                limit=1,
+            )
+            messages: list[dict] = result.get("messages", [])
+        except Exception:
+            logger.warning("slack_support_mention_parent_fetch_failed", channel=channel, thread_ts=thread_ts)
+            messages = []
+
+        if messages:
+            parent_msg = messages[0]
+            parent_user = parent_msg.get("user", "")
+            parent_text = parent_msg.get("text", "")
+            parent_blocks = parent_msg.get("blocks")
+            parent_files = parent_msg.get("files")
+
+            if parent_user and (parent_text.strip() or parent_files):
+                ticket = create_or_update_slack_ticket(
+                    team=team,
+                    slack_channel_id=channel,
+                    thread_ts=thread_ts,
+                    slack_user_id=parent_user,
+                    text=parent_text,
+                    blocks=parent_blocks,
+                    files=parent_files,
+                    is_thread_reply=False,
+                    slack_team_id=slack_team_id,
+                    channel_detail=ChannelDetail.SLACK_BOT_MENTION,
+                )
+                if ticket:
+                    _backfill_thread_replies(client, team, ticket, channel, thread_ts)
+                return
 
     create_or_update_slack_ticket(
         team=team,


### PR DESCRIPTION
## Problem

When a user posts a message in Slack and someone later replies in the thread tagging the SupportHog bot (@supporthog), the ticket was created from the `app_mention` reply — not from the original message that started the thread. The customer's actual question was lost as the ticket's first message.

## Changes

- `handle_support_mention` in `products/conversations/backend/slack.py`: when the mention is a thread reply on a thread that has no existing ticket, fetch the parent message via conversations_history and create the ticket from that message's author/text/files instead. Then call `_backfill_thread_replies` to pull in everything between the parent and the mention (same pattern used by handle_support_reaction).
- Top-level mentions (no `thread_ts`) and mentions on already-tracked threads are unaffected.
- channel_detail stays `SLACK_BOT_MENTION` in all cases.

## How did you test this code?

- `test_mention_in_thread_seeds_ticket_from_parent_message` — asserts that conversations_history is called, the ticket is created from the original poster's message (is_thread_reply=False), and backfill is triggered.
- `test_mention_in_thread_with_existing_ticket_adds_reply` — asserts that on an already-tracked thread, no parent fetch occurs and the mention is added as a normal reply.
