### PR TITLE
fix(shopify): treat GraphQL access-denied as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
@@ -1,0 +1,32 @@
+import pytest
+
+from posthog.temporal.data_imports.sources.shopify.source import ShopifySource
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Shopify GraphQL error: Access denied for fulfillmentOrders field.",
+        "Shopify GraphQL error: Access denied for markets field.",
+    ],
+)
+def test_graphql_access_denied_is_non_retryable(error_message):
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"GraphQL access-denied error '{error_message}' should match a non-retryable pattern"
+    )
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Shopify GraphQL error: Throttled",
+        "Shopify: internal error from request 500 Internal Server Error",
+        "Unexpected graphql response format in Shopify rows read. Keys: ['extensions']",
+    ],
+)
+def test_transient_graphql_errors_stay_retryable(error_message):
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert not any(pattern in error_message for pattern in patterns), (
+        f"transient error '{error_message}' should remain retryable"
+    )


### PR DESCRIPTION
## Problem

The Shopify data-warehouse source surfaces a recurring, high-volume error in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019e9347-f66d-7dc2-a2ee-ded83cc6435a)):

> `Exception: Shopify GraphQL error: Access denied for fulfillmentOrders field.`

The same fingerprint also fires for other fields (e.g. `markets field`). The exception is raised mid-sync in `posthog/temporal/data_imports/sources/shopify/shopify.py` when Shopify's GraphQL response contains an `ACCESS_DENIED` error — the connected store's access token is missing the OAuth scope a queried field requires (e.g. `read_fulfillments` for `fulfillmentOrders`, `read_markets` for `markets`).

This is an upstream/configuration problem: retrying cannot grant a scope. The connect-time `validate_credentials` permission probe doesn't catch a scope that's narrowed or revoked after the integration was connected, so it only shows up during a sync — and is then retried repeatedly, burning work with no chance of recovery.

## Changes

- Added the stable substring `Access denied for` (the field name is the volatile part) to `ShopifySource.get_non_retryable_errors`, mirroring the existing Stripe / Shopify token-auth patterns. The matcher is a substring check scoped to this source's jobs, so the match stays low-false-positive.
- Mapped it to a user-facing message prompting a reconnect with the required permissions.
- Added a regression test asserting the access-denied messages are recognised as non-retryable while transient GraphQL errors (throttling, 5xx, unexpected response shape) stay retryable.

Decision rationale: this is a user/upstream permissions error, not a code bug — the request and pagination are correct, the store simply hasn't granted the scope. The static GraphQL query can't drop a single denied field gracefully, so the right action is to stop retrying and tell the user to reconnect. Transient errors were deliberately left retryable.

## How did you test this code?

I'm an agent. I added and ran automated tests — no manual testing.

- `pytest posthog/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py` — 14 passed.
- `ruff check` / `ruff format` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Shopify source. Confirmed the issue in PostHog error tracking (stack trace top in-app frame at `shopify.py`, ~1.3k occurrences ramping over the last week), read the source implementation to locate where the exception is raised, and classified it as an upstream permissions error rather than a code bug. Followed the Stripe source's `get_non_retryable_errors` pattern. Tools used: PostHog error-tracking MCP (`query-error-tracking-issue`, `query-error-tracking-issue-events`) and Claude Code.