### PR TITLE
fix(mysql): recover from out-of-sort-memory via FORCE INDEX fallback

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -8,7 +8,7 @@ thin PostHog-layer wrapper that just holds an instance and validates
 credentials.
 
 Module-level free helpers (`_build_query`, `_sanitize_identifier`,
-`_safe_convert_date`, `_safe_convert_datetime`, `_is_bad_plan_timeout`)
+`_safe_convert_date`, `_safe_convert_datetime`, `_is_bad_plan_error`)
 are pure functions used by `MySQLImplementation` and exercised directly
 by unit tests. They take no MySQL-driver state and are fine as
 module-scope primitives.
@@ -79,6 +79,15 @@ STATEMENT_TIMEOUT_SECONDS = 600  # 10 mins
 # the filesort preparation exceeds a middlebox / server-side query timeout
 # before any rows stream back.
 _LOST_CONNECTION_DURING_QUERY_CODE = 2013
+
+# pymysql error code for "Out of sort memory, consider increasing server sort
+# buffer size" — the same bad plan (full scan + filesort over the incremental
+# field) seen from the other side: the filesort completes its planning but the
+# server's `sort_buffer_size` is too small to hold the sort, so MySQL aborts
+# before streaming. Forcing the incremental-field index lets MySQL read rows in
+# index order and skip the filesort entirely, so the same FORCE INDEX fallback
+# resolves it.
+_OUT_OF_SORT_MEMORY_CODE = 1038
 
 
 def _safe_convert_date(obj: Any) -> datetime.date | None:
