### PR TITLE
feat(retention): first-time anchoring in strict-calendar-date DWH variant

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -255,6 +255,12 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 start_event_timestamps_expr = ast.Array(exprs=[])
                 return_event_timestamps_expr = timestamps_expr
 
+        # First-time retention only affects the start side: replace the recurring set of within-window start
+        # intervals with the single cohorting interval derived from the entity-polymorphic first-time anchor.
+        # Mirrors the wrapping that build_base_query_legacy applies (lines below in this class).
+        if query_kind == "start" and (self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence):
+            start_event_timestamps_expr = self._first_time_start_event_timestamps_expr(entity)
+
         table_name = entity.table_name if entity_is_dwh else "events"
         assert table_name
         where_expr = None if entity_is_dwh else ast.And(exprs=self._event_filters())
@@ -278,6 +284,23 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             select_from=ast.JoinExpr(table=ast.Field(chain=[table_name])),
             where=where_expr,
             group_by=[ast.Field(chain=["actor_id"])],
+        )
+
+    def _first_time_start_event_timestamps_expr(self, entity: RetentionEntity) -> ast.Expr:
+        # The variant subquery is already GROUP BY actor_id, so the polymorphic first-time anchor (a minIf)
+        # resolves to one cohorting timestamp per actor. Emit that single bucketed interval when the anchor falls
+        # inside the query window, otherwise nothing. This mirrors the legacy
+        # if(has(_start_event_timestamps, min_timestamp), _start_event_timestamps, []) wrapping: in first-time
+        # mode the only element ever read is start_event_timestamps[1] (the minimum), so a single-element array is
+        # equivalent. A null anchor (first-ever occurrence not matching filters) or an out-of-window anchor both
+        # fail the window check and yield an empty array, excluding the actor.
+        anchor_expr = self.get_first_time_anchor_expr(entity)
+        return parse_expr(
+            "if({within_window}, [{bucketed_anchor}], [])",
+            {
+                "within_window": self.events_timestamp_filter(field=anchor_expr),
+                "bucketed_anchor": self.query_date_range.date_to_start_of_interval_hogql(anchor_expr),
+            },
         )
 
     def _get_dwh_property_aggregation_event_data_expr(

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -684,6 +684,67 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+        GROUP BY actor_id) AS retention_events
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_time_vs_first_ever_occurrence.2
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
             if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
@@ -701,6 +762,67 @@
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_time_vs_first_ever_occurrence.3
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT retention_events.actor_id AS actor_id,
+            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
+            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
+               [] AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+        GROUP BY actor_id
+        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+                         [] AS start_event_timestamps,
+                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+        GROUP BY actor_id) AS retention_events
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
+++ b/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
@@ -4,8 +4,6 @@ from typing import Any, TypeVar, cast
 
 from unittest.mock import patch
 
-from posthog.constants import RETENTION_FIRST_EVER_OCCURRENCE, RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS
-
 RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
     "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
     "retention_fixed_interval_base_query_use_dwh_variant"
@@ -59,12 +57,6 @@ class RetentionBaseQueryVariantComparisonMixin:
 
         minimum_occurrences = retention_filter.get("minimumOccurrences") or 1
         if minimum_occurrences > 1:
-            return True
-
-        if retention_filter.get("retentionType") in {
-            RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS,
-            RETENTION_FIRST_EVER_OCCURRENCE,
-        }:
             return True
 
         if query.get("breakdownFilter"):

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -709,3 +709,369 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
                 ]
             ),
         )
