### PR TITLE
fix(phai): run /usage billing period lookup off the event loop

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
@@ -40,7 +40,9 @@ class UsageCommand(SlashCommand):
                     messages=[AssistantMessage(content="Unable to retrieve conversation start time.", id=str(uuid4()))]
                 )
 
-            usage_period = get_ai_usage_period(self._team, config.get("configurable", {}).get("billing_context"))
+            usage_period = await sync_to_async(get_ai_usage_period, thread_sensitive=False)(
+                self._team, config.get("configurable", {}).get("billing_context")
+            )
 
             conversation_credits = await sync_to_async(get_ai_credits_for_conversation, thread_sensitive=False)(
                 team_id=self._team.id,
@@ -73,4 +75,4 @@ class UsageCommand(SlashCommand):
 
         except Exception as e:
             capture_exception(e)
-            raise Exception("PostHog AI usage information query failed. Please try again later.")
+            raise Exception("PostHog AI usage information query failed. Please try again later.") from e

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/command.py
@@ -8,6 +8,8 @@ from posthoganalytics import capture_exception
 
 from posthog.schema import AssistantMessage
 
+from posthog.sync import database_sync_to_async
+
 from ee.hogai.chat_agent.slash_commands.commands import SlashCommand
 from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
     format_usage_message,
@@ -34,13 +36,13 @@ class UsageCommand(SlashCommand):
                     messages=[AssistantMessage(content="Unable to retrieve conversation information.", id=str(uuid4()))]
                 )
 
-            conversation_start = await sync_to_async(get_conversation_start_time)(conversation_id)
+            conversation_start = await database_sync_to_async(get_conversation_start_time)(conversation_id)
             if not conversation_start:
                 return PartialAssistantState(
                     messages=[AssistantMessage(content="Unable to retrieve conversation start time.", id=str(uuid4()))]
                 )
 
-            usage_period = await sync_to_async(get_ai_usage_period, thread_sensitive=False)(
+            usage_period = await database_sync_to_async(get_ai_usage_period)(
                 self._team, config.get("configurable", {}).get("billing_context")
             )
 

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from uuid import uuid4
@@ -5,10 +6,16 @@ from uuid import uuid4
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.core.exceptions import SynchronousOnlyOperation
+
+from asgiref.sync import async_to_sync
 from parameterized import parameterized
+
+from posthog.schema import HumanMessage
 
 from products.posthog_ai.backend.models.assistant import Conversation
 
+from ee.hogai.chat_agent.slash_commands.commands.usage.command import UsageCommand
 from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
     CLOUD_REGION_TO_TEAM_ID,
     CLOUD_REGION_TO_URL,
@@ -23,6 +30,7 @@ from ee.hogai.chat_agent.slash_commands.commands.usage.queries import (
     get_ga_launch_date,
     get_past_month_start,
 )
+from ee.hogai.utils.types import AssistantState
 
 
 class TestUsage(BaseTest):
@@ -273,6 +281,53 @@ class TestUsage(BaseTest):
         self.assertEqual(usage_period.start, datetime(2025, 11, 20, tzinfo=UTC))
         self.assertEqual(usage_period.end, now)
         self.assertEqual(usage_period.query_start, datetime(2025, 11, 20, tzinfo=UTC))
+
+    def test_execute_runs_usage_period_off_event_loop(self):
+        # Without a billing context, get_ai_usage_period falls back to team.organization.usage, a sync
+        # ORM access. It must run off the event loop or Django raises SynchronousOnlyOperation, which the
+        # command would swallow into a generic failure. This guard mimics that check: it raises only when
+        # get_ai_usage_period executes directly on the running loop.
+        conversation = Conversation.objects.create(team=self.team, user=self.user)
+        config = {"configurable": {"thread_id": str(conversation.id)}}
+        state = AssistantState(messages=[HumanMessage(content="/usage")])
+
+        def usage_period_guarded(*args, **kwargs):
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return AiUsagePeriod(
+                    label="Past 30 days",
+                    start=datetime(2026, 5, 1, tzinfo=UTC),
+                    end=datetime(2026, 6, 1, tzinfo=UTC),
+                    query_start=datetime(2026, 5, 1, tzinfo=UTC),
+                )
+            raise SynchronousOnlyOperation(
+                "You cannot call this from an async context - use a thread or sync_to_async."
+            )
+
+        with (
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_usage_period",
+                side_effect=usage_period_guarded,
+            ),
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_credits_for_conversation",
+                return_value=10,
+            ),
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_credits_for_team",
+                return_value=100,
+            ),
+            patch(
+                "ee.hogai.chat_agent.slash_commands.commands.usage.command.get_ai_free_tier_credits",
+                return_value=2000,
+            ),
+        ):
+            result = async_to_sync(UsageCommand(self.team, self.user).execute)(config, state)
+
+        content = cast(str, result.messages[0].content)
+        self.assertIn("PostHog AI usage", content)
+        self.assertNotIn("query failed", content)
 
     def test_format_usage_message_no_usage(self):
         """Test formatting when no credits have been used."""

