### PR TITLE
chore(flags): remove flag-evaluation-runtimes feature flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4963,21 +4963,21 @@ snapshots:
     scenes-app-experiments--experiments--light:
         hash: v1.k794b7964.c0734f95a7f4d2780fc4537af7e7d3de39dc7c1536e0d834e111c88cf76398a3.Ne0BjhsC4DpPVp1gu4aaBe7W5Lgt84G7EtaDXSullCc
     scenes-app-feature-flags--edit-encrypted-remote-config-feature-flag--dark:
-        hash: v1.k794b7964.034f69b1cd11aab2f5376828b2365e02ccbb2ccf9ccdb0d759bb578f46950d51.PoPFMXE0I7i15nkvIK7BkyODMAmKYNhd3dRFHOBigIQ
+        hash: v1.k794b7964.a6b49f783d0c05d87963869a6b3273c368023135c3049bc3a661cd65a1678542.vcTLfQCSitKzzUbEAqX5CRuUWN87Ua8ibqyE5metpJw
     scenes-app-feature-flags--edit-encrypted-remote-config-feature-flag--light:
-        hash: v1.k794b7964.05c3564175381b22325b01b9b13da0dd2ad6e230be3904c73e710f15eaa7c5f1.Sb62G-22mNzi027n1QJNP51jsRFP7i_J09rj9MDUBr0
+        hash: v1.k794b7964.2d38fc4c3183ee8a02bfce8c6a9eed8e9fa6b3089a10019cb17867a7a3911a8d.vXXYgiyI0SQuN7dc4eYxjZ2fecPDFzpJLr-F_llHe0o
     scenes-app-feature-flags--edit-feature-flag--dark:
-        hash: v1.k794b7964.245a100df7cc734647e50d88a9059f0dea921672746692d924334ef70aa3a72a.X_XhkZUj2ETirpOUfkNxHqEW1UJrk_5PPpKcXfby4Hs
+        hash: v1.k794b7964.81e4a07a2b6cae30d4f818dbbe54e5cd5a26a263854bd7a177ed245b0e50a6d6.VyilroDupyNQUN9QXu1X0lvrdf2UuGOGhaEaPcZqM6Q
     scenes-app-feature-flags--edit-feature-flag--light:
-        hash: v1.k794b7964.5630d5412841ae3deef46093f6415f1df99c5b58293be06f481a1102cdd8029a.0wLh_CYIofX-NUDTrhTrwQTH_PE8XcTGYNC4eYhg1MY
+        hash: v1.k794b7964.34195fe170ac94963edb5cafe7f8e5ae72f7539e4818cff92815b415f042082c.kplIc2bsQfIokkXh4d7ZQbu15uPdky0ZXwycsIrwX78
     scenes-app-feature-flags--edit-multi-variate-feature-flag--dark:
-        hash: v1.k794b7964.d37a1d7cc7d12d2367a6ea4650c4bf35aebad3dabc21ac13a24a7930d9516c04.yH2nGgUwaKwKkJFJawIQtmtoRt8tYh_OXz_qchLj2Wk
+        hash: v1.k794b7964.977c2009fd5de2579f0dbf24d41e2d450b4bea98971b8823617b3b2614f72fb6.OGJP4mCKfVkFyjFdX_uhcZ3mQqVbK9u7gEYW7RZA-EA
     scenes-app-feature-flags--edit-multi-variate-feature-flag--light:
-        hash: v1.k794b7964.4dcf1c41d48ccab4559971018d672aa86c503970ebf7663bc7314c7cba3da86e.BaIWzoxQ-K6hCWxaEqJJJqht_Uy8ViUdJ8Ti96l9Q-o
+        hash: v1.k794b7964.a12e6c7ca6f1d704063908b2ca71ecae8a0e30411d6de77431d513488cad6e89.tMbL5NI4HivFAGYfugwyJ1MM1v77HdYWoyOYtAcB4Es
     scenes-app-feature-flags--edit-remote-config-feature-flag--dark:
-        hash: v1.k794b7964.93ecfe5493276e2bf76ac27fe91add645e3eddde71fc058475ccee68b412825d.sfb7Qe2pOBbDx5mIZVwsdUSKJIPw3LjN5WXAJXKEJ-k
+        hash: v1.k794b7964.9b5ce101c55c2b4edadacb72617f501b465bfd3ede36ef40862e1bc3a049e4b7.uE348cJaMeE3D-C0Olq-gJr1qEL8TzirwHjFC4EU4N0
     scenes-app-feature-flags--edit-remote-config-feature-flag--light:
