### PR TITLE
fix(mongodb): treat unescaped connection-string credentials as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -43,6 +43,11 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
+        unescaped_credentials_msg = (
+            "The username or password in your MongoDB connection string contains reserved characters "
+            "(such as @, :, /, or %) that must be percent-encoded. URL-encode them with "
+            "urllib.parse.quote_plus and update the connection string for this source."
+        )
         return {
             "The DNS query name does not exist": None,
             # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
@@ -65,6 +70,12 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # differently (a bare AutoReconnect / NetworkTimeout with no topology description) and
             # stays retryable.
             "Topology Description:": _MONGO_UNREACHABLE_MESSAGE,
+            # pymongo raises InvalidURI ("Username and password must be escaped according to RFC
+            # 3986, use urllib.parse.quote_plus") — and a ValueError with the same "must be escaped
+            # according to RFC 3986" hint — when the stored connection string has unescaped reserved
+            # characters in the credentials. The string itself is malformed, so every retry parses it
+            # the same way and fails identically; only the user fixing the connection string recovers it.
+            "must be escaped according to RFC 3986": unescaped_credentials_msg,
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -360,6 +360,17 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "27017: connection closed (configured timeouts: socketTimeoutMS: 20000.0ms, "
                 "connectTimeoutMS: 20000.0ms)')>]>",
             ),
+            # pymongo InvalidURI when credentials contain unescaped reserved characters.
+            (
+                "unescaped_credentials_invalid_uri",
+                "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus",
+            ),
+            # pymongo's ValueError variant of the same mistake (unescaped char read as part of the port).
+            (
+                "unescaped_credentials_port_hint",
+                "Port contains non-digit characters. Hint: username and password must be escaped "
+                "according to RFC 3986, use urllib.parse.quote_plus",
+            ),
         ]
     )
     def test_known_errors_are_non_retryable(self, _name, error_msg):
@@ -391,6 +402,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ("code_name", "AuthenticationFailed", "password"),
             ("message", "Authentication failed", "password"),
             ("unreachable_topology", "Topology Description:", "allowlist"),
+            ("unescaped_credentials", "must be escaped according to RFC 3986", "encode"),
         ]
     )
     def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):


### PR DESCRIPTION
## Problem

The MongoDB data-warehouse import source is throwing a recurring `InvalidURI` from PostHog error tracking:

> Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus

It originates in `mongo_client` (`posthog/temporal/data_imports/sources/mongodb/mongo.py`), where the user-supplied connection string is handed to `MongoClient(...)`. pymongo refuses to parse a connection string whose username or password contains reserved characters (`@`, `:`, `/`, `%`) that aren't percent-encoded.

This is a user/upstream configuration problem: the stored connection string is malformed per RFC 3986. Every sync retry parses the same string and fails identically — there's nothing transient to recover, and we can't safely re-escape the credentials ourselves (we can't tell an intentional `%` from an unescaped one). The job was being retried repeatedly instead of being marked non-retryable, so the error has been firing continuously.

## Changes

- Add the stable substring `must be escaped according to RFC 3986` to `MongoDBSource.get_non_retryable_errors()`, mirroring the existing Stripe/MongoDB pattern. The substring is low-false-positive: it matches both pymongo's `InvalidURI` form and its `ValueError` "Port contains non-digit characters" variant of the same mistake, contains no volatile data (URLs, ids, timestamps), and does not collide with the unrelated RFC 2396/2732 host-escaping errors.
- The friendly message tells the user to URL-encode the credentials with `urllib.parse.quote_plus` and update the connection string.
- Extend the existing `TestMongoDBNonRetryableErrors` parametrized tests to assert both message variants are recognised as non-retryable and that the pattern carries a friendly message.

## How did you test this code?

I'm an agent. I ran the source's unit tests with `uv run pytest` — the full `test_mongo.py` suite passes (49 tests, including the new non-retryable cases), and `ruff check` is clean on both changed files. No manual end-to-end testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MongoDB import source. Confirmed via the PostHog error-tracking tools that the failure's top in-app frame is `mongo_client` in this source (active, high volume, last seen today), read the source + shared helper to find that the connection string is passed verbatim to pymongo, and verified the exact pymongo message string in the installed `pymongo` package. Classified it as a user/upstream config error (malformed connection string, not a transient infra issue and not a code bug we can fix safely) and so extended `NonRetryableErrors` rather than changing code behavior. Chose the matching substring to be stable across pymongo's two message variants while avoiding the RFC 2396/2732 host errors.
