### PR TITLE
test(ci): DO NOT MERGE — validate backend CI deterministic cancellation

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -814,9 +814,10 @@ jobs:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true'
         timeout-minutes: 10
+        outputs:
+            setup_complete: ${{ steps.setup-complete.outputs.setup_complete }}
         permissions:
             contents: read
-            actions: write # to cancel this run when a deterministic check fails
         name: Repo checks (depot-ubuntu-latest)
         runs-on: depot-ubuntu-latest
         steps:
@@ -851,7 +852,9 @@ jobs:
             # canceling the whole run on a transient setup failure.
             - name: Mark setup complete
               id: setup-complete
-              run: echo "Setup complete — any failure below is a deterministic check failure"
+              run: |
+                  echo "setup_complete=true" >> "$GITHUB_OUTPUT"
+                  echo "Setup complete — any failure below is a deterministic check failure"
 
             - name: Bootstrap scaffold product
               run: ./bin/hogli product:bootstrap spline_reticulator --non-interactive
@@ -874,21 +877,27 @@ jobs:
             - name: Check product facade enforcement (import-linter)
               run: lint-imports
 
-            # A failure in the static checks above is deterministic — a retry can
-            # never fix it, so the rest of the run (50+ test shards) is wasted spend.
-            # PR-only: master and merge queue runs must complete (deploy gate,
-            # snapshots). Same-repo only: fork PR tokens are read-only.
-            - name: Cancel run on deterministic check failure
-              if: >
-                  failure() &&
-                  steps.setup-complete.outcome == 'success' &&
-                  github.event_name == 'pull_request' &&
-                  github.event.pull_request.head.repo.full_name == github.repository
+    cancel-backend-on-repo-check-failure:
+        needs: [repo-checks]
+        if: >
+            always() &&
+            needs.repo-checks.result == 'failure' &&
+            needs.repo-checks.outputs.setup_complete == 'true' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            actions: write
+        name: Cancel Backend CI after repo check failure
+        runs-on: ubuntu-latest
+        steps:
+            - name: Cancel run
               env:
                   GH_TOKEN: ${{ github.token }}
                   GH_REPO: ${{ github.repository }}
               run: |
-                  echo "::notice::Repo checks failed deterministically — canceling the remaining jobs in this run. A retry cannot fix this failure; push a fix to start a new run."
+                  echo "::notice title=Repo checks failed deterministically::Canceling remaining Backend CI jobs. A retry cannot fix this failure; push a fix to start a new run."
                   gh run cancel ${{ github.run_id }}
 
     # Validates product.yaml owners against PostHog/posthog collaborator teams.
@@ -1589,9 +1598,10 @@ jobs:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.openapi_types == 'true'
         timeout-minutes: 20
+        outputs:
+            openapi_check_failed: ${{ steps.openapi-check.outcome == 'failure' && 'true' || 'false' }}
         permissions:
             contents: read
-            actions: write # to cancel this run when the OpenAPI check fails
 
         name: Validate OpenAPI types
         runs-on: depot-ubuntu-latest
@@ -1787,21 +1797,27 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.openapi-app-token.outputs.token }}
 
-            # Schema generation and type drift failures are deterministic — a retry
-            # can never fix them, so the rest of the run is wasted spend. Keyed on the
-            # check step so transient setup or commit failures don't cancel anything.
-            # PR-only and same-repo only: fork PR tokens are read-only.
-            - name: Cancel run on deterministic check failure
-              if: >
-                  failure() &&
-                  steps.openapi-check.outcome == 'failure' &&
-                  github.event_name == 'pull_request' &&
-                  github.event.pull_request.head.repo.full_name == github.repository
+    cancel-backend-on-openapi-check-failure:
+        needs: [check-openapi-types]
+        if: >
+            always() &&
+            needs.check-openapi-types.result == 'failure' &&
+            needs.check-openapi-types.outputs.openapi_check_failed == 'true' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            actions: write
+        name: Cancel Backend CI after OpenAPI check failure
+        runs-on: ubuntu-latest
+        steps:
+            - name: Cancel run
               env:
                   GH_TOKEN: ${{ github.token }}
                   GH_REPO: ${{ github.repository }}
               run: |
