### PR TITLE
fix(google_ads): raise gRPC receive limit for large search pages

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import close_old_connections
 
 import pyarrow as pa
+from google.ads.googleads import client as google_ads_client_module
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v23.common import types as ga_common
 from google.ads.googleads.v23.enums import types as ga_enums
@@ -36,9 +37,36 @@ from products.data_warehouse.backend.types import IncrementalFieldType
 # `GoogleAdsServiceClient.DEFAULT_ENDPOINT`.
 GOOGLE_ADS_HOST = "googleads.googleapis.com"
 
+# The Google Ads SDK hardcodes `grpc.max_receive_message_length` to 64 MiB. A single
+# `GoogleAdsService.Search` page can carry up to 10,000 rows, and wide resources routinely
+# serialize past 64 MiB — when that happens the gRPC client aborts the call with a
+# RESOURCE_EXHAUSTED "Received message larger than max" before we process any row, failing
+# the whole sync. We can't ask the API for smaller pages (`page_size` is rejected with
+# PAGE_SIZE_NOT_SUPPORTED as of v17), so the only lever is raising the client's receive
+# limit. 512 MiB leaves comfortable headroom over the largest payloads we've observed.
+GRPC_MAX_RECEIVE_MESSAGE_LENGTH = 512 * 1024 * 1024
+_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_KEY = "grpc.max_receive_message_length"
+
+
+def _ensure_grpc_receive_limit() -> None:
+    """Raise the Google Ads gRPC client's inbound message cap in place.
+
+    ``get_service`` reads the SDK's module-level ``_GRPC_CHANNEL_OPTIONS`` each time it builds
+    a channel, so rewriting the entry here makes every channel we subsequently create pick up
+    the higher limit. The update is idempotent and safe to call repeatedly.
+    """
+    options = google_ads_client_module._GRPC_CHANNEL_OPTIONS
+    for index, (key, _value) in enumerate(options):
+        if key == _GRPC_MAX_RECEIVE_MESSAGE_LENGTH_KEY:
+            options[index] = (key, GRPC_MAX_RECEIVE_MESSAGE_LENGTH)
+            return
+    options.append((_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_KEY, GRPC_MAX_RECEIVE_MESSAGE_LENGTH))
+
 
 def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> GoogleAdsClient:
     """Initialize a `GoogleAdsClient` with provided config."""
+    _ensure_grpc_receive_limit()
+
     if isinstance(config, GoogleAdsSourceConfig):
         # Temporal activities run in a thread pool where Django DB connections can go
         # stale between uses (Postgres closes the connection server-side). This

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -185,6 +185,39 @@ class TestGoogleAdsNonRetryableErrors:
         assert "admin" in friendly.lower()
 
 
+class TestGrpcReceiveLimit:
+    # The largest search page observed aborting syncs in production was ~103 MB; the gRPC
+    # client must accept at least that much for the resource to sync at all.
+    _SDK_DEFAULT = 64 * 1024 * 1024
+    _LARGEST_OBSERVED_PAYLOAD = 103_046_535
+
+    def test_raises_sdk_default_receive_limit(self):
+        from google.ads.googleads import client as google_ads_client_module
+
+        from posthog.temporal.data_imports.sources.google_ads.google_ads import (
+            GRPC_MAX_RECEIVE_MESSAGE_LENGTH,
+            _ensure_grpc_receive_limit,
+        )
+
+        _ensure_grpc_receive_limit()
+
+        options = dict(google_ads_client_module._GRPC_CHANNEL_OPTIONS)
+        assert options["grpc.max_receive_message_length"] == GRPC_MAX_RECEIVE_MESSAGE_LENGTH
+        assert GRPC_MAX_RECEIVE_MESSAGE_LENGTH > self._SDK_DEFAULT
+        assert GRPC_MAX_RECEIVE_MESSAGE_LENGTH > self._LARGEST_OBSERVED_PAYLOAD
+
+    def test_is_idempotent(self):
+        from google.ads.googleads import client as google_ads_client_module
+
+        from posthog.temporal.data_imports.sources.google_ads.google_ads import _ensure_grpc_receive_limit
+
+        _ensure_grpc_receive_limit()
+        _ensure_grpc_receive_limit()
+
+        keys = [key for key, _ in google_ads_client_module._GRPC_CHANNEL_OPTIONS]
+        assert keys.count("grpc.max_receive_message_length") == 1
+
+
 class TestValidateCredentials:
     def test_missing_integration_returns_friendly_message(self):
         config = GoogleAdsSourceConfig(customer_id="123-456-7890", google_ads_integration_id=1)


### PR DESCRIPTION
## Problem

The `google_ads` data-warehouse import source fails for accounts with large result sets. Error tracking surfaced a recurring `_InactiveRpcError` raised in `_search_as_arrow_tables` while paginating `GoogleAdsService.Search`:

```
status = StatusCode.RESOURCE_EXHAUSTED
details = "CLIENT: Received message larger than max (103046535 vs. 67108864)"
```

The `CLIENT:` prefix means it's our gRPC client refusing the inbound response page. The Google Ads SDK hardcodes `grpc.max_receive_message_length` to 64 MiB (`67108864`) in its module-level `_GRPC_CHANNEL_OPTIONS`. A single search page can carry up to 10,000 rows, and wide resources routinely serialize past 64 MiB (observed payloads ranged from ~73 MB to ~103 MB), so the client aborts the call before a single row is processed and the whole sync fails.

This is a fixable bug in our integration, not a user/credential error and not transient — it fails deterministically on every retry for these accounts, so treating it as non-retryable would just permanently abandon valid accounts. We also can't ask the API for smaller pages: `page_size` is rejected with `PAGE_SIZE_NOT_SUPPORTED` as of API v17. The only lever is the client's receive limit.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019eac72-9259-7f11-8f09-94c7a5921e8c

## Changes

Raise the gRPC inbound message cap before building any Google Ads service. `get_service` reads the SDK's module-level `_GRPC_CHANNEL_OPTIONS` each time it builds a channel, so `_ensure_grpc_receive_limit()` rewrites that entry in place (idempotently) and every channel we subsequently create picks up the higher limit of 512 MiB — comfortable headroom over the largest payloads seen failing.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `TestGrpcReceiveLimit::test_raises_sdk_default_receive_limit` — asserts the limit is raised above both the 64 MiB SDK default and the largest observed failing payload (~103 MB).
- `TestGrpcReceiveLimit::test_is_idempotent` — asserts repeated calls leave a single `grpc.max_receive_message_length` entry.

All 49 tests in `posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py` pass, and `ruff check` / `ruff format` are clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the GoogleAds source. Confirmed the failure originates in `_search_as_arrow_tables` (gRPC client rejecting an oversized response page), inspected the installed `google-ads` SDK to find the hardcoded 64 MiB `grpc.max_receive_message_length`, and verified `page_size` is no longer a viable workaround (the v23 proto documents `PAGE_SIZE_NOT_SUPPORTED` as of v17). Rejected adding the error to `NonRetryableErrors` because the condition is deterministic and the accounts are valid — chose to raise the receive limit instead. Tools used: PostHog error-tracking MCP (`query-error-tracking-issue`), repo exploration, and pytest.
