### PR TITLE
fix(data-warehouse): stop bulk schema edits from stranding schedule updates

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -18,7 +18,7 @@ import temporalio
 from dateutil import parser
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_field
 from rest_framework import filters, serializers, status, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -496,6 +496,20 @@ class ExternalDataSourceBulkUpdateSchemasSerializer(serializers.Serializer):
         allow_empty=False,
         help_text="Schema updates to apply in a single batch.",
     )
+
+
+class BulkScheduleUpdateError(APIException):
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_code = "bulk_schedule_update_failed"
+
+    def __init__(self, failed_schema_names: list[str]) -> None:
+        names = ", ".join(failed_schema_names)
+        super().__init__(
+            detail=(
+                f"Schema settings were saved, but the sync schedule failed to update for: {names}. "
+                "Please retry to bring the schedule in sync with the saved settings."
+            )
+        )
 
 
 class ExternalDataJobSerializers(serializers.ModelSerializer):
@@ -3303,8 +3317,9 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
         serializer_context = self.get_serializer_context()
         updated_schemas: list[ExternalDataSchema] = []
-        post_commit_actions: list[Callable[[], None]] = []
-        update_serializer_context = {**serializer_context, "post_commit_actions": post_commit_actions}
+        # Keep each schema's deferred Temporal actions paired with the schema, so a failure can be
+        # attributed to the schema it belongs to rather than reported as one anonymous error.
+        deferred_actions: list[tuple[ExternalDataSchema, Callable[[], None]]] = []
 
         with transaction.atomic():
             for schema_update in schema_updates:
@@ -3312,17 +3327,38 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 schema = source_schemas_by_id[schema_id]
                 schema_payload = {key: value for key, value in schema_update.items() if key != "id"}
 
+                schema_post_commit_actions: list[Callable[[], None]] = []
                 schema_serializer = ExternalDataSchemaSerializer(
                     schema,
                     data=schema_payload,
                     partial=True,
-                    context=update_serializer_context,
+                    context={**serializer_context, "post_commit_actions": schema_post_commit_actions},
                 )
                 schema_serializer.is_valid(raise_exception=True)
-                updated_schemas.append(schema_serializer.save())
+                updated = schema_serializer.save()
+                updated_schemas.append(updated)
+                deferred_actions.extend((updated, action) for action in schema_post_commit_actions)
 
