### PR TITLE
fix(temporalio): treat empty host config as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -34,6 +34,10 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
         # rustls surfaces mTLS rejections as TLS alert names inside the tonic transport
         # error. These are credential problems — retrying can never recover.
         return {
+            # The Temporal SDK raises this when the host is blank, so `f"{host}:{port}"`
+            # has no host portion. That's a misconfigured source, not a transient failure —
+            # retrying can never recover until the host is set.
+            "invalid target URL: empty host": "This source has no host configured. Update the source with the host of your Temporal namespace's gRPC endpoint.",
             "received fatal alert: UnknownCA": "Temporal rejected this source's client certificate because it is not signed by a certificate authority the namespace trusts. This usually means the namespace's CA certificates were rotated — update the source with a client certificate and key signed by the current CA.",
             "received fatal alert: CertificateExpired": "This source's client certificate has expired. Update the source with a renewed client certificate and key.",
             "received fatal alert: CertificateRevoked": "This source's client certificate has been revoked. Update the source with a new client certificate and key.",

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -63,6 +63,20 @@ class TestTemporalIONonRetryableErrors:
     @pytest.mark.parametrize(
         "error_message",
         [
+            "invalid target URL: empty host",
+            "ValueError: invalid target URL: empty host",
+        ],
+    )
+    def test_empty_host_config_is_non_retryable(self, error_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert any(pattern in error_message for pattern in non_retryable_errors), (
+            f"Expected '{error_message}' to match a non-retryable pattern"
+        )
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
             "activity Heartbeat timeout",
             'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Os { code: 60, kind: TimedOut, message: "Operation timed out" }))) }',
         ],


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `ValueError: invalid target URL: empty host` ([issue](https://us.posthog.com/project/2/error_tracking/019dac51-5d86-7b22-a576-27bbf3682646)) originating in the TemporalIO data-warehouse import source. The stack trace confirms the failure begins in this source's own code:

```
_get_workflow_histories  posthog/temporal/data_imports/sources/temporalio/temporalio.py
  → _get_temporal_client  temporalio.py
    → connect             posthog/temporal/common/client.py:45
      → Client.connect    → ValueError: invalid target URL: empty host
```

The captured config shows every field empty (`host=''`, `port=''`, `namespace=''`, …), so `f"{host}:{port}"` collapses to `":"` and the Temporal SDK rejects it. This is a misconfigured source — there is nothing for us to do but stop retrying until the host is set. Left retryable, it retried tens of thousands of times.

## Changes

Add `"invalid target URL: empty host"` to `TemporalIOSource.get_non_retryable_errors()` (mirroring the Stripe pattern), with an actionable user-facing message asking the user to configure the host. The match is on the stable SDK error substring, with no volatile URL/id/timestamp content.

## How did you test this code?

I'm an agent (Claude Code). I added a parameterized regression test (`test_empty_host_config_is_non_retryable`) asserting the new string is recognised as non-retryable, and confirmed the existing transient-failure test still passes (transient errors stay retryable). Ran:

```
pytest posthog/temporal/data_imports/sources/temporalio/test_temporalio.py::TestTemporalIONonRetryableErrors
# 10 passed
```

Also ran `ruff check` and `ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue with Claude Code. Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the frames under `sources/temporalio/` are genuinely in the call path (not just serialized log context), and that the root cause is an empty `host` in the source config. Classified this as a user/upstream configuration error rather than a code bug — there is no response shape to handle or pagination to fix, the connection simply cannot succeed with no host — so the fix extends `NonRetryableErrors` rather than changing connection logic. Scoped strictly to this error; no retry-policy or pipeline-wide changes.
