### PR TITLE
fix(docker): ship common package marker so dagster can import common.hogvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -398,6 +398,11 @@ COPY --chown=posthog:posthog ./rust/persons_migrations ./rust/persons_migrations
 COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/
+# Ship the top-level `common` package marker so `common` resolves as a real package
+# (like `posthog`), not a namespace package. Without it, `import common.hogvm` fails
+# with `No module named 'common'` in launch contexts where the repo root isn't on
+# sys.path (e.g. the Dagster grpc code location), even though common/hogvm is present.
+COPY --chown=posthog:posthog common/__init__.py common/__init__.py
 COPY --chown=posthog:posthog common/hogvm common/hogvm/
 COPY --chown=posthog:posthog common/migration_utils common/migration_utils/
 COPY --chown=posthog:posthog products products/

--- a/Dockerfile
+++ b/Dockerfile
@@ -398,10 +398,6 @@ COPY --chown=posthog:posthog ./rust/persons_migrations ./rust/persons_migrations
 COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/
-# Ship the top-level `common` package marker so `common` resolves as a real package
-# (like `posthog`), not a namespace package. Without it, `import common.hogvm` fails
-# with `No module named 'common'` in launch contexts where the repo root isn't on
-# sys.path (e.g. the Dagster grpc code location), even though common/hogvm is present.
 COPY --chown=posthog:posthog common/__init__.py common/__init__.py
 COPY --chown=posthog:posthog common/hogvm common/hogvm/
 COPY --chown=posthog:posthog common/migration_utils common/migration_utils/


### PR DESCRIPTION
## Problem

The runtime image ships `common/hogvm` and `common/migration_utils` but **not `common/__init__.py`**, so the top-level `common` package only resolves as a namespace package — which works when the repo root happens to be on `sys.path` (e.g. web/worker running with `cwd=/code`) but fails in launch contexts where it isn't, most notably the **Dagster grpc code location**. There, `import common.hogvm.python.execute` (reached eagerly from `posthog/hogql/compiler/bytecode.py`) raises `ModuleNotFoundError: No module named 'common'`.

`posthog/` is copied whole (with its `__init__.py`) and resolves fine; `common/` is copied as only `COPY common/hogvm …`, so it doesn't. That asymmetry is the bug.

Impact: every Dagster job that compiles HogQL bytecode (e.g. the web-analytics eager precompute warmer, cache warming) fails at import time. The web-analytics precompute warmer has produced zero rows since this surfaced, leaving the pre-aggregated tables stale.

## Changes

Add `COPY --chown=posthog:posthog common/__init__.py common/__init__.py` to the runtime stage, next to the existing `common/hogvm` copy. This makes `common` a real package (like `posthog`) so `common.hogvm` imports resolve regardless of launch context, with no image-size impact.

This is the packaging fix that complements #63306 (which adds a `/_readyz` `hogvm` importability check + clearer error, but is detection-only and does not cover the Dagster role).

## How did you test this code?

I'm an agent (Claude Code), human-directed. No automated test covers Dockerfile layer contents. Verified by inspection: the runtime stage copied `common/hogvm` + `common/migration_utils` but never `common/__init__.py`, and `common/__init__.py` exists in the repo. The corresponding production exceptions (`ModuleNotFoundError: No module named 'common'` from `posthog/hogql/compiler/bytecode.py`, first seen 2026-06-12) confirm the missing-package signature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. Found while investigating why web-analytics precompute warming stopped producing rows on 2026-06-12. Traced it from "no inserts" → the Dagster warmer failing at import → `ModuleNotFoundError: No module named 'common'` in the `dagster` service logs → the Dockerfile runtime stage copying `common/hogvm` without the package's `__init__.py`. Considered dropping the dependency (not possible — HogQL bytecode execution requires `common.hogvm`) and a Dagster-specific image, but the minimal correct fix is to ship the package marker in the shared monolith image. A separate operational step (confirm the `dags` code location is running a current image and restart it) is still required to unblock the warmer.
