### PR TITLE
fix(reddit_ads): treat missing integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -35,7 +35,14 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
         return ExternalDataSourceType.REDDITADS
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
-        return {"401 Client Error": None, "404 Client Error": None}
+        return {
+            "401 Client Error": None,
+            "404 Client Error": None,
+            # Raised by OAuthMixin.get_oauth_integration when the connected Reddit Ads
+            # account has been deleted or disconnected. The integration row is gone, so
+            # retrying can never recover it — stop and ask the user to reconnect.
+            "Integration not found": "The connected Reddit Ads account is no longer available — it may have been disconnected. Please reconnect the source's account.",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -110,6 +110,31 @@ class TestRedditAdsSource:
         assert "Integration not found" in error_message
         mock_capture_exception.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
+            "404 Client Error: Not Found for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
+            "ValueError: Integration not found: 154683",
+        ],
+    )
+    def test_non_retryable_errors_match_known_failures(self, observed_error):
+        """Auth failures and deleted integrations must be recognised as non-retryable."""
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "500 Server Error for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
+            "ConnectionError: Connection reset by peer",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_transient(self, other_error):
+        """Transient infrastructure failures must stay retryable."""
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
     def test_get_schemas(self):
         """Test get_schemas returns all endpoint schemas."""
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

The `reddit_ads` data-warehouse import source repeatedly fails with `ValueError: Integration not found: <id>` and retries forever. This is surfaced by error tracking as a high-volume, never-resolving issue (tens of thousands of occurrences over weeks).

The error originates in `RedditAdsSource.source_for_pipeline`, which calls `OAuthMixin.get_oauth_integration(...)`. That helper raises `ValueError(f"Integration not found: {integration_id}")` when no `Integration` row matches the configured id — i.e. the connected Reddit Ads account was deleted or disconnected. There is nothing for us to do but stop retrying and ask the user to reconnect.

`Any_Source_Errors` already treats the sibling ORM message `Integration matching query does not exist` as non-retryable, but the explicit `.exists()`-check string raised by the mixin (`Integration not found: <id>`) is a different string and slips through, so the schema keeps retrying indefinitely.

## Changes

- Add `"Integration not found"` to `RedditAdsSource.get_non_retryable_errors()` with a friendly reconnect message, mirroring the Stripe source's pattern. The substring match is stable and low-false-positive (the volatile integration id is excluded).
- Add a parameterized regression test asserting auth failures and the missing-integration error are recognised as non-retryable, while transient failures (5xx, connection reset) stay retryable.

## How did you test this code?

I'm an agent. I ran the source's unit tests locally:

- `pytest posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py -k non_retryable` — 5 passed
- `pytest posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py` — 19 passed

`ruff check` and `ruff format` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the RedditAds source. Confirmed the failing frame is `source_for_pipeline` in `reddit_ads/source.py` calling `OAuthMixin.get_oauth_integration`, which raises `ValueError: Integration not found: <id>` when the integration row no longer exists. Classified as a user/upstream error (deleted/disconnected OAuth integration) rather than a code bug — retrying cannot recover a deleted integration — so the fix extends the source's `NonRetryableErrors` rather than changing pipeline logic. Matched on the stable `"Integration not found"` substring (excluding the volatile id), following the existing Stripe convention.