### PR TITLE
fix(clickhouse): stop reporting duplicate-PK probe budget exhaustion as errors

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -712,6 +712,16 @@ _DUPLICATE_PK_CHECK_SETTINGS: dict[str, Any] = {
     "max_memory_usage": 1_000_000_000,
 }
 
+# ClickHouse error names raised when the bounded probe exhausts one of its own
+# budgets (`max_memory_usage` → MEMORY_LIMIT_EXCEEDED, `max_execution_time` →
+# TIMEOUT_EXCEEDED). `optimize_aggregation_in_order` keeps the GROUP BY
+# streaming, but on large/slow (e.g. S3-backed) source tables the scan can
+# still hit these caps before `read_overflow_mode='break'` truncates on rows.
+# When that happens the probe behaves exactly as designed — fall back to
+# "assume duplicates" — so it's an expected outcome, not an error worth
+# reporting to error tracking.
+_DUPLICATE_PK_PROBE_BUDGET_ERRORS: tuple[str, ...] = ("MEMORY_LIMIT_EXCEEDED", "TIMEOUT_EXCEEDED")
+
 
 def _has_duplicate_primary_keys(
     client: ClickHouseClient,
@@ -748,14 +758,18 @@ def _has_duplicate_primary_keys(
         result = client.query(query, settings=_DUPLICATE_PK_CHECK_SETTINGS)
         return len(result.result_rows) > 0
     except ClickHouseError as e:
-        # Any unexpected server error is treated as "assume duplicates" —
-        # safer to force append mode than to merge against a key we couldn't
-        # verify. (We don't hit max_rows_to_read here because
-        # read_overflow_mode='break' turns that into a silent truncation.)
+        # Any server error is treated as "assume duplicates" — safer to force
+        # append mode than to merge against a key we couldn't verify. (We don't
+        # hit max_rows_to_read here because read_overflow_mode='break' turns
+        # that into a silent truncation.)
         logger.warning(
             f"_has_duplicate_primary_keys: assuming duplicates exist (probe failed for {database}.{table_name}): {e}"
         )
-        capture_exception(e)
+        # Exhausting the probe's own memory/time budget is the designed fallback
+        # on large source tables, not an exceptional condition — don't flood
+        # error tracking with it. Capture only genuinely unexpected errors.
+        if not any(name in str(e) for name in _DUPLICATE_PK_PROBE_BUDGET_ERRORS):
+            capture_exception(e)
         return True
 
 

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -653,10 +653,47 @@ class TestHasDuplicatePrimaryKeys:
 
     def test_fails_safe_to_true_on_clickhouse_error(self):
         client = MagicMock()
-        client.query.side_effect = ClickHouseError("Code: 241. Memory limit exceeded")
+        client.query.side_effect = ClickHouseError("Code: 62. DB::Exception: Syntax error")
         # On error we must assume duplicates exist so the incremental merge is
         # blocked. Returning False here would silently corrupt the Delta table.
         assert _has_duplicate_primary_keys(client, "db", "t", ["id"], self._logger()) is True
+
+    def test_captures_unexpected_clickhouse_error(self):
+        from posthog.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
+
+        client = MagicMock()
+        client.query.side_effect = ClickHouseError("Code: 62. DB::Exception: Syntax error")
+
+        with patch.object(ch_module, "capture_exception") as mock_capture:
+            assert _has_duplicate_primary_keys(client, "db", "t", ["id"], self._logger()) is True
+
+        mock_capture.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # max_memory_usage cap (code 241)
+            "HTTPDriver received ClickHouse error code 241\n Code: 241. DB::Exception: Query memory limit "
+            "exceeded: would use 958.14 MiB, maximum: 953.67 MiB: While executing AggregatingInOrderTransform. "
+            "(MEMORY_LIMIT_EXCEEDED)\n",
+            # max_execution_time cap (code 159)
+            "HTTPDriver received ClickHouse error code 159\n Code: 159. DB::Exception: Timeout exceeded: "
+            "elapsed 53343.4 ms, maximum: 30000 ms. (TIMEOUT_EXCEEDED)\n",
+        ],
+    )
+    def test_probe_budget_exhaustion_not_captured(self, error_msg):
+        from posthog.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
+
+        client = MagicMock()
+        client.query.side_effect = ClickHouseError(error_msg)
+
+        with patch.object(ch_module, "capture_exception") as mock_capture:
+            # Still assumes duplicates (safe append mode), but the probe hitting
+            # its own memory/time budget is the designed fallback — not error
+            # tracking noise.
+            assert _has_duplicate_primary_keys(client, "db", "t", ["id"], self._logger()) is True
+
+        mock_capture.assert_not_called()
 
     def test_passes_bounded_settings(self):
         client = MagicMock()


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse import source reports a high-volume `DatabaseError` to error tracking that is not actually a failure. The exception originates in `_has_duplicate_primary_keys` (`posthog/temporal/data_imports/sources/clickhouse/clickhouse.py`) and shows up with messages like:

