### PR TITLE
chore(mysql): guard that 1135 thread-exhaustion stays retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -806,3 +806,21 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Transient lost-connection error should remain retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # MySQL error 1135: the server reached the connection but couldn't spawn an OS thread
+            # to service it (errno 11 EAGAIN). This is a transient, server-side resource exhaustion
+            # — it clears as concurrent connections close — so it must keep retrying, just like
+            # Postgres's "too many connections" / "max clients reached" capacity errors.
+            "OperationalError: (1135, 'Can't create a new thread (errno 11 \"Resource temporarily "
+            'unavailable"); if you are not out of available memory, you can consult the manual for '
+            "a possible OS-dependent bug')",
+            'Can\'t create a new thread (errno 11 "Resource temporarily unavailable")',
+        ],
+    )
+    def test_cant_create_new_thread_stays_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Transient thread-exhaustion error should remain retryable: {error_msg}"


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OperationalError` from the MySQL data-warehouse import source:

> `(1135, 'Can't create a new thread (errno 11 "Resource temporarily unavailable"); if you are not out of available memory, you can consult the manual for a possible OS-dependent bug')`

The stack originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` at `connect` (the `pymysql.connect(...)` call), reached via the import pipeline's streaming path (`get_rows` → `_stream_with_optional_force_index` → `connect`). See error-tracking issue `019e5020-4f6e-7292-81fa-b9ca8983a107`.

**Triage decision: this is a transient upstream error and must stay retryable — no `NonRetryableErrors` change.**

MySQL error 1135 means the client *reached* the server and the connection/handshake started, but the server's host couldn't spawn an OS thread to service it (`errno 11` = `EAGAIN`, literally "Resource temporarily unavailable"). It's a momentary capacity ceiling on the customer's database host that clears as concurrent connections close — the textbook retryable condition. This is the same family as PostgreSQL's "too many connections" / "max clients reached", which the sibling Postgres source already deliberately keeps **retryable** (`test_transient_connection_errors_are_retryable`).

Adding 1135 to `NonRetryableErrors` would be wrong: it would flip `should_sync` off and disable the whole schema's sync on a transient hiccup, requiring manual re-enable. The error is **already retryable on master** (it propagates out of `connect` and Temporal retries the activity), so the behavior is correct as-is.

## Changes

Adds a regression guard test to `TestMySQLSourceNonRetryableErrors`, mirroring the existing `test_transient_lost_connection_stays_retryable`, asserting that the 1135 "Can't create a new thread" error (both the raw pymysql form and the wrapped form) is **not** matched by any `NonRetryableErrors` key and therefore stays retryable. This codifies the triage decision and prevents a future misclassification of this exact, observed error.

No production code changes — the source behaves correctly today; this locks that behavior in.

## How did you test this code?

I'm an agent. The local environment lacked the Python test runner, so I validated the new test's assertion logic directly against the source's `get_non_retryable_errors()` keys: both 1135 message variants pass through unmatched (→ retryable), confirming `assert not is_non_retryable` holds. I also verified the test file parses, the string literals render to the exact error message, and `ruff check` / `ruff format` pass. CI runs the full pytest suite.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the MySQL import source using the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in `mysql.py:connect`. Read the source's `get_non_retryable_errors`, the consuming logic in `external_data_job.py`, and the sibling Postgres source for precedent.

Decision: classified 1135 as a transient server-side resource-exhaustion error (retryable), not a user/upstream config error and not a code bug. Rejected adding it to `NonRetryableErrors` because (a) the Postgres source already treats analogous connection-capacity errors as retryable, (b) the error literally signals "temporarily unavailable" / `EAGAIN`, and (c) making it non-retryable would disable customer syncs on a momentary blip. Since the correct behavior already exists on master, the scoped contribution is a guard test rather than a behavior change.
