### PR TITLE
fix(mongodb): replace raw pymongo connection error with a clear message

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -47,6 +47,19 @@ _MONGO_ATLAS_SQL_MESSAGE = (
     "driver. Use your regular cluster connection string (e.g. mongodb+srv://...mongodb.net) instead."
 )
 
+_MONGO_HOST_UNRESOLVED_MESSAGE = (
+    "The MongoDB host could not be resolved. Check that the cluster address in your connection "
+    "string is spelled correctly."
+)
+
+# Substrings pymongo embeds in ServerSelectionTimeoutError when the OS can't resolve the host.
+_DNS_RESOLUTION_FAILURE_MARKERS = (
+    "No address associated with hostname",
+    "nodename nor servname provided",
+    "Name or service not known",
+    "Temporary failure in name resolution",
+)
+
 
 @SourceRegistry.register
 class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin):
@@ -150,7 +163,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
     def validate_credentials(
         self, config: MongoDBSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        from pymongo.errors import OperationFailure
+        from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
 
         try:
             connection_params = _parse_connection_string(config.connection_string, config.database_name)
@@ -177,6 +190,15 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         except OperationFailure as e:
             capture_exception(e)
             return False, f"MongoDB authentication failed: {str(e)}"
+        except ServerSelectionTimeoutError as e:
+            # pymongo dumps a verbose topology description into str(e); surface a concise,
+            # actionable message instead. A DNS failure means the host doesn't resolve at all,
+            # which is distinct from an allowlist/reachability problem.
+            capture_exception(e)
+            message = str(e)
+            if any(marker in message for marker in _DNS_RESOLUTION_FAILURE_MARKERS):
+                return False, _MONGO_HOST_UNRESOLVED_MESSAGE
+            return False, _MONGO_UNREACHABLE_MESSAGE
         except Exception as e:
             capture_exception(e)
             return False, f"Failed to connect to MongoDB database: {str(e)}"

--- a/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from posthog.temporal.data_imports.sources.mongodb.mongo import DATABASE_NAME_REQUIRED_ERROR, _parse_connection_string
 from posthog.temporal.data_imports.sources.mongodb.source import (
+    _DNS_RESOLUTION_FAILURE_MARKERS,
     _MONGO_HOST_UNRESOLVED_MESSAGE,
     _MONGO_UNREACHABLE_MESSAGE,
     MongoDBSource,
@@ -52,13 +53,14 @@ class TestMongoValidateCredentialsDatabaseName:
 
 
 class TestMongoValidateCredentialsServerSelection:
+    @pytest.mark.parametrize("marker", _DNS_RESOLUTION_FAILURE_MARKERS)
     @patch("posthog.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_dns_resolution_failure_returns_unresolved_message(self, mock_get_collections):
+    def test_dns_resolution_failure_returns_unresolved_message(self, mock_get_collections, marker):
         from pymongo.errors import ServerSelectionTimeoutError
 
         # The verbose topology-description message pymongo raises when the host doesn't resolve.
         mock_get_collections.side_effect = ServerSelectionTimeoutError(
-            "cluster0.qwi73.mongodb.net:27017: [Errno -5] No address associated with hostname "
+            f"cluster0.qwi73.mongodb.net:27017: [Errno -5] {marker} "
             "(configured timeouts: socketTimeoutMS: 20000.0ms), Topology Description: <TopologyDescription ...>"
         )
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})

--- a/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from posthog.temporal.data_imports.sources.mongodb.mongo import DATABASE_NAME_REQUIRED_ERROR, _parse_connection_string
-from posthog.temporal.data_imports.sources.mongodb.source import MongoDBSource
+from posthog.temporal.data_imports.sources.mongodb.source import (
+    _MONGO_HOST_UNRESOLVED_MESSAGE,
+    _MONGO_UNREACHABLE_MESSAGE,
+    MongoDBSource,
+)
 
 _SRV_NO_DB = "mongodb+srv://user:pass@cluster.abc.mongodb.net/?retryWrites=true&w=majority"
 _SRV_WITH_DB = "mongodb+srv://user:pass@cluster.abc.mongodb.net/realdb?retryWrites=true"
@@ -45,3 +49,36 @@ class TestMongoValidateCredentialsDatabaseName:
 
         assert ok is True
         assert err is None
+
+
+class TestMongoValidateCredentialsServerSelection:
+    @patch("posthog.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_dns_resolution_failure_returns_unresolved_message(self, mock_get_collections):
+        from pymongo.errors import ServerSelectionTimeoutError
+
+        # The verbose topology-description message pymongo raises when the host doesn't resolve.
+        mock_get_collections.side_effect = ServerSelectionTimeoutError(
+            "cluster0.qwi73.mongodb.net:27017: [Errno -5] No address associated with hostname "
+            "(configured timeouts: socketTimeoutMS: 20000.0ms), Topology Description: <TopologyDescription ...>"
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_HOST_UNRESOLVED_MESSAGE
+        assert "Topology Description" not in (err or "")
+
+    @patch("posthog.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_unreachable_cluster_returns_allowlist_message(self, mock_get_collections):
+        from pymongo.errors import ServerSelectionTimeoutError
+
+        mock_get_collections.side_effect = ServerSelectionTimeoutError(
+            "No servers found yet, Topology Description: ..."
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_UNREACHABLE_MESSAGE


### PR DESCRIPTION
## Problem

When MongoDB credential validation couldn't reach the cluster, the new-source wizard surfaced pymongo's raw `ServerSelectionTimeoutError` verbatim, e.g.:

```
Failed to connect to MongoDB database: cluster0.qwi73.mongodb.net:27017: [Errno -5] No address associated with hostname (configured timeouts: socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 10.0s, Topology Description: <TopologyDescription id: ..., servers: [...]>
```

The generic `except Exception` handler `str()`-formatted the exception, dumping the full topology description on the user. The DNS-resolution case ("No address associated with hostname") is the user typing a wrong host — but the message gives them no way to see that.

## Changes

In `MongoDBSource.validate_credentials`, catch `ServerSelectionTimeoutError` before the generic handler and return a concise message:

- DNS resolution failures → _"The MongoDB host could not be resolved. Check that the cluster address in your connection string is spelled correctly."_
- Other server-selection timeouts → the existing unreachable-cluster/allowlist message.

The generic fallback remains for genuinely unexpected errors. Only the error message changes — sync behavior and schemas are untouched.

## How did you test this code?

I'm an agent. I added two regression tests (DNS failure and generic unreachable) asserting the concise messages and that the raw topology description no longer leaks. Ran the suite:

\`\`\`
uv run pytest posthog/temporal/data_imports/sources/mongodb/test_database_name.py -q
# 9 passed
\`\`\`

Ran `ruff check --fix` and `ruff format` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day of data-warehouse source-creation failures grouped by source type. The MongoDB failure was a raw pymongo exception dump (a DNS resolution failure) leaking to the user — classified as an internal error leaking to users and fixed with a concise message, reusing the existing `_MONGO_UNREACHABLE_MESSAGE` for the non-DNS case.