### PR TITLE
chore(docs): document package placement, drop platform layer

### DIFF
--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -14,7 +14,6 @@ Pick a home with a real boundary first, in this order:
 - `tools/` — dev/CI tooling, not shipped at runtime
 - `services/` — independently deployed
 - `packages/` — a clean, published-style leaf with **no back-edges into app code** (see `packages/quill`)
-- `platform/` — cross-cutting glue/infra (aspirational; coordinate before creating it)
 
 Fall back to `common/` **only** when none of those fit _and_ the code can't yet be a clean leaf because it still imports app modules (`lib/*`, `scenes/*`, etc.). If you do, treat it as tracked debt: say so in the PR and name the intended graduation target. "It follows an existing `common/` precedent" is not, on its own, a reason to add more.
 

--- a/docs/internal/monorepo-layout.md
+++ b/docs/internal/monorepo-layout.md
@@ -1,6 +1,6 @@
 # Monorepo Layout
 
-High-level structure of the PostHog monorepo. Some directories are aspirational (e.g., `platform/` doesn't exist yet - shared code currently lives in `common/`).
+High-level structure of the PostHog monorepo.
 
 ## Directory structure
 
@@ -19,12 +19,16 @@ products/              # Product-specific apps (see products/README.md for layou
     frontend/          # React (scenes, components, logics)
     manifest.tsx       # Routes, scenes, URLs
     package.json
+    services/          # Optional: services this product deploys (see "What a product can own")
+    packages/          # Optional: libraries/CLIs this product owns
 
-services/              # Independent backend services
+services/              # Independent services NOT owned by any one product
   llm-gateway/         # LLM proxy service
   mcp/                 # Model Context Protocol service
   oauth-proxy/         # OAuth proxy (Cloudflare Worker)
   stripe-app/          # Stripe integration app
+
+packages/              # Libraries shared across more than one product/service (e.g. quill)
 
 common/                # Shared code — holding pen, NOT a destination (goal: shrink it)
   hogql_parser/        # HogQL parser
@@ -34,16 +38,6 @@ tools/                 # Developer/CI tooling, not imported by runtime code
   hogli-commands/      # PostHog-specific hogli commands (consumed via hogli.yaml)
 
 devenv/                # Developer environment config (intent map, process model)
-
-platform/              # Shared platform code (aspirational - not yet created)
-  integrations/        # External adapters
-    vercel/
-  auth/                # Token utils
-  http/                # Shared HTTP clients
-  storage/             # S3/GCS clients
-  queue/               # Message queue helpers
-  db/                  # Shared DB utilities
-  observability/       # Logging, tracing, metrics
 ```
 
 ### Products
@@ -56,6 +50,23 @@ User-facing features with their own backend (Django app) and frontend (React). E
 
 See [products/README.md](/products/README.md) for how to create products. For new isolated products, see [products/architecture.md](/products/architecture.md) for design principles (DTOs, facades, isolation rules).
 
+#### What a product can own
+
+Most products are a Django app plus React scenes. Some also own adjacent runtime and tooling — services they deploy, a CLI, packages, a standalone console. Nest those under the product instead of scattering them across top-level dirs:
+
+- `products/<product>/services/<svc>/`, `.../packages/<lib>/`, a product CLI, and so on. Top-level `services/`, `packages/`, `tools/`, and `cli/` are for things no single product owns.
+- Keep package names (`@posthog/<name>`) independent of location — pnpm resolves by name, so relocating later is a path move with no import churn.
+
+Nest because tooling boundaries become path-scoped (`products/<product>/**` for CODEOWNERS, CI filters, lint) instead of hand-synced `<product>-*` prefixes. A prefix doing a folder's job is the signal to nest.
+
+### Packages
+
+A package's location doesn't gate who can import it — pnpm resolves by name, so location is an ownership signal, not access control. Place by current ownership:
+
+- Owned by one product → `products/<product>/packages/<name>/` (the default — keeps the product self-contained).
+- Genuinely shared across more than one product/service → top-level `packages/<name>/` (e.g. `quill`).
+- Promote nested → root only when a second consumer actually depends on it — on real usage, not intent. It's a path rename with a stable package name (no import churn), so don't pay the "shared" cost before it's true.
+
 ### Services
 
 - are their own deployment
@@ -65,24 +76,8 @@ See [products/README.md](/products/README.md) for how to create products. For ne
 - aren’t cross-cutting glue
 - aren’t frontend-facing “products”
 
-These are not glue, because glue adapts other systems.  
-They are not products, because no one interacts with them as a user-facing feature.  
-They are not platform, because they own domain logic, not shared tooling.
-
-### Platform
-
-Cross-cutting glue and infrastructure: external adapters (Vercel), clients, shared libs. Must not import products/services.
-
-Why platform must not call product code:
-
-- If platform imports and calls product code, platform becomes a hidden orchestrator
-- it must know which products exist
-- it must route events to product logic
-- it accumulates product-specific conditionals
-- dependency direction flips (platform → products)
-- cycles become likely over time
-
-That destroys the "platform is foundational" property and makes boundaries brittle.
+These are not glue, because glue adapts other systems.
+They are not products, because no one interacts with them as a user-facing feature.
 
 ### Common
 

--- a/docs/internal/monorepo-layout.md
+++ b/docs/internal/monorepo-layout.md
@@ -61,11 +61,15 @@ Nest because tooling boundaries become path-scoped (`products/<product>/**` for 
 
 ### Packages
 
-A package's location doesn't gate who can import it — pnpm resolves by name, so location is an ownership signal, not access control. Place by current ownership:
+This covers **pnpm workspace packages** (JS/TS). Python and Rust differ — there, location and import name matter directly (a top-level Python package can even shadow a stdlib module, which is why there's no top-level `platform/`), so these rules don't apply.
+
+For pnpm packages, location doesn't gate who can import them (pnpm resolves by name), so location is an ownership signal, not access control. Place by current ownership:
 
 - Owned by one product → `products/<product>/packages/<name>/` (the default — keeps the product self-contained).
-- Genuinely shared across more than one product/service → top-level `packages/<name>/` (e.g. `quill`).
+- Genuinely shared across more than one product/service → top-level `packages/<name>/` (e.g. `packages/quill/`).
 - Promote nested → root only when a second consumer actually depends on it — on real usage, not intent. It's a path rename with a stable package name (no import churn), so don't pay the "shared" cost before it's true.
+
+`pnpm-workspace.yaml` globs are explicit (`products/*`, `packages/quill`, …) and don't yet match nested `products/<product>/packages/*` or a new top-level `packages/<name>/` — so register the package's path there when you add it, or `workspace:*` deps, filters, and scripts won't resolve.
 
 ### Services
 


### PR DESCRIPTION
## Problem

`docs/internal/monorepo-layout.md` described an aspirational top-level `platform/` directory as the home for "cross-cutting glue and infrastructure." In practice that concept was confusing and unworkable:

- It was never created, and the code it imagined a home for already lives elsewhere (shared infra under `posthog/`, the Vercel integration under `ee/`).
- It conflated two different things — dependency-free infrastructure vs. domain-aware integrations (which are really products) — under one rule ("must not import products/services") that integrations can't satisfy.
- A top-level `platform/` Python package would silently shadow the standard-library `platform` module (the repo root is a source root), a well-known import-shadowing trap.

Meanwhile the layout doc had no guidance on where packages go, or on products that own their own runtime (services, CLIs) — an active, real question.

## Changes

Docs only — no code or behavior changes.

- **Drop the `platform/` layer** from `docs/internal/monorepo-layout.md` (tree entry, intro mention, the `### Platform` section, and the Services contrast line) and from the `common/AGENTS.md` placement ladder.
- **Add a `### Packages` section**: a package's location is an ownership signal, not access control (pnpm resolves by name), so it lives under its owning product by default and is promoted to top-level `packages/` only when a second consumer actually depends on it.
- **Add `#### What a product can own`**: products may nest their own `services/`, `packages/`, and CLIs; top-level `services/`, `packages/`, `tools/`, and `cli/` are for things no single product owns.
- **Update the tree**: show top-level `packages/`, product-nested `services/`/`packages/`, and relabel top-level `services/` as "NOT owned by any one product."

## How did you test this code?

I'm an agent. This is a documentation-only change — no automated tests apply and I did not perform manual testing. I verified the rendered structure and that no `platform` references remain in the layout doc.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal engineering doc only; no user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by the PR assignee.

Authored with Claude Code (tools used: Bash/git, Read, Grep, Write/Edit, GitHub MCP). [Session](https://claude.ai/code/session_015zo6sbFwCxqqgRtH2x1Zwn).

This started as "where should a cross-boundary `platform/` layer live, given the name collides?" The decisions that shaped the outcome:

- Established that `platform` is not a Python keyword but a **stdlib module**, so a top-level `platform/` package would shadow it — the actual hazard.
- Explored and rejected several names/structures (`foundation`, `infra`, nesting under `posthog/`, a `posthog_platform/` sibling, a `packages/` leaf): each either reintroduced an import cycle (`posthog.settings` pulls `ee` → products), failed the "must not import products" guarantee, or solved a problem that didn't actually exist.
- Concluded the `platform/` concept itself was the confusion — a real integration (Vercel) is domain-aware glue and belongs in a product, not a dependency-free "platform" layer — so the doc drops `platform/` rather than renaming it.
- Folded in a separately-drafted set of package/product-ownership placement rules, condensed and generalized beyond services to CLIs and other product-owned runtime.

Agent-authored doc change — requires human review; not for self-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zo6sbFwCxqqgRtH2x1Zwn)_