### PR TITLE
feat(agents): scope native tool secret access to declared secrets

### DIFF
--- a/services/agent-console/src/lib/apiClient.ts
+++ b/services/agent-console/src/lib/apiClient.ts
@@ -1165,6 +1165,7 @@ export interface NativeToolCatalogEntry {
         requires: {
             integrations: string[]
             scopes: string[]
+            secrets: string[]
         }
         cost_hint: 'cheap' | 'medium' | 'expensive'
     }

--- a/services/agent-runner/src/loop/build-agent-tools.test.ts
+++ b/services/agent-runner/src/loop/build-agent-tools.test.ts
@@ -12,12 +12,13 @@ import {
     McpRef,
     newTestPrefix,
     S3BundleStore,
+    SECRET_WILDCARD,
     ToolRefSchema,
     wipeTestPrefix,
 } from '@posthog/agent-shared'
 import { setPosthogInternalClient } from '@posthog/agent-tools'
 
-import { AgentToolDeps, buildAgentTools } from './build-agent-tools'
+import { AgentToolDeps, buildAgentTools, makeScopedSecretAccessor, secretAllowlistFor } from './build-agent-tools'
 import type { OpenedMcp, RemoteMcpTool } from './mcp-clients'
 
 let bundlePrefix: string
@@ -432,6 +433,60 @@ describe('buildAgentTools', () => {
             await expect(buildAgentTools(rev, makeDeps(rev, { mcpClients: [brokenClient] }))).rejects.toThrow(
                 /mcp_list_tools_failed:flaky: socket hang up/
             )
+        })
+    })
+
+    describe('per-tool secret scoping', () => {
+        it('secretAllowlistFor passes an explicit list through verbatim', () => {
+            expect(secretAllowlistFor(['SLACK_BOT_TOKEN'], ['SLACK_BOT_TOKEN', 'OTHER'])).toEqual(
+                new Set(['SLACK_BOT_TOKEN'])
+            )
+            expect(secretAllowlistFor([], ['ANY'])).toEqual(new Set())
+        })
+
+        it('secretAllowlistFor widens the * wildcard to the spec-declared secrets', () => {
+            expect(secretAllowlistFor([SECRET_WILDCARD], ['A', 'B'])).toEqual(new Set(['A', 'B']))
+            // Wildcard is still bounded by spec.secrets, not the raw env.
+            expect(secretAllowlistFor([SECRET_WILDCARD], [])).toEqual(new Set())
+        })
+
+        it('a declared secret resolves with no denial log', () => {
+            const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = []
+            const accessor = makeScopedSecretAccessor(
+                { secrets: { SLACK_BOT_TOKEN: 'xoxb-1' }, log: (_l, msg, meta) => logs.push({ msg, meta }) },
+                '@posthog/slack-post-message',
+                new Set(['SLACK_BOT_TOKEN'])
+            )
+            expect(accessor('SLACK_BOT_TOKEN')).toBe('xoxb-1')
+            expect(logs).toEqual([])
+        })
+
+        it('warn-only (default): an undeclared secret still resolves but logs secret_access_denied', () => {
+            const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = []
+            const accessor = makeScopedSecretAccessor(
+                { secrets: { OTHER_API_KEY: 'sk-secret' }, log: (_l, msg, meta) => logs.push({ msg, meta }) },
+                '@posthog/slack-post-message',
+                new Set(['SLACK_BOT_TOKEN'])
+            )
+            expect(accessor('OTHER_API_KEY')).toBe('sk-secret')
+            expect(logs).toHaveLength(1)
+            expect(logs[0].msg).toBe('secret_access_denied')
+            expect(logs[0].meta).toMatchObject({
+                tool: '@posthog/slack-post-message',
+                secret: 'OTHER_API_KEY',
+                enforced: false,
+            })
+        })
+
+        it('enforce: an undeclared secret returns undefined (degrades like a missing secret)', () => {
+            const accessor = makeScopedSecretAccessor(
+                { secrets: { OTHER_API_KEY: 'sk-secret' }, log: () => undefined },
+                '@posthog/slack-post-message',
+                new Set(['SLACK_BOT_TOKEN']),
+                true
+            )
+            expect(accessor('OTHER_API_KEY')).toBeUndefined()
+            expect(accessor('SLACK_BOT_TOKEN')).toBeUndefined() // not in the env map
         })
     })
 })

--- a/services/agent-runner/src/loop/build-agent-tools.ts
+++ b/services/agent-runner/src/loop/build-agent-tools.ts
@@ -38,6 +38,7 @@ import {
     MemoryStore,
     TabularStore,
     Sandbox,
+    SECRET_WILDCARD,
     ToolContext,
 } from '@posthog/agent-shared'
 import { getNativeTool, hasNativeTool } from '@posthog/agent-tools'
