### PR TITLE
fix(bigquery): treat invalid_grant credential rejection as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from dateutil import parser
 from google.api_core.exceptions import BadRequest, Forbidden, NotFound, PermissionDenied
+from google.auth.exceptions import RefreshError
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
@@ -616,3 +617,42 @@ def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
 
     assert any(pattern in error_msg for pattern in non_retryable_errors)
+
+
+@pytest.mark.parametrize(
+    "error_description",
+    [
+        "Invalid grant: account not found",
+        "Invalid JWT Signature.",
+        "Token has been expired or revoked.",
+    ],
+)
+def test_bigquery_invalid_grant_is_non_retryable(error_description):
+    """google-auth raises `RefreshError: invalid_grant` when Google's token endpoint rejects the
+    service-account assertion (deleted account, rotated/disabled key, revoked grant). Retrying a
+    rejected credential never recovers, so it must be treated as non-retryable. Matching is the
+    same substring check used in `update_external_data_job_model`."""
+    error = RefreshError(
+        f"invalid_grant: {error_description}",
+        {"error": "invalid_grant", "error_description": error_description},
+    )
+    error_message = str(error)
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+
+    assert "invalid_grant" in non_retryable_errors
+    assert any(pattern in error_message for pattern in non_retryable_errors), (
+        f"Expected RefreshError message '{error_message}' to match a non-retryable pattern"
+    )
+
+
+def test_bigquery_unrelated_grant_error_is_retryable():
+    """Only the OAuth2 `invalid_grant` rejection is non-retryable. A transient token-endpoint
+    failure must stay retryable so genuine infrastructure blips aren't silently disabled."""
+    error_message = str(RefreshError("Failed to retrieve token: 503 Service Unavailable"))
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+
+    assert not any(pattern in error_message for pattern in non_retryable_errors), (
+        f"'{error_message}' must not match a non-retryable pattern"
+    )


### PR DESCRIPTION
## Problem

The BigQuery data-warehouse import source repeatedly fails with `RefreshError: invalid_grant` and retries the sync indefinitely. The failure surfaces in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019e660b-5cf4-7aa0-88b1-e91dafc27095)) with thousands of occurrences, all originating in our code path.

The full stack trace runs from the import activity → `sync_new_schemas.py` → `common/sql/base.py` → `bigquery.py` `get_columns` (which issues an `INFORMATION_SCHEMA.COLUMNS` query). That query triggers google-auth to mint an OAuth2 token from the service-account JWT, and Google's token endpoint rejects the assertion with `invalid_grant`. The `error_description` varies — `Invalid grant: account not found`, `Invalid JWT Signature.`, `Token has been expired or revoked.` — but they all mean the same thing: the service account was deleted, or its key was rotated, disabled, or revoked.

This is an upstream/credential problem, not a bug in our code. No amount of retrying recovers a rejected credential — the sync should stop and the user should be told to re-upload a valid key file.

## Changes

- Add `invalid_grant` to `BigQuerySource.get_non_retryable_errors()` with an actionable message pointing the user to upload a new Google Cloud JSON key file.
- Match on the stable OAuth2 error code `invalid_grant` rather than the volatile `error_description`, so all variants are covered with a low false-positive surface. Transient token-endpoint failures (e.g. a 503 from the token server) stay retryable.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests only — no manual testing:

- Added parameterized regression tests covering the real `RefreshError: invalid_grant` message variants (`account not found`, `Invalid JWT Signature`, `Token has been expired or revoked`), asserting they match the non-retryable pattern via the same substring check used in `update_external_data_job_model`.
- Added a negative test asserting an unrelated transient `RefreshError` (token-endpoint 503) stays retryable.
- `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — 24 passed.
- `ruff check` and `ruff format --check` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a BigQuery import error surfaced by error tracking. Confirmed via the error-tracking tooling that the failure originates in `bigquery.py` `get_columns` and is a credential rejection from Google's OAuth2 token endpoint (`invalid_grant`), not a logic bug on our side. Chose to extend `NonRetryableErrors` (mirroring the Stripe source pattern) rather than change code, since there is nothing recoverable about a rejected service-account credential. Deliberately matched the stable `invalid_grant` code and left other `RefreshError` variants retryable to avoid swallowing transient token-server failures.
