### PR TITLE
feat(cdp): add LZ4 envelope compression for cyclotron kafka payloads

### DIFF
--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -65,6 +65,10 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_CYCLOTRON_COMPRESS_VM_STATE: boolean
     CDP_CYCLOTRON_USE_BULK_COPY_JOB: boolean
     CDP_CYCLOTRON_COMPRESS_KAFKA_DATA: boolean
+    // Envelope codec used when CDP_CYCLOTRON_COMPRESS_KAFKA_DATA is on. WarpStream bills on
+    // uncompressed bytes, so we compress the payload itself rather than relying on the Kafka
+    // broker codec. 'snappy' is the legacy format; 'lz4' is tagged with a content-encoding header.
+    CDP_CYCLOTRON_KAFKA_COMPRESSION_CODEC: 'snappy' | 'lz4'
     CDP_REDIS_HOST: string
     CDP_REDIS_PORT: number
     CDP_REDIS_PASSWORD: string
@@ -180,6 +184,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_CYCLOTRON_COMPRESS_VM_STATE: isProdEnv() ? false : true,
         CDP_CYCLOTRON_USE_BULK_COPY_JOB: isProdEnv() ? false : true,
         CDP_CYCLOTRON_COMPRESS_KAFKA_DATA: true,
+        CDP_CYCLOTRON_KAFKA_COMPRESSION_CODEC: 'lz4',
         CDP_REDIS_HOST: '127.0.0.1',
         CDP_REDIS_PORT: 6379,
         CDP_REDIS_PASSWORD: '',

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.test.ts
@@ -1,6 +1,23 @@
-import { migrateKafkaCyclotronInvocation } from './job-queue-kafka'
+import { lz4CompressEnvelope, lz4DecompressEnvelope, migrateKafkaCyclotronInvocation } from './job-queue-kafka'
 
 describe('CyclotronJobQueueKafka', () => {
+    describe('lz4 envelope', () => {
+        it.each([
+            '{}',
+            '{"id":"abc","teamId":1,"queue":"hog"}',
+            JSON.stringify({ id: 'x'.repeat(10_000), nested: { values: Array.from({ length: 500 }, (_, i) => i) } }),
+        ])('round-trips payload %#', (jsonString) => {
+            const envelope = lz4CompressEnvelope(jsonString)
+            expect(lz4DecompressEnvelope(envelope).toString()).toBe(jsonString)
+        })
+
+        it('prefixes the uncompressed size as little-endian uint32', () => {
+            const jsonString = '{"id":"abc","teamId":1,"queue":"hog"}'
+            const envelope = lz4CompressEnvelope(jsonString)
+            expect(envelope.readUInt32LE(0)).toBe(Buffer.byteLength(jsonString, 'utf8'))
+        })
+    })
+
     describe('migrateKafkaCyclotronInvocation', () => {
         // Pulled from a real job in kafka
         const legacyFormat = {

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -14,7 +14,13 @@ import { logger } from '../../../utils/logger'
 import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { JobQueue } from './job-queue.interface'
-import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer, observeConsumedBatch } from './shared'
+import {
+    cdpCyclotronMessagesByEncoding,
+    cdpJobSizeCompressedKb,
+    cdpJobSizeKb,
+    createInvocationSanitizer,
+    observeConsumedBatch,
+} from './shared'
 
 const lz4: {
     encodeBound(size: number): number
@@ -234,10 +240,21 @@ export class CyclotronJobQueueKafka implements JobQueue {
 
             // LZ4 payloads are tagged with a content-encoding header; everything else is either
             // snappy-compressed or raw JSON, so fall back to snappy-or-raw for those.
-            const decompressedValue =
-                getContentEncoding(message.headers) === 'lz4'
-                    ? lz4DecompressEnvelope(rawValue)
-                    : await uncompress(rawValue).catch(() => rawValue)
+            let decompressedValue: Buffer
+            let encoding: string
+            if (getContentEncoding(message.headers) === 'lz4') {
+                decompressedValue = lz4DecompressEnvelope(rawValue)
+                encoding = 'lz4'
+            } else {
+                try {
+                    decompressedValue = await uncompress(rawValue)
+                    encoding = 'snappy'
+                } catch {
+                    decompressedValue = rawValue
+                    encoding = 'none'
+                }
+            }
+            cdpCyclotronMessagesByEncoding.labels(encoding).inc()
             const invocation: CyclotronJobInvocation = migrateKafkaCyclotronInvocation(
                 parseJSON(decompressedValue.toString())
             )

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -3,7 +3,7 @@
  * To make this easier this class is designed to abstract the queue as much as possible from
  * the underlying implementation.
  */
-import { Message } from 'node-rdkafka'
+import { Message, MessageHeader } from 'node-rdkafka'
 import { compress, uncompress } from 'snappy'
 
 import { KafkaConsumerInterface, createKafkaConsumer } from '../../../kafka/consumer'
@@ -16,6 +16,45 @@ import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueue
 import { JobQueue } from './job-queue.interface'
 import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer, observeConsumedBatch } from './shared'
 
+const lz4: {
+    encodeBound(size: number): number
+    encodeBlock(input: Buffer, output: Buffer): number
+    decodeBlock(input: Buffer, output: Buffer): number
+} = require('lz4')
+
+// LZ4 block payloads carry no length, so we prefix the 4-byte little-endian uncompressed size,
+// matching the session replay envelope format. The 'content-encoding: lz4' header is what tells
+// the consumer to use this path.
+export function lz4CompressEnvelope(jsonString: string): Buffer {
+    const input = Buffer.from(jsonString, 'utf8')
+    const output = Buffer.allocUnsafe(lz4.encodeBound(input.length))
+    const compressedSize = lz4.encodeBlock(input, output)
+    const envelope = Buffer.allocUnsafe(4 + compressedSize)
+    envelope.writeUInt32LE(input.length, 0)
+    output.copy(envelope, 4, 0, compressedSize)
+    return envelope
+}
+
+export function lz4DecompressEnvelope(buffer: Buffer): Buffer {
+    const uncompressedSize = buffer.readUInt32LE(0)
+    const output = Buffer.allocUnsafe(uncompressedSize)
+    lz4.decodeBlock(buffer.subarray(4), output)
+    return output
+}
+
+function getContentEncoding(headers: MessageHeader[] | undefined): string | null {
+    if (!headers) {
+        return null
+    }
+    for (const header of headers) {
+        const value = header['content-encoding']
+        if (value !== undefined) {
+            return typeof value === 'string' ? value : value.toString()
+        }
+    }
+    return null
+}
+
 export class CyclotronJobQueueKafka implements JobQueue {
     private kafkaConsumer?: KafkaConsumerInterface
     private kafkaProducer?: KafkaProducerWrapper
@@ -27,7 +66,9 @@ export class CyclotronJobQueueKafka implements JobQueue {
         private kafkaClientRack: string | undefined,
         private config: Pick<
             CdpConfig,
-            'CDP_CYCLOTRON_COMPRESS_KAFKA_DATA' | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
+            | 'CDP_CYCLOTRON_COMPRESS_KAFKA_DATA'
+            | 'CDP_CYCLOTRON_KAFKA_COMPRESSION_CODEC'
+            | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
         >,
         private consumerBatchSize: number
     ) {
@@ -103,20 +144,30 @@ export class CyclotronJobQueueKafka implements JobQueue {
             }
         })
 
+        const useLz4 =
+            this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA &&
+            this.config.CDP_CYCLOTRON_KAFKA_COMPRESSION_CODEC === 'lz4'
+
         await Promise.all(
             messages.map(async (msg) => {
-                const value = this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA
-                    ? await compress(msg.jsonString)
-                    : msg.jsonString
-
-                cdpJobSizeCompressedKb.labels('kafka').observe(value.length / 1024)
-
                 const headers: Record<string, string> = {
                     // NOTE: Later we should remove hogFunctionId as it is no longer used
                     hogFunctionId: msg.functionId,
                     functionId: msg.functionId,
                     teamId: msg.teamId.toString(),
                 }
+
+                let value: Buffer | string
+                if (!this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA) {
+                    value = msg.jsonString
+                } else if (useLz4) {
+                    value = lz4CompressEnvelope(msg.jsonString)
+                    headers['content-encoding'] = 'lz4'
+                } else {
+                    value = await compress(msg.jsonString)
+                }
+
+                cdpJobSizeCompressedKb.labels('kafka').observe(value.length / 1024)
 
                 await producer
                     .produce({
@@ -181,8 +232,12 @@ export class CyclotronJobQueueKafka implements JobQueue {
                 throw new Error('Bad message: ' + JSON.stringify(message))
             }
 
-            // Try to decompress, otherwise just use the value as is
-            const decompressedValue = await uncompress(rawValue).catch(() => rawValue)
+            // LZ4 payloads are tagged with a content-encoding header; everything else is either
+            // snappy-compressed or raw JSON, so fall back to snappy-or-raw for those.
+            const decompressedValue =
+                getContentEncoding(message.headers) === 'lz4'
+                    ? lz4DecompressEnvelope(rawValue)
+                    : await uncompress(rawValue).catch(() => rawValue)
             const invocation: CyclotronJobInvocation = migrateKafkaCyclotronInvocation(
                 parseJSON(decompressedValue.toString())
             )

--- a/nodejs/src/cdp/services/job-queue/shared.ts
+++ b/nodejs/src/cdp/services/job-queue/shared.ts
@@ -36,6 +36,12 @@ const cdpCyclotronJobsProcessed = new Counter({
     labelNames: ['queue', 'source'],
 })
 
+export const cdpCyclotronMessagesByEncoding = new Counter({
+    name: 'cdp_cyclotron_messages_by_encoding',
+    help: 'The number of kafka messages consumed broken down by envelope content-encoding',
+    labelNames: ['encoding'],
+})
+
 /**
  * Records throughput and batch utilization for a consumed batch.
  * `cdp_cyclotron_batch_utilization` is consumed by KEDA to autoscale the cyclotron workers, so this


### PR DESCRIPTION
## Problem

Cyclotron ingestion volume is growing and its WarpStream cluster cost is climbing. WarpStream bills on **uncompressed** stored bytes, and cyclotron job payloads are currently written as pure, uncompressed JSON. Kafka's broker-level `compression.codec` only compresses in transit, so it doesn't reduce the billed volume — only compressing the payload itself does. This mirrors the approach already taken for session replay (#61077).

## Changes

The cyclotron producer already had payload-level compression infrastructure (snappy, gated by `CDP_CYCLOTRON_COMPRESS_KAFKA_DATA`), but it was effectively off in production. This adds LZ4 as a selectable envelope codec:

- New `CDP_CYCLOTRON_KAFKA_COMPRESSION_CODEC` config (`'snappy' | 'lz4'`, default `'lz4'`), used when `CDP_CYCLOTRON_COMPRESS_KAFKA_DATA` is on.
- LZ4 payloads use the same envelope format as session replay — a 4-byte little-endian uncompressed-size prefix plus the LZ4 block — and carry a `content-encoding: lz4` header.
- The consumer decodes LZ4 when the header is present, and otherwise falls back to snappy-or-raw, so it round-trips every existing, in-flight, and future payload format. `snappy` remains available as an instant rollback via env without a code change.

- A `cdp_cyclotron_messages_by_encoding` counter (labeled `lz4` / `snappy` / `none`) on the consumer, mirroring the per-encoding rollout metric from #61077, so the cutover can be watched in real time.

This covers both the `cdp_cyclotron_hog` and `cdp_cyclotron_hogoverflow` topics, since both are written through the same producer path.

**Rollout:** the producer only emits LZ4 once `CDP_CYCLOTRON_COMPRESS_KAFKA_DATA` is enabled. Deploy this change everywhere first (consumers become LZ4-aware while still producing the current format), then flip the compression flag — at that point all consumers already understand LZ4.

## How did you test this code?

I'm an agent (PostHog Slack app). Automated only:

- Added a unit test asserting the LZ4 envelope round-trips (including a ~12 KB payload) and that the 4-byte little-endian size prefix matches the uncompressed length.
- Separately validated the exact encode/decode envelope logic against the real `lz4` package in isolation (round-trip correct; a representative payload compressed ~12 KB → ~2 KB).

I could not run the nodejs jest suite in this environment (workspace dependencies/native modules aren't installed here).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: turn on LZ4 compression for the cyclotron `cdp-cyclotron-hog` / overflow topics to cut WarpStream cost, following the session replay precedent (#61077).

Key decisions:
- Compressed at the **payload (envelope)** level, not via Kafka broker `compression.codec` — WarpStream bills uncompressed bytes, so only payload compression reduces cost (the same reason session replay went this route).
- Reused the existing `CDP_CYCLOTRON_COMPRESS_KAFKA_DATA` on/off switch and layered a codec selector on top rather than replacing it, keeping the existing env contract and snappy as a rollback path.
- Matched session replay's envelope format (4-byte LE size prefix + `content-encoding: lz4` header) so the decode path is consistent across the codebase, and kept the consumer fully backward-compatible (LZ4 / snappy / raw).


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1781192171730259?thread_ts=1781192171.730259&cid=C06GG249PR6)*


