### PR TITLE
fix(temporalio): treat TLS CertificateParseError as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -40,6 +40,11 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
             "received fatal alert: BadCertificate": "Temporal rejected this source's client certificate as invalid. Update the source with a valid client certificate and key.",
             "received fatal alert: CertificateUnknown": "Temporal rejected this source's client certificate. Update the source with a valid client certificate and key.",
             "invalid peer certificate": "The Temporal server's certificate could not be verified. Check the host and port point at your Temporal namespace's gRPC endpoint.",
+            # tonic/rustls raises CertificateParseError when one of the PEM credential blobs cannot be
+            # decoded at all (vs the alerts above, which reject an otherwise-parseable cert). The blobs
+            # come straight from the source config, so this is a malformed-credential problem — retrying
+            # can never recover.
+            "CertificateParseError": "Temporal could not parse this source's TLS credentials. Check that the client certificate, client private key, and server root CA are valid PEM and re-enter them on the source.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -51,6 +51,7 @@ class TestTemporalIONonRetryableErrors:
             "received fatal alert: BadCertificate",
             "received fatal alert: CertificateUnknown",
             "invalid peer certificate: UnknownIssuer",
+            "Failed client connect: Server connection error: tonic::transport::Error(Transport, CertificateParseError)",
         ],
     )
     def test_tls_certificate_failures_are_non_retryable(self, error_message):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `RuntimeError` from the `TemporalIO` data-warehouse import source:

```
Failed client connect: Server connection error: tonic::transport::Error(Transport, CertificateParseError)
```

The stack trace originates in this source — `temporalio.py` (`_get_temporal_client`) → `posthog/temporal/common/client.py:connect` → `Client.connect`. The source passes the user-supplied `client_certificate`, `client_private_key`, and `server_client_root_ca` straight into the TLS config. `CertificateParseError` is raised by tonic/rustls when one of those PEM blobs cannot be decoded at all — i.e. the credential is malformed. Retrying can never recover this; the customer has to re-enter valid PEM credentials.

This is distinct from the TLS-alert cases already handled in `get_non_retryable_errors` (`UnknownCA`, `CertificateExpired`, `CertificateRevoked`, `BadCertificate`, `CertificateUnknown`), which reject an otherwise-parseable certificate during the handshake. A parse failure happens before that and was still being retried.

## Changes

- Add `CertificateParseError` to `TemporalIOSource.get_non_retryable_errors()` with an actionable message pointing the user at their TLS credentials.
- Extend the existing parameterized non-retryable test with the real observed message.

Matching is on the stable `CertificateParseError` substring (the tonic transport error variant name), not on any volatile request-specific text.

## How did you test this code?

I'm an agent. I ran the source's unit tests:

```
pytest posthog/temporal/data_imports/sources/temporalio/test_temporalio.py::TestTemporalIONonRetryableErrors
```

All 9 cases pass, including the new `CertificateParseError` assertion and the existing checks that transient transport errors stay retryable. `ruff check` and `ruff format` pass on the changed files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the TemporalIO import source. Pulled the issue and a representative event via the PostHog error-tracking MCP tools, confirmed the failing variant (`CertificateParseError`) and that the stack genuinely originates in this source's connect path. Classified it as a user/credential error (malformed PEM) rather than a fixable bug or a transient transport error, so the fix extends `NonRetryableErrors` mirroring the Stripe source pattern rather than changing retry/backoff behavior. Scoped strictly to this one error string.
