### PR TITLE
fix(web-analytics): pre-warm common.hogvm in eager warmer so lazy query import resolves

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -123,6 +123,7 @@ jobs:
                         - 'posthog/products.py'
                         - 'posthog/cloud_utils.py'
                         - 'posthog/ducklake/**'
+                        - 'common/hogvm/**'
                         # Test infrastructure used by dagster tests
                         - conftest.py
                         - 'posthog/conftest.py'

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -78,6 +78,11 @@ from products.analytics_platform.backend.models.preaggregation_job import Preagg
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_precompute_enabled_for_team
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
 
+# Pre-warm the HogQL bytecode VM at code-location load, while /code is on sys.path: the query path
+# imports common.hogvm lazily, and the Dagster grpc process can't resolve it on first query, so
+# caching it here keeps that lazy import a hit.
+import common.hogvm.python.execute  # noqa: F401
+
 logger = structlog.get_logger(__name__)
 
 


### PR DESCRIPTION
## Problem

Since 2026-06-12 ~10–11 UTC the eager web-analytics precompute warmer dies with `ModuleNotFoundError: No module named 'common'`, raised lazily from `posthog/hogql/compiler/bytecode.py` (`from common.hogvm.python.execute import …`) on the precompute query path. The pre-aggregated tables have been stale since.

Root cause: first-party packages run from source (`uv sync --no-install-project`, `PYTHONPATH=/python-runtime`, cwd `/code`), so `common` resolves only via `/code` on `sys.path`. `common.hogvm` is imported lazily at first query. It used to be harmless because the `django.setup()` import graph transitively pre-loaded `common.hogvm` into `sys.modules` at boot — but #62726 ("cut setup-time import chains into the HogQL/schema layer") intentionally relocated those imports to first-use, so it's no longer pre-warmed. In the Dagster grpc process, `/code` isn't reachable for that first-query import, so it fails.

## Changes

Pre-warm `common.hogvm` with a module-level import in the eager warmer. The module loads at code-location/run-pod startup — while `/code` is on `sys.path` — so importing `common.hogvm.python.execute` caches the `common` package (and its `__path__`); the later lazy import on the query path is then a cache hit.

Deliberately scoped and minimal:
- It does **not** add anything to `sys.path` (no shadowing/import-surface change), and it does **not** touch the `django.setup()` path, so #62726's startup-import budget is untouched.
- It only re-warms the lightweight bytecode VM (`common.hogvm` is self-contained — no `posthog`/`schema`/`django` imports), not the heavy `posthog.schema`, so #62726's perf win is preserved.

This is the narrow, Dagster-scoped fix for the warming path. The broader runtime fix (`/code` on `PYTHONPATH`, #63652) and the packaging alternative (install `common`) are tracked separately for HogQL/DevEx to weigh in on.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Verified by inspection: `common.hogvm.python.execute` exists and is import-light; the warmer module is imported at code-location load while `/code` is reachable, so the pre-warm caches `common` before any query runs. `ruff check` / `ruff format` clean. Needs validation that the warmer produces rows again after deploy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. Traced the 06-12 outage to #62726 relocating HogQL/schema imports off `django.setup()`, which stopped pre-warming `common.hogvm`; the always-lazy import then began failing at query time where `/code` isn't on the process `sys.path`. Chose the module-scoped pre-warm (over `PYTHONPATH=/code` or installing `common`) because it's the smallest, lowest-risk change that fixes the warming path without adding import surface or touching the setup-import budget #62726 introduced.
