### PR TITLE
fix(logs): remove highly compressable/static fields from log row bytes

### DIFF
--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -47,14 +47,7 @@ pub struct KafkaLogRow {
 /// is the raw HTTP body size for the whole batch.
 pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
     let mut total: usize = 0;
-    total = total.saturating_add(row.uuid.len());
-    total = total.saturating_add(row.trace_id.len());
-    total = total.saturating_add(row.span_id.len());
     total = total.saturating_add(row.body.len());
-    total = total.saturating_add(row.severity_text.len());
-    total = total.saturating_add(row.service_name.len());
-    total = total.saturating_add(row.instrumentation_scope.len());
-    total = total.saturating_add(row.event_name.len());
     for (k, v) in &row.resource_attributes {
         total = total.saturating_add(k.len()).saturating_add(v.len());
     }

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -385,11 +385,10 @@ mod tests {
     #[test]
     fn test_compute_kafka_log_row_bytes_sums_string_and_map_lengths() {
         let row = sample_row();
-        // string fields: uuid(9) + trace_id(3) + span_id(3) + body(5) + severity_text(4)
-        // + service_name(3) + instrumentation_scope(7) + event_name(3) = 37
+        // string fields: body(5)
         // maps: resource_attributes "host.name"(9)+"localhost"(9)=18; attributes "k"(1)+"v"(1)=2
-        // total = 37 + 18 + 2 = 57
-        assert_eq!(compute_kafka_log_row_bytes(&row), 57);
+        // total = 5 + 18 + 2 = 25
+        assert_eq!(compute_kafka_log_row_bytes(&row), 25);
     }
 
     fn sample_row_bytes() -> u64 {

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -48,6 +48,17 @@ pub struct KafkaLogRow {
 pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
     let mut total: usize = 0;
     total = total.saturating_add(row.body.len());
+
+    // by default exclude instrumentation_scope and event_name as they are
+    // low cardinality and highly compressible, but add them if they are large
+    // to prevent abuse
+    if row.instrumentation_scope.len() > 50 {
+        total = total.saturating_add(row.instrumentation_scope.len());
+    }
+    if row.event_name.len() > 50 {
+        total = total.saturating_add(row.event_name.len());
+    }
+
     for (k, v) in &row.resource_attributes {
         total = total.saturating_add(k.len()).saturating_add(v.len());
     }


### PR DESCRIPTION

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
we were charging on several columns based on the string length, but in terms of actual storage these end up being massively lower (e.g. severity_text is effectively a 1 byte ENUM, not 5 bytes for "error" etc)

uuid we add, shouldn't charge customers for it as its not part of what they send us, and again we're charging like 32 bytes for the string instead of the 4 byte cost

service_name we _could_ charge but is low cardinality so very cheap for us in practise


we're trying to change from charging for the raw body size but the new calculation is bigger, i'm hoping remove these fields makes this both more fair and also easier to swap over as it won't increase people's bills
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
remove a bunch of fields from log size calculation
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
n/a - we're just testing this metric atm
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
