### PR TITLE
fix(postgres): degrade quietly when best-effort schema metadata connection drops

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -401,8 +401,14 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                     # Row-level security check powers the advisory warning in the table picker.
                     rls_active_by_table = _rls_active_from_conn(conn, config.schema, names)
             except Exception as e:
-                # Connection-level failure: neither lookup is usable.
-                capture_exception(e)
+                # Connection-level failure for the best-effort PK/index/RLS metadata lookup. The
+                # schema listing already succeeded above (`db_schemas`), so degrade quietly — log a
+                # warning and drop the optional metadata, consistent with the foreign-key and index
+                # lookups in this function. Don't `capture_exception` here: this connection is opened
+                # separately from schema discovery and is prone to transient drops (e.g. an SSH-tunnel
+                # hiccup raising "server closed the connection unexpectedly"), which would otherwise
+                # flood error tracking despite the listing still succeeding.
+                structlog.get_logger().warning("Failed to fetch PK/index/RLS metadata for Postgres schemas", exc_info=e)
                 pk_columns_by_table = {}
                 indexed_columns_by_table = None
                 tables_with_pks = set()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -869,6 +869,54 @@ class TestPostgresSourceGetSchemasDegradesGracefully:
         assert schemas[0].name == "public.users"
         assert schemas[0].foreign_keys == []
 
+    def test_metadata_connection_failure_degrades_quietly_without_capturing(self, source):
+        # The PK/index/RLS metadata connection is opened separately from schema discovery and is
+        # prone to transient drops (commonly an SSH-tunnel hiccup raising "server closed the
+        # connection unexpectedly"). Schema discovery already succeeded, so this must degrade quietly:
+        # surface the schema listing and DON'T flood error tracking with a captured exception.
+        discovered = {
+            "public.users": PostgresDiscoveredSchema(
+                source_catalog=None,
+                source_schema="public",
+                source_table_name="users",
+                columns=[("id", "integer", False)],
+            )
+        }
+
+        tunnel_cm = mock.MagicMock()
+        tunnel_cm.__enter__.return_value = ("localhost", 5432)
+        tunnel_cm.__exit__.return_value = None
+
+        connection_dropped = psycopg.OperationalError(
+            'connection failed: connection to server at "127.0.0.1", port 37761 failed: '
+            "server closed the connection unexpectedly\n\tThis probably means the server terminated "
+            "abnormally\n\tbefore or while processing the request."
+        )
+
+        with (
+            mock.patch.object(source, "with_ssh_tunnel", return_value=tunnel_cm),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.source.get_postgres_schemas",
+                return_value=discovered,
+            ),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.source.get_postgres_foreign_keys",
+                return_value={},
+            ),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.source.pg_connection",
+                side_effect=connection_dropped,
+            ),
+            mock.patch("posthog.temporal.data_imports.sources.postgres.source.capture_exception") as mock_capture,
+        ):
+            schemas = source.get_schemas(self._config(), team_id=1)
+
+        assert len(schemas) == 1
+        assert schemas[0].name == "public.users"
+        # Best-effort metadata is dropped, but the listing survives and nothing is captured.
+        assert schemas[0].supports_cdc is False
+        mock_capture.assert_not_called()
+
 
 class TestGetSslmode:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

The Postgres data-warehouse source surfaces a high-volume `OperationalError` in error tracking:

> connection failed: connection to server at "127.0.0.1", port … failed: server closed the connection unexpectedly

Tracing it through the stack (`source.py` `get_schemas` → `pg_connection` → `_connect_to_postgres`), the error originates from the **second**, best-effort connection in `get_schemas` — the one used only to gather optional PK / index / RLS metadata. Schema discovery itself (`get_postgres_schemas`) has already succeeded by that point, and the outer handler degrades gracefully by dropping the optional metadata.

The problem is purely noise: that handler called `capture_exception` on a connection-level failure. This connection is opened separately from schema discovery and is prone to transient drops — most of the affected sources use an SSH tunnel, where the local forward (`127.0.0.1:<random port>`) can close a connection mid-handshake. Because the listing still succeeds, every such transient drop became a tracked exception, accumulating thousands of occurrences that mask real issues.

This error never reaches the retry machinery (it is caught and swallowed), so it is not a `NonRetryableErrors` candidate — it is just an over-eager capture on an already-handled, best-effort path.

## Changes

In `get_schemas`, the connection-level `except` for the PK / index / RLS metadata lookup now logs a `structlog` warning (with `exc_info`) and drops the optional metadata, instead of calling `capture_exception`. This matches how the foreign-key and index lookups in the same function already degrade. The schema listing behavior is unchanged — only the noisy capture is removed; the full traceback is still available in logs.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests for the affected module; I did not perform manual testing.

- Added a regression test, `test_metadata_connection_failure_degrades_quietly_without_capturing`, that fails the metadata connection with the exact "server closed the connection unexpectedly" `OperationalError`, asserts the schema listing still returns, and asserts `capture_exception` is **not** called.
- Verified the new test **fails** against the pre-fix code (capture called once) and **passes** with the fix.
- Ran the full `TestPostgresSourceGetSchemasDegradesGracefully` class — all pass. Ran `ruff check` / `ruff format`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Postgres import source. Confirmed via the error-tracking data that the failing frame is the context-managed `pg_connection` inside `get_schemas` (the `contextlib.__enter__` frame and absence of a `postgres.py:get_schemas` frame pin it to the best-effort metadata connection, not schema discovery), and that the exception is `handled=true` — i.e. already caught and degraded, with `capture_exception` the only side effect.

Decision: not a `NonRetryableErrors` case (the error is swallowed, never retried) and not a transient-error retry-policy change. It is a noise/fragility fix — make the connection-level handler degrade quietly like its siblings. Scoped to that single handler; the inner PK handler and validation paths were left unchanged.

Tool used: Claude Code with the PostHog error-tracking MCP.