### PR TITLE
chore(phai): grant full read/write in MCP API key preset

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -192,11 +192,7 @@ export const API_KEY_SCOPE_PRESETS: {
     {
         value: 'mcp_server',
         label: 'MCP Server',
-        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway')).map(({ key }) =>
-            ['feature_flag', 'insight', 'dashboard', 'survey', 'experiment', 'event_definition'].includes(key)
-                ? `${key}:write`
-                : `${key}:read`
-        ),
+        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway')).map(({ key }) => `${key}:write`),
         access_type: 'all',
     },
     {

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -192,7 +192,9 @@ export const API_KEY_SCOPE_PRESETS: {
     {
         value: 'mcp_server',
         label: 'MCP Server',
-        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway')).map(({ key }) => `${key}:write`),
+        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway') && key !== 'file_system').map(
+            ({ key }) => `${key}:write`
+        ),
         access_type: 'all',
     },
     {

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -192,7 +192,7 @@ export const API_KEY_SCOPE_PRESETS: {
     {
         value: 'mcp_server',
         label: 'MCP Server',
-        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway') && key !== 'file_system').map(
+        scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway') && !key.includes('file_system')).map(
             ({ key }) => `${key}:write`
         ),
         access_type: 'all',


### PR DESCRIPTION
## Problem

The **MCP Server** personal API key preset granted `:write` on only six resources (feature flags, insights, dashboards, surveys, experiments, event definitions) and `:read` on everything else. That left MCP keys unable to write most resources, even though MCP tooling increasingly needs broader write access.

## Changes

The MCP Server preset now grants `:write` on **every** scope except those containing `llm_gateway`. Since `:write` implies `:read` in PostHog's scope check (`permissions.py` — a read requirement is satisfied by either `:read` or `:write`), this gives MCP keys full read/write across all non-`llm_gateway` resources.

```ts
scopes: API_SCOPES.filter(({ key }) => !key.includes('llm_gateway')).map(({ key }) => `${key}:write`),
```

This also drops the now-redundant per-resource write allowlist.

## How did you test this code?

Manual reasoning against the scope enforcement logic: confirmed `:write` satisfies `:read` requirements in `posthog/permissions.py`, so granting `:write` on all non-`llm_gateway` scopes yields full read/write. The preset is a pure derivation over `API_SCOPES`; no behavioral change beyond the broadened scope set.

## Publish to changelog?

no
