### PR TITLE
fix(mysql): sample avg row size over projected columns only

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -628,31 +628,27 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
     ) -> int | None:
         """Sample `LENGTH(COALESCE(col, ''))` across columns on the first 1000 rows.
 
-        Column names are pulled from `information_schema.COLUMNS`, then
-        each name is passed through the identifier quoter before being
-        interpolated into the `LENGTH(...)` sum. `inner_query` is the
-        SELECT the sync is about to run — its identifiers were already
-        quoted by the shared `SelectQueryBuilder`, and its arguments are
-        rebound as parameters here. No untrusted value ever reaches raw
-        SQL.
+        Column names come from `inner_query`'s own result metadata — not
+        `information_schema.COLUMNS` — because the sync only selects the
+        *projected* columns (column selection + primary keys + incremental
+        field), not every column on the table. Summing `LENGTH(...)` over
+        de-selected columns inside the `inner_query` subselect would
+        reference columns absent from the derived table and fail with
+        `Unknown column '<col>' in 'field list'`. Each name is still passed
+        through the identifier quoter before interpolation; `inner_query`
+        was already quoted by the shared `SelectQueryBuilder`, and its
+        arguments are rebound as parameters here. No untrusted value ever
+        reaches raw SQL.
         """
         try:
-            cursor.execute(
-                """
-                    SELECT COLUMN_NAME
-                    FROM INFORMATION_SCHEMA.COLUMNS
-                    WHERE TABLE_SCHEMA = %(schema)s
-                    AND TABLE_NAME = %(table_name)s
-                    ORDER BY ORDINAL_POSITION
-                """,
-                {"schema": schema, "table_name": table_name},
-            )
-            rows = cursor.fetchall()
-            if not rows:
+            # `LIMIT 0` fetches no rows but still populates the cursor
+            # description with exactly the columns the sync projects.
+            cursor.execute("SELECT * FROM (" + inner_query + ") as t LIMIT 0", inner_query_args)
+            columns = [col[0] for col in cursor.description or []]
+            if not columns:
                 logger.debug("fetch_average_row_size: No columns found.")
                 return None
 
-            columns = [row[0] for row in rows]
             length_sum = " + ".join(f"LENGTH(COALESCE({_IDENTIFIER_QUOTER.quote(col)}, ''))" for col in columns)
             # length_sum and inner_query are built from sanitized identifiers;
             # no user-supplied values are interpolated into the SQL itself.

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -327,30 +327,30 @@ class TestFetchTableStats:
 
 class TestFetchAverageRowSize:
     def test_returns_none_when_no_columns(self, impl, cursor, logger):
-        cursor.fetchall.return_value = []
+        cursor.description = []
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result is None
 
     def test_returns_none_when_sample_empty(self, impl, cursor, logger):
-        cursor.fetchall.return_value = [("id",), ("email",)]
+        cursor.description = [("id",), ("email",)]
         cursor.fetchone.return_value = None
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result is None
 
     def test_returns_row_size_bytes(self, impl, cursor, logger):
-        cursor.fetchall.return_value = [("id",), ("email",)]
+        cursor.description = [("id",), ("email",)]
         cursor.fetchone.return_value = (256.4,)
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result == 256
 
     def test_clamps_to_at_least_one(self, impl, cursor, logger):
-        cursor.fetchall.return_value = [("id",)]
+        cursor.description = [("id",)]
         cursor.fetchone.return_value = (0,)
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result == 1
 
     def test_quotes_column_names_in_length_sum(self, impl, cursor, logger):
-        cursor.fetchall.return_value = [("id",), ("email",)]
+        cursor.description = [("id",), ("email",)]
         cursor.fetchone.return_value = (100,)
         impl.fetch_average_row_size(cursor, "db", "t", "SELECT * FROM x", {}, logger)
         # The second execute call is the size query — inspect it.
@@ -360,11 +360,40 @@ class TestFetchAverageRowSize:
         assert "`email`" in sql
         assert "LENGTH(COALESCE(`id`" in sql
 
