### PR TITLE
chore(api): keep evaluation context logic local in project.py

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -42,8 +42,6 @@ from posthog.api.team import (
     _format_serializer_errors,
     get_or_mint_live_events_token,
     handle_conversations_token_on_update,
-    handle_default_evaluation_contexts,
-    handle_evaluation_context_suggestions,
     handle_logs_config,
     validate_team_attrs,
 )
@@ -104,6 +102,11 @@ from posthog.user_permissions import UserPermissions, UserPermissionsSerializerM
 from posthog.utils import get_instance_realm, get_ip_address, get_week_start_for_country_code
 
 from products.feature_flags.backend.models import TeamFeatureFlagDefaultsConfig
+from products.feature_flags.backend.models.evaluation_context import (
+    EvaluationContext,
+    TeamDefaultEvaluationContext,
+    normalize_context_name,
+)
 from products.notifications.backend.facade.api import (
     NotificationData,
     NotificationType,
@@ -411,6 +414,143 @@ def team_event_ingestion_restrictions_view(team: Team, request: request.Request)
         for restriction in restrictions
     ]
     return response.Response(data)
+
+
+def team_default_evaluation_contexts_view(
+    team: Team, request: request.Request, user_permissions: UserPermissions
+) -> response.Response:
+    """Manage default evaluation contexts for a project."""
+    # Feature flags persist contexts under the project root team (RootTeamMixin), so scope
+    # context lookups to the root team — otherwise flag-used contexts are invisible from
+    # child environments.
+    root_team = team.parent_team or team
+
+    if request.method == "GET":
+        defaults = TeamDefaultEvaluationContext.objects.filter(team=root_team).select_related("evaluation_context")
+        defaults_data = [{"id": d.id, "name": d.evaluation_context.name} for d in defaults]
+        all_contexts_qs = list(
+            EvaluationContext.objects.filter(team=root_team)
+            .values_list("name", "hidden_from_suggestions")
+            .order_by("name")
+        )
+        all_contexts = [name for name, hidden in all_contexts_qs if not hidden]
+        hidden_contexts = [name for name, hidden in all_contexts_qs if hidden]
+        return response.Response(
+            {
+                "default_evaluation_contexts": defaults_data,
+                "available_contexts": all_contexts,
+                "hidden_contexts": hidden_contexts,
+                "enabled": team.default_evaluation_contexts_enabled,
+            }
+        )
+
+    elif request.method == "POST":
+        context_name = request.data.get("context_name", "")
+        if not isinstance(context_name, str):
+            return response.Response({"error": "context_name must be a string"}, status=400)
+        context_name = normalize_context_name(context_name)
+        if not context_name:
+            return response.Response({"error": "context_name is required"}, status=400)
+        if len(context_name) > 255:
+            return response.Response({"error": "context_name must be at most 255 characters"}, status=400)
+
+        with transaction.atomic():
+            existing = list(TeamDefaultEvaluationContext.objects.filter(team=root_team).select_for_update())
+            if len(existing) >= 10:
+                return response.Response({"error": "Maximum of 10 default evaluation contexts allowed"}, status=400)
+
+            ctx, _ = EvaluationContext.objects.get_or_create(name=context_name, team=root_team)
+            if ctx.hidden_from_suggestions:
+                level = user_permissions.team(team).effective_membership_level
+                if level is not None and level >= OrganizationMembership.Level.ADMIN:
+                    ctx.hidden_from_suggestions = False
+                    ctx.save(update_fields=["hidden_from_suggestions"])
+            default_ctx, created = TeamDefaultEvaluationContext.objects.get_or_create(
+                team=root_team, evaluation_context=ctx
+            )
+
+            if created:
+                report_user_action(
+                    cast(User, request.user),
+                    "default evaluation context added",
+                    {"team_id": team.id, "context_name": context_name},
+                    team=team,
+                    request=request,
+                )
+
+        return response.Response(
+            {
+                "id": default_ctx.id,
+                "name": ctx.name,
+                "created": created,
+                "hidden_from_suggestions": ctx.hidden_from_suggestions,
+            }
+        )
+
+    else:  # DELETE
+        context_name = request.data.get("context_name", "") or request.GET.get("context_name", "")
+        if not isinstance(context_name, str):
+            return response.Response({"error": "context_name must be a string"}, status=400)
+        context_name = normalize_context_name(context_name)
+        if not context_name:
+            return response.Response({"error": "context_name is required"}, status=400)
+
+        with transaction.atomic():
+            try:
+                ctx = EvaluationContext.objects.get(name=context_name, team=root_team)
+                deleted_count, _ = TeamDefaultEvaluationContext.objects.filter(
+                    team=root_team, evaluation_context=ctx
+                ).delete()
+
+                if deleted_count > 0:
+                    report_user_action(
+                        cast(User, request.user),
+                        "default evaluation context removed",
+                        {"team_id": team.id, "context_name": context_name},
+                        team=team,
+                        request=request,
+                    )
+
+                return response.Response({"success": True})
+            except EvaluationContext.DoesNotExist:
+                return response.Response({"error": "Evaluation context not found"}, status=404)
+
+
+def team_evaluation_context_suggestions_view(team: Team, request: request.Request) -> response.Response:
+    """Hide an evaluation context name from the flag editor's suggestion list, or restore it.
+
+    POST hides the name; DELETE restores it. The underlying context row and any flags already
+    using it are never modified — this only controls what gets suggested."""
+    # Contexts are persisted under the project root team (see team_default_evaluation_contexts_view).
+    root_team = team.parent_team or team
+
+    context_name = request.data.get("context_name", "") or request.GET.get("context_name", "")
+    if not isinstance(context_name, str):
+        return response.Response({"error": "context_name must be a string"}, status=400)
+    context_name = normalize_context_name(context_name)
+    if not context_name:
+        return response.Response({"error": "context_name is required"}, status=400)
+
+    hidden = request.method == "POST"
+
+    with transaction.atomic():
+        try:
+            ctx = EvaluationContext.objects.select_for_update().get(name=context_name, team=root_team)
+        except EvaluationContext.DoesNotExist:
+            return response.Response({"error": "Evaluation context not found"}, status=404)
+
+        if ctx.hidden_from_suggestions != hidden:
+            ctx.hidden_from_suggestions = hidden
+            ctx.save(update_fields=["hidden_from_suggestions"])
+            report_user_action(
+                cast(User, request.user),
+                "evaluation context suggestion hidden" if hidden else "evaluation context suggestion restored",
+                {"team_id": team.id, "context_name": context_name},
+                team=team,
+                request=request,
+            )
+
+    return response.Response({"success": True, "name": context_name, "hidden_from_suggestions": hidden})
 
 
 class ProjectSerializer(serializers.ModelSerializer):
