### PR TITLE
fix(snowflake): treat expired password as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -186,6 +186,9 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # Snowflake error 250001: the user account was disabled by the customer's Snowflake admin
             # (e.g. `ALTER USER ... SET DISABLED = TRUE`). Retrying can never succeed until they re-enable it.
             "User access disabled. Contact your local system administrator": "Your Snowflake user account has been disabled. Please contact your Snowflake administrator to re-enable it, then resync.",
+            # Snowflake error 250001 (08001): the user's password has expired. Snowflake requires it
+            # to be changed via the web console before any login can succeed, so retrying never works.
+            "Specified password has expired": "Your Snowflake password has expired. Please change it in the Snowflake web console (or switch to key-pair authentication), then resync.",
             "MFA authentication is required": None,
             # The account enforces Duo Security multi-factor auth for this user, so the
             # connector's login is rejected (250001 / 08001). An unattended sync can't answer a

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -609,6 +609,20 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "Specified password has expired",
+            # The real shape from production: codes + host vary, but the substring is stable.
+            "250001 (08001): None: Failed to connect to DB: gbnacyk-mlb13594.snowflakecomputing.com:443. "
+            "Specified password has expired.  Password must be changed using the Snowflake web console.",
+        ],
+    )
+    def test_expired_password_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Expired-password error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
             "Operation timed out while waiting for the warehouse to resume",
         ],


### PR DESCRIPTION
## Problem

The Snowflake data-warehouse import source repeatedly fails (and Temporal keeps retrying) when a customer's Snowflake password has expired. Snowflake surfaces this at connection time as:

```
DatabaseError: 250001 (08001): None: Failed to connect to DB: <account>.snowflakecomputing.com:443. Specified password has expired.  Password must be changed using the Snowflake web console.
```

This is a permanent, user-side condition — Snowflake explicitly requires the password to be changed in its web console before any login can succeed — so every retry is doomed and just burns worker time while the sync stays broken with an opaque generic error. The failure originates in our own connection code (`posthog/temporal/data_imports/sources/snowflake/snowflake.py` `connect()`), surfaced via error tracking.

## Changes

- Add `"Specified password has expired"` to `SnowflakeSource.get_non_retryable_errors()` with an actionable message telling the user to change their password in the Snowflake web console (or switch to key-pair auth) and resync. This matches the existing pattern for disabled users and MFA-enforced accounts.
- The match key is a stable, low-false-positive substring — it deliberately excludes the per-request account host so it matches regardless of account or message-code formatting.
- Add a parametrized regression test covering both the bare substring and the full production-shaped message.

This is scoped strictly to the expired-password case; transient/connection errors remain retryable (covered by the existing `test_transient_errors_are_retryable`).

## How did you test this code?

I'm an agent. I added and ran the automated test for this change:

```
pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py::TestSnowflakeSourceNonRetryableErrors
# 8 passed
```

Also ran `ruff check` and `ruff format --check` on both changed files (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Snowflake import source. Confirmed via the error-tracking data that the failing frame is our own `snowflake.connector.connect(...)` call (not a serialized log variable), then read the source to classify the failure. Decision: this is a user/upstream credential-expiry error with no sensible retry, so it belongs in `NonRetryableErrors` rather than being a code bug — mirroring the existing Stripe/Snowflake patterns. Chose `"Specified password has expired"` as the match substring because it is stable across accounts and message-code variations, unlike the host/URL portions.
