### PR TITLE
fix(linkedin_ads): treat invalid account ID 400 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -52,6 +52,12 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # or PostHog no longer has access to it. Retrying can't fix a missing resource, so we
             # stop and surface a config-facing message instead of burning retries every schedule.
             "No virtual resource found": "LinkedIn could not find the configured ad account. Please check that the Account ID is correct and that PostHog still has access to it, then try again.",
+            # The Account ID is a free-text field. A malformed value (a profile URL, a name, stray
+            # whitespace) makes LinkedIn reject the `urn:li:sponsoredAccount:<id>` accounts param with
+            # a deterministic 400 ("...is invalid. Reason: Deserializing output ... failed"). Retrying
+            # never succeeds, so fail fast and tell the user to fix the configured Account ID. Match on
+            # the stable prefix only — the offending value that follows varies per source.
+            "Array parameter 'accounts' value 'urn:li:sponsoredAccount:": "The LinkedIn Ads Account ID is invalid. Please check the Account ID in your source configuration — it should be the numeric account ID from your LinkedIn Campaign Manager.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -1,7 +1,10 @@
+import json
+
 import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.generated_configs import LinkedinAdsSourceConfig
+from posthog.temporal.data_imports.sources.linkedin_ads.client import LinkedinAdsClient
 from posthog.temporal.data_imports.sources.linkedin_ads.source import LinkedInAdsSource
 
 
@@ -120,3 +123,55 @@ class TestLinkedInAdsSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
 
         assert not any(pattern in transient_message for pattern in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "invalid_account_id",
+        [
+            "Reed Lnkedin",
+            "https://www.linkedin.com/company/recruiteasy-ca",
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_invalid_account_id_error_is_non_retryable(self, mock_restli_client, invalid_account_id):
+        """A malformed Account ID makes LinkedIn reject the accounts URN with a deterministic 400.
+        The raised message must match a get_non_retryable_errors pattern, else the job retries forever."""
+        body = json.dumps(
+            {
+                "message": (
+                    f"Array parameter 'accounts' value 'urn:li:sponsoredAccount:{invalid_account_id}' is invalid. "
+                    f"Reason: Deserializing output 'urn:li:sponsoredAccount:{invalid_account_id}' failed"
+                ),
+                "status": 400,
+            }
+        )
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 400
+        mock_response.response.text = body
+        mock_restli_client.return_value.finder.return_value = mock_response
+
+        client = LinkedinAdsClient("test_access_token")
+        with pytest.raises(Exception) as exc_info:
+            client.get_accounts()
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_non_retryable_errors()
+        assert any(pattern in error_message for pattern in patterns), (
+            f"LinkedIn invalid-account error '{error_message}' does not match any non-retryable pattern"
+        )
+
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_unrelated_400_is_not_classified_as_non_retryable(self, mock_restli_client):
+        """The accounts-URN pattern must be specific — an unrelated 400 must not match it."""
+        body = json.dumps({"message": "Invalid 'fields' parameter", "status": 400})
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 400
+        mock_response.response.text = body
+        mock_restli_client.return_value.finder.return_value = mock_response
+
+        client = LinkedinAdsClient("test_access_token")
+        with pytest.raises(Exception) as exc_info:
+            client.get_accounts()
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_non_retryable_errors()
+        assert not any(pattern in error_message for pattern in patterns)


### PR DESCRIPTION
## Problem

The `linkedin_ads` data-warehouse source surfaces a recurring error in error tracking:

```
LinkedIn API error (400): {"message":"Array parameter 'accounts' value 'urn:li:sponsoredAccount:<value>' is invalid. Reason: Deserializing output 'urn:li:sponsoredAccount:<value>' failed","status":400}
```

The `Account ID` is a free-text source-config field. When a user enters a malformed value (a LinkedIn profile/company URL, a name, stray whitespace) instead of the numeric sponsored-account ID, every analytics request builds `urn:li:sponsoredAccount:<value>` and LinkedIn rejects it with a **deterministic 400**. The job currently treats this as a generic failure and retries it indefinitely, so a single misconfigured source produces a continuous stream of identical errors (tens of thousands of occurrences) that can never succeed until the config is fixed.

## Changes

This is a user/config error, not a code bug — the request is well-formed; the value the user supplied is invalid, and no amount of retrying will fix it. Following the established `get_non_retryable_errors` pattern (see the Stripe source), this adds the stable message prefix to `LinkedInAdsSource.get_non_retryable_errors` so the sync fails fast with an actionable message:

> The LinkedIn Ads Account ID is invalid. Please check the Account ID in your source configuration — it should be the numeric account ID from your LinkedIn Campaign Manager.

The match key is the stable prefix `Array parameter 'accounts' value 'urn:li:sponsoredAccount:` — the offending value that follows varies per source, so it is deliberately excluded from the match. Transient/5xx/short-window-429 errors are untouched and remain retryable.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated tests at the client/source layer:

- `test_invalid_account_id_error_is_non_retryable` (parametrized over two real offending values) drives a 400 with the LinkedIn body through `LinkedinAdsClient` and asserts the raised message matches a `get_non_retryable_errors` pattern.
- `test_unrelated_400_is_not_classified_as_non_retryable` asserts an unrelated 400 does **not** match the new pattern, guarding against over-broad matching.

```
pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
6 passed
```

`ruff check` and `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the `linkedin_ads` import source. Confirmed via the PostHog error-tracking tools that the failure originates in `linkedin_ads/client.py` (`_call_finder` raising on a non-200), then traced the call path: `account_id` flows from the free-text source config (`source.py`) through `linkedin_ads_source` into `client.get_analytics`, which interpolates it into the `accounts` URN.

Decision: classified as a user/upstream config error rather than a fixable code bug, because the value originates entirely from user input, the API response is a deterministic 400, and retries cannot succeed. Mirrored the Stripe `get_non_retryable_errors` approach and matched on a stable, low-false-positive substring (excluding the volatile account value). Tools used: Claude Code with the PostHog error-tracking MCP.
