### PR TITLE
fix(mcp): pin react resolution for vite 7 ui-apps build

### DIFF
--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -76,10 +76,7 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Install dependencies
-              # Match services/mcp/Dockerfile exactly (`--filter @posthog/mcp...`). Do NOT add
-              # `--filter ./products/*`: that links react/quill/etc. into products/*/node_modules,
-              # which the image never does, so files reached via the `products` vite alias resolve
-              # here but fail in the real build. The vite config aliases those deps instead.
+              # Match services/mcp/Dockerfile exactly
               run: pnpm --filter=@posthog/mcp... install --frozen-lockfile
 
             - name: Check generated UI apps are up to date

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -76,7 +76,11 @@ jobs:
                   token: ${{ github.token }}
 
             - name: Install dependencies
-              run: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
+              # Match services/mcp/Dockerfile exactly (`--filter @posthog/mcp...`). Do NOT add
+              # `--filter ./products/*`: that links react/quill/etc. into products/*/node_modules,
+              # which the image never does, so files reached via the `products` vite alias resolve
+              # here but fail in the real build. The vite config aliases those deps instead.
+              run: pnpm --filter=@posthog/mcp... install --frozen-lockfile
 
             - name: Check generated UI apps are up to date
               run: |

--- a/services/mcp/vite.ui-apps.config.ts
+++ b/services/mcp/vite.ui-apps.config.ts
@@ -58,15 +58,12 @@ export default defineConfig({
                 find: /^@posthog\/quill-charts$/,
                 replacement: resolve(__dirname, '../../packages/quill/packages/charts/src/index.ts'),
             },
-            // lucide-react isn't a workspace dep at the products/ level, so files
-            // resolved via the `products` alias can't find it. Pin to this
-            // package's installed copy (matches the version Quill expects).
+            // lucide-react, react, and react-dom aren't reachable from files
+            // resolved via the `products` alias (products/ isn't a dep of this
+            // package), so pin them to this package's copies. react needs its
+            // subpaths covered too: Vite 7 resolves the injected react/jsx-runtime
+            // import relative to the importing file.
             { find: /^lucide-react$/, replacement: resolve(__dirname, 'node_modules/lucide-react') },
-            // Same reason for react/react-dom: Vite 7 resolves the plugin-react
-            // jsx-runtime import relative to the importing file, and files reached
-            // via the `products` alias have no react in their node_modules tree
-            // (products/ isn't a dep of this package). Pin both, plus subpaths
-            // like react/jsx-runtime, to this package's installed copy.
             { find: 'react', replacement: resolve(__dirname, 'node_modules/react') },
             { find: 'react-dom', replacement: resolve(__dirname, 'node_modules/react-dom') },
             { find: '@common', replacement: resolve(__dirname, '../../common') },

--- a/services/mcp/vite.ui-apps.config.ts
+++ b/services/mcp/vite.ui-apps.config.ts
@@ -62,6 +62,13 @@ export default defineConfig({
             // resolved via the `products` alias can't find it. Pin to this
             // package's installed copy (matches the version Quill expects).
             { find: /^lucide-react$/, replacement: resolve(__dirname, 'node_modules/lucide-react') },
+            // Same reason for react/react-dom: Vite 7 resolves the plugin-react
+            // jsx-runtime import relative to the importing file, and files reached
+            // via the `products` alias have no react in their node_modules tree
+            // (products/ isn't a dep of this package). Pin both, plus subpaths
+            // like react/jsx-runtime, to this package's installed copy.
+            { find: 'react', replacement: resolve(__dirname, 'node_modules/react') },
+            { find: 'react-dom', replacement: resolve(__dirname, 'node_modules/react-dom') },
             { find: '@common', replacement: resolve(__dirname, '../../common') },
         ],
     },


### PR DESCRIPTION
## Problem

The MCP Container Image CD build has been failing on master since the Vite 5 to 7 bump in [af1689a](https://github.com/PostHog/posthog/commit/af1689a1f09028f27c5f31ff27446173185e3f7d) (#63451, the vitest v4 security update also bumped `vite` `^5.4.21` to `^7.3.5`).

The UI-apps build fails with:

```
Rollup failed to resolve import "react/jsx-runtime" from
"/code/products/visual_review/mcp/apps/VisualReviewSnapshotsView.tsx"
```

Vite 7 tightened module resolution. `@vitejs/plugin-react` injects `import { jsx } from "react/jsx-runtime"` into every JSX file, and Vite 7 now resolves that bare import relative to the **importing file's** location rather than the build's project root. Product-app components are reached through the `products` Vite alias (`products` -> `../../products`), so they live outside this package's `node_modules` tree. In the Docker build the dependencies are installed with `pnpm install --filter @posthog/mcp...`, which never links a `node_modules` under `products/`, so `react/jsx-runtime` is unresolvable from those files and the build fails.

This is the same class of problem the config already handles for `lucide-react`, `@posthog/quill`, and `@posthog/quill-charts`.

### Why PR CI didn't catch it

PR-time CI (`ci-mcp-ui-apps.yml`) installed dependencies with an extra `--filter ./products/*`, which links `react`/`quill`/`lucide-react` into `products/*/node_modules`. The Docker image installs with only `--filter @posthog/mcp...` and never creates those. So files reached via the `products` alias resolved in CI but not in the image, and the break sailed through to CD green.

## Changes

1. **Fix** — add `resolve.alias` entries for `react` and `react-dom` in `services/mcp/vite.ui-apps.config.ts`, pinned to the MCP package's installed copies. String aliases also cover subpaths like `react/jsx-runtime`, `react/jsx-dev-runtime`, and `react-dom/client`. This makes React resolution independent of the importer's location, mirroring the existing `lucide-react`/quill aliases.
2. **Regression guard** — drop `--filter ./products/*` from the `ci-mcp-ui-apps.yml` install step so PR CI installs exactly like the Dockerfile. The UI-apps build now runs under the image's resolution conditions, so a future break of this kind fails the PR instead of only failing CD.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated verification only, no manual UI testing:

- **Reproduced the failure locally (red).** The full local workspace install links `react` into `products/*/node_modules`, which masks the bug, so I removed those symlinks to mimic the Docker filtered-install layout. The build then failed with the exact CI error above.
- **Confirmed the fix (green).** With the symlinks still removed, applying the aliases made the build succeed.
- **Verified the regression guard end to end.** With `react` removed from all five product apps' `node_modules` (the layout the corrected CI filter produces), the full `build:ui-apps` built all apps cleanly: every standalone app plus all generated wrappers (actions, cohorts, workflows, experiments, surveys, feature flags, error tracking, traces, etc.), no resolve errors. Restored the symlinks afterward; working tree is just the two intended files.
- Confirmed every bare import across bundled product-app components (`react`, `lucide-react`, `@posthog/quill`, `@posthog/quill-charts`) is now covered by an alias, so the stricter install doesn't just move the failure to another app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact. Internal build-config fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by Robbie (assignee/DRI), who owns the incident.

Authored by Claude Code (Opus 4.8). The fix was flagged by automated CI-failure triage, which identified the Vite bump as the cause and proposed React resolve aliases. Rather than take that on faith, I traced the root cause to the difference between the full local workspace install (which links `react` under `products/`) and the Docker `--filter @posthog/mcp...` install (which does not), then built a red/green reproduction by removing the masking symlinks before and after applying the fix.

While verifying, I found the same install-filter mismatch was why PR CI never caught the break, so I aligned the CI install with the Dockerfile and added a comment pinning the rationale (re-adding the products filter would silently re-mask this class of bug). Chose string aliases over exact-match regex so React subpaths are covered, and over `resolve.dedupe` to stay consistent with the existing alias pattern in the same file.
