### PR TITLE
feat(agents): stamp provenance on tool result messages

### DIFF
--- a/services/agent-runner/src/loop/build-agent-tools.test.ts
+++ b/services/agent-runner/src/loop/build-agent-tools.test.ts
@@ -183,6 +183,30 @@ describe('buildAgentTools', () => {
         expect(byId(built, '@posthog/query').name).toBe('@posthog/query')
     })
 
+    it('records result provenance per tool (native readers/mcp/custom external, first-party internal)', async () => {
+        const ref: McpRef = { id: 'linear', url: 'https://example.com/mcp', secrets: [] }
+        const rev = makeRev(
+            [
+                { kind: 'native', id: '@posthog/web-search' },
+                { kind: 'native', id: '@posthog/slack-post-message' },
+                { kind: 'custom', id: 'my-tool', path: 'tools/my-tool' },
+            ],
+            [],
+            [ref]
+        )
+        const mcp = makeFakeMcp('linear', ref, {
+            'create-issue': { description: 'd', handler: async () => ({ ok: true }) },
+        })
+        const built = await buildAgentTools(rev, makeDeps(rev, { mcpClients: [mcp] }))
+        // External-content native reader, MCP, and sandboxed custom code.
+        expect(built.provenanceByName.get('@posthog/web-search')).toBe('external')
+        expect(built.provenanceByName.get('linear__create-issue')).toBe('external')
+        expect(built.provenanceByName.get('my-tool')).toBe('external')
+        // First-party output and control-flow meta tools.
+        expect(built.provenanceByName.get('@posthog/slack-post-message')).toBe('internal')
+        expect(built.provenanceByName.get('@posthog/meta-end-turn')).toBe('internal')
+    })
+
     it('meta-end-turn terminates with an end_turn control detail', async () => {
         const built = await buildAgentTools(makeRev([]), makeDeps(makeRev([])))
         const endTurn = await byId(built, '@posthog/meta-end-turn').execute('c1', {})

--- a/services/agent-runner/src/loop/build-agent-tools.ts
+++ b/services/agent-runner/src/loop/build-agent-tools.ts
@@ -36,9 +36,11 @@ import {
     HttpFetcher,
     IntegrationCredentials,
     MemoryStore,
+    nativeToolResultProvenance,
     TabularStore,
     Sandbox,
     ToolContext,
+    ToolResultProvenance,
 } from '@posthog/agent-shared'
 import { getNativeTool, hasNativeTool } from '@posthog/agent-tools'
 
@@ -160,11 +162,17 @@ export interface BuiltAgentTools {
      * sanitizes names on the wire and uses this map to translate the names a
      * strict provider echoes back to the original before the loop matches. */
     nameToId: Map<string, string>
+    /** Exposed tool name → provenance of its results. The driver stamps this
+     * onto each persisted `toolResult` message so a later detection/policy layer
+     * can tell agent/author-controlled output from attacker-influenceable
+     * output. Unknown names default to `external` (fail-safe) at the call site. */
+    provenanceByName: Map<string, ToolResultProvenance>
 }
 
 export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): Promise<BuiltAgentTools> {
     const tools: AgentTool<TSchema, ToolResultDetails>[] = []
     const seen = new Set<string>()
+    const provenanceByName = new Map<string, ToolResultProvenance>()
 
     // `@posthog/load-skill` is auto-included only when the agent has skills —
     // exposing it otherwise just adds a tool that errors on use.
@@ -182,6 +190,8 @@ export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): 
 
         if (CONTROL_FLOW_IDS.has(t.id)) {
             tools.push(makeControlFlowTool(t.id))
+            // Control-flow meta tools return only their own synthetic envelope.
+            provenanceByName.set(t.id, 'internal')
             continue
         }
         if (t.kind === 'native') {
@@ -191,6 +201,7 @@ export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): 
                 continue
             }
             tools.push(makeNativeTool(t.id, deps))
+            provenanceByName.set(t.id, nativeToolResultProvenance(t.id))
             continue
         }
         if (t.kind === 'client') {
@@ -203,11 +214,16 @@ export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): 
                 continue
             }
             tools.push(makeClientTool(t, deps))
+            // Result is whatever the connected client returns — outside the
+            // platform's control.
+            provenanceByName.set(t.id, 'external')
             continue
         }
         // custom — schema + description from the bundle, dispatched via sandbox.
         const { description, parameters } = await loadCustomSchema(rev, t.id, t.path, deps.bundle)
         tools.push(makeCustomTool(t.id, description, parameters, deps))
+        // Sandboxed author code can fetch arbitrary content.
+        provenanceByName.set(t.id, 'external')
     }
 
     // MCP-sourced tools — one per remote tool per opened client. `listTools()`
@@ -262,6 +278,8 @@ export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): 
                 }
                 seen.add(exposedName)
                 tools.push(makeMcpTool(exposedName, client, remote))
+                // Third-party server output — always external.
+                provenanceByName.set(exposedName, 'external')
             }
         }
     }
