### PR TITLE
fix(meta_ads): treat stale db connection lookup as recoverable

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -5,6 +5,8 @@ import collections.abc
 from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from django.db import close_old_connections
+
 from requests import Response
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
@@ -91,6 +93,12 @@ def _clean_account_id(s: str | None) -> str | None:
 
 def get_integration(config: MetaAdsSourceConfig, team_id: int) -> Integration:
     """Get the Meta Ads integration."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it, surfacing as
+    # `OperationalError: the connection is closed` — drop any stale connection first.
+    close_old_connections()
     integration = Integration.objects.get(id=config.meta_ads_integration_id, team_id=team_id)
     meta_ads_integration = MetaAdsIntegration(integration)
     meta_ads_integration.refresh_access_token()

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -5,6 +5,7 @@ import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.meta_ads import meta_ads
 from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     META_AUTH_ERROR_MESSAGE,
     PAGE_LIMIT_FALLBACK_SIZES,
@@ -732,3 +733,32 @@ class TestNonRetryableErrors:
     )
     def test_is_permanent_auth_error(self, body: dict, expected: bool) -> None:
         assert _is_permanent_auth_error(_mock_response(400, body)) is expected
+
+
+class TestGetIntegration:
+    def test_refreshes_stale_db_connection_before_query(self, monkeypatch) -> None:
+        # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: the connection is closed`. We must drop the stale
+        # connection before querying, so the read happens on a fresh connection.
+        calls: list[str] = []
+
+        monkeypatch.setattr(meta_ads, "close_old_connections", lambda: calls.append("close_old_connections"))
+
+        integration = mock.MagicMock()
+        integration.errors = None
+
+        def fake_get(*args: Any, **kwargs: Any) -> mock.MagicMock:
+            calls.append("Integration.objects.get")
+            return integration
+
+        monkeypatch.setattr(meta_ads.Integration.objects, "get", fake_get)
+        monkeypatch.setattr(meta_ads, "MetaAdsIntegration", lambda i: mock.MagicMock(integration=i))
+
+        config = mock.MagicMock()
+        config.meta_ads_integration_id = 1
+
+        result = meta_ads.get_integration(config, team_id=1)
+
+        assert calls == ["close_old_connections", "Integration.objects.get"]
+        assert result is integration


### PR DESCRIPTION
## Problem

Meta Ads imports were intermittently failing with `OperationalError: the connection is closed`. Error tracking shows this recurring steadily (issue `019ce164-d330-7ff2-bcaa-4f0308b9889d`), not a one-off blip.

The stack trace originates in the Meta Ads source: `meta_ads.get_rows` → `get_integration` → `Integration.objects.get(...)` → Django ORM → psycopg `the connection is closed`.

The source loads its `Integration` row via the ORM lazily inside `get_rows`, which the pipeline runs on a long-lived pooled worker thread (`_SOURCE_ITERATOR_EXECUTOR`). The Django connection cached on that thread can be closed server-side (idle/age) between activity runs, so the first ORM call hits a dead connection.

This is our code being fragile rather than a true transient infra blip — it is deterministic for a stale-connection thread and there is an established, in-repo fix for exactly this failure mode.

## Changes

`get_integration` now calls `close_old_connections()` immediately before the `Integration.objects.get(...)` lookup, so Django discards any unusable/obsolete connection and opens a fresh one for the read.

This mirrors the identical guard already present in the sibling ad-platform sources:
- `posthog/temporal/data_imports/sources/google_ads/google_ads.py`
- `posthog/temporal/data_imports/sources/google_search_console/google_search_console.py`

No retry policy or pipeline-wide behavior is changed — the fix is scoped to this source's integration lookup.

## How did you test this code?

I'm an agent. I added a regression test (`TestGetIntegration.test_refreshes_stale_db_connection_before_query`) that asserts `close_old_connections()` is invoked before `Integration.objects.get(...)`, mirroring the existing google_search_console test. It would have failed before this change.

I ran `ruff check` and `ruff format --check` on both files (passing) and `py_compile` on both. I could not execute the pytest suite in this sandbox because the Django dependencies are not installed here; CI will run it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Meta Ads data-warehouse source. Confirmed the issue in error tracking (1111 occurrences over 90 days, recurring), pulled the full stack trace, and verified the failing frame is genuinely in `meta_ads.py` (`get_integration` at the `Integration.objects.get` call), not just in serialized log context.

Decision: this is `OperationalError: the connection is closed` from a pooled Django connection going stale — not a user/upstream auth error (so NOT a `NonRetryableErrors` addition) and not an unfixable infra blip. It is a known fragility with a settled in-repo remedy (`close_old_connections()` before the ORM read), already applied to the two sibling Google sources. Applied the same minimal, source-scoped fix plus a mirrored regression test.
