### PR TITLE
fix(mssql): handle NULL row count from sp_spaceused on views

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -598,6 +598,13 @@ class MSSQLImplementation(SQLSourceImplementation[MSSQLSourceConfig, pymssql.Con
             # sp_spaceused returns: name, rows, reserved, data, index_size, unused
             _, total_rows, _, data_size, _, _ = result
 
+            # Views (and other storage-less objects) return NULL for rows/data
+            # from sp_spaceused. Treat that as "no stats available" and fall
+            # back to safe defaults rather than crashing on int(None).
+            if total_rows is None or data_size is None:
+                logger.debug("fetch_table_stats: sp_spaceused returned NULL row count or data size")
+                return None
+
             total_rows = int(total_rows)
 
             # Parse size with unit (e.g. "1024.45 MB" -> 1024.45, "MB")

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -302,6 +302,14 @@ class TestFetchTableStats:
         cursor.fetchone.return_value = ("t", "1000", "40 ZB", "32 ZB", "8 ZB", "0 ZB")
         assert impl.fetch_table_stats(cursor, "dbo", "t", logger) is None
 
+    def test_returns_none_when_view_returns_null_stats(self, impl, cursor, logger, mocker):
+        # sp_spaceused on a view returns NULL for rows/reserved/data. This must be a graceful
+        # skip — not an int(None) crash routed through capture_exception (which floods error tracking).
+        capture = mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.capture_exception")
+        cursor.fetchone.return_value = ("vw_thing", None, None, None, "0 KB", "0 KB")
+        assert impl.fetch_table_stats(cursor, "dbo", "vw_thing", logger) is None
+        capture.assert_not_called()
+
     def test_returns_none_on_exception(self, impl, cursor, logger):
         cursor.execute.side_effect = RuntimeError("boom")
         assert impl.fetch_table_stats(cursor, "dbo", "t", logger) is None


### PR DESCRIPTION
## Problem

The MSSQL data-warehouse import source is throwing a recurring `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` from `fetch_table_stats` in `posthog/temporal/data_imports/sources/mssql/mssql.py` (error tracking issue [`019e660a-9df1-76f0-a457-aeb14e23082b`](https://us.posthog.com/project/2/error_tracking/019e660a-9df1-76f0-a457-aeb14e23082b) — thousands of occurrences, still firing).

`fetch_table_stats` runs `EXEC sp_spaceused <table>` and unpacks the result into `name, rows, reserved, data, index_size, unused`, then does `int(total_rows)`. For **views** (and other storage-less objects) `sp_spaceused` returns `NULL` for the row count and data columns — the captured result was `["vw_...", null, null, null, "0 KB", "0 KB"]` — so `int(None)` raised.

The broad `except` caught it and returned `None`, so the sync itself still fell back to safe defaults and kept working. But that path also calls `capture_exception(e)`, so every stats fetch on a view re-reported the same handled `TypeError` to error tracking, generating the noise.

## Changes

After unpacking the `sp_spaceused` row, guard against a `NULL` row count or data size and treat it as a graceful skip (debug log + `return None`), mirroring the existing skip branches (no row, bad size format, unknown unit). Storage-less objects like views no longer raise or get captured.

Scoped strictly to this case — no change to retry policy or the surrounding pipeline.

## How did you test this code?

I'm an agent. Automated tests only:

- Added `TestFetchTableStats::test_returns_none_when_view_returns_null_stats`, which feeds the exact view-shaped `sp_spaceused` row (`(name, None, None, None, "0 KB", "0 KB")`), asserts the result is `None`, and asserts `capture_exception` is **not** called.
- Verified the new test fails on master (reproduces the `TypeError` via `capture_exception`) and passes with the fix.
- Ran the full `TestFetchTableStats` suite (5 passed) plus `ruff check` / `ruff format --check` on both files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) — the stack trace points squarely at `fetch_table_stats`, and the captured frame locals (`full_table_name = [dbo].[vw_...]`, `total_rows = None`, `result = [..., null, null, ...]`) made the view/NULL root cause unambiguous.

Decision: this is a fixable bug (fragile handling of a legitimate response shape), not a user/upstream credential error, so it does **not** belong in `NonRetryableErrors`. Fixed the code and added a regression test at the same layer. The test asserts on `capture_exception` rather than just the return value, because the broad `except` already returned `None` before the fix — the observable regression was the error-tracking noise, not a wrong return.