### PR TITLE
chore(skills): set product owner to team-self-driving

### DIFF
--- a/products/skills/product.yaml
+++ b/products/skills/product.yaml
@@ -1,3 +1,3 @@
 name: Skills
 owners:
-    - team-ai-observability
+    - team-self-driving


### PR DESCRIPTION
## Problem

The standalone Skills product (`products/skills/`) inherited `team-ai-observability` as its owner when the backend was moved over in C1 (#62920). Ownership should sit with the team that now drives the Skills product.

## Changes

- Change `products/skills/product.yaml` owner from `team-ai-observability` to `team-self-driving`.

This is the only ownership reference for the product. `.github/scripts/assign-reviewers.js` reads `product.yaml` `owners` to auto-request reviewers on `products/skills/**` PRs (soft, non-blocking). No `.github/CODEOWNERS` change is involved — that file is reserved for hard merge-blocking gates and isn't used for product ownership here.

## How did you test this code?

I'm an agent (Claude Code). Automated check I ran locally:

- `hogli product:lint skills` — all checks pass.
- Confirmed `team-self-driving` is a real GitHub team slug (so reviewer auto-assignment resolves).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by Andy. Verified that ownership in this repo flows through `product.yaml` (consumed by `assign-reviewers.js`), not `CODEOWNERS`, and that `team-self-driving` is a valid GitHub team (unlike `team-signals`, which is a 404 slug). Split out as a standalone PR from the C2 docs move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