-        for post_commit_action in post_commit_actions:
-            post_commit_action()
+        # The DB writes are already committed at this point. Run every deferred action even if some
+        # raise — otherwise one schema's Temporal failure strands the schedule updates for every
+        # schema after it in the batch, leaving them with the new frequency in the DB but the old
+        # schedule still running. Collect every failure (deduped per schema) and surface them all so
+        # the caller knows exactly which schemas didn't apply and can retry.
+        failed_schemas: dict[str, str] = {}
+        for updated_schema, post_commit_action in deferred_actions:
+            try:
+                post_commit_action()
+            except Exception as e:
+                capture_exception(e)
+                logger.exception(
+                    "bulk_update_schemas post-commit action failed",
+                    source_id=str(source.id),
+                    schema_id=str(updated_schema.id),
+                )
+                failed_schemas[str(updated_schema.id)] = updated_schema.name
+
+        if failed_schemas:
+            raise BulkScheduleUpdateError(sorted(failed_schemas.values()))
 
         return Response(
             ExternalDataSchemaSerializer(updated_schemas, many=True, context=serializer_context).data,

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 import psycopg
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import APIException
 
 from posthog.schema import (
     SourceFieldFileUploadConfig,
@@ -450,6 +451,56 @@ class TestExternalDataSource(APIBaseTest):
         assert mock_sync_external_data_job_workflow.call_count == 1
         assert mock_sync_external_data_job_workflow.call_args.kwargs == {"create": False, "should_sync": True}
         assert mock_sync_external_data_job_workflow.call_args.args[0].id == schema.id
+
+    @patch(
+        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+        return_value=False,
+    )
+    def test_bulk_update_schemas_one_schedule_failure_does_not_strand_others(self, _mock_workflow_exists):
+        # The deferred schedule updates run after the DB transaction commits. A failure on one
+        # schema must not strand the rest: every schema's schedule update has to be attempted,
+        # otherwise the DB shows the new frequency while the Temporal schedule keeps the old one.
+        source = self._create_external_data_source()
+        schemas = [
+            ExternalDataSchema.objects.create(
+                name=f"Table{i}",
+                team_id=self.team.pk,
+                source=source,
+                should_sync=True,
+                sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+            )
+            for i in range(3)
+        ]
+
+        attempted = 0
+
+        def _side_effect(schema, create=False, should_sync=True):
+            nonlocal attempted
+            attempted += 1
+            if attempted == 2:
+                raise APIException("temporal unavailable")
+            return schema
+
+        with patch(
+            "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow",
+            side_effect=_side_effect,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.id}/bulk_update_schemas",
+                data={"schemas": [{"id": str(s.id), "sync_frequency": "7day"} for s in schemas]},
+                format="json",
+            )
+
+        # Every schema's schedule update is attempted despite the second one failing.
+        assert attempted == 3
+        # The failure is surfaced and attributes the exact schema that didn't apply.
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        assert "Table1" in response.json()["detail"]
+        assert "Table0" not in response.json()["detail"]
+
+        for s in schemas:
+            s.refresh_from_db()
+            assert sync_frequency_interval_to_sync_frequency(s.sync_frequency_interval) == "7day"
 
     @patch(
         "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",


### PR DESCRIPTION
## Problem

Bulk-editing the sync frequency on several data warehouse schemas appeared to work — the new frequency showed up in the UI and persisted — but the affected schemas kept syncing at their old cadence. The DB was being updated without the corresponding Temporal schedule being updated.

## Changes

`bulk_update_schemas` commits all schema rows in a single `transaction.atomic()` block, then applies each schema's Temporal schedule change as a deferred post-commit action. The runner was a bare loop with no error isolation:

```python
for post_commit_action in post_commit_actions:
    post_commit_action()
```

If one schema's schedule update raised (e.g. a transient Temporal RPC error), the loop aborted and the request 500'd — but the DB transaction had **already committed** for every schema in the batch. So each schema after the failing one was left with the new frequency in Postgres and the old schedule still running in Temporal. The single-schema PATCH path doesn't have this problem because it runs its one schedule update inline.

The fix attempts every deferred action regardless of individual failures, captures/logs each failure, then re-raises the first one so the caller still learns the batch didn't fully apply and can retry. Behavior on a genuine failure stays consistent with the single-schema path (the request still surfaces the error), but a single schema's failure can no longer silently strand the rest of the batch.

Scope note: each deferred action also opens its own Temporal connection (`sync_connect()` is uncached), so a very large batch can be slow — the codebase already has single-connection `bulk_*_external_data_job_schedules` helpers for that. That's a separate performance concern and is left as a follow-up; this PR fixes the correctness bug.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing.

Added `test_bulk_update_schemas_one_schedule_failure_does_not_strand_others`, which bulk-updates three schemas, makes the second schema's schedule update raise, and asserts that all three updates are attempted, the failure is surfaced (non-2xx), and the frequency is persisted for every schema. It fails on the old code (`attempted == 2`) and passes with the fix. The existing `bulk_update_schemas` tests still pass (`pytest products/data_warehouse/backend/api/test/test_external_data_source.py -k bulk_update_schemas` → 4 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with PostHog Code. Traced the full path (frontend `bulkSetFrequency` → debounced `bulkUpdateSchemas` → `bulk_update_schemas` viewset → serializer `update()` → deferred Temporal schedule update). Confirmed the serializer logic and `update_schedule` are correct (the existing deferred-update test passes), which pointed at the post-commit runner rather than the per-schema logic. Considered a scale/timeout cause (per-call Temporal reconnects) but ruled it out as the primary issue for the reported small batch sizes, leaving the no-error-isolation loop as the root cause. Reproduced with a failing test before fixing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
