### PR TITLE
fix(experiments): allow sorting experiment list by result

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -433,6 +433,8 @@ class ExperimentService:
         "-duration",
         "status",
         "-status",
+        "conclusion",
+        "-conclusion",
     }
 
     ELIGIBLE_FLAGS_ORDER_ALLOWLIST = {
@@ -2479,6 +2481,22 @@ class ExperimentService:
                         F("created_by__email"),
                     )
                 ).order_by(f"{prefix}created_by_display")
+            elif order_value in ["conclusion", "-conclusion"]:
+                # `conclusion` is a free-form-ish enum, so alphabetical ordering is
+                # meaningless. Match the frontend column's ranking (won, lost,
+                # inconclusive, stopped_early, invalid) and bucket experiments without
+                # a conclusion last.
+                prefix = "-" if order_value.startswith("-") else ""
+                queryset = queryset.annotate(
+                    conclusion_sort_key=Case(
+                        When(conclusion="won", then=Value(1)),
+                        When(conclusion="lost", then=Value(2)),
+                        When(conclusion="inconclusive", then=Value(3)),
+                        When(conclusion="stopped_early", then=Value(4)),
+                        When(conclusion="invalid", then=Value(5)),
+                        default=Value(6),
+                    )
+                ).order_by(f"{prefix}conclusion_sort_key")
             else:
                 queryset = queryset.order_by(order_value)
         else:

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -200,7 +200,7 @@ def _slugify_feature_flag_key(name: str, *, team_id: int) -> str:
                 type=str,
                 description=(
                     "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, "
-                    "created_at, updated_at, start_date, end_date, duration, and status."
+                    "created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion."
                 ),
                 required=False,
             ),

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -5072,3 +5072,86 @@ class TestValidateExperimentParametersExcludedVariants:
     def test_excluded_variants_without_feature_flag_variants_raises(self):
         with pytest.raises(ValidationError, match="requires feature_flag_variants in the same request"):
             ExperimentService.validate_experiment_parameters({"excluded_variants": ["test-1"]})
+
+
+class TestExperimentListOrdering(APIBaseTest):
+    """Covers the order allowlist in `filter_experiments_queryset`.
+
+    Regression coverage for the experiments list breaking when sorted by the
+    `Result` (conclusion) or `Created by` columns.
+    """
+
+    def _service(self) -> ExperimentService:
+        return ExperimentService(team=self.team, user=self.user)
+
+    def _create_experiment(
+        self,
+        name: str,
+        *,
+        conclusion: str | None = None,
+        created_by: Any | None = None,
+    ) -> Experiment:
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=f"flag-{name}",
+            name=f"Flag for {name}",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        return Experiment.objects.create(
+            team=self.team,
+            name=name,
+            feature_flag=flag,
+            conclusion=conclusion,
+            created_by=created_by or self.user,
+        )
+
+    def _ordered_names(self, order: str) -> list[str]:
+        queryset = self._service().filter_experiments_queryset(
+            Experiment.objects.filter(team=self.team),
+            action="list",
+            query_params={"order": order},
+        )
+        return [experiment.name for experiment in queryset]
+
+    def test_order_by_conclusion_does_not_raise_and_ranks_by_result(self):
+        self._create_experiment("won-exp", conclusion="won")
+        self._create_experiment("lost-exp", conclusion="lost")
+        self._create_experiment("inconclusive-exp", conclusion="inconclusive")
+        self._create_experiment("stopped-exp", conclusion="stopped_early")
+        self._create_experiment("invalid-exp", conclusion="invalid")
+        self._create_experiment("none-exp", conclusion=None)
+
+        # Ascending matches the frontend column ranking, with no-conclusion last.
+        assert self._ordered_names("conclusion") == [
+            "won-exp",
+            "lost-exp",
+            "inconclusive-exp",
+            "stopped-exp",
+            "invalid-exp",
+            "none-exp",
+        ]
+
+        # Descending reverses it.
+        assert self._ordered_names("-conclusion") == [
+            "none-exp",
+            "invalid-exp",
+            "stopped-exp",
+            "inconclusive-exp",
+            "lost-exp",
+            "won-exp",
+        ]
+
+    def test_order_by_created_by_does_not_raise(self):
+        alice = self._create_user("alice@posthog.com", first_name="Alice")
+        bob = self._create_user("bob@posthog.com", first_name="Bob")
+        self._create_experiment("bob-exp", created_by=bob)
+        self._create_experiment("alice-exp", created_by=alice)
+
+        # Evaluates the queryset (forces SQL) so a bad annotation would surface here.
+        assert self._ordered_names("created_by") == ["alice-exp", "bob-exp"]
+        assert self._ordered_names("-created_by") == ["bob-exp", "alice-exp"]
+
+    def test_invalid_order_field_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="Invalid order field: 'bogus'"):
+            self._ordered_names("bogus")

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -5114,7 +5114,15 @@ class TestExperimentListOrdering(APIBaseTest):
         )
         return [experiment.name for experiment in queryset]
 
