### PR TITLE
chore(signals): fold obs-gaps dogfood learnings into canonical skill

### DIFF
--- a/products/signals/skills/signals-scout-observability-gaps/SKILL.md
+++ b/products/signals/skills/signals-scout-observability-gaps/SKILL.md
@@ -68,6 +68,18 @@ run has covered — to earn the close-out rather than inherit it. If the tripwir
 untriggered and the probe comes back clean, close out empty in minutes. Don't re-run
 coverage SQL a run verified hours ago; that's duplication, not diligence.
 
+One asymmetry to bake in: the **coverage** families (1, 3, 4, 5, 6) saturate
+_permanently_ on a mature team — every high-volume event already has dense coverage —
+but **insight drift (family 2) does not.** Drift is generated continuously as the
+product renames and sunsets events, so on an otherwise-saturated team it is the one
+durably productive angle. Lead with it and treat the coverage families as
+inherit-saturation unless their tripwire fires.
+
+When several probe angles exist (new-event emergence, alert coverage, insight drift),
+**rotate**: each run picks the _stalest_ angle — the one untouched longest — and
+inherits the others' recent readings. Rotating earns a genuinely fresh close-out each
+tick without re-running identical SQL hourly.
+
 ## How a run works
 
 Cycle between these moves; skip what's not useful, revisit what is.
@@ -136,8 +148,11 @@ Direct calls:
 - For zero-volume events, search `event-definitions-list` for similar names suggesting
   a rename (Levenshtein-close, same prefix, same property shape).
 
-Strong signal: insight has been viewed in the last 30d AND its primary event has 0
-firings in 7d AND a similar-named event is firing > 100/day.
+Strong signal: the insight is live (recent `last_modified_at`, or pinned to a live
+dashboard via `system.dashboard_tiles`) AND its primary event has 0 firings in 7d AND
+a similar-named event is firing > 100/day. Note `system.insights` exposes
+`last_modified_at` but has **no** `last_viewed_at` column — prove "live" by
+modification recency or a live dashboard tile, not view recency.
 
 #### 3. Critical event with no alerts configured
 
@@ -288,6 +303,11 @@ a separate "run metadata" scratchpad entry — the run summary already serves th
 - **Incident-investigation scaffolding** — short-lived events created during an
   incident, often with incident-named insights attached. They stop firing when the
   incident closes; flagging the stoppage as drift is a false positive.
+- **One-time backfills / deploy spikes** — a newly-instrumented event can dump its
+  whole history in a single ingest, faking a high-reach "stable" metric. Before
+  trusting volume, bucket the candidate by hour (`toStartOfHour`): if nearly all
+  events _and_ distinct users land in one hour, it's a backfill, not a stable metric —
+  disqualify it (it fails the 7-complete-day bar regardless of raw reach).
 - **Legacy event-name variants** — insights that deliberately union an old and a new
   event name for historical continuity are well-maintained, not drifted. Read the
   insight's query JSON before declaring a dead event "still referenced."


### PR DESCRIPTION
## Problem

We've been dogfooding the `signals-scout-observability-gaps` scout on PostHog's own project. Reviewing how it has actually behaved over the last ~10 days surfaced a few concrete ways the canonical SKILL.md can be sharper. This folds those learnings back into the source-of-truth skill (`products/signals/skills/`), which `lazy_seed` mirrors onto agent-enabled teams.

## Changes

Four targeted, lean edits to the scout body:

- **Fix a literal defect.** Family-2's "strong signal" instructed the scout to check whether an insight had been *"viewed in the last 30d"*, but `system.insights` has **no `last_viewed_at` column**. Replaced with a "is the insight live" check via `last_modified_at` recency or a live `system.dashboard_tiles` pin — which is what actually works against the schema.
- **Name the family asymmetry.** On a mature team the coverage families (1, 3, 4, 5, 6) saturate permanently — every high-volume event already has dense coverage — but **insight drift (family 2) does not**: drift is generated continuously as the product renames/sunsets events. The body now says to lead with drift and treat the coverage families as inherit-saturation unless their tripwire fires.
- **Codify probe rotation.** Document the discipline of picking the *stalest* probe angle each run and inheriting the others' recent readings, so a saturated team earns a genuinely fresh close-out each tick without re-running identical SQL hourly.
- **Add a backfill disqualifier.** A newly-instrumented event can dump its whole history in a single ingest and fake a high-reach "stable" metric. Added a disqualifier with a concrete hourly-distribution test (`toStartOfHour` — if nearly all events *and* distinct users land in one hour, it's a backfill).

These are in the same spirit as the earlier "harden observability-gaps scout with dogfood learnings" (#62555) pass.

## How did you test this code?

I'm an agent (Claude Code / Opus 4.8), human-directed. This is a documentation/skill-body change only — no code paths. No automated tests apply; the markdown formatter (`hogli format:markdown`) ran via lint-staged on commit. The four edits are each grounded in observed scout behavior and durable scratchpad memory on the dogfood project.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Andy via Claude Code, using the `exploring-signals-scouts` skill and the PostHog MCP (`signals-scout-config-list` / `-runs-list` / `-scratchpad-search`, `skill-get`, and `tasks-runs-session-logs-retrieve`) to inspect the live scout, then reconstructing two failed-run session logs to root-cause the timeouts.

Key decision: the scout's ~43% run-failure rate (all `poll_for_turn` timeouts) is **not** in scope here. Session-log reconstruction showed those runs do all their work in under 3 minutes, write their scratchpad memory, then hang silently on the final close-out turn until the timeout wall — a harness/infra reliability issue, not something a skill-body edit can fix. That finding is being routed to the Signals harness owners separately. This PR contains only the genuine skill-quality learnings.
