### PR TITLE
fix(plugin-server): upgrade undici to 7.24

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -131,7 +131,7 @@
         "tldts": "^6.1.57",
         "typescript": "catalog:",
         "ultimate-express": "2.0.9",
-        "undici": "7.8.0",
+        "undici": "^7.24.0",
         "undici-types": "7.3.0",
         "uuid": "^11.1.1",
         "xml-js": "^1.6.11",

--- a/nodejs/src/cdp/services/segment-destination-executor.service.ts
+++ b/nodejs/src/cdp/services/segment-destination-executor.service.ts
@@ -77,6 +77,9 @@ const convertFetchResponse = <Data = unknown>(response: FetchResponse, text: str
         arrayBuffer: () => {
             throw new Error('Not implemented')
         },
+        bytes: () => {
+            throw new Error('Not implemented')
+        },
         blob: () => {
             throw new Error('Not implemented')
         },

--- a/nodejs/src/utils/request.ts
+++ b/nodejs/src/utils/request.ts
@@ -12,7 +12,6 @@ import {
     RequestInfo,
     RequestInit,
     Response,
-    errors,
     request,
     fetch as undiciFetch,
 } from 'undici'
@@ -58,21 +57,23 @@ export type FetchResponse = {
     dump: () => Promise<void>
 }
 
-export class SecureRequestError extends errors.UndiciError {
+// These extend Error, not undici's UndiciError: UndiciError defines a code-based Symbol.hasInstance, so every
+// UndiciError subclass matches `instanceof` against every other one, which would defeat isFetchResponseRetriable.
+export class SecureRequestError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'SecureRequestError'
     }
 }
 
-export class InvalidRequestError extends errors.UndiciError {
+export class InvalidRequestError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'InvalidRequestError'
     }
 }
 
-export class ResolutionError extends errors.UndiciError {
+export class ResolutionError extends Error {
     constructor(message: string) {
         super(message)
         this.name = 'ResolutionError'
@@ -316,7 +317,7 @@ export async function _fetch(url: string, options: FetchOptions = {}, dispatcher
         headers: options.headers,
         body: options.body,
         dispatcher,
-        maxRedirections: 0, // No redirects allowed by default
+        // request() does not follow redirects, so a response can never bounce to an unvalidated host
         signal: options.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,7 +349,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -1639,8 +1639,8 @@ importers:
         specifier: 2.0.9
         version: 2.0.9
       undici:
-        specifier: 7.8.0
-        version: 7.8.0
+        specifier: ^7.24.0
+        version: 7.24.8
       undici-types:
         specifier: 7.3.0
         version: 7.3.0
@@ -21932,10 +21932,6 @@ packages:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.8.0:
-    resolution: {integrity: sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==}
-    engines: {node: '>=20.18.1'}
-
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -32034,7 +32030,7 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.37(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -39693,7 +39689,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -40128,7 +40124,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
-      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -46259,8 +46255,6 @@ snapshots:
   undici@7.18.2: {}
 
   undici@7.24.8: {}
-
-  undici@7.8.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Problem

Note that `npm audit` is a noisy signal https://overreacted.io/npm-audit-broken-by-design/

`pnpm audit` flags our pinned `undici@7.8.0` in plugin-server for several high/moderate advisories (WebSocket 64-bit length overflow, unbounded `permessage-deflate` memory consumption, `server_max_window_bits` validation, HTTP request/response smuggling, CRLF injection via the `upgrade` option). The in-range audit-fix PR (#63564) deliberately left this one out because the upgrade isn't drop-in. This PR is the standalone follow-up that does it properly.

## Changes

Bump `undici` `7.8.0` → `^7.24.0` (resolves to 7.24.8) and fix the three things 7.24 breaks in plugin-server:

1. **Fetch retries (the important one).** `SecureRequestError`, `InvalidRequestError`, and `ResolutionError` all extended undici's `UndiciError`. undici 7.24 gives `UndiciError` a brand-based `static [Symbol.hasInstance]` (keyed on a shared `Symbol.for('undici.error.UND_ERR')` set in its constructor). Because the three subclasses don't override it, **every `UndiciError` subclass now matches `instanceof` against every other one** — a `ResolutionError` reads as `instanceof SecureRequestError`. That made `isFetchResponseRetriable` classify retryable DNS-resolution failures as non-retryable security errors, so external fetches that hit a transient DNS failure stopped being retried. The three classes now extend `Error`, restoring distinct `instanceof` (and the original retry behaviour). Nothing relied on them being `UndiciError`, and undici still propagates them cleanly from the connect `lookup` callback (message preserved).
2. **`Response.bytes()`.** undici 7.24's `Response` type now requires `bytes()`. Added a `"Not implemented"` stub to the segment-destination mock response, matching the existing `arrayBuffer`/`blob`/`formData` stubs (none are used on that path).
3. **`maxRedirections`.** Removed from undici 7.24's `request()` options type. We passed `maxRedirections: 0`, which is already undici's default (low-level `request()` never follows redirects; SSRF protection is the `SecureAgent` DNS guard), so dropping it is behaviour-preserving.

## How did you test this code?

I'm an agent. What I actually ran:

- Reproduced the regression against the **real** `request.ts` `fetch()` path under undici 7.24.8 (a non-existent host → `ResolutionError`): before the fix it classified as `instanceof SecureRequestError` → `canRetry: false`; after the fix `instanceof` is distinct → `canRetry: true`. The existing `executeFetch › handles request errors` snapshots therefore stay valid (no snapshot churn).
- `tsc --noEmit` on plugin-server: the `bytes`, `maxRedirections`, and `errors`-import type errors are gone, with no new errors introduced.
- `pnpm install --frozen-lockfile` passes.

I did not run the full Jest suite locally (it needs a Hub: Postgres/Kafka/Redis/ClickHouse). CI exercises `hog-executor.service.test.ts` and the segment/native destination executors that share `isFetchResponseRetriable`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes; dependency upgrade plus the code changes it requires.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, who asked to land the plugin-server `undici` bump as a standalone PR after it was split out of the in-range audit PR (#63564).

Tool: Claude Code (Opus 4.8). The non-obvious part was the retry regression: an isolated undici repro propagated `ResolutionError` cleanly and could not reproduce it, which pointed at the custom error classes rather than undici's error propagation. Running the real `request.ts` path surfaced the cross-subclass `instanceof` collision from undici 7.24's brand-based `Symbol.hasInstance`. Fix chosen (extend `Error`) over patching the classifier to string `name` checks, because it removes the footgun for any future `instanceof` on these errors rather than papering over one call site.
