### PR TITLE
chore(signals): add importance-refresh sense-check to anomaly scout explore loop

### DIFF
--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -124,6 +124,13 @@ cares about:
 For each new candidate, do a first read to set its baseline and cadence, then add a
 `watchlist:` entry. Don't add more than a few per run — let coverage grow steadily.
 
+Explore is not only additive — **importance decays.** Every few days (~3), re-pull the ranking
+and reconcile the _existing_ watchlist against it: promote newly-hot items, demote or retire
+ones whose dashboards have gone cold. A large or "mature" watchlist is **not** a reason to skip
+explore — a frozen watchlist tracks last week's priorities, not today's. The refresh cadence and
+the `importance-refresh` memo are in
+[`references/watchlist-and-memory.md`](references/watchlist-and-memory.md).
+
 ### Save memory as you go
 
 Memory is continuous, not a final step. Maintain the watchlist and baselines as you work,

--- a/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/watchlist-and-memory.md
@@ -15,16 +15,17 @@ rewrites the entry in place (the idempotent refresh — use it to update a basel
 
 ### Key vocabulary
 
-| Key prefix                                           | Holds                                                                      |
-| ---------------------------------------------------- | -------------------------------------------------------------------------- |
-| `watchlist:anomaly_detection:insight:<short_id>`     | A curated insight to watch (the ledger row — see schema below).            |
-| `watchlist:anomaly_detection:dashboard:<id>`         | A curated whole dashboard to sweep (when its tiles are collectively key).  |
-| `baseline:anomaly_detection:insight:<short_id>`      | The learned normal: median + MAD per seasonal bucket, so scoring is cheap. |
-| `dedupe:anomaly_detection:insight:<short_id>:<date>` | An anomaly already surfaced, with the re-escalation condition.             |
-| `noise:anomaly_detection:<topic>`                    | A pattern to ignore (a chronically erratic insight, a seasonal quirk).     |
-| `addressed:anomaly_detection:<topic>`                | Team-confirmed expected (a launch/backfill) or fix shipped — skip.         |
-| `allowlist:anomaly_detection:insight:<short_id>`     | An insight to never surface (deprecated, sandbox, test).                   |
-| `not-in-use:anomaly_detection:team{team_id}`         | Close-out memo: team isn't actively using saved analytics right now.       |
+| Key prefix                                           | Holds                                                                             |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `watchlist:anomaly_detection:insight:<short_id>`     | A curated insight to watch (the ledger row — see schema below).                   |
+| `watchlist:anomaly_detection:dashboard:<id>`         | A curated whole dashboard to sweep (when its tiles are collectively key).         |
+| `watchlist:anomaly_detection:importance-refresh`     | Memo: when the watchlist's importance ranking was last reconciled + what changed. |
+| `baseline:anomaly_detection:insight:<short_id>`      | The learned normal: median + MAD per seasonal bucket, so scoring is cheap.        |
+| `dedupe:anomaly_detection:insight:<short_id>:<date>` | An anomaly already surfaced, with the re-escalation condition.                    |
+| `noise:anomaly_detection:<topic>`                    | A pattern to ignore (a chronically erratic insight, a seasonal quirk).            |
+| `addressed:anomaly_detection:<topic>`                | Team-confirmed expected (a launch/backfill) or fix shipped — skip.                |
+| `allowlist:anomaly_detection:insight:<short_id>`     | An insight to never surface (deprecated, sandbox, test).                          |
+| `not-in-use:anomaly_detection:team{team_id}`         | Close-out memo: team isn't actively using saved analytics right now.              |
 
 ### Watchlist entry schema
 
@@ -72,6 +73,27 @@ Each run, budget deliberately:
     dashboards are high-value by association.
   - Cross-check against the watchlist you already have; only add genuinely new items, at most
     ~2–3 per run, each with a first baseline + cadence.
+
+**Refresh importance every few days — the watchlist is not "done" once it's big.** Discovery
+isn't only adding new items; a watchlist's _membership and priorities_ go stale as the team's
+focus moves. Every ~3 days, treat the importance ranking itself as the thing to re-check:
+
+- Re-pull `insights-trending-retrieve` (`days=7`) and `recent_dashboards`, and reconcile them
+  against the watchlist you already have — not just to add, but to **re-rank and prune**: bump
+  the `priority` of items climbing the view counts, and **demote or retire** items whose
+  dashboard is no longer accessed or whose view count has collapsed (drop them, or mark
+  `priority: low` and stretch their cadence). A dashboard created last week that's now the
+  most-opened one belongs on the list; one nobody has opened in a month should not keep burning
+  the budget.
+- A large watchlist is **not** a reason to skip this. "The watchlist is already mature" is the
+  trap: it freezes coverage on whatever was important when you bootstrapped. The refresh is
+  cheap — two reads plus a diff — and it is what keeps "important" meaning _currently_
+  important.
+- Make it actually happen: keep one `watchlist:anomaly_detection:importance-refresh` memo with a
+  `last_refreshed` timestamp and a one-line note of what changed. If it's missing or more than ~3
+  days old, do the refresh this run before exploiting, then reuse the key to update it in place.
+  Like the weekly baseline re-derivation above, this stops the watchlist going stale — but run it
+  more often, because the team's attention shifts faster than a metric's own distribution does.
 
 **Round-robin, don't re-scan everything.** The watchlist + `next_due` timestamps are what let
 successive runs cover different items instead of all repeating the same top insights every


### PR DESCRIPTION
## Problem

The `signals-scout-anomaly-detection` scout earns its leverage from a durable watchlist of the dashboards/insights a team actually views, split each run between **exploit** (re-checking due items) and **explore** (discovering new ones). But the explore guidance was purely *additive* — find new high-value insights and append them. There was no rule to revisit the watchlist's **membership or priorities** once it felt complete.

Baselines already carried a "re-derive ≈weekly or they go stale" rule; **importance had no equivalent**. The asymmetry has a real failure mode: a scout can bootstrap a watchlist, decide it's "mature", and stop exploring — freezing its notion of what's important at bootstrap while the team's actual focus moves on. Newly-popular dashboards never get picked up, and dashboards nobody opens anymore keep burning the run budget.

## Changes

Adds a recurring **importance-refresh** discipline to the anomaly scout (guidance only — no tools, schedule, or scoring changes):

- **`references/watchlist-and-memory.md`** — a new block in the Explore-vs-exploit section: every **~3 days**, re-pull the view-count ranking (`insights-trending-retrieve` / `recent_dashboards`) and reconcile it against the *existing* watchlist — **re-rank** climbers up, **demote/retire** cold items — not just add. Explicitly closes the "watchlist is already mature → skip explore" loophole, and tracks the cadence with a new `watchlist:anomaly_detection:importance-refresh` memo (added to the scratchpad key vocabulary) so it actually recurs. Runs more often than the weekly baseline re-derivation it parallels, because team attention shifts faster than a metric's own distribution.
- **`SKILL.md`** — one lean reinforcing paragraph in the Explore section ("importance decays … a frozen watchlist tracks last week's priorities") pointing at the reference, so a run sees it before opening the reference file.

The depth lives in the reference; the body stays lean per the scout authoring conventions.

## How did you test this code?

I'm an agent (Claude Code). No manual/runtime testing — scouts only run on their schedule. Automated check run: `hogli lint:skills` passes (80 skills OK). This is a docs/instruction-only change to one canonical scout; `lazy_seed` mirrors it onto non-diverged enrolled teams on the next coordinator tick.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of @andrewm4894. The work started as a read-only health review of the project-2 dogfood anomaly scout (via the `exploring-signals-scouts` skill): its scratchpad showed baselines/dedupe/noise updating every run, but the watchlist *membership and priorities* hadn't changed since bootstrap, with recent runs explicitly skipping explore ("watchlist already mature"). We traced that to a gap in the canonical skill's explore guidance and switched to `authoring-signals-scouts` to fix it at the source.

Decisions: kept this to additive *guidance* rather than a mechanism (no new tools or schedule change) since the explore slice already exists — it just needed a recurring importance reconciliation and an anti-ossification guard. Cadence set to ~3 days (tighter than the weekly baseline refresh) because attention moves faster than metric distributions. Detail pushed into the reference to honor the lean-body rule.

Note for reviewers: project 2's own scout row may be "diverged" (manually edited), in which case it won't auto-receive this canonical update without a reset — flagged separately, not addressed here.