### PR TITLE
fix(snowflake): treat no-active-warehouse error as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -173,6 +173,11 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "This account has been marked for decommission": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
+            # Snowflake error 000606 (57P03): the session has no active warehouse, so the first query
+            # needing compute fails. The connector doesn't fail at connect time even when the configured
+            # warehouse is missing/suspended or the role lacks USAGE on it — it just leaves the session
+            # warehouse unset. Retrying can never succeed until the customer fixes the grant or warehouse.
+            "No active warehouse selected in the current session": "No active warehouse is available for this connection. Check that the configured warehouse exists, is running, and that the connecting role has USAGE on it, then resync.",
             "404 Not Found": None,
             "Your free trial has ended": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
             "Your account is suspended due to lack of payment method": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -580,6 +580,20 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "No active warehouse selected in the current session.  Select an active warehouse with the 'use warehouse' command.",
+            # The real shape from production: the query id varies, but the warehouse substring is stable.
+            "000606 (57P03): 01c51211-0105-f139-0002-113a46e58fba: No active warehouse selected in the current "
+            "session.  Select an active warehouse with the 'use warehouse' command.",
+        ],
+    )
+    def test_no_active_warehouse_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"No-active-warehouse error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
             "Operation timed out while waiting for the warehouse to resume",
         ],


### PR DESCRIPTION
## Problem

The Snowflake data-warehouse import source repeatedly fails with a `ProgrammingError`:

```
000606 (57P03): <query-id>: No active warehouse selected in the current session.
Select an active warehouse with the 'use warehouse' command.
```

This is surfaced by error tracking as a high-frequency, recurring issue (raised in `posthog/temporal/data_imports/sources/snowflake/snowflake.py` during schema discovery → `get_columns`).

This is a customer configuration problem, not a transient one. The Snowflake connector does **not** fail at connect time when the configured warehouse is missing/suspended or the connecting role lacks `USAGE` on it — it simply leaves the session with no active warehouse. The first query that needs compute (here, the `INFORMATION_SCHEMA.COLUMNS` read in `get_columns`) then fails with `000606 (57P03)`. Retrying can never succeed until the customer grants the role `USAGE` on a valid, running warehouse, so the sync should stop retrying and surface an actionable message instead of churning.

## Changes

- Add `"No active warehouse selected in the current session"` to `SnowflakeSource.get_non_retryable_errors`, mapped to an actionable message telling the customer to check the warehouse exists, is running, and that the connecting role has `USAGE` on it.

A friendly message for this string already existed in `SnowflakeErrors`, but that map is only consulted during credential validation — the sync-time retry path (`external_data_job.py`, substring match against `get_non_retryable_errors`) did not recognise it. The match key avoids the volatile query-id/error-code prefix, so it stays low-false-positive. It does not match the transient `"Operation timed out while waiting for the warehouse to resume"` error, which remains retryable.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_no_active_warehouse_is_non_retryable`) covering both the bare and full production-shape messages, and ran the automated suite:

- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` — 66 passed
- `ruff check` and `ruff format --check` on the source dir — clean

The existing `test_transient_errors_are_retryable` test still passes, confirming the warehouse-resume timeout stays retryable.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Snowflake import source. Confirmed the stack genuinely originates in this source's `get_columns` (call path `get_schemas` → `get_columns`), with the configured warehouse present in the connection but unusable by the session. Classified as a user/upstream configuration error rather than a code bug — Snowflake's connect-time silence means our code has nothing sensible to do but stop retrying — so extended `NonRetryableErrors` rather than changing connection logic. Mirrors the existing pattern used for disabled-user and Duo-MFA errors in the same source.

Tools used: PostHog error-tracking MCP tools to confirm the issue and pull the stack trace; standard editor/test tooling.
