### PR TITLE
fix(bigquery): treat malformed dataset id table error as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -66,6 +66,12 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # so match the stable phrasing here. Retrying can't recover — the user must fix the
             # dataset or set the correct region.
             "was not found in location": "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or it may live in a different region — verify your dataset and table names, and set the dataset region in your source configuration if it isn't in the US.",
+            # Raised by google-cloud-bigquery's `TableReference.from_string` when a table id has
+            # more than the three `project.dataset.table` components. This happens when the
+            # Dataset ID field is set to `project.dataset` instead of just `dataset` — we then
+            # build `project.project.dataset.table` and the client rejects it. It's a deterministic
+            # config error, so retrying never succeeds.
+            "table_id must be a fully-qualified ID in standard SQL format": "Your BigQuery Dataset ID looks misconfigured — it should be just the dataset name (for example `analytics`), not `project.dataset`. Please update the Dataset ID in your source configuration.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a
             # narrower numeric type) after the destination table was created with the narrower

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -294,16 +294,39 @@ def test_non_retryable_errors_match_rejected_credentials(observed_error):
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Raised when the Dataset ID is `project.dataset`, so we build a 4-component table id.
+        'table_id must be a fully-qualified ID in standard SQL format, e.g., "project.dataset.table_id", '
+        "got immortal-407108.immortal-407108.analytics_529249625.events_20260325",
+        'table_id must be a fully-qualified ID in standard SQL format, e.g., "project.dataset.table_id", '
+        "got immortal-407108.immortal-407108.analytics_529249625.__posthog_import_abc_def_123",
+    ],
+)
+def test_bigquery_malformed_table_id_is_non_retryable(observed_error):
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Malformed table id error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
     "transient_error",
     [
         # A token refresh that failed for a transient reason must stay retryable.
         "RefreshError: ('Failed to retrieve token', {'error': 'internal_failure'})",
         "RefreshError: HTTPError 503 Service Unavailable",
+        "Connection reset by peer",
+        "ReadTimeout: The read operation timed out",
+        "503 Service Unavailable",
     ],
 )
 def test_non_retryable_errors_does_not_match_transient_refresh_failures(transient_error):
+    """Transient errors must not match any non-retryable key, so they stay retryable. Mirrors the
+    real matching mechanism (substring against every key) to guard against an overly broad key."""
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
-    assert not any(key in transient_error for key in non_retryable_errors)
+    matching = [key for key in non_retryable_errors if key in transient_error]
+    assert not matching, f"Transient error should remain retryable, but matched keys: {matching}"
 
 
 def _run_delete_all_temp_destination_tables(side_effect, logger):


### PR DESCRIPTION
## Problem

BigQuery data-warehouse imports were failing repeatedly with:

```
ValueError: table_id must be a fully-qualified ID in standard SQL format,
e.g., "project.dataset.table_id", got <project>.<project>.<dataset>.<table>
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e6605-f70c-7c03-ae58-2c7e501cdaf1 — tens of thousands of occurrences, with individual jobs retried hundreds of thousands of times.

The root cause is configuration. When the **Dataset ID** field is set to `project.dataset` (i.e. it already includes the project) rather than just `dataset`, the pipeline builds fully-qualified ids as `f"{project_id}.{dataset_id}.{table}"`, which then has four components. `google-cloud-bigquery`'s `TableReference.from_string` accepts at most `project.dataset.table` and raises `ValueError`. It fails the same way at both `get_table` and `delete_table`, on every attempt.

Schema discovery happens to tolerate the malformed Dataset ID (it backtick-quotes the value and passes `project` separately), so the source validates and the schema is created — but every actual data sync then fails deterministically. Because this error wasn't in `NonRetryableErrors`, jobs retried indefinitely instead of surfacing an actionable message.

## Changes

Add the stable library error substring `table_id must be a fully-qualified ID in standard SQL format` to `BigQuerySource.get_non_retryable_errors`, with a friendly message directing the user to fix the Dataset ID (it should be just the dataset name, not `project.dataset`). The match deliberately excludes the volatile `got <id>` tail so it stays low-false-positive — a four-component id can essentially only arise when the user's `dataset_id` contains a dot, so this won't mask a genuine pipeline bug.

## How did you test this code?

I'm an agent (Claude Code). I added parametrized regression tests in `bigquery/tests/test_source.py` using the real error strings observed in production: one set asserting the malformed-table-id errors are recognised as non-retryable and carry a non-null friendly message, and one asserting transient errors (connection reset, read timeout, 503) are not matched by the new key and stay retryable.

Automated tests run locally:

- `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — 25 passed
- `ruff check` / `ruff format --check` on both changed files — clean

No manual end-to-end sync testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Used the PostHog error-tracking MCP tools to confirm the issue, pull the full stack trace, and read the `code_variables` on the `build_pipeline` frame — which showed `destination_table_dataset_id` was `project.dataset` and `config.key_file.project_id` was the same project, producing a four-component id.

Decision: treated as a user/upstream configuration error rather than a code bug. The failure is deterministic (retries can never succeed until the user edits the Dataset ID), and "fixing" the code to silently accept `project.dataset` would be a riskier behavior change that interacts with the dedicated `dataset_project` config field. Per the triage guidance, extending `NonRetryableErrors` with an actionable message is the safer, tightly-scoped action; it also stops the runaway retries. Mirrors the existing Stripe `get_non_retryable_errors` pattern.
