### PR TITLE
chore(product-analytics): test PR review workflow

### DIFF
--- a/products/product_analytics/TEST_REVIEW_WORKFLOW.md
+++ b/products/product_analytics/TEST_REVIEW_WORKFLOW.md
@@ -1,0 +1,5 @@
+# Test: product analytics PR review workflow
+
+Scratch file used to exercise the automated PR hygiene-check workflow that fires
+when a PR is labeled `team/product-analytics`. Safe to delete — this PR is a test
+and will be closed.


### PR DESCRIPTION
## Problem

We set up an automated PR hygiene-check workflow that should fire when a PR is labeled `team/product-analytics`. This PR exists to verify that end-to-end (webhook → trigger → condition → task run → comment). It is a test and will be closed.

## Changes

Adds a single scratch markdown file under `products/product_analytics/`. No code or behavior changes.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests were run — this is a docs-only scratch file with no logic to test. The purpose of the PR is to exercise the labeling workflow, not to ship a change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created by PostHog Code at Sam's direction to validate the `team/product-analytics` PR review workflow. The change is intentionally trivial (one throwaway markdown file) so the PR can be opened, labeled, observed, and closed safely.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
