### PR TITLE
fix(postgres): treat jsonb_each on non-object as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -280,6 +280,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 '(PostgreSQL reported "has not been populated"). Run REFRESH MATERIALIZED VIEW on it in '
                 "your database so it contains data, then re-enable the sync."
             ),
+            # Raised by Postgres while reading a view/materialized view whose own definition calls
+            # `jsonb_each()` (or `jsonb_each_text()`) on a jsonb value that isn't an object for some
+            # rows (a JSON array, scalar, or `'null'`). We only ever run `SELECT ... FROM <relation>`;
+            # the function lives in the customer's view definition. The failure is deterministic
+            # against the source data, so retrying re-evaluates the same view and hits the same row.
+            "cannot call jsonb_each on a non-object": "A view you're syncing calls jsonb_each() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
+            "cannot call jsonb_each_text on a non-object": "A view you're syncing calls jsonb_each_text() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each_text() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
         }
 
     def reconcile_schema_metadata(

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -344,6 +344,20 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "cannot call jsonb_each on a non-object",
+            "InvalidParameterValue: cannot call jsonb_each on a non-object",
+            "cannot call jsonb_each_text on a non-object",
+            "InvalidParameterValue: cannot call jsonb_each_text on a non-object",
+        ],
+    )
+    def test_jsonb_each_on_non_object_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"jsonb_each on non-object error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source is repeatedly failing and retrying on a deterministic, customer-side error surfaced by error tracking:

- **Exception:** `InvalidParameterValue: cannot call jsonb_each on a non-object`
- **Issue:** https://us.posthog.com/project/2/error_tracking/019e7444-00c4-7293-9185-121d968d8ccd

The real frame is `postgres.py:get_rows` → psycopg server cursor `fetchmany` → the Postgres server raises the error while streaming rows. Our code only ever runs `SELECT <cols> FROM <relation>` — it never calls `jsonb_each`. The relation being synced is a **view / materialized view** (the source syncs relkinds `v`/`m`) whose own definition calls `jsonb_each()` on a jsonb column that, for at least one row, holds a non-object value (a JSON array, scalar, or `'null'`). Postgres evaluates the view at fetch time and aborts.

This is deterministic against the source view + data: there is nothing for us to fix or wait out, and each retry re-evaluates the same view into the same row. So it should not consume retries.

## Changes

Add the error to `PostgresSource.get_non_retryable_errors` so the sync stops and surfaces an actionable message instead of retrying:

- `cannot call jsonb_each on a non-object`
- `cannot call jsonb_each_text on a non-object` (the sibling function raises the identical error class via the same root cause)

The friendly message points the customer at the fix: guard the call in their view definition (e.g. only call `jsonb_each()` when `jsonb_typeof(col) = 'object'`), or remove that view from the sync. Match strings are stable, low-false-positive substrings of the server error text — no URLs, ids, or timestamps.

This is scoped strictly to this error; global retry policy is untouched, and the transient/recovery-conflict errors remain retryable.

## How did you test this code?

I'm an agent (Claude Code). I added a parametrized regression test (`test_jsonb_each_on_non_object_is_non_retryable`) and ran the source's non-retryable suite:

```
pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors
# 23 passed
```

`ruff check` and `ruff format --check` pass on both changed files. No manual end-to-end run against a live Postgres source was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres source. Used PostHog error-tracking MCP tools to confirm the issue (active, 210 occurrences, last seen today) and pull the full stack trace, which placed the failure in `get_rows` while fetching from a server-side cursor. Read the source implementation to confirm we never emit `jsonb_each` ourselves and that the source syncs views — leading to the conclusion that this is a customer view-definition + data-shape problem (upstream/user error), not a fixable bug in our code or request shaping. Chose `NonRetryableErrors` over a code fix because the failure is deterministic and unfixable from our side. Included the `jsonb_each_text` variant since it is the same failure mode with an identical error shape.