### PR TITLE
fix(data-warehouse): serialize Plain filter timestamps with millisecond precision

### DIFF
--- a/posthog/temporal/data_imports/sources/plain/plain.py
+++ b/posthog/temporal/data_imports/sources/plain/plain.py
@@ -29,12 +29,18 @@ _MESSAGE_INFO_FIELDS: list[tuple[str, str]] = [
 
 
 def _datetime_to_plain_iso8601(value: datetime) -> str:
-    """Serialize a datetime to the ISO-8601 format Plain returns and accepts (e.g. 2024-01-15T10:30:00.000Z)."""
+    """Serialize a datetime to the ISO-8601 format Plain returns and accepts (e.g. 2024-01-15T10:30:00.000Z).
+
+    Plain's ``DatetimeFilter`` only accepts millisecond precision (``yyyy-MM-dd'T'HH:mm:ss.SSS'Z'``) or
+    whole seconds; ``datetime.isoformat()`` emits microseconds (6 fractional digits) whenever they are
+    non-zero, which Plain rejects with a validation error. Pin the precision to milliseconds so the value
+    always matches what Plain expects regardless of the source datetime's microsecond component.
+    """
     if value.tzinfo is None:
         value = value.replace(tzinfo=UTC)
     else:
         value = value.astimezone(UTC)
-    return value.isoformat().replace("+00:00", "Z")
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _updated_at_filter(updated_at_gte: datetime) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
+++ b/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
@@ -231,10 +231,21 @@ class TestPlainRetryableError:
 
 class TestDatetimeHelpers:
     def test_datetime_to_plain_iso8601_uses_z_suffix(self):
-        assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)) == "2024-01-15T10:30:00Z"
+        assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)) == "2024-01-15T10:30:00.000Z"
 
     def test_datetime_to_plain_iso8601_assumes_utc_for_naive(self):
-        assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0)) == "2024-01-15T10:30:00Z"
+        assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0)) == "2024-01-15T10:30:00.000Z"
+
+    def test_datetime_to_plain_iso8601_truncates_microseconds_to_milliseconds(self):
+        # Plain's DatetimeFilter rejects 6-digit microseconds; only millisecond precision is accepted.
+        assert (
+            _datetime_to_plain_iso8601(datetime(2026, 6, 7, 18, 3, 36, 624000, tzinfo=UTC))
+            == "2026-06-07T18:03:36.624Z"
+        )
+        assert (
+            _datetime_to_plain_iso8601(datetime(2026, 6, 7, 18, 3, 36, 624789, tzinfo=UTC))
+            == "2026-06-07T18:03:36.624Z"
+        )
 
     def test_parse_plain_datetime_from_string(self):
         assert _parse_plain_datetime("2024-01-15T10:30:00Z") == datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
@@ -362,7 +373,8 @@ class TestFetchPaginatedEndpointIncrementalFilter:
         assert recorded, "expected customers query to be issued"
         _, variables = recorded[0]
         # Plain's DatetimeFilter uses `after` (>=), not `gte` — sending `gte` is rejected with a 400.
-        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
+        # The timestamp is serialized with millisecond precision; microseconds are rejected by Plain.
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00.000Z"}}
 
     def test_omits_filter_for_full_sync(self):
         recorded = []
@@ -407,7 +419,8 @@ class TestFetchTimelineEntriesStreaming:
         assert recorded, "expected threads query to be issued"
         _, variables = recorded[0]
         # Plain's DatetimeFilter uses `after` (>=), not `gte` — sending `gte` is rejected with a 400.
-        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
+        # The timestamp is serialized with millisecond precision; microseconds are rejected by Plain.
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00.000Z"}}
 
     def test_streams_thread_pages_without_buffering_all_ids(self):
         executed_queries: list[str] = []


### PR DESCRIPTION
## Problem

The Plain data warehouse source has been failing incremental syncs with a `400 Client Error: Bad Request` from the Plain API. Two error tracking issues track the failures, and although their historical descriptions mention older problems (querying `actorType`/`assignedToUser` directly, sending a `gte` filter) that were already fixed, the **current** live failure for both is a single remaining bug:

```
field: updatedAt.after — Invalid ISO date time format,
expected: yyyy-MM-dd'T'HH:mm:ss.SSS'Z' or yyyy-MM-dd'T'HH:mm:ss'Z'
```

The incremental cursor was being serialized as `2026-06-07T18:03:36.624000Z` — 6-digit microseconds. Plain's `DatetimeFilter` only accepts millisecond precision (`.SSS`) or whole seconds, so it rejected every request. This broke the `customers`, `threads`, and `timeline_entries` endpoints, which all send an `updatedAt.after` filter on incremental runs.

The root cause is `_datetime_to_plain_iso8601`, which used `datetime.isoformat()`. That emits microseconds whenever the source datetime has a non-zero microsecond component — which incremental cursors routinely do.

## Changes

- Pin `_datetime_to_plain_iso8601` to millisecond precision via `isoformat(timespec="milliseconds")`, so the output always matches Plain's accepted format (e.g. `2026-06-07T18:03:36.624Z`) regardless of the cursor's microsecond component. This already matched the function's own docstring example.
- Updated the existing datetime/`after`-filter tests to expect the millisecond suffix and added a regression test covering both a `.624000` (trailing-zero) and a `.624789` (truncated) microsecond value.

## How did you test this code?

I'm an agent (Claude Code). pytest is not installed in this environment, so I could not run the repo's test suite. I verified the serialization logic directly against the exact failing input observed in production and the existing test expectations:

- `2024-01-15T10:30:00 (UTC)` → `2024-01-15T10:30:00.000Z`
- `2024-01-15T10:30:00 (naive)` → `2024-01-15T10:30:00.000Z`
- `2026-06-07T18:03:36.624000 (UTC)` → `2026-06-07T18:03:36.624Z`
- `2026-06-07T18:03:36.624789 (UTC)` → `2026-06-07T18:03:36.624Z`

`ruff check` and `ruff format --check` both pass on the changed files. The updated unit tests in `test_plain.py` should be run in CI to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal data-import bug fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at Tom Owers' direction, who pointed at two error tracking issues to fix. I used the PostHog MCP error-tracking tools to pull the latest raw `$exception` events for both issues. The truncated issue descriptions pointed at GraphQL field-name and `gte` problems, but inspecting the most recent events showed those were already resolved in the current code — the live failure for both issues had converged on the same `updatedAt.after` "Invalid ISO date time format" validation error. The variables payload in the stack frames (`{"updatedAt": {"after": "...624000Z"}}`) made the microsecond-precision mismatch the clear root cause, so the fix targets the single shared serializer rather than the stale per-issue symptoms.
