### PR TITLE
fix(signals): make report enrichment best-effort on detail views

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -646,6 +646,18 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["report"]["source_products"] == ["zendesk"]
 
+    def test_source_products_resilient_to_clickhouse_failure_on_retrieve(self):
+        report = self._create_report()
+
+        with patch(
+            "products.signals.backend.views.fetch_source_products_for_reports",
+            side_effect=Exception("clickhouse timeout"),
+        ):
+            response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["source_products"] == []
+
     # --- legacy choice removal ---
 
     def test_actionability_null_for_legacy_choice_artefact(self):
@@ -762,6 +774,26 @@ class TestSignalReportSuppressionAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json()["source_products"] == ["zendesk"]
+
+    def test_state_transition_resilient_to_clickhouse_failure(self):
+        # A ClickHouse hiccup during best-effort enrichment must not 500 an already-committed
+        # state change — the transition is persisted and the response degrades to empty.
+        report = self._create_report()
+
+        with patch(
+            "products.signals.backend.views.fetch_source_products_for_reports",
+            side_effect=Exception("clickhouse timeout"),
+        ):
+            response = self.client.post(
+                self._state_url(str(report.id)),
+                data=json.dumps({"state": "suppressed"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["source_products"] == []
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.SUPPRESSED
 
     @parameterized.expand(
         [

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -702,11 +702,24 @@ class SignalReportViewSet(
     def _enriched_report_context(self, report: SignalReport) -> dict:
         # Detail-view parity with list(): inject the source-product and PR-url maps the
         # SignalReportSerializer reads, so single-report responses aren't silently degraded.
+        # Both lookups are best-effort: the serializer degrades to empty values when a map
+        # is missing, so a ClickHouse/Postgres hiccup must not turn an otherwise-available
+        # report (or an already-committed state change) into a 500.
         report_ids = [str(report.id)]
+        try:
+            source_products_map = fetch_source_products_for_reports(self.team, report_ids)
+        except Exception:
+            logger.exception("signals.enriched_context.source_products_failed", report_id=str(report.id))
+            source_products_map = {}
+        try:
+            implementation_pr_url_map = fetch_implementation_pr_urls_for_reports(report_ids)
+        except Exception:
+            logger.exception("signals.enriched_context.implementation_pr_url_failed", report_id=str(report.id))
+            implementation_pr_url_map = {}
         return {
             **self.get_serializer_context(),
-            "source_products_map": fetch_source_products_for_reports(self.team, report_ids),
-            "implementation_pr_url_map": fetch_implementation_pr_urls_for_reports(report_ids),
+            "source_products_map": source_products_map,
+            "implementation_pr_url_map": implementation_pr_url_map,
         }
 
     def retrieve(self, request, *args, **kwargs):


### PR DESCRIPTION
## Problem

PR #62811 wired source-product attribution into the `retrieve`, `signals`, and `state` paths of `SignalReportViewSet` via a shared `_enriched_report_context()` helper. That helper calls `fetch_source_products_for_reports()` — a synchronous ClickHouse/HogQL query — with no error handling, making it a hard dependency on three responses that were previously Postgres-only or already empty.

Two consequences flagged in review:

- **`retrieve`** — `GET /signals/reports/:id/` was a pure-Postgres read that returned `source_products: []` during a ClickHouse hiccup. It now returns a 500 instead, even though all the report data is available (most visible for MCP/detail callers during ClickHouse instability).
- **`state`** — the transition and dismissal artefact commit inside `transaction.atomic()`, then the enrichment runs *after* the commit. If ClickHouse fails there, the client gets a 500 for a change that actually succeeded, and a retry hits a different transition path (often 409) rather than safely replaying the original operation.

## Changes

- Wrap both lookups in `_enriched_report_context` (the ClickHouse source-products query and the Postgres PR-url query) in try/except, falling back to empty maps and logging the failure. The serializer already degrades gracefully to empty values when a map is missing, so detail responses stay available and the committed state change is never masked by a best-effort enrichment failure.

## How did you test this code?

I'm an agent (Claude Code). I ran the affected test module locally against the dev Postgres/ClickHouse stack. Added two tests:

- `test_source_products_resilient_to_clickhouse_failure_on_retrieve` — retrieve still returns 200 with `source_products: []` when the enrichment query raises.
- `test_state_transition_resilient_to_clickhouse_failure` — the `state` POST still returns 200, degrades to `[]`, and the transition is persisted (`status == SUPPRESSED`) when the enrichment query raises.

The existing `source_products` happy-path tests still pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the two P2 Codex review comments left on #62811, which flagged the new enrichment as a hard ClickHouse dependency on the detail/write paths. Andy reviewed the merged code and asked for the follow-up. The fix keeps the enrichment best-effort rather than reverting it, so the source-product parity from #62811 is preserved on the happy path while ClickHouse failures degrade to the pre-existing empty-map behavior. The Greptile comment on the same PR (missing `state` test for `source_products`) was already addressed in-PR. Tools: Claude Code (Read/Grep/Edit/Bash, gh CLI).
