### PR TITLE
fix(vitally): treat auth failures as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -103,6 +103,14 @@ class VitallySource(SimpleSource[VitallySourceConfig]):
 
         return False, "Invalid credentials"
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # The Vitally host is per-customer on US (`<subdomain>.rest.vitally.io`), so match on the
+        # stable status text rather than a fixed URL prefix.
+        return {
+            "401 Client Error: Unauthorized for url": "Your Vitally secret token is invalid or has been revoked. Please check your token and reconnect.",
+            "403 Client Error: Forbidden for url": "Your Vitally secret token does not have permission to access this data. Please check the token's permissions and reconnect.",
+        }
+
     def source_for_pipeline(self, config: VitallySourceConfig, inputs: SourceInputs) -> SourceResponse:
         items = vitally_source(
             secret_token=config.secret_token,

--- a/posthog/temporal/data_imports/sources/vitally/tests/test_vitally.py
+++ b/posthog/temporal/data_imports/sources/vitally/tests/test_vitally.py
@@ -268,3 +268,30 @@ class TestVitallySourceGetSchemas:
         names = {s.name for s in schemas}
         assert {"Accounts", "Conversations", "Custom_Objects", "Messages"} <= names
         assert not any(s.name.startswith(CUSTOM_OBJECT_SCHEMA_PREFIX) for s in schemas)
+
+
+class TestVitallyNonRetryableErrors:
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            # US uses a per-customer subdomain, EU a fixed host — both must be recognised.
+            "401 Client Error: Unauthorized for url: https://acme.rest.vitally.io/resources/conversations?limit=100",
+            "403 Client Error: Forbidden for url: https://acme.rest.vitally.io/resources/organizations?limit=100",
+            "401 Client Error: Unauthorized for url: https://rest.vitally-eu.io/resources/users?limit=1",
+        ],
+    )
+    def test_auth_failures_are_non_retryable(self, observed_error):
+        non_retryable_errors = VitallySource().get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "500 Server Error for url: https://acme.rest.vitally.io/resources/conversations",
+            "429 Client Error: Too Many Requests for url: https://acme.rest.vitally.io/resources/accounts",
+            "Connection aborted: read timeout",
+        ],
+    )
+    def test_transient_errors_remain_retryable(self, other_error):
+        non_retryable_errors = VitallySource().get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

The Vitally data-warehouse import source surfaces a high-volume, recurring `HTTPError` in error tracking:

```
401 Client Error: Unauthorized for url: https://<subdomain>.rest.vitally.io/resources/conversations?limit=100&sortBy=updatedAt&updatedAt=...
```

The same issue also captures `403 Client Error: Forbidden` variants. The failure originates in the source itself — `vitally_source` (`posthog/temporal/data_imports/sources/vitally/vitally.py:530`) paginates through the Vitally REST API and the shared REST client raises `HTTPError` on `raise_for_status()`.

Vitally authenticates with HTTP basic auth using the customer's secret token, so a 401/403 means that token is invalid, revoked, or lacks permission for the requested resource. There is nothing for us to do but stop retrying. However, `VitallySource` never overrode `get_non_retryable_errors`, so only the generic `Any_Source_Errors` applied — none of which cover 401/403 — and the pipeline kept retrying a request that can never succeed without the customer fixing their credentials.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019dd0c4-661f-7d61-ae24-65b592ef3e80

## Changes

Override `get_non_retryable_errors` on `VitallySource` to recognise Vitally auth failures as non-retryable, mirroring the established pattern (e.g. Stripe, Asana, BambooHR):

- `401 Client Error: Unauthorized for url` → token invalid/revoked
- `403 Client Error: Forbidden for url` → token lacks permission

The US region uses a per-customer subdomain (`<subdomain>.rest.vitally.io`), so the match is on the stable status text rather than a fixed URL prefix (the URL, ids, and timestamps are all volatile). Transient errors (5xx, 429, read timeouts) are deliberately left out so they remain retryable.

## How did you test this code?

I'm an agent (Claude Code). I added a regression test (`TestVitallyNonRetryableErrors`) asserting the 401/403 messages — across both US and EU host shapes — are recognised as non-retryable, and that transient errors (500, 429, read timeout) are not. Automated tests run locally:

- `pytest posthog/temporal/data_imports/sources/vitally/tests/test_vitally.py` — 24 passed
- `ruff check` / `ruff format` — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Vitally source. Confirmed via the error-tracking issue and a sampled event that the stack trace genuinely originates in `vitally.py` → shared REST client `_send_request`, and that the exception is a 401/403 from the Vitally API (basic-auth credential/permission failure). Classified this as a user/upstream error rather than a code bug — the only sensible action is to stop retrying — so extended the source's `NonRetryableErrors` rather than changing pipeline behaviour. Matched on host-agnostic status text because the US region's host is per-customer.
