### PR TITLE
fix(clickhouse): treat HTTP 404 from host as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -157,6 +157,12 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "No route to host": None,
             "certificate verify failed": None,
             "SSL: WRONG_VERSION_NUMBER": None,
+            # The host answers over HTTP but returns 404 (Not Found) instead of a ClickHouse
+            # response — the configured host/port points at something that is not a ClickHouse
+            # HTTP interface (e.g. a proxy or tunnel that no longer routes to it). The endpoint
+            # is reachable and definitively answering, so retrying won't help. Match only 404 so
+            # transient gateway errors (502/503/504) stay retryable.
+            "returned response code 404": "PostHog reached your host, but it returned HTTP 404 (Not Found) instead of a ClickHouse response. Check that the host, port, and HTTPS setting point at your ClickHouse HTTP interface.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `Int32` → `Int64`) after
             # the destination table was created with the narrower type. Delta Lake can't widen

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -522,6 +522,8 @@ class TestClickHouseSourceNonRetryableErrors:
             "Could not resolve the ClickHouse host",
             "Connection refused",
             "certificate verify failed",
+            # Host is reachable but not serving a ClickHouse HTTP interface — won't self-heal.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 404",
         ],
     )
     def test_permanent_errors_are_non_retryable(self, source, error_msg):
@@ -535,6 +537,9 @@ class TestClickHouseSourceNonRetryableErrors:
             "Code: 159. DB::Exception: Timeout exceeded",  # query timeout — could be retried
             "Code: 999. DB::Exception: Keeper exception",  # transient zookeeper-style errors
             "Code: 209. DB::Exception: Socket timeout",
+            # Gateway errors are transient proxy hiccups — keep retrying, don't match like 404.
+            "HTTPDriver for https://example.com:443 returned response code 502",
+            "HTTPDriver for https://example.com:443 returned response code 503",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `DatabaseError` on the ClickHouse data-warehouse import source: `HTTPDriver for <url> returned response code 404`, raised from `_get_client` in `posthog/temporal/data_imports/sources/clickhouse/clickhouse.py` while initializing the `clickhouse-connect` client. It has fired hundreds of times over the past week and keeps retrying on the multi-day activity window.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019e9311-f10d-7a81-94ba-f1ebb328f960

A `404` here means the configured host answers over HTTP but is **not** serving a ClickHouse HTTP interface at that location (a proxy or tunnel that no longer routes to it, a decommissioned/moved endpoint, etc.). Unlike a connection refused/timeout, the server is reachable and definitively answering "Not Found", so retrying across the activity window cannot fix it — the connection details must be corrected. The repeated identical failures confirm it never self-heals.

## Changes

- Add `returned response code 404` to `ClickHouseSource.get_non_retryable_errors()` with a user-facing message pointing the customer at their host/port/HTTPS settings.
- Match **only** the 404 status so transient gateway errors (502/503/504 — proxy hiccups) stay retryable, per our retry guidelines.

## How did you test this code?

I'm an agent. I added regression cases to the existing parameterized tests and ran them:

- `TestClickHouseSourceNonRetryableErrors::test_permanent_errors_are_non_retryable` — now covers the 404 message.
- `TestClickHouseSourceNonRetryableErrors::test_transient_errors_are_retryable` — now asserts 502/503 stay retryable.

`pytest posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py::TestClickHouseSourceNonRetryableErrors` → 12 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the stack genuinely originates in this source (`_get_client` → `clickhouse_source` → `source_for_pipeline` → `import_data_activity_sync`), then read the source and the existing `get_non_retryable_errors` pattern (mirrored from the Stripe source). Decision: the 404 is an upstream/config error with nothing sensible to do but stop retrying, so it belongs in `NonRetryableErrors`. Deliberately scoped the match to 404 only — 502/503/504 are transient gateway errors and must remain retryable — and added a test locking that distinction in. Used PostHog error-tracking MCP tools to pull the trace, exception type, and frequency.