### PR TITLE
fix(snowflake): treat network policy IP block as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -202,6 +202,10 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # lives in the customer's object, not in our SQL. Retrying can't fix it until they repair
             # the object or reconfigure the synced columns.
             "invalid identifier": "A Snowflake table or view you're syncing references a column that no longer exists (for example a stale view definition, or a column that was dropped or renamed). Please fix the table or view in Snowflake, or reconfigure the columns selected for this table, then resync.",
+            # Snowflake error 250001 (08001): a network policy (IP allowlist) on the customer's account
+            # rejects the connection because PostHog's egress IP isn't permitted. Retrying can never
+            # succeed until their admin allowlists our IPs, so stop retrying and surface what to do.
+            "is not allowed to access Snowflake": "Snowflake rejected the connection because a network policy (IP allowlist) on your account does not permit PostHog's IP address. Ask your Snowflake administrator to add PostHog's egress IP addresses to the network policy allowlist, then resync.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. a narrower NUMBER widened
             # to a larger NUMBER/BIGINT) after the destination table was created with the

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -623,6 +623,23 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "is not allowed to access Snowflake",
+            # The real shape from production: codes, IP/token, host, and help URL all vary,
+            # but the network-policy substring is stable.
+            "250001 (08001): None: Failed to connect to DB: ihoilnv-wd33458.snowflakecomputing.com:443. "
+            "Incoming request with IP/Token 44.208.188.173 is not allowed to access Snowflake. "
+            "Contact your account administrator. For more information about this error, go to "
+            "https://community.snowflake.com/s/ip-xxxxxxxxxxxx-is-not-allowed-to-access.",
+        ],
+    )
+    def test_network_policy_block_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Network-policy block should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
             "Operation timed out while waiting for the warehouse to resume",
         ],


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `DatabaseError` from the Snowflake data-warehouse import source (raised at `posthog/temporal/data_imports/sources/snowflake/snowflake.py:223`, inside `connect()`):

```
250001 (08001): None: Failed to connect to DB: <account>.snowflakecomputing.com:443. Incoming request with IP/Token <ip> is not allowed to access Snowflake. Contact your account administrator.
```

This is a Snowflake **network policy** (IP allowlist) rejection: the customer's Snowflake account restricts access to a set of IPs that doesn't include PostHog's egress address. The connection fails the moment we call `snowflake.connector.connect(...)`, and the import activity then retries on the default policy for up to 7 days. No retry can ever succeed — only the customer's Snowflake admin can add our IPs to the allowlist — so every attempt is wasted work and the issue keeps re-firing.

## Changes

- Add `"is not allowed to access Snowflake"` to `SnowflakeSource.get_non_retryable_errors()` so the sync stops retrying immediately and surfaces an actionable message telling the customer to ask their Snowflake admin to allowlist PostHog's egress IPs. The substring is the stable part of the message — the error code, IP/token, host, and help URL are all volatile, so they're deliberately excluded from the match.
- Add a regression test (`test_network_policy_block_is_non_retryable`) covering both the bare substring and the full production-shaped message.

This follows the existing pattern for user/upstream errors in this source (disabled user, Duo MFA, suspended account) and mirrors Stripe's `get_non_retryable_errors`. Transient errors (timeouts, connection resets) are intentionally left retryable — the existing `test_transient_errors_are_retryable` still guards that.

## How did you test this code?

I'm an agent. I ran the automated tests I added/touched:

```
python -m pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py::TestSnowflakeSourceNonRetryableErrors
# 8 passed
```

Also ran `ruff check` and `ruff format` on both changed files (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue for the Snowflake import source using PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`). Confirmed all sampled events for this message originate at `snowflake.py:223` in `connect()` via the import pipeline, so the failure genuinely lives in this source.
- Decision: this is a customer/upstream configuration error (Snowflake network policy IP allowlist), not a bug in our code and not a transient infra error, so the right fix is to extend `NonRetryableErrors` rather than change code behavior or retry policy. Matched on the stable substring only, to avoid false positives on volatile fields.
