### PR TITLE
feat(skills): give skills its own ProductKey and nav identity

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -200,7 +200,7 @@
             "type": "revenue",
             "intents": ["revenue_analytics"]
         },
-        { "path": "Skills", "category": "Tools", "iconType": null, "type": "llm_skills", "intents": ["llm_prompts"] },
+        { "path": "Skills", "category": "Tools", "iconType": null, "type": "llm_skills", "intents": ["skills"] },
         { "path": "Surveys", "category": "Behavior", "iconType": "survey", "type": "survey", "intents": ["surveys"] },
         { "path": "Toolbar", "category": "Tools", "iconType": "toolbar", "type": "toolbar", "intents": ["toolbar"] },
         {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1989,7 +1989,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     },
     {
         path: 'Skills',
-        intents: [ProductKey.LLM_PROMPTS],
+        intents: [ProductKey.SKILLS],
         category: ProductItemCategory.TOOLS,
         type: 'llm_skills',
         iconType: 'llm_prompts' as FileSystemIconType,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -29706,6 +29706,7 @@
                 "session_replay",
                 "replay_vision",
                 "site_apps",
+                "skills",
                 "subscriptions",
                 "streamlit_apps",
                 "surveys",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -6756,6 +6756,7 @@ export enum ProductKey {
     SESSION_REPLAY = 'session_replay',
     REPLAY_VISION = 'replay_vision',
     SITE_APPS = 'site_apps',
+    SKILLS = 'skills',
     SUBSCRIPTIONS = 'subscriptions',
     STREAMLIT_APPS = 'streamlit_apps',
     SURVEYS = 'surveys',

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2252,6 +2252,7 @@ class ProductKey(StrEnum):
     SESSION_REPLAY = "session_replay"
     REPLAY_VISION = "replay_vision"
     SITE_APPS = "site_apps"
+    SKILLS = "skills"
     SUBSCRIPTIONS = "subscriptions"
     STREAMLIT_APPS = "streamlit_apps"
     SURVEYS = "surveys"

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -50,7 +50,7 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'Skills',
-            intents: [ProductKey.LLM_PROMPTS],
+            intents: [ProductKey.SKILLS],
             category: ProductItemCategory.TOOLS,
             type: 'llm_skills',
             iconType: 'llm_prompts' as FileSystemIconType,


### PR DESCRIPTION
## Problem

Skills was extracted into a standalone `products/skills/` product over migration steps A–C (URLs, frontend, backend, MCP tool rename). But its navigation card still rode under the `LLM_PROMPTS` product intent, so skills had no product identity of its own — the product tree, onboarding/setup, and nav-advertisement mappings all attributed it to LLM prompts.

## Changes

This is **step D (product identity)** of the skills standalone migration.

- Add `ProductKey.SKILLS` (`'skills'`) to the query schema.
- Repoint the skills product card's `intents` from `ProductKey.LLM_PROMPTS` to `ProductKey.SKILLS` in `products/skills/manifest.tsx`.
- Regenerate the derived artifacts: `schema.json`, `posthog/schema_enums.py`, `frontend/src/products.tsx`, `frontend/src/products.json`.

Deliberately **out of scope**, each deferred to its own follow-up:

- **Backend API path** stays `/llm_skills`. Renaming to `/skills` churns every drf-spectacular operationId, which would re-break the MCP tool bindings + generated client just shipped in C3 — it deserves an isolated, backward-compat PR.
- **RBAC** continues to inherit from `llm_analytics` (`llm_skill → llm_analytics` in `user_access_control.py`). Promoting `llm_skill` to its own access-control resource is a real behavior change and is left for a dedicated PR.
- **Icon/color** keeps the existing `llm_prompts` purple; a distinct skills color can come later with design input.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran locally:

- `pnpm schema:build` and `pnpm build:products` — regenerated all derived files cleanly; diffs are limited to the single `SKILLS` enum addition and the one intent flip.
- `pnpm --filter=@posthog/frontend typescript:check` — no errors touching these changes. (The run surfaces pre-existing stale-kea-typegen errors in `products/workflows/`, unrelated to this PR and present on master.)
- `hogli test products/skills/frontend/skillsUrls.test.ts` — 5/5 pass.
- `python -c 'from posthog.schema_enums import ProductKey; ProductKey.SKILLS'` — imports correctly.

`posthog/test/test_products.py` could not run locally (no Postgres in this environment) — relying on CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @andrewm4894 as part of the skills standalone-product migration (step D, tracked in the `llma-skills` skill).

Key decisions:

- **Split product identity from the API-path rename.** The initial ask included moving `/llm_skills → /skills`, but investigation showed the rename re-churns the operationId-bound MCP tools and generated client that C3 shipped days earlier, and is a breaking change for external API-key callers. Scoped this PR to the non-breaking product-identity core and deferred the API rename to its own PR.
- **State-minimal change.** Only the source enum + manifest intent are hand-edited; everything else is regenerated, keeping the diff to 6 files / 6 insertions.

This is agent-authored and requires human review.
