### PR TITLE
fix(linkedin_ads): treat invalid Account ID 400 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -42,6 +42,10 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
         return {
             "REVOKED_ACCESS_TOKEN": None,
             "The token used in the request has expired": "Failed to refresh token for LinkedIn Ads integration. Please re-authorize the integration.",
+            # LinkedIn rejects a non-numeric Account ID with a 400 whose message names the offending
+            # key value (volatile) followed by this stable type-coercion phrase. The account id is a
+            # fixed config value, so retrying can't help — fail fast and tell the user to fix it.
+            "must be of type 'java.lang.Long'": "LinkedIn rejected the configured Account ID. It must be the numeric LinkedIn ad account ID (digits only). Please correct the Account ID in your source settings and re-sync.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.generated_configs import LinkedinAdsSourceConfig
@@ -59,3 +60,28 @@ class TestLinkedInAdsSource:
         assert "Failed to validate LinkedIn Ads credentials" in error_message
         assert "Database error" in error_message
         mock_capture_exception.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            # A non-numeric Account ID raises this 400 — the quoted key value is volatile, the
+            # type-coercion phrase is the stable part we match on.
+            'LinkedIn API error (400): {"message":"Key value \'Reed%20Lnkedin\' must be of type \'java.lang.Long\'","status":400}',
+            'LinkedIn API error (400): {"message":"Key value \'LI\' must be of type \'java.lang.Long\'","status":400}',
+        ],
+    )
+    def test_non_retryable_errors_match_invalid_account_id(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            # Transient transport / 5xx errors must stay retryable.
+            "LinkedIn API error (retryable, 503): service unavailable",
+            'LinkedIn daily rate limit reached (429): {"message":"throttled","status":429}',
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

The LinkedIn Ads warehouse source surfaced a high-volume error in error tracking:

```
Exception: LinkedIn API error (400): {"message":"Key value 'Reed%20Lnkedin' must be of type 'java.lang.Long'","status":400}
```

Raised at `posthog/temporal/data_imports/sources/linkedin_ads/client.py:309` (`_call_finder`), reached via `linkedin_ads_source` → `client.get_data_by_resource` → `_make_request` / `_make_paginated_request`.

The quoted key value is the customer's configured **Account ID**. LinkedIn requires the ad account ID to be numeric (a `java.lang.Long`); when a non-numeric value is entered (observed values: `Reed Lnkedin`, `LI`), every request fails with this `400`. Because the Account ID is a fixed config value, the import activity kept retrying with no possibility of success — the issue accumulated ~16.5k occurrences over roughly two months.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019db9e4-bd68-7120-b6ab-e45d86efd12b

## Changes

This is a user/config error, not a bug in our request construction or a transient failure — there is nothing sensible to do but stop retrying and tell the user to fix the Account ID.

- Added the stable substring `must be of type 'java.lang.Long'` to `LinkedInAdsSource.get_non_retryable_errors`, mapped to an actionable message ("LinkedIn rejected the configured Account ID. It must be the numeric LinkedIn ad account ID (digits only). Please correct the Account ID in your source settings and re-sync.").
- Matched on the stable type-coercion phrase only — the quoted key value is volatile and excluded from the match.

Transient errors (5xx, short-window 429) are deliberately left retryable and are covered by a negative test.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing.

Added parametrized tests in `test_linkedin_source.py`:
- `test_non_retryable_errors_match_invalid_account_id` — asserts both observed `400` messages are recognised as non-retryable.
- `test_non_retryable_errors_does_not_match_unrelated` — asserts a retryable 5xx and a daily-rate-limit message are NOT matched.

```
python -m pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py -q
7 passed
```

`ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the LinkedIn Ads data-warehouse source. Confirmed the issue in error tracking (stack trace, exception type, representative events, frequency) and traced the raise site into the source's own code. Decision: the failure is driven by an invalid customer-configured Account ID, so retrying cannot help — extended the source's `NonRetryableErrors` (mirroring the Stripe `get_non_retryable_errors` pattern) rather than changing request logic or global retry policy. Matched a low-false-positive, stable substring of the message and added both positive and negative regression tests.
