### PR TITLE
fix(google_sheets): skip worksheets whose header range can't be parsed

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -112,7 +112,19 @@ def get_schema_incremental_fields(config: GoogleSheetsSourceConfig, worksheet_na
 
     worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id)
 
-    rows = worksheet.get_all_values("1:2")  # Get the first two rows
+    try:
+        rows = worksheet.get_all_values("1:2")  # Get the first two rows
+    except gspread.exceptions.APIError as e:
+        # Google rejects the unbounded "1:2" row range with a 400 "Unable to parse range" for
+        # some worksheets (e.g. empty sheets, or sheets resized to have no columns). This is
+        # deterministic, so retrying never helps. We're only probing the first rows to detect an
+        # incremental "id" column here, so a worksheet we can't read simply has no detectable
+        # incremental field — return [] rather than letting one odd sheet break schema discovery
+        # for the entire spreadsheet. Other API errors (e.g. transient 5xx) still propagate so
+        # they can be retried.
+        if e.code == 400 and "Unable to parse range" in str(e):
+            return []
+        raise
 
     if len(rows) > 1 and "id" in rows[0]:
         index_of_id = rows[0].index("id")

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -10,10 +10,17 @@ from posthog.temporal.data_imports.sources.generated_configs import GoogleSheets
 from posthog.temporal.data_imports.sources.google_sheets.google_sheets import (
     _PERMISSION_DENIED_MESSAGE,
     _get_worksheet,
+    get_schema_incremental_fields,
     get_schemas,
     google_sheets_source,
 )
 from posthog.temporal.data_imports.sources.google_sheets.source import GoogleSheetsSource
+
+
+def _api_error(code: int, message: str, status: str) -> gspread.exceptions.APIError:
+    response = mock.MagicMock()
+    response.json.return_value = {"error": {"code": code, "message": message, "status": status}}
+    return gspread.exceptions.APIError(response)
 
 
 def test_get_worksheet_backoff():
@@ -211,3 +218,49 @@ def test_not_found_api_error_is_non_retryable():
     assert any(key in error_msg for key in non_retryable_errors), (
         f"Google Sheets 404 error {error_msg!r} did not match any non-retryable pattern"
     )
+
+
+def test_get_schema_incremental_fields_skips_unparseable_range():
+    """Google rejects the unbounded "1:2" row range with a 400 'Unable to parse range' for some
+    worksheets (e.g. empty sheets). That deterministic error must not break schema discovery — the
+    worksheet should just report no incremental fields so the rest of the spreadsheet still syncs."""
+    config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+    mock_worksheet = mock.MagicMock()
+    mock_worksheet.get_all_values.side_effect = _api_error(
+        400, "Unable to parse range: 'csm_followups'!1:2", "INVALID_ARGUMENT"
+    )
+
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.get_schemas",
+            return_value=[("csm_followups", 123)],
+        ),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets._get_worksheet",
+            return_value=mock_worksheet,
+        ),
+    ):
+        assert get_schema_incremental_fields(config, "csm_followups") == []
+
+
+def test_get_schema_incremental_fields_reraises_other_api_errors():
+    """Only the deterministic 'Unable to parse range' 400 is swallowed. Other API errors (e.g.
+    transient 5xx) must still propagate so Temporal can retry them."""
+    config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+    mock_worksheet = mock.MagicMock()
+    mock_worksheet.get_all_values.side_effect = _api_error(500, "Internal error encountered.", "INTERNAL")
+
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets.get_schemas",
+            return_value=[("sheet1", 123)],
+        ),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_sheets.google_sheets._get_worksheet",
+            return_value=mock_worksheet,
+        ),
+        pytest.raises(gspread.exceptions.APIError),
+    ):
+        get_schema_incremental_fields(config, "sheet1")


### PR DESCRIPTION
## Problem

The Google Sheets import source surfaced a high-frequency error in error tracking:

```
APIError: [400]: Unable to parse range: '<worksheet>'!1:2
```

origin: `posthog/temporal/data_imports/sources/google_sheets/google_sheets.py` → `get_schema_incremental_fields`.

During schema discovery, `get_schemas` loops over **every** worksheet in a spreadsheet and calls `get_schema_incremental_fields`, which probes the first two rows via the unbounded `"1:2"` row range to detect an incremental `id` column. Google rejects that range with a deterministic `400 INVALID_ARGUMENT — "Unable to parse range"` for some worksheets (e.g. empty sheets, or sheets resized to have no columns). The `gspread.APIError` propagated out of the probe and crashed the whole loop, so a **single** odd worksheet broke schema discovery for the **entire** spreadsheet — every other worksheet became undiscoverable. The error recurred continuously (the import retries, hits the same bad sheet, fails again).

## Changes

`get_schema_incremental_fields` now catches the deterministic `400 "Unable to parse range"` from the row probe and returns `[]` (no detectable incremental field) instead of letting it propagate. Incremental-field detection is an optimization — a worksheet we can't probe simply falls back to full-refresh sync — so the safe degradation is to skip it and let the rest of the spreadsheet sync.

Scope is deliberately narrow:
- Only the deterministic `400 "Unable to parse range"` is swallowed. Other API errors (e.g. transient `5xx`) still propagate and remain retryable.
- No change to the source's `NonRetryableErrors` or to any global retry policy. Adding this 400 to `NonRetryableErrors` was considered and rejected: it would permanently fail the whole source because of one odd worksheet, whereas the graceful skip keeps the good worksheets working.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing against live Google Sheets. I added and ran automated regression tests at the same layer as the fix:

- `test_get_schema_incremental_fields_skips_unparseable_range` — a worksheet whose `get_all_values("1:2")` raises the `400 "Unable to parse range"` returns `[]` rather than raising.
- `test_get_schema_incremental_fields_reraises_other_api_errors` — a `500` API error still propagates (stays retryable).

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py -q
15 passed
```

`ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tooling: Claude Code, triaged via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in this source's code.
- Decision: classified as a fixable robustness bug (missing graceful-skip), not a `NonRetryableError`. The 400 is deterministic, but failing the source outright would punish the spreadsheet's other healthy worksheets; skipping the unreadable one is strictly better. Transient errors deliberately left retryable.
