### PR TITLE
fix(linkedin_ads): refresh stale db connection before integration lookup

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
@@ -3,6 +3,8 @@ import datetime as dt
 import collections.abc
 from dataclasses import dataclass
 
+from django.db import close_old_connections
+
 import pyarrow as pa
 import structlog
 from structlog.types import FilteringBoundLogger
@@ -100,6 +102,12 @@ def get_schemas() -> dict[str, LinkedinAdsSchema]:
 
 def linkedin_ads_client(config: LinkedinAdsSourceConfig, team_id: int) -> LinkedinAdsClient:
     """Initialize a LinkedIn Ads client with provided config."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it, surfacing as `OperationalError: server
+    # closed the connection unexpectedly` — drop any stale connection first.
+    close_old_connections()
     integration = Integration.objects.get(id=config.linkedin_ads_integration_id, team_id=team_id)
     if not integration.access_token:
         raise ValueError("LinkedIn Ads integration does not have an access token")

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
@@ -370,9 +370,12 @@ class TestLinkedinAdsClientFunction:
 
         mock_integration = mock.MagicMock()
         mock_integration.access_token = "token"
-        mock_integration_model.objects.get.side_effect = lambda *args, **kwargs: (
-            calls.append("Integration.objects.get") or mock_integration
-        )
+
+        def record_get(*args, **kwargs):
+            calls.append("Integration.objects.get")
+            return mock_integration
+
+        mock_integration_model.objects.get.side_effect = record_get
 
         config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=123, account_id="456")
 

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
@@ -361,6 +361,29 @@ class TestLinkedinAdsClientFunction:
         with pytest.raises(ValueError, match="LinkedIn Ads integration does not have an access token"):
             linkedin_ads_client(config, team_id=789)
 
+    def test_linkedin_ads_client_refreshes_stale_db_connection_before_query(self, mock_integration_model):
+        # The ORM read runs lazily inside `get_rows` on a pooled worker thread whose
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: server closed the connection unexpectedly`. We must drop
+        # the stale connection before querying, so the read happens on a fresh one.
+        calls: list[str] = []
+
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "token"
+        mock_integration_model.objects.get.side_effect = lambda *args, **kwargs: (
+            calls.append("Integration.objects.get") or mock_integration
+        )
+
+        config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=123, account_id="456")
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.close_old_connections",
+            side_effect=lambda: calls.append("close_old_connections"),
+        ):
+            linkedin_ads_client(config, team_id=789)
+
+        assert calls == ["close_old_connections", "Integration.objects.get"]
+
 
 @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.linkedin_ads_client")
 class TestLinkedinAdsSource:


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError: consuming input failed: server closed the connection unexpectedly` originating in the LinkedIn Ads data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019d25be-5478-7f81-adb9-ad80da8f1d05) — 359 occurrences, still firing several times a day).

The full stack trace lands on `Integration.objects.get(...)` in `linkedin_ads_client` (`linkedin_ads.py`), invoked lazily from inside `get_rows`:

```
pipeline.async_iterate → _next → linkedin_ads.get_rows → linkedin_ads.linkedin_ads_client
  → Integration.objects.get() → django ORM → psycopg execute → OperationalError
```

`get_rows` executes on a long-lived, pooled `_SOURCE_ITERATOR_EXECUTOR` thread. Django DB connections are thread-local, so a pooled thread can hold a connection that Postgres has already closed server-side after an idle period. The first ORM query on that dead connection then raises this error.

This is a **transient infrastructure error** (a connection drop), not a credential/upstream/config problem, so it should stay retryable — adding it to `NonRetryableErrors` would be wrong. The actual bug is that our code does an ORM read on a possibly-stale pooled connection without refreshing it first.

## Changes

`linkedin_ads_client` now calls `close_old_connections()` before `Integration.objects.get(...)`, dropping any stale/unusable connection so the lookup runs on a fresh one. This mirrors the established pattern already used by the sibling Google sources (`google_ads.py`, `google_search_console.py`), which guard the exact same integration lookup for the exact same reason.

The change is scoped strictly to this source — no global retry-policy changes.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated test added and run:

- Added `test_linkedin_ads_client_refreshes_stale_db_connection_before_query`, which asserts `close_old_connections()` is called before `Integration.objects.get()`. It fails without the fix.
- Ran `posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py::TestLinkedinAdsClientFunction` — both tests pass.
- `ruff check` and `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by an agent (Claude Code). Pulled the full stack trace via the PostHog MCP error-tracking tools and confirmed the failure genuinely originates in `linkedin_ads.py` (the LinkedIn frames are real stack frames, not just serialized log context — the raise point follows directly from `linkedin_ads_client`).

Decision: this is a transient Postgres connection drop, not an upstream/credential error, so it must remain retryable rather than be added to `get_non_retryable_errors()`. Identified the root cause as a stale thread-local connection on the pooled source-iterator thread, and confirmed the idiomatic fix by finding `close_old_connections()` already guarding the identical `Integration.objects.get()` lookup in the Google Ads and Google Search Console sources. Applied the same guard plus a regression test.