-                  echo "::notice::OpenAPI check failed deterministically — canceling the remaining jobs in this run. A retry cannot fix this failure; push a fix to start a new run."
+                  echo "::notice title=OpenAPI check failed deterministically::Canceling remaining Backend CI jobs. A retry cannot fix this failure; push a fix to start a new run."
                   gh run cancel ${{ github.run_id }}
 
     build_django_matrix:
@@ -2612,23 +2628,49 @@ jobs:
                     echo "### Backend CI dependency results"
                     echo "| Dependency | Result |"
                     echo "| --- | --- |"
+                    echo "| repo-checks | ${{ needs.repo-checks.result }} |"
+                    echo "| check-openapi-types | ${{ needs.check-openapi-types.result }} |"
                     echo "| django | ${{ needs.django.result }} |"
                     echo "| check-migrations | ${{ needs.check-migrations.result }} |"
-                    echo "| check-openapi-types | ${{ needs.check-openapi-types.result }} |"
                     echo "| async-migrations | ${{ needs.async-migrations.result }} |"
-                    echo "| repo-checks | ${{ needs.repo-checks.result }} |"
                     echo "| turbo-discover | ${{ needs.turbo-discover.result }} |"
                     echo "| turbo-tests | ${{ needs.turbo-tests.result }} |"
                     echo "| handle-snapshots | ${{ needs.handle-snapshots.result }} |"
+                    if [[ "${{ needs.repo-checks.result }}" == "failure" && "${{ needs.repo-checks.outputs.setup_complete }}" == "true" ]]; then
+                      echo ""
+                      echo "**Root cause:** Repo checks failed deterministically. Open the repo checks job logs; downstream cancelled jobs are expected."
+                    fi
+                    if [[ "${{ needs.check-openapi-types.result }}" == "failure" && "${{ needs.check-openapi-types.outputs.openapi_check_failed }}" == "true" ]]; then
+                      echo ""
+                      echo "**Root cause:** OpenAPI type checks failed deterministically. Open the OpenAPI type check job logs; downstream cancelled jobs are expected."
+                    fi
                   } | tee -a "$GITHUB_STEP_SUMMARY"
 
             - name: Check dependency results
               run: |
+                  deterministic_failure=false
+                  failure_count=0
+
+                  if [[ "${{ needs.repo-checks.result }}" == "failure" && "${{ needs.repo-checks.outputs.setup_complete }}" == "true" ]]; then
+                    echo "::error title=Repo checks failed deterministically::Open the repo checks job for the root failure. Backend CI cancelled downstream jobs to save runners; retrying will not fix this."
+                    deterministic_failure=true
+                  fi
+
+                  if [[ "${{ needs.check-openapi-types.result }}" == "failure" && "${{ needs.check-openapi-types.outputs.openapi_check_failed }}" == "true" ]]; then
+                    echo "::error title=OpenAPI type checks failed deterministically::Open the OpenAPI type check job for the root failure. Backend CI cancelled downstream jobs to save runners; retrying will not fix this."
+                    deterministic_failure=true
+                  fi
+
                   check_required_result() {
                     local label="$1"
                     local result="$2"
 
                     if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+                      return
+                    fi
+
+                    if [[ "$deterministic_failure" == "true" && "$result" == "cancelled" ]]; then
+                      echo "::notice::$label was cancelled after a deterministic failure."
                       return
                     fi
 
@@ -2638,20 +2680,19 @@ jobs:
                       echo "::error::$label failed with result '$result'."
                     fi
 
-                    exit 1
+                    failure_count=$((failure_count + 1))
                   }
 
+                  check_required_result "Repo checks" "${{ needs.repo-checks.result }}"
+                  check_required_result "OpenAPI type checks" "${{ needs.check-openapi-types.result }}"
                   check_required_result "Django test matrix" "${{ needs.django.result }}"
                   check_required_result "Migration checks" "${{ needs.check-migrations.result }}"
-                  check_required_result "OpenAPI type checks" "${{ needs.check-openapi-types.result }}"
                   check_required_result "Async migration tests" "${{ needs.async-migrations.result }}"
-                  check_required_result "Repo checks" "${{ needs.repo-checks.result }}"
                   check_required_result "Turbo discover" "${{ needs.turbo-discover.result }}"
                   check_required_result "Product/Turbo tests" "${{ needs.turbo-tests.result }}"
