### PR TITLE
fix(bigquery): treat dataset-not-found-in-location as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -42,7 +42,6 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "PermissionDenied: 403 request failed": "BigQuery permission denied. Please check that your service account has the necessary permissions.",
-            "NotFound: 404": "BigQuery dataset or table not found. Please verify your project, dataset, and table names.",
             # OAuth2 error code returned by Google's token endpoint when the service account grant
             # is rejected — a rotated/revoked private key ("Invalid JWT Signature") or a deleted
             # service account ("account not found"). Raised as a `RefreshError` while refreshing the
@@ -64,8 +63,8 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # dataset/table doesn't exist in the location we query — the dataset was deleted or
             # renamed, or it lives in a different region than the one we run against. The google
             # exception stringifies as "404 Not found: Dataset ... was not found in location US",
-            # which the "NotFound: 404" pattern above never matches, so match the stable phrasing
-            # here. Retrying can't recover — the user must fix the dataset or set the correct region.
+            # so match the stable phrasing here. Retrying can't recover — the user must fix the
+            # dataset or set the correct region.
             "was not found in location": "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or it may live in a different region — verify your dataset and table names, and set the dataset region in your source configuration if it isn't in the US.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -60,6 +60,13 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # customer's service account — retrying can't resolve them; the user must grant the
             # missing permission (or the referenced table/dataset must exist).
             "Access Denied:": "BigQuery denied access to a table or dataset. Please ensure your service account has read access (the bigquery.tables.getData permission, e.g. the BigQuery Data Viewer role) on every dataset and table you're syncing, then reconnect the source.",
+            # Raised from schema discovery (`get_columns`) and query jobs when the configured
+            # dataset/table doesn't exist in the location we query — the dataset was deleted or
+            # renamed, or it lives in a different region than the one we run against. The google
+            # exception stringifies as "404 Not found: Dataset ... was not found in location US",
+            # which the "NotFound: 404" pattern above never matches, so match the stable phrasing
+            # here. Retrying can't recover — the user must fix the dataset or set the correct region.
+            "was not found in location": "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or it may live in a different region — verify your dataset and table names, and set the dataset region in your source configuration if it isn't in the US.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `INT64` widened from a
             # narrower numeric type) after the destination table was created with the narrower

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -573,3 +573,24 @@ def test_has_duplicate_primary_keys_captures_unexpected_errors():
 
     assert result is False
     mock_capture.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["US", "EU", "asia-northeast1"],
+)
+def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
+    """A deleted/renamed dataset (or one in a region we don't query) surfaces from schema
+    discovery as a google-api-core NotFound. Its str() is "404 Not found: Dataset ... was
+    not found in location <X>" — which the stale "NotFound: 404" pattern never matched — so
+    it must be recognised as non-retryable instead of retrying forever."""
+    error = NotFound(
+        f"Not found: Dataset my-proj:my_dataset was not found in location {location}; "
+        f"reason: notFound, message: Not found: Dataset my-proj:my_dataset was not found in location {location}"
+    )
+
+    # Mirror the substring match in `sync_new_schemas_activity` / `update_external_data_job_model`.
+    error_msg = str(error)
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+
+    assert any(pattern in error_msg for pattern in non_retryable_errors)

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -582,8 +582,8 @@ def test_has_duplicate_primary_keys_captures_unexpected_errors():
 def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     """A deleted/renamed dataset (or one in a region we don't query) surfaces from schema
     discovery as a google-api-core NotFound. Its str() is "404 Not found: Dataset ... was
-    not found in location <X>" — which the stale "NotFound: 404" pattern never matched — so
-    it must be recognised as non-retryable instead of retrying forever."""
+    not found in location <X>", which must be recognised as non-retryable via the
+    "was not found in location" pattern instead of retrying forever."""
     error = NotFound(
         f"Not found: Dataset my-proj:my_dataset was not found in location {location}; "
         f"reason: notFound, message: Not found: Dataset my-proj:my_dataset was not found in location {location}"


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a high-frequency, ongoing failure in the BigQuery data-warehouse import source (`posthog/temporal/data_imports/sources/bigquery/bigquery.py`, `get_columns`):

> `NotFound`: Not found: Dataset `<dataset>` was not found in location US; reason: notFound

Issue: https://us.posthog.com/project/2/error_tracking/019e6606-8b09-7360-8111-a5d271b7a159 — ~7.9k occurrences over ~3 weeks, still firing.

Schema discovery (`get_columns`) runs an `INFORMATION_SCHEMA.COLUMNS` query job. When the configured dataset/table no longer exists in the queried location (it was deleted or renamed, or it lives in a different region than the one we run against), BigQuery raises `google.api_core.exceptions.NotFound`. `get_columns` only catches `Forbidden`, so this propagates out of the `sync_new_schemas` discovery activity, which re-raises it and lets Temporal retry — forever, since retrying can never recover.

The source's `get_non_retryable_errors()` already declares intent to treat "dataset or table not found" as non-retryable via a `"NotFound: 404"` pattern. But the google-api-core exception stringifies as `"404 Not found: Dataset … was not found in location US"`, so `"NotFound: 404"` never actually matches — the pattern is dead and the error keeps retrying.

## Changes

Add a stable, low-false-positive substring (`"was not found in location"`) to `BigQuerySource.get_non_retryable_errors()`. This is the canonical BigQuery phrasing for a missing dataset/table in a given location and is always a user/config issue (deleted/renamed dataset, or a region not configured via the existing `use_custom_region` field) — never our bug, and never recoverable by retrying. The substring deliberately excludes the volatile dataset name and the location value (US/EU/region).

Once matched, `sync_new_schemas_activity` skips discovery quietly and the per-schema sync path surfaces a friendly message and stops re-syncing, instead of spamming retries and error tracking.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I ran:

- Added a parameterized regression test (`test_bigquery_dataset_not_found_in_location_is_non_retryable`, locations US/EU/asia-northeast1) that builds the real `google.api_core.exceptions.NotFound` and asserts its `str()` is matched by `get_non_retryable_errors()`, mirroring the exact substring match used in `sync_new_schemas_activity`.
- `uv run pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — 23 passed.
- `ruff check` / `ruff format --check` — clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude Code. Investigation path: confirmed the issue and stack frame in error tracking, traced the call path (`sync_new_schemas_activity` → `SQLSource.get_schemas` → `BigQueryImplementation.get_columns`), and read how non-retryable errors are matched (plain substring against `str(e)` in `sync_new_schemas.py` and `external_data_job.py`).

Decision — user/upstream error → extend `NonRetryableErrors` (not a code bug): the dataset genuinely doesn't exist in the queried location, so retrying can't help and the existing code already treats dataset/table-not-found as non-retryable. Verified against the installed google-api-core `GoogleAPICallError.__str__` (`"{code} {message}"`) that the existing `"NotFound: 404"` pattern can never match the real exception string while `"was not found in location"` always does.