### PR TITLE
fix(google_sheets): retry transient API errors during schema discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -1,6 +1,7 @@
 import time
 import random
-from typing import Any, Optional
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar
 
 from django.conf import settings
 
@@ -56,22 +57,15 @@ _RETRYABLE_API_ERROR_CODES = {429, 500, 502, 503, 504}
 # stable, descriptive message so downstream matching can identify it.
 _PERMISSION_DENIED_MESSAGE = "Spreadsheet access denied. Please share the spreadsheet with the PostHog service account."
 
+T = TypeVar("T")
 
-@cached(cache)
-def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
-    """Attempt to get a worksheet with linear backoff. Google Sheets has a 300
-    request quota per minute, and also returns transient 5xx server errors. We
-    retry both (see `_RETRYABLE_API_ERROR_CODES`) and add a +- 10s jitter to the
-    sleep per attempt so that multiple jobs blocked by quota limits dont all retry
-    at the same time"""
 
-    def execute():
-        client = google_sheets_client()
-        try:
-            spreadsheet = client.open_by_url(spreadsheet_url)
-        except PermissionError as e:
-            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
-        return spreadsheet.get_worksheet_by_id(worksheet_id)
+def _retry_on_transient_api_error(execute: Callable[[], T]) -> T:
+    """Run `execute` with linear backoff, retrying transient Google Sheets API
+    errors. Google Sheets has a 300 request quota per minute, and also returns
+    transient 5xx server errors (see `_RETRYABLE_API_ERROR_CODES`). We retry both
+    and add a +- 10s jitter to the sleep per attempt so that multiple jobs blocked
+    by quota limits dont all retry at the same time."""
 
     attempts = 1
 
@@ -89,15 +83,34 @@ def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet
             attempts = attempts + 1
 
 
+@cached(cache)
+def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet:
+    def execute():
+        client = google_sheets_client()
+        try:
+            spreadsheet = client.open_by_url(spreadsheet_url)
+        except PermissionError as e:
+            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        return spreadsheet.get_worksheet_by_id(worksheet_id)
+
+    return _retry_on_transient_api_error(execute)
+
+
 def get_schemas(config: GoogleSheetsSourceConfig) -> list[tuple[str, int]]:
     """Returns a tuple of worksheets in the form of (title, id)"""
 
-    client = google_sheets_client()
-    try:
-        spreadsheet = client.open_by_url(config.spreadsheet_url)
-    except PermissionError as e:
-        raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
-    worksheets = spreadsheet.worksheets()
+    # `open_by_url` and `worksheets()` hit the Sheets API and so are subject to the same
+    # transient quota (429) and 5xx server errors as `_get_worksheet` — retry them with backoff
+    # rather than letting a transient blip fail the whole sync during schema discovery.
+    def execute():
+        client = google_sheets_client()
+        try:
+            spreadsheet = client.open_by_url(config.spreadsheet_url)
+        except PermissionError as e:
+            raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        return spreadsheet.worksheets()
+
+    worksheets = _retry_on_transient_api_error(execute)
 
     return [(NamingConvention.normalize_identifier(worksheet.title), worksheet.id) for worksheet in worksheets]
 

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -83,6 +83,59 @@ def test_get_worksheet_retries_transient_api_errors(status_code):
         assert mock_get_worksheet_by_id.call_count == 10
 
 
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+def test_get_schemas_retries_transient_api_errors(status_code):
+    """Schema discovery (`open_by_url`/`worksheets`) hits the Sheets API just like
+    `_get_worksheet`, so a transient quota 429 or 5xx server error (e.g.
+    "[500]: Internal error encountered.") must be retried with backoff rather than
+    failing the whole sync on the first occurrence."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {
+            "error": {"code": status_code, "message": "Internal error encountered.", "status": "INTERNAL"}
+        }
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.side_effect = gspread.exceptions.APIError(mock_response)
+
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schemas(config)
+
+        assert instance.open_by_url.call_count == 10
+
+
+def test_get_schemas_does_not_retry_non_transient_api_error():
+    """A non-transient API error (e.g. 400) raised during schema discovery should be
+    raised immediately without burning through the retry budget."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+        ) as mock_google_sheets_client,
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"),
+    ):
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {
+            "error": {"code": 400, "message": "Bad request", "status": "INVALID_ARGUMENT"}
+        }
+
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.side_effect = gspread.exceptions.APIError(mock_response)
+
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+        with pytest.raises(gspread.exceptions.APIError):
+            get_schemas(config)
+
+        assert instance.open_by_url.call_count == 1
+
+
 def test_get_worksheet_does_not_retry_non_transient_api_error():
     """A non-transient API error (e.g. 400) should be raised immediately without
     burning through the retry budget."""


### PR DESCRIPTION
## Problem

Google Sheets imports were failing with `gspread.exceptions.APIError: [500]: Internal error encountered.` (and the equivalent `[503]: The service is currently unavailable.`) raised from `get_schemas` in `posthog/temporal/data_imports/sources/google_sheets/google_sheets.py`.

These are transient Google server-side errors. The source already recognises Google 5xx (500/502/503/504) and quota 429s as transient and retryable — `_RETRYABLE_API_ERROR_CODES` plus the linear-backoff loop in `_get_worksheet`. But `get_schemas` makes the same kind of Sheets API calls (`open_by_url`, `worksheets()`) **without** that retry wrapper. Schema discovery runs at the start of every sync (and is called by every entry point into this source), so a transient blip there failed the entire sync instead of being retried.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019cdc53-50af-71c0-b9f8-b22d2526ce01

## Changes

- Extracted the transient-API-error backoff loop out of `_get_worksheet` into a shared `_retry_on_transient_api_error` helper (same codes, same linear backoff + jitter, same `max_attempts`).
- Applied that helper to `get_schemas`' `open_by_url` / `worksheets()` calls, mirroring `_get_worksheet`.
- No behaviour change to `_get_worksheet` or to non-transient errors (e.g. 400 still raises immediately; 404 / permission errors still surface to the existing non-retryable matchers).

This is deliberately **not** a `NonRetryableErrors` change: a 5xx is a transient infra error that should stay retryable, not be swallowed.

## How did you test this code?

I'm an agent. I ran the automated test suite for this source — `posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py` — all 19 tests pass, including new parametrized regression tests:

- `test_get_schemas_retries_transient_api_errors` — asserts `get_schemas` retries 429/500/502/503/504 with backoff (10 attempts), which would have caught this bug.
- `test_get_schemas_does_not_retry_non_transient_api_error` — asserts a 400 raises immediately (1 attempt).

Ran `ruff check --fix` and `ruff format` on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Confirmed the failure originates in this source (stack frame `google_sheets.py:97`, `get_schemas` → `client.open_by_url`), read the implementation, and classified it as a fixable bug rather than a user/upstream error: the code already treats Google 5xx as retryable elsewhere, but the schema-discovery path was missing that protection. Chose to extract and reuse the existing backoff helper rather than introduce a new abstraction, keeping the change scoped to the observed crash path.