-    def test_order_by_conclusion_does_not_raise_and_ranks_by_result(self):
+    @parameterized.expand(
+        [
+            # Ascending matches the frontend column ranking, with no-conclusion last.
+            ("conclusion", ["won-exp", "lost-exp", "inconclusive-exp", "stopped-exp", "invalid-exp", "none-exp"]),
+            # Descending reverses it.
+            ("-conclusion", ["none-exp", "invalid-exp", "stopped-exp", "inconclusive-exp", "lost-exp", "won-exp"]),
+        ]
+    )
+    def test_order_by_conclusion_ranks_by_result(self, order: str, expected_names: list[str]):
         self._create_experiment("won-exp", conclusion="won")
         self._create_experiment("lost-exp", conclusion="lost")
         self._create_experiment("inconclusive-exp", conclusion="inconclusive")
@@ -5122,35 +5130,22 @@ class TestExperimentListOrdering(APIBaseTest):
         self._create_experiment("invalid-exp", conclusion="invalid")
         self._create_experiment("none-exp", conclusion=None)
 
-        # Ascending matches the frontend column ranking, with no-conclusion last.
-        assert self._ordered_names("conclusion") == [
-            "won-exp",
-            "lost-exp",
-            "inconclusive-exp",
-            "stopped-exp",
-            "invalid-exp",
-            "none-exp",
-        ]
+        assert self._ordered_names(order) == expected_names
 
-        # Descending reverses it.
-        assert self._ordered_names("-conclusion") == [
-            "none-exp",
-            "invalid-exp",
-            "stopped-exp",
-            "inconclusive-exp",
-            "lost-exp",
-            "won-exp",
+    @parameterized.expand(
+        [
+            ("created_by", ["alice-exp", "bob-exp"]),
+            ("-created_by", ["bob-exp", "alice-exp"]),
         ]
-
-    def test_order_by_created_by_does_not_raise(self):
+    )
+    def test_order_by_created_by_does_not_raise(self, order: str, expected_names: list[str]):
         alice = self._create_user("alice@posthog.com", first_name="Alice")
         bob = self._create_user("bob@posthog.com", first_name="Bob")
         self._create_experiment("bob-exp", created_by=bob)
         self._create_experiment("alice-exp", created_by=alice)
 
         # Evaluates the queryset (forces SQL) so a bad annotation would surface here.
-        assert self._ordered_names("created_by") == ["alice-exp", "bob-exp"]
-        assert self._ordered_names("-created_by") == ["bob-exp", "alice-exp"]
+        assert self._ordered_names(order) == expected_names
 
     def test_invalid_order_field_raises_validation_error(self):
         with pytest.raises(ValidationError, match="Invalid order field: 'bogus'"):

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -825,7 +825,7 @@ export type ExperimentsListParams = {
      */
     offset?: number
     /**
-     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.
      */
     order?: string
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -51102,7 +51102,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.
+     * Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.
      */
     order?: string;
     /**

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -134,7 +134,7 @@ export const ExperimentsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status."
+            "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion."
         ),
     prompt_name: zod
         .string()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-get-all.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-get-all.json
@@ -26,7 +26,7 @@
             "type": "number"
         },
         "order": {
-            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.",
+            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.",
             "type": "string"
         },
         "prompt_name": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-list.json
@@ -26,7 +26,7 @@
             "type": "number"
         },
         "order": {
-            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, updated_at, start_date, end_date, duration, and status.",
+            "description": "Field to order by. Prefix with '-' for descending. Allowlisted fields include name, created_at, created_by, updated_at, start_date, end_date, duration, status, and conclusion.",
             "type": "string"
         },
         "prompt_name": {


### PR DESCRIPTION
## Problem

Sorting the experiments list by the **Result** column failed with `Load experiments failed: Invalid order field: 'conclusion'`. Clicking the header sets `order=conclusion` in the URL, but `conclusion` was never added to the backend order allowlist, so the list request 400'd.

The companion **Created by** symptom from the report (a 500) is already resolved on `master` — `created_by` is allowlisted and handled with a `Coalesce(first_name, email)` annotation. This PR adds the matching coverage so it can't regress.

**Why:** the experiments table advertises these columns as sortable, so clicking them should sort the list, not error out.

Closes #63621

## Changes

- Add `conclusion` / `-conclusion` to `EXPERIMENT_ORDER_ALLOWLIST`.
- Order by a `Case/When` ranking that matches the frontend column semantics (won → lost → inconclusive → stopped_early → invalid), bucketing experiments with no result last — alphabetical ordering of the enum would be meaningless.
- Update the `order` query-param schema docstring to list the now-complete set of allowlisted fields.
- Add `TestExperimentListOrdering` covering `conclusion` (both directions), `created_by`, and the invalid-field `ValidationError`. The list-ordering allowlist previously had no test coverage, which is how `conclusion` slipped through.

## How did you test this code?

I'm an agent (PostHog Slack app). I added automated tests in `TestExperimentListOrdering` but could **not** run them in my environment (no Postgres available). The three changed files compile cleanly. Please run `products/experiments/backend/test/test_experiment_service.py::TestExperimentListOrdering` in CI / locally to confirm.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread reporting the bug. Traced the failure to server-side sorting: the frontend `Result` column (`key: 'conclusion'`) emits `order=conclusion`, validated against `EXPERIMENT_ORDER_ALLOWLIST` in `filter_experiments_queryset`. `conclusion` was absent, hence the 400. Chose to add a semantic `Case/When` ranking (rather than raw `order_by("conclusion")`) so the server order matches the existing client-side `sorter` ranking on that column. Confirmed `created_by` is already handled on `master`, so this PR only completes the `conclusion` gap and backfills tests for the whole allowlist.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1781542873480819)*
