### PR TITLE
fix(redshift): stop EXPLAIN debug helper flooding error tracking

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -338,6 +338,27 @@ class TestExplainQuery:
 
         cursor.connection.rollback.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            psycopg.errors.InFailedSqlTransaction(
+                "current transaction is aborted, commands ignored until end of transaction block"
+            ),
+            RuntimeError("boom"),
+        ],
+    )
+    def test_does_not_capture_exception_on_failure(self, exc, logger):
+        # Regardless of the failure type — an already-aborted transaction (`InFailedSqlTransaction`)
+        # or any other error — the debug-only EXPLAIN probe must never report to error tracking.
+        cursor = MagicMock()
+        cursor.execute.side_effect = exc
+        cursor.connection.info.transaction_status = TransactionStatus.IDLE
+
+        with patch("posthog.temporal.data_imports.sources.redshift.redshift.capture_exception") as mock_capture:
+            _explain_query(cursor, sql.SQL("SELECT 1").format(), logger)
+
+        mock_capture.assert_not_called()
+
 
 class TestFetchAverageRowSize:
     def _inner(self):


### PR DESCRIPTION
## Problem

PostHog error tracking is flooded with a handled `InFailedSqlTransaction` ("current transaction is aborted, commands ignored until end of transaction block") originating in the Redshift data-warehouse import source — tens of thousands of occurrences over the last month.

The frame is `_explain_query` at `posthog/temporal/data_imports/sources/redshift/redshift.py:226`. `_explain_query` is a **debug-only, best-effort helper**: it runs `EXPLAIN <query>` solely so it can `logger.debug(...)` the plan. It shares the caller's cursor and transaction.

In `build_pipeline`, all the metadata probes run sequentially on one cursor in one psycopg transaction. The helper methods (`get_rows_to_sync`, `fetch_average_row_size`, `fetch_table_stats`, `has_duplicate_primary_keys`) catch and swallow query errors to keep discovery going, but never roll back — so the first failure poisons the transaction, and every subsequent statement (including the diagnostic `EXPLAIN`) raises `InFailedSqlTransaction`. `_explain_query` was passing each of those to `capture_exception`, reporting a non-actionable downstream symptom to error tracking on every metadata query.

The sibling Postgres source's `_explain_query` was already corrected to swallow these (no `capture_exception`); the Redshift twin was missed.

## Changes

- Remove the `capture_exception(e)` call from Redshift's `_explain_query`; keep the existing debug log. This matches the already-fixed Postgres `_explain_query`.
- Add a regression test (`TestExplainQuery`) asserting the helper does **not** call `capture_exception` when EXPLAIN raises `InFailedSqlTransaction` (or any other exception), and never propagates.

This is a noise fix, not error-swallowing: the real query failures that poison the transaction are still captured at their own call sites with accurate fingerprints. The EXPLAIN failure carried no information those don't already.

## How did you test this code?

I'm an agent (Claude Code). I ran the source's unit suite locally:

```
python -m pytest posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py -q
# 77 passed
```

plus `ruff check` / `ruff format` on the two changed files. No manual end-to-end run against a live Redshift cluster.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Redshift import source. Confirmed the issue in error tracking (stack frame `_explain_query:226`, cursor reported `[INERROR]`, EXPLAIN target was `fetch_table_stats`'s `svv_table_info` query), read the implementation, and traced the abort to an earlier swallowed failure poisoning the shared transaction. Classified as a fixable bug rather than a user/upstream error — `InFailedSqlTransaction` is internal transaction-state mismanagement, and the diagnostic helper should never report its own swallowed failures. Chose to mirror the Postgres source's already-blessed fix rather than restructure transaction handling, keeping the change scoped to the reported issue.
