### PR TITLE
fix(mongodb): treat Atlas "bad auth" failure as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -51,6 +51,11 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # matched the real message — key off the stable codeName and the capitalised message.
             "AuthenticationFailed": auth_failed_msg,
             "Authentication failed": auth_failed_msg,
+            # MongoDB Atlas reports bad credentials differently from self-hosted MongoDB: it raises
+            # OperationFailure with codeName 'AtlasError' (code 8000) and the lowercase errmsg
+            # 'bad auth : authentication failed', so neither key above matches. "bad auth" is the
+            # stable, auth-specific prefix Atlas uses for credential failures.
+            "bad auth": auth_failed_msg,
             "SSL handshake failed": None,
             # pymongo raises ServerSelectionTimeoutError when it can't select a usable cluster node
             # for the whole selection timeout. The reason varies — "No servers found yet" / "No

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -337,6 +337,12 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', "
                 "'code': 18, 'codeName': 'AuthenticationFailed'}",
             ),
+            # Real pymongo OperationFailure string for bad credentials on MongoDB Atlas (code 8000).
+            (
+                "atlas_bad_auth",
+                "bad auth : authentication failed, full error: {'ok': 0, 'errmsg': 'bad auth : "
+                "authentication failed', 'code': 8000, 'codeName': 'AtlasError'}",
+            ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
             # ServerSelectionTimeoutError variants — cluster unreachable for the whole selection
@@ -390,6 +396,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         [
             ("code_name", "AuthenticationFailed", "password"),
             ("message", "Authentication failed", "password"),
+            ("atlas_bad_auth", "bad auth", "password"),
             ("unreachable_topology", "Topology Description:", "allowlist"),
         ]
     )


### PR DESCRIPTION
## Problem

The `mongodb` data-warehouse import source is repeatedly retrying jobs that fail with `OperationFailure: bad auth : authentication failed` (codeName `AtlasError`, code 8000). This is a credentials error on MongoDB Atlas — the username/password configured for the source is wrong — so retrying can never succeed, yet the job keeps retrying instead of stopping and telling the user to fix their credentials.

The source already classifies the self-hosted MongoDB credential failure as non-retryable (codeName `AuthenticationFailed`, code 18, errmsg `Authentication failed.`). But the non-retryable match is a **case-sensitive substring** match, and Atlas returns a different shape: lowercase `bad auth : authentication failed` with codeName `AtlasError`. Neither the `AuthenticationFailed` nor the `Authentication failed` pattern matches that string, so the Atlas variant slips through and stays retryable.

Surfaced by PostHog error tracking: https://us.posthog.com/project/2/error_tracking/019e42e3-0a72-7c42-87f2-5540a5c072dc — the stack originates in `posthog/temporal/data_imports/sources/mongodb/mongo.py` (cursor iteration → pymongo connect → SCRAM auth), confirming the failure is the import source connecting with bad credentials.

## Changes

Added a `"bad auth"` pattern to `MongoDBSource.get_non_retryable_errors()`, mapped to the existing friendly "check the username and password" message. `"bad auth"` is the stable, auth-specific prefix Atlas uses for credential failures and carries low false-positive risk. Extended the unit tests with the real Atlas `OperationFailure` string and a friendly-message assertion for the new pattern.

This is scoped strictly to the wrong-credentials case — transient connectivity errors remain retryable (existing `test_transient_errors_are_retryable` still holds).

## How did you test this code?

I'm an agent. I ran the existing unit suite for this source's non-retryable classification, which now includes the new Atlas case:

```
.venv/bin/pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py::TestMongoDBNonRetryableErrors -q
# 13 passed
```

Ruff check passed on both changed files. No manual end-to-end run against a live Atlas cluster.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the MongoDB import source. Pulled the issue and sampled events via the PostHog error-tracking MCP tools, confirmed the stack originates in `sources/mongodb/mongo.py`, and traced the failure to a bad-credentials `OperationFailure` from Atlas. Decided this is a user/upstream credentials error (nothing for us to do but stop retrying) rather than a code bug, so the fix extends the source's `NonRetryableErrors` mapping rather than changing pipeline behavior. Chose the substring `bad auth` over the volatile full error dict (which embeds a cluster-time signature) as the stable match key.
