### PR TITLE
feat(mcp): detect opencode client for CLI mode

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -77,6 +77,11 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     // but an LLM-driven consumer that benefits from the same single-exec mode
     // and formatted-text rendering as coding agents).
     'notion',
+    // OpenCode is a terminal coding agent (and the engine behind clients like
+    // OpenWork). It connects through OpenCode's MCP client, which self-reports
+    // `clientInfo.name` as `opencode`. It renders text, not MCP Apps UI, so it
+    // wants single-exec mode like the other coding agents.
+    'opencode',
 ] as const
 
 // Known `x-anthropic-client` (`vendorClient`) header values. Anthropic pools

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -32,6 +32,7 @@ describe('isCliModeEnabledClient', () => {
             ['devin'],
             ['librechat'],
             ['notion'],
+            ['opencode'],
         ])('returns true for %s', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })
@@ -55,6 +56,8 @@ describe('isCliModeEnabledClient', () => {
             ['notion-mcp-client'],
             ['Notion'],
             ['Devin'],
+            ['OpenCode'],
+            ['opencode/1.2.3'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })


### PR DESCRIPTION
## Problem

OpenWork (an open-source desktop agent app) reported that PostHog's MCP didn't behave well in their client. OpenWork is built on [OpenCode](https://github.com/sst/opencode) and connects through OpenCode's MCP client, which self-reports `clientInfo.name` as `opencode`. Because `opencode` wasn't in our coding-agent detection list, it fell into the default `tools` mode and missed the single-exec (CLI) experience that other terminal coding agents get.

## Changes

Add `opencode` to `CODING_AGENT_CLIENT_NAME_FRAGMENTS` so OpenCode-based clients (including OpenWork) are detected as coding agents and default to single-exec / CLI mode, dropping `structuredContent` when a `formatted_results` override is set — the same treatment as Claude Code, Codex, etc.

OpenCode is a terminal agent that renders text, not MCP Apps UI. `render-ui` remains gated behind `isClaudeUiHost()` (Claude web/desktop only), so OpenCode correctly does **not** receive `render-ui`.

## How did you test this code?

I'm an agent. I added parameterized cases to `tests/unit/client-detection.test.ts` covering `opencode` and variants (`OpenCode`, `opencode/1.2.3`) and ran the unit suite: 162 tests pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy directed this work from a Slack thread. I traced OpenWork → OpenCode and confirmed via the OpenCode source that its MCP client constructs with `{ name: "opencode", version: InstallationVersion }`, so `opencode` is the identifier that reaches our handshake parsing. I scoped the change to the client-detection fragment list and verified that render-ui exposure (gated on `isClaudeUiHost()`) is unaffected, since OpenCode is not an MCP Apps UI host.

Tools used: PostHog Slack app (Claude Code harness) with Explore subagent and WebFetch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AV33BDCJ3/p1781280537946729?thread_ts=1781280537.946729&cid=C0AV33BDCJ3)*
