### PR TITLE
fix(google_ads): treat deleted integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -56,6 +56,11 @@ class GoogleAdsSource(
             # has restricted third-party API access for this app (org policy / app not approved).
             # Retrying cannot recover — an admin must grant access before the user reconnects.
             "access_not_configured": "Your Google Workspace administrator has restricted API access for this app. Ask your admin to approve it, then reconnect your Google Ads account.",
+            # Integration.DoesNotExist raised by `google_ads_client` when the stored OAuth
+            # integration row has been deleted/disconnected before the sync runs. Retrying cannot
+            # recover — the user must reconnect their Google Ads account. Model-specific so we don't
+            # swallow unrelated `DoesNotExist` errors from other models, which may be real bugs.
+            "Integration matching query does not exist": "Your Google Ads connection is no longer available — it may have been disconnected. Please reconnect your Google Ads account.",
         }
 
     # TODO: clean up google ads source to not have two auth config options

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -139,6 +139,29 @@ class TestGoogleAdsNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # `str(Integration.DoesNotExist)` as raised by `google_ads_client` during a sync when
+            # the OAuth integration row has been deleted/disconnected.
+            "Integration matching query does not exist.",
+        ],
+    )
+    def test_missing_integration_is_non_retryable(self, error_msg):
+        is_non_retryable = any(pattern in error_msg for pattern in self.non_retryable.keys())
+        assert is_non_retryable, f"Expected error to be non-retryable: {error_msg}"
+
+    def test_missing_integration_has_friendly_message(self):
+        friendly = self.non_retryable["Integration matching query does not exist"]
+        assert friendly is not None
+        assert "reconnect" in friendly.lower()
+
+    def test_other_model_does_not_exist_is_not_swallowed(self):
+        # The pattern is model-specific so an unrelated model's DoesNotExist — which may be a real
+        # bug — is not silently treated as non-retryable.
+        error_msg = "ExternalDataSchema matching query does not exist."
+        assert not any(pattern in error_msg for pattern in self.non_retryable.keys())
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Transient network/infrastructure errors should still be retried.
             "DeadlineExceeded: 504 Deadline Exceeded",
             "UNAVAILABLE: The service is currently unavailable",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a high-frequency, unrecoverable failure on the Google Ads data-warehouse source: [`Integration.DoesNotExist` — "Integration matching query does not exist."](https://us.posthog.com/project/2/error_tracking/019ce352-f17c-7e80-8e04-be4ecec3f596)

The failing frame is `google_ads_client` in `posthog/temporal/data_imports/sources/google_ads/google_ads.py`, where the OAuth integration row is fetched:

```python
integration = Integration.objects.get(id=config.google_ads_integration_id, team_id=team_id)
```

When a user deletes or disconnects the linked Google Ads integration, this row no longer exists, so the lookup raises `Integration.DoesNotExist` during the sync. Retrying can never recover — the integration is gone until the user reconnects — yet this string was not in the source's `get_non_retryable_errors`, so the pipeline retried it repeatedly (tens of thousands of occurrences in the issue above).

`validate_credentials` already surfaces a friendly reconnect message for this case at config-test time, but the live sync path did not treat it as non-retryable.

## Changes

- Add `"Integration matching query does not exist"` to `GoogleAdsSource.get_non_retryable_errors` with a user-facing reconnect message, so a deleted/disconnected integration fails fast instead of retrying.
- The match is model-specific (`Integration matching query does not exist`, not the bare `matching query does not exist`) to avoid swallowing unrelated `DoesNotExist` errors from other models, which may be genuine bugs.

This is a user/upstream condition (the customer removed their integration), so the correct behavior is to stop retrying and prompt a reconnect — matching the established pattern for the source's other auth/permission errors.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests run locally:

- `posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py` — 50 passed.
- Added regression tests asserting the new message is recognised as non-retryable, that it has a friendly reconnect message, and that an unrelated model's `DoesNotExist` is **not** matched by the pattern.
- `ruff check` and `ruff format --check` pass on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Google Ads source. Pulled the issue's stack trace and confirmed the failure originates in `google_ads_client` (`Integration.objects.get`). Decided this is a user/upstream error rather than a code bug: the integration row has been deleted/disconnected, and no retry or code change can recover it — the user must reconnect. Followed the Stripe source's `get_non_retryable_errors` convention and the source's existing `validate_credentials` handling for the same condition, choosing a model-specific substring to keep false positives low.
