### PR TITLE
chore(exporter): log export_format on export_asset.starting

### DIFF
--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -98,6 +98,7 @@ def export_asset_direct(
         "export_asset.starting",
         exported_asset_id=exported_asset.id,
         team_id=team.id,
+        export_format=exported_asset.export_format,
     )
 
     from posthog.clickhouse.query_tagging import tag_queries


### PR DESCRIPTION
## Problem

`export_asset.starting` only logs `exported_asset_id` and `team_id`, so we can't tell from logs whether a given Celery export is an image render or a CSV/XLSX. We need this to confirm whether the legacy Celery `export_asset` path (the `exports` queue, `posthog-worker-django` `longrunning` worker) ever renders **images** — relevant before [PostHog/charts#12154](https://github.com/PostHog/charts/pull/12154) removes the in-container Chromium and makes `BROWSERLESS_CDP_URL` mandatory for image exports.

Image renders log `exporting_asset`, but only *after* the `BROWSERLESS_CDP_URL` check — so a would-be image export that fails that check produces no image-specific log line. Adding the format to `export_asset.starting` gives an unambiguous, pre-render signal.

## Change

Add `export_format` to the `export_asset.starting` structured log.

## Confirmation query (Loki)

```logql
{app="posthog-worker-django"} |= "export_asset.starting" | json | export_format="image/png"
```

If this fires, the Celery worker does render images and the charts PR is required; if it stays at zero, that path is dormant. (Over the last 30 days, the image-render line `exporting_asset` shows **0** on `posthog-worker-django`