### PR TITLE
fix(linkedin_ads): treat 404 resource-not-found as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -47,6 +47,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # key value (volatile) followed by this stable type-coercion phrase. The account id is a
             # fixed config value, so retrying can't help — fail fast and tell the user to fix it.
             "must be of type 'java.lang.Long'": "LinkedIn rejected the configured Account ID. It must be the numeric LinkedIn ad account ID (digits only). Please correct the Account ID in your source settings and re-sync.",
+            # LinkedIn returns 404 RESOURCE_NOT_FOUND / "No virtual resource found" when the
+            # account-scoped resource can't be resolved — the configured ad account doesn't exist
+            # or PostHog no longer has access to it. Retrying can't fix a missing resource, so we
+            # stop and surface a config-facing message instead of burning retries every schedule.
+            "No virtual resource found": "LinkedIn could not find the configured ad account. Please check that the Account ID is correct and that PostHog still has access to it, then try again.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -85,3 +85,38 @@ class TestLinkedInAdsSource:
     def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "pattern,raised_message",
+        [
+            (
+                "No virtual resource found",
+                'LinkedIn API error (404): {"status":404,"code":"RESOURCE_NOT_FOUND","message":"No virtual resource found"}',
+            ),
+            (
+                "The token used in the request has expired",
+                "LinkedIn API error (401): The token used in the request has expired",
+            ),
+        ],
+    )
+    def test_get_non_retryable_errors_pattern_recognised(self, pattern, raised_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert pattern in non_retryable_errors
+        assert pattern in raised_message
+
+    @pytest.mark.parametrize(
+        "transient_message",
+        [
+            # Transient transport / 5xx failures must stay retryable — matching any of these would
+            # disable the schema sync after a handful of recoverable blips.
+            "LinkedIn API error (retryable, 500): Internal Server Error",
+            "LinkedIn API error (retryable, 504): Gateway Timeout",
+            "ConnectionError: HTTPSConnectionPool(host='api.linkedin.com', port=443): Max retries exceeded",
+            "ReadTimeout: The read operation timed out",
+        ],
+    )
+    def test_get_non_retryable_errors_does_not_match_transient_failures(self, transient_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert not any(pattern in transient_message for pattern in non_retryable_errors)


### PR DESCRIPTION
## Problem

PostHog error tracking flagged a recurring `Exception` from the `linkedin_ads` data-warehouse import source:

```
LinkedIn API error (404): {"status":404,"code":"RESOURCE_NOT_FOUND","message":"No virtual resource found"}
```

Issue: https://us.posthog.com/project/2/error_tracking/019e3120-85a1-7ac2-a843-d5a161d57101 (~600 occurrences over ~10 days, ongoing).

LinkedIn returns `404 RESOURCE_NOT_FOUND / "No virtual resource found"` when the account-scoped (virtual) resource can't be resolved — i.e. the configured ad account doesn't exist or PostHog no longer has access to it. The same error-tracking issue also groups a sibling `400` (`"Key value '…' must be of type 'java.lang.Long'"`), which is a non-numeric account value — both point at the customer-supplied account configuration.

`client.py` raises a bare `Exception` for any non-2xx response, and this message was not in the source's `NonRetryableErrors`, so Temporal kept retrying a request that can never succeed until the user fixes their config — every scheduled sync, indefinitely.

## Changes

- Add `"No virtual resource found"` to `LinkedInAdsSource.get_non_retryable_errors()` with a config-facing friendly message ("check that the Account ID is correct and that PostHog still has access to it").
- Match on the stable LinkedIn message substring only — no volatile URLs/ids/timestamps.
- Scoped strictly to this 404 class. Transient 5xx / connection / timeout errors stay retryable (they remain `LinkedinAdsRetryableError` / transport errors and are not added here).

## Decision: user/upstream error → NonRetryableErrors

A 404 resource-not-found is definitively non-transient: retrying within the run or on the next schedule cannot conjure a resource that doesn't exist. There is nothing sensible for us to do but stop retrying and surface an actionable message. This is the same pattern as the Stripe source's `get_non_retryable_errors`.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests run locally:

- `pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py` — 9 passed, including:
  - `test_get_non_retryable_errors_pattern_recognised` — asserts `"No virtual resource found"` is recognised as non-retryable and is a substring of the real 404 body.
  - `test_get_non_retryable_errors_does_not_match_transient_failures` — asserts transient 5xx / connection / timeout messages do **not** match any non-retryable pattern.
- `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue end to end: confirmed the failure originates in `posthog/temporal/data_imports/sources/linkedin_ads/{client,linkedin_ads}.py` (the bare-`Exception` raise at the non-2xx branch in `client.py`), pulled the exact 404 body and message-distribution from error tracking, then classified it as a user/upstream config error rather than a fixable bug or a transient error. Considered matching on the broader LinkedIn error code `RESOURCE_NOT_FOUND` but chose the narrower, observed message `"No virtual resource found"` to avoid over-broadening `NonRetryableErrors` and swallowing unrelated 404s. Left the sibling 400 ("must be of type java.lang.Long") untouched as out of scope.
