### PR TITLE
fix(bigquery): treat billingNotEnabled 403 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -81,6 +81,10 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # build `project.project.dataset.table` and the client rejects it. It's a deterministic
             # config error, so retrying never succeeds.
             "table_id must be a fully-qualified ID in standard SQL format": "Your BigQuery Dataset ID looks misconfigured — it should be just the dataset name (for example `analytics`), not `project.dataset`. Please update the Dataset ID in your source configuration.",
+            # Forbidden 403 with `reason: billingNotEnabled` — the customer's Google Cloud project
+            # has billing disabled (BigQuery sandbox mode), so any query job is rejected before it
+            # runs. There's nothing we can do but stop retrying until they enable billing.
+            "Billing has not been enabled for this project": "BigQuery billing is not enabled for your Google Cloud project. Enable billing in the Google Cloud console (https://console.cloud.google.com/billing), then resume this source.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a
             # narrower numeric type) after the destination table was created with the narrower

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -667,3 +667,20 @@ def test_bigquery_storage_read_client_disables_grpc_message_size_limit():
     options = dict(mock_transport_cls.create_channel.call_args.kwargs["options"])
     assert options["grpc.max_receive_message_length"] == -1
     assert options["grpc.max_send_message_length"] == -1
+
+
+def test_bigquery_billing_not_enabled_is_non_retryable():
+    """A `billingNotEnabled` Forbidden 403 is a customer config issue — retrying never helps."""
+    # Representative message from a real failed job (the `reason: billingNotEnabled` 403 raised
+    # by `job.result()` when the source project has BigQuery billing disabled / is in sandbox mode).
+    internal_error = (
+        "Forbidden: 403 Billing has not been enabled for this project. Enable billing at "
+        "https://console.cloud.google.com/billing. Datasets must have a default expiration time "
+        "and default partition expiration time of less than 60 days while in sandbox mode.; "
+        "reason: billingNotEnabled, message: Billing has not been enabled for this project."
+    )
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+
+    # Mirror the substring match used by `update_external_data_job_model`.
+    assert any(key in internal_error for key in non_retryable_errors)

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -670,7 +670,7 @@ def test_bigquery_storage_read_client_disables_grpc_message_size_limit():
 
 
 def test_bigquery_billing_not_enabled_is_non_retryable():
-    """A `billingNotEnabled` Forbidden 403 is a customer config issue — retrying never helps."""
+    # A `billingNotEnabled` Forbidden 403 is a customer config issue — retrying never helps.
     # Representative message from a real failed job (the `reason: billingNotEnabled` 403 raised
     # by `job.result()` when the source project has BigQuery billing disabled / is in sandbox mode).
     internal_error = (
@@ -682,5 +682,7 @@ def test_bigquery_billing_not_enabled_is_non_retryable():
 
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
 
+    billing_key = "Billing has not been enabled for this project"
+    assert billing_key in non_retryable_errors, "expected billing key to be non-retryable"
     # Mirror the substring match used by `update_external_data_job_model`.
-    assert any(key in internal_error for key in non_retryable_errors)
+    assert billing_key in internal_error


### PR DESCRIPTION
## Problem

A BigQuery data-warehouse import source whose Google Cloud project has billing disabled (BigQuery "sandbox mode") fails every sync with a `Forbidden` 403:

```
Forbidden: 403 Billing has not been enabled for this project. Enable billing at
https://console.cloud.google.com/billing. ...; reason: billingNotEnabled, ...
```

The error is raised by `job.result()` in `get_rows` (`posthog/temporal/data_imports/sources/bigquery/bigquery.py`) when the data-read query job runs. This is purely a customer-side configuration issue — the project simply has no billing enabled — so every retry fails identically. Because the message wasn't in the source's `NonRetryableErrors`, the pipeline kept retrying it indefinitely (observed attempt counts in the tens of thousands), generating a large, non-actionable error volume.

Surfaced by error tracking: [issue `019cdc8e-1546-75e2-87a1-80cda9deef4f`](https://us.posthog.com/project/2/error_tracking/019cdc8e-1546-75e2-87a1-80cda9deef4f).

## Changes

- Add `"Billing has not been enabled for this project"` to `BigQuerySource.get_non_retryable_errors()` with an actionable user-facing message pointing to the Google Cloud billing console. The substring is the stable, machine-independent part of the message (no URLs, job IDs, regions, or timestamps), keeping false positives low. The dispatcher (`update_external_data_job_model`) then marks the schema as not-to-sync and surfaces the friendly message instead of retrying.
- Add a regression test asserting the representative real error string is matched as non-retryable, mirroring the substring match the dispatcher uses.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing. Automated test run:

- `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — 21 passed, including the new `test_bigquery_billing_not_enabled_is_non_retryable`.
- `ruff check` on both changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged the error-tracking issue end to end: confirmed via the PostHog error-tracking MCP tools that the top in-app frame is `get_rows` at `bigquery.py:782` (the incremental-path `job.result()` data read), exception type `Forbidden` from `google.api_core.exceptions`, with `reason: billingNotEnabled`. Classified it as a user/upstream config error (billing disabled on the customer's GCP project) rather than a code bug — there is no response shape or pagination we can fix, and retrying can never succeed — so the correct action is extending `NonRetryableErrors` rather than changing code under the source. Matched on the stable human-readable phrase over volatile parts (URL, job id, region), following the existing BigQuery/Stripe patterns.
