### PR TITLE
fix(shopify): treat GraphQL access-scope denials as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -41,6 +41,14 @@ SHOPIFY_ACCESS_TOKEN_AUTH_ERROR = (
     "app was uninstalled. Please reconnect your Shopify integration."
 )
 
+# Substring of the GraphQL error Shopify returns when the connected access token lacks the
+# scope needed to read a field, e.g. "Access denied for fulfillmentOrders field." or
+# "Access denied for paymentTerms field. Required access: `read_payment_terms` access scope."
+# Retrying can't grant the missing scope — the user must reconnect with expanded permissions —
+# so `ShopifySource.get_non_retryable_errors` matches this substring to fail the job fast.
+# The field name varies, so the match anchors on the stable leading phrase.
+SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR = "Access denied for"
+
 
 @dataclasses.dataclass
 class ShopifyResumeConfig:

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -18,6 +18,7 @@ from posthog.temporal.data_imports.sources.shopify.constants import SHOPIFY_GRAP
 from posthog.temporal.data_imports.sources.shopify.settings import ENDPOINT_CONFIGS
 from posthog.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+    SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR,
     ShopifyPermissionError,
     ShopifyResumeConfig,
     shopify_source,
@@ -38,6 +39,13 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             # 4xx from Shopify's OAuth token endpoint — invalid/revoked app credentials.
             # Retrying cannot recover; the user must reconnect the integration.
             SHOPIFY_ACCESS_TOKEN_AUTH_ERROR: SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+            # GraphQL "Access denied for <field> field" — the access token is missing the
+            # scope required to read this resource. The scope can't change on retry, so fail
+            # fast and tell the user to reconnect with the required permissions.
+            SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR: (
+                "Your Shopify access token is missing the permissions required to read some of your data. "
+                "Please reconnect your Shopify integration and grant the requested access scopes."
+            ),
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -53,3 +53,33 @@ def test_get_access_token_transient_stays_retryable(status_code):
 def test_get_access_token_success_returns_token():
     with _patched_token_call(_mock_response(200, ok=True, json_data={"access_token": "tok"})):
         assert _get_shopify_access_token("store", "client-id", "client-secret") == "tok"
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Shopify GraphQL error: Access denied for fulfillmentOrders field.",
+        "Shopify GraphQL error: Access denied for paymentTerms field. Required access: `read_payment_terms` access scope.",
+        "Shopify GraphQL error: Access denied for orders field.; Access denied for paymentTerms field.",
+    ],
+)
+def test_graphql_access_denied_is_non_retryable(error_message):
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"GraphQL access-scope error '{error_message}' should match a non-retryable pattern"
+    )
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Shopify: rate limit exceeded...",
+        "Shopify: internal error from request 503 Service Unavailable",
+        "Unexpected graphql response format in Shopify rows read. Keys: ['extensions']",
+    ],
+)
+def test_transient_graphql_errors_stay_retryable(error_message):
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert not any(pattern in error_message for pattern in patterns), (
+        f"transient error '{error_message}' should remain retryable"
+    )


### PR DESCRIPTION
## Problem

The `shopify` data-warehouse import source is throwing a high volume of errors that surface in error tracking as:

> `Shopify GraphQL error: Access denied for fulfillmentOrders field.`
> `Shopify GraphQL error: Access denied for paymentTerms field. Required access: \`read_payment_terms\` access scope.`

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ce1c8-e80a-71c0-a7db-59b28d157b71

The failure originates in `posthog/temporal/data_imports/sources/shopify/shopify.py` — `_make_paginated_shopify_request.execute()` raises a generic `Exception` whenever the GraphQL response contains `errors`. Shopify returns these `Access denied for <field> field` errors when the connected access token was granted **without** the access scope required to read a particular field/connection.

Because the message wasn't matched by `ShopifySource.get_non_retryable_errors`, the activity kept retrying. Retrying can never recover: the granted scopes don't change between attempts. The only fix is for the user to reconnect the Shopify integration with the required scopes. So each affected sync burned retries before failing, repeatedly re-firing the same error.

## Changes

- Add `SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR` (substring `"Access denied for"`) in `shopify.py`. The field name in the message varies (`fulfillmentOrders`, `paymentTerms`, …), so the match anchors on the stable leading phrase rather than a volatile field name or scope name.
- Extend `ShopifySource.get_non_retryable_errors` to map it to an actionable message telling the user to reconnect and grant the requested access scopes.
- Add parametrized regression tests asserting the access-denied variants are recognized as non-retryable, and that transient errors (rate limit, 5xx, unexpected response shape) stay retryable so we don't over-widen the match.

This mirrors the existing pattern for the OAuth-token 4xx case (`SHOPIFY_ACCESS_TOKEN_AUTH_ERROR`) and the Stripe source's handling of permission/credential errors.

### Decision: user/upstream error vs. fixable bug

This is a **user/upstream permission error** (Shopify access-scope denial, equivalent to a 403). There is nothing for our code to do at runtime but stop retrying — the scope can only change when the user reconnects with expanded permissions. Transient errors were deliberately left retryable.

## How did you test this code?

I'm an agent. I added and ran automated tests — no manual testing.

- `posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py` — 15 passed, including the 6 new parametrized cases covering both the positive (access-denied) and negative (transient-stays-retryable) paths.
- `ruff check` and `ruff format --check` pass on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a live error-tracking issue for the Shopify warehouse source. Confirmed the stack trace terminates in `sources/shopify/shopify.py` (`execute`, the generic GraphQL-error raise), read the source and the shared non-retryable-error matching in `external_data_job.py` / `import_data_sync.py` (substring match), and concluded the error is an upstream access-scope denial rather than a code bug. Followed the Stripe `get_non_retryable_errors` pattern. Chose to match the stable `"Access denied for"` prefix over the volatile field/scope names to keep false positives low while covering the observed variants.