+    def test_samples_only_projected_inner_query_columns(self, impl, cursor, logger):
+        # Regression: the sync projects a subset of columns (column
+        # selection / primary keys / incremental field). Column names must
+        # come from the `inner_query`'s own projection — reading every table
+        # column from information_schema previously summed `LENGTH(...)` over
+        # de-selected columns inside the subselect and failed with
+        # "Unknown column '<col>' in 'field list'".
+        cursor.description = [("id",), ("task_id",), ("status",)]
+        cursor.fetchone.return_value = (42,)
+        inner_query = "select `id`, `task_id`, `status` from `db`.`t` where `id` > %(id)s order by `id` asc"
+
+        result = impl.fetch_average_row_size(cursor, "db", "t", inner_query, {"id": 5}, logger)
+        assert result == 42
+
+        # First execute discovers the projected columns from the inner query
+        # itself (LIMIT 0 fetches no rows), reusing the same bound args.
+        discovery_sql, discovery_args = cursor.execute.call_args_list[0].args
+        assert inner_query in discovery_sql
+        assert "LIMIT 0" in discovery_sql
+        assert discovery_args == {"id": 5}
+
+        # Size query references only the projected columns — no de-selected
+        # column (e.g. `tool_input`) leaks into the LENGTH(...) sum.
+        size_sql = cursor.execute.call_args_list[1].args[0]
+        assert "LENGTH(COALESCE(`id`" in size_sql
+        assert "`task_id`" in size_sql
+        assert "`status`" in size_sql
+        assert "tool_input" not in size_sql
+
     def test_rejects_malformed_column_names(self, impl, cursor, logger):
-        # If INFORMATION_SCHEMA somehow returns a weird column name, we must
+        # If the inner query somehow exposes a weird column name, we must
         # reject it rather than splice it into SQL. The quoter raises; the
         # method catches and returns None.
-        cursor.fetchall.return_value = [("bad;col",)]
+        cursor.description = [("bad;col",)]
         cursor.fetchone.return_value = (1,)
         result = impl.fetch_average_row_size(cursor, "db", "t", "SELECT 1", {}, logger)
         assert result is None


### PR DESCRIPTION
## Problem

The MySQL data-warehouse import source repeatedly throws `OperationalError (1054, "Unknown column '<col>' in 'field list'")` from `fetch_average_row_size`, surfaced via PostHog error tracking ([issue `019e5001-f23a-7f92-a6db-a7a84ba6a87c`](https://us.posthog.com/project/2/error_tracking/019e5001-f23a-7f92-a6db-a7a84ba6a87c)) — active, with thousands of occurrences across many tables and sources.

`fetch_average_row_size` estimates the average row size to tune the streaming chunk size. It built the `LENGTH(COALESCE(col, ''))` sum from **every** column returned by `information_schema.COLUMNS`, but wraps the sync's `inner_query` in a derived table. The `inner_query` only selects the **projected** columns (column selection + primary keys + incremental field). When a user deselects columns, the outer `AVG(...)` references columns that are not present in the derived table `t`, so MySQL/Vitess rejects the query with `Unknown column '<col>' in 'field list'`.

The exception is caught (`capture_exception` + return `None`), so the sync continues with the default chunk size — but it is noisy in error tracking and the chunk-size optimization silently never works for any column-projected MySQL sync.

This is a code bug (we construct an inconsistent query), not a user/upstream error.

## Changes

- `fetch_average_row_size` now derives the column list from the `inner_query`'s own result metadata — `SELECT * FROM (inner_query) as t LIMIT 0`, reading `cursor.description` — instead of `information_schema.COLUMNS`. `LIMIT 0` fetches no rows but still populates the column description, so the `LENGTH(...)` sum references exactly the columns the sync projects (whether `SELECT *`, a subset, or PKs + incremental field only). Identifiers are still passed through the existing quoter before interpolation, preserving the SQL-safety contract.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing against a live MySQL/Vitess instance. Automated tests run locally (`pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py`):

- Updated the existing `TestFetchAverageRowSize` cases to source columns from `cursor.description`.
- Added `test_samples_only_projected_inner_query_columns` — a regression test asserting the discovery query wraps the projected `inner_query` (with `LIMIT 0` and the same bound args) and that the size query references only the projected columns, never a de-selected one.
- Full file: 92 passed. `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the MySQL import source. Used the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue is real, active, and originates in `fetch_average_row_size` (top in-app frame). Read the MySQL source and shared SQL implementation to find the root cause: the average-row-size probe enumerated all table columns while sampling over a column-projected subquery. Compared with the MSSQL driver (which samples `SELECT TOP 100 *` over the full table and so doesn't hit this) before settling on deriving columns from the inner query's result metadata — the most scoped fix that keeps the probe consistent with what the sync actually fetches, without changing the shared base-class signature.
