### PR TITLE
fix(google_sheets): handle integer columns exceeding int64 range

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -362,6 +362,35 @@ def test_table_from_py_list_with_rescaling_decimal_data_loss_error():
     assert table.schema.equals(expected_schema)
 
 
+def test_table_from_py_list_int_column_exceeding_int64_promoted_to_decimal():
+    # Python ints are unbounded; a value past int64 overflows pyarrow's inferred int64 type with
+    # "Python int too large to convert to C long". It should be promoted to decimal instead.
+    over_int64 = 2**63 + 1
+
+    table = table_from_py_list([{"column": over_int64}, {"column": 1}, {"column": None}])
+
+    assert pa.types.is_decimal(table.schema.field("column").type)
+    assert table.column("column").to_pylist() == [decimal.Decimal(over_int64), decimal.Decimal(1), None]
+
+
+def test_table_from_py_list_huge_int_column_falls_back_to_string():
+    # A value too large even for decimal256 (76 digits) must not crash the sync — keep it as text.
+    enormous = int("1" * 340)
+
+    table = table_from_py_list([{"column": enormous}, {"column": 5}])
+
+    assert table.schema.field("column").type == pa.string()
+    assert table.column("column").to_pylist() == [str(enormous), "5"]
+
+
+def test_table_from_py_list_normal_int_column_stays_int64():
+    # Values within int64 are unaffected by the overflow handling.
+    table = table_from_py_list([{"column": 1}, {"column": 2}, {"column": None}])
+
+    assert table.schema.field("column").type == pa.int64()
+    assert table.column("column").to_pylist() == [1, 2, None]
+
+
 @pytest.mark.parametrize(
     "data, schema, expected_type",
     [

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -47,6 +47,11 @@ DLT_TO_PA_TYPE_MAP: dict[
 DEFAULT_NUMERIC_PRECISION = 38  # Delta Lake maximum precision
 DEFAULT_NUMERIC_SCALE = 18  # Good default scale for decimal128, 20 int digits plus 18 decimal cases
 MAX_NUMERIC_SCALE = 32  # Maximum scale for Delta Lake
+
+# pyarrow infers `int64` for Python `int` columns; values outside this range overflow with
+# "OverflowError: Python int too large to convert to C long" (Python ints are unbounded).
+INT64_MIN = -(2**63)
+INT64_MAX = 2**63 - 1
 DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES = 200 * 1024 * 1024  # 200 MB
 
 type SupportedDltDataType = Literal["text", "bigint", "bool", "timestamp", "json", "double", "date", "time", "decimal"]
@@ -890,6 +895,38 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
             columnar_table_data[field_name] = number_arr
             if arrow_schema:
                 arrow_schema = arrow_schema.set(field_index, arrow_schema.field(field_index).with_type(new_field_type))
+
+        # Integer columns can hold Python ints larger than pyarrow's int64 range (e.g. a Google
+        # Sheets cell with a huge number). pyarrow raises "OverflowError: Python int too large to
+        # convert to C long" while inferring int64. Such a column already failed `pa.array(values)`
+        # above and fell back to an object ndarray, so restrict the scan to those candidates to
+        # avoid touching every normal int column. Promote to decimal when it fits, else stringify.
+        if (
+            py_type is int
+            and unique_types_in_column == {int}
+            and isinstance(columnar_table_data[field_name], np.ndarray)
+        ):
+            all_values = _to_list_array(columnar_table_data[field_name])
+            if any(value is not None and not (INT64_MIN <= value <= INT64_MAX) for value in all_values):
+                try:
+                    overflow_arr = _decimal_array_from_values(
+                        [None if value is None else decimal.Decimal(value) for value in all_values]
+                    )
+                    py_type = decimal.Decimal
+                    unique_types_in_column = {decimal.Decimal}
+                except ValueError:
+                    # Too large even for decimal256 — keep it as text rather than crash the sync.
+                    overflow_arr = pa.array(
+                        [None if value is None else str(value) for value in all_values], type=pa.string()
+                    )
+                    py_type = str
+                    unique_types_in_column = {str}
+
+                columnar_table_data[field_name] = overflow_arr
+                if arrow_schema:
+                    arrow_schema = arrow_schema.set(
+                        field_index, arrow_schema.field(field_index).with_type(overflow_arr.type)
+                    )
 
         # If one type is a list, then make everything into a list
         if len(unique_types_in_column) > 1 and list in unique_types_in_column:


### PR DESCRIPTION
## Problem

The `GoogleSheets` data-warehouse source crashes with `OverflowError: Python int too large to convert to C long` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019cdc8c-28d1-73d2-b916-209bfa143497), 1k+ occurrences since March).

The stack ends in `posthog/temporal/data_imports/sources/google_sheets/google_sheets.py` (`get_rows`), which hands the sheet rows to the shared `table_from_py_list` helper. The real crash is in that helper's `_process_batch`: when a column is purely integer, pyarrow infers an `int64` type and `pa.Table.from_pydict` overflows the moment a value exceeds the int64 range. Python ints are unbounded, so a sheet cell can easily hold a number larger than `2**63 - 1` — in the captured event the offending column was a ~340-digit value (a binary-looking "presence" string that Sheets returned as a number).

This is a fragility bug in our generic table builder, not a credentials/config/upstream problem — retrying never helps because the data shape never changes. So the right fix is to make the helper handle the value rather than mark it non-retryable.

## Changes

In `_process_batch` (the shared pipeline helper that the Google Sheets source — and every other source — routes through), pure-integer columns containing a value outside the int64 range are now promoted instead of crashing:

- **Decimal** when the value fits (`decimal128`/`decimal256`), preserving numeric semantics for moderately large ids.
- **String** when the value is too large even for `decimal256` (76 digits), keeping the data rather than failing the sync.

The scan is restricted to columns that already failed pyarrow's `int64` inference (object-dtype fallback), so normal int64 columns are completely untouched — no extra work and no type changes for the common case.

## How did you test this code?

I'm an agent. I added regression tests at the same layer as the fix (`test_pipeline_utils.py`) and ran them:

- `test_table_from_py_list_int_column_exceeding_int64_promoted_to_decimal` — value past int64 → decimal.
- `test_table_from_py_list_huge_int_column_falls_back_to_string` — 340-digit value (reproduces production) → string, no crash.
- `test_table_from_py_list_normal_int_column_stays_int64` — guards against regressing normal int columns.

Full file: `74 passed`. Also reproduced the original `OverflowError` against unpatched `from_pydict` to confirm root cause, and verified `ruff check` / `ruff format --check` are clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `GoogleSheets` source. Used the PostHog error-tracking MCP tools to pull the full stack trace and a representative event, which revealed the offending column held a value far beyond int64. Confirmed the failure originates in the shared `_process_batch`/`from_pydict` path (the source frame only calls `table_from_py_list`), so the fix lives in the shared helper rather than `NonRetryableErrors` — the data is recoverable, not a user/upstream dead end. Considered decimal-only promotion but the captured value exceeds `decimal256`, hence the string fallback.