### PR TITLE
fix(postgres): treat permission-denied errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -186,7 +186,19 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "TemporaryFileSizeExceedsLimitException": None,
             "Name or service not known": None,
             "Network is unreachable": None,
+            # `InsufficientPrivilege` is the psycopg exception class name. It only appears once
+            # Temporal wraps the activity failure (`ApplicationError` stringifies as
+            # "InsufficientPrivilege: ..."), so it matches at the workflow layer but NOT in the
+            # activity-level check, where `error_msg = str(e)` is the raw psycopg message —
+            # PostgreSQL's SQLSTATE 42501 text "permission denied for table/view/... <name>".
+            # Match that message substring so the role-lacks-SELECT case is caught at both layers
+            # and we stop retrying instead of re-reading into the same denial every attempt.
             "InsufficientPrivilege": None,
+            "permission denied for": (
+                "PostHog's database role isn't allowed to read one or more of the tables you selected to sync "
+                '(PostgreSQL reported "permission denied"). Grant the connecting role SELECT on those tables '
+                "(for example: GRANT SELECT ON <table> TO <role>), then re-enable the sync."
+            ),
             "Connection refused": None,
             "No route to host": None,
             "password authentication failed connection": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -189,6 +189,29 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)) — no class name.
+            "permission denied for table brand",
+            "permission denied for view posthog_areas",
+            "permission denied for materialized view posthog_notifications",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "InsufficientPrivilege: permission denied for table brand",
+        ],
+    )
+    def test_permission_denied_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Permission-denied error should be non-retryable: {error_msg}"
+
+    def test_permission_denied_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = "permission denied for table brand"
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Permission-denied error should surface an actionable message"
+        assert "SELECT" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source surfaced a recurring `InsufficientPrivilege` error in error tracking — `permission denied for table <name>` (also for views and materialized views). This happens when the connecting database role lacks `SELECT` on a table the customer selected to sync. It's a credential/grant problem on the source database, so retrying can never succeed.

The source already listed `InsufficientPrivilege` in its non-retryable errors, but it wasn't being caught at the right layer. The activity-level non-retryable check (`import_data_sync.py`) matches against `str(e)`, which for a raw psycopg exception is just PostgreSQL's message (`permission denied for table brand`) and does **not** contain the `InsufficientPrivilege` class name. That name only appears once Temporal wraps the failure in an `ApplicationError` ("InsufficientPrivilege: …"), which is what the workflow-level check sees. As a result the fast non-retryable path was bypassed and the activity kept retrying, re-capturing the same error on every attempt.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019d0147-42cd-75f2-8d62-c02ec192cda3

## Changes

Add a stable, message-based key `permission denied for` to the Postgres source's `get_non_retryable_errors()`. PostgreSQL's SQLSTATE 42501 text always starts with this substring (`permission denied for table/view/materialized view/sequence/... <name>`), so it matches both the raw psycopg message (activity layer) and the Temporal-wrapped message (workflow layer). The key carries an actionable message telling the customer to grant the connecting role `SELECT` on the affected tables.

Kept the existing `InsufficientPrivilege` key — it still matches at the workflow layer and is harmless. Scoped strictly to this error; no change to global retry policy.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests I added/touched — no manual testing:

- `pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors` — **24 passed**.
- New parametrized `test_permission_denied_errors_are_non_retryable` covers the raw psycopg message form and the Temporal-wrapped form.
- New `test_permission_denied_returns_friendly_message` asserts the actionable `SELECT`-grant message is surfaced.
- Existing retryable-error tests (transient connection errors, recovery-conflict transients) still pass, confirming the new substring introduces no false positives.
- `ruff check` and `ruff format --check` pass on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Postgres import source. Pulled the full stack trace and sampled events via the PostHog error-tracking tools, confirming the failure originates in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`get_rows` → `cursor.execute`) raising psycopg's `InsufficientPrivilege`.

Decision: this is a user/upstream permission error that should be non-retryable. Verified empirically that `str(psycopg.errors.InsufficientPrivilege(...))` yields only the message (`permission denied for table brand`) while `str(temporalio ApplicationError(...))` prepends the type — explaining why the existing class-name key matched only at the workflow layer and the activity kept retrying. Chose to match the stable message substring `permission denied for` rather than the volatile object name, mirroring the Stripe `get_non_retryable_errors` pattern. Confirmed the introspection permission paths (e.g. `get_leading_index_columns`) are caught locally and unaffected.
