### PR TITLE
feat(data-warehouse): lift source onboarding conversion and fix Google OAuth source errors

### DIFF
--- a/frontend/src/scenes/onboarding/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/onboardingLogic.test.ts
@@ -539,8 +539,8 @@ describe('onboardingLogic — flow composition', () => {
     describe('completion redirect URL', () => {
         // Each entry: [primary, expected redirect path-substring].
         // Verifies that each per-product provider's `completeRedirectUrl` is wired up.
-        // Two products (DATA_WAREHOUSE and EXPERIMENTS) intentionally fall through to
-        // urls.default() — same behaviour as the original central switch.
+        // EXPERIMENTS intentionally falls through to urls.default() — same behaviour as
+        // the original central switch.
         const cases: Array<[ProductKey, RegExp]> = [
             [ProductKey.PRODUCT_ANALYTICS, /quickstart|insight/i],
             [ProductKey.WEB_ANALYTICS, /web/i],
@@ -551,6 +551,7 @@ describe('onboardingLogic — flow composition', () => {
             [ProductKey.AI_OBSERVABILITY, /ai-observability/i],
             [ProductKey.WORKFLOWS, /workflow/i],
             [ProductKey.LOGS, /log/i],
+            [ProductKey.DATA_WAREHOUSE, /sources|data-management/i],
         ]
 
         it.each(cases)('%s lands on a product-specific page', (product, pattern) => {
@@ -558,10 +559,8 @@ describe('onboardingLogic — flow composition', () => {
             expect(logic.values.onCompleteOnboardingRedirectUrl).toMatch(pattern)
         })
 
-        it('experiments and data warehouse fall through to urls.default()', () => {
+        it('experiments falls through to urls.default()', () => {
             logic.actions.setProductKey(ProductKey.EXPERIMENTS)
-            expect(logic.values.onCompleteOnboardingRedirectUrl).toBe('/')
-            logic.actions.setProductKey(ProductKey.DATA_WAREHOUSE)
             expect(logic.values.onCompleteOnboardingRedirectUrl).toBe('/')
         })
 

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -73,7 +73,7 @@ Any_Source_Errors: dict[str, str | None] = {
     "Could not establish session to SSH gateway": None,
     "Primary key required for incremental syncs": None,
     "The primary keys for this table are not unique": None,
-    "Integration matching query does not exist": None,
+    "Integration matching query does not exist": "The connected account for this source is no longer available — it may have been disconnected. Please reconnect the source's account.",
 }
 
 

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -275,4 +275,10 @@ class GoogleAdsSource(
                     False,
                     "The Google account is not associated with any Google Ads accounts. Please use an account with Google Ads access.",
                 )
+            if "matching query does not exist" in error_message:
+                return (
+                    False,
+                    "Your Google Ads connection is no longer available — it may have been disconnected. "
+                    "Please reconnect your Google Ads account.",
+                )
             return False, f"Error validating credentials: {error_message}"

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -181,3 +181,23 @@ class TestGoogleAdsNonRetryableErrors:
         friendly = self.non_retryable["access_not_configured"]
         assert friendly is not None
         assert "admin" in friendly.lower()
+
+
+class TestValidateCredentials:
+    def test_missing_integration_returns_friendly_message(self):
+        from unittest import mock
+
+        from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
+
+        config = GoogleAdsSourceConfig(customer_id="123-456-7890", google_ads_integration_id=1)
+        # A disconnected/deleted OAuth integration makes the client builder raise
+        # `Integration.DoesNotExist` ("... matching query does not exist"). Surface an
+        # actionable reconnect message instead of the raw ORM error.
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            side_effect=Exception("Integration matching query does not exist"),
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "reconnect your Google Ads account" in (message or "")

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1,5 +1,7 @@
 import pytest
+from unittest import mock
 
+from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
 from posthog.temporal.data_imports.sources.google_ads.configs import clean_customer_id
 from posthog.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
 
@@ -185,10 +187,6 @@ class TestGoogleAdsNonRetryableErrors:
 
 class TestValidateCredentials:
     def test_missing_integration_returns_friendly_message(self):
-        from unittest import mock
-
-        from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
-
         config = GoogleAdsSourceConfig(customer_id="123-456-7890", google_ads_integration_id=1)
         # A disconnected/deleted OAuth integration makes the client builder raise
         # `Integration.DoesNotExist` ("... matching query does not exist"). Surface an

--- a/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -117,7 +117,13 @@ def _credentials(integration_id: int, team_id: int) -> OAuthCredentials:
         client_id=settings.GOOGLE_SEARCH_CONSOLE_APP_CLIENT_ID,
         client_secret=settings.GOOGLE_SEARCH_CONSOLE_APP_CLIENT_SECRET,
         token_uri="https://oauth2.googleapis.com/token",
-        scopes=["https://www.googleapis.com/auth/webmasters.readonly"],
+        # No `scopes=` on purpose. With a refresh-token grant, google-auth forwards the
+        # requested scopes to Google's token endpoint, which rejects anything that isn't an
+        # exact subset of what the original consent granted — surfacing as
+        # "invalid_scope: Bad Request" and failing every sync/validation. Omitting it
+        # refreshes with the originally-granted scopes (matching the Google Ads client). A
+        # genuinely missing scope then shows up as a 403 on the sites call, which we map to
+        # an actionable "reconnect" message instead.
     )
 
 

--- a/posthog/temporal/data_imports/sources/google_search_console/source.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/source.py
@@ -104,6 +104,11 @@ class GoogleSearchConsoleSource(
         try:
             session = google_search_console_session(config.google_search_console_integration_id, team_id)
         except Exception as e:
+            if "matching query does not exist" in str(e):
+                return False, (
+                    "Your Google Search Console connection is no longer available — it may have been "
+                    "disconnected. Please reconnect your Google Search Console account."
+                )
             return False, f"Could not load Google Search Console credentials: {e}"
 
         try:

--- a/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
@@ -154,3 +154,17 @@ def test_validate_credentials_succeeds_for_verified_site():
 
     assert ok is True
     assert message is None
+
+
+def test_validate_credentials_handles_missing_integration():
+    # A disconnected/deleted OAuth integration makes the credentials lookup raise
+    # `Integration.DoesNotExist` ("... matching query does not exist"). Surface an
+    # actionable reconnect message instead of the raw ORM error.
+    with mock.patch(
+        "posthog.temporal.data_imports.sources.google_search_console.source.google_search_console_session",
+        side_effect=Exception("Integration matching query does not exist"),
+    ):
+        ok, message = GoogleSearchConsoleSource().validate_credentials(_config(), team_id=1)
+
+    assert ok is False
+    assert "reconnect your Google Search Console account" in (message or "")

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -110,7 +110,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                         label="Host",
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
-                        placeholder="localhost",
+                        placeholder="db.example.com",
+                        caption=(
+                            "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
+                            "firewall allowlist (see the docs above) and use a public host — `localhost` and private "
+                            "IPs (10.x, 172.16–31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "exposed publicly, enable the SSH tunnel below."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(

--- a/products/data_warehouse/frontend/onboarding/steps.tsx
+++ b/products/data_warehouse/frontend/onboarding/steps.tsx
@@ -1,11 +1,10 @@
 import { OnboardingDataWarehouseSourcesStep } from 'scenes/onboarding/data-warehouse/OnboardingDataWarehouseSourcesStep'
 import { type ProductOnboardingProvider } from 'scenes/onboarding/types'
+import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { OnboardingStepKey } from '~/types'
 
-// `completeRedirectUrl` intentionally omitted: data warehouse falls through to
-// urls.default() — same behaviour as the original central switch.
 export const dataWarehouseOnboarding: ProductOnboardingProvider = {
     steps: (ctx) => [
         {
@@ -16,4 +15,8 @@ export const dataWarehouseOnboarding: ProductOnboardingProvider = {
             render: () => <OnboardingDataWarehouseSourcesStep />,
         },
     ],
+    // Land freshly-onboarded users on the sources list — where they can connect or manage a
+    // source — instead of falling through to urls.default() (the home page), which drops the
+    // data-warehouse intent on the floor. Every other product redirects to its own surface.
+    completeRedirectUrl: () => urls.sources(),
 }


### PR DESCRIPTION
## Problem

Analytics on data warehouse source onboarding surfaced three concrete, fixable issues:

- **Onboarding intent leaks.** 3,318 users select "data warehouse" during onboarding (30d) but only 126 (3.8%) ever connect a source. A root cause: data warehouse onboarding had **no `completeRedirectUrl`**, so finishing (or skipping) the step fell through to the home page — every other product redirects to its own surface, but the data-warehouse intent just evaporated.
- **Google Search Console `invalid_scope`.** GSC led credential-validation failures (157 in 3 days) with `('invalid_scope: Bad Request')`. The GSC client passed `scopes=` into the refresh-token credentials; google-auth forwards those scopes to Google's token endpoint, which rejects anything that isn't an exact subset of the original consent. The Google Ads client (which works) omits `scopes` for exactly this reason.
- **Cryptic "Integration matching query does not exist".** When a Google OAuth integration is disconnected/deleted, GSC and Google Ads source validation surfaced the raw Django `DoesNotExist` string to users.

## Changes

- **Onboarding redirect** (`products/data_warehouse/frontend/onboarding/steps.tsx`): redirect to `urls.sources()` on completion. Helps both paths — completers land where they can manage the source, and skippers land on the sources list (with its connect CTA) instead of the home page.
- **GSC `invalid_scope` fix** (`google_search_console.py`): drop the `scopes=` argument from the refresh-token credentials so refresh uses the originally-granted scopes (matching the Google Ads client). A genuinely missing scope now surfaces as a 403 on the sites call, already mapped to an actionable reconnect message.
- **Friendly "reconnect" errors** for a missing integration in GSC and Google Ads `validate_credentials`, plus a user-facing message for the same error on the sync path (`external_data_job.py`) — kept **non-retryable** so a permanently-disconnected integration doesn't retry forever.
- **Tests** for both integration-missing validation paths.

Deferred (tracked, not in this PR): inline Postgres connectivity validation in the source wizard; and steering agents from `external-data-sources-create` to the one-step `data-warehouse-source-setup` tool (that touches the same MCP files as the in-flight warehouse-sources attribution PR and is best folded in there). Larger onboarding levers (non-skippable step, adding data warehouse to use-case recommendations) are intentionally left as product/experiment decisions.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- `pytest` on the GSC + Google Ads source suites — **60 passed** (58 existing + 2 new tests covering the integration-missing friendly messages).
- `ruff check` / `ruff format` clean on all changed Python.
- Verified `urls.sources()` is an existing, widely-used helper; the redirect mirrors the pattern used by ~10 other products' onboarding providers.

I did not run the full frontend typecheck (kea-typegen output and some built workspace packages are absent in my local env); CI should cover it. No manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. A maintainer asked to turn an MCP/onboarding analytics review into TODOs and implement the high-confidence fixes, with a deep dive on onboarding.

Approach and decisions:
- Parallel read-only investigations mapped the onboarding flow and the two Google OAuth bugs before any edits.
- Onboarding deep-dive finding: the inline source picker already exists in the step; the clear, low-risk win was the missing post-onboarding redirect. Skippability / recommendation-inclusion changes were deliberately **not** forced — the code marks the recommendation exclusion as intentional and the value-prop step is under an active feature-flag experiment.
- GSC `invalid_scope`: diagnosed by contrasting the failing GSC credential builder (passes `scopes`) with the working Google Ads one (omits them); the fix aligns them.
- Integration-missing errors were fixed at the validation layer (where the onboarding failures fire) and given a friendly message on the sync path, while preserving the exact non-retryable matcher behavior.
