### PR TITLE
fix(tracing): support span-attribute filters for all operators

### DIFF
--- a/products/tracing/backend/aggregation_query_runner.py
+++ b/products/tracing/backend/aggregation_query_runner.py
@@ -55,7 +55,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
 from posthog.models.filters.mixins.utils import cached_property
 
-from .logic import TIME_BUCKET_DATE_RANGE_WHERE, translate_span_filter
+from .logic import TIME_BUCKET_DATE_RANGE_WHERE, translate_span_filter, with_span_attribute_type_suffix
 
 if TYPE_CHECKING:
     from posthog.models import Team, User
@@ -90,14 +90,6 @@ class _SpanAggregationMixin:
         # Replicates the filter extraction the per-trace runner mixin does. We can't reuse
         # that mixin directly: it validates against TraceSpansQuery and wires a paginator
         # that does not apply here.
-        def get_property_type(value: str | float | bool) -> str:
-            try:
-                float(value)
-                return "float"
-            except (ValueError, TypeError):
-                pass
-            return "str"
-
         self.span_filters: list[SpanPropertyFilter] = []
         self.span_attribute_filters: list[SpanPropertyFilter] = []
         self.resource_attribute_filters: list[SpanPropertyFilter] = []
@@ -113,18 +105,8 @@ class _SpanAggregationMixin:
                 elif prop_type == SpanPropertyFilterType.SPAN:
                     self.span_filters.append(cast(SpanPropertyFilter, prop))
                 elif prop_type == SpanPropertyFilterType.SPAN_ATTRIBUTE:
