### PR TITLE
feat(mcp-analytics): clip tool description 

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
-import { IconArrowLeft, IconArrowRight, IconChevronDown } from '@posthog/icons'
+import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
 import { LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
@@ -359,43 +359,6 @@ function IntentCoverageTag({
     )
 }
 
-function ClampedDescription({ description }: { description: string }): JSX.Element {
-    const [isExpanded, setIsExpanded] = useState(false)
-    const [isOverflowing, setIsOverflowing] = useState(false)
-    const contentRef = useRef<HTMLDivElement>(null)
-
-    useEffect(() => {
-        const el = contentRef.current
-        if (el) {
-            setIsOverflowing(el.scrollHeight > el.clientHeight)
-        }
-    }, [description])
-
-    return (
-        <>
-            <div ref={contentRef} className={isExpanded ? undefined : 'line-clamp-3'}>
-                <LemonMarkdown className="text-sm leading-snug" lowKeyHeadings>
-                    {description}
-                </LemonMarkdown>
-            </div>
-            {isOverflowing && (
-                <button
-                    type="button"
-                    onClick={() => setIsExpanded((prev) => !prev)}
-                    className="flex items-center gap-1 text-[11px] text-secondary hover:text-default cursor-pointer w-fit"
-                >
-                    <IconChevronDown
-                        className="transition-transform"
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={isExpanded ? { transform: 'rotate(180deg)' } : undefined}
-                    />
-                    {isExpanded ? 'Show less' : 'Show more'}
-                </button>
-            )}
-        </>
-    )
-}
-
 function DescriptionBlock({
     descriptions,
     loading,
@@ -413,7 +376,9 @@ function DescriptionBlock({
     return (
         <div className="flex flex-col gap-1 max-w-3xl">
             <span className="text-[11px] uppercase tracking-wider text-secondary">Description</span>
-            <ClampedDescription description={latest.description} />
+            <LemonMarkdown className="text-sm leading-snug line-clamp-3" lowKeyHeadings>
+                {latest.description}
+            </LemonMarkdown>
             {older.length > 0 ? (
                 <Tooltip
                     title={

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
+import { IconArrowLeft, IconArrowRight, IconChevronDown } from '@posthog/icons'
 import { LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
@@ -359,6 +359,43 @@ function IntentCoverageTag({
     )
 }
 
+function ClampedDescription({ description }: { description: string }): JSX.Element {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [isOverflowing, setIsOverflowing] = useState(false)
+    const contentRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const el = contentRef.current
+        if (el) {
+            setIsOverflowing(el.scrollHeight > el.clientHeight)
+        }
+    }, [description])
+
+    return (
+        <>
+            <div ref={contentRef} className={isExpanded ? undefined : 'line-clamp-3'}>
+                <LemonMarkdown className="text-sm leading-snug" lowKeyHeadings>
+                    {description}
+                </LemonMarkdown>
+            </div>
+            {isOverflowing && (
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded((prev) => !prev)}
+                    className="flex items-center gap-1 text-[11px] text-secondary hover:text-default cursor-pointer w-fit"
+                >
+                    <IconChevronDown
+                        className="transition-transform"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={isExpanded ? { transform: 'rotate(180deg)' } : undefined}
+                    />
+                    {isExpanded ? 'Show less' : 'Show more'}
+                </button>
+            )}
+        </>
+    )
+}
+
 function DescriptionBlock({
     descriptions,
     loading,
@@ -376,9 +413,7 @@ function DescriptionBlock({
     return (
         <div className="flex flex-col gap-1 max-w-3xl">
             <span className="text-[11px] uppercase tracking-wider text-secondary">Description</span>
-            <LemonMarkdown className="text-sm leading-snug" lowKeyHeadings>
-                {latest.description}
-            </LemonMarkdown>
+            <ClampedDescription description={latest.description} />
             {older.length > 0 ? (
                 <Tooltip
                     title={


### PR DESCRIPTION
## Problem

On the MCP analytics tool detail page (e.g. `query-trends`), the captured tool/skill description (`$mcp_tool_description`) was rendered in full. These descriptions can be arbitrarily long and dominated the whole page vertically, pushing the actual metrics and charts below the fold.

## Changes

Clamp the latest description to **3 lines** via a `line-clamp-3` utility on the existing `LemonMarkdown` in `DescriptionBlock`. No new component — just the clamp. The "+N previous versions" tooltip is unchanged.

## How did you test this code?

I'm an agent. The frontend `node_modules` weren't installed in my environment, so `typescript:check` and the formatter couldn't run fully. The change is a single Tailwind class on an existing element, so there are no new type implications. Visual confirmation in a running app (long description clips to 3 lines; short descriptions unaffected) still needs a human pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Opus 4.8) at the user's direction. Initially built a clamp + "Show more/less" toggle component; the user asked to simplify to a plain clip, so it's now just a `line-clamp-3` class. Confirmed there's no shared reusable expandable-description component to adopt (`SceneTitleSection` only fully shows/hides its description, no line clamp).
