### PR TITLE
fix(bigquery): treat max_staleness storage-read failure as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -66,6 +66,11 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # so match the stable phrasing here. Retrying can't recover — the user must fix the
             # dataset or set the correct region.
             "was not found in location": "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or it may live in a different region — verify your dataset and table names, and set the dataset region in your source configuration if it isn't in the US.",
+            # BigQuery's Storage Read API can't read a source table that runs runtime merge jobs
+            # because its change-data-capture `max_staleness` is set too low for the background
+            # apply to keep up (a documented Storage Read API incompatibility). The fix lives on
+            # the source side — there's nothing for us to do but stop retrying and surface it.
+            "un-applied upsert data that is not fresh enough to meet table's max_staleness": "This BigQuery table uses change data capture with a max_staleness value that's too low for its background apply to keep up, so it can't be read via the Storage Read API. Increase the table's max_staleness (or give its background reservation more resources), then re-sync.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a
             # narrower numeric type) after the destination table was created with the narrower

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -594,3 +594,16 @@ def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
 
     assert any(pattern in error_msg for pattern in non_retryable_errors)
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        "request failed: The table has un-applied upsert data that is not fresh enough to meet table's max_staleness.",
+        "400 request failed: The table has un-applied upsert data that is not fresh enough to meet table's max_staleness.",
+    ],
+)
+def test_max_staleness_storage_read_errors_are_non_retryable(error_msg):
+    non_retryable = BigQuerySource().get_non_retryable_errors()
+    is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+    assert is_non_retryable


### PR DESCRIPTION
## Problem

BigQuery data-warehouse imports are repeatedly failing with an `InvalidArgument` raised from the BigQuery Storage Read API:

> request failed: The table has un-applied upsert data that is not fresh enough to meet table's max_staleness.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019cdda2-0332-7bc1-8fa0-5c27ded697bf (1440 occurrences over ~3 months, persistently retrying without ever succeeding).

The failure originates in `posthog/temporal/data_imports/sources/bigquery/bigquery.py` in `get_rows`, at the `bq_storage.create_read_session(...)` call in the direct-storage-read branch (non-incremental, non-view tables).

This is a documented BigQuery limitation: the Storage Read API cannot read a source table that runs *runtime merge jobs*, which happens when a change-data-capture (CDC) table's `max_staleness` is set too low for its background apply to keep up. The cause and the remedy both live on the source side — increase the table's `max_staleness`, give its background reservation more resources, or wait for the apply watermark to advance. There is nothing PostHog can do to stream the table while it is in this state, so retrying just burns worker cycles and keeps the sync in a failing loop.

## Changes

- Add the stable message substring `un-applied upsert data that is not fresh enough to meet table's max_staleness` to `BigQuerySource.get_non_retryable_errors`, with an actionable user-facing message explaining the source-side fix. This mirrors the existing Stripe / Redshift `get_non_retryable_errors` pattern.
- The substring deliberately excludes volatile parts (no URLs, ids, or timestamps), keeping false-positive risk low.
- Add a parameterized regression test asserting the message (raw and with a leading `400` status prefix) is recognised as non-retryable.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I actually ran:

- `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — all 22 tests pass, including the 2 new `test_max_staleness_storage_read_errors_are_non_retryable` cases.
- `ruff check` / `ruff format` — clean.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from an error-tracking webhook. Confirmed via the PostHog error-tracking MCP tools that the full stack trace genuinely terminates in `get_rows` → `create_read_session` in this source's code (not just serialized log context), then read the implementation and Google's CDC documentation to classify the error.

Decision: this is an upstream/source configuration condition, not a fixable bug in our code. A code workaround (routing such tables through a query-job copy like we do for views, which forces the runtime merge) is theoretically possible but adds cost/complexity and depends on a too-low `max_staleness` the customer controls; per the safer default for ambiguous-but-source-side errors, it's marked non-retryable with a clear message rather than silently retried forever.