@@ -269,7 +287,7 @@ export async function buildAgentTools(rev: AgentRevision, deps: AgentToolDeps): 
     // Tools are named with their original ids (the loop matches calls by name).
     // The map keys the provider-safe form back to the original so the driver's
     // streamFn can translate names a strict provider echoed back.
-    return { tools, nameToId: buildToolNameMap(tools.map((t) => t.name)) }
+    return { tools, nameToId: buildToolNameMap(tools.map((t) => t.name)), provenanceByName }
 }
 
 function makeControlFlowTool(id: string): AgentTool<TSchema, ToolResultDetails> {

--- a/services/agent-runner/src/loop/driver.ts
+++ b/services/agent-runner/src/loop/driver.ts
@@ -365,7 +365,7 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
             http: deps.http,
             posthogApiBaseUrl: deps.posthogApiBaseUrl,
         }
-        const { tools, nameToId } = await buildAgentTools(rev, toolDeps)
+        const { tools, nameToId, provenanceByName } = await buildAgentTools(rev, toolDeps)
 
         await emit('session_started', {
             team_id: session.team_id,
@@ -509,7 +509,14 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
                 case 'message_end': {
                     // Every finalized message (steering/user, assistant, tool result)
                     // lands in the persisted transcript in emission order.
-                    session.conversation.push(event.message as ConversationMessage)
+                    const msg = event.message as ConversationMessage
+                    if (msg.role === 'toolResult') {
+                        // Label whether the result carries agent/author-controlled
+                        // content or potentially attacker-influenceable content.
+                        // Unknown names fail safe to `external`.
+                        msg.provenance = provenanceByName.get(msg.toolName) ?? 'external'
+                    }
+                    session.conversation.push(msg)
                     return
                 }
                 case 'tool_execution_start': {

--- a/services/agent-shared/src/index.ts
+++ b/services/agent-shared/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 export * from './spec/spec'
+export * from './spec/provenance'
 export * from './spec/slack-manifest'
 export * from './spec/summarize-conversation'
 export * from './spec/tool'

--- a/services/agent-shared/src/spec/provenance.test.ts
+++ b/services/agent-shared/src/spec/provenance.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { EXTERNAL_CONTENT_NATIVE_TOOL_IDS, nativeToolResultProvenance } from './provenance'
+
+describe('nativeToolResultProvenance', () => {
+    it('marks external-content readers as external', () => {
+        for (const id of [
+            '@posthog/web-search',
+            '@posthog/web-fetch',
+            '@posthog/http-request',
+            '@posthog/slack-read-channel',
+            '@posthog/slack-read-thread',
+            '@posthog/query',
+        ]) {
+            expect(nativeToolResultProvenance(id)).toBe('external')
+            expect(EXTERNAL_CONTENT_NATIVE_TOOL_IDS.has(id)).toBe(true)
+        }
+    })
+
+    it('defaults first-party tools to internal', () => {
+        for (const id of [
+            '@posthog/memory-write',
+            '@posthog/table-append',
+            '@posthog/slack-post-message',
+            '@posthog/meta-end-turn',
+            '@posthog/unknown-future-tool',
+        ]) {
+            expect(nativeToolResultProvenance(id)).toBe('internal')
+        }
+    })
+})

--- a/services/agent-shared/src/spec/provenance.ts
+++ b/services/agent-shared/src/spec/provenance.ts
@@ -1,0 +1,42 @@
+/**
+ * Provenance of a tool result's content — does it carry data the agent and its
+ * author control, or data influenced by something outside that boundary?
+ *
+ *   - `internal` — first-party / agent-owned output: the agent's own memory and
+ *     tables, control-flow meta tools, confirmations of actions it took.
+ *   - `external` — output that can carry attacker-influenceable content: web
+ *     pages, arbitrary HTTP bodies, third-party MCP servers, messages read from
+ *     Slack, sandboxed custom-tool code, client-supplied results, and end-user
+ *     event/person data surfaced by analytics queries.
+ *
+ * Stamped onto each persisted `ToolResultMessage` by the runner. It is a label,
+ * not a gate: it gives a later detection / policy layer a machine-readable way
+ * to tell trusted output from untrusted, and makes "did external content reach
+ * the model before an egress call?" answerable from the transcript.
+ */
+export type ToolResultProvenance = 'internal' | 'external'
+
+/**
+ * Native tool ids whose results can carry content from outside the agent's and
+ * author's control. Conservative by design — when a tool's output could include
+ * anything an end user or third party authored, it belongs here (false external
+ * labels are cheap; a missed one hides a real injection vector). This is the
+ * shared taxonomy a spec-level data-flow check can reuse.
+ */
+export const EXTERNAL_CONTENT_NATIVE_TOOL_IDS: ReadonlySet<string> = new Set([
+    '@posthog/web-search',
+    '@posthog/web-fetch',
+    '@posthog/http-request',
+    '@posthog/slack-read-channel',
+    '@posthog/slack-read-thread',
+    // Analytics results can contain end-user-authored strings (event names,
+    // person properties, cohort names), so treat them as external content.
+    '@posthog/query',
+])
+
+/** Provenance for a native tool's result, by id. Unknown ids default to
+ *  `internal` — first-party native tools are the norm; any native tool that
+ *  surfaces outside content must be added to `EXTERNAL_CONTENT_NATIVE_TOOL_IDS`. */
+export function nativeToolResultProvenance(id: string): ToolResultProvenance {
+    return EXTERNAL_CONTENT_NATIVE_TOOL_IDS.has(id) ? 'external' : 'internal'
+}

--- a/services/agent-shared/src/spec/spec.ts
+++ b/services/agent-shared/src/spec/spec.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod'
 
+import { ToolResultProvenance } from './provenance'
+
 export const ModelIdSchema = z.string().min(1)
 
 /**
@@ -1009,6 +1011,13 @@ export interface ToolResultMessage {
     content: (TextContent | ImageContent)[]
     isError: boolean
     timestamp: number
+    /**
+     * Whether this result's content is agent/author-controlled (`internal`) or
+     * potentially attacker-influenceable (`external`). Stamped by the runner
+     * from the tool surface; absent on rows predating provenance stamping.
+     * See `ToolResultProvenance`.
+     */
+    provenance?: ToolResultProvenance
 }
 
 export interface TextContent {


### PR DESCRIPTION
## Problem

Tool results land in a session's persisted conversation as opaque JSON with no machine-readable origin. There's no way for anything downstream — a detection layer, a policy check, an audit query — to tell output the agent and its author control (its own memory, tables, action confirmations) from output that can carry attacker-influenceable content (web pages, arbitrary HTTP bodies, third-party MCP servers, Slack messages, end-user event/person data).

This is the substrate for the broader prompt-injection / least-privilege work on the agent platform: before you can detect or gate on "untrusted content reached the model," you have to label where each tool result came from.

## Changes

- **`ToolResultProvenance`** (`internal` | `external`) added in `agent-shared`, plus an optional `provenance` field on `ToolResultMessage`. The conversation is stored as JSONB and `JSON.stringify`'d on write (no zod stripping), so the field persists end-to-end with no migration.
- **Classification at session start.** `buildAgentTools` returns a `provenanceByName` map built as it assembles the tool surface, where the tool kinds are known:
  - `external` — native external-content readers (`web-search`, `web-fetch`, `http-request`, `slack-read-channel`, `slack-read-thread`, `query` — analytics results can contain end-user-authored strings), all MCP tools, sandboxed custom tools, and client tools.
  - `internal` — first-party native tools and control-flow meta tools.
- **Stamping.** The driver sets `provenance` on each `toolResult` message in `message_end` before persisting. Unknown tool names **fail safe to `external`** (a false external label is cheap; a missed one would hide a real injection vector).
- The external-content taxonomy lives in one place (`EXTERNAL_CONTENT_NATIVE_TOOL_IDS`) so a future spec-level data-flow check can reuse it.

This is a **label, not a gate** — no behavior change for the agent or the model. It makes "did external content reach the model before an egress/write call?" answerable from the transcript, and is the foundation for a later detection/policy layer.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Automated checks I actually ran in a worktree, all passing:

- `tsc --noEmit` on `agent-shared` and `agent-runner` — clean.
- `vitest` — new `provenance.test.ts` (classifier: external readers vs first-party default vs unknown→internal) and a new case in `build-agent-tools.test.ts` (native reader/MCP/custom → external; first-party + meta → internal) — green.
- `oxlint` (0 warnings on the new/changed files) and `oxfmt --check` on all touched files.

Not run locally (no SeaweedFS/Postgres/Redis in this environment): the S3/PG-backed cases in `build-agent-tools.test.ts` and the e2e harness in `agent-tests`. The driver stamping is exercised by the existing e2e `toolResult` cases, which read fields structurally (`.isError`, `.content`) rather than asserting exact objects, so the new optional field doesn't break them. CI covers these.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored from a Claude Code session (Opus 4.8) directed by Ben, out of a review of the agent platform's prompt-injection posture. This is the "P4b" recommendation (provenance tagging), shipped as its own PR independent of the P2 secret-scoping PR — the two are logically unrelated (P2 touches secret access; this touches message labeling).

Key decisions:
- **Label, not enforcement.** Deliberately no gating in this PR — provenance is the substrate a later detection/policy step builds on. Keeping it inert makes it safe to land early.
- **Fail safe to `external`** for unknown tool names and for MCP/custom/client (their output is outside the platform's control).
- **`query` is `external`** because analytics results surface end-user-authored strings (event names, person properties) — a real injection vector, not just web/HTTP content.
- **Classify where kinds are known** (in `buildAgentTools`) rather than guessing from tool-name shape in the driver — custom/client ids are arbitrary.

Targets `ass` (where the agent platform work lives), branched from `ass` (not stacked on the P2 branch).
