### PR TITLE
fix(mongodb): treat atlas bad auth as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -51,6 +51,11 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # matched the real message — key off the stable codeName and the capitalised message.
             "AuthenticationFailed": auth_failed_msg,
             "Authentication failed": auth_failed_msg,
+            # MongoDB Atlas returns a different shape for bad credentials: codeName 'AtlasError'
+            # (code 8000) with the lowercase errmsg 'bad auth : authentication failed'. That casing
+            # matches neither pattern above, so match on the stable Atlas message text. Keying off
+            # 'AtlasError' alone would be too broad — Atlas reuses code 8000 for non-auth failures.
+            "bad auth : authentication failed": auth_failed_msg,
             "SSL handshake failed": None,
             # pymongo raises ServerSelectionTimeoutError when it can't select a usable cluster node
             # for the whole selection timeout. The reason varies — "No servers found yet" / "No

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -337,6 +337,12 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', "
                 "'code': 18, 'codeName': 'AuthenticationFailed'}",
             ),
+            # MongoDB Atlas variant for bad credentials: lowercase errmsg, code 8000, AtlasError.
+            (
+                "atlas_bad_auth",
+                "bad auth : authentication failed, full error: {'ok': 0, 'errmsg': 'bad auth : "
+                "authentication failed', 'code': 8000, 'codeName': 'AtlasError'}",
+            ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
             # ServerSelectionTimeoutError variants — cluster unreachable for the whole selection
@@ -390,6 +396,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         [
             ("code_name", "AuthenticationFailed", "password"),
             ("message", "Authentication failed", "password"),
+            ("atlas_bad_auth", "bad auth : authentication failed", "password"),
             ("unreachable_topology", "Topology Description:", "allowlist"),
         ]
     )


### PR DESCRIPTION
## Problem

The `mongodb` data-warehouse import source surfaced a high-volume error in error tracking: `OperationFailure: bad auth : authentication failed, full error: {'ok': 0, 'errmsg': 'bad auth : authentication failed', 'code': 8000, 'codeName': 'AtlasError'}`.

This is a MongoDB **Atlas** credentials failure — the database user's username/password is wrong or revoked. Retrying never recovers; the customer has to fix their credentials.

The source already had non-retryable patterns for the self-hosted MongoDB shape of this error (`OperationFailure` with code 18, `codeName: 'AuthenticationFailed'`, errmsg `'Authentication failed.'`). But Atlas returns a different shape: `codeName: 'AtlasError'` (code 8000) with the **lowercase** errmsg `bad auth : authentication failed`. Because non-retryable matching is case-sensitive substring matching, neither existing pattern (`AuthenticationFailed`, `Authentication failed`) matched the Atlas message, so these jobs kept being retried instead of failing fast.

The failure originates in `posthog/temporal/data_imports/sources/mongodb/mongo.py` (`_get_rows_to_sync` → pymongo `count_documents` → auth handshake), confirmed via the error-tracking issue's stack trace and sampled events.

## Changes

- Add `bad auth : authentication failed` to `MongoDBSource.get_non_retryable_errors()`, mapped to the existing user-facing "check the username and password" message.
- Match on the stable message text rather than `AtlasError` — Atlas reuses code 8000 for non-auth failures, so keying off the codeName alone would be too broad and risk swallowing real, retryable problems.
- Extend the existing `TestMongoDBNonRetryableErrors` parameterized tests to cover the Atlas variant (both the recognition test and the friendly-message test).

## How did you test this code?

I'm an agent. The local environment couldn't run the full pytest suite (missing core deps), so I:
- Verified the matching logic in isolation against the exact error string from the error-tracking event, confirming the new pattern matches it, the prior code-18 variant still matches, and transient errors (`connection closed`, `NetworkTimeout`) remain retryable.
- Ran `ruff check` and `ruff format --check` on both changed files (pass).

The added test cases follow the existing parameterized patterns in `test_mongo.py` and should run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MongoDB data-warehouse source. Decision: this is a user/upstream credentials error (Atlas `bad auth`, code 8000), not a bug in our code — the correct action is to stop retrying, so I extended the source's `NonRetryableErrors` rather than changing pipeline behavior. Chose to match the stable message substring over the `AtlasError` codeName to avoid false positives on other code-8000 failures. Scoped strictly to this error; no retry-policy or unrelated changes.
