### PR TITLE
fix(redshift): run import metadata probes in autocommit to avoid InFailedSqlTransaction

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -940,6 +940,13 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
         enabled_columns = inputs.enabled_columns
 
         with self.connect(config) as connection:
+            # Gather metadata in autocommit so each probe is its own transaction. Several of these
+            # helpers (`get_chunk_size`/`fetch_average_row_size`, `get_rows_to_sync`, …) swallow query
+            # errors and keep going; without autocommit a single swallowed failure leaves the shared
+            # transaction aborted, and every later probe then raises a misleading
+            # `InFailedSqlTransaction` instead of running. These are all read-only probes, so there is
+            # no atomicity to preserve. `SET statement_timeout` still persists for the connection.
+            connection.autocommit = True
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
                 full_table = self.get_table_metadata(cursor, schema, table_name, logger)

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -615,27 +615,27 @@ def build_pipeline_mocks(mocker):
     # The metadata pass uses the patched `RedshiftImplementation`
     # methods, so a single cursor mock can serve both connections —
     # only the streaming connection requires `conn.adapters` to be set.
-    state = {"first_conn": True}
+    connections: list[MagicMock] = []
 
     def connect_side_effect(*args, **kwargs):
         conn = MagicMock()
         conn.__enter__.return_value = conn
         conn.cursor.return_value = streaming_cursor
-        if not state["first_conn"]:
+        if connections:
             conn.adapters = MagicMock()
-        state["first_conn"] = False
+        connections.append(conn)
         return conn
 
     mock_connect = mocker.patch(
         "posthog.temporal.data_imports.sources.redshift.redshift.psycopg.connect",
         side_effect=connect_side_effect,
     )
-    return mock_connect, streaming_cursor
+    return mock_connect, streaming_cursor, connections
 
 
 class TestBuildPipeline:
     def test_returns_source_response(self, build_pipeline_mocks):
-        mock_connect, _ = build_pipeline_mocks
+        mock_connect, _, _ = build_pipeline_mocks
         impl = RedshiftImplementation()
         response = impl.build_pipeline(_make_config(), _make_inputs())
         assert response.name == "messages"
@@ -644,12 +644,23 @@ class TestBuildPipeline:
         assert mock_connect.called
 
     def test_streaming_drains_without_error(self, build_pipeline_mocks):
-        _, streaming_cursor = build_pipeline_mocks
+        _, streaming_cursor, _ = build_pipeline_mocks
         impl = RedshiftImplementation()
         response = impl.build_pipeline(_make_config(), _make_inputs())
         list(response.items())  # type: ignore[arg-type]
         # streaming cursor.execute should have been invoked for the streaming query
         assert streaming_cursor.execute.called
+
+    def test_metadata_connection_runs_in_autocommit(self, build_pipeline_mocks):
+        # Regression: the metadata probes share one connection and several swallow query errors and
+        # keep going. Without autocommit, one swallowed failure leaves the transaction aborted and the
+        # next probe raises a misleading `InFailedSqlTransaction`. Autocommit makes each probe its own
+        # transaction so a failed probe can't poison the rest.
+        _, _, connections = build_pipeline_mocks
+        impl = RedshiftImplementation()
+        impl.build_pipeline(_make_config(), _make_inputs())
+        # First connection is the metadata pass — it must be put into autocommit.
+        assert connections[0].autocommit is True
 
     def test_chunk_size_override_skips_probe(self, build_pipeline_mocks, mocker):
         mocked_chunk_size = mocker.patch.object(RedshiftImplementation, "get_chunk_size")


### PR DESCRIPTION
## Problem

The Redshift data-warehouse import source is generating a high volume of `InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block` errors, raised from `posthog/temporal/data_imports/sources/redshift/redshift.py` in `get_rows_to_sync`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e659a-d2b8-7a43-a562-226466bb983a

The `InFailedSqlTransaction` is a symptom, not the cause. `build_pipeline` gathers table metadata over a single psycopg connection in the default (non-autocommit) mode, so all of its probes run inside one transaction:

`get_table_metadata` → `SET statement_timeout` → `get_primary_keys_for_table` → `get_chunk_size`/`fetch_average_row_size` (which runs an `EXPLAIN` plus a `pg_column_size` sampling query) → `get_rows_to_sync` → `get_partition_settings` → `has_duplicate_primary_keys`.

Several of these probes deliberately **swallow query errors and keep going** (`_explain_query`, `fetch_average_row_size`, `fetch_table_stats`, `has_duplicate_primary_keys`, `get_rows_to_sync`). But in Postgres/Redshift, once any statement errors inside a transaction, the transaction enters the aborted state and **every subsequent statement raises `InFailedSqlTransaction` until a rollback**. The captured stack trace confirms this: the cursor is in `[INERROR]` state and `get_rows_to_sync`'s `SELECT COUNT(*) FROM (...)` is simply the next statement to run after an earlier swallowed probe (most plausibly the `EXPLAIN` / row-size sampling in `get_chunk_size`) poisoned the transaction.

This is our bug, not a customer/upstream problem: `InFailedSqlTransaction` is never the customer's fault. The current behaviour both **masks the real root-cause error** (we capture a misleading `InFailedSqlTransaction` instead of the original failure) and makes `get_rows_to_sync` silently return `0`.

## Changes

Put the `build_pipeline` metadata connection into **autocommit** mode before running the probes. With autocommit each probe is its own transaction, so a swallowed failure in one probe can no longer poison the transaction for the next. These are all read-only metadata probes, so there is no atomicity to preserve, and `SET statement_timeout` still persists for the connection. A real underlying failure now gets captured at its actual site instead of being hidden behind `InFailedSqlTransaction`.

Scoped strictly to the metadata-gathering phase where the error occurs — the separate streaming connection in `get_rows()` and the discovery/listing path are untouched. No change to global retry policy.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing against a live Redshift cluster. Automated tests I actually ran:

- Added a regression test `TestBuildPipeline::test_metadata_connection_runs_in_autocommit` asserting the metadata connection is placed into autocommit before the probes run. It fails without the fix (the connection would never be set to autocommit).
- Ran the full source test suite: `pytest posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py` — 76 passed.
- `ruff check` and `ruff format --check` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Redshift import source using Claude Code. I confirmed the issue via the PostHog error-tracking MCP tools (`query-error-tracking-issue` + `query-error-tracking-issue-events`), pulled the stack trace and a representative event, and verified the failing frame is `redshift.py:get_rows_to_sync` with the cursor in `[INERROR]` state.

Decision: this is a fixable bug, **not** a `NonRetryableErrors` candidate — `InFailedSqlTransaction` is an artifact of our own un-rolled-back transaction state, so swallowing it would hide real failures. Considered per-probe savepoints/rollbacks as an alternative; chose connection-level autocommit because it eliminates the whole class of transaction-poisoning across every swallow-and-continue probe in one place, the probes are read-only, and it keeps the change minimal.
