### PR TITLE
fix(hubspot): treat deleted integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -90,6 +90,10 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             "Hubspot refresh token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",
             # Raised by source_for_pipeline (OAuth path) when the integration is missing its access or refresh token.
             "Hubspot refresh or access token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",
+            # Raised by OAuthMixin.get_oauth_integration when the referenced integration row no longer
+            # exists (e.g. the HubSpot connection was deleted while the source still points at it).
+            # Retrying cannot recreate a deleted integration. Match the stable prefix, not the volatile id.
+            "Integration not found": "The linked HubSpot integration no longer exists. Please reconnect your HubSpot account.",
         }
 
     # TODO: clean up hubspot job inputs to not have two auth config options

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -226,6 +226,9 @@ class TestSettingsShape:
         "Hubspot refresh token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b",
         # HubspotSourceConfig OAuth path
         "Hubspot refresh or access token not found for job 019cdc50-67a5-0000-c023-0d6a4e057e9b",
+        # OAuthMixin.get_oauth_integration when the integration row was deleted (id varies per source)
+        "Integration not found: 56366",
+        "Integration not found: 157288",
     ],
 )
 def test_missing_token_error_is_non_retryable(error_msg: str) -> None:


### PR DESCRIPTION
## Problem

The `hubspot` data-warehouse import source surfaced a high-volume error in error tracking:

- **Exception:** `ValueError: Integration not found: <id>`
- **Raised in:** `OAuthMixin.get_oauth_integration` (`posthog/temporal/data_imports/sources/common/mixins.py:175`), called from `HubspotSource.source_for_pipeline` (`posthog/temporal/data_imports/sources/hubspot/source.py:139`)
- **Issue:** https://us.posthog.com/project/2/error_tracking/019cdc44-8b5c-74e0-8486-174aee6d1373

The source config still carries a `hubspot_integration_id`, but the referenced `Integration` row no longer exists (the HubSpot connection was deleted while the source kept pointing at it). `get_oauth_integration` looks it up, finds nothing, and raises. Because this string wasn't in the source's `get_non_retryable_errors`, the import job retried a permanent misconfiguration indefinitely.

## Changes

- Add `"Integration not found"` to `HubspotSource.get_non_retryable_errors`, with a friendly reconnect message. This mirrors the existing Stripe source, which already treats the same string as non-retryable.
- Match on the stable `"Integration not found"` prefix (the matcher is a substring check) rather than the volatile integration id.
- Extend the existing parametrized non-retryable test with the real error messages.

A deleted integration cannot be recreated by retrying, so this is a user/upstream configuration error: stop retrying and prompt the user to reconnect. Scope is limited to this one error string — no global retry-policy change.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran:

- `pytest posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py` — 36 passed, including the 4 cases of `test_missing_token_error_is_non_retryable` (2 new).
- `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the HubSpot warehouse source. Confirmed via the PostHog error-tracking MCP tools that the failure originates in the source's own call path (`source_for_pipeline` → `get_oauth_integration`), not just in serialized log context. Classified it as a user/upstream error (deleted integration, unrecoverable by retry) rather than a code bug, and extended `NonRetryableErrors` following the documented Stripe pattern — which already handles the identical `"Integration not found"` case for its OAuth path.