@@ -299,6 +300,9 @@ function makeControlFlowTool(id: string): AgentTool<TSchema, ToolResultDetails> 
 
 function makeNativeTool(id: string, deps: AgentToolDeps): AgentTool<TSchema, ToolResultDetails> {
     const native = getNativeTool(id)
+    // Least privilege: this tool may only read the secrets it declares in
+    // `requires.secrets`. The accessor handed to `run` denies anything else.
+    const allowedSecrets = secretAllowlistFor(native.schema.requires.secrets, deps.rev.spec.secrets)
     return {
         name: id,
         label: id,
@@ -307,9 +311,54 @@ function makeNativeTool(id: string, deps: AgentToolDeps): AgentTool<TSchema, Too
         execute: async (_callId, args): Promise<AgentToolResult<ToolResultDetails>> => {
             // Throws propagate: the loop renders them as an error tool_result
             // (content = message, isError: true) — same shape as the old path.
-            const result = await native.run(args, buildToolContext(deps))
+            const result = await native.run(args, buildToolContext(deps, { toolId: id, allowedSecrets }))
             return { content: [{ type: 'text', text: JSON.stringify(result) }], details: { output: result } }
         },
+    }
+}
+
+/**
+ * Warn-only switch for per-tool secret scoping. While `false`, a read of an
+ * undeclared secret is logged (`secret_access_denied`) but still returns the
+ * value — so prod denials surface in the logs before we enforce. Flip to `true`
+ * once the logs are clean for every shipped agent (a one-line follow-up).
+ */
+export const ENFORCE_SECRET_SCOPING = false
+
+/**
+ * Resolve the set of secret names a native tool may read. An explicit
+ * `requires.secrets` list passes through verbatim; the `*` wildcard widens to
+ * every secret the spec declares (`spec.secrets`) — still narrower than the
+ * full decrypted env, and reserved for by-name resolvers like
+ * `@posthog/http-request`.
+ */
+export function secretAllowlistFor(requiresSecrets: readonly string[], specSecrets: readonly string[]): Set<string> {
+    if (requiresSecrets.includes(SECRET_WILDCARD)) {
+        return new Set(specSecrets)
+    }
+    return new Set(requiresSecrets)
+}
+
+/**
+ * Build the `ctx.secret` accessor scoped to `allowed`. A read outside the set
+ * logs `secret_access_denied`; under `enforce` it returns undefined (which
+ * tools already handle as a missing secret), otherwise it returns the value so
+ * we can observe denials without changing behaviour during rollout.
+ */
+export function makeScopedSecretAccessor(
+    deps: Pick<AgentToolDeps, 'secrets' | 'log'>,
+    toolId: string,
+    allowed: Set<string>,
+    enforce: boolean = ENFORCE_SECRET_SCOPING
+): (name: string) => string | undefined {
+    return (name: string): string | undefined => {
+        if (!allowed.has(name)) {
+            deps.log('warn', 'secret_access_denied', { tool: toolId, secret: name, enforced: enforce })
+            if (enforce) {
+                return undefined
+            }
+        }
+        return deps.secrets[name]
     }
 }
 
@@ -425,8 +474,15 @@ function makeMcpTool(
     }
 }
 
