### PR TITLE
feat(devex): Add scoping for fish

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -146,8 +146,6 @@ fish = '''
   set -gx GOCACHE "$FLOX_ENV_CACHE/go-build"
   set -gx GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
-  # -g keeps this session-scoped (matching bash/zsh/tcsh) instead of fish's
-  # default universal scope, which would persist into non-flox shells
   fish_add_path -g "$FLOX_ENV/bin"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if not test -f "$UV_PROJECT_ENVIRONMENT/bin/activate.fish"

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -146,7 +146,9 @@ fish = '''
   set -gx GOCACHE "$FLOX_ENV_CACHE/go-build"
   set -gx GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
-  fish_add_path "$FLOX_ENV/bin"
+  # -g keeps this session-scoped (matching bash/zsh/tcsh) instead of fish's
+  # default universal scope, which would persist into non-flox shells
+  fish_add_path -g "$FLOX_ENV/bin"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if not test -f "$UV_PROJECT_ENVIRONMENT/bin/activate.fish"
     uv sync


### PR DESCRIPTION
## Problem

In fish, flox would set PATH to prepend the flox paths persistently using fish_add_path. This produces unintended friction when using commands like pnpm outside of the posthog directory and does not happen with other shells.

## Changes

Adds the -g flag to scope the change to the terminal with the flox session.
