### PR TITLE
fix(clickhouse): redact credentials from logged query repr

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -580,6 +580,8 @@ def redact_sql_secrets(sql: str) -> str:
 def _redact_parameters(parameters: Any) -> Any:
     if isinstance(parameters, Mapping):
         return {k: ("[REDACTED]" if "password" in str(k).lower() else v) for k, v in parameters.items()}
+    if isinstance(parameters, list):
+        return [_redact_parameters(p) for p in parameters]
     return parameters
 
 
@@ -595,7 +597,8 @@ class Query:
     def __repr__(self) -> str:
         query = redact_sql_secrets(self.query)
         if self.parameters and isinstance(self.parameters, list):
-            params_repr = f"{self.parameters[:50]!r} (showing first 50 out of {len(self.parameters)} parameters)"
+            shown = _redact_parameters(self.parameters[:50])
+            params_repr = f"{shown!r} (showing first 50 out of {len(self.parameters)} parameters)"
         else:
             params_repr = f"{_redact_parameters(self.parameters)!r}"
         return f"Query(query={query!r}, parameters={params_repr}, settings={self.settings!r})"

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import abc
 import time
 import logging
@@ -565,6 +566,23 @@ def get_cluster(
     )
 
 
+# Masks inline credentials (e.g. dictionary `SOURCE(CLICKHOUSE(... PASSWORD '…'))` or
+# `CREATE USER … IDENTIFIED BY '…'`) so they never reach logs. ClickHouse needs the password in
+# the source SQL for dictionary reloads to authenticate, so we redact at the logging boundary
+# rather than dropping it from the query.
+_SQL_SECRET_RE = re.compile(r"(?i)\b(PASSWORD|IDENTIFIED\s+WITH\s+\S+\s+BY|IDENTIFIED\s+BY)\s+'(?:[^']|'')*'")
+
+
+def redact_sql_secrets(sql: str) -> str:
+    return _SQL_SECRET_RE.sub(r"\1 '[REDACTED]'", sql)
+
+
+def _redact_parameters(parameters: Any) -> Any:
+    if isinstance(parameters, Mapping):
+        return {k: ("[REDACTED]" if "password" in str(k).lower() else v) for k, v in parameters.items()}
+    return parameters
+
+
 @dataclass
 class Query:
     query: str
@@ -575,11 +593,12 @@ class Query:
         return client.execute(self.query, self.parameters, settings=self.settings)
 
     def __repr__(self) -> str:
+        query = redact_sql_secrets(self.query)
         if self.parameters and isinstance(self.parameters, list):
             params_repr = f"{self.parameters[:50]!r} (showing first 50 out of {len(self.parameters)} parameters)"
         else:
