### PR TITLE
fix(postgres): treat Supavisor "(ENOTFOUND) tenant/user not found" as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -171,6 +171,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "is not permitted to log in": None,
             "Tenant or user not found connection to server": None,
             "FATAL: Tenant or user not found": None,
+            # Newer Supabase/Supavisor poolers report a missing tenant/user with a different
+            # wording than the two lines above ("FATAL: (ENOTFOUND) tenant/user <user> not found").
+            # It means the pooler can't resolve the project ref or pooler username — the project is
+            # paused/deleted or the credentials are wrong — so it's permanent until the customer
+            # fixes their config. Match the stable fragment and exclude the volatile username/host.
+            "(ENOTFOUND) tenant/user": (
+                "Your database connection pooler couldn't find the tenant or user "
+                '("tenant/user not found"). This usually means the database project is paused or '
+                "deleted, or the pooler username/host is wrong. Check that your database is active "
+                "and the connection details are correct, then re-enable the sync."
+            ),
             "error received from server in SCRAM exchange: Wrong password": None,
             "could not translate host name": None,
             "timeout expired connection to server at": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -143,12 +143,29 @@ class TestPostgresSourceNonRetryableErrors:
             'FATAL: no such database "nonexistent_db"',
             "Name or service not known",
             "BaseSSHTunnelForwarderError: Could not establish session to SSH gateway",
+            # Newer Supabase/Supavisor pooler wording for a missing tenant/user. The older
+            # "Tenant or user not found connection to server" / "FATAL: Tenant or user not found"
+            # patterns don't substring-match this, so it needs its own key.
+            'connection failed: connection to server at "52.45.94.125", port 6543 failed: FATAL:  (ENOTFOUND) tenant/user postgres.hksbxxtlcfeyyalgveif not found',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Permanent error should be non-retryable: {error_msg}"
+
+    def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
+        # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,
+        # so confirm it's specifically the new key that recognises this message.
+        error_msg = (
+            'connection failed: connection to server at "52.45.94.125", port 6543 failed: '
+            "FATAL:  (ENOTFOUND) tenant/user postgres.hksbxxtlcfeyyalgveif not found"
+        )
+        non_retryable = source.get_non_retryable_errors()
+        assert "(ENOTFOUND) tenant/user" in non_retryable
+        assert "Tenant or user not found connection to server" not in error_msg
+        assert "FATAL: Tenant or user not found" not in error_msg
+        assert any(pattern in error_msg for pattern in non_retryable.keys())
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import source surfaced a high-volume, still-active `OperationalError` in error tracking:

```
connection failed: connection to server at "…", port 6543 failed:
FATAL:  (ENOTFOUND) tenant/user postgres.<ref> not found
```

This is the Supabase/Supavisor connection-pooler way of saying the tenant (project ref) or pooler user can't be resolved — the database project is paused or deleted, or the pooler username/host is wrong. It's a permanent customer-side config error, so there's nothing for us to do but stop retrying.

The source already marks the *older* Supavisor wording as non-retryable (`Tenant or user not found connection to server`, `FATAL: Tenant or user not found`), but neither of those is a substring of the newer `(ENOTFOUND) tenant/user … not found` message. So the import kept retrying this permanent error, which is what generated the large occurrence count on the issue.

## Changes

- Add `(ENOTFOUND) tenant/user` to `PostgresSource.get_non_retryable_errors()` with an actionable, customer-facing message. The matched fragment is stable and deliberately excludes the volatile username, host, and IP to keep false positives low.
- Scoped strictly to this message. The same error-tracking issue also groups genuinely transient `server closed the connection unexpectedly` failures — those are left retryable and untouched.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Extended `TestPostgresSourceNonRetryableErrors::test_permanent_connection_errors_are_non_retryable` with the real Supavisor message wording.
- Added `test_supavisor_enotfound_tenant_user_uses_new_key`, which asserts the new key recognises the message and documents that the two older tenant/user patterns do **not** substring-match it.
- Ran `pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors` → 21 passed. `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. Confirmed via the PostHog error-tracking tools that the issue is active and that the stack originates in `posthog/temporal/data_imports/sources/postgres/` (`source.py` `get_schemas` → `postgres.py` `pg_connection` / `_connect_to_postgres`). Decided this is a user/upstream config error rather than a fixable bug or a transient infra error, so the fix extends `NonRetryableErrors` (mirroring the Stripe source pattern) rather than changing retry/backoff. Confirmed the message was not already covered by the existing tenant/user matchers before adding the new one.