@@ -1495,7 +1635,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     )
     def default_evaluation_contexts(self, request: request.Request, id: str, **kwargs) -> response.Response:
         """Manage default evaluation contexts for a project."""
-        return handle_default_evaluation_contexts(request, self.get_object().passthrough_team, self.user_permissions)
+        return team_default_evaluation_contexts_view(self.get_object().passthrough_team, request, self.user_permissions)
 
     @extend_schema(
         methods=["POST"],
@@ -1528,7 +1668,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         POST hides the name; DELETE restores it. The underlying context row and any flags already
         using it are never modified — this only controls what gets suggested.
         """
-        return handle_evaluation_context_suggestions(request, self.get_object().passthrough_team)
+        return team_evaluation_context_suggestions_view(self.get_object().passthrough_team, request)
 
     @action(methods=["GET"], detail=True)
     def settings_as_of(self, request: request.Request, **kwargs) -> response.Response:


### PR DESCRIPTION
## Problem

#63595 fixed the team↔project parity break (evaluation context endpoints missing on `/api/projects/`) by having `project.py` **import** `handle_default_evaluation_contexts` / `handle_evaluation_context_suggestions` from `team.py`. It's green and behaves correctly, but it runs against the documented design.

`project.py` carries explicit comments (from #61229) stating that team-config action logic must be defined **locally**, not imported from `team.py`:

- top of `project.py`: imports from team.py are temporary; the parity logic "is defined locally below rather than imported, so it survives that removal" (when `/api/environments/` is retired).
- above the backward-compat helpers: "They live here — not imported from team.py — so `/api/projects/` keeps working after `/api/environments/` is retired. Until then both surfaces intentionally carry equivalent logic; the introspection test in `test_team_project_parity.py` guards against drift."

`/api/environments/` (`team.py`) is the surface slated for retirement; `/api/projects/` (`project.py`) is canonical and must stand alone once `team.py` is deleted. Importing action logic from `team.py` makes the surviving surface depend on the doomed one — backwards.

## Changes

Replace the two imports with local `team_default_evaluation_contexts_view` / `team_evaluation_context_suggestions_view` copies in `project.py`, matching the four sibling helpers (`release_conditions`, `experiments_config`, `settings_as_of`, `event_ingestion_restrictions`). The `ProjectViewSet` actions point at the local copies.

No behavior change and no API-surface change — the duplication is intentional and guarded by `test_team_project_parity.py`. `team.py` keeps its own handlers for its own use; they retire with `team.py`.

Follow-up (separate, not here): `frontend/src/scenes/feature-flags/defaultEvaluationContextsLogic.ts` still hand-codes `/api/environments/...` URLs and sits on the `no-environments-api-urls-frontend` exclude backlog. Now that the project-side route + generated client exist, it can migrate to the generated client and come off the backlog.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally against the dev stack:

- `test_team_project_parity.py`, `test_team_project_differential.py`, `test_environments_redirect.py`, and `products/feature_flags/backend/api/test/test_feature_flag_default_evaluation_contexts.py` — **158 passed**.
- `hogli build:openapi` → no drift (only `project.py` changed; generated files untouched), confirming the API surface is identical.
- ruff + ty pass via lint-staged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @webjunkie. This is a corrective follow-up to #63595. While starting a separate de-dup cleanup, the documented design intent (keep parity logic local in `project.py`, don't import from `team.py`) surfaced — which #63595's import-based fix had inadvertently contradicted. Course-corrected to local copies after confirming the design via the in-code comments (#61229) and the `EnvironmentsRedirectMiddleware` / semgrep direction (#60407). Verified no behavior or schema change.
