### PR TITLE
fix(convex): retry Cloudflare 52x transient errors during sync

### DIFF
--- a/posthog/temporal/data_imports/sources/convex/convex.py
+++ b/posthog/temporal/data_imports/sources/convex/convex.py
@@ -12,10 +12,21 @@ from requests.exceptions import (
 )
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.http import DEFAULT_RETRY, make_tracked_session
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 logger = logging.getLogger(__name__)
+
+# Convex deployments are served behind Cloudflare, which surfaces transient edge/origin
+# problems as the 52x family (520 Unknown Error, 521 Web Server Down, 522 Connection Timed
+# Out, 523 Origin Unreachable, 524 Timeout). These are retryable just like the standard 5xx
+# codes, but urllib3's default forcelist doesn't include them — so a single transient 520
+# would otherwise fail the whole sync. All Convex requests are idempotent GETs, so retrying
+# them is safe. Derive from DEFAULT_RETRY so backoff/total/allowed-methods stay in sync.
+_CLOUDFLARE_TRANSIENT_STATUSES = frozenset({520, 521, 522, 523, 524})
+_CONVEX_RETRY = DEFAULT_RETRY.new(
+    status_forcelist=frozenset(DEFAULT_RETRY.status_forcelist) | _CLOUDFLARE_TRANSIENT_STATUSES
+)
 
 
 @dataclasses.dataclass
@@ -77,7 +88,7 @@ def _headers(deploy_key: str) -> dict[str, str]:
 
 def get_json_schemas(deploy_url: str, deploy_key: str) -> dict[str, Any]:
     url = f"{deploy_url.rstrip('/')}/api/json_schemas"
