### PR TITLE
fix(salesforce): treat inactive user as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/salesforce/source.py
+++ b/posthog/temporal/data_imports/sources/salesforce/source.py
@@ -32,6 +32,10 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
             "400 Client Error: Bad Request for url": None,
             "403 Client Error: Forbidden for url": None,
             "inactive organization": None,
+            # Salesforce's OAuth token endpoint returns error_description "inactive user" when the
+            # user that authorized the connection has been deactivated. Retrying can't fix it —
+            # the user must be reactivated in Salesforce or the source reconnected with an active user.
+            "inactive user": "The Salesforce user for this connection is inactive. Reactivate it in Salesforce or reconnect the source with an active user.",
             # SalesforceAuthRequestError.raise_from_response formats token-refresh failures as
             # "<code> Client Error: <reason>: <error_description>", so the "... for url" patterns
             # above never match it. Key off the stable error_description returned by Salesforce

--- a/posthog/temporal/data_imports/sources/salesforce/test/test_auth.py
+++ b/posthog/temporal/data_imports/sources/salesforce/test/test_auth.py
@@ -100,14 +100,21 @@ def test_get_salesforce_access_token_from_code_raises_on_server_failure():
     assert response_body in str(exc.value)
 
 
-def test_expired_refresh_token_error_is_non_retryable():
-    """The SalesforceAuthRequestError raised for an expired refresh token must match a
-    non-retryable pattern, otherwise the job retries a permanent auth failure forever."""
+@pytest.mark.parametrize(
+    "error_description",
+    [
+        "expired access/refresh token",
+        "inactive user",
+    ],
+)
+def test_auth_error_is_non_retryable(error_description: str):
+    """SalesforceAuthRequestErrors raised for permanent auth failures (expired/revoked token,
+    deactivated user) must match a non-retryable pattern, otherwise the job retries forever."""
     from posthog.temporal.data_imports.sources.salesforce.source import SalesforceSource
 
     response = requests.Response()
     response.status_code = 400
-    response._content = json.dumps({"error_description": "expired access/refresh token"}).encode("utf-8")
+    response._content = json.dumps({"error_description": error_description}).encode("utf-8")
 
     with (
         unittest.mock.patch(


### PR DESCRIPTION
## Problem

The Salesforce data-warehouse import source raises `SalesforceAuthRequestError: 400 Client Error: Bad Request: inactive user` during OAuth token refresh and then retries it indefinitely. Surfaced by error tracking: [issue 019dd090-e091-7e60-bbf4-bf7651a79df0](https://us.posthog.com/project/2/error_tracking/019dd090-e091-7e60-bbf4-bf7651a79df0).

Salesforce's OAuth token endpoint returns `error_description: "inactive user"` when the user that authorized the connection has been deactivated. The stack confirms the failure originates in `posthog/temporal/data_imports/sources/salesforce/auth.py`: `SalesforceAuth.__call__` → `obtain_token` → `salesforce_refresh_access_token` → `SalesforceAuthRequestError.raise_from_response`.

This is a user/upstream error — the credentials' Salesforce user has been disabled, so there is nothing for us to do but stop retrying. It is not caught by any existing non-retryable pattern: token-refresh failures are formatted as `"<code> Client Error: <reason>: <error_description>"`, so the existing `"400 Client Error: Bad Request for url"` key never matches, and the existing entries cover `"inactive organization"` / `"expired access/refresh token"` but not an inactive user.

## Changes

- Add `"inactive user"` to `SalesforceSource.get_non_retryable_errors()`, mirroring the existing `"inactive organization"` entry. Matches on the stable Salesforce `error_description` substring (no volatile URL/id/timestamp), with a friendly message telling the customer to reactivate the user in Salesforce or reconnect the source with an active user.
- Parameterize the existing non-retryable auth test to also assert the `"inactive user"` token-refresh error is recognised as non-retryable.

## How did you test this code?

I'm an agent. I ran the source's auth test suite, which now covers the new case:

```
pytest posthog/temporal/data_imports/sources/salesforce/test/test_auth.py
# 6 passed
```

Also ran `ruff check` and `ruff format` on both changed files (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed via the PostHog error-tracking tools that the issue's sampled events carry the message `400 Client Error: Bad Request: inactive user` and that the stack terminates inside `salesforce/auth.py` (`raise_from_response`), so the failure genuinely originates in this source. Classified it as a user/upstream error (deactivated Salesforce user — unrecoverable by retry) rather than a code bug, so the fix extends `NonRetryableErrors` rather than changing pipeline logic, following the same pattern as the Stripe source. Scope kept strictly to this one error string; global retry policy untouched.
