### PR TITLE
fix(mysql): stop flooding error tracking from best-effort row-count probe

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -574,8 +574,13 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
             logger.debug(f"get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
             return rows_to_sync_int
         except Exception as e:
+            # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.
+            # It shares its FROM/WHERE with the real streaming query, so any genuine problem
+            # (missing column, bad incremental field, permissions) resurfaces there and is
+            # classified through the normal retryable/non-retryable path. The MAX_EXECUTION_TIME
+            # hint above also makes timeouts here expected. Capturing it would only flood error
+            # tracking with handled duplicates, so we log at debug and fall back to 0.
             logger.debug(f"get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
-            capture_exception(e)
             return 0
 
     def fetch_table_stats(

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -291,6 +291,26 @@ class TestGetRowsToSync:
         # Swallows the error rather than propagating — matches pre-refactor behavior.
         assert impl.get_rows_to_sync(cursor, "SELECT * FROM t", {}, logger) == 0
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pymysql.err.OperationalError(1054, "Unknown column 'favoritor_id' in 'where clause'"),
+            pymysql.err.OperationalError(
+                3024, "Query execution was interrupted, maximum statement execution time exceeded"
+            ),
+            RuntimeError("boom"),
+        ],
+    )
+    def test_does_not_capture_handled_probe_failures(self, impl, cursor, logger, error, mocker):
+        # The COUNT(*) probe is best-effort: it falls back to 0 and must not flood error
+        # tracking with handled failures (e.g. a bad incremental field or the MAX_EXECUTION_TIME
+        # timeout). Genuine problems resurface in the real streaming query and are classified there.
+        cursor.execute.side_effect = error
+        capture = mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.capture_exception")
+
+        assert impl.get_rows_to_sync(cursor, "SELECT * FROM t", {}, logger) == 0
+        capture.assert_not_called()
+
     def test_wraps_inner_query_as_subselect(self, impl, cursor, logger):
         cursor.fetchone.return_value = (5,)
         impl.get_rows_to_sync(cursor, "SELECT x FROM y WHERE a = %(a)s", {"a": 1}, logger)


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a high-volume `OperationalError` issue originating in `posthog/temporal/data_imports/sources/mysql/mysql.py` at `get_rows_to_sync` ([issue](https://us.posthog.com/project/2/error_tracking/019e5002-c971-7200-ab81-7b9df7b09baf)). The representative message is `(1054, "Unknown column '<col>' in 'where clause'")`, alongside co-grouped `(3024, 'maximum statement execution time exceeded')` timeouts. Several thousand occurrences accumulated.

The catch: `get_rows_to_sync` is a **best-effort** `COUNT(*)` probe used only for progress reporting and partition sizing. It already catches the exception, returns `0`, and lets the sync proceed (the events are `handled: true`). The errors reaching error tracking come purely from a `capture_exception(e)` call in that handler — they are not job failures.

This is not a non-retryable-error case: because the exception is swallowed it never becomes the job's `internal_error`, so the `get_non_retryable_errors()` matcher in `external_data_job.py` never sees it. Adding the string there would be a no-op for this issue. The fix has to be in the probe itself.

## Changes

- Removed the `capture_exception(e)` call from `MySQLImplementation.get_rows_to_sync`. The handler still logs at debug and falls back to `0`.
- Added a comment explaining why: the probe shares its FROM/WHERE with the real streaming query, so any genuine problem (missing/renamed incremental column, bad incremental field, permissions) resurfaces there and is classified through the normal retryable/non-retryable path. The `MAX_EXECUTION_TIME` hint also makes probe timeouts expected.
- Added a parameterized regression test asserting the probe falls back to `0` and does **not** call `capture_exception` for the unknown-column error, the statement-timeout error, and a generic error.

This mirrors the existing Postgres `_get_rows_to_sync`, which already dropped the same capture for the same reason (its comment even names "missing column" as a tolerated condition). The sibling MySQL probes (`fetch_average_row_size`, `explain_query`) follow the same anti-pattern but are distinct error-tracking issues; left out to keep this scoped.

## How did you test this code?

I'm an agent. I did not perform manual testing. Automated tests I ran locally:

- `pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py::TestGetRowsToSync` — 7 passed (includes the 3 new cases).
- `pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — 94 passed.
- `ruff check` / `ruff format` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue via the PostHog MCP tools: pulled the issue, sampled `$exception` events, and confirmed a real in-app frame at `mysql.py:564` with `mechanism.handled = true`.
- Decision path: considered extending `get_non_retryable_errors` (the "unknown column" message reads like user/upstream schema drift), but rejected it — the exception is swallowed by the probe and never reaches the job's `internal_error`, so non-retryable matching can't fire and would not reduce the volume. Classified it instead as error-tracking noise from a best-effort probe and matched the already-shipped Postgres behaviour.
- Scoped strictly to `get_rows_to_sync`; did not touch retry policy or the sibling probes.
