### PR TITLE
fix(funnels): match compare colors on hog-charts funnel trends

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -91,9 +91,6 @@ export function FunnelLineChart({
                 getColor: (step) =>
                     getFunnelsColor({
                         ...step,
-                        // Pair current/previous compare rows on the same base color: `colorIndex`
-                        // is shared across a current/previous pair (keyed on breakdown_value only),
-                        // whereas `seriesIndex` differs and would pick a different palette color.
                         breakdownIndex: step.colorIndex,
                     } as unknown as FlattenedFunnelStepByBreakdown),
             }),

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -91,7 +91,10 @@ export function FunnelLineChart({
                 getColor: (step) =>
                     getFunnelsColor({
                         ...step,
-                        breakdownIndex: step.seriesIndex,
+                        // Pair current/previous compare rows on the same base color: `colorIndex`
+                        // is shared across a current/previous pair (keyed on breakdown_value only),
+                        // whereas `seriesIndex` differs and would pick a different palette color.
+                        breakdownIndex: step.colorIndex,
                     } as unknown as FlattenedFunnelStepByBreakdown),
             }),
         [steps, incompletenessOffsetFromEnd, getFunnelsColor]

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.test.ts
@@ -73,6 +73,37 @@ describe('funnelChartTransforms', () => {
         })
     })
 
+    describe('compare against previous period', () => {
+        const compareSteps: IndexedFunnelStep[] = [
+            makeStep({ id: 0, seriesIndex: 0, colorIndex: 0, compare: true, compare_label: 'current' }),
+            makeStep({ id: 1, seriesIndex: 1, colorIndex: 0, compare: true, compare_label: 'previous' }),
+        ]
+
+        it('builds a comparisonOf map keyed on the previous-period series so it gets dimmed', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: compareSteps,
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: false,
+            })
+
+            expect(config.comparisonOf).toEqual({ '1': '1' })
+        })
+
+        it('omits comparisonOf when no series is a previous-period comparison', () => {
+            const config = buildFunnelLineTimeSeriesConfig({
+                indexedSteps: [makeStep()],
+                interval: 'day',
+                timezone: 'UTC',
+                allDays: ['2024-06-10'],
+                showTrendLines: false,
+            })
+
+            expect(config.comparisonOf).toBeUndefined()
+        })
+    })
+
     describe('buildFunnelLineTimeSeriesConfig', () => {
         it('produces a percentage y-axis tick formatter', () => {
             const config = buildFunnelLineTimeSeriesConfig({
@@ -132,7 +163,7 @@ describe('funnelChartTransforms', () => {
     describe('type contracts', () => {
         it('IndexedFunnelStep is assignable from FunnelStepWithNestedBreakdown', () => {
             const step: FunnelStepWithNestedBreakdown = makeStep()
-            const indexed: IndexedFunnelStep = { ...step, id: 0, seriesIndex: 0 }
+            const indexed: IndexedFunnelStep = { ...step, id: 0, seriesIndex: 0, colorIndex: 0 }
             expect(indexed.id).toBe(0)
         })
     })

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.ts
@@ -8,7 +8,15 @@ import type { FunnelStepWithNestedBreakdown, IntervalType } from '~/types'
 import { buildTrendsLineTimeSeriesConfig, buildTrendsSeries } from '../../trends/TrendsLineChart/trendsChartTransforms'
 import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
 
-export type IndexedFunnelStep = FunnelStepWithNestedBreakdown & { id: number; seriesIndex: number }
+// `colorIndex`, `compare`, and `compare_label` are added at runtime by `funnelDataLogic.indexedSteps`
+// (the base FunnelStep types don't declare them).
+export type IndexedFunnelStep = FunnelStepWithNestedBreakdown & {
+    id: number
+    seriesIndex: number
+    colorIndex: number
+    compare?: boolean
+    compare_label?: string | null
+}
 
 // The API populates `data`/`days`, but the base FunnelStep type marks them optional —
 // normalize so the trends transform never receives undefined.
@@ -19,6 +27,10 @@ interface NormalizedFunnelStep {
     days?: string[]
     breakdown_value?: SeriesDatum['breakdown_value']
     order: number
+    // Carried through so `buildDerivedConfigs` builds the `comparisonOf` map that dims
+    // the previous-period series.
+    compare?: boolean
+    compare_label?: string | null
 }
 
 function normalizeStep(step: IndexedFunnelStep): NormalizedFunnelStep {
@@ -29,6 +41,8 @@ function normalizeStep(step: IndexedFunnelStep): NormalizedFunnelStep {
         days: step.days,
         breakdown_value: step.breakdown_value as SeriesDatum['breakdown_value'],
         order: step.order,
+        compare: step.compare,
+        compare_label: step.compare_label,
     }
 }
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/funnelChartTransforms.ts
@@ -27,8 +27,6 @@ interface NormalizedFunnelStep {
     days?: string[]
     breakdown_value?: SeriesDatum['breakdown_value']
     order: number
-    // Carried through so `buildDerivedConfigs` builds the `comparisonOf` map that dims
-    // the previous-period series.
     compare?: boolean
     compare_label?: string | null
 }


### PR DESCRIPTION
## Problem

On the new hog-charts funnel **trends** visualization (`FunnelLineChart`, behind the `product-analytics-hog-charts-funnel` flag), the "compare to previous period" series rendered in a different palette colour (purple) instead of a lighter shade of the current series. The old `LineGraph`-based chart draws both periods in the same base colour with the previous one dimmed to 50% opacity — the new chart should match.

This is the follow-up to the hog-charts adapter noted in the funnel-trends compare colour work: that change fixed the old `LineGraph`, this one fixes the new chart.

## Changes

Two independent issues in the new chart's colour pipeline:

- **Wrong base colour.** `FunnelLineChart` resolved the series colour from `seriesIndex`, which differs between the current (0) and previous (1) rows, so they mapped to different palette presets (blue vs purple). It now uses `colorIndex`, which `funnelDataLogic.indexedSteps` keys on `breakdown_value` only — so a current/previous pair shares one base colour. This mirrors the trends chart, which already relies on `colorIndex`.
- **No dimming.** `normalizeStep` dropped `compare`/`compare_label`, so the shared `buildDerivedConfigs` never built the `comparisonOf` map that drives quill's `applyComparisonDimming`. Carrying those fields through restores the 50% dimming on the previous-period line (and, as a bonus, stops the completed previous period from getting the in-progress dashed tail).

`IndexedFunnelStep` is extended with the runtime-added `colorIndex`/`compare`/`compare_label` fields so the changes typecheck without casts.

## How did you test this code?

I'm an agent. Automated checks I ran locally:

- `funnelChartTransforms.test.ts` — passes (11/11), including two new tests asserting `comparisonOf` is built for a current/previous pair and omitted otherwise.
- `tsc --noEmit` — no type errors in the changed files.
- `oxfmt` — clean.

Manual verification in a running app (flag on, funnel trends with `compareFilter.compare: true`) has **not** been done by me — it needs a human or a follow-up with the dev server. The expected result: both lines the same blue, with the previous-period line a lighter/dimmed shade, matching the old chart.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tools: Claude Code (Explore + Plan agents for investigation, then implementation). The investigation traced the colour through `funnelDataLogic.indexedSteps` → `getFunnelResultCustomizationColorToken` → quill's `applyComparisonDimming`, and confirmed the trends chart as the working reference. Two root causes were identified and fixed minimally; the type change keeps the existing cast-free call sites honest. Diff is intentionally scoped to the new chart's adapter — the old `LineGraph` path is unchanged.
