### PR TITLE
fix(google_sheets): retry transient API errors in get_schemas

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -1,6 +1,7 @@
 import time
 import random
-from typing import Any, Optional
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 
 from django.conf import settings
 
@@ -56,28 +57,23 @@ _RETRYABLE_API_ERROR_CODES = {429, 500, 502, 503, 504}
 # stable, descriptive message so downstream matching can identify it.
 _PERMISSION_DENIED_MESSAGE = "Spreadsheet access denied. Please share the spreadsheet with the PostHog service account."
 
+T = TypeVar("T")
 
-@cached(cache)
-def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
-    """Attempt to get a worksheet with linear backoff. Google Sheets has a 300
+
+def _with_api_retries(fn: Callable[[], T]) -> T:
+    """Run a Google Sheets API call with linear backoff. Google Sheets has a 300
     request quota per minute, and also returns transient 5xx server errors. We
     retry both (see `_RETRYABLE_API_ERROR_CODES`) and add a +- 10s jitter to the
     sleep per attempt so that multiple jobs blocked by quota limits dont all retry
-    at the same time"""
-
-    def execute():
-        client = google_sheets_client()
-        try:
-            spreadsheet = client.open_by_url(spreadsheet_url)
-        except PermissionError as e:
-            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
-        return spreadsheet.get_worksheet_by_id(worksheet_id)
+    at the same time. Every API call site should go through this helper — an
+    unwrapped call lets a transient "[500]: Internal error encountered." fail the
+    sync on the first occurrence."""
 
     attempts = 1
 
     while True:
         try:
-            return execute()
+            return fn()
         except gspread.exceptions.APIError as e:
             if e.code not in _RETRYABLE_API_ERROR_CODES or attempts >= max_attempts:
                 raise
@@ -89,15 +85,31 @@ def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet
             attempts = attempts + 1
 
 
+@cached(cache)
+def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
+    def execute():
+        client = google_sheets_client()
+        try:
+            spreadsheet = client.open_by_url(spreadsheet_url)
+        except PermissionError as e:
+            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        return spreadsheet.get_worksheet_by_id(worksheet_id)
+
+    return _with_api_retries(execute)
+
+
 def get_schemas(config: GoogleSheetsSourceConfig) -> list[tuple[str, int]]:
     """Returns a tuple of worksheets in the form of (title, id)"""
 
-    client = google_sheets_client()
-    try:
-        spreadsheet = client.open_by_url(config.spreadsheet_url)
-    except PermissionError as e:
-        raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
-    worksheets = spreadsheet.worksheets()
+    def execute():
+        client = google_sheets_client()
+        try:
+            spreadsheet = client.open_by_url(config.spreadsheet_url)
+        except PermissionError as e:
+            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        return spreadsheet.worksheets()
+
+    worksheets = _with_api_retries(execute)
 
     return [(NamingConvention.normalize_identifier(worksheet.title), worksheet.id) for worksheet in worksheets]
 

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -83,6 +83,57 @@ def test_get_worksheet_retries_transient_api_errors(status_code):
         assert mock_get_worksheet_by_id.call_count == 10
 
 
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+def test_get_schemas_retries_transient_api_errors(status_code):
+    """get_schemas opens the spreadsheet and lists worksheets directly (not via
+    _get_worksheet), so it must apply the same backoff — otherwise a transient
+    "[500]: Internal error encountered." from open_by_url fails the sync on the
+    first occurrence."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {
+            "error": {"code": status_code, "message": "Internal error encountered.", "status": "INTERNAL"}
+        }
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.side_effect = gspread.exceptions.APIError(mock_response)
+
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schemas(config)
+
+        assert instance.open_by_url.call_count == 10
+
+
+def test_get_schemas_does_not_retry_non_transient_api_error():
+    """A non-transient API error (e.g. 400) raised from get_schemas should surface
+    immediately without burning through the retry budget."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {
+            "error": {"code": 400, "message": "Bad request", "status": "INVALID_ARGUMENT"}
+        }
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.side_effect = gspread.exceptions.APIError(mock_response)
+
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schemas(config)
+
+        assert instance.open_by_url.call_count == 1
+
+
 def test_get_worksheet_does_not_retry_non_transient_api_error():
     """A non-transient API error (e.g. 400) should be raised immediately without
     burning through the retry budget."""


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `APIError: [500]: Internal error encountered.` from the `google_sheets` data-warehouse import source ([issue 019ce74d](https://us.posthog.com/project/2/error_tracking/019ce74d-df3b-7ed1-8f52-ce736a268d6b)). The stack consistently bottoms out at `get_schemas` (`google_sheets.py:97`) calling `client.open_by_url(...)`, reached via `source_for_pipeline` → `google_sheets_source` → `get_schemas`.

This is a transient Google server-side error (Google's own guidance is to retry 5xx with backoff), so it should **not** be made non-retryable. The source already agrees: it classifies `{429, 500, 502, 503, 504}` as retryable in `_RETRYABLE_API_ERROR_CODES`. The bug is that the backoff loop lived **only** inside `_get_worksheet`. `get_schemas()` — called at the top of both `google_sheets_source` and `get_schema_incremental_fields` — issued raw `open_by_url()` / `worksheets()` calls with no retry, so a transient 500 from that path propagated immediately and failed the sync on its first occurrence, defeating the code's own intent.

## Changes

- Extracted the existing linear-backoff-with-jitter retry loop out of `_get_worksheet` into a shared `_with_api_retries` helper.
- Routed both `_get_worksheet` and `get_schemas` through it, so every Google Sheets API call site retries the transient errors the source already classifies as retryable.

No behavior change beyond retrying the errors the code already intended to retry; non-transient errors (e.g. 400) and the `PermissionError` re-raise are unaffected.

## How did you test this code?

I'm an agent. I added and ran automated tests (`.venv/bin/python -m pytest posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py` — 19 passed):

- `test_get_schemas_retries_transient_api_errors` (parametrized over 429/500/502/503/504): asserts `open_by_url` is attempted the full 10 times. This fails against the pre-fix code, where `get_schemas` attempted the call exactly once.
- `test_get_schemas_does_not_retry_non_transient_api_error`: a 400 surfaces immediately (single attempt), so the retry budget isn't burned on permanent failures.

Existing `_get_worksheet` retry/caching/permission tests continue to pass.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue surfaced via webhook. Used the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue originates in this source (stack frame in `get_schemas`), then read the source to understand the retry design. Decided this is a fixable bug rather than a user/upstream error or a candidate for `NonRetryableErrors`: the 500 is a transient server-side error the code already intends to retry, but the retry didn't cover the originating call site. Kept the change scoped to extracting the existing retry into a shared helper and applying it to `get_schemas`.
