### PR TITLE
fix(mongodb): treat unescaped connection-string credentials as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -50,6 +50,11 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
+        unescaped_userinfo_msg = (
+            "Your MongoDB connection string has special characters (such as '@', ':', '/', or '%') in the "
+            "username or password that must be percent-encoded. URL-encode them — for example replace '@' "
+            "with '%40' — and update the connection string for this source."
+        )
         return {
             "The DNS query name does not exist": None,
             # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
@@ -73,6 +78,12 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # is the stable signal here, and it must be matched before the generic "Topology Description:"
             # entry below so Atlas SQL users get the wrong-endpoint message rather than the allowlist one.
             "query.mongodb.net": _MONGO_ATLAS_SQL_MESSAGE,
+            # pymongo raises InvalidURI ("Username and password must be escaped according to RFC 3986,
+            # use urllib.parse.quote_plus") when the connection string's userinfo contains characters
+            # that aren't percent-encoded (e.g. an unescaped '@' in the password). The connection string
+            # is static, so every retry hits the same parse failure before any network call — it can
+            # never succeed until the user fixes their credentials.
+            "must be escaped according to RFC 3986": unescaped_userinfo_msg,
             # pymongo raises ServerSelectionTimeoutError when it can't select a usable cluster node
             # for the whole selection timeout. The reason varies — "No servers found yet" / "No
             # replica set members found yet" when nothing was ever discovered, or a per-server

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -378,6 +378,12 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "('atlas-sql-681905984ce3f87167df11fa-wf3cgp.a.query.mongodb.net', 27017) "
                 "server_type: Unknown, rtt: None, error=AutoReconnect('...connection closed...')>]>",
             ),
+            # Real pymongo InvalidURI string when the userinfo (e.g. an unescaped '@' in the password)
+            # isn't percent-encoded. The connection string is static, so retrying can never succeed.
+            (
+                "unescaped_userinfo",
+                "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus",
+            ),
         ]
     )
     def test_known_errors_are_non_retryable(self, _name, error_msg):
@@ -411,6 +417,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ("atlas_bad_auth", "bad auth", "password"),
             ("unreachable_topology", "Topology Description:", "allowlist"),
             ("atlas_sql_endpoint", "query.mongodb.net", "connection string"),
+            ("unescaped_userinfo", "must be escaped according to RFC 3986", "percent-encoded"),
         ]
     )
     def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):


### PR DESCRIPTION
## Problem

The MongoDB data-warehouse import source is throwing a recurring `InvalidURI` error from pymongo: _"Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"_.

This fires when a user's connection string has special characters (such as `@`, `:`, `/`, or `%`) in the username or password that aren't percent-encoded — pymongo refuses to parse the URI before any network call is made. Because the connection string is static, the import job retries the same parse failure on every attempt and can never succeed until the user fixes their credentials. The surfaced issue shows ~1.9k occurrences and attempts climbing into the high single digits per run.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e4313-5b7d-7683-8de5-b000b0840f53

The stack trace originates squarely in this source:
`MongoDBSource.source_for_pipeline` → `mongo_source` → `mongo_client` (`mongo.py:242`, the `MongoClient(...)` construction) → pymongo `_validate_uri` / `parse_userinfo` → `InvalidURI`.

## Changes

Treat the `InvalidURI` parse failure as non-retryable in `MongoDBSource.get_non_retryable_errors`, matching on the stable substring `must be escaped according to RFC 3986` (no volatile URLs/ids/timestamps). When matched, the user gets an actionable message telling them to percent-encode the special characters in their credentials and update the connection string.

This is a user/upstream configuration error — there is nothing sensible for us to do but stop retrying. Auto-escaping the userinfo was rejected: a connection string with an unescaped `@` in the password is genuinely ambiguous to split, and MongoDB itself requires users to percent-encode userinfo, so silently rewriting it could connect with the wrong credentials.

Scope is strictly this one error string; the global retry policy is untouched.

## How did you test this code?

I'm an agent (Claude Code). I added the real pymongo `InvalidURI` message to the existing `TestMongoDBNonRetryableErrors` parameterized cases (both the "is non-retryable" assertion and the friendly-message assertion) and ran the source's unit tests:

- `pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py` — 48 passed
- `ruff check` on the changed files — clean

No manual end-to-end run against a live MongoDB source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MongoDB import source. Used PostHog error-tracking MCP tools to confirm the issue (full stack trace, representative event, frequency) and verified the failure originates in `posthog/temporal/data_imports/sources/mongodb/`. Decided this is a user/upstream config error rather than a code bug — the connection string is static and the parse fails deterministically before any I/O — so the fix extends `NonRetryableErrors` (mirroring the Stripe source pattern) instead of changing pipeline behavior. Considered and rejected auto-percent-encoding the userinfo because it is ambiguous and could mask wrong-credential connections.