--- a/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/usage/test/test_usage.py
@@ -9,9 +9,10 @@ from unittest.mock import patch
 from django.core.exceptions import SynchronousOnlyOperation
 
 from asgiref.sync import async_to_sync
+from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
 
-from posthog.schema import HumanMessage
+from posthog.schema import AssistantMessage, HumanMessage
 
 from products.posthog_ai.backend.models.assistant import Conversation
 
@@ -288,7 +289,7 @@ class TestUsage(BaseTest):
         # command would swallow into a generic failure. This guard mimics that check: it raises only when
         # get_ai_usage_period executes directly on the running loop.
         conversation = Conversation.objects.create(team=self.team, user=self.user)
-        config = {"configurable": {"thread_id": str(conversation.id)}}
+        config = RunnableConfig(configurable={"thread_id": str(conversation.id)})
         state = AssistantState(messages=[HumanMessage(content="/usage")])
 
         def usage_period_guarded(*args, **kwargs):
@@ -325,7 +326,9 @@ class TestUsage(BaseTest):
         ):
             result = async_to_sync(UsageCommand(self.team, self.user).execute)(config, state)
 
-        content = cast(str, result.messages[0].content)
+        message = result.messages[0]
+        assert isinstance(message, AssistantMessage)
+        content = cast(str, message.content)
         self.assertIn("PostHog AI usage", content)
         self.assertNotIn("query failed", content)
 


### PR DESCRIPTION
## Problem

The `/usage` slash command in PostHog AI fails for a large share of users with a generic "PostHog AI usage information query failed. Please try again later." error — the underlying credit/usage data never loads.

Root cause: `UsageCommand.execute()` is `async`, but it called `get_ai_usage_period()` synchronously. When no usable billing context is supplied for the turn, that helper falls back to `_get_billing_period_from_organization()`, which reads `team.organization.usage` — a synchronous ORM access. Running on the event loop, Django raises `SynchronousOnlyOperation`, which the command's broad `except` swallowed into the generic failure message.

This is reached whenever the turn lacks a usable `billing_context` (the frontend only sends it for org admins/owners with the relevant flag, and only when it contains a billing period). It is **not** region-specific — it surfaces in both US and EU clouds. The three sibling data calls in the same method were already wrapped in `sync_to_async`; `get_ai_usage_period` was simply missed.

## Changes

- Wrap `get_ai_usage_period` in `sync_to_async(..., thread_sensitive=False)`, matching the other data calls in `execute()`, so the `team.organization` fallback runs off the event loop.
- Chain the original exception (`raise ... from e`) so the real cause reaches the trace's `$ai_error` instead of being masked by the generic wrapper.
- Add a regression test that exercises the no-billing-context path and asserts `get_ai_usage_period` is not invoked directly on the event loop.

## How did you test this code?

I'm an agent (Claude Code, directed by the PR assignee). I did not perform manual testing. Automated tests I actually ran:

- `test_execute_runs_usage_period_off_event_loop` — new. Uses a guard that raises `SynchronousOnlyOperation` only if `get_ai_usage_period` runs on the active event loop. Verified it fails on the pre-fix code (generic failure, now with chained cause visible) and passes with the fix.
- Full `test_usage.py` suite: 29 passed.
- `ruff check` / `ruff format`: clean.

Not run locally: mypy (CI), and a live `/usage` run against a running stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a failing `/usage` trace in PostHog AI observability. Using the PostHog MCP trace and error-tracking tools, traced the opaque user-facing error to a captured `SynchronousOnlyOperation` / `KeyError: 'organization'` at `team.organization` access in `get_ai_usage_period`'s org fallback. An initial hypothesis that the failure was a region-specific ClickHouse timeout was rejected after comparing a failing (EU) and succeeding (US) conversation: the failing span died in ~86ms (before any ClickHouse work) while the succeeding one ran the full ~5s path, and the captured exceptions span both clouds — pointing at the unwrapped sync ORM access, not the region-dependent query.

Chose the minimal fix consistent with the existing pattern (`sync_to_async` wrapper, as already used by the sibling calls) over a broader `select_related("organization")` refactor. The regression test deliberately encodes the invariant (the lookup must not run on the loop) rather than depending on environment-sensitive async-guard behavior.
