### PR TITLE
fix(llma): scope trace clustering reads via durable summary events

### DIFF
--- a/posthog/temporal/ai_observability/trace_clustering/data.py
+++ b/posthog/temporal/ai_observability/trace_clustering/data.py
@@ -26,6 +26,8 @@ from posthog.temporal.ai_observability.trace_clustering.models import (
     ItemSummaries,
 )
 
+from products.ai_observability.backend.summarization.models import SummarizationMode
+
 logger = structlog.get_logger(__name__)
 
 # ClickHouse max_execution_time for clustering queries (seconds).
@@ -42,18 +44,23 @@ def fetch_item_embeddings_for_clustering(
     analysis_level: AnalysisLevel = "trace",
     job_id: str | None = None,
 ) -> tuple[list[ItemId], ItemEmbeddings, ItemBatchRunIds]:
-    """Query item IDs and embeddings from document_embeddings table.
+    """Query item IDs and embeddings from the document_embeddings table.
 
     Two paths:
-    - job_id present: scope to one ClusteringJob via ``metadata.job_id``
-    - no job_id: return all embeddings for the document type (legacy/unfiltered)
 
-    The ``batch_run_id`` used to pair each embedding with its summary event now lives in the
-    embedding's ``metadata`` JSON (read via JSONExtractString); ``rendering`` is just the
-    summary mode. Transitional fallbacks keep pre-migration rows working: the job filter also
-    suffix-matches the legacy ``rendering = {team}_{ts}_{job_id}`` form, and the batch_run_id
-    falls back to ``rendering`` when ``metadata.batch_run_id`` is absent. Both fallbacks can be
-    dropped once the table's 3-month TTL has cycled out all pre-migration rows.
+    - **job_id present** — scope to one ClusteringJob via its durable summary events
+      (``$ai_clustering_job_id``), then read the shared per-item embeddings by ``document_id``.
+      The embeddings' own ``metadata.job_id`` is deliberately *not* used for scoping: the table
+      is a ReplacingMergeTree keyed on ``(team_id, toDate(timestamp), product, document_type,
+      rendering, cityHash64(document_id))``, so when two jobs summarize the same item on the same
+      day in the same mode their rows share a key and collapse on merge — only one job's
+      ``metadata.job_id`` survives, and the other job would silently lose those embeddings. The
+      summary events are written one-per-job-run and never collapse, so each job recovers its
+      own complete sample regardless of overlap.
+    - **no job_id** — return all embeddings for the document type (legacy/unfiltered), pairing
+      each embedding to its summary via ``batch_run_id`` (metadata, falling back to the
+      pre-migration ``rendering`` form). The fallback can be dropped once the table's 3-month TTL
+      has cycled out all pre-migration rows.
     """
     document_type = (
         constants.LLMA_GENERATION_DOCUMENT_TYPE
@@ -62,52 +69,43 @@ def fetch_item_embeddings_for_clustering(
     )
 
     if job_id:
-        query = parse_select(
-            """
-            SELECT document_id, embedding, rendering, JSONExtractString(metadata, 'batch_run_id') AS meta_batch_run_id
-            FROM raw_document_embeddings
-            WHERE timestamp >= {start_dt}
-                AND timestamp < {end_dt}
-                AND product = {product}
-                AND document_type = {document_type}
-                AND length(embedding) > 0
-                AND (JSONExtractString(metadata, 'job_id') = {job_id} OR endsWith(rendering, {job_id_suffix}))
-            ORDER BY rand()
-            LIMIT {max_samples}
-            """
+        return _fetch_job_scoped_embeddings(
+            team=team,
+            job_id=job_id,
+            window_start=window_start,
+            window_end=window_end,
+            max_samples=max_samples,
+            analysis_level=analysis_level,
+            document_type=document_type,
         )
-    else:
-        query = parse_select(
-            """
-            SELECT document_id, embedding, rendering, JSONExtractString(metadata, 'batch_run_id') AS meta_batch_run_id
-            FROM raw_document_embeddings
-            WHERE timestamp >= {start_dt}
-                AND timestamp < {end_dt}
-                AND product = {product}
-                AND (
-                    document_type = {document_type}
-                    OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
-                )
-                AND length(embedding) > 0
-            ORDER BY rand()
-            LIMIT {max_samples}
-            """
-        )
+
+    # Legacy/unfiltered path (no clustering job): all embeddings for the document type in-window.
+    query = parse_select(
+        """
+        SELECT document_id, embedding, rendering, JSONExtractString(metadata, 'batch_run_id') AS meta_batch_run_id
+        FROM raw_document_embeddings
+        WHERE timestamp >= {start_dt}
+            AND timestamp < {end_dt}
+            AND product = {product}
+            AND (
+                document_type = {document_type}
+                OR (document_type = {document_type_legacy} AND rendering = {rendering_legacy})
+            )
+            AND length(embedding) > 0
+        ORDER BY rand()
+        LIMIT {max_samples}
+        """
+    )
 
     placeholders: dict[str, ast.Expr] = {
         "start_dt": ast.Constant(value=window_start),
         "end_dt": ast.Constant(value=window_end),
         "product": ast.Constant(value=constants.LLMA_TRACE_PRODUCT),
         "document_type": ast.Constant(value=document_type),
+        "document_type_legacy": ast.Constant(value=constants.LLMA_TRACE_DOCUMENT_TYPE_LEGACY),
+        "rendering_legacy": ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY),
         "max_samples": ast.Constant(value=max_samples),
     }
-
-    if job_id:
-        placeholders["job_id"] = ast.Constant(value=job_id)
-        placeholders["job_id_suffix"] = ast.Constant(value=f"_{job_id}")
-    else:
-        placeholders["document_type_legacy"] = ast.Constant(value=constants.LLMA_TRACE_DOCUMENT_TYPE_LEGACY)
-        placeholders["rendering_legacy"] = ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY)
 
     with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team.id):
         result = execute_hogql_query(
@@ -132,15 +130,13 @@ def fetch_item_embeddings_for_clustering(
     embeddings_map: ItemEmbeddings = {}
     batch_run_ids_map: ItemBatchRunIds = {}
 
-    # `rendering` values that are NOT batch_run_ids: the current mode enum (post-migration
-    # rendering = the summary mode) plus the older legacy render modes. A row whose rendering
-    # is one of these and whose metadata lacks a batch_run_id contributes no pairing key, so
-    # fetch_item_summaries falls back to accepting any matching summary.
+    # `rendering` values that are NOT batch_run_ids: the current summary-mode enum plus the older
+    # legacy render modes. A row whose rendering is one of these and whose metadata lacks a
+    # batch_run_id contributes no pairing key, so fetch_item_summaries accepts any matching summary.
     non_batch_run_id_renderings = {
         constants.LLMA_TRACE_RENDERING_LEGACY,  # "llma_trace_detailed"
-        "llma_trace_minimal",  # Other legacy mode
-        "detailed",  # SummarizationMode.DETAILED — current rendering value
-        "minimal",  # SummarizationMode.MINIMAL — current rendering value
+        "llma_trace_minimal",  # legacy minimal rendering
+        *(mode.value for mode in SummarizationMode),  # current rendering values
     }
 
     for row in rows:
@@ -159,6 +155,139 @@ def fetch_item_embeddings_for_clustering(
             batch_run_ids_map[item_id] = rendering_value
 
     return item_ids, embeddings_map, batch_run_ids_map
+
+
+def _fetch_job_scoped_item_ids(
+    team: Team,
+    job_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    max_samples: int,
+    analysis_level: AnalysisLevel,
+) -> list[ItemId]:
+    """Item ids a clustering job summarized in-window, read from its durable summary events.
+
+    ``$ai_trace_summary`` / ``$ai_generation_summary`` events carry ``$ai_clustering_job_id`` and
+    are written one-per-job-run, so they never collapse the way the embeddings ReplacingMergeTree
+    rows do — two jobs that sampled the same item each recover their own complete scope.
+    Random-sampled to ``max_samples`` to bound the downstream embedding read.
+    """
+    event_name = "$ai_generation_summary" if analysis_level == "generation" else "$ai_trace_summary"
+    id_property = "$ai_generation_id" if analysis_level == "generation" else "$ai_trace_id"
+
+    # ast.Field placeholders so HogQL resolves materialized columns instead of JSONExtract.
+    query = parse_select(
+        """
+        SELECT {id_prop} AS item_id
+        FROM events
+        WHERE event = {event_name}
+            AND timestamp >= {start_dt}
+            AND timestamp < {end_dt}
+            AND {job_id_prop} = {job_id}
+        GROUP BY item_id
+        ORDER BY rand()
+        LIMIT {max_samples}
+        """
+    )
+
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team.id):
+        result = execute_hogql_query(
+            query_type="JobScopedItemIdsForClustering",
+            query=query,
+            placeholders={
+                "id_prop": ast.Field(chain=["properties", id_property]),
+                "event_name": ast.Constant(value=event_name),
+                "start_dt": ast.Constant(value=window_start),
+                "end_dt": ast.Constant(value=window_end),
+                "job_id_prop": ast.Field(chain=["properties", "$ai_clustering_job_id"]),
+                "job_id": ast.Constant(value=job_id),
+                "max_samples": ast.Constant(value=max_samples),
+            },
+            team=team,
+            settings=HogQLGlobalSettings(max_execution_time=CLUSTERING_QUERY_MAX_EXECUTION_TIME),
+        )
+
+    rows = result.results or []
+    return [row[0] for row in rows if row[0]]
+
+
+def _fetch_job_scoped_embeddings(
+    team: Team,
+    job_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    max_samples: int,
+    analysis_level: AnalysisLevel,
+    document_type: str,
+) -> tuple[list[ItemId], ItemEmbeddings, ItemBatchRunIds]:
+    """Embeddings for the items a clustering job summarized, scoped via its summary events.
+
+    Embeddings are shared per ``(item, mode)`` and read by ``document_id``, so overlapping jobs
+    reuse the same row without collision. ``batch_run_ids`` comes back empty: pairing is by
+    ``item_id`` downstream (fetch_item_summaries accepts any matching summary when no batch_run_id
+    is supplied), since there is no per-job embedding row to match against.
+    """
+    item_ids = _fetch_job_scoped_item_ids(
+        team=team,
+        job_id=job_id,
+        window_start=window_start,
+        window_end=window_end,
+        max_samples=max_samples,
+        analysis_level=analysis_level,
+    )
+    if not item_ids:
+        logger.info(
+            "fetch_item_embeddings_for_clustering_result",
+            num_rows=0,
+            num_items=0,
+            analysis_level=analysis_level,
+            job_id=job_id,
+        )
+        return [], {}, {}
+
+    query = parse_select(
+        """
+        SELECT document_id, embedding
+        FROM raw_document_embeddings
+        WHERE timestamp >= {start_dt}
+            AND timestamp < {end_dt}
+            AND product = {product}
+            AND document_type = {document_type}
+            AND document_id IN {item_ids}
+            AND length(embedding) > 0
+        """
+    )
+    item_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=iid) for iid in item_ids])
+
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team.id):
+        result = execute_hogql_query(
+            query_type="ItemEmbeddingsForClustering",
+            query=query,
+            placeholders={
+                "start_dt": ast.Constant(value=window_start),
+                "end_dt": ast.Constant(value=window_end),
+                "product": ast.Constant(value=constants.LLMA_TRACE_PRODUCT),
+                "document_type": ast.Constant(value=document_type),
+                "item_ids": item_ids_tuple,
+            },
+            team=team,
+            settings=HogQLGlobalSettings(max_execution_time=CLUSTERING_QUERY_MAX_EXECUTION_TIME),
+        )
+
+    rows = result.results or []
+    # Dedupe on document_id: pre-merge the table can briefly hold one row per job for the same
+    # item, but the embedding content is identical, so either row is fine.
+    embeddings_map: ItemEmbeddings = {row[0]: row[1] for row in rows}
+    scoped_item_ids: list[ItemId] = list(embeddings_map.keys())
+
+    logger.info(
+        "fetch_item_embeddings_for_clustering_result",
+        num_rows=len(rows),
+        num_items=len(scoped_item_ids),
+        analysis_level=analysis_level,
+        job_id=job_id,
+    )
+    return scoped_item_ids, embeddings_map, {}
 
 
 def fetch_item_summaries(

--- a/posthog/temporal/ai_observability/trace_clustering/tests/test_data.py
+++ b/posthog/temporal/ai_observability/trace_clustering/tests/test_data.py
@@ -114,14 +114,20 @@ class TestFetchItemEmbeddingsForClustering:
         assert "job_id_suffix" not in call_kwargs["placeholders"]
 
     @patch("posthog.temporal.ai_observability.trace_clustering.data.execute_hogql_query")
-    def test_job_id_filters_by_metadata_with_rendering_fallback(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = [
-            ("trace_1", [0.1, 0.2], "detailed", "2_abc-123"),
+    def test_job_id_scopes_via_summary_events_then_fetches_shared_embeddings(self, mock_execute, mock_team):
+        # The job path scopes its sample from the durable summary events ($ai_clustering_job_id),
+        # then reads the shared per-item embeddings by document_id — NOT by the embeddings'
+        # metadata.job_id, which a ReplacingMergeTree merge can drop for overlapping jobs.
+        items_result = MagicMock()
+        items_result.results = [("trace_1",), ("trace_2",)]
+        embeddings_result = MagicMock()
+        embeddings_result.results = [
+            ("trace_1", [0.1, 0.2]),
+            ("trace_2", [0.3, 0.4]),
         ]
-        mock_execute.return_value = mock_result
+        mock_execute.side_effect = [items_result, embeddings_result]
 
-        fetch_item_embeddings_for_clustering(
+        trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
@@ -129,35 +135,65 @@ class TestFetchItemEmbeddingsForClustering:
             job_id="abc-123",
         )
 
-        call_kwargs = mock_execute.call_args.kwargs
-        # job scoping reads metadata.job_id, with a transitional suffix match on legacy rendering
-        assert call_kwargs["placeholders"]["job_id"].value == "abc-123"
-        assert call_kwargs["placeholders"]["job_id_suffix"].value == "_abc-123"
-        # job_id path should not include legacy fallback placeholders
-        assert "document_type_legacy" not in call_kwargs["placeholders"]
-        assert "rendering_legacy" not in call_kwargs["placeholders"]
+        assert trace_ids == ["trace_1", "trace_2"]
+        assert embeddings_map == {"trace_1": [0.1, 0.2], "trace_2": [0.3, 0.4]}
+        # No per-job embedding row to pair against — summaries pair by item_id downstream.
+        assert batch_run_ids == {}
+
+        assert mock_execute.call_count == 2
+        scope_call, embeddings_call = mock_execute.call_args_list
+        # First query scopes by the clustering job's summary events.
+        assert scope_call.kwargs["query_type"] == "JobScopedItemIdsForClustering"
+        assert scope_call.kwargs["placeholders"]["job_id"].value == "abc-123"
+        assert scope_call.kwargs["placeholders"]["event_name"].value == "$ai_trace_summary"
+        # Second query fetches embeddings by document_id, never by metadata.job_id.
+        assert embeddings_call.kwargs["query_type"] == "ItemEmbeddingsForClustering"
+        assert "item_ids" in embeddings_call.kwargs["placeholders"]
+        assert "job_id" not in embeddings_call.kwargs["placeholders"]
 
     @patch("posthog.temporal.ai_observability.trace_clustering.data.execute_hogql_query")
-    def test_returns_empty_when_no_results(self, mock_execute, mock_team):
-        mock_result = MagicMock()
-        mock_result.results = []
-        mock_execute.return_value = mock_result
+    def test_job_id_generation_level_scopes_by_generation_summary_events(self, mock_execute, mock_team):
+        items_result = MagicMock()
+        items_result.results = [("gen_1",)]
+        embeddings_result = MagicMock()
+        embeddings_result.results = [("gen_1", [0.1, 0.2])]
+        mock_execute.side_effect = [items_result, embeddings_result]
+
+        item_ids, embeddings_map, _batch_run_ids = fetch_item_embeddings_for_clustering(
+            team=mock_team,
+            window_start=datetime(2025, 1, 1, tzinfo=UTC),
+            window_end=datetime(2025, 1, 8, tzinfo=UTC),
+            max_samples=100,
+            analysis_level="generation",
+            job_id="abc-123",
+        )
+
+        assert item_ids == ["gen_1"]
+        assert embeddings_map == {"gen_1": [0.1, 0.2]}
+        scope_call = mock_execute.call_args_list[0]
+        assert scope_call.kwargs["placeholders"]["event_name"].value == "$ai_generation_summary"
+
+    @patch("posthog.temporal.ai_observability.trace_clustering.data.execute_hogql_query")
+    def test_job_id_returns_empty_without_a_second_query_when_no_summary_events(self, mock_execute, mock_team):
+        # No summary events for the job → no embedding read at all (early return).
+        items_result = MagicMock()
+        items_result.results = []
+        mock_execute.return_value = items_result
 
         trace_ids, embeddings_map, batch_run_ids = fetch_item_embeddings_for_clustering(
             team=mock_team,
             window_start=datetime(2025, 1, 1, tzinfo=UTC),
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
             max_samples=100,
-            job_id="some-job",
+            job_id="abc-123",
         )
 
-        assert trace_ids == []
-        assert embeddings_map == {}
-        assert batch_run_ids == {}
+        assert (trace_ids, embeddings_map, batch_run_ids) == ([], {}, {})
+        assert mock_execute.call_count == 1
 
     @patch("posthog.temporal.ai_observability.trace_clustering.data.execute_hogql_query")
-    def test_single_query_for_all_cases(self, mock_execute, mock_team):
-        """Both job_id and no-job_id paths use a single execute_hogql_query call."""
+    def test_no_job_path_uses_single_query(self, mock_execute, mock_team):
+        """The unfiltered (no job_id) path reads embeddings in a single query."""
         mock_result = MagicMock()
         mock_result.results = [("id_1", [0.1], "detailed", "batch_1")]
         mock_execute.return_value = mock_result
@@ -168,7 +204,6 @@ class TestFetchItemEmbeddingsForClustering:
             window_end=datetime(2025, 1, 8, tzinfo=UTC),
             max_samples=100,
             analysis_level="generation",
-            job_id="test-job",
         )
 
         assert mock_execute.call_count == 1

--- a/posthog/temporal/ai_observability/trace_summarization/tests/test_summarize_and_save.py
+++ b/posthog/temporal/ai_observability/trace_summarization/tests/test_summarize_and_save.py
@@ -143,7 +143,7 @@ class TestSummarizeAndSaveActivity:
             ) as mock_create_event,
             patch(
                 "posthog.temporal.ai_observability.trace_summarization.summarize_and_save.LLMTracesSummarizerEmbedder"
-            ),
+            ) as mock_embedder_class,
         ):
             mock_load.return_value = "generation text repr"
             mock_summarize.return_value = mock_summary
@@ -158,6 +158,14 @@ class TestSummarizeAndSaveActivity:
             assert call_kwargs["properties"]["$ai_generation_id"] == generation_id
             assert call_kwargs["properties"]["$ai_clustering_job_id"] == input_data.job_id
             assert call_kwargs["properties"]["$ai_clustering_job_name"] == input_data.job_name
+
+            # rendering stays the low-cardinality mode enum; batch_run_id + job_id live in metadata
+            embed_kwargs = mock_embedder_class.return_value.embed_document.call_args.kwargs
+            assert embed_kwargs["rendering"] == input_data.mode
+            assert embed_kwargs["metadata"] == {
+                "batch_run_id": input_data.batch_run_id,
+                "job_id": input_data.job_id,
+            }
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Follow-up to #63493. That PR moved the clustering `job_id` out of the LowCardinality `rendering` column into the embedding's `metadata` JSON. That fixed the cardinality problem but introduced a silent data-loss regression in clustering reads.

`document_embeddings` is a ReplacingMergeTree keyed on `(team_id, toDate(timestamp), product, document_type, rendering, cityHash64(document_id))`. When two clustering jobs summarize the **same** trace/generation on the same day in the same mode, their rows now share a key (the `job_id` discriminator lives in `metadata`, which is not part of the key) and collapse on merge. Only one job's `metadata.job_id` survives, so the clustering read for the *other* job — which filters embeddings by `JSONExtractString(metadata, 'job_id')` — silently drops those items.

It's a time-dependent failure: `raw_document_embeddings` is read without `FINAL`, so both jobs' rows are visible until a background merge collapses them, after which one job loses data. Overlapping jobs sampling the same item is a real, expected scenario.

## Changes

Scope a clustering job's sample from its **durable summary events** instead of from the collapse-fragile embedding metadata:

- The job path of `fetch_item_embeddings_for_clustering` now reads the job's item ids from its `$ai_trace_summary` / `$ai_generation_summary` events via `$ai_clustering_job_id` (set on every summary event since #49525, one event per job-run, never RMT-collapsed), then fetches the shared per-item embeddings by `document_id`.
- Embeddings stay one-per-`(item, mode)` and `document_id` stays equal to the trace/generation id, so the shared vector index and the user-facing `find_similar_traces` search (which maps result `document_id` → `LLMTraceSummary.trace_id`) are unaffected.
- `batch_run_ids` comes back empty for the job path: there is no per-job embedding row to pair against, so summaries pair by `item_id` downstream (`fetch_item_summaries` already accepts any matching summary when no batch_run_id is supplied). For a trace summarized by two jobs this uses whichever job's summary the query returns — equivalent for labeling since same trace+mode summaries are interchangeable.
- Covers trace- **and** generation-level clustering (via `analysis_level`). The unfiltered no-job path is unchanged.

Considered and rejected the alternative of making embeddings per-job (composing `document_id` with `job_id`): it would break `find_similar_traces` (composite ids no longer match `trace_id`) and pollute the shared vector index with duplicate vectors.

**Out of scope:** the `evaluation_clustering` path shares the same `metadata.job_id` pattern but this approach doesn't fit it — its `document_id` is already a unique event uuid, its sample is a non-reproducible `ORDER BY rand()` draw, and there is no durable event carrying the job→eval-event mapping to scope from. It was not touched by #63493. Fixed separately (per-job `document_id`) in #63511.

Also addresses two review comments from #63493: splat `SummarizationMode` into the legacy rendering set (no drift if a third mode is added), and mirror the rendering/metadata assertions onto the generation summary test.

## ClickHouse performance

This turns one embeddings query into two. Net impact is roughly neutral; the change is contained to a background Temporal activity (120s timeout), so the extra round-trip is immaterial.

- **Embeddings fetch (changed): marginally cheaper.** Old filtered `JSONExtractString(metadata, 'job_id') = {job_id}`; new filters `document_id IN (≤max_samples ids)`. Same granules scanned either way (the embeddings sort key is `(team_id, toDate(timestamp), product, document_type, rendering, cityHash64(document_id))`, so neither predicate prunes below `document_type`), but a per-row hash-set lookup beats a per-row JSON parse. The `ORDER BY rand() LIMIT` moves off this query; the result is bounded by the id set.
- **Summary-events scan (new): bounded.** The added query hits `events` filtered by `event = '$ai_trace_summary'` / `'$ai_generation_summary'` + timestamp window. `event` is in the events sort key (`team_id, toDate(timestamp), event, …`), so granule pruning restricts the scan to one team's summary events in the window — a low-volume set written by the summarization pipeline (≈one per summarized item), not raw product traffic. `fetch_item_summaries` already queries these same events, so it's an established access pattern. `ORDER BY rand() LIMIT max_samples` matches the sampling pattern the old embeddings query already used, so no new risk class.
- **Materialization (minor lever, not a blocker):** the `properties.$ai_clustering_job_id` filter and `properties.$ai_trace_id` / `$ai_generation_id` select may not be materialized columns. If not, there's a JSON parse per row — but only over the already-pruned summary-event set, so the cost is small. The id field is written as `ast.Field(["properties", …])` so HogQL uses the materialized column when one exists.
- **Thing to keep an eye on:** a team with an enormous number of summary events in the window could make the `ORDER BY rand()` more expensive — but that was already a property of the prior design.

## How did you test this code?

I'm an agent (Claude Code, directed by Andy). Automated tests I ran locally:

- `posthog/temporal/ai_observability/trace_clustering/tests/test_data.py` — 13 passed. Updated the job-path tests to assert the two-query event-scoped flow (scope query uses `$ai_clustering_job_id`; embedding query filters by `document_id`, never `metadata.job_id`), added a generation-level scope test, and a no-summary-events early-return test. No-job legacy path tests unchanged and passing.
- `posthog/temporal/ai_observability/trace_summarization/tests/test_summarize_and_save.py` — 4 passed, including the newly mirrored generation assertions.
- `ruff check` / `ruff format` / `ty check` clean (via pre-commit).

No manual testing against a live cluster.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the work; assigned as DRI.

Used Claude Code (Opus 4.8). Started from Carlos's review on #63493 (an approving review with a Codex P1 flagging the per-job collapse, plus Carlos's "could this actually happen?"). Confirmed with Andy that overlapping jobs are real, then audited the blast radius across the shared `document_embeddings` table before choosing an approach.

Key decision: weighed "Option A" (scope via summary events, embeddings stay shared) against "Option B" (per-job `document_id`). B looked like the smaller diff but the blast-radius audit showed `document_id` is load-bearing for `find_similar_traces` and that B would duplicate vectors in the shared index — so A is both more correct and lower-risk for the rest of the system. Verified `$ai_clustering_job_id` has been on summary events far longer than the 7-day clustering lookback, so no transitional fallback is needed.

