### PR TITLE
fix(postgres): retry transient dropped connection on CDC connect

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -7,23 +7,27 @@ approach — batch reads on a schedule.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import psycopg
+import structlog
 from psycopg import sql
 
 from posthog.temporal.data_imports.cdc.types import ChangeEvent
 from posthog.temporal.data_imports.sources.postgres.cdc.decoder import PgOutputDecoder
-from posthog.temporal.data_imports.sources.postgres.postgres import _connect_to_postgres, get_primary_key_columns
+from posthog.temporal.data_imports.sources.postgres.postgres import (
+    _connect_to_postgres,
+    _connect_with_dropped_retry,
+    get_primary_key_columns,
+)
 
 if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,12 +77,21 @@ class PgCDCStreamReader:
             self._effective_host, self._effective_port = tunnel_cm.__enter__()
             self._tunnel_cm = tunnel_cm
 
-        self._conn = _connect_to_postgres(
-            host=self._effective_host,
-            port=self._effective_port,
-            database=self._params.database,
-            user=self._params.user,
-            password=self._params.password,
+        # The initial connect reaches the source through the just-opened SSH tunnel /
+        # connection pooler, either of which can drop the first connection with a
+        # transient "server closed the connection unexpectedly". Mirror the non-CDC
+        # read paths and absorb those drops in-process instead of failing the whole
+        # extraction activity; permanent errors (auth, SSL-required) are re-raised
+        # immediately by the helper.
+        self._conn = _connect_with_dropped_retry(
+            lambda: _connect_to_postgres(
+                host=self._effective_host,
+                port=self._effective_port,
+                database=self._params.database,
+                user=self._params.user,
+                password=self._params.password,
+            ),
+            logger,
         )
 
     def read_changes(self) -> Iterator[ChangeEvent]:
@@ -142,7 +155,7 @@ class PgCDCStreamReader:
         finally:
             advance_conn.close()
 
-        logger.info("Advanced slot %s to position %s", self._params.slot_name, position)
+        logger.info("advanced_slot", slot_name=self._params.slot_name, position=position)
 
     def get_primary_key_columns(self, schema_name: str, table_names: list[str]) -> dict[str, list[str]]:
         """Query information_schema for PK columns of the given tables.

--- a/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest import mock
+from unittest.mock import patch
+
+import psycopg
+
+from posthog.temporal.data_imports.sources.postgres.cdc.stream_reader import PgCDCConnectionParams, PgCDCStreamReader
+
+
+@pytest.fixture
+def params():
+    return PgCDCConnectionParams(
+        host="localhost",
+        port=5432,
+        database="postgres",
+        user="postgres",
+        password="password",
+        slot_name="posthog_slot",
+        publication_name="posthog_pub",
+    )
+
+
+class TestPgCDCStreamReaderConnect:
+    def test_connect_retries_transient_dropped_connection(self, params):
+        good_conn = mock.MagicMock()
+        connect = mock.MagicMock(
+            side_effect=[
+                # The exact transient drop surfaced in production when the SSH tunnel /
+                # pooler closes the first connection before it is established.
+                psycopg.OperationalError("server closed the connection unexpectedly"),
+                good_conn,
+            ]
+        )
+
+        reader = PgCDCStreamReader(params)
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"),
+        ):
+            reader.connect()
+
+        assert reader._conn is good_conn
+        assert connect.call_count == 2
+
+    def test_connect_does_not_retry_permanent_error(self, params):
+        connect = mock.MagicMock(
+            side_effect=psycopg.OperationalError(
+                'connection to server at "10.0.0.1" failed: FATAL: password authentication failed'
+            )
+        )
+
+        reader = PgCDCStreamReader(params)
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"),
+        ):
+            with pytest.raises(psycopg.OperationalError):
+                reader.connect()
+
+        assert connect.call_count == 1


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports with CDC enabled were repeatedly failing during the extraction activity's initial connection with:

```
OperationalError: connection failed: connection to server at "127.0.0.1", port <random> failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

The connection is to `127.0.0.1:<random>` because CDC reaches the source through an SSH tunnel (and, for several affected sources, a connection pooler behind it). Either layer can drop the *first* connection before it is fully established — a transient blip, not a permanent failure.

This error string is already explicitly classified as transient/recoverable in this source (`_CONNECTION_DROPPED_ERROR_SUBSTRINGS` → `_is_connection_dropped_error`), and every non-CDC read path opens its connection through `_connect_with_dropped_retry`, which retries those drops in-process with bounded backoff. The CDC stream reader's `connect()` was the one path that called `_connect_to_postgres` directly, so the same transient drop escaped and failed the whole activity instead of being absorbed.

Surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019d97bd-633a-7ab3-bbf6-e097a1f8e2f6

## Changes

- Wrap the CDC stream reader's initial connect in the existing `_connect_with_dropped_retry` helper, mirroring the non-CDC read paths. Transient connection drops are retried in-process; permanent errors (auth failure, SSL-required) are still re-raised immediately by the helper, so this does not mask real configuration problems.
- Switch the module logger to `structlog` (the convention across `posthog/temporal/`) so the structured-logger type the helper expects is satisfied; updated the one existing log call accordingly.

This is deliberately **not** added to `NonRetryableErrors`: the error is genuinely transient infrastructure noise, so it must stay retryable — the fix improves resilience rather than giving up.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I added and ran:

- New `cdc/tests/test_stream_reader.py`:
  - `test_connect_retries_transient_dropped_connection` — a "server closed the connection unexpectedly" on the first attempt is retried and succeeds.
  - `test_connect_does_not_retry_permanent_error` — a password-auth failure is raised immediately, not retried.
- Re-ran the existing `TestConnectWithDroppedRetry`, `TestIsConnectionDroppedError`, and `TestPostgresSourceNonRetryableErrors` suites — all green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Postgres data-warehouse source with Claude Code. Pulled the issue's stack trace and representative events via the PostHog MCP error-tracking tools, confirmed the failure originates in `posthog/temporal/data_imports/sources/postgres/` (`stream_reader.connect` → `_connect_to_postgres`), and read the surrounding implementation.

Decision: the message is already treated as a transient connection-dropped error elsewhere in the source, so adding it to `NonRetryableErrors` would have been wrong. The real gap was that the CDC connect path didn't reuse the in-process dropped-connection retry that every other read path already uses — a fragility fix, scoped to that one call site plus a regression test.
