### PR TITLE
feat(toolbox-cli): add survey

### DIFF
--- a/tools/infra-scripts/clitools/README.md
+++ b/tools/infra-scripts/clitools/README.md
@@ -6,7 +6,13 @@ The primary function is to help manage and connect to PostHog toolbox pods in a 
 
 1. Ensure you have Python 3.x installed on your system
 2. Clone this repository or download `toolbox.py`
-3. Make the script executable (Unix-based systems):
+3. Install dependencies (the PostHog SDK, used for anonymous usage telemetry):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Make the script executable (Unix-based systems):
 
    ```bash
    chmod +x toolbox.py
@@ -16,6 +22,7 @@ The primary function is to help manage and connect to PostHog toolbox pods in a 
 
 - Python 3.x
 - kubectl installed and configured
+- the PostHog Python SDK (`pip install -r requirements.txt`) — telemetry is skipped gracefully if it's missing
 - your current settings and k8s context let you access the cluster that you want your toolbox to be claimed in
 
 ## Usage

--- a/tools/infra-scripts/clitools/requirements.txt
+++ b/tools/infra-scripts/clitools/requirements.txt
@@ -1,0 +1,4 @@
+# PostHog Python SDK — used by toolbox/telemetry.py to capture usage events.
+# https://posthog.com/docs/libraries/python
+# >=3 required: the `Posthog` client class doesn't exist in older 1.x/2.x releases.
+posthog>=7.19.0

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Import functions from the modular package
 from toolbox.kubernetes import select_context, validate_context
 from toolbox.pod import ClaimRaceError, claim_pod, connect_to_pod, delete_pod, get_toolbox_pod
+from toolbox.telemetry import capture_invocation, prompt_for_reason
 from toolbox.user import get_current_user
 
 # `default_namespace` is where the pool lives when KUBE_NAMESPACE isn't set.
@@ -94,6 +95,10 @@ def main():
         )
         args = parser.parse_args()
 
+        # Ask up front (before the kubectl waits) what this session is for; skipped
+        # automatically on non-interactive stdin so automation never blocks.
+        usage_reason = prompt_for_reason()
+
         pool = POOLS[args.pool]
         app_label = pool["app_label"]
         claimed_label_key = pool["claimed_label_key"]
@@ -137,6 +142,23 @@ def main():
             extra_selector=extra_selector,
         )
         print(f"🎯 Found pod: {pod_name}")  # noqa: T201
+
+        # Best-effort usage event; counts invocations and records the environment +
+        # the user's stated reason. Never raises, so it can't break connecting.
+        capture_invocation(
+            distinct_id=user_labels[claimed_label_key],
+            properties={
+                "pool": args.pool,
+                "namespace": namespace,
+                "kube_context": selected_context,
+                "pod_name": pod_name,
+                "was_already_claimed": is_already_claimed,
+                "claim_duration_hours": args.claim_duration,
+                "update_claim": args.update_claim,
+                "auto_delete": args.auto_delete,
+                "usage_reason": usage_reason,
+            },
+        )
 
         # Calculate duration
         future_time = datetime.now() + timedelta(hours=args.claim_duration)

--- a/tools/infra-scripts/clitools/toolbox/telemetry.py
+++ b/tools/infra-scripts/clitools/toolbox/telemetry.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Best-effort usage telemetry for the toolbox CLI.
+
+Sends a single event per invocation via the PostHog Python SDK (``posthog``, see
+https://posthog.com/docs/libraries/python). The SDK is a declared dependency of
+this tool (see ``requirements.txt``); if it isn't installed the capture degrades
+to a no-op. Every failure is swallowed — telemetry must never delay or break
+connecting to a pod. The project API key embedded here is a write-only ingestion
+key (the same kind shipped in client SDKs), overridable per-environment via
+``TOOLBOX_POSTHOG_API_KEY`` / ``TOOLBOX_POSTHOG_HOST``.
+"""
+
+import os
+import sys
+import platform
+
+# Write-only project API key. Safe to embed; override per-environment with the env var.
+DEFAULT_API_KEY = "sTMFPsFhdP1Ssg"
+DEFAULT_HOST = "https://us.i.posthog.com"
+
+EVENT_NAME = "toolbox cli used"
+
+# The free-text reason is also submitted as a PostHog API-type survey response so
+# it lands in the Surveys UI (response browsing + AI summary). Create an API-type
+# survey with one open-text question in PostHog, then set SURVEY_ID (or the env var
+# below). For a single-question survey the `$survey_response` shorthand binds to the
+# first question, so no per-question id is needed. Left empty, the survey submission
+# is skipped and only EVENT_NAME fires.
+# https://posthog.com/docs/surveys/implementing-custom-surveys
+SURVEY_ID = "019ecbd7-19cd-0000-0adf-226a0612404f"
+SURVEY_QUESTION_TEXT = "What are you using the toolbox for today?"
+
+
+def prompt_for_reason() -> str:
+    """Ask the user what they're using the toolbox for.
+
+    Skipped when stdin isn't a TTY (CI, piped input, --auto-delete automation) so
+    it never blocks a non-interactive run. Returns "" when skipped or on EOF/Ctrl-C.
+    """
+    if not sys.stdin.isatty():
+        return ""
+    try:
+        return input(f"📝 {SURVEY_QUESTION_TEXT} (press Enter to skip): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        # Don't let an empty/aborted answer derail the run; a Ctrl-C here just skips the question.
+        return ""
+
+
+def _capture_survey_response(client, distinct_id: str, answer: str) -> None:
+    """Submit the free-text reason as a PostHog API-type survey response.
+
+    No-op unless the survey id is configured and the user gave an answer, so an
+    unconfigured survey or a skipped prompt never emits a half-formed event.
+    """
+    survey_id = os.environ.get("TOOLBOX_SURVEY_ID", SURVEY_ID)
+    if not (survey_id and answer.strip()):
+        return
+
+    client.capture(
+        event="survey sent",
+        distinct_id=distinct_id,
+        properties={
+            "$survey_id": survey_id,
+            # Single-question survey: `$survey_response` binds to the first question.
+            "$survey_response": answer,
+            "$survey_questions": [{"question": SURVEY_QUESTION_TEXT}],
+        },
+    )
+    print(f"📊 Telemetry: submitted survey response to survey {survey_id}")  # noqa: T201
+
+
+def capture_invocation(distinct_id: str, properties: dict) -> None:
+    """Fire a single best-effort capture event via the PostHog SDK. Never raises."""
+    api_key = os.environ.get("TOOLBOX_POSTHOG_API_KEY", DEFAULT_API_KEY)
+    host = os.environ.get("TOOLBOX_POSTHOG_HOST", DEFAULT_HOST)
+    if not api_key or api_key == "phc_REPLACE_ME":
+        # No real key configured — stay silent rather than spamming a dead endpoint.
+        print("📊 Telemetry skipped: no PostHog API key configured.")  # noqa: T201
+        return
+
+    try:
+        # Imported lazily so a missing SDK degrades to a no-op instead of breaking
+        # the import of this module. Install with `pip install -r requirements.txt`.
+        from posthog import Posthog  # type: ignore[import-not-found]  # noqa: PLC0415 — optional dep, kept off the import path
+
+        resolved_distinct_id = distinct_id or "unknown"
+        client = Posthog(project_api_key=api_key, host=host)
+        client.capture(
+            event=EVENT_NAME,
+            distinct_id=resolved_distinct_id,
+            properties={
+                **properties,
+                "os": platform.system(),
+                "os_release": platform.release(),
+                "python_version": platform.python_version(),
+            },
+        )
+        print(f"📊 Telemetry: sent '{EVENT_NAME}' event to {host}")  # noqa: T201
+
+        _capture_survey_response(client, resolved_distinct_id, properties.get("usage_reason", ""))
+
+        # Synchronous flush so events aren't lost when the long-lived shell session ends.
+        client.shutdown()
+    except ImportError:
+        print("📊 Telemetry skipped: posthog SDK not installed (pip install -r requirements.txt).")  # noqa: T201
+    except Exception as telemetry_error:
+        # Best-effort only; never let a send failure block connecting to a pod.
+        print(f"📊 Telemetry failed (ignored): {telemetry_error}")  # noqa: T201


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Track toolbox.py with events and prompt users for use cases to eliminate those later with automation. 

## Changes

- track usage event
- prompt cli user for usage tracked by a survey

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