-            params_repr = f"{self.parameters!r}"
-        return f"Query(query={self.query!r}, parameters={params_repr}, settings={self.settings!r})"
+            params_repr = f"{_redact_parameters(self.parameters)!r}"
+        return f"Query(query={query!r}, parameters={params_repr}, settings={self.settings!r})"
 
 
 @dataclass

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -22,6 +22,7 @@ from posthog.clickhouse.cluster import (
     RetryPolicy,
     T,
     get_cluster,
+    redact_sql_secrets,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 
@@ -714,3 +715,38 @@ def test_alter_mutation_force_parameter(cluster: ClickhouseCluster) -> None:
     # Should have more mutations after using force=True
     for host in mutations_count_before:
         assert mutations_count_after[host][0][0] > mutations_count_before[host][0][0]
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        (
+            "SOURCE(CLICKHOUSE(TABLE 'web_bot_definition' USER 'default' PASSWORD 'sup3r-s3cret'))",
+            "SOURCE(CLICKHOUSE(TABLE 'web_bot_definition' USER 'default' PASSWORD '[REDACTED]'))",
+        ),
+        # case-insensitive keyword
+        ("source(clickhouse(password 'pw'))", "source(clickhouse(password '[REDACTED]'))"),
+        # CREATE USER
+        ("CREATE USER bob IDENTIFIED BY 'hunter2'", "CREATE USER bob IDENTIFIED BY '[REDACTED]'"),
+        (
+            "CREATE USER bob IDENTIFIED WITH sha256_password BY 'hunter2'",
+            "CREATE USER bob IDENTIFIED WITH sha256_password BY '[REDACTED]'",
+        ),
+        # no secret -> unchanged
+        ("SELECT * FROM events WHERE name = 'password'", "SELECT * FROM events WHERE name = 'password'"),
+    ],
+)
+def test_redact_sql_secrets(sql, expected):
+    assert redact_sql_secrets(sql) == expected
+
+
+def test_query_repr_redacts_inline_password():
+    rendered = repr(Query("SOURCE(CLICKHOUSE(TABLE 't' PASSWORD 'sup3r-s3cret'))"))
+    assert "sup3r-s3cret" not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_query_repr_redacts_password_parameter():
+    rendered = repr(Query("SOURCE(CLICKHOUSE(DB %(db)s PASSWORD %(password)s))", {"db": "posthog", "password": "pw"}))
+    assert "pw" not in rendered
+    assert "'db': 'posthog'" in rendered

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -750,3 +750,10 @@ def test_query_repr_redacts_password_parameter():
     rendered = repr(Query("SOURCE(CLICKHOUSE(DB %(db)s PASSWORD %(password)s))", {"db": "posthog", "password": "pw"}))
     assert "pw" not in rendered
     assert "'db': 'posthog'" in rendered
+    assert "'password': '[REDACTED]'" in rendered
+
+
+def test_query_repr_redacts_password_in_list_parameters():
+    rendered = repr(Query("INSERT INTO t VALUES", [{"db": "posthog", "password": "pw"}]))
+    assert "pw" not in rendered
+    assert "'password': '[REDACTED]'" in rendered


### PR DESCRIPTION
## Problem

Every ClickHouse dictionary embeds the CH password in its `SOURCE(CLICKHOUSE(… PASSWORD '…'))` SQL. The password is load-bearing — the dict's background refresh connection authenticates separately, so reloads fail auth without it (see #19344, #35728). Migrations log `Query.__repr__` with the full SQL at INFO and nothing redacts it, so the password lands in migration logs in plaintext.

Flagged by a review bot on #60586, but it's a pre-existing, repo-wide pattern (`channel_type`, `exchange_rate`, `dmat_slot_assignments`, `web_preaggregated`, plus the deletes/person-override dags), not new to that PR.

## Changes

Redact secrets at the logging boundary instead of removing them from the SQL (which would break dictionary reloads). `Query.__repr__` now:

- masks `PASSWORD '…'` and `IDENTIFIED [WITH …] BY '…'` values in the query text → `'[REDACTED]'`
- masks parameter values whose key contains `password` (covers the dags `%(password)s` path)

Because every cluster query flows through the shared `Query` type, this covers all call sites at once.

Out of scope: this closes the migration-log vector but does not touch `clickhouse_driver`'s own DEBUG query logging. The durable fix is migrating dictionary sources to ClickHouse [named collections](https://clickhouse.com/docs/operations/named-collections) so credentials leave the query text entirely — worth a separate tracked issue.

## How did you test this code?

Agent-authored, automated only:

- 7 new parameterized unit tests in `posthog/clickhouse/test/test_cluster.py` covering inline password, case-insensitivity, `CREATE USER … IDENTIFIED BY`, `IDENTIFIED WITH … BY`, a non-secret string left untouched, and the two `Query.__repr__` paths (inline + parameter). All pass.
- `ruff check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Skip.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @lricoy. Origin was a review-bot finding on #60586. We confirmed via git history that embedding the password in dictionary `SOURCE` SQL is intentional and required for CH dictionary reloads, so dropping it from the query was rejected; redacting in `Query.__repr__` was chosen as the minimal fix that protects all callers without changing execution behavior. Named-collections migration was deferred to a follow-up.
