### PR TITLE
fix(homepage): prevent input text overlapping "Tab to search" button

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -56,7 +56,7 @@ function IdleInput(): JSX.Element {
                 htmlFor="homepage-input"
                 className="min-h-[40px] group input-like flex flex-col items-start relative w-full bg-fill-input border border-primary focus-within:ring-primary rounded-lg justify-stretch overflow-hidden"
             >
-                <div className="flex w-full py-1 px-1 max-h-[300px]">
+                <div className="flex w-full py-1 px-1 max-h-[300px] items-end gap-1">
                     {!query && (
                         <span className="text-tertiary pointer-events-none absolute left-2.5 top-2 flex items-center gap-1">
                             <span className="text-tertiary">What can I help you with?</span>
@@ -69,7 +69,7 @@ function IdleInput(): JSX.Element {
                         ref={inputRef}
                         id="homepage-input"
                         data-attr="homepage-input"
-                        wrapperClassName="w-full"
+                        wrapperClassName="flex-1 min-w-0"
                         value={query}
                         onChange={(e) => {
                             const value = e.target.value
@@ -117,8 +117,8 @@ function IdleInput(): JSX.Element {
                         className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
                         autoFocus
                     />
-                    <div className="flex items-end shrink-0 absolute right-[0.5rem] bottom-[0.2rem]">
-                        <div className="flex items-center gap-1 ">
+                    <div className="flex items-end shrink-0">
+                        <div className="flex items-center gap-1">
                             <ButtonPrimitive
                                 size="xs"
                                 className="text-tertiary hover:text-primary shrink-0"


### PR DESCRIPTION
## Problem

On the AI-first project homepage, the chat input's action buttons ("Tab to search", the optional mic, and the submit arrow) were absolutely positioned on top of a full-width textarea. No horizontal space was reserved for them, so once a user typed a single line long enough, the text slid underneath and visually overlapped the "Tab to search" button.

## Changes

Converted the button cluster from absolute positioning into a normal flex sibling of the textarea:

- The inner row is now `flex ... items-end gap-1` so the buttons sit beside the textarea and stay pinned to the bottom as it grows.
- The textarea wrapper changed from `w-full` to `flex-1 min-w-0`, letting it flex to fill the remaining width and shrink instead of overflowing under the buttons.
- Removed the now-unneeded absolute offsets on the button container.

## How did you test this code?

I'm an agent. I made the layout change but did not run the frontend tooling (it isn't installed in this environment) or perform manual browser testing. This is a CSS-only layout change with no logic changes; reviewers should sanity-check the input visually at narrow and wide widths.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread: the typed text was running over the "Tab to search" hint in the main homepage chat input. Root cause was an absolutely-positioned button cluster sharing space with a full-width textarea. Chose a flex-sibling layout over a fixed right-padding reservation because the button cluster's width varies (the mic button is feature-flagged), and a flex layout reserves exactly the needed space regardless.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781544712712409?thread_ts=1781544712.712409&cid=C0ACRAMJUAG)*