-        hash: v1.k794b7964.91fdf2be9faacb7297ebde3bd432f1c84ad547797ef159c531c63a0497aa5f4b.fweoGnYTE5OL5lk6vTAZI1UFVSBcFNt1kwKvbI_LLYo
+        hash: v1.k794b7964.dd65da2ecfb1fec107e0807b528a4f7b834845992e4354302c9e1706f3befaee.4y2oUfTDfnBqIotvBSrOyIGJ8_NyX-fhIp4Qiw4JFyc
     scenes-app-feature-flags--feature-flag-not-found--dark:
         hash: v1.k794b7964.36bbf6870a8070c1b5284a2bba1b659324f1986f1af18220b97d0ef22af5b314.0fdhZmbn_ck5kOOvzOzuMeg6oFHGAonFrOQ037BzwCU
     scenes-app-feature-flags--feature-flag-not-found--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -305,7 +305,6 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation
     FEATURE_FLAGS_ACROSS_PROJECTS_INDEX: 'feature-flags-across-projects-index', // owner: #team-platform-features
     FIELD_NOTES: 'field-notes', // owner: @adamleith
-    FLAG_EVALUATION_RUNTIMES: 'flag-evaluation-runtimes', // owner: @dmarticus #team-feature-flags
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics

--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.test.tsx
@@ -4,14 +4,6 @@ import { render } from '@testing-library/react'
 
 import { FeatureFlagFiltersSection } from './FeatureFlagFilters'
 
-jest.mock('lib/logic/featureFlagLogic', () => ({
-    featureFlagLogic: {
-        values: {
-            featureFlags: {},
-        },
-    },
-}))
-
 const mockFilters = {
     search: '',
     page: 1,
@@ -162,6 +154,7 @@ describe('FeatureFlagFiltersSection', () => {
         expect(container.querySelector('[data-attr="feature-flag-select-type"]')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="feature-flag-select-status"]')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="feature-flag-select-created-by"]')).toBeInTheDocument()
+        expect(container.querySelector('[data-attr="feature-flag-select-runtime"]')).toBeInTheDocument()
     })
 
     it('ignores false values in config', () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
@@ -2,8 +2,6 @@ import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { TagSelect } from 'lib/components/TagSelect'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 
 import { FeatureFlagEvaluationRuntime } from '~/types'
 
@@ -169,37 +167,36 @@ export function FeatureFlagFiltersSection({
                             />
                         </>
                     )}
-                    {config.runtime &&
-                        enabledFeaturesLogic.values.featureFlags?.[FEATURE_FLAGS.FLAG_EVALUATION_RUNTIMES] && (
-                            <>
-                                <span className="ml-1">
-                                    <b>Runtime</b>
-                                </span>
-                                <LemonSelect
-                                    dropdownMatchSelectWidth={false}
-                                    size="small"
-                                    onChange={(runtime) => {
-                                        const { evaluation_runtime, ...restFilters } = filters || {}
-                                        if (runtime === 'any') {
-                                            setFeatureFlagsFilters({ ...restFilters, page: 1 }, true)
-                                        } else {
-                                            setFeatureFlagsFilters(
-                                                { ...restFilters, evaluation_runtime: runtime, page: 1 },
-                                                true
-                                            )
-                                        }
-                                    }}
-                                    options={[
-                                        { label: 'Any', value: 'any', 'data-attr': 'feature-flag-select-runtime-any' },
-                                        { label: 'All', value: FeatureFlagEvaluationRuntime.ALL },
-                                        { label: 'Client', value: FeatureFlagEvaluationRuntime.CLIENT },
-                                        { label: 'Server', value: FeatureFlagEvaluationRuntime.SERVER },
-                                    ]}
-                                    value={filters.evaluation_runtime ?? 'any'}
-                                    data-attr="feature-flag-select-runtime"
-                                />
-                            </>
-                        )}
+                    {config.runtime && (
+                        <>
+                            <span className="ml-1">
+                                <b>Runtime</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(runtime) => {
+                                    const { evaluation_runtime, ...restFilters } = filters || {}
+                                    setFeatureFlagsFilters(
+                                        {
+                                            ...restFilters,
+                                            ...(runtime !== 'any' ? { evaluation_runtime: runtime } : {}),
+                                            page: 1,
+                                        },
+                                        true
+                                    )
+                                }}
+                                options={[
+                                    { label: 'Any', value: 'any', 'data-attr': 'feature-flag-select-runtime-any' },
+                                    { label: 'All', value: FeatureFlagEvaluationRuntime.ALL },
+                                    { label: 'Client', value: FeatureFlagEvaluationRuntime.CLIENT },
+                                    { label: 'Server', value: FeatureFlagEvaluationRuntime.SERVER },
+                                ]}
+                                value={filters.evaluation_runtime ?? 'any'}
+                                data-attr="feature-flag-select-runtime"
+                            />
+                        </>
+                    )}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagOverview.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagOverview.tsx
@@ -61,7 +61,6 @@ export function FeatureFlagOverview({ featureFlag }: FeatureFlagOverviewProps): 
     const { toggleFeatureFlagActive } = useActions(featureFlagLogic)
 
     const hasEvaluationContexts = !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATION_TAGS] // NB: the tag was named "flag-evaluation-tags" before we renamed the concept – i.e. this powers evaluation contexts even though the name implies tags
-    const hasEvaluationRuntimes = !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATION_RUNTIMES]
 
     const multivariateEnabled = !!featureFlag.filters?.multivariate
     const variants = featureFlag.filters?.multivariate?.variants || []
