### PR TITLE
fix(docker): put /code on PYTHONPATH so lazy first-party imports resolve in every process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -358,8 +358,12 @@ RUN echo $COMMIT_HASH > /code/commit.txt
 # Copy the Python dependencies and Django staticfiles from the posthog-build stage.
 COPY --from=posthog-build --chown=posthog:posthog /code/staticfiles /code/staticfiles
 COPY --from=posthog-build --chown=posthog:posthog /python-runtime /python-runtime
+# Keep /code on sys.path explicitly. First-party packages (posthog, products, common, dags)
+# run from source (uv sync --no-install-project), so they resolve via the repo root. Pinning it
+# in PYTHONPATH makes that independent of cwd, so lazily-imported modules (e.g. common.hogvm,
+# imported on first query) resolve in every process — web, workers, and the Dagster grpc server.
 ENV PATH=/python-runtime/bin:$PATH \
-    PYTHONPATH=/python-runtime
+    PYTHONPATH=/code:/python-runtime
 
 # Install the system dependencies (fonts, shared libs) that headless Chromium screenshots need,
 # but NOT the Playwright-bundled Chromium binary. Heatmap screenshots drive the system chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -358,10 +358,6 @@ RUN echo $COMMIT_HASH > /code/commit.txt
 # Copy the Python dependencies and Django staticfiles from the posthog-build stage.
 COPY --from=posthog-build --chown=posthog:posthog /code/staticfiles /code/staticfiles
 COPY --from=posthog-build --chown=posthog:posthog /python-runtime /python-runtime
-# Keep /code on sys.path explicitly. First-party packages (posthog, products, common, dags)
-# run from source (uv sync --no-install-project), so they resolve via the repo root. Pinning it
-# in PYTHONPATH makes that independent of cwd, so lazily-imported modules (e.g. common.hogvm,
-# imported on first query) resolve in every process — web, workers, and the Dagster grpc server.
 ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/code:/python-runtime
 


### PR DESCRIPTION
## Problem

Since **2026-06-12 ~10–11 UTC**, HogQL bytecode compilation has been throwing `ModuleNotFoundError: No module named 'common'` from `posthog/hogql/compiler/bytecode.py` (`from common.hogvm.python.execute import …`). It's concentrated on web-analytics queries (heaviest user of the placeholder→bytecode path) and took down the web-analytics Dagster warmer. Error tracking: https://us.posthog.com/project/2/error_tracking/019ebb82-b53e-7bc3-a21e-2e9aa59ede6c

Root cause is a runtime import-resolution gap, not a logic bug:

- First-party packages (`posthog`, `products`, `common`, `dags`) are **not installed** — the image runs `uv sync --no-install-project`, with `PYTHONPATH=/python-runtime` (deps only) and `WORKDIR=/code`. So they resolve only because `/code` happens to be on `sys.path` via the cwd.
- `common.hogvm` is imported **lazily, at first query** (inline import in `posthog/hogql/placeholders.py` and `models/utils.py`). It used to be harmless because the large `django.setup()` import graph transitively pre-loaded `common.hogvm` into `sys.modules` at boot, while `/code` was reachable.
- #62726 ("cut setup-time import chains into the HogQL/schema layer", merged 06-12 10:19 UTC) intentionally relocated those boot imports to first-use — a good change. But it stopped pre-warming `common.hogvm`, so the lazy import now executes for real at query time, in processes where `/code` isn't on `sys.path` then → `No module named 'common'`.

## Changes

Add `/code` to `PYTHONPATH` in the runtime stage (`/code:/python-runtime`). `/code` becomes a persistent, absolute `sys.path` entry independent of cwd, so any lazily-imported first-party module (`common.hogvm` and anything else relocated off boot) resolves in every process — web, workers, and the Dagster grpc code-location/run pods.

This is deliberately complementary to #62726 — it adds **zero** setup-time imports, so the boot-time win is fully preserved. It just makes the import path correct regardless of *when* an import fires.

Supersedes #63626 (the `common/__init__.py` packaging approach), which only addressed namespace-vs-regular resolution and didn't fix reachability.

## How did you test this code?

I'm an agent (Claude Code), human-directed. No automated test covers image env. Verified by inspection + a timeline correlation: the failure begins the hour #62726 deployed; `common.hogvm` is self-contained (no `posthog`/`schema`/`django` imports), so referencing it via `/code` on `PYTHONPATH` is safe; and `posthog`/`products` already resolve from `/code`, so pinning it explicitly only makes existing behavior deterministic. Needs validation in a failing pod (`PYTHONPATH=/code:/python-runtime python -c "import common.hogvm"`) before/after.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. Found by correlating the precompute insert/error timelines against the deploy log: the warmer ran cleanly for ~13h with the web-analytics PRs live, then broke sharply at 06-12 10–11 UTC — the hour #62726 (HogQL setup-import trimming) rolled out. Considered (a) reverting #62726 (rejected — its perf win is real and this is a latent packaging gap it merely exposed), (b) `common/__init__.py` (#63626, insufficient — doesn't fix reachability), and (c) re-pinning `common.hogvm` into the setup graph (viable but re-adds setup imports). `PYTHONPATH=/code` is the least-invasive fix that preserves #62726 and covers every process type. Flagging for HogQL/DevEx (Julian, #62726 author) to confirm the mechanism and choose between this and the targeted pre-warm.
