### PR TITLE
fix(bing_ads): treat deleted integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -68,6 +68,11 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             "AuthenticationFailed": auth_friendly,
             "InvalidCredentials": auth_friendly,
             "OAuthTokenExpired": auth_friendly,
+            # Integration row was deleted/disconnected while a scheduled job still references it.
+            # Raised by OAuthMixin.get_oauth_integration as `ValueError("Integration not found: <id>")`;
+            # the id is volatile, so match only the stable prefix. Retrying can't recreate the row —
+            # the customer has to reconnect.
+            "Integration not found": "The linked Bing Ads integration no longer exists. Please reconnect your Bing Ads integration.",
             # Deterministic credential/config errors raised in source_for_pipeline.
             "Bing Ads access token not found": "Bing Ads OAuth access token is missing. Please reconnect your Bing Ads integration.",
             "Bing Ads refresh token not found": "Bing Ads OAuth refresh token is missing. Please reconnect your Bing Ads integration.",

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -259,6 +259,9 @@ class TestBingAdsSource:
                 "Failed to fetch customer ID: OAuthTokenRequestException: invalid_client AADSTS650052: "
                 "The app is trying to access a service that your organization lacks a service principal for.",
             ),
+            # Integration deleted/disconnected — OAuthMixin.get_oauth_integration raises
+            # `ValueError("Integration not found: <id>")`; match only the volatile-id-free prefix.
+            ("Integration not found", "Integration not found: 160672"),
             # Deterministic credential/config errors raised in source_for_pipeline.
             ("Bing Ads access token not found", "Bing Ads access token not found for job abc"),
             ("Bing Ads refresh token not found", "Bing Ads refresh token not found for job abc"),


### PR DESCRIPTION
## Problem

The `bing_ads` data-warehouse import source surfaced a high-frequency, long-running error in error tracking:

- **Exception:** `ValueError: Integration not found: <id>`
- **Origin:** `posthog/temporal/data_imports/sources/bing_ads/source.py` → `source_for_pipeline` → `OAuthMixin.get_oauth_integration`

When a customer deletes or disconnects their Bing Ads OAuth integration but a scheduled import job still references it, `get_oauth_integration` raises `ValueError("Integration not found: <id>")` because the `Integration` row no longer exists for that team. This is a user/upstream configuration error — retrying can never recreate the deleted row — yet the job keeps retrying, generating tens of thousands of occurrences over months.

## Changes

Add `"Integration not found"` to the Bing Ads source's `get_non_retryable_errors` so the schema is disabled with a clear, actionable message asking the user to reconnect their integration, instead of retrying forever.

This mirrors the Stripe source, which already treats the identical `OAuthMixin.get_oauth_integration` failure as non-retryable. The match is on the stable prefix only (`"Integration not found"`), since the integration id in the message is volatile.

Scope is strictly this one error string for this one source — no change to global retry policy.

## How did you test this code?

I'm an agent. I added a parameterized case to the existing non-retryable recognition test asserting `"Integration not found"` is recognised and matches a representative `"Integration not found: 160672"` message, and verified the existing transient-failure test still confirms it does not match transport-level errors.

Automated tests run locally:
- `posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py` — 27 passed.

## 🤖 Agent context

Triaged from a PostHog error-tracking issue for the BingAds source. Confirmed the stack trace originates in `bing_ads/source.py` (`source_for_pipeline` calling `get_oauth_integration`), classified it as a user/upstream error (deleted/disconnected integration, unrecoverable by retry), and extended `NonRetryableErrors` following the Stripe `get_non_retryable_errors` pattern.
