### PR TITLE
fix(linear): treat deleted integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -55,6 +55,10 @@ class LinearSource(ResumableSource[LinearSourceConfig, LinearResumeConfig], OAut
         return {
             "401 Client Error": "Invalid Linear credentials. Please reconnect your account.",
             "403 Client Error": "Access forbidden. Your token may lack required permissions.",
+            # The linked OAuth integration was deleted while the source still references it.
+            # Retrying can never resolve this — the integration won't reappear — so stop and
+            # ask the user to reconnect. Matched as a substring; the trailing integration id varies.
+            "Integration not found": "The linked Linear integration no longer exists. Please reconnect your Linear account.",
         }
 
     def _get_access_token(self, config: LinearSourceConfig, team_id: int) -> str:

--- a/posthog/temporal/data_imports/sources/linear/test_linear.py
+++ b/posthog/temporal/data_imports/sources/linear/test_linear.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.sources.linear.linear import (
     _make_paginated_request,
     linear_source,
 )
+from posthog.temporal.data_imports.sources.linear.source import LinearSource
 
 
 def _make_response(nodes: list[dict[str, Any]], has_next_page: bool, end_cursor: str | None) -> MagicMock:
@@ -252,3 +253,30 @@ class TestLinearSource:
 
         assert pages == [[{"id": "a"}], [{"id": "b"}]]
         manager.save_state.assert_called_once_with(LinearResumeConfig(cursor="cursor-a"))
+
+
+class TestLinearSourceNonRetryableErrors:
+    @parameterized.expand(
+        [
+            # The OAuthMixin raises "Integration not found: <id>" when the linked integration was
+            # deleted. The id varies, so matching must rely on the stable prefix.
+            ("deleted_integration", "Integration not found: 165665"),
+            ("auth_401", "401 Client Error: Unauthorized for url: https://api.linear.app/graphql"),
+            ("forbidden_403", "403 Client Error: Forbidden for url: https://api.linear.app/graphql"),
+        ]
+    )
+    def test_non_retryable_errors_match(self, _name: str, observed_error: str) -> None:
+        non_retryable_errors = LinearSource().get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @parameterized.expand(
+        [
+            ("transient_500", "500 Server Error for url: https://api.linear.app/graphql"),
+            ("rate_limited", "Linear: rate limited (429)"),
+            ("graphql_error", "Linear GraphQL error: Something failed"),
+        ]
+    )
+    def test_non_retryable_errors_does_not_match_transient(self, _name: str, observed_error: str) -> None:
+        non_retryable_errors = LinearSource().get_non_retryable_errors()
+        # Transient/server errors must stay retryable so the pipeline backs off and retries.
+        assert not any(key in observed_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

The Linear data-warehouse import source surfaces a high-frequency, handled `ValueError: Integration not found: <id>` in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019d476f-310a-78e3-886c-0c0876a3f847)). It has fired continuously for months.

The failure originates in `LinearSource._get_access_token` (`posthog/temporal/data_imports/sources/linear/source.py`), which calls `OAuthMixin.get_oauth_integration`. That helper raises `Integration not found: <id>` when the linked OAuth integration row no longer exists — i.e. the user deleted/disconnected their Linear account, but the import source still references it.

This is a user/upstream-config error, not a bug in our pipeline: the integration will never reappear within a run, so every retry is wasted work and adds noise.

## Changes

Extend `LinearSource.get_non_retryable_errors` with the stable `"Integration not found"` substring (the trailing integration id varies, so it's deliberately excluded from the match), surfacing a "reconnect your Linear account" message. This mirrors the existing handling in the Stripe source.

Added a parameterized regression test asserting the deleted-integration message (and existing 401/403 cases) is recognised as non-retryable, while transient/server/rate-limit errors stay retryable.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests only — no manual testing:

- `pytest posthog/temporal/data_imports/sources/linear/test_linear.py` — 18 passed
- `ruff check` + `ruff format --check` on both changed files — clean

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from a PostHog error-tracking webhook for the `linear` import source. Confirmed via the error-tracking MCP tools that the top in-app frame is `get_oauth_integration` (mixins.py) reached through `linear/source.py:_get_access_token`, and that the message is the deleted-integration case. Decision was user/upstream error → extend the source's `NonRetryableErrors` rather than change code behaviour, matching the established Stripe pattern. Matched on the stable substring only, leaving transient errors (500s, 429 rate limits) retryable.