### PR TITLE
fix(stripe): treat missing-scope 403 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,8 +1,16 @@
 import pytest
 
+from stripe import PermissionError as StripePermissionError
+
 from posthog.temporal.data_imports.sources.stripe.source import StripeSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+def _is_non_retryable(source: StripeSource, error_msg: str) -> bool:
+    # Mirror the matcher in import_data_sync / external_data_job: substring match of each
+    # non-retryable key against the raw exception string.
+    return any(key in error_msg for key in source.get_non_retryable_errors())
 
 
 class TestStripeSource:
@@ -40,3 +48,31 @@ class TestStripeSource:
     def test_non_retryable_errors_do_not_match_transient(self, other_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "scope_message",
+        [
+            # Restricted key missing the Credit Notes Read scope.
+            (
+                "Permission denied. The provided key 'rk_live_xxxx' does not have the required "
+                "permissions for this endpoint on account 'acct_1'. Enabling \"Credit Notes Read\" "
+                "('credit_note_read') permissions on this key would allow this request to continue. "
+                "You can edit permissions at https://dashboard.stripe.com/..."
+            ),
+            # Same shape for any other missing resource scope (Stripe's phrasing is stable).
+            (
+                "Permission denied. The provided key 'rk_live_yyyy' does not have the required "
+                "permissions for this endpoint on account 'acct_2'. Having the 'rak_payment_method_read' "
+                "permission would allow this request to continue."
+            ),
+        ],
+    )
+    def test_missing_scope_permission_error_is_non_retryable(self, scope_message: str) -> None:
+        # Build the real exception string the SDK raises (includes request id prefix) so the test
+        # would have caught the bug where the message never contained the literal "PermissionError".
+        error = StripePermissionError(scope_message)
+        error.request_id = "req_zpuHpEJEXoOIl2"
+        error_msg = str(error)
+
+        assert "PermissionError" not in error_msg
+        assert _is_non_retryable(self.source, error_msg)


### PR DESCRIPTION
## Problem

The Stripe data-warehouse import source repeatedly retries a 403 that the customer can only fix on their side. When a restricted API key (`rk_live_…`) is missing a resource scope, Stripe raises a `PermissionError` whose message is:

> Request `req_…`: Permission denied. The provided key `rk_live_…` does not have the required permissions for this endpoint on account `acct_…`. Enabling "Credit Notes Read" (`credit_note_read`) permissions on this key would allow this request to continue.

This surfaced in error tracking as a `PermissionError` originating in `posthog/temporal/data_imports/sources/stripe/` (786 occurrences, still firing). It is a **user/upstream configuration error** — the customer needs to enable the scope on their key; there is nothing for us to do but stop retrying and surface an actionable message.

The non-retryable matcher (`import_data_sync` / `external_data_job`) does a **substring match against `str(exception)`**. The source already listed a `"PermissionError"` key intended to catch this, but `str(stripe.PermissionError)` is `"Request <id>: Permission denied. …"` — it never contains the literal `"PermissionError"` (that's the exception class name error tracking groups on, not part of the message). So the key never matched and these 403s were retried on every sync.

## Changes

- In `StripeSource.get_non_retryable_errors`, replace the ineffective `"PermissionError"` key with the stable, low-false-positive phrase **`"does not have the required permissions for this endpoint"`** — Stripe's canonical wording for a restricted key lacking a resource scope. It carries no volatile parts (request id, key, account id, scope name, URL), so it won't go stale or mis-match.
- Keep the friendly value as `None` so Stripe's raw message (which names the exact missing scope) is surfaced to the user, as the original code intended.
- Add `tests/test_stripe_source.py` covering the new behavior.

## How did you test this code?

I'm an agent (Claude Code). I ran only automated tests — no manual testing.

- Added `posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py`. It builds the real `str(stripe.PermissionError)` (asserting `"PermissionError"` is genuinely absent from it — the bug that made the old key dead) and asserts the matcher recognizes it as non-retryable, for both the Credit Notes message and the generic "Having the '…' permission would allow this request to continue" variant.
- `pytest posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py` → 7 passed.
- `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged an error-tracking issue for the Stripe import source. Confirmed via PostHog error tracking that the failure originates in the source (frame under `posthog/temporal/data_imports/sources/stripe/`) and is a 403 caused by a customer restricted key missing the `credit_note_read` scope.
- Verified empirically that `str(stripe.PermissionError)` does not contain `"PermissionError"`, so the existing key was dead and the error was being retried — classified as user/upstream and extended `NonRetryableErrors` rather than changing retry policy.
- Tools: Claude Code with the PostHog MCP error-tracking tools.
