### PR TITLE
fix(postgres): stop alerting on read-replica recovery conflicts in partition sizing

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -145,6 +145,21 @@ def _is_connection_dropped_error(error: BaseException) -> bool:
     return False
 
 
+def _is_recovery_conflict_error(error: BaseException) -> bool:
+    """True if `error` is a Postgres standby recovery conflict.
+
+    A read replica cancels an in-flight query when WAL replay needs to remove row
+    versions the query might still read ("canceling statement due to conflict with
+    recovery", SQLSTATE 40001 -> psycopg SerializationFailure). It's transient and
+    expected on replicas — the row-streaming reader already retries it in-process and
+    `get_non_retryable_errors` deliberately keeps the raw message retryable — so
+    best-effort probes should degrade quietly rather than alert on a handled condition.
+    """
+    return isinstance(error, psycopg.errors.SerializationFailure) and "conflict with recovery" in " ".join(
+        str(arg) for arg in error.args
+    )
+
+
 def _connect_with_dropped_retry(
     connect: Callable[[], psycopg.Connection],
     logger: FilteringBoundLogger,
@@ -1401,7 +1416,12 @@ def _get_partition_settings(
     except psycopg.errors.QueryCanceled:
         raise
     except Exception as e:
-        capture_exception(e)
+        # A read replica can cancel this best-effort sizing query with a recovery conflict; it's
+        # transient (the row-streaming reader retries it in-process) and expected on replicas, so
+        # degrade quietly instead of flooding error tracking with a handled condition. Genuinely
+        # unexpected failures are still captured.
+        if not _is_recovery_conflict_error(e):
+            capture_exception(e)
         logger.debug(f"_get_partition_settings: returning None due to error: {e}")
         return None
 

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -59,6 +59,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _is_connection_dropped_error,
     _is_partitioned_table,
     _is_read_replica,
+    _is_recovery_conflict_error,
     _is_unsupported_function_error,
     _normalize_function_names,
     _rls_active_from_conn,
@@ -1677,6 +1678,51 @@ class TestGetPartitionSettings:
         mock_detect.assert_not_called()
         mock_partitioned.assert_called_once()
         assert result is sentinel
+
+    def test_recovery_conflict_returns_none_without_capturing(self):
+        # Regression: a read-replica recovery conflict cancels the best-effort sizing query.
+        # It's transient and the row-streaming reader retries it in-process, so degrade to None
+        # without flooding error tracking with a handled condition.
+        logger = structlog.get_logger()
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = psycopg.errors.SerializationFailure(
+            "canceling statement due to conflict with recovery"
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+            result = _get_partition_settings(cast(Any, cursor), "public", "t", logger, is_partitioned=False)
+
+        assert result is None
+        capture_mock.assert_not_called()
+
+    def test_unexpected_error_is_still_captured(self):
+        # A genuinely unexpected failure on the sizing query must still surface to error tracking.
+        logger = structlog.get_logger()
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = Exception("some unexpected failure")
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+            result = _get_partition_settings(cast(Any, cursor), "public", "t", logger, is_partitioned=False)
+
+        assert result is None
+        capture_mock.assert_called_once()
+
+
+class TestIsRecoveryConflictError:
+    @pytest.mark.parametrize(
+        "error,expected",
+        [
+            (psycopg.errors.SerializationFailure("canceling statement due to conflict with recovery"), True),
+            (psycopg.errors.SerializationFailure("could not serialize access due to conflict with recovery"), True),
+            # A non-recovery serialization failure (true 40001 write conflict) is not ours to swallow.
+            (psycopg.errors.SerializationFailure("could not serialize access due to concurrent update"), False),
+            # Right message, wrong type -> not a recovery conflict we recognise here.
+            (psycopg.errors.QueryCanceled("canceling statement due to conflict with recovery"), False),
+            (Exception("canceling statement due to conflict with recovery"), False),
+        ],
+    )
+    def test_recognises_recovery_conflict(self, error, expected):
+        assert _is_recovery_conflict_error(error) is expected
 
 
 class TestPostgreSQLColumnToArrowField:


### PR DESCRIPTION
## Problem

Error tracking has been flooded with a handled `SerializationFailure` raised from `_get_partition_settings` in the Postgres data-warehouse import source (tens of thousands of occurrences):

> `canceling statement due to conflict with recovery`
> `DETAIL: User query might have needed to see row versions that must be removed.`

This is a Postgres **standby recovery conflict** (SQLSTATE 40001 → psycopg `SerializationFailure`): a read replica cancels an in-flight query when WAL replay from the primary needs to remove row versions the query might still read. The affected events come from connections to read replicas.

`_get_partition_settings` runs a best-effort `COUNT(*) + pg_table_size` sizing probe. When the replica cancels it, the function's generic `except Exception` handler called `capture_exception(e)` and returned `None`. The sync degrades fine (partition sizing is an optimization), so this was pure error-tracking noise.

## Changes

The recovery conflict is already treated as **transient and retryable by design** elsewhere in this source:
- `get_non_retryable_errors` deliberately keeps the raw "conflict with recovery" message retryable (only the exhausted-retries message is non-retryable).
- The row-streaming/windowing paths retry it in-process with backoff (`offset_chunking`, `iterate_date_windows`).
- The probe connection runs in autocommit precisely so a cancelled probe stays contained.
- The sibling probe `_get_rows_to_sync` already degrades quietly without capturing.

This PR brings `_get_partition_settings` in line: a small `_is_recovery_conflict_error` helper detects the read-replica recovery conflict, and the handler skips `capture_exception` for it while still degrading to `None`. Genuinely unexpected failures are still captured. This mirrors the existing `_rls_active_from_conn` / `_is_unsupported_function_error` quiet-degrade pattern. **No retry behavior is changed.**

## How did you test this code?

I'm an agent (Claude Code); I did not perform manual testing. Automated tests I added and ran:

- `TestIsRecoveryConflictError` — parametrized coverage of the helper: recognizes the two recovery-conflict messages, rejects a non-recovery 40001 write conflict, rejects the right message on the wrong exception type.
- `TestGetPartitionSettings::test_recovery_conflict_returns_none_without_capturing` — a cancelled sizing query returns `None` and does **not** call `capture_exception`.
- `TestGetPartitionSettings::test_unexpected_error_is_still_captured` — an unexpected error still returns `None` and **does** call `capture_exception`.

All new tests pass (`7 passed`). Existing `TestPostgresSourceNonRetryableErrors`, `TestRlsActiveFromConnErrorHandling`, and the mock-based `TestGetPartitionSettings` tests pass; two pre-existing `TestGetRowsToSync` tests error only because they need a live Postgres DB unavailable in this sandbox. `ruff check` and `ruff format --check` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in error tracking: top in-app frame is `_get_partition_settings` (`postgres.py`), exception `SerializationFailure` with the recovery-conflict message, occurring on read-replica connections.

Decision: this is a fixable bug (error-tracking flood / missing graceful-skip), **not** a `NonRetryableErrors` candidate. The codebase already classifies the raw recovery conflict as transient/retryable — adding it to `NonRetryableErrors` would contradict the in-process retry paths and fail syncs that currently recover. So the scoped fix is to stop alerting on this one already-handled, already-degraded path, matching the sibling probes. Tool used: Claude Code with the PostHog error-tracking MCP tools to pull the stack trace and representative event.