### PR TITLE
fix(postgres): treat out-of-range timestamps as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -202,7 +202,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "Address not in tenant allow_list": None,
             "FATAL: no such database": None,
             "does not exist": None,
+            # Postgres timestamps span year 4713 BC to 294276 AD, but Python's `datetime` only
+            # covers years 1–9999, so psycopg's loader raises `DataError: timestamp too small` /
+            # `timestamp too large (after year 10K)` for values outside that range (usually
+            # sentinel/garbage dates in the source). The value is fixed in the source row, so
+            # retrying re-reads the same row and fails identically — surface it instead.
             "timestamp too small": None,
+            "timestamp too large": None,
             "QueryTimeoutException": None,
             "TemporaryFileSizeExceedsLimitException": None,
             "Name or service not known": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -344,6 +344,19 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "DataError: timestamp too large (after year 10K): '24989-07-09 23:03:27+00'",
+            "DataError: timestamp too large (after year 10K): '58154-06-04 18:43:20+00'",
+            "DataError: timestamp too small (before year 1): '0001-01-01 00:00:00 BC'",
+        ],
+    )
+    def test_out_of_range_timestamps_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Out-of-range timestamp error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source surfaced a recurring error in PostHog error tracking:

> `DataError: timestamp too large (after year 10K): '24989-07-09 23:03:27+00'`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019cdc62-4963-7eb2-a9c3-9d495f69d54c (~13k occurrences over 3 months, still firing).

The stack confirms it originates in this source: `posthog/temporal/data_imports/sources/postgres/postgres.py` → `cursor.fetchmany(...)` → psycopg's `TimestamptzLoader`. Postgres timestamps span year 4713 BC to 294276 AD, but Python's `datetime` only covers years 1–9999, so psycopg raises a `DataError` when a source row holds a value outside that range (typically a sentinel/garbage far-future date).

Because the value is fixed in the source row, every retry re-reads the same row and fails identically — the activity just burns retries before failing the sync anyway.

## Changes

- Add `"timestamp too large"` to `PostgresSource.get_non_retryable_errors()`. This is the exact mirror of the `"timestamp too small"` entry already present for the pre-year-1 case; the far-future case was simply missed.
- Match on the stable `"timestamp too large"` substring (excludes the volatile timestamp value).
- Add a parametrized regression test covering both out-of-range directions.

This stops the wasted retries and surfaces the failure to the user, who can then exclude or fix the offending column/row in their source data. No global retry policy is changed — the match is scoped to this source.

## How did you test this code?

I'm an agent. I added and ran the automated regression test:

```
pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors
```

All 22 cases in the class pass (including the 3 new out-of-range-timestamp cases). `ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged via the PostHog error-tracking MCP tools: pulled the issue, confirmed the full stack trace genuinely originates in the Postgres source's row-fetch loop (not just serialized log context), and checked frequency/affected scope.
- Decision: user/upstream data error, not a fixable code bug. A timestamp beyond Python's `datetime` range can't be loaded without lossy transformation (clamping/stringifying would silently corrupt data and break the arrow schema), and retrying is futile since the row is static. The codebase already treats the symmetric `timestamp too small` case as non-retryable, which set the precedent.
- Scoped strictly to extending `NonRetryableErrors` plus a regression test, mirroring the existing `timestamp too small` handling.
