### PR TITLE
fix(bigquery): drop tz offset from DATETIME incremental cursor literal

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -431,7 +431,16 @@ def _get_query(
         else:
             last_value = db_incremental_field_last_value
 
-        if isinstance(last_value, datetime) or isinstance(last_value, date):
+        if isinstance(last_value, datetime):
+            # BigQuery DATETIME columns are timezone-naive and reject a literal that carries
+            # a UTC offset (e.g. `1970-01-01T00:00:00+00:00`), failing with "Could not cast
+            # literal ... to type DATETIME". The shared initial cursor value is tz-aware UTC,
+            # so drop the offset for DATETIME fields. TIMESTAMP columns are timezone-aware and
+            # keep it.
+            if incremental_field_type == IncrementalFieldType.DateTime and last_value.tzinfo is not None:
+                last_value = last_value.replace(tzinfo=None)
+            last_value = f"'{last_value.isoformat()}'"
+        elif isinstance(last_value, date):
             last_value = f"'{last_value.isoformat()}'"
 
         operator = incremental_type_to_operator(incremental_field_type)

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -177,6 +177,49 @@ def test_bigquery_get_query_keeps_incremental_field_in_projection():
     assert "WHERE `updated_at` > 42" in query
 
 
+def test_bigquery_get_query_datetime_initial_value_has_no_timezone_offset():
+    """BigQuery DATETIME columns are timezone-naive; a literal with a UTC offset (the shared
+    tz-aware initial cursor value) fails with "Could not cast literal ... to type DATETIME"."""
+    bq_table = mock.MagicMock(dataset_id="ds", table_id="t")
+    query = _get_query(
+        should_use_incremental_field=True,
+        db_incremental_field_last_value=None,
+        bq_table=bq_table,
+        incremental_field="updated_at",
+        incremental_field_type=IncrementalFieldType.DateTime,
+    )
+    assert "WHERE `updated_at` > '1970-01-01T00:00:00'" in query
+    assert "+00:00" not in query
+
+
+def test_bigquery_get_query_datetime_strips_offset_from_stored_value():
+    """A stored tz-aware cursor value must also lose its offset for DATETIME columns."""
+    bq_table = mock.MagicMock(dataset_id="ds", table_id="t")
+    last_value = parser.parse("2024-03-11T09:26:04+00:00")
+    query = _get_query(
+        should_use_incremental_field=True,
+        db_incremental_field_last_value=last_value,
+        bq_table=bq_table,
+        incremental_field="updated_at",
+        incremental_field_type=IncrementalFieldType.DateTime,
+    )
+    assert "WHERE `updated_at` > '2024-03-11T09:26:04'" in query
+    assert "+00:00" not in query
+
+
+def test_bigquery_get_query_timestamp_keeps_timezone_offset():
+    """BigQuery TIMESTAMP columns are timezone-aware, so the UTC offset must be preserved."""
+    bq_table = mock.MagicMock(dataset_id="ds", table_id="t")
+    query = _get_query(
+        should_use_incremental_field=True,
+        db_incremental_field_last_value=None,
+        bq_table=bq_table,
+        incremental_field="created_at",
+        incremental_field_type=IncrementalFieldType.Timestamp,
+    )
+    assert "WHERE `created_at` > '1970-01-01T00:00:00+00:00'" in query
+
+
 @pytest.mark.parametrize(
     "malicious_column",
     [


### PR DESCRIPTION
## Problem

BigQuery imports of tables with a `DATETIME` incremental field were failing on the incremental sync query with:

```
BadRequest: Could not cast literal "1970-01-01T00:00:00+00:00" to type DATETIME at [3:45]
```

Observed in error tracking: [issue 019cddb8-6d20-7fe3-bfd3-4f82621e5fd6](https://us.posthog.com/project/2/error_tracking/019cddb8-6d20-7fe3-bfd3-4f82621e5fd6) — the failing frame is `get_rows` in `posthog/temporal/data_imports/sources/bigquery/bigquery.py`, raised when `job.result()` runs the cursor query.

Root cause: BigQuery's `DATETIME` type is timezone-*naive* and rejects a literal that carries a UTC offset. The shared `incremental_type_to_initial_value(DateTime)` returns a tz-aware UTC datetime (`1970-01-01T00:00:00+00:00`), and `_get_query` formatted it straight into the `WHERE` clause via `isoformat()`. BigQuery `TIMESTAMP` columns *are* timezone-aware, so the offset is valid there — which is why `filter_bigquery_incremental_fields` already maps the two BigQuery types to distinct `IncrementalFieldType`s. The first incremental sync of any `DATETIME` column hit the initial-value path and failed, then failed again on every retry without advancing.

## Changes

In `_get_query`, when the incremental field type is `DateTime`, drop the timezone offset from the cursor literal (both the initial value and any tz-aware stored value). `Timestamp` fields keep the offset. This is a code bug in how we build the query, not a credentials/config/upstream problem, so it's fixed rather than added to `NonRetryableErrors`.

## How did you test this code?

I'm an agent (Claude Code). I added regression tests at the same layer as the fix (`_get_query`) and ran the source test suite — no manual end-to-end run against BigQuery:

- `test_bigquery_get_query_datetime_initial_value_has_no_timezone_offset` — initial-value path emits `'1970-01-01T00:00:00'` with no `+00:00`.
- `test_bigquery_get_query_datetime_strips_offset_from_stored_value` — a stored tz-aware cursor value also loses its offset.
- `test_bigquery_get_query_timestamp_keeps_timezone_offset` — TIMESTAMP fields keep `+00:00`.

All 23 tests in `posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` pass; `ruff check` and `ruff format --check` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the BigQuery data-warehouse source. Used PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the failure and pull the stack trace, then traced the call path from the import pipeline into `_get_query`. Decision: this is a fixable query-construction bug (we emit an invalid literal for tz-naive DATETIME columns), not a user/upstream error, so the fix targets the query builder and is covered by a regression test rather than extending `NonRetryableErrors`.
