### PR TITLE
chore(common): reframe common/ as a holding pen, add agent guidance

### DIFF
--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -1,0 +1,28 @@
+# common/ — read before adding code here
+
+`common/` is a **transitional holding pen, not a destination.** It holds shared code that predates a better home. Do not treat it as the default place for new shared code.
+
+## Disclaimer
+
+The name is the smell. A catch-all `common/` reliably rots into a junk drawer — unscoped, unenforced, imported by everything — i.e. a second monolith with worse boundaries than the first. Unlike `products/*` (guarded by tach + turbo), **nothing mechanically guards what lands here**, so the only thing keeping it honest is this file. The goal for `common/` is to **shrink, not grow.**
+
+## Before adding anything here
+
+Pick a home with a real boundary first, in this order:
+
+- `products/<name>/` — owned by one product
+- `tools/` — dev/CI tooling, not shipped at runtime
+- `services/` — independently deployed
+- `packages/` — a clean, published-style leaf with **no back-edges into app code** (see `packages/quill`)
+- `platform/` — cross-cutting glue/infra (aspirational; coordinate before creating it)
+
+Fall back to `common/` **only** when none of those fit _and_ the code can't yet be a clean leaf because it still imports app modules (`lib/*`, `scenes/*`, etc.). If you do, treat it as tracked debt: say so in the PR and name the intended graduation target. "It follows an existing `common/` precedent" is not, on its own, a reason to add more.
+
+## Graduating out
+
+When something here becomes a clean leaf (no back-edges into app code), promote it to `packages/` or into the owning product, and delete it from `common/`. That is the success path — `quill` took it.
+
+## Conventions
+
+- Keep folder names `under_score` cased — dashes break Python imports.
+- Human-facing overview: [README.md](README.md). Repo-wide layout: [monorepo layout](../docs/internal/monorepo-layout.md).

--- a/common/CLAUDE.md
+++ b/common/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/common/README.md
+++ b/common/README.md
@@ -1,8 +1,12 @@
 # Common
 
-Shared libraries, tools, and utilities used across the monorepo.
+Shared libraries, tools, and utilities that predate a better home.
 
-**Transitional bucket** — new code should prefer `platform/`, `tools/`, `products/`, or `services/` depending on what it is. Items here will migrate to more specific locations over time.
+> [!WARNING]
+> **`common/` is a holding pen, not a destination — the goal is to shrink it, not grow it.**
+> A catch-all "common" reliably rots into a junk drawer: unscoped, unenforced, imported by everything — a second monolith with worse boundaries than the first. The name itself is the smell; context-named homes are the cure. Unlike `products/*` (tach + turbo), nothing mechanically guards what lands here, so this disclaimer is the only thing keeping it honest.
+
+New code should go somewhere with a real boundary first — `products/<name>/`, `tools/`, `services/`, or `packages/` (a clean, published-style leaf like `packages/quill`). Land code in `common/` only when none of those fit _and_ it can't yet be a clean leaf because it still imports app modules (`lib/*`, `scenes/*`). When it can stand alone, graduate it out to `packages/` or the owning product and delete it from here. See [AGENTS.md](AGENTS.md) for the agent-facing version.
 
 - Internal RFC: https://github.com/PostHog/product-internal/pull/703
 - Keep folder names `under_score` cased — dashes break Python imports

--- a/docs/internal/monorepo-layout.md
+++ b/docs/internal/monorepo-layout.md
@@ -26,7 +26,7 @@ services/              # Independent backend services
   oauth-proxy/         # OAuth proxy (Cloudflare Worker)
   stripe-app/          # Stripe integration app
 
-common/                # Shared code (transitional - prefer other locations for new code)
+common/                # Shared code — holding pen, NOT a destination (goal: shrink it)
   hogql_parser/        # HogQL parser
 
 tools/                 # Developer/CI tooling, not imported by runtime code
@@ -86,7 +86,11 @@ That destroys the "platform is foundational" property and makes boundaries britt
 
 ### Common
 
-Transitional bucket for shared code that exists today: `hogql_parser` and other cross-cutting utilities. New code should prefer `platform/`, `tools/`, `products/`, or `services/` — `common/` should not become the default dumping ground. Items here will migrate to more specific locations over time.
+A holding pen for shared code that predates a better home (`hogql_parser` and other cross-cutting utilities) — **not** a destination, and the goal is to shrink it, not grow it.
+
+A catch-all "common" reliably rots into a junk drawer: unscoped, unenforced, imported by everything — a second monolith with worse boundaries than the first. The name itself is the smell; context-named homes are the cure. Unlike `products/*` (tach + turbo), nothing mechanically guards what lands here — only the convention, and conventions erode unless they're made hard to violate.
+
+So new code should go somewhere with a real boundary first: `products/<name>/`, `tools/`, `services/`, or `packages/` (a clean, published-style leaf — `packages/quill` is the model). Land code in `common/` only when none of those fit _and_ it can't yet be a clean leaf because it still imports app modules (`lib/*`, `scenes/*`); when that's the case, treat it as tracked debt and name the graduation target. Once something here becomes a clean leaf, promote it out to `packages/` or the owning product and delete it from `common/`. See `common/AGENTS.md` for the agent-facing rules.
 
 ### Tools
 


### PR DESCRIPTION
## Problem

`common/` is meant to be transitional — shared code that predates a better home — but the only thing saying so was a soft "transitional bucket" line in the README and layout doc, and there was no agent-facing file at all. That's the weakest possible guardrail on the one directory we most want to shrink. A prose convention erodes the moment a large PR cites "it follows an existing `common/` precedent" as license to add more, which is exactly the pressure `common/` is under right now.

## Changes

Sharpen the framing across the three touchpoints so the stance is unambiguous — `common/` is a holding pen, not a destination, and the goal is to shrink it, not grow it:

- `common/README.md` — leads with a warning callout; spells out "pick a real home first" and the graduation path.
- `docs/internal/monorepo-layout.md` — tree comment + `### Common` section rewritten with the same framing, including why a catch-all rots (junk drawer, no mechanical boundary unlike `products/*`).
- `common/AGENTS.md` (+ `CLAUDE.md` symlink) — new, agent-facing rules matching the repo convention (real file + symlink). Gives an ordered home-selection list and explicitly rejects "precedent" as a reason to add more.

No mechanical enforcement here — that's the real fix (e.g. a tach boundary on `common/` so back-edges into app code are counted and capped) and a separate follow-up. This PR just makes the convention sharp and visible to both humans and agents.

## How did you test this code?

Docs only. Authored by an agent (Claude Code); markdown lint ran clean via lint-staged on commit. No code paths touched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @webjunkie. Came out of reasoning about whether large new packages belong in `common/` (prompted by the query-frontend refactor in #63334) and a short web-research pass on the shared/common "junk drawer" anti-pattern — consensus being that the fix isn't deleting the bucket but giving it scoped, enforced boundaries, and that conventions without enforcement erode. This PR is the convention-tightening half; enforcement is a planned follow-up.

Authored with Claude Code (Opus 4.8).
