### PR TITLE
fix(mysql): treat host-blocked (error 1129) as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -119,6 +119,13 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             "ProgrammingError: (1146": None,  # Table not found error
             "OperationalError: (1356": None,  # View not found error
             "Bad handshake": None,
+            # MySQL/MariaDB error 1129 (ER_HOST_IS_BLOCKED): the server has blocked our import
+            # host because aborted/interrupted connections from it exceeded `max_connect_errors`.
+            # The block is server-side state that only a DB admin can clear (FLUSH HOSTS /
+            # `mysqladmin flush-hosts`, a restart, or raising `max_connect_errors`) — retrying just
+            # adds more failed connections and keeps the host blocked. Match only the stable phrase,
+            # not the volatile host IP or the `mysqladmin`/`mariadb-admin` wording that varies by server.
+            "is blocked because of many connection errors": "Your MySQL/MariaDB server has blocked PostHog's host after too many interrupted connections (error 1129). Ask your database admin to run 'FLUSH HOSTS' (or 'mysqladmin flush-hosts') and consider raising 'max_connect_errors', then retry the sync.",
             # OpenSSL's signature for "tried to speak TLS to an endpoint that replied with
             # non-TLS bytes" — the source has SSL enabled but the server (or a proxy in front
             # of it, e.g. a plain TCP proxy) doesn't speak TLS, or the host/port is wrong. This

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -797,6 +797,23 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "is blocked because of many connection errors",
+            # MariaDB phrasing (suggests mariadb-admin) — what we actually observed in the wild.
+            "OperationalError: (1129, \"Host '172.31.4.130' is blocked because of many connection "
+            "errors; unblock with 'mariadb-admin flush-hosts'\")",
+            # MySQL phrasing (suggests mysqladmin) — same root cause, different unblock hint.
+            "OperationalError: (1129, \"Host '10.0.1.5' is blocked because of many connection "
+            "errors; unblock with 'mysqladmin flush-hosts'\")",
+        ],
+    )
+    def test_host_blocked_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Host-blocked error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a high-frequency `OperationalError` from the MySQL data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019e5003-e188-7151-aec0-e06704b381dd)):

```
OperationalError: (1129, "Host '…' is blocked because of many connection errors; unblock with 'mariadb-admin flush-hosts'")
```

It is raised from `posthog/temporal/data_imports/sources/mysql/mysql.py` in the `connect()` context manager (the `pymysql.connect(...)` call), reached via `get_schemas` / the import pipeline.

MySQL/MariaDB error `1129` (`ER_HOST_IS_BLOCKED`) is server-side state: the source database has blocked our import host because aborted or interrupted connections from it exceeded the server's `max_connect_errors`. Only a database admin can clear it — `FLUSH HOSTS` (`mysqladmin` / `mariadb-admin flush-hosts`), a server restart, or raising `max_connect_errors`. There is nothing PostHog can do, and continuing to retry adds more failed connections that keep the host blocked, which is why the issue accumulated a very large number of occurrences.

## Changes

Treat error `1129` as a non-retryable, user/upstream error in the MySQL source's `get_non_retryable_errors`. The match keys on the stable phrase `is blocked because of many connection errors` — it deliberately avoids the volatile host IP and the `mysqladmin` vs `mariadb-admin` wording that varies between servers. The surfaced message tells the customer to flush hosts and consider raising `max_connect_errors`, then retry.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_host_blocked_is_non_retryable`) covering the raw phrase plus both the MariaDB and MySQL full-message phrasings, and ran the source's non-retryable test suite:

```
python -m pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py::TestMySQLSourceNonRetryableErrors
# 11 passed
```

`ruff check` and `ruff format` pass on the changed files. The existing `test_transient_lost_connection_stays_retryable` continues to assert that genuine transient drops stay retryable, so this change does not widen retry suppression beyond error 1129.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue. Confirmed via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) that the failure genuinely originates in the MySQL source's `connect()` frame. Decided this is an upstream/config error rather than a fixable bug or transient infra error: the host block requires DB-admin action and retrying is actively counterproductive, so extending `NonRetryableErrors` (mirroring the Stripe pattern) is the correct fix. Chose a low-false-positive substring that excludes volatile message parts.