```
Code: 241. DB::Exception: Query memory limit exceeded: would use 958.14 MiB ... maximum: 953.67 MiB: While executing AggregatingInOrderTransform. (MEMORY_LIMIT_EXCEEDED)
Code: 159. DB::Exception: Timeout exceeded: elapsed 53343 ms, maximum: 30000 ms. (TIMEOUT_EXCEEDED)
```

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019e14ae-1ca0-77a2-becd-56fed431e7ac (~1099 occurrences over the window).

### Root cause

Before an incremental sync, the source probes whether the chosen sorting key has duplicate combinations. To keep this cheap on huge tables, the probe runs a bounded `GROUP BY ... HAVING count() > 1 LIMIT 1` with deliberately tight self-imposed budgets — `max_memory_usage = 1 GB` (≈ 953.67 MiB) and `max_execution_time = 30 s`.

On large/slow source tables (e.g. S3-backed storage with wide string columns), the streaming aggregation can hit those caps before `read_overflow_mode='break'` truncates on the row budget. ClickHouse then raises MEMORY_LIMIT_EXCEEDED (241) / TIMEOUT_EXCEEDED (159).

The `except ClickHouseError` handler already does the right *functional* thing — it logs and returns `True` ("assume duplicates", forcing safe append mode rather than an unverified merge). The bug is that it *also* called `capture_exception(e)` unconditionally, so the probe's designed-for fallback was reported to error tracking on every sync of an affected table.

This is **not** a retry/credential/config problem: the import never fails or retries on it (`mechanism.handled = true`), so it does not belong in `NonRetryableErrors`. (And the timeout code is explicitly asserted to stay retryable in the existing test suite.)

## Changes

In `_has_duplicate_primary_keys`, treat the probe's own budget-exhaustion errors (`MEMORY_LIMIT_EXCEEDED`, `TIMEOUT_EXCEEDED`) as the expected graceful outcome: still log a warning and still return `True`, but skip `capture_exception` for them. Genuinely unexpected `ClickHouseError`s are still captured.

The match is on the stable ClickHouse error-name substrings rather than volatile parts of the message (memory figures, elapsed times, URLs).

## How did you test this code?

I'm an agent. I ran the source's unit tests with `uv run pytest`:

- Extended `TestHasDuplicatePrimaryKeys` with:
  - `test_probe_budget_exhaustion_not_captured` (parameterized over the 241 and 159 messages) — asserts the probe still returns `True` but `capture_exception` is **not** called.
  - `test_captures_unexpected_clickhouse_error` — asserts an unrelated error (e.g. syntax error) still returns `True` **and** is captured.
- Full file: `139 passed`.
- `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above using the PostHog error-tracking MCP tools to pull the stack trace, representative events, and frequency, then traced the call path from `clickhouse_source` into `_has_duplicate_primary_keys`.

Decision: classified as a fixable observability bug rather than a `NonRetryableErrors` extension — the failure is already handled gracefully and is self-inflicted by the probe's own resource caps, so the correct fix is to stop reporting the expected fallback, not to change retry behavior. Kept the change strictly scoped to the capture decision; left the probe's budgets, return semantics, and logging untouched.