-                    if isinstance(prop, SpanPropertyFilter) and prop.value:
-                        property_type = "str"
-                        if isinstance(prop.value, list):
-                            property_types = {get_property_type(v) for v in prop.value}
-                            if len(property_types) == 1:
-                                property_type = property_types.pop()
-                        else:
-                            property_type = get_property_type(prop.value)
-
-                        prop = prop.model_copy(deep=True)
-                        prop.key = f"{prop.key}__{property_type}"
-
+                    if isinstance(prop, SpanPropertyFilter):
+                        prop = with_span_attribute_type_suffix(prop)
                     self.span_attribute_filters.append(cast(SpanPropertyFilter, prop))
 
     def validate_query_runner_access(self, user: "User") -> bool:

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -23,6 +23,7 @@ from posthog.schema import (
     IntervalType,
     PropertyGroupFilter,
     PropertyGroupsMode,
+    PropertyOperator,
     SpanPropertyFilter,
     SpanPropertyFilterType,
     TraceSpansAggregationQuery,
@@ -170,6 +171,56 @@ def translate_span_filter(span_filter: SpanPropertyFilter) -> None:
         span_filter.value = cast("list[str | int | float]", _normalise_status_code_values(values))
 
 
+# Operators whose semantics require numeric ordering — only these need the Float64 map. Every other
+# operator (equality, substring, regex, set/unset) is correct on the universal str map.
+_NUMERIC_SPAN_ATTRIBUTE_OPERATORS = frozenset(
+    {
+        PropertyOperator.GT,
+        PropertyOperator.GTE,
+        PropertyOperator.LT,
+        PropertyOperator.LTE,
+        PropertyOperator.BETWEEN,
+        PropertyOperator.NOT_BETWEEN,
+    }
+)
+
+
+def _is_numeric(value: object) -> bool:
+    # bool is a numeric subclass in Python, but OTel booleans are stored as the strings 'true'/'false'
+    # (so they live in the str map, not the float map) — keep them off the numeric path.
+    if isinstance(value, bool):
+        return False
+    try:
+        float(value)  # type: ignore[arg-type]
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def with_span_attribute_type_suffix(prop: SpanPropertyFilter) -> SpanPropertyFilter:
+    """Return a copy of a span-attribute filter whose key carries its physical-map type suffix.
+
+    Span attributes live in typed ClickHouse Maps; the property-group resolver routes a key by its
+    suffix — ``__str`` → ``attributes_map_str`` (every attribute, string values) and ``__float`` →
+    ``attributes_map_float`` (only attributes whose stored value parsed numeric). A bare key matches no
+    group and prints an illegal JSON read on the Map column (a 500), so a suffix is always required.
+
+    Route by *operator*, not by the filter value's type: only numeric comparison operators need the
+    float map for correct ordering, and only when their value is actually numeric. Everything else —
+    equality, substring/regex, and value-less is_set/is_not_set — uses the universal str map, so
+    string-stored values are never silently dropped and booleans resolve against their stored form.
+    """
+    suffix = "str"
+    if prop.operator in _NUMERIC_SPAN_ATTRIBUTE_OPERATORS:
+        values = prop.value if isinstance(prop.value, list) else [prop.value]
+        if values and all(_is_numeric(v) for v in values):
+            suffix = "float"
+
+    prop = prop.model_copy(deep=True)
+    prop.key = f"{prop.key}__{suffix}"
+    return prop
+
+
 class TraceSpansQueryRunnerMixin(QueryRunner):
     """Shared WHERE clause and settings for all trace span query runners."""
 
@@ -185,14 +236,6 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
         self.modifiers.convertToProjectTimezone = False
         self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
 
-        def get_property_type(value: str | float | bool) -> str:
-            try:
-                float(value)
-                return "float"
-            except (ValueError, TypeError):
-                pass
-            return "str"
-
         self.span_filters: list[SpanPropertyFilter] = []
         self.span_attribute_filters: list[SpanPropertyFilter] = []
         self.resource_attribute_filters: list[SpanPropertyFilter] = []
@@ -205,18 +248,8 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     if prop_type == SpanPropertyFilterType.SPAN:
                         self.span_filters.append(prop)
                     elif prop_type == SpanPropertyFilterType.SPAN_ATTRIBUTE:
-                        if isinstance(prop, SpanPropertyFilter) and prop.value:
-                            property_type = "str"
-                            if isinstance(prop.value, list):
-                                property_types = {get_property_type(v) for v in prop.value}
-                                if len(property_types) == 1:
-                                    property_type = property_types.pop()
-                            else:
-                                property_type = get_property_type(prop.value)
-
-                            prop = prop.model_copy(deep=True)
-                            prop.key = f"{prop.key}__{property_type}"
-
+                        if isinstance(prop, SpanPropertyFilter):
+                            prop = with_span_attribute_type_suffix(prop)
                         self.span_attribute_filters.append(prop)
 
     def where(self) -> ast.Expr:

--- a/products/tracing/backend/tests/test_span_attribute_filter.py
+++ b/products/tracing/backend/tests/test_span_attribute_filter.py
@@ -1,0 +1,241 @@
+import base64
+import datetime as dt
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.traces.spans import TRACE_SPANS_DISTRIBUTED_TABLE_SQL, TRACE_SPANS_TABLE_SQL
+
+DATE_FROM = "2026-06-02T07:00:00Z"
+DATE_TO = "2026-06-02T09:00:00Z"
+
+# Span A carries the OTel code.* source-location attributes; span B has none of them.
+WITH_CODE = "posthog-feature-flags"
+WITHOUT_CODE = "other-service"
+FILEPATH = "feature-flags/src/flags/flag_matching.rs"
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+class TestSpanAttributeFilter(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        tag_queries(product="tracing", feature="query")
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        sync_execute(
+            "ALTER TABLE trace_spans ADD COLUMN IF NOT EXISTS "
+            "is_root_span Bool MATERIALIZED (replaceAll(trimRight(parent_span_id, '='), 'A', '')) = ''"
+        )
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+
+        base = dt.datetime(2026, 6, 2, 8, 0, 0)
+        ts_str = base.strftime("%Y-%m-%d %H:%M:%S.%f")
+        end_str = (base + dt.timedelta(milliseconds=5)).strftime("%Y-%m-%d %H:%M:%S.%f")
+        # Keys in attributes_map_str carry a 5-char type suffix (__str); the `attributes` ALIAS strips it.
+        sync_execute(
+            "INSERT INTO trace_spans (uuid, team_id, trace_id, span_id, parent_span_id, name, kind, "
+            "timestamp, end_time, observed_timestamp, status_code, service_name, attributes_map_str, "
+            "resource_attributes) VALUES "
+            "("
+            f"'019e8754-0000-0000-0000-000000000001', {cls.team.id}, '{_b64((1).to_bytes(16, 'big'))}', "
+            f"'{_b64((1).to_bytes(8, 'big'))}', '', 'root.with_code', 2, '{ts_str}', '{end_str}', '{ts_str}', 0, "
+            f"'{WITH_CODE}', "
+            "map('code.filepath__str', '" + FILEPATH + "', 'code.namespace__str', 'flags', "
+            "'code.lineno__str', '42', 'cache.hit__str', 'true'), "
+            "map('service.version', '1.2.3')),"
+            "("
+            f"'019e8754-0000-0000-0000-000000000002', {cls.team.id}, '{_b64((2).to_bytes(16, 'big'))}', "
+            f"'{_b64((2).to_bytes(8, 'big'))}', '', 'root.without_code', 2, '{ts_str}', '{end_str}', '{ts_str}', 0, "
+            f"'{WITHOUT_CODE}', "
+            # http.status is stored as a NON-numeric string; req.tag is non-numeric. These guard the
+            # "numeric-looking filter value silently routes to the float map" regression.
+            "map('http.method__str', 'GET', 'http.status__str', '500ok', 'req.tag__str', 'v2'), "
+            "map('service.version', '1.2.3'))"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+        super().tearDownClass()
+
+    def _query_services(self, prop: dict, root_spans: bool = False) -> list[str]:
+        body = {
+            "query": {
+                "dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO},
+                "rootSpans": root_spans,
+                "filterGroup": [prop],
+            }
+        }
+        res = self.client.post(f"/api/projects/{self.team.id}/tracing/spans/query/", body, format="json")
+        self.assertEqual(res.status_code, 200, res.content)
+        return sorted(row["service_name"] for row in res.json()["results"])
+
+    @parameterized.expand(
+        [
+            # Value-bearing operators already worked; value-less operators used to 500 (bare key -> illegal
+            # JSON read on the Map column). All five must return 200 with the right spans.
+            (
+                "exact",
+                {"key": "code.filepath", "type": "span_attribute", "operator": "exact", "value": FILEPATH},
+                [WITH_CODE],
+            ),
+            (
+                "icontains",
+                {
+                    "key": "code.filepath",
+                    "type": "span_attribute",
+                    "operator": "icontains",
+                    "value": "flag_matching.rs",
+                },
+                [WITH_CODE],
+            ),
+            (
+                "is_not",
+                {"key": "code.filepath", "type": "span_attribute", "operator": "is_not", "value": "nope.rs"},
+                sorted([WITH_CODE, WITHOUT_CODE]),
+            ),
+            ("is_set", {"key": "code.filepath", "type": "span_attribute", "operator": "is_set"}, [WITH_CODE]),
+            (
+                "is_not_set",
+                {"key": "code.filepath", "type": "span_attribute", "operator": "is_not_set"},
+                [WITHOUT_CODE],
+            ),
+            # code.namespace — a second standard code.* key.
+            (
+                "namespace_icontains",
+                {"key": "code.namespace", "type": "span_attribute", "operator": "icontains", "value": "flag"},
+                [WITH_CODE],
+            ),
+            (
+                "namespace_is_set",
+                {"key": "code.namespace", "type": "span_attribute", "operator": "is_set"},
+                [WITH_CODE],
+            ),
+            # Equality on a numeric attribute uses the universal str map (string ops don't need __float).
+            (
+                "lineno_exact",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "exact", "value": "42"},
+                [WITH_CODE],
+            ),
+            # Regression: a numeric-looking value with a string operator must NOT route to the float map,
+            # which would silently drop the non-numeric stored value '500ok'.
+            (
+                "numeric_value_icontains_on_string_attr",
+                {"key": "http.status", "type": "span_attribute", "operator": "icontains", "value": "50"},
+                [WITHOUT_CODE],
+            ),
+            (
+                "numeric_value_exact_on_string_attr",
+                {"key": "http.status", "type": "span_attribute", "operator": "exact", "value": "500ok"},
+                [WITHOUT_CODE],
+            ),
+            (
+                "digit_icontains_on_alnum_attr",
+                {"key": "req.tag", "type": "span_attribute", "operator": "icontains", "value": "2"},
+                [WITHOUT_CODE],
+            ),
+            # Regression: a boolean filter value must resolve against the str map (where booleans are
+            # stored as 'true'/'false'), not 500 by comparing the Float64 map to a string.
+            (
+                "bool_value_exact",
+                {"key": "cache.hit", "type": "span_attribute", "operator": "exact", "value": True},
+                [WITH_CODE],
+            ),
+            # Numeric comparison operators DO need the float map for correct ordering.
+            (
+                "lineno_gt_matches",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "gt", "value": "40"},
+                [WITH_CODE],
+            ),
+            (
+                "lineno_gt_excludes",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "gt", "value": "50"},
+                [],
+            ),
+            # between/not_between are routed to the float map (both bounds numeric) — confirm the
+            # two-element list value and float-map suffix resolve correctly.
+            (
+                "lineno_between_matches",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "between", "value": ["40", "50"]},
+                [WITH_CODE],
+            ),
+            (
+                "lineno_between_excludes",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "between", "value": ["50", "60"]},
+                [],
+            ),
+            (
+                "lineno_not_between_matches",
+                {"key": "code.lineno", "type": "span_attribute", "operator": "not_between", "value": ["0", "41"]},
+                [WITH_CODE],
+            ),
+        ]
+    )
+    def test_query_span_attribute_filters(self, _name, prop, expected_services):
+        self.assertEqual(self._query_services(prop), expected_services)
+
+    def test_span_attribute_filter_composes_with_root_spans_flag(self):
+        # rootSpans=True (the query endpoint's default) ANDs `is_root_span = 1` onto the attribute
+        # filter (commit #61397). Both test spans are roots, so an attribute filter still narrows
+        # correctly in either mode — i.e. our suffix fix and the root-span gating compose cleanly.
+        prop = {"key": "code.filepath", "type": "span_attribute", "operator": "is_set"}
+        self.assertEqual(self._query_services(prop, root_spans=True), [WITH_CODE])
+        self.assertEqual(self._query_services(prop, root_spans=False), [WITH_CODE])
+
+    def _count(self, prop: dict) -> int:
+        body = {
+            "query": {
+                "dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO},
+                "filterGroup": [prop],
+            }
+        }
+        res = self.client.post(f"/api/projects/{self.team.id}/tracing/spans/count/", body, format="json")
+        self.assertEqual(res.status_code, 200, res.content)
+        return res.json()["count"]
+
+    @parameterized.expand(
+        [
+            # The aggregation runner (count/sparkline/histogram/tree) shared the same value-less bug.
+            ("is_set", {"key": "code.filepath", "type": "span_attribute", "operator": "is_set"}, 1),
+            ("is_not_set", {"key": "code.filepath", "type": "span_attribute", "operator": "is_not_set"}, 1),
+            (
+                "icontains",
+                {
+                    "key": "code.filepath",
+                    "type": "span_attribute",
+                    "operator": "icontains",
+                    "value": "flag_matching.rs",
+                },
+                1,
+            ),
+        ]
+    )
+    def test_count_span_attribute_filters(self, _name, prop, expected_count):
+        self.assertEqual(self._count(prop), expected_count)
+
+    def test_invalid_operator_returns_400_not_500(self):
+        # A genuinely malformed filter is rejected at model validation with a clean 400, never a bare 500.
+        body = {
+            "query": {
+                "dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO},
+                "rootSpans": False,
+                "filterGroup": [
+                    {"key": "code.filepath", "type": "span_attribute", "operator": "not_a_real_operator", "value": "x"}
+                ],
+            }
+        }
+        res = self.client.post(f"/api/projects/{self.team.id}/tracing/spans/query/", body, format="json")
+        self.assertEqual(res.status_code, 400, res.content)