+                  check_required_result "Snapshot commit job" "${{ needs.handle-snapshots.result }}"
 
-                  # Check handle-snapshots result (OK if skipped, but fail if it failed)
-                  if [[ "${{ needs.handle-snapshots.result }}" == "failure" ]]; then
-                    echo "Snapshot commit job failed."
+                  if [[ "$deterministic_failure" == "true" || "$failure_count" -gt 0 ]]; then
                     exit 1
                   fi
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -815,7 +815,7 @@ jobs:
         if: needs.changes.outputs.backend == 'true'
         timeout-minutes: 10
         outputs:
-            setup_complete: ${{ steps.setup-complete.outputs.setup_complete }}
+            deterministic_failure: ${{ steps.deterministic-failure.outputs.deterministic_failure || 'false' }}
         permissions:
             contents: read
         name: Repo checks (depot-ubuntu-latest)
@@ -848,13 +848,11 @@ jobs:
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
             # Boundary between network-dependent setup and the deterministic
-            # checks below. The cancellation job uses this output to avoid
-            # canceling the whole run on a transient setup failure.
+            # checks below. The "Flag deterministic failure" step keys off this
+            # step's outcome so a transient setup failure doesn't cancel the run.
             - name: Mark setup complete
               id: setup-complete
-              run: |
-                  echo "setup_complete=true" >> "$GITHUB_OUTPUT"
-                  echo "Setup complete — any failure below is a deterministic check failure"
+              run: echo "Setup complete — any failure below is a deterministic check failure"
 
             - name: Bootstrap scaffold product
               run: ./bin/hogli product:bootstrap spline_reticulator --non-interactive
@@ -877,12 +875,18 @@ jobs:
             - name: Check product facade enforcement (import-linter)
               run: lint-imports
 
+            # Deterministic = a static check above failed after setup completed.
+            # A retry can't fix it, so this signals the cancellation gate to stop the run.
+            - name: Flag deterministic failure
+              id: deterministic-failure
+              if: failure() && steps.setup-complete.outcome == 'success'
+              run: echo "deterministic_failure=true" >> "$GITHUB_OUTPUT"
+
     cancel-backend-on-repo-check-failure:
         needs: [repo-checks]
         if: >
             always() &&
-            needs.repo-checks.result == 'failure' &&
-            needs.repo-checks.outputs.setup_complete == 'true' &&
+            needs.repo-checks.outputs.deterministic_failure == 'true' &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository
         timeout-minutes: 5
@@ -1599,7 +1603,7 @@ jobs:
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.openapi_types == 'true'
         timeout-minutes: 20
         outputs:
-            openapi_check_failed: ${{ steps.openapi-check.outcome == 'failure' && 'true' || 'false' }}
+            deterministic_failure: ${{ steps.deterministic-failure.outputs.deterministic_failure || 'false' }}
         permissions:
             contents: read
 
@@ -1771,6 +1775,13 @@ jobs:
 
                   echo "needs-commit=true" >> $GITHUB_OUTPUT
 
+            # Deterministic = the OpenAPI check step itself failed (not a transient
+            # setup or commit-step failure), so a retry can't fix it. Mirrors repo-checks.
+            - name: Flag deterministic failure
+              id: deterministic-failure
+              if: failure() && steps.openapi-check.outcome == 'failure'
+              run: echo "deterministic_failure=true" >> "$GITHUB_OUTPUT"
+
             - name: Get app token for OpenAPI type commits
               if: steps.openapi-check.outputs.needs-commit == 'true'
               id: openapi-app-token
@@ -1801,8 +1812,7 @@ jobs:
         needs: [check-openapi-types]
         if: >
             always() &&
-            needs.check-openapi-types.result == 'failure' &&
-            needs.check-openapi-types.outputs.openapi_check_failed == 'true' &&
+            needs.check-openapi-types.outputs.deterministic_failure == 'true' &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.head.repo.full_name == github.repository
         timeout-minutes: 5
@@ -2636,11 +2646,11 @@ jobs:
                     echo "| turbo-discover | ${{ needs.turbo-discover.result }} |"
                     echo "| turbo-tests | ${{ needs.turbo-tests.result }} |"
                     echo "| handle-snapshots | ${{ needs.handle-snapshots.result }} |"
