### PR TITLE
fix(redshift): isolate schema-discovery probes with autocommit

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -940,6 +940,11 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
         enabled_columns = inputs.enabled_columns
 
         with self.connect(config) as connection:
+            # Autocommit so each best-effort discovery probe runs in its own transaction. A probe
+            # that fails — a permission error, an EXPLAIN the cluster rejects, a cancelled COUNT(*) —
+            # otherwise leaves the shared transaction aborted (INERROR), and every probe after it
+            # raises `InFailedSqlTransaction` until a rollback. Mirrors the postgres source.
+            connection.autocommit = True
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
                 full_table = self.get_table_metadata(cursor, schema, table_name, logger)

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -616,20 +616,26 @@ def build_pipeline_mocks(mocker):
     # methods, so a single cursor mock can serve both connections —
     # only the streaming connection requires `conn.adapters` to be set.
     state = {"first_conn": True}
+    created_conns: list = []
 
     def connect_side_effect(*args, **kwargs):
         conn = MagicMock()
         conn.__enter__.return_value = conn
         conn.cursor.return_value = streaming_cursor
+        # psycopg requires autocommit be set before a transaction starts; default the mock to
+        # False so a test can assert build_pipeline flips it on the metadata connection.
+        conn.autocommit = False
         if not state["first_conn"]:
             conn.adapters = MagicMock()
         state["first_conn"] = False
+        created_conns.append(conn)
         return conn
 
     mock_connect = mocker.patch(
         "posthog.temporal.data_imports.sources.redshift.redshift.psycopg.connect",
         side_effect=connect_side_effect,
     )
+    mock_connect.created_conns = created_conns
     return mock_connect, streaming_cursor
 
 
@@ -642,6 +648,17 @@ class TestBuildPipeline:
         assert response.primary_keys == ["id"]
         # psycopg.connect was called at least once for the metadata pass
         assert mock_connect.called
+
+    def test_metadata_connection_uses_autocommit(self, build_pipeline_mocks):
+        # Regression: discovery probes share one connection. Without autocommit a single failing
+        # best-effort probe leaves the transaction aborted (INERROR) and every probe after it —
+        # `has_duplicate_primary_keys` was the reported one — raises `InFailedSqlTransaction`.
+        mock_connect, _ = build_pipeline_mocks
+        impl = RedshiftImplementation()
+        impl.build_pipeline(_make_config(), _make_inputs())
+
+        metadata_conn = mock_connect.created_conns[0]
+        assert metadata_conn.autocommit is True
 
     def test_streaming_drains_without_error(self, build_pipeline_mocks):
         _, streaming_cursor = build_pipeline_mocks


### PR DESCRIPTION
## Problem

PostHog error tracking is reporting a high-volume `InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block` originating in the Redshift data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019e659a-da62-7571-b85c-da02f8190a62), ~7.2k occurrences, ongoing).

The captured frame is `has_duplicate_primary_keys` at `redshift.py`, on `cursor.execute(query)`. The cursor's own repr shows it is already in the `INERROR` state when that query runs — i.e. the transaction was aborted by an *earlier* statement, not by this query.

Root cause: `build_pipeline` runs every schema-discovery probe (table metadata, primary keys, chunk-size sampling, rows-to-sync `COUNT(*)`, partition settings, and finally the duplicate-PK check) on a **single shared psycopg connection in non-autocommit mode**. Many of those probes are best-effort and deliberately swallow exceptions. When one probe's statement fails (a permission error, an `EXPLAIN` the cluster rejects, a cancelled count, …), psycopg marks the transaction aborted and does **not** auto-rollback. Every probe after it then fails with `InFailedSqlTransaction` until a rollback — and `has_duplicate_primary_keys`, being the last probe, is where the cascade gets captured.

The exception is already handled (the method catches it and returns `False`), so it isn't crashing syncs — but it floods error tracking and, more importantly, means earlier probes silently degraded to their fallback values (default chunk size, `0` rows, no partition settings) whenever a single probe tripped.

## Changes

Set `connection.autocommit = True` on the metadata/discovery connection in `RedshiftImplementation.build_pipeline`, so each best-effort probe runs in its own transaction and a single failing probe can no longer poison the ones that follow. This mirrors the fix already applied to the Postgres source (#63630). The session-level `SET statement_timeout` continues to work under autocommit (no `LOCAL` keyword).

This is a code fix rather than a `NonRetryableErrors` addition: the `InFailedSqlTransaction` is a symptom of our shared-transaction fragility masking diverse underlying probe failures (some transient), not a stable user/upstream condition.

## How did you test this code?

I'm an agent. I added a regression test (`test_metadata_connection_uses_autocommit`) at the same layer as the fix, asserting that `build_pipeline` flips the metadata connection to autocommit. I confirmed it fails before the fix (`assert False is True`) and passes after. The full Redshift source suite passes locally (`pytest posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py` — 76 passed). `ruff check` and `ruff format --check` are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Used PostHog error-tracking MCP tools to pull the stack trace, a representative event, and frequency, then traced the call path through `build_pipeline`. Confirmed the failing frame is genuinely in this source and that the cursor was already `INERROR` on entry, pointing at an upstream swallowed probe failure rather than a fault in the duplicate-PK query itself. Considered and rejected adding the message to `NonRetryableErrors` (it would mask real bugs and the underlying failures are heterogeneous), choosing instead to mirror the established Postgres autocommit isolation. Scoped strictly to the discovery connection — the streaming read path and credential validation are untouched.