@@ -196,14 +205,24 @@ def _build_query(
     return result.sql, params
 
 
-def _is_bad_plan_timeout(e: pymysql.err.OperationalError) -> bool:
-    """Return True if the error suggests we hit a bad-plan-induced query timeout.
+def _is_bad_plan_error(e: pymysql.err.OperationalError) -> bool:
+    """Return True if the error is a symptom of MySQL filesorting the incremental
+    `ORDER BY` instead of using an index — recoverable via the FORCE INDEX fallback.
 
-    Narrowly matches `OperationalError(2013, ...)`. Other `OperationalError`s
-    (access denied, table missing, etc.) should propagate untouched.
+    Matches two codes, both signalling the optimizer picked a full scan + filesort
+    over the incremental field:
+
+    - `2013` (lost connection during query): the filesort preparation outran a
+      middlebox / server-side query timeout before any rows streamed back.
+    - `1038` (out of sort memory): the filesort itself overran the server's
+      `sort_buffer_size`.
+
+    Forcing the incremental-field index makes MySQL read rows in index order and
+    skip the filesort, resolving both. Other `OperationalError`s (access denied,
+    table missing, etc.) should propagate untouched.
     """
     code = e.args[0] if e.args else None
-    return code == _LOST_CONNECTION_DURING_QUERY_CODE
+    return code in (_LOST_CONNECTION_DURING_QUERY_CODE, _OUT_OF_SORT_MEMORY_CODE)
 
 
 def _release_streaming_cursor(cursor: SSCursor) -> None:
@@ -864,22 +883,22 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
                     yield chunk
                 return
             except pymysql.err.OperationalError as e:
-                if not _is_bad_plan_timeout(e):
+                if not _is_bad_plan_error(e):
                     raise
                 if yielded_any:
                     logger.warning(
-                        f"Streaming query died with bad-plan timeout (error {e.args[0] if e.args else '?'}) "
+                        f"Streaming query died with a bad query plan (error {e.args[0] if e.args else '?'}) "
                         f"after already yielding rows — skipping FORCE INDEX fallback to avoid duplicates."
                     )
                     raise
                 logger.warning(
-                    f"Streaming query died with bad-plan timeout (error {e.args[0] if e.args else '?'}). "
+                    f"Streaming query died with a bad query plan (error {e.args[0] if e.args else '?'}). "
                     f"Attempting FORCE INDEX fallback."
                 )
                 if not should_use_incremental_field or not incremental_field:
                     # Without an incremental field there's no cursor to force an index on.
                     logger.warning(
-                        "Bad-plan timeout hit, but sync has no incremental field — cannot apply FORCE INDEX fallback."
+                        "Bad query plan hit, but sync has no incremental field — cannot apply FORCE INDEX fallback."
                     )
                     raise
 
@@ -891,13 +910,13 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
 
                 if not force_index_name:
                     logger.warning(
-                        f"Bad-plan timeout hit and no usable index on "
+                        f"Bad query plan hit and no usable index on "
                         f"{schema}.{table_name}.{incremental_field} — cannot apply FORCE INDEX fallback. "
                         f"Customer should add an index on the incremental field."
                     )
                     raise
 
-                logger.warning(f"Retrying streaming query with FORCE INDEX ({force_index_name}) after bad-plan timeout")
+                logger.warning(f"Retrying streaming query with FORCE INDEX ({force_index_name}) after bad query plan")
                 yield from _stream_with_optional_force_index(force_index_name)
 
         name = NamingConvention.normalize_identifier(table_name)

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -15,7 +15,7 @@ from posthog.temporal.data_imports.sources.mysql.mysql import (
     MySQLColumn,
     MySQLImplementation,
     _build_query,
-    _is_bad_plan_timeout,
+    _is_bad_plan_error,
     _release_streaming_cursor,
     _safe_convert_date,
     _safe_convert_datetime,
@@ -635,9 +635,16 @@ class TestStreamingCursorTeardown:
         assert ss_cursor.connection is None
 
 
-class TestIsBadPlanTimeout:
+class TestIsBadPlanError:
     def test_matches_error_2013(self):
-        assert _is_bad_plan_timeout(pymysql.err.OperationalError(2013, "Lost connection to MySQL server during query"))
+        assert _is_bad_plan_error(pymysql.err.OperationalError(2013, "Lost connection to MySQL server during query"))
+
+    def test_matches_error_1038_out_of_sort_memory(self):
+        # Out of sort memory is the same bad plan (filesort over the incremental
+        # field) seen from the other side — the FORCE INDEX fallback resolves it.
+        assert _is_bad_plan_error(
+            pymysql.err.OperationalError(1038, "Out of sort memory, consider increasing server sort buffer size")
+        )
 
     @pytest.mark.parametrize(
         "code,message",
@@ -647,10 +654,10 @@ class TestIsBadPlanTimeout:
         ],
     )
     def test_does_not_match_other_error_codes(self, code, message):
-        assert not _is_bad_plan_timeout(pymysql.err.OperationalError(code, message))
+        assert not _is_bad_plan_error(pymysql.err.OperationalError(code, message))
 
     def test_does_not_match_error_without_args(self):
-        assert not _is_bad_plan_timeout(pymysql.err.OperationalError())
+        assert not _is_bad_plan_error(pymysql.err.OperationalError())
 
 
 class TestBuildQueryForceIndex:


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError (1038, 'Out of sort memory, consider increasing server sort buffer size')` originating in the MySQL data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019db1b7-d41e-7b81-b496-0d73babab03e), thousands of occurrences over ~2 months).

The incremental MySQL sync builds queries of the form `SELECT * FROM ... WHERE \`updatedAt\` > %(incremental_value)s ORDER BY \`updatedAt\` ASC`. When MySQL chooses a full scan + filesort to satisfy that `ORDER BY` (instead of reading rows in index order), the source server's `sort_buffer_size` can overflow and raise error 1038.

This is the **same bad query plan** the source already recovers from for error 2013 (`Lost connection to MySQL server during query`) — both are symptoms of the optimizer filesorting the incremental field rather than using an index. The existing `FORCE INDEX` fallback (`_stream_with_optional_force_index`) makes MySQL read rows in index order and skips the filesort entirely, so it resolves both. But the fallback only triggered on error 2013, so error 1038 propagated and the sync failed permanently.

## Changes

- Generalize the fallback-trigger predicate `_is_bad_plan_timeout` → `_is_bad_plan_error`, matching both error 2013 (lost connection during query) and the newly handled error 1038 (out of sort memory).
- Add `_OUT_OF_SORT_MEMORY_CODE = 1038` with a comment explaining why the same `FORCE INDEX` recovery applies.
- Generalize the now-inaccurate "bad-plan timeout" log wording to "bad query plan".

The fallback's existing safety guards are unchanged: it only restarts the stream when no rows have yet been yielded (the filesort fails before any row streams, so this holds), and when no usable index exists on the incremental field it re-raises (staying retryable) and logs that the customer should add an index — identical to the established behaviour for error 2013. No changes to global retry policy or `NonRetryableErrors`.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I ran locally (all green):

- `posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — full file, 92 passed.
- Added a regression test `TestIsBadPlanError::test_matches_error_1038_out_of_sort_memory` asserting error 1038 now triggers the fallback (this is the single gate that decides whether `FORCE INDEX` runs; before the fix it returned `False` for 1038). Existing 2013 / unrelated-code / no-args cases retained.
- `ruff check` and `ruff format --check` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in PostHog error tracking (full stack trace, exception type, representative event, frequency) and verified the failure originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` (`_stream_with_optional_force_index`, line 838).

Decision: **fixable bug**, not a user/upstream error. Although out-of-sort-memory is influenced by the source server's `sort_buffer_size`, the source already has dedicated, tested machinery to recover from exactly this class of bad plan (filesort over the incremental field) by forcing the incremental-field index — so there *is* something sensible we can do beyond stopping retries. Extending that existing fallback was the scoped fix; adding 1038 to `NonRetryableErrors` was rejected because it would forgo automatic recovery and "swallow" a case the code can handle.

Authored with Claude Code (Opus 4.8).
