### PR TITLE
fix(mongodb): stop reporting swallowed count errors to error tracking

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -15,6 +15,7 @@ from bson import Binary, DatetimeMS, ObjectId
 from bson.codec_options import DatetimeConversion
 from pymongo import MongoClient
 from pymongo.collection import Collection
+from pymongo.errors import PyMongoError
 from pymongo.server_description import ServerDescription
 from structlog.types import FilteringBoundLogger
 
@@ -470,7 +471,16 @@ def _get_rows_to_sync(collection: Collection, query: dict[str, Any], logger: Fil
         rows_to_sync = collection.count_documents(query)
         logger.debug(f"_get_rows_to_sync: rows_to_sync={rows_to_sync}")
         return rows_to_sync
+    except PyMongoError as e:
+        # rows_to_sync is only a progress estimate, so a failed count degrades to 0
+        # rather than failing the sync. Connectivity/auth failures here are expected
+        # operational errors — the real data read fails and is classified by
+        # get_non_retryable_errors — so log and move on instead of flooding error
+        # tracking with non-actionable noise.
+        logger.warning(f"_get_rows_to_sync: could not count documents ({e}). Using 0 as rows to sync")
+        return 0
     except Exception as e:
+        # Unexpected, non-PyMongo error — surface it so genuine bugs aren't hidden.
         logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
         capture_exception(e)
         return 0

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -9,9 +9,11 @@ from django.test import SimpleTestCase, override_settings
 from bson import Binary, DatetimeMS, ObjectId
 from bson.binary import UUID_SUBTYPE
 from parameterized import parameterized
+from pymongo.errors import ServerSelectionTimeoutError
 from pymongo.server_description import ServerDescription
 
 from posthog.temporal.data_imports.sources.mongodb.mongo import (
+    _get_rows_to_sync,
     _make_safe_server_selector,
     _process_doc_with_field_logging,
     _process_nested_value,
@@ -374,3 +376,30 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         message = self.non_retryable[pattern]
         assert message is not None
         assert expected_substring in message.lower()
+
+
+class TestGetRowsToSync(SimpleTestCase):
+    """rows_to_sync is a best-effort progress estimate; a failed count must degrade to
+    0 without failing the sync, and expected pymongo errors must not be reported to
+    error tracking (they are transient/operational and classified by the real data read)."""
+
+    def test_returns_count_on_success(self):
+        coll = MagicMock()
+        coll.count_documents.return_value = 42
+        assert _get_rows_to_sync(coll, {}, MagicMock()) == 42
+
+    def test_pymongo_error_returns_zero_without_capture(self):
+        coll = MagicMock()
+        coll.count_documents.side_effect = ServerSelectionTimeoutError(
+            "atlas-sql.query.mongodb.net:27017: connection closed, Timeout: 10.0s"
+        )
+        with patch("posthog.temporal.data_imports.sources.mongodb.mongo.capture_exception") as capture:
+            assert _get_rows_to_sync(coll, {}, MagicMock()) == 0
+            capture.assert_not_called()
+
+    def test_unexpected_error_returns_zero_and_captures(self):
+        coll = MagicMock()
+        coll.count_documents.side_effect = ValueError("unexpected bug")
+        with patch("posthog.temporal.data_imports.sources.mongodb.mongo.capture_exception") as capture:
+            assert _get_rows_to_sync(coll, {}, MagicMock()) == 0
+            capture.assert_called_once()


### PR DESCRIPTION
## Problem

Error tracking has surfaced a high-volume `ServerSelectionTimeoutError` originating in the MongoDB data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/0199e927-1200-7420-a699-9b41b4baa4ed), 16k+ occurrences, still firing). The top in-app frame is `_get_rows_to_sync` at `posthog/temporal/data_imports/sources/mongodb/mongo.py`, calling pymongo's `count_documents`.

Crucially, `_get_rows_to_sync` only computes a **best-effort progress estimate** (`rows_to_sync`). It already wraps the call in a `try/except` that logs, returns `0`, and lets the sync continue — so this failure never fails the import and never reaches the retry/non-retryable classification layer. The error volume comes entirely from a `capture_exception(e)` inside that broad `except`, which reports the deliberately-tolerated, non-fatal failure to error tracking.

The underlying error (`connection closed ... Timeout`) is a transient/operational MongoDB connectivity error. The codebase already treats `"connection closed"` as retryable on purpose (see `test_transient_errors_are_retryable`), so it correctly does **not** belong in `NonRetryableErrors`. The bug is that we report it at all from a count-estimate helper.

## Changes

In `_get_rows_to_sync`, catch `PyMongoError` separately: log a warning and degrade to `0` without calling `capture_exception`. Connectivity/auth failures here are expected operational errors and are already surfaced elsewhere — `validate_credentials` reports them at setup, and the real data read is classified by `get_non_retryable_errors`. The existing `capture_exception` is kept for unexpected, non-pymongo exceptions so genuine bugs still surface.

This eliminates the error-tracking noise without changing retry behavior or swallowing any real failure path.

## How did you test this code?

I'm an agent (Claude Code). I added a regression test class `TestGetRowsToSync` asserting:
- a successful count is returned,
- a `PyMongoError` (`ServerSelectionTimeoutError`) returns `0` and does **not** call `capture_exception`,
- an unexpected error (`ValueError`) returns `0` and **does** call `capture_exception`.

Automated checks run locally:
- `pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py` — 49 passed
- `ruff check` and `ruff format --check` — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook using the PostHog error-tracking tools to pull the full stack trace, exception type, representative event, and frequency. Confirmed the failure genuinely originates in this source's code (real in-app frame at `mongo.py:_get_rows_to_sync`), then traced how `rows_to_sync` is used.

Decision: not a `NonRetryableErrors` case — the error is swallowed before reaching that layer, and `"connection closed"` is an intentionally-retryable transient error (existing test asserts this). It's a fixable bug: capturing a tolerated, non-fatal estimate failure to error tracking. Fix scoped to splitting expected `PyMongoError` (log + degrade) from unexpected errors (still captured).