### PR DESCRIPTION
## Problem

Filtering trace spans by a span-level OTel attribute (e.g. `code.filepath`) could 500 or silently return wrong results, which blocks editor-side APM enrichment (joining spans on `code.filepath` / `code.lineno`).

- **Value-less operators** (`is_set` / `is_not_set`) produced a bare attribute key. The HogQL printer turned that into a JSON read on a ClickHouse `Map` column → `CHQueryErrorIllegalTypeOfArgument` → unhandled **500**.
- The typed sub-map was selected from the **filter value's** parseability rather than the operator, so numeric-looking values on string-stored attributes **silently missed** (`icontains "50"` on a stored `"500ok"` → `[]`), and boolean values **500'd** (`Float64 = 'false'`).

## Changes

- Extract `with_span_attribute_type_suffix()` into `logic.py`, shared by both span query runners (per-trace + aggregation), replacing two duplicated blocks.
- Always suffix the attribute key so it resolves to a typed `Map` — never a bare key, so no 500.
- **Route by operator, not value type:** only numeric comparison operators (`gt`/`gte`/`lt`/`lte`/`between`/`not_between`) with numeric values use `attributes_map_float`; everything else — equality, substring/regex, `is_set`/`is_not_set` — uses the universal `attributes_map_str`, so string-stored values are never silently dropped and booleans resolve against their stored form.

