### PR TITLE
fix(linkedin_ads): refresh stale db connection before integration read

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
@@ -3,6 +3,8 @@ import datetime as dt
 import collections.abc
 from dataclasses import dataclass
 
+from django.db import close_old_connections
+
 import pyarrow as pa
 import structlog
 from structlog.types import FilteringBoundLogger
@@ -100,6 +102,12 @@ def get_schemas() -> dict[str, LinkedinAdsSchema]:
 
 def linkedin_ads_client(config: LinkedinAdsSourceConfig, team_id: int) -> LinkedinAdsClient:
     """Initialize a LinkedIn Ads client with provided config."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it — drop any stale connection first,
+    # otherwise the read surfaces as `OperationalError: the connection is closed`.
+    close_old_connections()
     integration = Integration.objects.get(id=config.linkedin_ads_integration_id, team_id=team_id)
     if not integration.access_token:
         raise ValueError("LinkedIn Ads integration does not have an access token")

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
@@ -361,6 +361,32 @@ class TestLinkedinAdsClientFunction:
         with pytest.raises(ValueError, match="LinkedIn Ads integration does not have an access token"):
             linkedin_ads_client(config, team_id=789)
 
+    def test_refreshes_stale_db_connection_before_query(self, mock_integration_model, monkeypatch):
+        # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: the connection is closed`. We must drop the stale
+        # connection before querying, so the read happens on a fresh connection.
+        calls: list[str] = []
+
+        monkeypatch.setattr(
+            "posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.close_old_connections",
+            lambda: calls.append("close_old_connections"),
+        )
+
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "access-token"
+
+        def fake_get(*args, **kwargs):
+            calls.append("Integration.objects.get")
+            return mock_integration
+
+        mock_integration_model.objects.get.side_effect = fake_get
+
+        config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=123, account_id="456")
+        linkedin_ads_client(config, team_id=789)
+
+        assert calls == ["close_old_connections", "Integration.objects.get"]
+
 
 @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.linkedin_ads_client")
 class TestLinkedinAdsSource:


### PR DESCRIPTION
## Problem

The LinkedIn Ads data-warehouse import source repeatedly fails with `OperationalError: the connection is closed`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ce025-0ea0-75e1-b901-8a7084fcc573)) — hundreds of occurrences over the last 30 days.

The failing frame is `linkedin_ads_client` in `posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py`, on this line:

```python
integration = Integration.objects.get(id=config.linkedin_ads_integration_id, team_id=team_id)
```

This function is invoked lazily from inside the source `get_rows` generator, which runs on a long-lived `ThreadPoolExecutor` worker. The pooled Django connection for that thread can be closed server-side after sitting idle for minutes between uses; the next ORM read on it then raises `OperationalError: the connection is closed`.

This is not a LinkedIn credential/config problem (so not a `NonRetryableErrors` case) — it's a fragility in how we access the DB from a pooled worker thread. The exact same failure mode was already fixed in the sibling OAuth sources: `google_ads` and `google_search_console` both call `close_old_connections()` immediately before their `Integration.objects.get(...)`. LinkedIn Ads was missing that guard.

## Changes

- Call `django.db.close_old_connections()` in `linkedin_ads_client` before reading the integration, dropping any stale connection so the read runs on a fresh one. Mirrors the established pattern in the Google Ads / Search Console sources.
- Added a regression test asserting `close_old_connections()` runs before the `Integration` query.

## How did you test this code?

I'm an agent. I ran the automated tests only — no manual testing:

- `pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py` — all 31 tests pass, including the new `test_refreshes_stale_db_connection_before_query`.
- `ruff check` and `ruff format --check` on both touched files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the LinkedIn Ads source. Pulled the full chained stack trace via the PostHog error-tracking MCP tools and confirmed the raising frame is the `Integration.objects.get` ORM read inside `linkedin_ads_client`, called from the pipeline's source-iterator thread pool.

Decision: the error is a transient/stale-DB-connection issue, not an upstream credential error, so it stays retryable — `NonRetryableErrors` was deliberately not touched. Instead the fragility is fixed at the source, matching the precedent already present in `google_ads.py` and `google_search_console.py` (same lazy-read-on-pooled-thread shape, both already guarded with `close_old_connections()`).

Tools: Claude Code (Opus 4.8) with the PostHog MCP error-tracking tools.