### PR TITLE
fix(visual-review): exclude quarantined and tolerated snapshots from approval comment

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1790,6 +1790,22 @@ def _image_cell(url: str | None, alt: str) -> str:
 _IMAGE_TABLE_HEADER = "| Snapshot | Before | After |\n| --- | --- | --- |"
 
 
+_REVIEWABLE_RESULTS = (SnapshotResult.CHANGED, SnapshotResult.NEW, SnapshotResult.REMOVED)
+
+
+def _reviewable_snapshot_qs(run: Run) -> db_models.QuerySet[RunSnapshot]:
+    return run.snapshots.using(READER_DB).filter(result__in=_REVIEWABLE_RESULTS)
+
+
+def _postable_snapshot_qs(run: Run) -> db_models.QuerySet[RunSnapshot]:
+    """Reviewable snapshots minus the ones an approval comment should not surface.
+
+    Quarantined snapshots are suppressed by policy and tolerated ones are
+    intentional known drift, so neither belongs in the comment.
+    """
+    return _reviewable_snapshot_qs(run).exclude(is_quarantined=True).exclude(review_state=ReviewState.TOLERATED)
+
+
 def _build_snapshot_image_tables(run: Run, repo: Repo) -> str:
     """Before/after image tables for the approved snapshots.
 
@@ -1800,8 +1816,7 @@ def _build_snapshot_image_tables(run: Run, repo: Repo) -> str:
     resolved (e.g. object storage disabled) so the comment stays text-only.
     """
     snapshots = list(
-        run.snapshots.using(READER_DB)
-        .filter(result__in=(SnapshotResult.CHANGED, SnapshotResult.NEW, SnapshotResult.REMOVED))
+        _postable_snapshot_qs(run)
         .select_related(
             "current_artifact",
             "current_artifact__thumbnail",
@@ -1861,11 +1876,8 @@ def _build_approval_comment_body(run: Run, repo: Repo, approver: _Approver | Non
     reviewer can eyeball them without leaving the PR (omitted when no image can
     be resolved).
     """
-    counts = Counter(
-        run.snapshots.filter(
-            result__in=(SnapshotResult.CHANGED, SnapshotResult.NEW, SnapshotResult.REMOVED)
-        ).values_list("result", flat=True)
-    )
+    counts = Counter(_postable_snapshot_qs(run).values_list("result", flat=True))
+    suppressed_only = not counts and _reviewable_snapshot_qs(run).exists()
 
     if approver is None:
         approver_text = "a reviewer"
@@ -1892,6 +1904,8 @@ def _build_approval_comment_body(run: Run, repo: Repo, approver: _Approver | Non
     ]
     if summary:
         sections.append(f"{summary}.")
+    elif suppressed_only:
+        sections.append("All visual changes in this run were quarantined or tolerated.")
     if add_images:
         tables = _build_snapshot_image_tables(run, repo)
         if tables:

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -2428,6 +2428,70 @@ class TestApprovalComment:
         assert "changed" not in body
         assert "new" not in body
         assert "removed" not in body
+        # A genuinely empty run stays silent — the suppressed-only note must not fire
+        assert "quarantined or tolerated" not in body
+
+    def test_build_approval_comment_body_excludes_quarantined_and_tolerated(self, repo):
+        run = Run.objects.create(
+            team_id=repo.team_id,
+            repo=repo,
+            commit_sha="mixed",
+            branch="feature",
+            pr_number=42,
+            review_decision=ReviewDecision.HUMAN_APPROVED,
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id, run=run, identifier="Real/Change", result=SnapshotResult.CHANGED
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run,
+            identifier="Flaky/Quarantined",
+            result=SnapshotResult.CHANGED,
+            is_quarantined=True,
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run,
+            identifier="Known/Tolerated",
+            result=SnapshotResult.NEW,
+            review_state=ReviewState.TOLERATED,
+        )
+
+        body = logic._build_approval_comment_body(run, repo, logic._Approver(label="bob", is_github_login=True))
+
+        assert "1 changed." in body
+        assert "new" not in body
+        assert "quarantined or tolerated" not in body
+
+    def test_build_approval_comment_body_notes_when_only_quarantined_and_tolerated(self, repo):
+        run = Run.objects.create(
+            team_id=repo.team_id,
+            repo=repo,
+            commit_sha="suppressed",
+            branch="feature",
+            pr_number=42,
+            review_decision=ReviewDecision.HUMAN_APPROVED,
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run,
+            identifier="Flaky/Quarantined",
+            result=SnapshotResult.CHANGED,
+            is_quarantined=True,
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run,
+            identifier="Known/Tolerated",
+            result=SnapshotResult.NEW,
+            review_state=ReviewState.TOLERATED,
+        )
+
+        body = logic._build_approval_comment_body(run, repo, logic._Approver(label="bob", is_github_login=True))
+
+        assert "All visual changes in this run were quarantined or tolerated." in body
+        assert "1 changed" not in body
 
     def test_post_approval_comment_skips_when_pr_comments_disabled(self, repo, run_with_snapshots, mocker):
         repo.enable_pr_comments = False
@@ -2598,6 +2662,35 @@ class TestApprovalComment:
         assert "_(none)_" in body
         # Long-lived URL so GitHub's image proxy can still fetch it later
         assert f"exp={logic._COMMENT_IMAGE_URL_EXPIRATION}" in body
+
+    def test_build_snapshot_image_tables_excludes_quarantined_and_tolerated(self, repo, run_with_artifacts, mocker):
+        mocker.patch.object(logic, "ArtifactStorage", self._fake_storage())
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run_with_artifacts,
+            identifier="Flaky/Quarantined",
+            result=SnapshotResult.CHANGED,
+            is_quarantined=True,
+            baseline_artifact=self._mk_artifact(repo, "base_q"),
+            current_artifact=self._mk_artifact(repo, "curr_q"),
+        )
+        RunSnapshot.objects.create(
+            team_id=repo.team_id,
+            run=run_with_artifacts,
+            identifier="Known/Tolerated",
+            result=SnapshotResult.CHANGED,
+            review_state=ReviewState.TOLERATED,
+            baseline_artifact=self._mk_artifact(repo, "base_t"),
+            current_artifact=self._mk_artifact(repo, "curr_t"),
+        )
+
+        body = logic._build_snapshot_image_tables(run_with_artifacts, repo)
+
+        assert "Flaky/Quarantined" not in body
+        assert "Known/Tolerated" not in body
+        assert "curr_q" not in body
+        assert "curr_t" not in body
+        assert "Login/Form" in body
 
     def test_build_approval_comment_body_deep_links_each_snapshot(self, repo, run_with_artifacts, mocker):
         mocker.patch.object(logic, "ArtifactStorage", self._fake_storage())


### PR DESCRIPTION
## Problem

The post-approval PR comment (shipped in #62635) summarised counts and embedded before/after images straight from the changed/new/removed set. That set includes **quarantined** snapshots (suppressed by policy) and **tolerated** ones (intentional, known drift). Neither belongs in the approval comment — surfacing them posts noise a reviewer has already decided not to care about.

## Changes

- A shared `_postable_snapshot_qs` helper is now the single source of truth for "changed/new/removed snapshots a reviewer should see", excluding `is_quarantined=True` and `review_state=TOLERATED`.
- Both the textual summary counts and the before/after image tables draw from that helper, so quarantined and tolerated snapshots no longer appear in either.
- When the only changes in a run were quarantined or tolerated, the comment now says "All visual changes in this run were quarantined or tolerated." rather than implying there was nothing to review.

Backend-only; no frontend or schema changes.

## How did you test this code?

I'm an agent. I added and ran automated backend tests (no manual testing):

- `test_build_approval_comment_body_excludes_quarantined_and_tolerated`
- `test_build_approval_comment_body_notes_when_only_quarantined_and_tolerated`
- `test_build_snapshot_image_tables_excludes_quarantined_and_tolerated`

Plus the existing approval-comment suite (25 tests) to guard against regressions — all pass locally via `hogli test products/visual_review/backend/tests/test_logic.py`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed this off a regression he spotted after #62635 merged: the approval comment posted quarantined and tolerated snapshots it shouldn't have.

Authored with PostHog Code (Claude Opus). The fix consolidates the snapshot selection into one queryset helper rather than duplicating the exclusion in both the summary and the image-table paths, keeping the rule expressed once.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*