### PR TITLE
fix(slack-app): pass region when evaluating slack-app-assistant flag

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1718,6 +1718,9 @@ def _assistant_enabled(team: Team) -> bool:
                 _ASSISTANT_FEATURE_FLAG,
                 str(team.uuid),
                 groups={"organization": str(team.organization_id)},
+                person_properties={"region": get_instance_region() or "unknown"},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
             )
         )
     except Exception:


### PR DESCRIPTION
## Problem

The new `slack-app-assistant` flag can't be targeted by `person.region` — the backend call doesn't send region, so any `person.region == DEV` (or similar) rule never matches.

## Changes

Mirror the untagged-thread-followups helper: pass `person_properties={"region": ...}`, plus `only_evaluate_locally=False` and `send_feature_flag_events=False`.

## How did you test this code?

Agent-authored. No automated coverage added — the 3-line addition mirrors the existing `_untagged_thread_followups_enabled` helper which is exercised in production.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta flagged the discrepancy after attempting to roll the flag out to the DEV region. Claude Code (Bash/Read/Edit) located the helper, compared it against the working untagged-thread helper, and applied the fix.