### PR TITLE
fix(klaviyo): clamp future incremental cursor to now

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -44,6 +44,25 @@ def _format_incremental_value(value: Any) -> str:
     return str(value)
 
 
+def _clamp_future_value_to_now(value: Any) -> Any:
+    """Cap a future datetime/date incremental cursor at the current time.
+
+    The incremental cursor tracks the max value seen for the endpoint's datetime field
+    (e.g. an event's customer-supplied `datetime`). If the source's data contains a
+    future-dated record, the cursor advances past now and every subsequent sync builds
+    a `greater-than(<field>,<future>)` filter that Klaviyo rejects with a 400, wedging
+    the sync. Asking for records newer than now is a no-op anyway, so capping the value
+    keeps the request valid and lets the sync self-heal.
+    """
+    now = datetime.now(UTC)
+    if isinstance(value, datetime):
+        aware_value = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+        return now if aware_value > now else value
+    if isinstance(value, date):
+        return now.date() if value > now.date() else value
+    return value
+
+
 def _build_filter(
     config: KlaviyoEndpointConfig,
     incremental_field: str | None,
@@ -114,6 +133,10 @@ def _build_initial_params(
     # On first sync/full refresh, apply a lookback window to avoid fetching the entire history
     if should_use_incremental_field and not db_incremental_field_last_value and config.default_lookback_days:
         db_incremental_field_last_value = datetime.now(UTC) - timedelta(days=config.default_lookback_days)
+
+    # Future-dated source data can push the cursor past now; Klaviyo 400s on a future filter value.
+    if should_use_incremental_field and db_incremental_field_last_value:
+        db_incremental_field_last_value = _clamp_future_value_to_now(db_incremental_field_last_value)
 
     formatted_last_value = (
         _format_incremental_value(db_incremental_field_last_value)

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -1,10 +1,13 @@
 from datetime import UTC, date, datetime
 
+from freezegun import freeze_time
+
 from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.klaviyo.klaviyo import (
     _build_filter,
     _build_initial_params,
+    _clamp_future_value_to_now,
     _format_incremental_value,
 )
 from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS, KlaviyoEndpointConfig
@@ -88,3 +91,57 @@ class TestBuildInitialParams:
         assert "filter" in params
         assert "+00:00" not in params["filter"]
         assert params["filter"].endswith("Z)")
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_future_cursor_is_clamped_to_now(self) -> None:
+        # A future-dated cursor would otherwise build greater-than(datetime,<future>),
+        # which Klaviyo rejects with a 400 and wedges every subsequent sync.
+        config = KLAVIYO_ENDPOINTS["events"]
+        params = _build_initial_params(
+            config,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2027, 2, 5, 21, 46, 42, tzinfo=UTC),
+            incremental_field="datetime",
+        )
+        assert params["filter"] == "greater-than(datetime,2026-06-15T12:00:00.000Z)"
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_past_cursor_is_not_modified(self) -> None:
+        config = KLAVIYO_ENDPOINTS["events"]
+        params = _build_initial_params(
+            config,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            incremental_field="datetime",
+        )
+        assert params["filter"] == "greater-than(datetime,2026-03-04T02:58:14.000Z)"
+
+
+class TestClampFutureValueToNow:
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_future_datetime_is_clamped(self) -> None:
+        assert _clamp_future_value_to_now(datetime(2027, 2, 5, 21, 46, 42, tzinfo=UTC)) == datetime(
+            2026, 6, 15, 12, 0, 0, tzinfo=UTC
+        )
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_naive_future_datetime_is_clamped(self) -> None:
+        assert _clamp_future_value_to_now(datetime(2027, 2, 5, 21, 46, 42)) == datetime(
+            2026, 6, 15, 12, 0, 0, tzinfo=UTC
+        )
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_past_datetime_is_unchanged(self) -> None:
+        value = datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC)
+        assert _clamp_future_value_to_now(value) == value
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_future_date_is_clamped(self) -> None:
+        assert _clamp_future_value_to_now(date(2027, 2, 5)) == date(2026, 6, 15)
+
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_past_date_is_unchanged(self) -> None:
+        assert _clamp_future_value_to_now(date(2026, 3, 4)) == date(2026, 3, 4)
+
+    def test_string_passthrough(self) -> None:
+        assert _clamp_future_value_to_now("some-cursor-value") == "some-cursor-value"


### PR DESCRIPTION
## Problem

The Klaviyo data-warehouse source surfaced a recurring `HTTPError: 400 Client Error: Bad Request` from `posthog/temporal/data_imports/sources/klaviyo/klaviyo.py` (in `fetch_page`, on `response.raise_for_status()`). The failing request was against the `events` endpoint with a filter whose datetime was in the future, e.g.:

```
GET https://a.klaviyo.com/api/events?filter=greater-than(datetime,2027-02-05T21:46:42.000Z)
```

The source's incremental cursor tracks the max value seen for the endpoint's datetime field. For the `events` endpoint that field is `datetime`, a customer-supplied event timestamp. When a source's data contains a future-dated record (clock skew, bad integration), the cursor advances past "now". Every subsequent sync then builds a `greater-than(datetime,<future>)` filter that Klaviyo rejects with a 400, so the schema never recovers on its own — the error repeats on every retry.

The filter syntax itself is valid per Klaviyo's docs (unquoted, ISO 8601 with `Z`); the only problem is the future value.

## Changes

- Added `_clamp_future_value_to_now` to the Klaviyo source: a datetime/date incremental cursor that is in the future is capped at the current time before the filter is built (non-datetime cursors pass through unchanged).
- Applied the clamp in `_build_initial_params` for all endpoints that filter on a datetime cursor. In the normal case the cursor is in the past, so this is a no-op; it only changes behavior for the wedged future-cursor case.

Requesting records newer than now never returns anything useful, so capping the value keeps the request valid and lets the sync self-heal on the next run. This is scoped strictly to the Klaviyo source — no change to global retry policy and no addition to `NonRetryableErrors` (that would abandon the sync permanently rather than fix the malformed request).

## How did you test this code?

I'm an agent. I added and ran automated unit tests at the same layer as the fix (`pytest posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py`, 20 passed):

- `_clamp_future_value_to_now`: future aware datetime, future naive datetime, past datetime, future date, past date, and string passthrough (using `freeze_time`).
- `_build_initial_params`: a future cursor produces a filter clamped to "now"; a past cursor is unchanged.

Also ran `ruff check` / `ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Klaviyo source. Confirmed via the error-tracking data that the stack originates in `klaviyo.py` `fetch_page` and that the recent occurrences are all the same `events` 400 stuck on an identical future timestamp (consistent with a wedged cursor, not a transient failure). Checked Klaviyo's API docs to rule out a filter-syntax/formatting cause, which isolated the future datetime value as the trigger.

Decision: treated as a fixable bug (a malformed request we generate) rather than a non-retryable user/upstream error. Clamping the cursor unbreaks the sync; marking it non-retryable would have left affected sources permanently broken. Kept the fix scoped to the Klaviyo source.