-                    if [[ "${{ needs.repo-checks.result }}" == "failure" && "${{ needs.repo-checks.outputs.setup_complete }}" == "true" ]]; then
+                    if [[ "${{ needs.repo-checks.outputs.deterministic_failure }}" == "true" ]]; then
                       echo ""
                       echo "**Root cause:** Repo checks failed deterministically. Open the repo checks job logs; downstream cancelled jobs are expected."
                     fi
-                    if [[ "${{ needs.check-openapi-types.result }}" == "failure" && "${{ needs.check-openapi-types.outputs.openapi_check_failed }}" == "true" ]]; then
+                    if [[ "${{ needs.check-openapi-types.outputs.deterministic_failure }}" == "true" ]]; then
                       echo ""
                       echo "**Root cause:** OpenAPI type checks failed deterministically. Open the OpenAPI type check job logs; downstream cancelled jobs are expected."
                     fi
@@ -2651,12 +2661,12 @@ jobs:
                   deterministic_failure=false
                   failed=false
 
-                  if [[ "${{ needs.repo-checks.result }}" == "failure" && "${{ needs.repo-checks.outputs.setup_complete }}" == "true" ]]; then
+                  if [[ "${{ needs.repo-checks.outputs.deterministic_failure }}" == "true" ]]; then
                     echo "::error title=Repo checks failed deterministically::Open the repo checks job for the root failure. Backend CI cancelled downstream jobs to save runners; retrying will not fix this."
                     deterministic_failure=true
                   fi
 
-                  if [[ "${{ needs.check-openapi-types.result }}" == "failure" && "${{ needs.check-openapi-types.outputs.openapi_check_failed }}" == "true" ]]; then
+                  if [[ "${{ needs.check-openapi-types.outputs.deterministic_failure }}" == "true" ]]; then
                     echo "::error title=OpenAPI type checks failed deterministically::Open the OpenAPI type check job for the root failure. Backend CI cancelled downstream jobs to save runners; retrying will not fix this."
                     deterministic_failure=true
                   fi

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2649,7 +2649,7 @@ jobs:
             - name: Check dependency results
               run: |
                   deterministic_failure=false
-                  failure_count=0
+                  failed=false
 
                   if [[ "${{ needs.repo-checks.result }}" == "failure" && "${{ needs.repo-checks.outputs.setup_complete }}" == "true" ]]; then
                     echo "::error title=Repo checks failed deterministically::Open the repo checks job for the root failure. Backend CI cancelled downstream jobs to save runners; retrying will not fix this."
@@ -2661,26 +2661,31 @@ jobs:
                     deterministic_failure=true
                   fi
 
+                  # cancel_ok tolerates a bare 'cancelled' result (the optional snapshot commit job);
+                  # required jobs treat an unexpected cancel as a failure.
                   check_required_result() {
                     local label="$1"
                     local result="$2"
+                    local cancel_ok="${3:-false}"
 
                     if [[ "$result" == "success" || "$result" == "skipped" ]]; then
                       return
                     fi
 
-                    if [[ "$deterministic_failure" == "true" && "$result" == "cancelled" ]]; then
-                      echo "::notice::$label was cancelled after a deterministic failure."
-                      return
-                    fi
-
                     if [[ "$result" == "cancelled" ]]; then
+                      if [[ "$deterministic_failure" == "true" ]]; then
+                        echo "::notice::$label was cancelled after a deterministic failure."
+                        return
+                      fi
+                      if [[ "$cancel_ok" == "true" ]]; then
+                        return
+                      fi
                       echo "::error::$label was cancelled or timed out."
                     else
                       echo "::error::$label failed with result '$result'."
                     fi
 
-                    failure_count=$((failure_count + 1))
+                    failed=true
                   }
 
                   check_required_result "Repo checks" "${{ needs.repo-checks.result }}"
@@ -2690,15 +2695,9 @@ jobs:
                   check_required_result "Async migration tests" "${{ needs.async-migrations.result }}"
                   check_required_result "Turbo discover" "${{ needs.turbo-discover.result }}"
                   check_required_result "Product/Turbo tests" "${{ needs.turbo-tests.result }}"
+                  check_required_result "Snapshot commit job" "${{ needs.handle-snapshots.result }}" true
 
