### PR TITLE
fix(flags): support legacy ruby user agent

### DIFF
--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -569,6 +569,7 @@ mod tests {
         #[case(Some("posthog-flutter/4.0.0"), "posthog-flutter")]
         #[case(Some("posthog-python/1.4.0"), "posthog-python")]
         #[case(Some("posthog-ruby/2.0.0"), "posthog-ruby")]
+        #[case(Some("posthog-ruby2.0.0"), "posthog-ruby")]
         #[case(Some("posthog-php/3.0.0"), "posthog-php")]
         #[case(Some("posthog-java/1.0.0"), "posthog-java")]
         #[case(Some("posthog-go/0.1.0"), "posthog-go")]

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -630,6 +630,7 @@ mod tests {
         let server_sdks = vec![
             "posthog-python/1.4.0",
             "posthog-ruby/2.0.0",
+            "posthog-ruby2.0.0",
             "posthog-php/3.0.0",
             "posthog-java/1.0.0",
             "posthog-go/0.1.0",

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -274,6 +274,7 @@ mod tests {
     #[case("posthog-python/2.5.0", Library::PosthogPython)]
     #[case("posthog-php/3.0.0", Library::PosthogPhp)]
     #[case("posthog-ruby/2.3.0", Library::PosthogRuby)]
+    #[case("posthog-ruby2.3.0", Library::PosthogRuby)]
     #[case("posthog-go/1.0.0", Library::PosthogGo)]
     #[case("posthog-java/1.2.0", Library::PosthogJava)]
     #[case("posthog-dotnet/1.0.0", Library::PosthogDotnet)]

--- a/rust/feature-flags/src/utils/user_agent.rs
+++ b/rust/feature-flags/src/utils/user_agent.rs
@@ -70,6 +70,15 @@ impl UserAgentInfo {
 
     /// Parse a PostHog SDK User-Agent (after stripping "posthog-" prefix).
     fn parse_posthog_sdk(rest: &str) -> Self {
+        if let Some(legacy_ruby_version) = Self::legacy_ruby_version(rest) {
+            return Self {
+                sdk_name: Some("posthog-ruby"),
+                sdk_version: Some(legacy_ruby_version.to_string()),
+                is_browser: false,
+                runtime: RuntimeType::Server,
+            };
+        }
+
         // Pattern: <sdk-name>/<version> [optional extra info]
         let Some(slash_idx) = rest.find('/') else {
             return Self::unknown();
@@ -116,6 +125,17 @@ impl UserAgentInfo {
             sdk_version: Some(version.to_string()),
             is_browser: false,
             runtime,
+        }
+    }
+
+    fn legacy_ruby_version(rest: &str) -> Option<&str> {
+        let version = rest.strip_prefix("ruby")?;
+        let first = version.chars().next()?;
+
+        if first.is_ascii_digit() {
+            Some(version)
+        } else {
+            None
         }
     }
 
@@ -200,6 +220,12 @@ mod tests {
     )]
     #[case(
         "posthog-ruby/2.0.0",
+        Some("posthog-ruby"),
+        Some("2.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-ruby2.0.0",
         Some("posthog-ruby"),
         Some("2.0.0"),
         RuntimeType::Server
@@ -326,6 +352,8 @@ mod tests {
 
     #[rstest]
     #[case("posthog-python", None, None)] // No slash
+    #[case("posthog-ruby", None, None)] // Legacy Ruby format still needs a version
+    #[case("posthog-rubybeta", None, None)] // Legacy Ruby version must start with a digit
     #[case("posthog-python/", None, None)] // Empty version
     #[case("posthog-/1.0.0", None, None)] // Empty SDK name
     #[case("", None, None)] // Empty string
@@ -356,6 +384,7 @@ mod tests {
     #[case(Some("posthog-flutter/4.0.0"), "posthog-flutter")]
     #[case(Some("posthog-python/1.4.0"), "posthog-python")]
     #[case(Some("posthog-ruby/2.0.0"), "posthog-ruby")]
+    #[case(Some("posthog-ruby2.0.0"), "posthog-ruby")]
     #[case(Some("posthog-php/3.0.0"), "posthog-php")]
     #[case(Some("posthog-java/1.0.0"), "posthog-java")]
     #[case(Some("posthog-go/0.1.0"), "posthog-go")]
@@ -388,6 +417,7 @@ mod tests {
     #[rstest]
     #[case("posthog-python/3.0.0", Some("posthog-python"))]
     #[case("posthog-node/1.2.3", Some("posthog-node"))]
+    #[case("posthog-ruby2.0.0", Some("posthog-ruby"))]
     #[case("posthog-rs/0.10.0", Some("posthog-rs"))]
     #[case("posthog-android/3.0.0", Some("posthog-android"))]
     #[case("posthog-server/1.0.0", Some("posthog-server"))]

--- a/rust/feature-flags/src/utils/user_agent.rs
+++ b/rust/feature-flags/src/utils/user_agent.rs
@@ -133,7 +133,7 @@ impl UserAgentInfo {
         let first = version.chars().next()?;
 
         if first.is_ascii_digit() {
-            Some(version)
+            Some(version.split_whitespace().next().unwrap_or(version))
         } else {
             None
         }
@@ -226,6 +226,12 @@ mod tests {
     )]
     #[case(
         "posthog-ruby2.0.0",
+        Some("posthog-ruby"),
+        Some("2.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-ruby2.0.0 (Linux)",
         Some("posthog-ruby"),
         Some("2.0.0"),
         RuntimeType::Server


### PR DESCRIPTION
## Problem

Older versions of the Ruby SDK sent feature flag request user agents without the separator used by the canonical SDK format, for example `posthog-ruby3.10.0` instead of `posthog-ruby/3.10.0`.

The feature flags service uses the user agent to classify SDK library and runtime. Without compatibility parsing, older Ruby SDK requests can be classified as unknown instead of server-side Ruby requests.

This was fixed in the Ruby SDK as of today and released in v3.11.1: https://github.com/PostHog/posthog-ruby/pull/174

## Changes

- Add Ruby-specific compatibility parsing for the legacy `posthog-ruby<version>` user agent shape.
- Preserve canonical `posthog-ruby/<version>` parsing.
- Add tests for SDK classification, runtime detection, client type labeling, and logging library extraction.

## How did you test this code?

As an agent, I ran:

```bash
cargo fmt --manifest-path rust/Cargo.toml --package feature-flags
flox activate -- bash -c 'set -euo pipefail
SQLX_OFFLINE=true cargo test --manifest-path rust/Cargo.toml -p feature-flags utils::user_agent::tests
SQLX_OFFLINE=true cargo test --manifest-path rust/Cargo.toml -p feature-flags handler::types::tests::test_library_from_user_agent
SQLX_OFFLINE=true cargo test --manifest-path rust/Cargo.toml -p feature-flags handler::flags::tests::test_detect_evaluation_runtime_all_server_sdks
SQLX_OFFLINE=true cargo test --manifest-path rust/Cargo.toml -p feature-flags handler::decoding::tests::client_type_label_tests::test_client_type_label'
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is a server-side compatibility fix for SDK user agent parsing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored this PR after a human asked whether the Ruby SDK user agent normalization should be backported for compatibility. The chosen approach keeps the Ruby SDK fix canonical while adding a narrow server-side parser fallback for only the known legacy Ruby shape, avoiding broader no-slash parsing for unknown SDKs.
