### PR TITLE
fix(replay-vision): stop classifier freeform tags duplicating fixed vocabulary

### DIFF
--- a/products/replay_vision/backend/temporal/scanners/classifier.py
+++ b/products/replay_vision/backend/temporal/scanners/classifier.py
@@ -70,8 +70,9 @@ class ClassifierScanner(BaseScanner, frozen=True):
                     default_factory=list,
                     max_length=_MAX_FREEFORM_TAGS,
                     description=(
-                        f"Up to {_MAX_FREEFORM_TAGS} short lowercase phrases capturing aspects not covered by the "
-                        "fixed vocabulary. Skip when nothing meaningful applies."
+                        f"Up to {_MAX_FREEFORM_TAGS} short lowercase snake_case identifiers, ONLY for concepts no "
+                        "fixed-vocabulary tag covers. Never paraphrase or restate a fixed tag here. Skip when nothing "
+                        "meaningful applies."
                     ),
                 ),
             )

--- a/products/replay_vision/backend/temporal/scanners/prompts/classifier.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/classifier.jinja
@@ -4,6 +4,6 @@
 
 Choose tags from this fixed vocabulary: [{{ vocabulary }}]. {% if multi_label %}Pick every tag that applies.{% else %}Pick exactly one tag.{% endif %} Use `reasoning` to justify your choice.
 {% if allow_freeform_tags %}
-You may additionally emit up to {{ max_freeform_tags }} `tags_freeform` — short lowercase snake_case identifiers (e.g. `password_reset`, `slow_checkout`) capturing aspects not covered by the fixed vocabulary. Skip the field entirely when the fixed tags already say everything that matters.
+The fixed vocabulary above is authoritative — whenever a fixed tag fits, pick it. You may additionally emit up to {{ max_freeform_tags }} `tags_freeform` ONLY for a concept that no fixed tag covers, even loosely. Each is a short lowercase snake_case identifier (e.g. `password_reset`, `slow_checkout`). Never emit a freeform tag that restates, paraphrases, abbreviates, pluralizes, or is a synonym of a fixed tag — pick the fixed tag instead (e.g. if `create new scanner` is in the vocabulary, do not coin `new_scanner` or `made_new_scanner`). Use one canonical identifier per concept; do not emit multiple wordings of the same idea. Skip the field entirely when the fixed tags already say everything that matters.
 {% endif %}
 {{ cite_in('reasoning') }}{% endblock %}

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -363,6 +363,22 @@ class TestClassifierScanner:
         assert "tags_freeform" in on.build_prompt(team_name="Acme", events=events)
         assert "tags_freeform" not in off.build_prompt(team_name="Acme", events=events)
 
+    def test_freeform_prompt_block_discourages_paraphrasing_fixed_vocab(self) -> None:
+        scanner = scanner_from_db(
+            _build_replay_scanner(
+                scanner_type=ScannerType.CLASSIFIER,
+                scanner_config={"prompt": "x", "tags": ["create new scanner"], "allow_freeform_tags": True},
+            )
+        )
+        rendered = scanner.build_prompt(team_name="Acme", events=EventTable(columns=[], rows=[]))
+        # Fixed vocabulary is authoritative and the model is told not to paraphrase a fixed tag into freeform.
+        assert "authoritative" in rendered
+        assert "synonym" in rendered
+        assert "'create new scanner'" in rendered
+        # Examples and the skip instruction survive the rewrite.
+        assert "password_reset" in rendered
+        assert "Skip the field entirely" in rendered
+
     def test_finalize_strips_overlap_with_fixed_vocab_case_insensitive(self) -> None:
         scanner = scanner_from_db(
             _build_replay_scanner(


### PR DESCRIPTION
## Problem

A classifier-type Replay Vision scanner with **Allow freeform tags** enabled was producing freeform tags that simply paraphrase a tag the scanner's fixed vocabulary already contains. With a predefined tag like `create new scanner`, the model still coined freeform near-duplicates such as `new_scanner` and `made_new_scanner`, fragmenting the tag space and making observations harder to group and search.

The root cause is in the classifier prompt, not the storage/search layer. The recent format-insensitive search/storage work (#63464) normalizes tags on read and write, but `finalize()` only strips freeform tags whose slug *exactly* matches a fixed-vocab slug — so paraphrases survive. The prompt itself never told the model that the fixed vocabulary is authoritative or that it must not restate a fixed tag as freeform.

## Changes

- Rewrote the freeform-tags block in `classifier.jinja`: the fixed vocabulary is now explicitly authoritative, freeform tags are reserved for concepts no fixed tag covers, and the model is told not to restate/paraphrase/abbreviate/pluralize/synonymize a fixed tag (with a concrete worked example). Existing format contract (snake_case, cap, "skip the field" guidance) is preserved.
- Aligned the `tags_freeform` response-schema description in `classifier.py` with the prompt so the schema and prompt give the model consistent instructions.

This is a prompt-only fix scoped to vocabulary-overlap duplicates. It does not attempt cross-session consolidation of two genuinely-novel freeform concepts (each scan is stateless), and it only affects future scans — existing observations are not retagged.

## How did you test this code?

I'm an agent (PostHog Code). I ran the automated scanner test suite — `products/replay_vision/backend/tests/test_scanners.py`, 58 passed — including a new `test_freeform_prompt_block_discourages_paraphrasing_fixed_vocab` that renders the classifier prompt and asserts the anti-paraphrase guidance, the fixed-vocab reference, and the surviving examples are present. Ran `ruff check`/`ruff format` clean; lint-staged (ruff + ty check) passed at commit time. No manual UI testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). Kim Dugan reported the duplicate-tag behavior from a live classifier scanner and directed the work. We scoped the fix to prompt-only after weighing it against a heavier option (feeding a scanner's previously-used freeform tags back into each scan to also fix cross-session drift); that was rejected for this pass to avoid a per-scan query and prompt growth, since the reported case is purely fixed-vocab paraphrasing. The prompt is the correct lever here because `finalize()` can only catch exact-slug overlap, not semantic near-duplicates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*