-                  if [[ "${{ needs.handle-snapshots.result }}" == "failure" ]]; then
-                    echo "::error::Snapshot commit job failed."
-                    failure_count=$((failure_count + 1))
-                  elif [[ "$deterministic_failure" == "true" && "${{ needs.handle-snapshots.result }}" == "cancelled" ]]; then
-                    echo "::notice::Snapshot commit job was cancelled after a deterministic failure."
-                  fi
-
-                  if [[ "$deterministic_failure" == "true" || "$failure_count" -gt 0 ]]; then
+                  if [[ "$deterministic_failure" == "true" || "$failed" == "true" ]]; then
                     exit 1
                   fi
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -854,6 +854,13 @@ jobs:
               id: setup-complete
               run: echo "Setup complete — any failure below is a deterministic check failure"
 
+            # DELETEME: synthetic post-setup failure to validate deterministic
+            # cancellation end-to-end. Remove before merge — this PR must never land.
+            - name: TEST forced deterministic failure (DO NOT MERGE)
+              run: |
+                  echo "Forcing a deterministic repo-check failure to validate run cancellation."
+                  exit 1
+
             - name: Bootstrap scaffold product
               run: ./bin/hogli product:bootstrap spline_reticulator --non-interactive
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -847,8 +847,8 @@ jobs:
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
-            # Boundary between network-dependent setup (can flake) and the pure
-            # static checks below — the cancel step at the end uses it to avoid
+            # Boundary between network-dependent setup and the deterministic
+            # checks below. The cancellation job uses this output to avoid
             # canceling the whole run on a transient setup failure.
             - name: Mark setup complete
               id: setup-complete
@@ -2690,7 +2690,13 @@ jobs:
                   check_required_result "Async migration tests" "${{ needs.async-migrations.result }}"
                   check_required_result "Turbo discover" "${{ needs.turbo-discover.result }}"
                   check_required_result "Product/Turbo tests" "${{ needs.turbo-tests.result }}"
-                  check_required_result "Snapshot commit job" "${{ needs.handle-snapshots.result }}"
+
+                  if [[ "${{ needs.handle-snapshots.result }}" == "failure" ]]; then
+                    echo "::error::Snapshot commit job failed."
+                    failure_count=$((failure_count + 1))
+                  elif [[ "$deterministic_failure" == "true" && "${{ needs.handle-snapshots.result }}" == "cancelled" ]]; then
+                    echo "::notice::Snapshot commit job was cancelled after a deterministic failure."
+                  fi
 
                   if [[ "$deterministic_failure" == "true" || "$failure_count" -gt 0 ]]; then
                     exit 1

--- a/posthog/_ci_cancel_test_marker.py
+++ b/posthog/_ci_cancel_test_marker.py
@@ -1,0 +1,4 @@
+# DELETEME: throwaway marker so the backend paths-filter triggers repo-checks +
+# the downstream shards for the CI deterministic-cancellation validation test.
+# This PR must never be merged. Delete this file and the synthetic failing step
+# in .github/workflows/ci-backend.yml before closing out the test.


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — throwaway test PR

Validates the deterministic-cancellation behavior from the backend CI cancellation PR (#63570) end-to-end on real runners. **Close + delete branch when done.**

### What it does

- Adds a synthetic `exit 1` step to `repo-checks`, immediately after "Mark setup complete" — a guaranteed deterministic failure *after* setup (so `steps.setup-complete.outcome == 'success'` holds and the flag step fires).
- Adds a throwaway `posthog/_ci_cancel_test_marker.py` so the backend paths-filter sets `backend == 'true'` and the full Django/product shard matrix spins up — giving us in-flight jobs to watch get cancelled.

### What to verify on the run

1. **`Repo checks` ends red (failed)** — the actionable root cause, not cancelled.
2. **`Cancel Backend CI after repo check failure` runs** and calls `gh run cancel`.
3. **Downstream shards (Django, migrations, etc.) show `cancelled`**, not failed — the runner-saving behavior.
4. **`Django Tests Pass` still runs** (it's `if: always()`), prints the step-summary **"Root cause: Repo checks failed deterministically"** callout, emits one `::error::`, downgrades the cancelled shards to notices, and **fails the gate**.

The OpenAPI path is symmetric (same flag-step → cancel-job → gate mechanism), so a green-light here covers both.
