### PR TITLE
fix(meta_ads): refresh stale DB connection before integration lookup

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -5,6 +5,8 @@ import collections.abc
 from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from django.db import close_old_connections
+
 from requests import Response
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
@@ -91,6 +93,12 @@ def _clean_account_id(s: str | None) -> str | None:
 
 def get_integration(config: MetaAdsSourceConfig, team_id: int) -> Integration:
     """Get the Meta Ads integration."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it — drop any stale connection first,
+    # otherwise the ORM read raises `OperationalError: the connection is closed`.
+    close_old_connections()
     integration = Integration.objects.get(id=config.meta_ads_integration_id, team_id=team_id)
     meta_ads_integration = MetaAdsIntegration(integration)
     meta_ads_integration.refresh_access_token()

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -5,6 +5,8 @@ import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
+from posthog.temporal.data_imports.sources.meta_ads import meta_ads as meta_ads_module
 from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     META_AUTH_ERROR_MESSAGE,
     PAGE_LIMIT_FALLBACK_SIZES,
@@ -15,6 +17,7 @@ from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     _next_smaller_limit,
     _override_limit,
     _strip_access_token,
+    get_integration,
 )
 from posthog.temporal.data_imports.sources.meta_ads.source import MetaAdsSource
 
@@ -680,6 +683,34 @@ class TestMidChunkLimitFallback:
 
         # Initial + failed cursor only — the limit ladder is not exercised for auth errors.
         assert mock_get.return_value.get.call_count == 2
+
+
+class TestGetIntegration:
+    def test_refreshes_stale_db_connection_before_query(self, monkeypatch) -> None:
+        # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: the connection is closed`. We must drop the stale
+        # connection before querying, so the read happens on a fresh connection.
+        calls: list[str] = []
+
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", lambda: calls.append("close_old_connections"))
+
+        integration = mock.MagicMock()
+        integration.errors = None
+
+        def fake_get(*args, **kwargs):
+            calls.append("Integration.objects.get")
+            return integration
+
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", fake_get)
+        # Avoid touching the real token-refresh path (network + DB).
+        monkeypatch.setattr(meta_ads_module, "MetaAdsIntegration", lambda i: mock.MagicMock(integration=i, errors=None))
+
+        config = MetaAdsSourceConfig(account_id="act_1", meta_ads_integration_id=42, sync_lookback_days=None)
+        get_integration(config, team_id=1)
+
+        # The stale connection must be dropped before the ORM read is issued.
+        assert calls == ["close_old_connections", "Integration.objects.get"]
 
 
 class TestNonRetryableErrors:


### PR DESCRIPTION
## Problem

Meta Ads imports surface a recurring `OperationalError: the connection is closed` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ce027-b001-7dd2-9488-23087696a0d8)). The stack originates in `meta_ads.py` at `get_rows` → `get_integration` → `Integration.objects.get(...)`, where psycopg raises because the Django connection has already been closed server-side.

`get_integration` runs **lazily** from inside the `get_rows` generator that the import pipeline iterates on a Temporal worker thread. By the time it executes, the pooled Django connection has frequently been idle for minutes, and Postgres closes idle connections server-side. The next ORM call then fails with `the connection is closed`.

This is a transient infrastructure error, not a Meta credential/upstream problem — so it should stay **retryable** and does not belong in `NonRetryableErrors`. The real issue is that our code is fragile: it reaches for a potentially-stale pooled connection without refreshing it first.

## Changes

Call `close_old_connections()` at the start of `get_integration`, before the `Integration.objects.get(...)` read, so any stale connection is dropped and the ORM read happens on a fresh one.

This mirrors the identical, already-shipped fix in the `google_ads` and `google_search_console` sources, which had the same lazy-ORM-read-on-a-worker-thread pattern. The change is intentionally scoped — no retry-policy changes and no new `NonRetryableErrors` entries.

## How did you test this code?

I'm an agent. I added a regression test (`TestGetIntegration.test_refreshes_stale_db_connection_before_query`) asserting `close_old_connections()` is invoked before the ORM read, and ran the automated tests I actually executed:

- `pytest posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py` — 52 passed
- `ruff check` / `ruff format` on both changed files — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `meta_ads` source. Pulled the full stack trace and a representative event via the PostHog MCP error-tracking tools, confirmed the failure genuinely raises in `meta_ads.get_integration` (not just serialized log context), and classified it as a transient infra error rather than a user/upstream one. Considered and rejected adding it to `NonRetryableErrors` (it must stay retryable). Chose the `close_old_connections()` fix after finding the exact same remedy already applied to two sibling sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)