### PR TITLE
fix(meta_ads): refresh stale db connection before integration read

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -835,7 +835,9 @@ class TestGetIntegration:
             return integration
 
         monkeypatch.setattr(meta_ads.Integration.objects, "get", fake_get)
-        monkeypatch.setattr(meta_ads, "MetaAdsIntegration", lambda i: mock.MagicMock(integration=i))
+
+        meta_ads_integration = mock.MagicMock(integration=integration)
+        monkeypatch.setattr(meta_ads, "MetaAdsIntegration", lambda _: meta_ads_integration)
 
         config = mock.MagicMock()
         config.meta_ads_integration_id = 1
@@ -843,4 +845,5 @@ class TestGetIntegration:
         result = meta_ads.get_integration(config, team_id=1)
 
         assert calls == ["close_old_connections", "Integration.objects.get"]
+        meta_ads_integration.refresh_access_token.assert_called_once()
         assert result is integration


### PR DESCRIPTION
## Problem

The `meta_ads` data-warehouse import source raises `OperationalError: the connection is closed` from `get_integration` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ce021-4f35-7271-8bde-4e527b4f99ed)). It has been firing steadily and is the dominant failure for this source.

`get_integration` calls `Integration.objects.get(...)` against PostHog's own Postgres DB. It is invoked lazily from inside `get_rows`, which runs on a worker thread in the data-imports thread pool. By the time the sync reaches it, the pooled Django connection has often been idle for minutes and has been closed server-side — psycopg then raises `the connection is closed` on the next cursor.

This is our own bug, not an upstream/credential problem: the read is against our database, the connection is stale, and we already know how to handle it. It is also not a transient infra error to leave retryable — the sibling ads sources fixed it deterministically rather than relying on retries.

## Changes

Call `close_old_connections()` at the top of `get_integration`, before the ORM read, so the query runs on a fresh connection. This mirrors the identical guard already present in the Google Ads (`google_ads_client`) and Google Search Console (`_credentials`) sources, which share the same lazy-read-from-`get_rows` structure.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing claimed.

- Added `TestGetIntegration::test_refreshes_stale_db_connection_before_query`, a regression test asserting `close_old_connections()` is called before `Integration.objects.get`, mirroring the existing Google Search Console test.
- Ran the full `test_meta_ads.py` suite locally: 52 passed.
- `ruff check` / `ruff format`: clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the full stack trace via the PostHog error-tracking MCP tools and confirmed the in-app frames originate in `meta_ads.py` (`get_rows` → `get_integration` → Django ORM → psycopg). Decided this is a fixable bug rather than a `NonRetryableErrors` addition: the failing read is against PostHog's own DB on a stale pooled connection, and the two structurally-identical sibling sources (Google Ads, Google Search Console) already guard the same call with `close_old_connections()`. Scoped the change to just that guard plus a regression test.

Tools used: PostHog MCP error-tracking tools, Claude Code.