## How did you test this code?

Agent-authored — automated tests only, no manual testing. New `test_span_attribute_filter.py` (API-level, hits `/tracing/spans/query/` and `/tracing/spans/count/`):

- `exact` / `icontains` / `is_not` / `is_set` / `is_not_set` across `code.filepath` and `code.namespace`
- numeric-looking value on a string-stored attribute (regression for the silent miss)
- boolean filter value (regression for the 500)
- `gt` resolving through the float map (numeric ordering still works)
- invalid operator → `400` (not a bare 500)
- composition with the `rootSpans` flag

Full tracing backend suite green (75 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Jon directed the work (DRI).

Authored with Claude Code (Opus 4.8). Root-caused by reproduction: the original report was imprecise — value-bearing operators already worked; the real 500 was value-less operators emitting bare keys. A follow-up `/code-review` surfaced two further bugs (numeric-value silent miss, boolean 500), fixed by switching from value-type to operator-aware map routing. Promoting `code.*` to dedicated indexed columns (the "strongly preferred" acceptance item) was deferred: `attributes_map_str` already carries bloom-filter skip indexes on keys and values, so that's a separate perf PR.

Known follow-ups, out of scope here: the editor-enrichment caller must send `rootSpans: false` (the endpoint defaults to `True`, and `code.*` lives on non-root spans); the `__datetime` typed map remains unreachable; the logs query runner has the identical latent value-less bug.