-/** Replicates the `ToolContext` the old `dispatchTool` built for native tools. */
-function buildToolContext(deps: AgentToolDeps): ToolContext {
+/**
+ * Replicates the `ToolContext` the old `dispatchTool` built for native tools.
+ * `secretScope` scopes the `secret` accessor to the calling tool's declared
+ * `requires.secrets` (see `makeScopedSecretAccessor`).
+ */
+function buildToolContext(
+    deps: AgentToolDeps,
+    secretScope: { toolId: string; allowedSecrets: Set<string> }
+): ToolContext {
     const credentialBroker = deps.credentialBroker
     const sessionId = deps.session.id
     // The `@posthog/*` data tools act as the invoking PostHog user, so they
@@ -442,7 +498,7 @@ function buildToolContext(deps: AgentToolDeps): ToolContext {
         applicationId: deps.rev.application_id,
         sessionId,
         integrations: deps.integrations,
-        secret: (name) => deps.secrets[name],
+        secret: makeScopedSecretAccessor(deps, secretScope.toolId, secretScope.allowedSecrets),
         log: deps.log,
         skillIndex: deps.rev.spec.skills.map((s) => ({ id: s.id, description: s.description, path: s.path })),
         readBundleFile: async (path: string): Promise<string | null> => {

--- a/services/agent-shared/src/spec/tool.ts
+++ b/services/agent-shared/src/spec/tool.ts
@@ -34,10 +34,30 @@ export interface NativeToolSchema {
     requires: {
         integrations: string[]
         scopes: string[]
+        /**
+         * Env keys from `spec.secrets` this tool is allowed to read through
+         * `ctx.secret`. The runner scopes each native tool's secret accessor
+         * to this list, so a tool can only reach the credentials it declares —
+         * `@posthog/slack-*` reads only `SLACK_BOT_TOKEN`, not every secret on
+         * the application. `[SECRET_WILDCARD]` ('*') means "any secret the spec
+         * declares", reserved for tools that resolve secrets by an
+         * author-supplied name (e.g. `@posthog/http-request`'s `${NAME}`
+         * interpolation); even then the scope is `spec.secrets`, not the raw
+         * decrypted env.
+         */
+        secrets: string[]
     }
     /** Hint for runner timeout selection + authoring UI cost annotations. */
     cost_hint: 'cheap' | 'medium' | 'expensive'
 }
+
+/**
+ * `requires.secrets` sentinel: this tool reads secrets by author-supplied name
+ * rather than a fixed set, so it may read any secret the spec declares
+ * (`spec.secrets`) — still narrower than the full decrypted `encrypted_env`.
+ * A tool declaring this is the broad-access case worth flagging in spec review.
+ */
+export const SECRET_WILDCARD = '*'
 
 export interface ToolContext {
     /**
@@ -150,6 +170,7 @@ export function defineNativeTool<TArgsSchema extends TSchema, TReturnSchema exte
             requires: {
                 integrations: def.requires?.integrations ?? [],
                 scopes: def.requires?.scopes ?? [],
+                secrets: def.requires?.secrets ?? [],
             },
             cost_hint: def.cost_hint ?? 'medium',
         },

--- a/services/agent-tools/src/registry.test.ts
+++ b/services/agent-tools/src/registry.test.ts
@@ -45,7 +45,11 @@ describe('native tool registry', () => {
             expect(t.schema.args).not.toBeUndefined()
             expect(t.schema.returns).not.toBeUndefined()
             expect(t.schema.requires).toEqual(
-                expect.objectContaining({ integrations: expect.any(Array), scopes: expect.any(Array) })
+                expect.objectContaining({
+                    integrations: expect.any(Array),
+                    scopes: expect.any(Array),
+                    secrets: expect.any(Array),
+                })
             )
             expect(['cheap', 'medium', 'expensive']).toContain(t.schema.cost_hint)
         }

--- a/services/agent-tools/src/tools/http-request.v1.ts
+++ b/services/agent-tools/src/tools/http-request.v1.ts
@@ -26,7 +26,7 @@
  * API."
  */
 
-import { defineNativeTool, type ToolContext, Type } from '@posthog/agent-shared'
+import { defineNativeTool, SECRET_WILDCARD, type ToolContext, Type } from '@posthog/agent-shared'
 
 const SECRET_REF = /\$\{([A-Z][A-Z0-9_]*)\}/g
 
@@ -152,7 +152,10 @@ export const httpRequestV1 = defineNativeTool({
         url: Type.String(),
         truncated: Type.Boolean({ description: 'True if the response body was clipped to max_response_bytes.' }),
     }),
-    requires: { integrations: [], scopes: ['web:fetch'] },
+    // Resolves `${NAME}` placeholders by author-supplied name, so it must reach
+    // any secret the spec declares — the `*` wildcard scopes it to `spec.secrets`
+    // (still narrower than the raw decrypted env).
+    requires: { integrations: [], scopes: ['web:fetch'], secrets: [SECRET_WILDCARD] },
     cost_hint: 'medium',
     async run(args, ctx) {
         const url = substituteSecrets(args.url, ctx)

--- a/services/agent-tools/src/tools/slack.v1.ts
+++ b/services/agent-tools/src/tools/slack.v1.ts
@@ -99,7 +99,7 @@ export const slackPostMessageV1 = defineNativeTool({
         ts: Type.String(),
         channel: Type.String(),
     }),
-    requires: { scopes: ['chat:write'] },
+    requires: { scopes: ['chat:write'], secrets: [SLACK_BOT_TOKEN_KEY] },
     cost_hint: 'cheap',
     async run(args, ctx) {
         const token = slackBotToken(ctx)
@@ -121,7 +121,7 @@ export const slackUpdateMessageV1 = defineNativeTool({
         text: Type.String(),
     }),
     returns: Type.Object({ ok: Type.Boolean() }),
-    requires: { scopes: ['chat:write'] },
+    requires: { scopes: ['chat:write'], secrets: [SLACK_BOT_TOKEN_KEY] },
     cost_hint: 'cheap',
     async run(args, ctx) {
         const token = slackBotToken(ctx)
@@ -146,7 +146,7 @@ export const slackReadChannelV1 = defineNativeTool({
         has_more: Type.Boolean(),
         next_cursor: Type.Optional(Type.String()),
     }),
-    requires: { scopes: ['channels:history', 'groups:history'] },
+    requires: { scopes: ['channels:history', 'groups:history'], secrets: [SLACK_BOT_TOKEN_KEY] },
     cost_hint: 'cheap',
     async run(args, ctx) {
         const token = slackBotToken(ctx)
@@ -189,7 +189,7 @@ export const slackReadThreadV1 = defineNativeTool({
         has_more: Type.Boolean(),
         next_cursor: Type.Optional(Type.String()),
     }),
-    requires: { scopes: ['channels:history', 'groups:history'] },
+    requires: { scopes: ['channels:history', 'groups:history'], secrets: [SLACK_BOT_TOKEN_KEY] },
     cost_hint: 'cheap',
     async run(args, ctx) {
         const token = slackBotToken(ctx)
@@ -225,7 +225,7 @@ export const slackReactV1 = defineNativeTool({
         name: Type.String(),
     }),
     returns: Type.Object({ ok: Type.Boolean() }),
-    requires: { scopes: ['reactions:write'] },
+    requires: { scopes: ['reactions:write'], secrets: [SLACK_BOT_TOKEN_KEY] },
     cost_hint: 'cheap',
     async run(args, ctx) {
         const token = slackBotToken(ctx)


### PR DESCRIPTION
## Problem

Native tools in the agent runner execute **in-process**, and `buildToolContext` previously handed every native tool a `ctx.secret` accessor over the application's *entire* decrypted `encrypted_env`:

```ts
secret: (name) => deps.secrets[name],
```

So any native tool could read any secret on the application — `@posthog/slack-post-message` could read a third-party API key, a JWT issuer secret, a shared-secret value, etc. — regardless of whether it needed it. That makes a single buggy or subverted native tool a credential-harvesting primitive over the whole secret set. This is the P2 item from a review of the agent platform's prompt-injection / least-privilege posture: shrink the secret blast radius to what each tool declares.

## Changes

- **Declare allowed secrets per tool.** `NativeToolSchema.requires` gains a `secrets: string[]` field (defaulted by `defineNativeTool`), naming the env keys a tool may read via `ctx.secret`.
- **Scope the accessor.** `makeNativeTool` computes an allowlist (`secretAllowlistFor`) and `buildToolContext` builds a scoped `ctx.secret` (`makeScopedSecretAccessor`) that only resolves declared secrets.
- **Wildcard for by-name resolvers.** `@posthog/http-request` resolves `${NAME}` placeholders by author-supplied name, so it declares the `*` wildcard (`SECRET_WILDCARD`). The wildcard widens to `spec.secrets` (the names the spec declares) — still narrower than the raw `encrypted_env`, and a clear "broad-access" signal for spec review. `@posthog/slack-*` declare just the bot token.
- **Warn-only rollout.** `ENFORCE_SECRET_SCOPING = false`: an undeclared read logs `secret_access_denied` (with `tool`/`secret`/`enforced`) but still returns the value, so real denials surface in prod logs before enforcement. Flipping to `true` is a one-line follow-up once the logs are clean. Under enforcement an undeclared read returns `undefined`, which tools already handle as a missing secret (they throw a precise error), so it degrades gracefully.

No behavior change while warn-only — this PR lays the mechanism and the per-tool declarations.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Automated checks I actually ran in a worktree, all passing:

- `tsc --noEmit` on `agent-shared`, `agent-tools`, `agent-runner` — clean.
- `vitest` — new `per-tool secret scoping` suite in `build-agent-tools.test.ts` (explicit-list vs `*`-wildcard resolution; declared read has no log; warn-only returns value + logs `secret_access_denied`; enforce returns `undefined`), plus `agent-tools` `registry.test.ts` / `slack.v1.test.ts` / `http-request.v1.test.ts` — all green.
- `oxlint` (0 errors) and `oxfmt --check` on all touched files.

Not run: the S3/Postgres-backed tests in `build-agent-tools.test.ts` (no local SeaweedFS/PG in this environment) and the full e2e harness. The new tests are pure and don't touch those services.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored from a Claude Code session (Opus 4.8) directed by Ben. Came out of a review of the agent platform's prompt-injection / least-privilege controls; this is the "P2" recommendation — per-tool secret scoping — picked as the first PR because it's self-contained and shrinks the credential blast radius immediately.

Key decisions:
- **Warn-only first** rather than enforce-on-merge, since the http-request wildcard tightening (env → `spec.secrets`) is the riskiest behavior change and could break agents referencing undeclared env keys. Observe denials, then flip.
- **Wildcard scoped to `spec.secrets`, not unrestricted**, so even by-name resolvers stay narrower than the raw env and the wildcard remains a meaningful review signal.
- Kept the change native-tools-only by design: custom tools already get sandbox nonces, MCP secrets are interpolated at connect time — neither uses `ctx.secret`.

Targets the `ass` branch (not master) since that's where the agent platform work lives.
