### PR TITLE
feat(wizard): show timed-out state after 5 minutes on setup wizard

### DIFF
--- a/frontend/src/scenes/wizard/Wizard.tsx
+++ b/frontend/src/scenes/wizard/Wizard.tsx
@@ -80,6 +80,16 @@ export function Wizard(): JSX.Element {
                         </p>
                     </>
                 )}
+                {view === 'timed_out' && (
+                    <>
+                        <h1 className="text-xl font-bold">Session timed out</h1>
+                        <SurprisedHog className="h-48 w-48" />
+                        <p className="text-lg">
+                            This setup session expired after 5 minutes for security reasons. Head back to your terminal
+                            and re-run the wizard to start a new one.
+                        </p>
+                    </>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/wizard/wizardLogic.test.tsx
+++ b/frontend/src/scenes/wizard/wizardLogic.test.tsx
@@ -7,7 +7,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { AppContext } from '~/types'
 
-import { wizardLogic } from './wizardLogic'
+import { WIZARD_SESSION_TIMEOUT_MS, wizardLogic } from './wizardLogic'
 
 const MOCK_HASH = 'mock-hash'
 
@@ -74,6 +74,43 @@ describe('wizardLogic', () => {
                 view: 'pending',
                 wizardHash: MOCK_HASH,
             })
+        })
+    })
+
+    describe('session timeout', () => {
+        beforeEach(() => {
+            window.POSTHOG_APP_CONTEXT = {
+                current_user: {
+                    organization: {
+                        teams: [MOCK_DEFAULT_TEAM, { ...MOCK_DEFAULT_TEAM, id: MOCK_DEFAULT_TEAM.id + 1 }],
+                    },
+                },
+            } as unknown as AppContext
+            initKeaTests()
+            logic = wizardLogic()
+            logic.mount()
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('shows timed_out after 5 minutes on the project view', async () => {
+            jest.useFakeTimers()
+            router.actions.push('/wizard', { hash: MOCK_HASH })
+
+            await expectLogic(logic).toMatchValues({ view: 'project' })
+
+            jest.advanceTimersByTime(WIZARD_SESSION_TIMEOUT_MS)
+
+            await expectLogic(logic).toMatchValues({ view: 'timed_out' })
+        })
+
+        it('does not clobber a completed flow when the timer fires', async () => {
+            logic.actions.setView('success')
+            logic.actions.sessionTimedOut()
+
+            await expectLogic(logic).toMatchValues({ view: 'success' })
         })
     })
 

--- a/frontend/src/scenes/wizard/wizardLogic.tsx
+++ b/frontend/src/scenes/wizard/wizardLogic.tsx
@@ -12,6 +12,13 @@ export interface WizardTokenResponseType {
     success: boolean
 }
 
+// Mirror the server-side OAuth authorization code expiry (`AUTHORIZATION_CODE_EXPIRE_SECONDS`,
+// 5 minutes). Once it elapses the callback is dead, so we proactively surface a timed-out state
+// instead of letting the user complete the flow into a failed authentication.
+export const WIZARD_SESSION_TIMEOUT_MS = 5 * 60 * 1000
+
+export type WizardView = 'project' | 'pending' | 'success' | 'invalid' | 'timed_out'
+
 export const wizardLogic = kea<wizardLogicType>([
     path(['scenes', 'wizard', 'wizardLogic']),
     connect(() => ({
@@ -19,11 +26,13 @@ export const wizardLogic = kea<wizardLogicType>([
     })),
     actions({
         setWizardHash: (wizardHash: string | null) => ({ wizardHash }),
-        setView: (view: 'project' | 'pending' | 'success' | 'invalid') => ({ view }),
+        setView: (view: WizardView) => ({ view }),
         setSelectedProjectId: (projectId: number | null) => ({ projectId }),
         authenticateWizard: (wizardHash: string, projectId: number) => ({ wizardHash, projectId }),
         continueToAuthentication: () => ({}),
         handleWizardRouting: () => ({}),
+        startSessionTimer: () => ({}),
+        sessionTimedOut: () => ({}),
     }),
     loaders(({ actions }) => ({
         wizardToken: [
@@ -55,7 +64,7 @@ export const wizardLogic = kea<wizardLogicType>([
             },
         ],
         view: [
-            'project' as 'project' | 'pending' | 'success' | 'invalid',
+            'project' as WizardView,
             {
                 setView: (_, { view }) => view,
             },
@@ -88,7 +97,29 @@ export const wizardLogic = kea<wizardLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
+        startSessionTimer: () => {
+            // Store an absolute deadline so the timer survives the disposables plugin's
+            // pause/resume on tab visibility — if the 5 minutes lapse while the tab is hidden,
+            // setup recomputes a non-positive delay on return and fires immediately.
+            cache.sessionDeadline = Date.now() + WIZARD_SESSION_TIMEOUT_MS
+            cache.disposables.add(() => {
+                const remainingMs = Math.max(0, (cache.sessionDeadline ?? 0) - Date.now())
+                const timeoutId = setTimeout(() => actions.sessionTimedOut(), remainingMs)
+                return () => clearTimeout(timeoutId)
+            }, 'wizardSessionTimer')
+        },
+        sessionTimedOut: () => {
+            cache.disposables.dispose('wizardSessionTimer')
+            // Only interrupt while the user is still deciding — never clobber a completed flow.
+            if (values.view === 'project') {
+                actions.setView('timed_out')
+            }
+        },
+        authenticateWizard: () => {
+            // The user has acted (or we auto-authenticated); the waiting clock no longer applies.
+            cache.disposables.dispose('wizardSessionTimer')
+        },
         continueToAuthentication: () => {
             const projectId = values.selectedProjectId
             const wizardHash = values.wizardHash
@@ -121,6 +152,8 @@ export const wizardLogic = kea<wizardLogicType>([
                 actions.setView('pending')
             } else {
                 actions.setView('project')
+                // User now has to pick a project — start the clock while they're away.
+                actions.startSessionTimer()
             }
         },
     })),


### PR DESCRIPTION
## Problem

PostHog's setup-wizard auth flow is backed by an OAuth authorization code that expires after **5 minutes** (`AUTHORIZATION_CODE_EXPIRE_SECONDS` in `posthog/settings/web.py`). The wizard page itself gave no indication of this window — a user could open the project-selection view, step away to do something else, come back several minutes later, finish the flow, and only then discover the callback was dead. The paste-URL fallback fails the same way because it carries the same expired code.

## Changes

Adds a client-side session timer to the `/wizard` scene that mirrors the server's 5-minute OAuth window:

- Starts a 5-minute timer when the wizard lands on the project-selection view (the state where the user is most likely to walk away).
- On expiry, shows a dedicated **"Session timed out"** view that explains the flow expired for security and prompts the user to head back to their terminal and re-run the wizard.
- The timer is cancelled the moment authentication begins, and `sessionTimedOut` never overrides a flow that already reached success/pending/invalid.
- The timer is **deadline-based** (absolute timestamp) rather than a plain `setTimeout`, so it survives the kea disposables plugin's pause/resume on tab-visibility changes — if the 5 minutes lapse while the tab is hidden, the user sees the timed-out screen immediately on return instead of a silently-dead callback.

This is purely additive UX on the wizard side; the server-side timeout is unchanged.

## How did you test this code?

I'm an agent (PostHog Slack app) — I did not perform manual browser testing. I added and ran automated unit tests:

- `frontend/src/scenes/wizard/wizardLogic.test.tsx` — new cases asserting the view becomes `timed_out` after advancing 5 minutes on the project view, and that a completed flow is not clobbered when the timer fires.
- Full wizard suite passes (7/7 via `jest`), `tsc --noEmit` reports no errors for the wizard scene, and `oxlint` is clean on the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The user reported that the auth flow's callback URL was dead after stepping away (~7 min), traced it to the 5-minute OAuth authorization-code expiry, and asked for a wizard-side timer that surfaces a "session timed out" state prompting a re-run.

Implementation notes for reviewers:
- Chose a deadline-based timer over a plain `setTimeout` specifically because the kea disposables plugin tears down and re-creates disposables on tab-visibility changes; a naive timer would restart its countdown each time the user returned to the tab. The absolute deadline makes the timer fire immediately on return when the window already elapsed — which is exactly the reported "came back and it's dead" case.
- The 5-minute value mirrors the OAuth code expiry, not the longer 10-minute wizard cache TTL, since the auth code is the binding constraint that actually kills the flow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1781442337729579?thread_ts=1781442337.729579&cid=C09GTQY5RLZ)*
