### PR TITLE
chore(ci): skip playwright e2e and mcp integration tests on draft PRs

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -89,7 +89,7 @@ jobs:
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event.pull_request.head.repo.full_name == github.repository &&
-             github.event.pull_request.draft != true)
+             github.event.pull_request.draft != true))
         name: Determine need to run E2E checks
         outputs:
             shouldRun: ${{ steps.decide.outputs.shouldRun }}

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -6,6 +6,11 @@
 name: E2E CI Playwright
 on:
     pull_request:
+        # Draft PRs skip E2E entirely — the broad path filter below matches nearly
+        # every code PR, and a full ~25-minute stack boot per draft push is the
+        # remaining big per-PR cost. The ready-for-review full run is the merge
+        # gate; use workflow_dispatch to force a run on a draft.
+        types: [opened, synchronize, reopened, ready_for_review]
     workflow_dispatch:
         inputs:
             playwright_retries:
@@ -76,14 +81,15 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Run on master push, manual dispatch, and on internal-repo PRs.
-        # Skipped on merge_group (explicitly, though the allowlist below would
-        # also skip it implicitly) — see the trigger comment above.
+        # Run on master push, manual dispatch, and on ready internal-repo PRs.
+        # Drafts skip E2E (see the trigger comment); the `Playwright tests pass`
+        # aggregator treats skipped as success, and drafts can't merge anyway.
         if: |
             github.event_name != 'merge_group' && (
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
-            github.event.pull_request.head.repo.full_name == github.repository)
+            (github.event.pull_request.head.repo.full_name == github.repository &&
+             github.event.pull_request.draft != true)
         name: Determine need to run E2E checks
         outputs:
             shouldRun: ${{ steps.decide.outputs.shouldRun }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -4,11 +4,10 @@ on:
     push:
         branches: [master]
     pull_request:
-    # Required so `MCP Tests Pass` (a required status check) reports on merge
-    # queue entries — without it the queue would wait for the check until timeout.
-    # The jobs themselves skip on merge_group (the suite already runs in full on
-    # every PR) and the aggregator treats skipped as success.
-    merge_group:
+        # Draft PRs run build + unit tests only; the integration tests (which boot
+        # the full PostHog backend and trigger on any Python change) run when the
+        # PR is marked ready for review — that full run is the merge gate.
+        types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -252,7 +251,11 @@ jobs:
         runs-on: depot-ubuntu-latest-4
         needs: changes
         timeout-minutes: 30
-        if: needs.changes.outputs.mcp == 'true'
+        # Skipped on drafts: these boot the full PostHog backend and trigger on any
+        # Python change, so they're the expensive half of this workflow. Build and
+        # unit tests still run on drafts; the `MCP Tests Pass` aggregator treats
+        # skipped as success, and the ready-for-review run is the merge gate.
+        if: needs.changes.outputs.mcp == 'true' && github.event.pull_request.draft != true
         env:
             OPT_OUT_CAPTURE: 1
             SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -8,6 +8,11 @@ on:
         # the full PostHog backend and trigger on any Python change) run when the
         # PR is marked ready for review — that full run is the merge gate.
         types: [opened, synchronize, reopened, ready_for_review]
+    # Required so `MCP Tests Pass` (a required status check) reports on merge
+    # queue entries — without it the queue would wait for the check until timeout.
+    # The jobs themselves skip on merge_group (the suite already runs in full on
+    # every PR) and the aggregator treats skipped as success.
+    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Problem

Playwright E2E's path filter matches nearly every code PR, so every draft push boots the full stack and runs the whole suite for ~25 minutes. MCP integration tests likewise boot the full backend on any Python change. This is a large per-PR CI cost paid even while a PR is still in draft and can't merge.

## Changes

Both suites now skip draft PRs and run when the PR is marked ready for review, matching the draft/ready model the backend, frontend, and storybook suites already follow:

- **`ci-e2e-playwright.yml`** — adds `ready_for_review` to the `pull_request` trigger types and gates the `changes` job on `draft != true`. Drafts skip E2E entirely; a draft that needs E2E can use `workflow_dispatch`. Fixed an `actionlint` error: the `changes` job `if:` expression was missing its outer closing parenthesis after the draft check.
- **`ci-mcp.yml`** — drafts run build + unit tests only (cheap, fast feedback on MCP code itself); the integration tests, which boot the full backend, run on `ready_for_review`. Retains `merge_group` as a trigger so `MCP Tests Pass` (a required status check) is still reported on merge-queue entries — without it the queue would wait until timeout.

In both cases the ready-for-review run is the merge gate, the aggregators (`Playwright tests pass`, `MCP Tests Pass`) treat skipped as success, and drafts can't merge anyway. The `changes` job skips on `merge_group` events and the aggregator treats that as success, matching the pattern `ci-e2e-playwright.yml` already follows.

No selection/narrowing for E2E: Playwright's `--only-changed` traces test-file imports, which can't see app-code changes for tests that drive the real app, so a narrowed E2E run would be false confidence.

## How did you test this code?

I'm an agent. I did not run the workflows. These are GitHub Actions trigger/condition changes; correctness is verified by inspection against the existing draft/ready pattern used by the backend, frontend, and storybook workflows. The behavior is exercised by this PR itself once opened as a draft vs. marked ready.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cherry-picked an existing commit (`3db8cb9`) onto a fresh branch at the user's direction, then committed and opened this PR. A follow-up commit (`fe1ff5e`) restored the `merge_group` trigger in `ci-mcp.yml` (accidentally dropped in the initial apply) and fixed an `actionlint` failure in the E2E workflow's `if:` expression.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>