### PR TITLE
fix(meta_ads): drop stale DB connection before integration lookup

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -5,6 +5,8 @@ import collections.abc
 from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from django.db import close_old_connections
+
 from requests import Response
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
@@ -91,6 +93,12 @@ def _clean_account_id(s: str | None) -> str | None:
 
 def get_integration(config: MetaAdsSourceConfig, team_id: int) -> Integration:
     """Get the Meta Ads integration."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it, surfacing as
+    # `OperationalError: the connection is closed` — drop any stale connection first.
+    close_old_connections()
     integration = Integration.objects.get(id=config.meta_ads_integration_id, team_id=team_id)
     meta_ads_integration = MetaAdsIntegration(integration)
     meta_ads_integration.refresh_access_token()

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -5,6 +5,8 @@ import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
+from posthog.temporal.data_imports.sources.meta_ads import meta_ads as meta_ads_module
 from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     META_AUTH_ERROR_MESSAGE,
     PAGE_LIMIT_FALLBACK_SIZES,
@@ -15,6 +17,7 @@ from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     _next_smaller_limit,
     _override_limit,
     _strip_access_token,
+    get_integration,
 )
 from posthog.temporal.data_imports.sources.meta_ads.source import MetaAdsSource
 
@@ -732,3 +735,34 @@ class TestNonRetryableErrors:
     )
     def test_is_permanent_auth_error(self, body: dict, expected: bool) -> None:
         assert _is_permanent_auth_error(_mock_response(400, body)) is expected
+
+
+class TestGetIntegration:
+    def test_refreshes_stale_db_connection_before_query(self, monkeypatch) -> None:
+        # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: the connection is closed`. We must drop the stale
+        # connection before querying, so the read happens on a fresh connection.
+        calls: list[str] = []
+
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", lambda: calls.append("close_old_connections"))
+
+        integration = mock.MagicMock()
+
+        def fake_get(*args: Any, **kwargs: Any) -> mock.MagicMock:
+            calls.append("Integration.objects.get")
+            return integration
+
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", fake_get)
+
+        meta_ads_integration = mock.MagicMock()
+        meta_ads_integration.integration = integration
+        meta_ads_integration.integration.errors = None
+        monkeypatch.setattr(meta_ads_module, "MetaAdsIntegration", lambda _integration: meta_ads_integration)
+
+        config = MetaAdsSourceConfig(account_id="act_1", meta_ads_integration_id=1, sync_lookback_days=90)
+        result = get_integration(config, team_id=1)
+
+        # The stale connection must be dropped before the ORM read is issued.
+        assert calls == ["close_old_connections", "Integration.objects.get"]
+        assert result is integration


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError: the connection is closed` originating in the Meta Ads data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019dd90c-107e-76a1-8cc9-e1c72bf12dae), ~67 occurrences over the last 6 weeks).

The full stack shows the failure is raised at `meta_ads.get_integration` (`meta_ads.py:94`) when it runs `Integration.objects.get(...)`. The underlying exception comes from `psycopg` / `django.db.utils` — the pooled Postgres connection had been closed server-side.

`get_integration` is invoked lazily from inside `get_rows`, on a worker thread in a long-running Temporal activity. By the time the source starts iterating, the Django connection has often been idle for minutes, so Postgres (or a proxy in front of it) has dropped it. The first ORM read on that stale handle then raises `the connection is closed`.

This is a transient infrastructure error, not a user/upstream auth problem — so it should stay retryable and does **not** belong in `NonRetryableErrors`. The fix is to make the lazy read resilient instead.

## Changes

`get_integration` now calls Django's `close_old_connections()` before the `Integration.objects.get(...)` read, so a stale connection is discarded and the query runs on a fresh one.

This mirrors the identical, already-shipped fix in the sibling sources `google_ads` (`google_ads.py:47`) and `google_search_console` (`google_search_console.py:112`), which solved the exact same "connection is closed" failure on their lazy integration lookups.

## How did you test this code?

I'm an agent (PostHog Code). I added a regression test, `TestGetIntegration::test_refreshes_stale_db_connection_before_query`, that asserts `close_old_connections()` is invoked before the ORM read (it would fail without the fix), mirroring the equivalent google_search_console test. Automated tests I ran locally:

- `pytest posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py` — 52 passed (including the new test).
- `ruff check` / `ruff format` — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Investigation: pulled the issue and a representative event's full stack trace via the PostHog MCP error-tracking tools, confirmed the in-app frame is genuinely in `meta_ads.py` and the real exception is a closed Postgres connection from the lazy `Integration.objects.get`. Decision: classified as transient infrastructure (keep retryable, not a `NonRetryableErrors` candidate) but with a concrete, low-risk code fix already proven in two sibling sources — so applied the `close_old_connections()` guard rather than touching retry policy. Scope kept to the single failing function plus a regression test.
