### PR TITLE
fix(google-ads): surface clear error when the connection no longer exists

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -13,6 +13,7 @@ from posthog.schema import (
     SuggestedTable,
 )
 
+from posthog.models.integration import Integration
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import (
     MARKETING_ANALYTICS_SUGGESTED_TABLE_TOOLTIP,
@@ -266,6 +267,11 @@ class GoogleAdsSource(
                     f"Customer ID {config.customer_id} is not correct. Please check your customer ID and try again.",
                 )
             return True, None
+        except Integration.DoesNotExist:
+            return (
+                False,
+                "The Google Ads connection for this source no longer exists. Please reconnect your Google Ads account.",
+            )
         except Exception as e:
             error_message = str(e)
             if "ACCESS_TOKEN_SCOPE_INSUFFICIENT" in error_message:

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest import mock
 
+from posthog.models.integration import Integration
 from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
 from posthog.temporal.data_imports.sources.google_ads.configs import clean_customer_id
 from posthog.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
@@ -186,11 +187,25 @@ class TestGoogleAdsNonRetryableErrors:
 
 
 class TestValidateCredentials:
-    def test_missing_integration_returns_friendly_message(self):
-        config = GoogleAdsSourceConfig(customer_id="123-456-7890", google_ads_integration_id=1)
-        # A disconnected/deleted OAuth integration makes the client builder raise
-        # `Integration.DoesNotExist` ("... matching query does not exist"). Surface an
+    def test_missing_integration_does_not_exist_returns_reconnect_message(self):
+        # `google_ads_client` calls `Integration.objects.get(...)`, which raises the typed
+        # `Integration.DoesNotExist` when the OAuth connection row is gone. Surface an
         # actionable reconnect message instead of the raw ORM error.
+        config = GoogleAdsSourceConfig(customer_id="1234567890", google_ads_integration_id=1)
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            side_effect=Integration.DoesNotExist(),
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "no longer exists" in (message or "")
+        assert "Integration matching query" not in (message or "")
+
+    def test_missing_integration_string_match_returns_friendly_message(self):
+        # The same condition can also surface as a generic exception whose message contains
+        # the ORM "matching query does not exist" text; still surface a reconnect message.
+        config = GoogleAdsSourceConfig(customer_id="123-456-7890", google_ads_integration_id=1)
         with mock.patch(
             "posthog.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
             side_effect=Exception("Integration matching query does not exist"),


### PR DESCRIPTION
## Problem

When a Google Ads source was validated but its connected integration row no longer existed (e.g. the user deleted the integration after configuring the source), the wizard surfaced Django's raw ORM error:

```
Error validating credentials: Integration matching query does not exist.
```

`google_ads_client` does `Integration.objects.get(...)`, whose `DoesNotExist` was caught by the generic `except Exception` in `validate_credentials` and `str()`-formatted into the message. It references internal model names and gives the user nothing to act on.

## Changes

Catch `Integration.DoesNotExist` explicitly in `GoogleAdsSource.validate_credentials` (before the generic handler) and return: _"The Google Ads connection for this source no longer exists. Please reconnect your Google Ads account."_

Only the error message changes — sync behavior and schemas are untouched. The customer-ID and scope/permission messages were already clear and are left as-is.

## How did you test this code?

I'm an agent. I added a regression test mocking `google_ads_client` to raise `Integration.DoesNotExist`, asserting the new message and that the raw `Integration matching query` string no longer leaks. Ran the suite:

\`\`\`
uv run pytest posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py -q
# 47 passed
\`\`\`

Ran `ruff check --fix` and `ruff format` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day of data-warehouse source-creation failures grouped by source type. For Google Ads, the only message warranting a fix was the leaked `Integration matching query does not exist.` (an internal Django string); the customer-ID and insufficient-permissions messages were already actionable and left unchanged.