### PR TITLE
docs(exporter): note the celery export path is a dead legacy fallback

### DIFF
--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -67,7 +67,13 @@ def export_asset(
     ).get(pk=exported_asset_id)
 
     # Retries are handled by Temporal at the activity level.
-    # The Celery path is a legacy fallback until one-off exports are fully migrated.
+    # The Celery path is a legacy fallback that is effectively dead in prod. As of 2026-06 every
+    # export runs through the Temporal export_asset_activity on the analytics-platform task queue —
+    # both regular exports (`export-asset` workflow) and subscription images (`process-subscription`
+    # workflow). Verified in prod-us logs: the EXPORTS Celery queue (the posthog-worker-django
+    # "longrunning" worker) renders zero images and only rarely receives a stray CSV. In particular
+    # the headless-browser path (image_exporter._export_to_png, gated on BROWSERLESS_CDP_URL) is
+    # never exercised here — so the browser env/infra on that worker can go once this task is retired.
     try:
         export_asset_direct(exported_asset, limit=limit, max_height_pixels=max_height_pixels)
     except Exception:

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -66,14 +66,18 @@ def export_asset(
         "created_by", "team", "team__organization"
     ).get(pk=exported_asset_id)
 
-    # Retries are handled by Temporal at the activity level.
-    # The Celery path is a legacy fallback that is effectively dead in prod. As of 2026-06 every
-    # export runs through the Temporal export_asset_activity on the analytics-platform task queue —
-    # both regular exports (`export-asset` workflow) and subscription images (`process-subscription`
-    # workflow). Verified in prod-us logs: the EXPORTS Celery queue (the posthog-worker-django
-    # "longrunning" worker) renders zero images and only rarely receives a stray CSV. In particular
-    # the headless-browser path (image_exporter._export_to_png, gated on BROWSERLESS_CDP_URL) is
-    # never exercised here — so the browser env/infra on that worker can go once this task is retired.
+    # Retries are handled by Temporal at the activity level. The Celery path is legacy but NOT dead:
+    # the main export flow and subscription images run via the Temporal export_asset_activity
+    # (analytics-platform task queue), yet a few callers still enqueue here, so it can't simply be
+    # deleted. As of 2026-06 the live Celery callers are:
+    #   - Logs export (products/logs/backend/api.py) — CSV
+    #   - Advanced Activity Logs export (posthog/api/advanced_activity_logs) — CSV/XLSX
+    #   - Legacy Slack link image-unfurl (ee/api/integration.py slack/events -> ee/tasks/slack.py),
+    #     which renders a PNG; looks superseded by the metadata-only products/slack_app unfurl.
+    # In prod-us the headless-browser/image path (image_exporter._export_to_png, gated on
+    # BROWSERLESS_CDP_URL) is NOT observed on this queue (0 image renders in 30d) — the only live
+    # Celery callers are tabular. Retiring this task + the browser env on the EXPORTS worker requires
+    # migrating those callers (and confirming the legacy Slack unfurl is dead) first.
     try:
         export_asset_direct(exported_asset, limit=limit, max_height_pixels=max_height_pixels)
     except Exception:


### PR DESCRIPTION
## Summary

Documents that the Celery `export_asset` path is a dead legacy fallback, so a future cleanup can confidently retire it and the browser env/infra that hangs off it.

## Context

All exports run through the Temporal `export_asset_activity` (analytics-platform task queue) — both regular exports (`export-asset` workflow) and subscription images (`process-subscription` workflow). Verified in prod-us logs (after adding `export_format` to the `export_asset.starting` log in #63634):

- `temporal-worker-analytics-platform`: steady stream of `export_asset.starting` with `export_format` of `text/csv` / `image/png` / `xlsx`, including `process-subscription` workflows emitting `image/png`.
- `posthog-worker-django` "longrunning" worker (the EXPORTS Celery queue): **zero** export starts of any format over 6h; only 2 stray *CSV* failures over 7 days; **no** image renders in 30 days.

So the headless-browser path on the Celery worker (`image_exporter._export_to_png`, gated on `BROWSERLESS_CDP_URL`) is never exercised. This comment is the breadcrumb for removing that worker's browser env/infra (and eventually the Celery task) once it's formally retired.

Comment-only; no behavior change.
