### PR TITLE
fix(clickhouse): skip materialized view inner tables in source discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -228,10 +228,26 @@ def get_schemas(
     schema_list: dict[str, list[tuple[str, str, bool]]] = collections.defaultdict(list)
     for row in result.result_rows:
         table_name, column_name, raw_type = row[0], row[1], row[2]
+        if _is_inner_table(table_name):
+            continue
         _, nullable = _strip_type_modifiers(raw_type)
         schema_list[table_name].append((column_name, raw_type, nullable))
 
     return schema_list
+
+
+def _is_inner_table(table_name: str) -> bool:
+    """Whether a table is a materialized view's hidden inner table.
+
+    ClickHouse backs a materialized view created without an explicit `TO`
+    target with an auto-generated inner table — `.inner.<mv_name>` on older
+    Ordinary databases, `.inner_id.<uuid>` on Atomic databases. These are
+    implementation details, not user data: their `.inner_id.<uuid>` names
+    change whenever the view is recreated, so a sync pointed at one breaks
+    the moment the view is rebuilt. Discover the materialized view by its own
+    name instead, never its inner table.
+    """
+    return table_name.startswith(".inner.") or table_name.startswith(".inner_id.")
 
 
 # Match `TO db.table` or `TO table` clause in MV CREATE statement.

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -592,6 +592,30 @@ class TestGetSchemas:
         assert events_cols["id"] == ("UInt64", False)
         assert events_cols["name"] == ("Nullable(String)", True)
 
+    def test_excludes_materialized_view_inner_tables(self):
+        from posthog.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
+
+        rows = [
+            ("events", "id", "UInt64"),
+            (".inner_id.8c612ff0-b72c-4b20-8ea5-405ed002c2f6", "id", "UInt64"),
+            (".inner_id.8c612ff0-b72c-4b20-8ea5-405ed002c2f6", "count", "UInt64"),
+            (".inner.my_legacy_mv", "value", "String"),
+        ]
+        mock_client = self._make_mock_client(rows)
+
+        with patch.object(ch_module, "_get_client", return_value=mock_client):
+            schemas = ch_module.get_schemas(
+                host="localhost",
+                port=8443,
+                database="default",
+                user="default",
+                password="",
+                secure=True,
+                verify=True,
+            )
+
+        assert set(schemas.keys()) == {"events"}
+
 
 class TestSourceClassValidateCredentials:
     """High-level checks on validate_credentials error mapping."""


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse source surfaces a recurring, currently-firing `ValueError` in error tracking:

> `Table <db>..inner_id.<uuid> not found or has no columns`

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019e6f70-c1c1-73a3-bda5-3137182be3f3) — 217 occurrences, still active (last seen today).

The stack ends in this source's own code:

```
posthog/temporal/data_imports/sources/clickhouse/source.py:source_for_pipeline
  → clickhouse.py:clickhouse_source
    → clickhouse.py:_get_table   ← raises ValueError
```

The schema name that fails is `.inner_id.<uuid>` — a ClickHouse **materialized-view inner table**. ClickHouse backs a materialized view created without an explicit `TO` target with an auto-generated inner table (`.inner.<name>` on Ordinary databases, `.inner_id.<uuid>` on Atomic databases). `get_schemas` reads table names from `system.columns`, which lists these inner tables, so one was offered as an importable schema and a sync schema was created for it.

Inner-table names embed a UUID that changes whenever the view is recreated. When the view was later rebuilt, the old inner table disappeared, so at import time `_get_table` queried `system.columns` for it, got zero rows, and raised the `ValueError`. Retrying can never succeed — the table is gone.

## Changes

Treat this as a fixable bug rather than a user/upstream error: these inner tables are implementation details we should never have exposed. `get_schemas` now skips any table whose name starts with `.inner.` or `.inner_id.`, so they are never selectable. Materialized views themselves (listed under their own names) are unaffected and remain importable.

This is the root-cause fix — it prevents new sync schemas from ever being created against a volatile inner-table name. (Pre-existing schemas already pointing at a now-deleted inner table are stale data and should be removed by the source owner; the pipeline will no longer recreate them.)

Scoped strictly to discovery filtering — no change to retry policy or to the global pipeline.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Added `TestGetSchemas::test_excludes_materialized_view_inner_tables`, a regression test asserting `.inner_id.<uuid>` and `.inner.<name>` tables are excluded from discovery while normal tables are kept. This test fails without the fix.
- Ran the full source test module: `pytest posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py` → **137 passed**.
- `ruff check` and `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking webhook for the ClickHouse import source. Used the PostHog error-tracking MCP tools to pull the full stack trace and a representative event, confirming the failure originates in `clickhouse.py:_get_table` and that the failing schema name is a materialized-view inner table (`.inner_id.<uuid>`).

Decision: the message could superficially read as an upstream "table deleted" condition (which would point at `NonRetryableErrors`), but the deeper cause is that our own discovery exposed a ClickHouse MV inner table with a volatile UUID name — fragile code we can fix. Chose the root-cause fix (filter inner tables in `get_schemas`) over widening `NonRetryableErrors`, so these schemas are never created in the first place.