@@ -195,18 +194,16 @@ export function FeatureFlagOverview({ featureFlag }: FeatureFlagOverviewProps): 
                                 />
                             </div>
 
-                            {hasEvaluationRuntimes && (
-                                <div className="flex flex-col gap-2">
-                                    <label className="text-sm font-medium">Evaluation runtime</label>
-                                    <div className="flex items-center gap-2">
-                                        {evaluationRuntimeDisplay.icon}
-                                        <span className="text-sm">{evaluationRuntimeDisplay.label}</span>
-                                        <LemonTag type="muted" size="small">
-                                            {evaluationRuntimeDisplay.tag}
-                                        </LemonTag>
-                                    </div>
+                            <div className="flex flex-col gap-2">
+                                <label className="text-sm font-medium">Evaluation runtime</label>
+                                <div className="flex items-center gap-2">
+                                    {evaluationRuntimeDisplay.icon}
+                                    <span className="text-sm">{evaluationRuntimeDisplay.label}</span>
+                                    <LemonTag type="muted" size="small">
+                                        {evaluationRuntimeDisplay.tag}
+                                    </LemonTag>
                                 </div>
-                            )}
+                            </div>
 
                             {!featureFlag.is_remote_configuration && (
                                 <div className="flex flex-col gap-2">

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -337,6 +337,12 @@ export const scene: SceneExport = {
     productKey: ProductKey.FEATURE_FLAGS,
 }
 
+const RUNTIME_LABELS: Record<FeatureFlagEvaluationRuntime, string> = {
+    [FeatureFlagEvaluationRuntime.ALL]: 'All',
+    [FeatureFlagEvaluationRuntime.CLIENT]: 'Client',
+    [FeatureFlagEvaluationRuntime.SERVER]: 'Server',
+}
+
 export function OverviewTab({
     flagPrefix = '',
     searchPlaceholder = 'Search for feature flags (or experiment keys)',
@@ -487,29 +493,19 @@ export function OverviewTab({
                 return <FeatureFlagStatusCell featureFlag={featureFlag} />
             },
         },
-        ...(enabledFeaturesLogic.values.featureFlags?.[FEATURE_FLAGS.FLAG_EVALUATION_RUNTIMES]
-            ? [
-                  {
-                      title: 'Runtime',
-                      dataIndex: 'evaluation_runtime' as keyof FeatureFlagType,
-                      width: 120,
-                      render: function RenderFlagRuntime(_: any, featureFlag: FeatureFlagType) {
-                          const runtime = featureFlag.evaluation_runtime || FeatureFlagEvaluationRuntime.ALL
-                          return (
-                              <LemonTag type="default" className="uppercase">
-                                  {runtime === FeatureFlagEvaluationRuntime.ALL
-                                      ? 'All'
-                                      : runtime === FeatureFlagEvaluationRuntime.CLIENT
-                                        ? 'Client'
-                                        : runtime === FeatureFlagEvaluationRuntime.SERVER
-                                          ? 'Server'
-                                          : 'All'}
-                              </LemonTag>
-                          )
-                      },
-                  },
-              ]
-            : []),
+        {
+            title: 'Runtime',
+            dataIndex: 'evaluation_runtime' as keyof FeatureFlagType,
+            width: 120,
+            render: function RenderFlagRuntime(_: any, featureFlag: FeatureFlagType) {
+                const runtime = featureFlag.evaluation_runtime || FeatureFlagEvaluationRuntime.ALL
+                return (
+                    <LemonTag type="default" className="uppercase">
+                        {RUNTIME_LABELS[runtime]}
+                    </LemonTag>
+                )
+            },
+        },
         {
             width: 0,
             render: function Render(_, featureFlag: FeatureFlagType) {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -501,7 +501,7 @@ export function OverviewTab({
                 const runtime = featureFlag.evaluation_runtime || FeatureFlagEvaluationRuntime.ALL
                 return (
                     <LemonTag type="default" className="uppercase">
-                        {RUNTIME_LABELS[runtime]}
+                        {RUNTIME_LABELS[runtime] ?? RUNTIME_LABELS[FeatureFlagEvaluationRuntime.ALL]}
                     </LemonTag>
                 )
             },


### PR DESCRIPTION
## Problem

The `flag-evaluation-runtimes` flag gated the evaluation runtime UI: the runtime filter in the flags list, the runtime column in the overview table, and the runtime section on the flag detail page. The feature is rolled out, so the flag and its gates can go.

## Changes

- Removes `FLAG_EVALUATION_RUNTIMES` from `FEATURE_FLAGS` constants
- Unconditionally renders the runtime filter in `FeatureFlagFilters`, the runtime column in `FeatureFlags`, and the evaluation runtime section in `FeatureFlagOverview`
- Simplifies the runtime column renderer with a `RUNTIME_LABELS` lookup instead of a nested ternary chain
- Drops the now-unneeded `featureFlagLogic` mock from `FeatureFlagFilters.test.tsx` and adds an assertion that the runtime filter renders

## How did you test this code?

Ran `hogli test frontend/src/scenes/feature-flags/FeatureFlagFilters.test.tsx`, 9 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?