+
+    def _first_time_dwh_query(self, *, table_name: str, retention_type: str) -> dict[str, Any]:
+        return {
+            "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+            "retentionFilter": {
+                "period": "Day",
+                "totalIntervals": 4,
+                "retentionType": retention_type,
+                "targetEntity": {
+                    "id": table_name,
+                    "name": table_name,
+                    "type": "data_warehouse",
+                    "table_name": table_name,
+                    "aggregation_target_field": "person_id",
+                    "timestamp_field": "occurred_at",
+                    "properties": [
+                        {"key": "activity_type", "value": "signed_up", "operator": "exact", "type": "data_warehouse"}
+                    ],
+                },
+                "returningEntity": {
+                    "id": table_name,
+                    "name": table_name,
+                    "type": "data_warehouse",
+                    "table_name": table_name,
+                    "aggregation_target_field": "person_id",
+                    "timestamp_field": "occurred_at",
+                    "properties": [
+                        {"key": "activity_type", "value": "renewed", "operator": "exact", "type": "data_warehouse"}
+                    ],
+                },
+            },
+        }
+
+    def test_retention_first_time_vs_first_ever_dwh_same_table(self):
+        # user-1's first row in the table ("browsed") does not match the start filter ("signed_up"); a later
+        # row does. So under first_time (first occurrence matching filters) user-1 cohorts on the first signed_up
+        # row, but under first_ever_occurrence user-1 is excluded because their first-ever row isn't a match.
+        person_ids = self._create_people()
+        activity_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_time_activity.csv",
+            table_name="warehouse_first_time_activity",
+            header=["id", "person_id", "activity_type", "occurred_at"],
+            rows=[
+                [1, person_ids["user-1"], "browsed", "2025-01-01 09:00:00"],
+                [2, person_ids["user-1"], "signed_up", "2025-01-02 09:00:00"],
+                [3, person_ids["user-1"], "renewed", "2025-01-03 12:00:00"],
+                [4, person_ids["user-2"], "signed_up", "2025-01-01 10:00:00"],
+                [5, person_ids["user-2"], "renewed", "2025-01-02 12:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "activity_type": "String",
+                "occurred_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        first_time_result = self.run_query(
+            query=self._first_time_dwh_query(table_name=activity_table_name, retention_type="retention_first_time")
+        )
+        # user-2 cohorts on day 0 (first signed_up), user-1 on day 1 (first signed_up, after the non-matching
+        # "browsed" row); each renews one interval later.
+        self.assertEqual(
+            pluck(first_time_result, "values", "count"),
+            pad([[1, 1, 0, 0], [1, 1, 0], [0, 0], [0], [0]]),
+        )
+
+        first_ever_result = self.run_query(
+            query=self._first_time_dwh_query(
+                table_name=activity_table_name, retention_type="retention_first_ever_occurrence"
+            )
+        )
+        # user-1's first-ever row is "browsed", not "signed_up", so they are excluded entirely; only user-2
+        # (whose first-ever row is "signed_up") is cohorted, on day 0.
+        self.assertEqual(
+            pluck(first_ever_result, "values", "count"),
+            pad([[1, 1, 0, 0], [0, 0, 0], [0, 0], [0], [0]]),
+        )
+
+    def test_retention_first_time_dwh_excludes_anchor_before_window(self):
+        # The first-time anchor scans the whole table (all time), so a user whose first matching row is before
+        # date_from is cohorted on that out-of-window interval and therefore excluded — even though they have a
+        # later matching row inside the window. (Reading the recurring within-window set would wrongly cohort
+        # them on the in-window row.)
+        person_ids = self._create_people()
+        activity_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_time_before_window.csv",
+            table_name="warehouse_first_time_before_window",
+            header=["id", "person_id", "activity_type", "occurred_at"],
+            rows=[
+                [1, person_ids["user-1"], "signed_up", "2024-12-30 09:00:00"],  # before window — the true anchor
+                [2, person_ids["user-1"], "signed_up", "2025-01-02 09:00:00"],  # in window, but not the first
+                [3, person_ids["user-1"], "renewed", "2025-01-03 12:00:00"],
+                [4, person_ids["user-2"], "signed_up", "2025-01-01 10:00:00"],
+                [5, person_ids["user-2"], "renewed", "2025-01-02 12:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "activity_type": "String",
+                "occurred_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        result = self.run_query(
+            query=self._first_time_dwh_query(table_name=activity_table_name, retention_type="retention_first_time")
+        )
+        # user-1's first signed_up is before date_from, so they are excluded; only user-2 cohorts (day 0).
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad([[1, 1, 0, 0], [0, 0, 0], [0, 0], [0], [0]]),
+        )
+
+    def test_retention_first_ever_dwh_start_events_return(self):
+        # Cross-table: data warehouse start entity, events return entity. The first-ever anchor is resolved on the
+        # data warehouse table (all time), so user-1 — whose first signup row is before the window — is excluded.
+        person_ids = self._create_people()
+        signups_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_ever_signups.csv",
+            table_name="warehouse_first_ever_signups",
+            header=["id", "person_id", "signed_up_at"],
+            rows=[
+                [1, person_ids["user-1"], "2024-12-29 09:00:00"],  # before window — first-ever anchor, excludes user-1
+                [2, person_ids["user-1"], "2025-01-01 09:00:00"],
+                [3, person_ids["user-2"], "2025-01-01 10:00:00"],
+                [4, person_ids["user-3"], "2025-01-02 09:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "signed_up_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        for distinct_id, timestamp in [
+            ("user-1", "2025-01-02T12:00:00Z"),  # user-1 is excluded by the anchor, regardless of returns
+            ("user-2", "2025-01-02T12:00:00Z"),
+            ("user-3", "2025-01-03T12:00:00Z"),
+        ]:
+            _create_event(team=self.team, event="$pageview", distinct_id=distinct_id, timestamp=timestamp)
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "retentionType": "retention_first_ever_occurrence",
+                    "targetEntity": {
+                        "id": signups_table_name,
+                        "name": signups_table_name,
+                        "type": "data_warehouse",
+                        "table_name": signups_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "signed_up_at",
+                    },
+                    "returningEntity": {"id": "$pageview", "name": "$pageview", "type": "events"},
+                },
+            }
+        )
+        # user-2 cohorts day 0 (returns day 1), user-3 cohorts day 1 (returns day 2); user-1 excluded.
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad([[1, 1, 0, 0], [1, 1, 0], [0, 0], [0], [0]]),
+        )
+
+    def test_retention_first_ever_events_start_dwh_return(self):
+        # Cross-table: events start entity, data warehouse return entity. The first-ever anchor is resolved on the
+        # events table (all time), so user-1 — whose first signup event is before the window — is excluded.
+        person_ids = self._create_people()
+        for distinct_id, timestamp in [
+            ("user-1", "2024-12-29T09:00:00Z"),  # before window — first-ever anchor, excludes user-1
+            ("user-1", "2025-01-01T09:00:00Z"),
+            ("user-2", "2025-01-01T10:00:00Z"),
+            ("user-3", "2025-01-02T09:00:00Z"),
+        ]:
+            _create_event(team=self.team, event="$user_signed_up", distinct_id=distinct_id, timestamp=timestamp)
+        flush_persons_and_events()
+
+        renewals_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_ever_renewals.csv",
+            table_name="warehouse_first_ever_renewals",
+            header=["id", "person_id", "renewed_at"],
+            rows=[
+                [1, person_ids["user-1"], "2025-01-02 12:00:00"],  # user-1 excluded by the anchor, regardless
+                [2, person_ids["user-2"], "2025-01-02 12:00:00"],
+                [3, person_ids["user-3"], "2025-01-03 12:00:00"],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "renewed_at": "DateTime64(3, 'UTC')",
+            },
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "retentionType": "retention_first_ever_occurrence",
+                    "targetEntity": {"id": "$user_signed_up", "name": "$user_signed_up", "type": "events"},
+                    "returningEntity": {
+                        "id": renewals_table_name,
+                        "name": renewals_table_name,
+                        "type": "data_warehouse",
+                        "table_name": renewals_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "renewed_at",
+                    },
+                },
+            }
+        )
+        # user-2 cohorts day 0 (returns day 1), user-3 cohorts day 1 (returns day 2); user-1 excluded.
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad([[1, 1, 0, 0], [1, 1, 0], [0, 0], [0], [0]]),
+        )
+
+    def test_retention_first_time_vs_first_ever_dwh_property_aggregation_same_entity(self):
+        # Property aggregation × first-time on a single data warehouse entity. user-1's first-ever purchase is
+        # "basic" (not the "pro" the filter requires), so first_ever excludes them while first_time cohorts them
+        # on their first "pro" purchase — and the per-interval aggregated amounts follow the chosen anchor.
+        person_ids = self._create_people()
+        purchases_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_time_purchases.csv",
+            table_name="warehouse_first_time_purchases",
+            header=["id", "person_id", "tier", "occurred_at", "amount"],
+            rows=[
+                [1, person_ids["user-1"], "basic", "2025-01-01 09:00:00", 10],  # first-ever row excludes user-1
+                [2, person_ids["user-1"], "pro", "2025-01-02 09:00:00", 100],
+                [3, person_ids["user-1"], "pro", "2025-01-03 09:00:00", 50],
+                [4, person_ids["user-2"], "pro", "2025-01-01 10:00:00", 30],
+                [5, person_ids["user-2"], "pro", "2025-01-02 10:00:00", 70],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "tier": "String",
+                "occurred_at": "DateTime64(3, 'UTC')",
+                "amount": "Float64",
+            },
+        )
+
+        def query_for(retention_type: str) -> dict[str, Any]:
+            pro_entity = {
+                "id": purchases_table_name,
+                "name": purchases_table_name,
+                "type": "data_warehouse",
+                "table_name": purchases_table_name,
+                "aggregation_target_field": "person_id",
+                "timestamp_field": "occurred_at",
+                "properties": [{"key": "tier", "value": "pro", "operator": "exact", "type": "data_warehouse"}],
+            }
+            return {
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "retentionType": retention_type,
+                    "targetEntity": pro_entity,
+                    "returningEntity": pro_entity,
+                    "aggregationType": "sum",
+                    "aggregationProperty": "amount",
+                    "aggregationPropertyType": "data_warehouse",
+                },
+            }
+
+        first_time_result = self.run_query(query=query_for("retention_first_time"))
+        # user-2 cohorts day 0 (start value 30, returns 70 on day 1); user-1 cohorts day 1 (start value 100,
+        # returns 50 on day 2).
+        self.assertEqual(
+            pluck(first_time_result, "values", "count"),
+            pad([[1, 1, 0, 0], [1, 1, 0], [0, 0], [0], [0]]),
+        )
+        self.assertEqual(
+            pluck(first_time_result, "values", "aggregation_value"),
+            pad([[30, 70, 0, 0], [100, 50, 0], [0, 0], [0], [0]]),
+        )
+
+        first_ever_result = self.run_query(query=query_for("retention_first_ever_occurrence"))
+        # user-1's first-ever purchase is "basic", so they are excluded; only user-2 cohorts (day 0).
+        self.assertEqual(
+            pluck(first_ever_result, "values", "count"),
+            pad([[1, 1, 0, 0], [0, 0, 0], [0, 0], [0], [0]]),
+        )
+        self.assertEqual(
+            pluck(first_ever_result, "values", "aggregation_value"),
+            pad([[30, 70, 0, 0], [0, 0, 0], [0, 0], [0], [0]]),
+        )
+
+    def test_retention_first_time_dwh_property_aggregation_different_events(self):
+        # first-time × property aggregation across two different events in the same table. Each user signs up
+        # once, so first_time cohorts on that signup (identical cohorts to recurring) while the start event
+        # contributes a zero-valued interval-0 marker and aggregated amounts come from the "payment" return rows.
+        person_ids = self._create_people()
+        activity_table_name = self._create_data_warehouse_table(
+            filename="warehouse_first_time_agg_activity.csv",
+            table_name="warehouse_first_time_agg_activity",
+            header=["id", "person_id", "activity_type", "occurred_at", "amount"],
+            rows=[
+                [1, person_ids["user-1"], "signup", "2025-01-01 09:00:00", 0],
+                [2, person_ids["user-1"], "payment", "2025-01-01 12:00:00", 50],
+                [3, person_ids["user-1"], "payment", "2025-01-02 12:00:00", 100],
+                [4, person_ids["user-2"], "payment", "2025-01-01 08:00:00", 999],
+                [5, person_ids["user-2"], "signup", "2025-01-01 10:00:00", 0],
+                [6, person_ids["user-2"], "payment", "2025-01-01 11:00:00", 30],
+                [7, person_ids["user-3"], "signup", "2025-01-02 09:00:00", 0],
+                [8, person_ids["user-3"], "payment", "2025-01-03 13:00:00", 200],
+            ],
+            table_columns={
+                "id": "Int64",
+                "person_id": "UUID",
+                "activity_type": "String",
+                "occurred_at": "DateTime64(3, 'UTC')",
+                "amount": "Float64",
+            },
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "retentionType": "retention_first_time",
+                    "targetEntity": {
+                        "id": activity_table_name,
+                        "name": activity_table_name,
+                        "type": "data_warehouse",
+                        "table_name": activity_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "occurred_at",
+                        "properties": [
+                            {"key": "activity_type", "value": "signup", "operator": "exact", "type": "data_warehouse"}
+                        ],
+                    },
+                    "returningEntity": {
+                        "id": activity_table_name,
+                        "name": activity_table_name,
+                        "type": "data_warehouse",
+                        "table_name": activity_table_name,
+                        "aggregation_target_field": "person_id",
+                        "timestamp_field": "occurred_at",
+                        "properties": [
+                            {"key": "activity_type", "value": "payment", "operator": "exact", "type": "data_warehouse"}
+                        ],
+                    },
+                    "aggregationType": "sum",
+                    "aggregationProperty": "amount",
+                    "aggregationPropertyType": "data_warehouse",
+                },
+            }
+        )
+        # Each user signs up once → first_time cohorts identically to recurring (same values as the recurring
+        # different-events aggregation test).
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            pad([[2, 1, 0, 0], [1, 1, 0], [0, 0], [0], [0]]),
+        )
+        self.assertEqual(
+            pluck(result, "values", "aggregation_value"),
+            pad([[80, 100, 0, 0], [0, 200, 0], [0, 0], [0], [0]]),
+        )


