### PR TITLE
feat(cdp): add cyclotron v2 dead-letter table

### DIFF
--- a/rust/cyclotron-node-migrations/20260612000001_add_dead_letter_table.sql
+++ b/rust/cyclotron-node-migrations/20260612000001_add_dead_letter_table.sql
@@ -1,0 +1,25 @@
+-- Dead-letter store for poison-pill jobs. The janitor moves the full job row
+-- here (instead of failing + deleting it) so runs survive fleet-wide worker
+-- outages and can be replayed into cyclotron_jobs once the fleet is healthy.
+CREATE TABLE IF NOT EXISTS cyclotron_jobs_dead_letter (
+    id UUID PRIMARY KEY,
+    team_id INT NOT NULL,
+    function_id UUID,
+    original_queue_name TEXT NOT NULL,
+    priority SMALLINT NOT NULL,
+    scheduled TIMESTAMPTZ NOT NULL,
+    created TIMESTAMPTZ NOT NULL,
+    janitor_touch_count SMALLINT NOT NULL,
+    transition_count SMALLINT NOT NULL,
+    last_transition TIMESTAMPTZ NOT NULL,
+    parent_run_id TEXT,
+    state BYTEA,
+    distinct_id TEXT,
+    person_id TEXT,
+    action_id TEXT,
+    reason TEXT NOT NULL,
+    dlq_time TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_cyclotron_jobs_dead_letter_dlq_time
+    ON cyclotron_jobs_dead_letter (dlq_time);

--- a/rust/cyclotron-node-migrations/20260612000001_add_dead_letter_table.sql
+++ b/rust/cyclotron-node-migrations/20260612000001_add_dead_letter_table.sql
@@ -6,9 +6,14 @@ CREATE TABLE IF NOT EXISTS cyclotron_jobs_dead_letter (
     team_id INT NOT NULL,
     function_id UUID,
     original_queue_name TEXT NOT NULL,
+    -- The job's status when it was dead-lettered (always 'running' for poison
+    -- pills today) plus its last heartbeat — kept for replay triage, e.g.
+    -- re-queuing only genuinely stalled runs.
+    original_status CyclotronJobStatus NOT NULL,
     priority SMALLINT NOT NULL,
     scheduled TIMESTAMPTZ NOT NULL,
     created TIMESTAMPTZ NOT NULL,
+    last_heartbeat TIMESTAMPTZ,
     janitor_touch_count SMALLINT NOT NULL,
     transition_count SMALLINT NOT NULL,
     last_transition TIMESTAMPTZ NOT NULL,


### PR DESCRIPTION
## Problem

The Cyclotron V2 (Node) janitor currently fails poison-pill jobs and then hard-deletes them during cleanup, permanently dropping in-flight runs with no recovery path. Restoring the V1 dead-letter behavior needs a place to preserve those jobs.

## Changes

Adds a single sqlx migration creating `cyclotron_jobs_dead_letter` in the `cyclotron_node` database. The table mirrors the `cyclotron_jobs` columns plus `original_queue_name`, `reason`, and `dlq_time`, with an index on `dlq_time`.

This is **migration-only**, deliberately split from the janitor service change (PR #63584) so the table lands and deploys before the code that reads and writes it — per the migration/service separation policy.

## How did you test this code?

I'm an agent. The migration applies cleanly against a fresh `cyclotron_node` Postgres via the standard `migrate-entry`/sqlx path, and the dependent service code in #63584 was validated against it (Cyclotron V2 unit suite and the workflows e2e suite, both green locally). No automated test is added here since this is a schema-only change.

## 🤖 Agent context

Split out from #63584. The follow-up service PR (the V2 janitor dead-letter + fleet-health work) depends on this table existing, so this should merge and deploy first. Modeled on the V1 Rust cyclotron's `cyclotron_dead_letter_metadata` + dead-letter queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXea6mXQ3Yqh4TXF1fRve2)_