### PR TITLE
fix(bigquery): treat rejected service account credentials as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -41,6 +41,14 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
         return {
             "PermissionDenied: 403 request failed": "BigQuery permission denied. Please check that your service account has the necessary permissions.",
             "NotFound: 404": "BigQuery dataset or table not found. Please verify your project, dataset, and table names.",
+            # OAuth2 error code returned by Google's token endpoint when the service account grant
+            # is rejected — a rotated/revoked private key ("Invalid JWT Signature") or a deleted
+            # service account ("account not found"). Raised as a `RefreshError` while refreshing the
+            # token, so it surfaces on every BigQuery call rather than at a single site. Retrying
+            # can't recover invalid credentials; the user must upload a new key file. Matched on the
+            # stable `invalid_grant` code rather than `RefreshError`, which can also wrap transient
+            # token-endpoint failures that should stay retryable.
+            "invalid_grant": "Your BigQuery service account credentials were rejected by Google. The key may have been rotated or revoked, or the service account deleted. Please upload a new Google Cloud JSON key file.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a
             # narrower numeric type) after the destination table was created with the narrower

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -193,6 +193,35 @@ def test_bigquery_select_clause_rejects_injection_attempts(malicious_column):
         _bq_select_clause([malicious_column], primary_keys=None, incremental_field=None)
 
 
+@pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Rotated/revoked service account private key.
+        "('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})",
+        # Deleted service account.
+        "('invalid_grant: Invalid grant: account not found', {'error': 'invalid_grant', 'error_description': 'Invalid grant: account not found'})",
+    ],
+)
+def test_non_retryable_errors_match_rejected_credentials(observed_error):
+    """A `RefreshError` carrying the OAuth2 `invalid_grant` code means Google rejected the
+    service account grant — retrying can't recover, so the sync must be disabled."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert any(key in observed_error for key in non_retryable_errors)
+
+
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        # A token refresh that failed for a transient reason must stay retryable.
+        "RefreshError: ('Failed to retrieve token', {'error': 'internal_failure'})",
+        "RefreshError: HTTPError 503 Service Unavailable",
+    ],
+)
+def test_non_retryable_errors_does_not_match_transient_refresh_failures(transient_error):
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert not any(key in transient_error for key in non_retryable_errors)
+
+
 def _run_delete_all_temp_destination_tables(side_effect, logger):
     bq = mock.MagicMock()
     bq.list_tables.side_effect = side_effect


### PR DESCRIPTION
## Problem

BigQuery data-warehouse imports surface a recurring `RefreshError` from Google's OAuth2 client during service-account token refresh:

```
RefreshError: ('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})
RefreshError: ('invalid_grant: Invalid grant: account not found', {'error': 'invalid_grant', 'error_description': 'Invalid grant: account not found'})
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e6616-9ea5-7932-a543-d54f2a43f8c3

The stack runs from the import pipeline (`import_data_sync.py` → `sources/common/sql/base.py` → `sources/bigquery/bigquery.py`) into `google.cloud.bigquery` and `google.oauth2`, where the token refresh raises. `invalid_grant` is the OAuth2 error code Google's token endpoint returns when it rejects the service-account grant — a rotated/revoked private key (`Invalid JWT Signature`) or a deleted service account (`account not found`). Because the refresh happens on every BigQuery call, the failure currently retries indefinitely and re-fires on every sync, even though it can never succeed without the user fixing their credentials.

## Changes

Added `invalid_grant` to `BigQuerySource.get_non_retryable_errors()` with a user-facing message asking them to upload a new Google Cloud JSON key file. When matched, the pipeline stops the schema from syncing and surfaces the friendly error instead of retrying.

Matched on the stable `invalid_grant` substring rather than the broader `RefreshError` type, because a `RefreshError` can also wrap transient token-endpoint failures (e.g. a 5xx) that should remain retryable. `invalid_grant` is specifically the credential-rejection code and does not appear for transient infrastructure errors.

## How did you test this code?

I'm an agent. I added and ran automated tests at the source layer (`posthog/temporal/data_imports/sources/bigquery/tests/test_source.py`):

- `test_non_retryable_errors_match_rejected_credentials` — asserts both real `invalid_grant` message variants (bad JWT signature, deleted account) are recognised as non-retryable.
- `test_non_retryable_errors_does_not_match_transient_refresh_failures` — asserts transient `RefreshError` messages without `invalid_grant` are *not* matched, so they stay retryable.

Ran the full file (`24 passed`) plus `ruff check` and `ruff format --check` on both changed files (clean). I did not perform manual end-to-end testing against a live BigQuery source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BigQuery import source. Confirmed via the error-tracking MCP tools that the failure originates in this source's code (frame under `posthog/temporal/data_imports/sources/bigquery/bigquery.py`), then read the implementation to confirm the `RefreshError` comes from service-account token refresh. Classified it as a user/upstream credential error (revoked key / deleted account) with no recovery other than reconnecting, so the fix extends `NonRetryableErrors` following the Stripe source pattern. Chose to match on `invalid_grant` rather than `RefreshError` to avoid disabling syncs on transient refresh failures.