-    response = make_tracked_session().get(
+    response = make_tracked_session(retry=_CONVEX_RETRY).get(
         url, headers=_headers(deploy_key), params={"deltaSchema": "true", "format": "json"}, timeout=30
     )
     response.raise_for_status()
@@ -111,7 +122,9 @@ def list_snapshot(
         if snapshot is not None:
             params["snapshot"] = snapshot
 
-        response = make_tracked_session().get(base_url, headers=_headers(deploy_key), params=params, timeout=60)
+        response = make_tracked_session(retry=_CONVEX_RETRY).get(
+            base_url, headers=_headers(deploy_key), params=params, timeout=60
+        )
         response.raise_for_status()
         data = response.json()
 
@@ -160,7 +173,9 @@ def document_deltas(
     while True:
         params: dict[str, Any] = {"tableName": table_name, "cursor": current_cursor, "format": "json"}
 
-        response = make_tracked_session().get(base_url, headers=_headers(deploy_key), params=params, timeout=60)
+        response = make_tracked_session(retry=_CONVEX_RETRY).get(
+            base_url, headers=_headers(deploy_key), params=params, timeout=60
+        )
 
         if response.status_code == 400:
             error_data = response.json()

--- a/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.convex.convex import (
+    _CONVEX_RETRY,
     ConvexResumeConfig,
     InvalidDeployUrlError,
     convex_source,
@@ -188,6 +189,17 @@ class TestDocumentDeltasResumable:
         assert first_params["cursor"] == 10
 
     @patch("posthog.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_session_uses_convex_retry_policy(self, mock_get: Mock) -> None:
+        manager = _make_manager(can_resume=False)
+        mock_get.return_value.get.return_value = _make_response({"values": [], "cursor": 10, "hasMore": False})
+
+        list(document_deltas("https://x.convex.cloud", "key", "t", 10, manager))
+
+        # The Cloudflare-aware retry policy must be wired into the HTTP session, otherwise a
+        # transient 520 is raised immediately instead of retried.
+        assert mock_get.call_args.kwargs["retry"] is _CONVEX_RETRY
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.make_tracked_session")
     def test_resume_overrides_db_cursor(self, mock_get: Mock) -> None:
         saved = ConvexResumeConfig(cursor=25)
         manager = _make_manager(can_resume=True, state=saved)
@@ -202,6 +214,33 @@ class TestDocumentDeltasResumable:
         first_params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
         assert first_params["cursor"] == 25
         manager.save_state.assert_not_called()
+
+
+class TestConvexRetryPolicy:
+    @parameterized.expand(
+        [
+            # Cloudflare 52x family — Convex sits behind Cloudflare and emits these on transient
+            # edge/origin trouble. The 520 here is the exact code that fails syncs in production.
+            ("cf_520_unknown_error", 520, True),
+            ("cf_521_web_server_down", 521, True),
+            ("cf_522_connection_timed_out", 522, True),
+            ("cf_523_origin_unreachable", 523, True),
+            ("cf_524_timeout", 524, True),
+            # Standard transient codes inherited from DEFAULT_RETRY must still be retried.
+            ("rate_limited_429", 429, True),
+            ("internal_500", 500, True),
+            ("bad_gateway_502", 502, True),
+            ("service_unavailable_503", 503, True),
+            ("gateway_timeout_504", 504, True),
+            # Client errors are not transient — they must not be retried away.
+            ("bad_request_400", 400, False),
+            ("unauthorized_401", 401, False),
+            ("forbidden_403", 403, False),
+            ("not_found_404", 404, False),
+        ]
+    )
+    def test_retry_status_handling(self, _name: str, status_code: int, expected_retry: bool) -> None:
+        assert _CONVEX_RETRY.is_retry("GET", status_code) is expected_retry
 
 
 class TestConvexSource:


### PR DESCRIPTION
## Problem

The Convex data-warehouse import source fails syncs with an uncaught `HTTPError: 520 Server Error` raised from `document_deltas` in `posthog/temporal/data_imports/sources/convex/convex.py`.

Convex deployments are served behind Cloudflare. When the origin/edge has transient trouble, Cloudflare returns the `52x` status family (520 Unknown Error, 521 Web Server Down, 522 Connection Timed Out, 523 Origin Unreachable, 524 Timeout). These are transient and should be retried, but the shared `DEFAULT_RETRY` policy only retries the standard 5xx codes (`429, 500, 502, 503, 504`). A single transient `520` therefore propagated straight out of `response.raise_for_status()` and failed the whole table sync.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019d67dd-1e28-7822-bd72-0871a978dee8 (hundreds of occurrences, all originating in `convex.py`).

## Changes

This is a fixable fragility, not a user/upstream config error — a `520` is transient and must stay **retryable**, so it does not belong in `NonRetryableErrors`.

- Add a Convex-specific retry policy derived from `DEFAULT_RETRY` (via `Retry.new(...)`, so backoff/total/allowed-methods stay in sync) that extends the status forcelist with the Cloudflare `52x` family.
- Wire that policy into all three Convex HTTP call sites (`get_json_schemas`, `list_snapshot`, `document_deltas`). All Convex requests are idempotent GETs, so retrying these codes is safe.

Scope is limited to the Convex source — the global retry policy and pipeline-wide retry behavior are unchanged.

## How did you test this code?

I'm an agent. I added and ran automated tests only — no manual testing.

- Parameterized `TestConvexRetryPolicy` asserting the new policy retries the Cloudflare `52x` family and the inherited standard transient codes (`429/500/502/503/504`), while client errors (`400/401/403/404`) are not retried.
- A call-site test asserting `document_deltas` constructs its session with the Convex retry policy, so a future edit that drops the `retry=` kwarg is caught.
- Full source test suite passes: `pytest posthog/temporal/data_imports/sources/convex/tests/test_convex.py` (46 passed). Ruff check + format clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a PostHog error-tracking webhook for the Convex source. Confirmed the issue via the PostHog error-tracking MCP tools: pulled the full stack trace and a representative event, verifying the failure originates at `convex.py` `document_deltas` (`raise_for_status`) reached through the data-imports pipeline.
- Decision: classified `520` as a transient upstream/edge error rather than a user/upstream credential/config problem, so it stays retryable (not added to `NonRetryableErrors`). Root cause is that `DEFAULT_RETRY`'s forcelist omits Cloudflare's non-standard `52x` codes; fix retries them for Convex's idempotent GETs.
- Tools used: Claude Code with the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`).
