### PR TITLE
fix(plain): cap incremental filter datetimes at millisecond precision

### DIFF
--- a/posthog/temporal/data_imports/sources/plain/plain.py
+++ b/posthog/temporal/data_imports/sources/plain/plain.py
@@ -29,12 +29,20 @@ _MESSAGE_INFO_FIELDS: list[tuple[str, str]] = [
 
 
 def _datetime_to_plain_iso8601(value: datetime) -> str:
-    """Serialize a datetime to the ISO-8601 format Plain returns and accepts (e.g. 2024-01-15T10:30:00.000Z)."""
+    """Serialize a datetime to an ISO-8601 format Plain accepts.
+
+    Plain's ``DatetimeFilter`` only accepts ``yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`` (millisecond precision)
+    or ``yyyy-MM-dd'T'HH:mm:ss'Z'`` (whole seconds). ``datetime.isoformat()`` emits microseconds
+    (six fractional digits) whenever the value has sub-second precision, which Plain rejects with a
+    generic ``There was a validation error.``. Incremental watermarks routinely carry microseconds,
+    so cap the precision at milliseconds (and drop the fractional part entirely for whole seconds).
+    """
     if value.tzinfo is None:
         value = value.replace(tzinfo=UTC)
     else:
         value = value.astimezone(UTC)
-    return value.isoformat().replace("+00:00", "Z")
+    timespec = "seconds" if value.microsecond == 0 else "milliseconds"
+    return value.isoformat(timespec=timespec).replace("+00:00", "Z")
 
 
 def _updated_at_filter(updated_at_gte: datetime) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
+++ b/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
@@ -236,6 +236,15 @@ class TestDatetimeHelpers:
     def test_datetime_to_plain_iso8601_assumes_utc_for_naive(self):
         assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0)) == "2024-01-15T10:30:00Z"
 
+    def test_datetime_to_plain_iso8601_caps_microseconds_at_milliseconds(self):
+        # Plain rejects 6-digit microsecond precision with "There was a validation error.";
+        # incremental watermarks carry microseconds, so we must emit millisecond precision.
+        assert (
+            _datetime_to_plain_iso8601(datetime(2026, 6, 7, 18, 3, 36, 624000, tzinfo=UTC))
+            == "2026-06-07T18:03:36.624Z"
+        )
+        assert _datetime_to_plain_iso8601(datetime(2024, 1, 15, 10, 30, 0, 1, tzinfo=UTC)) == "2024-01-15T10:30:00.000Z"
+
     def test_parse_plain_datetime_from_string(self):
         assert _parse_plain_datetime("2024-01-15T10:30:00Z") == datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 


### PR DESCRIPTION
## Problem

The `plain` data-warehouse import source was throwing an unhandled `Exception` during incremental syncs:

> `Plain GraphQL error: There was a validation error.`

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019e2d0e-16fa-7e93-bb1c-cee44a168b68 (126 occurrences of this message, still firing today).

The generic message hides the real cause, which Plain returns in the GraphQL error `extensions.fields`:

```json
{
  "field": "updatedAt.after",
  "message": "Invalid ISO date time format, expected: yyyy-MM-dd'T'HH:mm:ss.SSS'Z' or yyyy-MM-dd'T'HH:mm:ss'Z'"
}
```

The request sent `"after": "2026-06-07T18:03:36.624000Z"` — **six fractional digits (microseconds)**. Plain's `DatetimeFilter` only accepts **three digits (milliseconds)** or no fractional part at all.

The culprit is `_datetime_to_plain_iso8601`, which serialized with `datetime.isoformat()`. That emits microseconds whenever the value has sub-second precision. Incremental sync watermarks (`db_incremental_field_last_value`) routinely carry microseconds, so any incremental run whose watermark had non-zero microseconds was rejected. The function's own docstring already claimed it produced `…000Z` (milliseconds), so this was a latent contract violation.

## Changes

- `_datetime_to_plain_iso8601` now caps precision at milliseconds: `timespec="milliseconds"` when there is a sub-second component, `timespec="seconds"` when the value is on a whole second. Both outputs match a format Plain accepts (`…SSS'Z'` or `…ss'Z'`), and microseconds are never emitted.
- Updated the docstring to describe the two accepted formats and why microseconds break.
- Added a regression test asserting microsecond datetimes are truncated to milliseconds (`…624000` → `…624Z`).

This is scoped to the serialization helper used by both the paginated (`customers`/`threads`) and timeline-entries incremental filters. The three other (older) message groups in the same error-tracking issue — `Cannot query field …` and `Field "gte" is not defined …` — stopped firing days ago and correspond to query/filter shapes already fixed on master; this change targets only the message still occurring.

## How did you test this code?

I'm an agent. I added and ran automated unit tests — no manual testing.

- `posthog/temporal/data_imports/sources/plain/tests/test_plain.py` — 30 passed (includes the new `test_datetime_to_plain_iso8601_caps_microseconds_at_milliseconds` and the pre-existing whole-second assertions, which still pass because whole seconds keep the no-fractional form).
- `ruff check` and `ruff format` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Plain source. Confirmed the issue is live and pulled a representative event's stack trace and local variables via the PostHog query API. The captured `payload` local on the raising frame contained Plain's `extensions.fields` detail, which pinpointed `updatedAt.after` and the expected date format — the deciding evidence that this is a fixable bug in our serialization rather than an upstream/credentials problem. Chose the minimal fix (cap precision in the existing helper) over restructuring the filter builders, and preserved the whole-second output so existing tests and on-the-wire behavior stay unchanged for that case.

Tools: Claude Code (PostHog Code).