### PR DESCRIPTION
TL;DR: I've (temporarily) added a parallel branch that implements DWH support for retention insights. This branch did not support "first ever" and "first matching filter" type queries. Now it does.

## Problem

Strict-calendar-date retention maintains two base-query builders behind a feature flag: the legacy events-only `build_base_query_legacy` and the data-warehouse-capable `build_base_query_dwh` ("the variant"). The variant never implemented first-time retention anchoring, so whenever it was active — a data warehouse entity is present, or the flag is enabled — a first-time retention type (`retention_first_time` / `retention_first_ever_occurrence`) silently produced recurring-style results instead of cohorting on the first occurrence. These query shapes were excluded from the parity comparison harness, so the discrepancy went uncaught.

This is Track A, step 3a of the "Complete data warehouse support for retention insights" project, building on the already-merged entity-polymorphic first-time anchor foundation.

## Changes

- `build_base_query_dwh`'s start-event subquery now applies first-time anchor logic for both first-time retention types. Because each variant subquery is already grouped per actor, the entity-polymorphic `get_first_time_anchor_expr` resolves to a single anchor timestamp; the subquery emits `[start_of_interval(anchor)]` when the anchor falls inside the query window and `[]` otherwise. This mirrors the legacy `if(has(_start_event_timestamps, min_timestamp), _start_event_timestamps, [])` wrapping — equivalent because first-time validity checks only ever read the first (minimum) element of the array. The return side is unchanged.
- The matching first-time exclusion was removed from `_query_uses_known_retention_base_query_variant_gap` **in the same diff**, so the parity comparison harness now runs first-time events-only queries through both legacy and variant and asserts equal results.

