### PR TITLE
fix(linkedin_ads): treat daily rate limit as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -42,6 +42,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
         return {
             "REVOKED_ACCESS_TOKEN": None,
             "The token used in the request has expired": "Failed to refresh token for LinkedIn Ads integration. Please re-authorize the integration.",
+            # LinkedIn's per-member/app daily call budget only resets at midnight UTC, so retrying
+            # within the run just burns the remaining budget on doomed calls. The client already
+            # avoids in-process retries by raising LinkedinAdsDailyRateLimitError; failing the
+            # activity here too lets the next scheduled sync resume instead of retry-storming.
+            "LinkedIn daily rate limit reached (429)": "LinkedIn's daily API rate limit was reached. The sync will resume automatically on the next scheduled run once the limit resets.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.generated_configs import LinkedinAdsSourceConfig
@@ -59,3 +60,26 @@ class TestLinkedInAdsSource:
         assert "Failed to validate LinkedIn Ads credentials" in error_message
         assert "Database error" in error_message
         mock_capture_exception.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            'LinkedIn daily rate limit reached (429): {"status":429,"serviceErrorCode":101,"code":"TOO_MANY_REQUESTS","message":"Resource level throttle APPLICATION_AND_MEMBER DAY limit for calls to this resource is reached."}',
+            "LinkedinAdsDailyRateLimitError: LinkedIn daily rate limit reached (429): {}",
+        ],
+    )
+    def test_non_retryable_errors_match_daily_rate_limit(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            # Short-window 429s stay retryable — they are not the daily budget throttle.
+            'LinkedIn API error (retryable, 429): {"message":"Resource throttle MINUTE limit reached."}',
+            "LinkedIn API error (retryable, 503): service unavailable",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_transient(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

The `linkedin_ads` data-warehouse import source surfaces a high-frequency error in error tracking: `LinkedinAdsDailyRateLimitError — LinkedIn daily rate limit reached (429)` ([issue](https://us.posthog.com/project/2/error_tracking/019e6e74-8173-7051-9046-e4dd0292a9bf)), with tens of thousands of occurrences over a couple of weeks.

LinkedIn's 429 throttle bodies name the exceeded window (SECOND / MINUTE / DAY). A DAY throttle is the per-member/app daily call budget that only resets at midnight UTC. The client already classifies this case correctly — it raises a dedicated `LinkedinAdsDailyRateLimitError` and deliberately excludes it from the in-process `tenacity` retry, with a docstring stating the intent: "fail fast and let the next scheduled sync resume."

The gap: that intent was only wired up at the in-process layer. At the **Temporal activity** layer, the source's `get_non_retryable_errors` did not list this error, so the whole import activity kept retrying — and every retry re-hit the same daily limit, producing the retry-storm of identical errors.

## Changes

Add the stable, code-controlled message substring `"LinkedIn daily rate limit reached (429)"` to `LinkedInAdsSource.get_non_retryable_errors`, with a user-facing message explaining the sync will resume on the next scheduled run once the limit resets.

This completes the existing design rather than introducing new behavior. The matched substring is a fixed phrase we emit ourselves (no volatile URLs/ids/timestamps), so it won't false-positive. Short-window (SECOND/MINUTE) 429s continue to raise the retryable `LinkedinAdsRetryableError` and are unaffected.

## How did you test this code?

I'm an agent. I added parameterized unit tests in `test_linkedin_source.py` and ran them:

- `test_non_retryable_errors_match_daily_rate_limit` — the daily-limit message (raw and class-prefixed forms) is recognised as non-retryable.
- `test_non_retryable_errors_does_not_match_transient` — short-window 429s and 5xx retryable errors are **not** matched.

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py -q
7 passed
```

`ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Read the full stack trace (raised in `linkedin_ads/client.py:_call_finder`, reached via `get_analytics` → `get_data_by_resource` → the source's `get_rows`) and confirmed the failure genuinely originates in this source. Decision: this is an upstream throttle where retrying within the run is futile until the daily budget resets, so the right action is extending `get_non_retryable_errors` (mirroring the Stripe pattern) rather than a code fix — the in-process classification was already correct; only the activity-level retry policy needed to honour it. Tools: PostHog error-tracking MCP for triage, repo search/read, pytest + ruff locally.
