### PR TITLE
fix(bing_ads): treat non-numeric account ID as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/bing_ads.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/bing_ads.py
@@ -89,6 +89,17 @@ def bing_ads_source(
         resource = BingAdsResource(resource_name)
 
         today = dt.date.today()
+        # Bing Ads Account IDs are numeric. Users sometimes enter their alphanumeric Account
+        # Number (e.g. "F118FDGN") instead, which can't be parsed into the integer the API
+        # expects. Raise a deterministic, actionable error here so it can be flagged
+        # non-retryable rather than crashing on a bare int() and retrying forever.
+        if not account_id.isdigit():
+            raise ValueError(
+                "Bing Ads Account ID must be numeric. "
+                f"The configured Account ID {account_id!r} is not a number — you may have entered "
+                "your alphanumeric Account Number instead. Update the Account ID in the source "
+                "settings and try again."
+            )
         account_id_int = int(account_id)
 
         if schema.is_stats:

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -94,6 +94,14 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             # the id is volatile, so match only the stable prefix. Retrying can't recreate the row —
             # the customer has to reconnect.
             "Integration not found": "The linked Bing Ads integration no longer exists. Please reconnect your Bing Ads integration.",
+            # Non-numeric Account ID — the user entered their alphanumeric Account Number instead
+            # of the numeric Account ID. Retrying can't fix a bad config value, so flag it and surface
+            # actionable guidance. The matched phrase is stable and precedes the volatile id in the
+            # raised message (see bing_ads_source.get_rows), keeping false positives at zero.
+            "Bing Ads Account ID must be numeric": (
+                "Bing Ads Account ID must be numeric. You may have entered your alphanumeric Account Number "
+                "instead. Update the Account ID in the source settings and try again."
+            ),
             # Deterministic credential/config errors raised in source_for_pipeline.
             "Bing Ads access token not found": "Bing Ads OAuth access token is missing. Please reconnect your Bing Ads integration.",
             "Bing Ads refresh token not found": "Bing Ads OAuth refresh token is missing. Please reconnect your Bing Ads integration.",

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads.py
@@ -342,6 +342,32 @@ class TestBingAdsSource:
             assert isinstance(items, Iterable)
             list(items)
 
+    @parameterized.expand(
+        [
+            ("account_number", "F118FDGN"),
+            ("alphanumeric", "ABC123"),
+            ("empty", ""),
+        ]
+    )
+    @patch("posthog.temporal.data_imports.sources.bing_ads.bing_ads.BingAdsClient")
+    @patch("posthog.temporal.data_imports.sources.bing_ads.bing_ads.integrations")
+    def test_bing_ads_source_non_numeric_account_id(self, _name, account_id, mock_integrations, mock_client_class):
+        """A non-numeric account ID raises a deterministic, non-retryable error instead of a bare int() crash."""
+        mock_integrations.BING_ADS_DEVELOPER_TOKEN = "test_dev_token"
+
+        result = bing_ads_source(
+            account_id=account_id,
+            resource_name="campaigns",
+            access_token=self.access_token,
+            refresh_token=self.refresh_token,
+            resumable_source_manager=_mock_resumable_manager(),
+        )
+
+        with pytest.raises(ValueError, match="Bing Ads Account ID must be numeric"):
+            items = result.items()
+            assert isinstance(items, Iterable)
+            list(items)
+
     @patch("posthog.temporal.data_imports.sources.bing_ads.bing_ads.BingAdsClient")
     @patch("posthog.temporal.data_imports.sources.bing_ads.bing_ads.integrations")
     def test_bing_ads_source_incremental_missing_field(self, mock_integrations, mock_client_class):

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -276,6 +276,14 @@ class TestBingAdsSource:
             # Integration deleted/disconnected — OAuthMixin.get_oauth_integration raises
             # `ValueError("Integration not found: <id>")`; match only the volatile-id-free prefix.
             ("Integration not found", "Integration not found: 160672"),
+            # Non-numeric Account ID — raised by bing_ads_source.get_rows. The matched phrase
+            # precedes the volatile account id in the message.
+            (
+                "Bing Ads Account ID must be numeric",
+                "Bing Ads Account ID must be numeric. The configured Account ID 'F118FDGN' is not a number — "
+                "you may have entered your alphanumeric Account Number instead. Update the Account ID in the "
+                "source settings and try again.",
+            ),
             # Deterministic credential/config errors raised in source_for_pipeline.
             ("Bing Ads access token not found", "Bing Ads access token not found for job abc"),
             ("Bing Ads refresh token not found", "Bing Ads refresh token not found for job abc"),


### PR DESCRIPTION
## Problem

PostHog error tracking is surfacing a high-volume `ValueError` from the Bing Ads data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019cdc3c-0e87-74e1-9151-9d44738567f6)):

```
ValueError: invalid literal for int() with base 10: 'F118FDGN'
```

A Bing Ads **Account ID** is numeric, but some users enter their alphanumeric **Account Number** (e.g. `F118FDGN`) into the field instead. In `bing_ads_source.get_rows`, the bare `int(account_id)` then crashes with a raw Python `ValueError`. Because that error wasn't recognised as non-retryable, the import kept retrying forever (observed attempt counts in the tens of thousands) — retrying can never succeed, since the only fix is for the user to correct the configured Account ID.

## Changes

- Guard the `int(account_id)` conversion in `bing_ads.py` so a non-numeric Account ID raises a deterministic, actionable error explaining that the value must be numeric and that the alphanumeric Account Number was likely entered by mistake.
- Register a stable matching phrase (`"Bing Ads Account ID must be numeric"`) in `BingAdsSource.get_non_retryable_errors`, mirroring the existing deterministic-config-error pattern (and Stripe's). The matched phrase precedes the volatile account id in the message, so it has zero false positives and doesn't leak per-customer values into the match key.

This is scoped strictly to this error — it does not change the global retry policy or affect transient/network failures, which remain retryable.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Added a parametrized regression test in `test_bing_ads.py` asserting `bing_ads_source` raises `ValueError: Bing Ads Account ID must be numeric` for non-numeric account IDs (account number, alphanumeric, empty).
- Extended the non-retryable pattern tests in `test_bing_ads_source.py` to assert the new phrase is recognised as non-retryable; the existing transient-failure test confirms it does not match network/timeout errors.
- Ran `pytest` for both bing_ads test files (44 passed) and `ruff check`/`ruff format` (clean).

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used Claude Code with the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue: the top in-app frame is `bing_ads.py:92` (`int(account_id)`) with `account_id` values like `F118FDGN`/`F107QDK3`/`F145DHGG`.

Decision: this is a user/config error, not a fixable pipeline bug — the Account ID value is wrong and no retry can fix it — so the right move is to stop retrying. Rather than match the raw `invalid literal for int()` Python message (fragile, and the volatile id is embedded in it), I raise a clear deterministic error first and match on a stable leading phrase, which is both more actionable for the user and a lower-false-positive match.