### PR TITLE
fix(data-warehouse): isolate postgres schema-discovery probes with autocommit

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1133,11 +1133,11 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
 
     try:
         # Debug-only and best-effort: a query may use syntax the source DB rejects (e.g.
-        # TABLESAMPLE on CockroachDB). Savepoint so a failure doesn't poison the transaction.
-        with cursor.connection.transaction(savepoint_name="explain_query"):
-            query_with_explain = sql.SQL("EXPLAIN {}").format(query)
-            cursor.execute(query_with_explain)
-            rows = cursor.fetchall()
+        # TABLESAMPLE on CockroachDB). Discovery runs autocommit, so a failed EXPLAIN is
+        # isolated to its own statement and can't poison later probes.
+        query_with_explain = sql.SQL("EXPLAIN {}").format(query)
+        cursor.execute(query_with_explain)
+        rows = cursor.fetchall()
         explain_result: str = ""
         # Build up a single string of the EXPLAIN output
         for row in rows:
@@ -1283,13 +1283,12 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
             ) as subquery
         """).format(inner_query)
 
-        # Best-effort: the sampled query can fail (e.g. TABLESAMPLE on CockroachDB). Savepoint
-        # so a failure falls back to DEFAULT_CHUNK_SIZE without poisoning the transaction.
-        with cursor.connection.transaction(savepoint_name="table_chunk_size"):
-            _explain_query(cursor, query, logger)
-            logger.debug(f"Running query: {query.as_string()}")
-            cursor.execute(query)
-            row = cursor.fetchone()
+        # Best-effort: the sampled query can fail (e.g. TABLESAMPLE on CockroachDB). Discovery
+        # runs autocommit, so a failure falls back to DEFAULT_CHUNK_SIZE without affecting later probes.
+        _explain_query(cursor, query, logger)
+        logger.debug(f"Running query: {query.as_string()}")
+        cursor.execute(query)
+        row = cursor.fetchone()
 
         if row is None:
             logger.debug(f"_get_table_chunk_size: No results returned. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}")
@@ -1366,13 +1365,22 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
 
 
 def _get_partition_settings(
-    cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
+    cursor: psycopg.Cursor,
+    schema: str,
+    table_name: str,
+    logger: FilteringBoundLogger,
+    *,
+    is_partitioned: bool | None = None,
 ) -> PartitionSettings | None:
     # For partitioned tables, a plain COUNT(*) and pg_table_size on the
     # parent would scan every child partition / return 0. Use catalog
     # estimates instead.
     try:
-        if _is_partitioned_table(cursor, schema, table_name):
+        # Reuse the partition flag the caller already computed when available; only fall back
+        # to detecting it here when it wasn't passed. Saves a redundant catalog round trip.
+        if is_partitioned is None:
+            is_partitioned = _is_partitioned_table(cursor, schema, table_name)
+        if is_partitioned:
             return _get_partition_settings_for_partitioned_table(cursor, schema, table_name, logger)
     except Exception as e:
         logger.debug(f"_get_partition_settings: partition detection failed, falling back: {e}")
@@ -1617,13 +1625,11 @@ def _get_table(
     # already materialized on disk and behave like tables here.
     if unconstrained_numeric_columns and probe_unconstrained_numeric_scale and not is_view:
         try:
-            # Isolate the probe in a savepoint so that any failure (permission denied, bad
-            # type, statement_timeout, network blip) rolls back cleanly without poisoning the
-            # enclosing metadata transaction. Without this, a probe error leaves the
-            # transaction in `INERROR` state and every subsequent query in `postgres_source`
-            # (SET LOCAL statement_timeout, _is_read_replica, _get_primary_keys, _get_rows_to_sync,
-            # ...) fails with `InFailedSqlTransaction: current transaction is aborted`.
-            with cursor.connection.transaction(savepoint_name="probe_numeric_scale"):
+            # Wrap the probe in its own transaction purely to scope the 30s `SET LOCAL
+            # statement_timeout` below to this one aggregation (it auto-resets on exit).
+            # Discovery runs autocommit, so this is a self-contained BEGIN/COMMIT — a probe
+            # failure rolls back cleanly and can't poison later probes.
+            with cursor.connection.transaction():
                 # Scope a short statement_timeout to the probe so a pathologically large table
                 # or slow aggregation can't hang schema discovery. The outer 10-minute
                 # statement_timeout isn't set until `postgres_source` continues after
@@ -1804,6 +1810,14 @@ def postgres_source(
                 ) from e
             raise
 
+        # Schema discovery runs a series of best-effort probes (row counts, RLS, partition
+        # detection, numeric-scale). Run them in autocommit so each probe is its own implicit
+        # transaction: a probe that fails — e.g. a read-replica recovery conflict on a slow
+        # COUNT(*), a statement timeout, a permission error — can't leave an aborted transaction
+        # that poisons every subsequent probe with `InFailedSqlTransaction`. This replaces the
+        # per-probe savepoint wrappers that previously guarded against that poisoning.
+        connection.autocommit = True
+
         with connection:
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
@@ -1822,8 +1836,11 @@ def postgres_source(
                     probe_unconstrained_numeric_scale=fresh_schema_being_created,
                 )
 
+                # Session-level (not LOCAL): under autocommit there's no surrounding transaction
+                # for a LOCAL setting to bind to, so it would be a no-op. A session SET persists
+                # across the autocommit probes below until the connection closes.
                 cursor.execute(
-                    sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
+                    sql.SQL("SET statement_timeout = {timeout}").format(
                         timeout=sql.Literal(1000 * 60 * 10)  # 10 mins
                     )
                 )
@@ -1934,7 +1951,7 @@ def postgres_source(
 
                     logger.debug("Getting partition settings...")
                     partition_settings = (
-                        _get_partition_settings(cursor, schema, table_name, logger)
+                        _get_partition_settings(cursor, schema, table_name, logger, is_partitioned=is_partitioned)
                         if should_use_incremental_field
                         else None
                     )

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1132,9 +1132,8 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
     logger.debug(f"Running EXPLAIN on {query.as_string()}")
 
     try:
-        # Debug-only and best-effort: a query may use syntax the source DB rejects (e.g.
-        # TABLESAMPLE on CockroachDB). Discovery runs autocommit, so a failed EXPLAIN is
-        # isolated to its own statement and can't poison later probes.
+        # Debug-only, best-effort: EXPLAIN may use syntax the source rejects (e.g. TABLESAMPLE
+        # on CockroachDB), so swallow failures.
         query_with_explain = sql.SQL("EXPLAIN {}").format(query)
         cursor.execute(query_with_explain)
         rows = cursor.fetchall()
@@ -1283,8 +1282,7 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
             ) as subquery
         """).format(inner_query)
 
