### PR TITLE
fix(stripe): treat 403 permission-denied errors as non-retryable during sync

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -235,7 +235,20 @@ If automatic creation failed due to a permissions error and you're using a restr
             # continue"), which is more actionable than a generic "check your permissions" toast.
             # `_clean_stripe_error_message` collapses the redacted-key asterisk run before the
             # message reaches this layer, so it stays toast-sized.
+            #
+            # NOTE: this `"PermissionError"` key only matches the refresh-schemas path, which compares
+            # against `f"{type(error).__name__}: {message}"`. The import/sync path compares against
+            # `str(exc)` only — and `StripeError.__str__` returns `"Request <id>: <message>"` with no
+            # class name — so the type-name key never matches a 403 raised mid-sync. Match Stripe's
+            # stable permission-denied message text directly so a misconfigured key stops retrying.
             "PermissionError": None,
+            # Restricted key is missing a read scope for the endpoint being synced (e.g. "Prices Read"
+            # / 'plan_read'). The customer must add the scope in Stripe — retrying won't help. Surface
+            # Stripe's raw message (None) since it names the exact scope to enable.
+            "does not have the required permissions for this endpoint": None,
+            # A non-Connect key was sent with a `stripe_account` header (the source's "Account id"),
+            # so Stripe rejects the whole request for the account rather than a specific scope.
+            "Only Stripe Connect platforms can work with other accounts": "Stripe rejected the request because your API key isn't authorized for the configured Stripe account. The 'Account id' in your source settings only applies to Stripe Connect platform accounts — remove or correct it if your key belongs directly to the account, then reconnect.",
             # Deterministic credential/config errors from _get_api_key and OAuthMixin
             "Missing Stripe API key": "Stripe API key is not configured. Please update the source configuration.",
             "Missing Stripe integration ID": "Stripe integration ID is not configured. Please reconnect your Stripe account.",

--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,0 +1,42 @@
+import pytest
+
+from posthog.temporal.data_imports.sources.stripe.source import StripeSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestStripeSource:
+    def setup_method(self):
+        self.source = StripeSource()
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.STRIPE
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            # 403 raised mid-sync — `str(StripeError)` is "Request <id>: <message>", with no class
+            # name, so these are matched on the stable message text rather than "PermissionError".
+            "Request req_Zb0EgUuheEd4gf: Permission denied. The provided key 'rk_live_***j4va7j' does not have the required permissions for this endpoint on account 'acct_123'. Enabling \"Prices Read\" ('plan_read') permissions on this key would allow this request to continue.",
+            "Request req_abc123: Only Stripe Connect platforms can work with other accounts. If you specified a client_id parameter, make sure it's correct.",
+            # 401/403 surfaced as a requests HTTPError keep matching the existing URL-based keys.
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "403 Client Error: Forbidden for url: https://api.stripe.com/v1/prices",
+        ],
+    )
+    def test_non_retryable_errors_match_permission_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            # Transient/infra errors must stay retryable.
+            "HTTPSConnectionPool(host='api.stripe.com', port=443): Read timed out.",
+            "500 Server Error: Internal Server Error for url: https://api.stripe.com/v1/charges",
+            "Connection reset by peer",
+        ],
+    )
+    def test_non_retryable_errors_do_not_match_transient(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

Stripe data-warehouse imports were repeatedly retrying a `PermissionError` (403) that can never succeed without the customer changing their Stripe configuration. The error surfaced in error tracking as a `PermissionError` originating in `posthog/temporal/data_imports/sources/stripe/stripe.py` (`_call_stripe`), with two main flavours:

- A restricted key missing a read scope for the endpoint being synced (e.g. *"… does not have the required permissions for this endpoint … Enabling 'Prices Read' ('plan_read') permissions on this key would allow this request to continue"*).
- A non-Connect key sent with the source's *Account id* (`stripe_account` header), which Stripe rejects with *"Only Stripe Connect platforms can work with other accounts"*.

Both are upstream/customer-configuration errors — retrying does nothing but burn worker time.

The Stripe source already declared a `"PermissionError"` entry in `get_non_retryable_errors`, but it only matched the **refresh-schemas** path, which compares against `f"{type(error).__name__}: {message}"`. The **import/sync** path (where these 403s are raised) compares against `str(exc)` only, and `StripeError.__str__` returns `"Request <id>: <message>"` with no class name — so the type-name key never matched a 403 raised mid-sync, and the job kept retrying.

## Changes

Extended the Stripe source's `get_non_retryable_errors` with two stable, low-false-positive substrings that actually appear in `str(exc)`:

- `"does not have the required permissions for this endpoint"` → surfaces Stripe's raw message (it names the exact missing scope).
- `"Only Stripe Connect platforms can work with other accounts"` → friendly message pointing the customer at the *Account id* setting.

The existing `"PermissionError"` key is kept (it still serves the refresh-schemas path) with a comment explaining why the type-name key alone is insufficient for the sync path. Transient/infra errors (timeouts, 5xx, connection resets) are deliberately left retryable.

## How did you test this code?

I'm an agent. I added `posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py` (mirroring the existing per-source non-retryable test pattern) asserting that both 403 message variants and the existing 401/403 URL forms are recognised as non-retryable, while transient errors (read timeout, 500, connection reset) are not. Ran the new tests locally — all 8 pass. Also ran `ruff check` and `ruff format --check` on the changed files (clean).

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue (Stripe source `PermissionError`, ~4.8k occurrences) using the PostHog error-tracking MCP tools to pull the stack trace, exception type, and representative messages, confirming the failure originates in `_call_stripe`.
- Traced the two non-retryable-error consumers: the sync path matches `str(exc)` (no class name) while the refresh-schemas path matches `"<ClassName>: <message>"`. This explained why the pre-existing `"PermissionError"` key didn't stop the retries during sync.
- Decided this is an upstream/customer-config error (not a code bug) and followed the NonRetryableErrors approach, matching on stable message substrings rather than volatile request ids / dashboard URLs.