First-time combined with breakdowns, `minimumOccurrences > 1`, or sampling stays excluded by the remaining gap checks — those are later steps in the project.

Note on semantics: for a data warehouse entity, "first-ever occurrence" is scoped to that table (the table is its own stream), since the no-properties matcher for a DWH entity is a truthy constant. This matches the foundation primitive and is pinned by a test.

## How did you test this code?

I'm an agent (PostHog Code). I drove development test-first, one vertical slice at a time. All testing is automated:

- New ground-truth tests in `test_retention_data_warehouse.py` for first-time retention with a DWH start entity: first-ever vs first-time on a same-table distinguishing actor (first row doesn't match the filter, a later row does), out-of-window anchor exclusion, cross-table (DWH start + events return, and events start + DWH return), and property aggregation × first-time (same-entity with hand-computed per-interval values, plus different-events). All pass.
- After removing the parity-gap exclusion, ran the first-time/first-ever subset of `test_retention_query_runner.py`: 19 first-time tests now pass through both legacy and variant (byte-equal parity). I regenerated the one affected ClickHouse query snapshot and verified the generated variant SQL matches the intended anchor + window-check shape.
- The remaining local failures are all `run_actors_query` tests failing because the local personhog service was down (gRPC :50052 refused) — confirmed identical failures on the base branch, i.e. pre-existing and unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — internal query-builder behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus) using a test-driven, vertical-slice workflow: each behavior got a failing ground-truth test before its implementation increment. The key decision was to express the DWH first-time anchor as a single bucketed-anchor array rather than re-deriving and gating the full within-window timestamp set the legacy path keeps — provably equivalent given first-time validity checks read only `start_event_timestamps[1]`, and it keeps each per-side subquery small. The window check reuses the existing `events_timestamp_filter` against the anchor, so null anchors (first-ever occurrence not matching filters) and out-of-window anchors fall out naturally to an empty array (the actor is excluded). The property-aggregation path needed no change beyond the start-timestamp gating, because interval-0 value selection is keyed off `start_interval_index`, which the gate already drives.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