-        # Best-effort: the sampled query can fail (e.g. TABLESAMPLE on CockroachDB). Discovery
-        # runs autocommit, so a failure falls back to DEFAULT_CHUNK_SIZE without affecting later probes.
+        # Best-effort: the sampled query can fail (e.g. TABLESAMPLE on CockroachDB); fall back.
         _explain_query(cursor, query, logger)
         logger.debug(f"Running query: {query.as_string()}")
         cursor.execute(query)
@@ -1376,8 +1374,7 @@ def _get_partition_settings(
     # parent would scan every child partition / return 0. Use catalog
     # estimates instead.
     try:
-        # Reuse the partition flag the caller already computed when available; only fall back
-        # to detecting it here when it wasn't passed. Saves a redundant catalog round trip.
+        # Reuse the caller's partition flag when given; saves a redundant catalog round trip.
         if is_partitioned is None:
             is_partitioned = _is_partitioned_table(cursor, schema, table_name)
         if is_partitioned:
@@ -1625,10 +1622,8 @@ def _get_table(
     # already materialized on disk and behave like tables here.
     if unconstrained_numeric_columns and probe_unconstrained_numeric_scale and not is_view:
         try:
-            # Wrap the probe in its own transaction purely to scope the 30s `SET LOCAL
-            # statement_timeout` below to this one aggregation (it auto-resets on exit).
-            # Discovery runs autocommit, so this is a self-contained BEGIN/COMMIT — a probe
-            # failure rolls back cleanly and can't poison later probes.
+            # Own transaction so the 30s `SET LOCAL statement_timeout` below scopes to this
+            # aggregation and auto-resets (a self-contained BEGIN/COMMIT under autocommit).
             with cursor.connection.transaction():
                 # Scope a short statement_timeout to the probe so a pathologically large table
                 # or slow aggregation can't hang schema discovery. The outer 10-minute
@@ -1810,12 +1805,9 @@ def postgres_source(
                 ) from e
             raise
 
-        # Schema discovery runs a series of best-effort probes (row counts, RLS, partition
-        # detection, numeric-scale). Run them in autocommit so each probe is its own implicit
-        # transaction: a probe that fails — e.g. a read-replica recovery conflict on a slow
-        # COUNT(*), a statement timeout, a permission error — can't leave an aborted transaction
-        # that poisons every subsequent probe with `InFailedSqlTransaction`. This replaces the
-        # per-probe savepoint wrappers that previously guarded against that poisoning.
+        # Autocommit so each best-effort probe is its own transaction: one that fails — a
+        # read-replica recovery conflict on a slow COUNT(*), or syntax the source rejects like
+        # TABLESAMPLE on CockroachDB — can't poison the rest. Replaces the per-probe savepoints.
         connection.autocommit = True
 
         with connection:
@@ -1836,9 +1828,7 @@ def postgres_source(
                     probe_unconstrained_numeric_scale=fresh_schema_being_created,
                 )
 
-                # Session-level (not LOCAL): under autocommit there's no surrounding transaction
-                # for a LOCAL setting to bind to, so it would be a no-op. A session SET persists
-                # across the autocommit probes below until the connection closes.
+                # Session, not LOCAL: under autocommit a LOCAL timeout has no transaction to bind to.
                 cursor.execute(
                     sql.SQL("SET statement_timeout = {timeout}").format(
                         timeout=sql.Literal(1000 * 60 * 10)  # 10 mins

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1328,17 +1328,34 @@ class TestIsPartitionedTable:
 
 class TestGetTableChunkSize:
     @pytest.mark.django_db
-    def test_failing_probe_falls_back_without_poisoning_transaction(self):
+    def test_failing_probe_isolated_by_autocommit(self):
+        # Discovery runs the probes on an autocommit connection (no shared transaction), so a
+        # failing probe falls back to DEFAULT_CHUNK_SIZE and — crucially — doesn't poison the
+        # connection for later probes. A raw autocommit connection mirrors production here; the
+        # default django_db cursor runs inside a transaction and wouldn't exercise that path.
         logger = structlog.get_logger()
 
-        with django_connection.cursor() as dj_cursor:
-            inner_query = sql.SQL("SELECT * FROM does_not_exist_chunk_probe").format()
+        sd = django_connection.settings_dict
+        conn = psycopg.connect(
+            host=sd["HOST"] or None,
+            port=sd["PORT"] or None,
+            dbname=sd["NAME"],
+            user=sd["USER"] or None,
+            password=sd["PASSWORD"] or None,
+            autocommit=True,
+        )
+        try:
+            with conn.cursor() as cursor:
+                inner_query = sql.SQL("SELECT * FROM does_not_exist_chunk_probe").format()
 
-            chunk_size = _get_table_chunk_size(cast(Any, dj_cursor), inner_query, logger)
-            assert chunk_size == DEFAULT_CHUNK_SIZE
+                chunk_size = _get_table_chunk_size(cast(Any, cursor), inner_query, logger)
+                assert chunk_size == DEFAULT_CHUNK_SIZE
 
-            dj_cursor.execute("SELECT 1")
-            assert dj_cursor.fetchone()[0] == 1
+                # No poisoning: the next probe on the same connection still works.
+                cursor.execute("SELECT 1")
+                assert cursor.fetchone()[0] == 1
+        finally:
+            conn.close()
 
 
 class TestGetRowsToSync:
@@ -1360,6 +1377,35 @@ class TestGetRowsToSync:
         # Best-effort estimate falls back to 0 and never reports the handled failure.
         assert rows == 0
         mock_capture.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_failing_count_isolated_by_autocommit(self):
+        # Regression for the reported incident: on a read replica the COUNT(*) for rows-to-sync
+        # gets cancelled ("conflict with recovery"). Under the autocommit discovery connection
+        # that failure must stay contained — return 0 and leave the connection usable for the
+        # remaining probes — rather than poisoning a shared transaction.
+        logger = structlog.get_logger()
+        sd = django_connection.settings_dict
+        conn = psycopg.connect(
+            host=sd["HOST"] or None,
+            port=sd["PORT"] or None,
+            dbname=sd["NAME"],
+            user=sd["USER"] or None,
+            password=sd["PASSWORD"] or None,
+            autocommit=True,
+        )
+        count_query = sql.SQL("SELECT COUNT(*) FROM {table} WHERE {col} > 0").format(
+            table=sql.Identifier("information_schema", "tables"),
+            col=sql.Identifier("does_not_exist_count_col"),
+        )
+        try:
+            with conn.cursor() as cursor:
+                assert _get_rows_to_sync(cast(Any, cursor), count_query, logger) == 0
+
+                cursor.execute("SELECT 1")
+                assert cursor.fetchone()[0] == 1
+        finally:
+            conn.close()
 
     def test_temp_file_limit_error_still_raises(self):
         logger = structlog.get_logger()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1326,86 +1326,72 @@ class TestIsPartitionedTable:
             assert _is_partitioned_table(cast(Any, dj_cursor), "public", table_name) is expected
 
 
+@pytest.fixture
+def autocommit_pg_connection():
+    # Raw autocommit connection to the test DB — mirrors how discovery connects in production
+    # (no shared transaction). The default django_db cursor runs inside a transaction and can't
+    # exercise the isolation path.
+    sd = django_connection.settings_dict
+    conn = psycopg.connect(
+        host=sd["HOST"] or None,
+        port=sd["PORT"] or None,
+        dbname=sd["NAME"],
+        user=sd["USER"] or None,
+        password=sd["PASSWORD"] or None,
+        autocommit=True,
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
 class TestGetTableChunkSize:
     @pytest.mark.django_db
-    def test_failing_probe_isolated_by_autocommit(self):
-        # Discovery runs the probes on an autocommit connection (no shared transaction), so a
-        # failing probe falls back to DEFAULT_CHUNK_SIZE and — crucially — doesn't poison the
-        # connection for later probes. A raw autocommit connection mirrors production here; the
-        # default django_db cursor runs inside a transaction and wouldn't exercise that path.
+    def test_failing_probe_isolated_by_autocommit(self, autocommit_pg_connection):
+        # A failing probe falls back to DEFAULT_CHUNK_SIZE and, under autocommit, doesn't poison
+        # the connection for later probes.
         logger = structlog.get_logger()
+        with autocommit_pg_connection.cursor() as cursor:
+            inner_query = sql.SQL("SELECT * FROM does_not_exist_chunk_probe").format()
 
-        sd = django_connection.settings_dict
-        conn = psycopg.connect(
-            host=sd["HOST"] or None,
-            port=sd["PORT"] or None,
-            dbname=sd["NAME"],
-            user=sd["USER"] or None,
-            password=sd["PASSWORD"] or None,
-            autocommit=True,
-        )
-        try:
-            with conn.cursor() as cursor:
-                inner_query = sql.SQL("SELECT * FROM does_not_exist_chunk_probe").format()
+            chunk_size = _get_table_chunk_size(cast(Any, cursor), inner_query, logger)
+            assert chunk_size == DEFAULT_CHUNK_SIZE
 
-                chunk_size = _get_table_chunk_size(cast(Any, cursor), inner_query, logger)
-                assert chunk_size == DEFAULT_CHUNK_SIZE
-
-                # No poisoning: the next probe on the same connection still works.
-                cursor.execute("SELECT 1")
-                assert cursor.fetchone()[0] == 1
-        finally:
-            conn.close()
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()[0] == 1
 
 
 class TestGetRowsToSync:
+    # Mirrors a misconfigured incremental field: COUNT(*) over a column that doesn't exist.
+    _FAILING_COUNT_QUERY = sql.SQL("SELECT COUNT(*) FROM {table} WHERE {col} > 0").format(
+        table=sql.Identifier("information_schema", "tables"),
+        col=sql.Identifier("does_not_exist_count_col"),
+    )
+
     @pytest.mark.django_db
     def test_failing_count_query_falls_back_to_zero_without_capturing(self):
         logger = structlog.get_logger()
 
-        # Count query references a column that doesn't exist — mirrors a misconfigured
-        # incremental field (e.g. djstripe_updated on a table that lacks it).
-        count_query = sql.SQL("SELECT COUNT(*) FROM {table} WHERE {col} > 0").format(
-            table=sql.Identifier("information_schema", "tables"),
-            col=sql.Identifier("does_not_exist_count_col"),
-        )
-
         with django_connection.cursor() as dj_cursor:
             with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
-                rows = _get_rows_to_sync(cast(Any, dj_cursor), count_query, logger)
+                rows = _get_rows_to_sync(cast(Any, dj_cursor), self._FAILING_COUNT_QUERY, logger)
 
         # Best-effort estimate falls back to 0 and never reports the handled failure.
         assert rows == 0
         mock_capture.assert_not_called()
 
     @pytest.mark.django_db
-    def test_failing_count_isolated_by_autocommit(self):
-        # Regression for the reported incident: on a read replica the COUNT(*) for rows-to-sync
-        # gets cancelled ("conflict with recovery"). Under the autocommit discovery connection
-        # that failure must stay contained — return 0 and leave the connection usable for the
-        # remaining probes — rather than poisoning a shared transaction.
+    def test_failing_count_isolated_by_autocommit(self, autocommit_pg_connection):
+        # Regression for the reported incident: a read-replica recovery conflict cancels the
+        # rows-to-sync COUNT(*). Under autocommit the failure stays contained — returns 0 and
+        # leaves the connection usable — instead of poisoning a shared transaction.
         logger = structlog.get_logger()
-        sd = django_connection.settings_dict
-        conn = psycopg.connect(
-            host=sd["HOST"] or None,
-            port=sd["PORT"] or None,
-            dbname=sd["NAME"],
-            user=sd["USER"] or None,
-            password=sd["PASSWORD"] or None,
-            autocommit=True,
-        )
-        count_query = sql.SQL("SELECT COUNT(*) FROM {table} WHERE {col} > 0").format(
-            table=sql.Identifier("information_schema", "tables"),
-            col=sql.Identifier("does_not_exist_count_col"),
-        )
-        try:
-            with conn.cursor() as cursor:
-                assert _get_rows_to_sync(cast(Any, cursor), count_query, logger) == 0
+        with autocommit_pg_connection.cursor() as cursor:
+            assert _get_rows_to_sync(cast(Any, cursor), self._FAILING_COUNT_QUERY, logger) == 0
 
-                cursor.execute("SELECT 1")
-                assert cursor.fetchone()[0] == 1
-        finally:
-            conn.close()
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()[0] == 1
 
     def test_temp_file_limit_error_still_raises(self):
         logger = structlog.get_logger()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1659,6 +1659,25 @@ class TestGetPartitionSettings:
             assert result is not None
             assert result.partition_size > 0
 
+    def test_reuses_passed_is_partitioned_flag(self):
+        # When the caller already knows the table is partitioned, skip re-detecting it.
+        logger = structlog.get_logger()
+        cursor = mock.MagicMock()
+        sentinel = object()
+
+        with (
+            patch("posthog.temporal.data_imports.sources.postgres.postgres._is_partitioned_table") as mock_detect,
+            patch(
+                "posthog.temporal.data_imports.sources.postgres.postgres._get_partition_settings_for_partitioned_table",
+                return_value=sentinel,
+            ) as mock_partitioned,
+        ):
+            result = _get_partition_settings(cast(Any, cursor), "public", "t", logger, is_partitioned=True)
+
+        mock_detect.assert_not_called()
+        mock_partitioned.assert_called_once()
+        assert result is sentinel
+
 
 class TestPostgreSQLColumnToArrowField:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Postgres data-warehouse syncs (including Supabase, which serves reads from a hot standby) can get stuck on large tables. Schema discovery in `postgres_source` runs a series of best-effort probes — row counts, RLS check, partition detection, numeric-scale — and they all share **one transaction**.

When a probe's query is cancelled, the probe swallows the error and returns a fallback (that part is by design), **but the shared transaction is now aborted**. Every subsequent probe then fails with `InFailedSqlTransaction: current transaction is aborted`, and discovery limps to a confusing end.

The trigger we see in practice is a **read-replica recovery conflict** (`canceling statement due to conflict with recovery`) on the rows-to-sync `COUNT(*)`: on a large table with a stale incremental watermark the count runs long enough to exceed the standby's `max_standby_streaming_delay`, so the replica cancels it. `_get_rows_to_sync` had **no** savepoint protection at all, so its failure poisoned the whole discovery transaction.

Some probes (`_explain_query`, `_get_table_chunk_size`, the numeric-scale probe) had been retrofitted with per-probe savepoints to avoid exactly this — but it was done piecemeal and missed the COUNT.

## Changes

Run the discovery connection in **autocommit** so each probe is its own implicit transaction. A single probe failure (recovery conflict, statement timeout, permission error, unsupported function) can no longer leave an aborted transaction that breaks every probe after it. This is a structural fix and lets us drop the ad-hoc savepoint scaffolding.

In `posthog/temporal/data_imports/sources/postgres/postgres.py`:

- **`connection.autocommit = True`** on the schema-discovery connection (the per-sync `postgres_source` connection only — the streaming/read connection is untouched and keeps its deliberate transaction handling).
- **Removed the savepoint wrappers** from `_explain_query` and `_get_table_chunk_size` — their sole purpose was poisoning isolation, now handled at the connection level.
- **`SET LOCAL` → session `SET`** for the discovery 10-min `statement_timeout` (a `LOCAL` setting is a no-op without a surrounding transaction).
- **Numeric-scale probe** keeps a transaction, now *only* to scope its tighter 30s `statement_timeout` (auto-resets on exit). It auto-adapts: a real `BEGIN/COMMIT` under autocommit, a savepoint when a caller is already mid-transaction.
- **Reuse** the already-computed `is_partitioned` flag in `_get_partition_settings` instead of re-running the `_is_partitioned_table` catalog lookup — one fewer round trip per discovery.

Note on scope: this makes discovery resilient so the sync no longer wedges on a cancelled probe. The replica conflict on the actual data read is a separate, already-handled path (`offset_chunking`).

## How did you test this code?

I'm an agent (PostHog Code); I did not do manual testing. Automated tests only, run locally via `hogli test` against local Postgres + ClickHouse:

- Reworked `TestGetTableChunkSize` to `test_failing_probe_isolated_by_autocommit`: opens a real **autocommit** connection, runs a failing probe, asserts the fallback **and** that the next query on the same connection still works (proving no poisoning). The old test asserted the now-removed savepoint behavior on a non-autocommit cursor.
- Added `TestGetRowsToSync::test_failing_count_isolated_by_autocommit` — a direct regression for the reported incident: a failing `COUNT(*)` under autocommit returns 0 and leaves the connection usable.
- Full `test_postgres.py` suite green (280 passed). The numeric-scale probe tests still pass unchanged — `connection.transaction()` auto-generates a savepoint inside the django test transaction.
- `ruff` + `ty check` clean (the latter via the pre-commit hook).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal pipeline reliability fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). This supersedes an earlier PR that, working from the reported `Explicit commit() forbidden within a Transaction context` symptom, added a dropped-connection backstop. Inspecting the real run logs showed the actual cause is a read-replica recovery conflict on the rows-to-sync `COUNT(*)`, not a dropped connection — `connection.broken` is `False`, so that backstop would never fire. The real fault is shared-transaction poisoning across best-effort probes.

Considered savepoint-wrapping the remaining unprotected probes vs. making discovery autocommit; chose autocommit because it fixes the class of problem structurally (every probe isolated), removes the piecemeal savepoint scaffolding, and trims round trips on slow replicas. Kept one transaction for the numeric-scale probe purely to scope its statement_timeout. Left the source-setup table-listing path (`_row_counts_from_conn` / `_rls_active_from_conn`) untouched — different connection, out of scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
