### PR TITLE
chore(django): clean up some dead persons ORM code

### DIFF
--- a/.semgrep/rules/no-direct-persons-db-orm.yaml
+++ b/.semgrep/rules/no-direct-persons-db-orm.yaml
@@ -13,7 +13,8 @@ rules:
       severity: WARNING
       languages: [python]
       patterns:
-          - pattern: $MODEL.objects
+          - pattern: $MODEL.objects.$METHOD(...)
+          - pattern-not: $MODEL.objects.none()
           - metavariable-regex:
                 metavariable: $MODEL
                 regex: >-

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -4,8 +4,6 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
-from django.db.models import Prefetch
-
 import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
@@ -59,7 +57,6 @@ from posthog.models.person.bulk_delete import (
 )
 from posthog.models.person.deletion import reset_deleted_person_distinct_ids
 from posthog.models.person.missing_person import MissingPerson
-from posthog.models.person.person import PersonDistinctId
 from posthog.models.person.util import (
     get_distinct_ids_for_persons,
     get_person_by_pk_or_uuid,
@@ -442,7 +439,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         (*tuple(api_settings.DEFAULT_RENDERER_CLASSES), csvrenderers.PaginatedCSVRenderer),
     )
     parser_classes = [JSONParser]
-    queryset = Person.objects.all()  # nosemgrep: no-direct-persons-db-orm
+    queryset = Person.objects.none()
     serializer_class = PersonSerializer
     pagination_class = PersonLimitOffsetPagination
     lifecycle_class = Lifecycle
@@ -475,22 +472,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             property_type=PropertyDefinition.Type.PERSON,
         )
         return context
-
-    def safely_get_queryset(self, queryset):
-        queryset = queryset.prefetch_related(
-            Prefetch(
-                "persondistinctid_set",
-                # nosemgrep: no-direct-persons-db-orm
-                queryset=PersonDistinctId.objects.filter(
-                    team_id=self.team_id
-                ).order_by(  # nosemgrep: no-direct-persons-db-orm
-                    "id"
-                ),  # nosemgrep: no-direct-persons-db-orm
-                to_attr="distinct_ids_cache",
-            )
-        )
-        queryset = queryset.only("id", "created_at", "properties", "uuid", "is_identified")
-        return queryset
 
     def safely_get_object(self, queryset):
         person_id = self.kwargs[self.lookup_field]


### PR DESCRIPTION
## Problem

The `PersonViewSet` had two direct ORM access paths to the persons database that were dead code
1. `queryset = Person.objects.all()` The viewset requires a queryset attribute for model introspection, but PersonViewSet never actually evaluated it:
- `list()` is overriden to query Clickhouse rather than PG
- `get_object()` builds the queryset then passes it to `safely_get_object()`, which now ignores it and calls `get_person_by_pk_or_uuid()` (a personhog routed call)
2. `safely_get_queryset()` This added a couple filters to the query set to make it safe, but the queryset is never actually evaluated (see 1.) so these were never executed

## Changes

Changes `Person.objects.all()` -> `Person.objects.none()` to ensure that there is no chance this will every run a query against the database/does not need a DB connection to execute. Django asserts that the queryset for a view set is defined, so this couldn't just be completely removed, and we need the viewset to support the Clickhouse overrides and automatic genration of other aspects of set of persons endpoints.

Removed the `safely_get_queryset()` function which was dead code

## How did you test this code?

Current tests all pass indicating that the removal is safe
