### PR TITLE
fix(intercom): retry companies scroll past stale scroll_exists lock

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import AsyncIterable, Callable, Iterable, Iterator
 from typing import Any, Optional
 
@@ -29,6 +30,24 @@ def _is_not_found(exc: HTTPError) -> bool:
     the parent listing and the per-row detail fetch — Intercom then returns
     404. Skip that single row instead of failing the whole sync."""
     return exc.response is not None and exc.response.status_code == 404
+
+
+def _is_scroll_exists(exc: HTTPError) -> bool:
+    """Intercom permits only one open companies scroll per workspace; opening a
+    new scroll while another is still alive returns `400` with `code:
+    scroll_exists`. A scroll left behind by an interrupted or concurrent sync
+    clears itself once it expires (~1 min idle), so the lock is transient —
+    wait it out and retry rather than failing the whole sync. Match on the
+    stable error `code`, not the message text or URL."""
+    resp = exc.response
+    if resp is None or resp.status_code != 400:
+        return False
+    try:
+        body = resp.json()
+    except Exception:
+        return False
+    errors = body.get("errors") if isinstance(body, dict) else None
+    return any(isinstance(e, dict) and e.get("code") == "scroll_exists" for e in errors or [])
 
 
 def _default_headers() -> dict[str, str]:
@@ -259,6 +278,40 @@ def _conversation_parts_generator(
             yield part
 
 
+# Intercom expires an idle companies scroll after ~1 minute, so a stale scroll
+# left by an interrupted or concurrent sync clears within that window. Wait
+# past it before retrying the open, and cap the retries so a genuinely stuck
+# lock still surfaces instead of looping forever.
+_SCROLL_EXISTS_BACKOFF_SECONDS = 60
+_SCROLL_EXISTS_MAX_RETRIES = 2
+
+
+def _open_companies_scroll(session: Session) -> dict[str, Any]:
+    """Open a fresh companies scroll, waiting out a stale `scroll_exists` lock.
+
+    See `_is_scroll_exists`: a scroll left open by an interrupted or concurrent
+    sync blocks a new one with `400 scroll_exists` until it expires. Back off
+    and retry the open instead of failing — re-opening is the only recovery, as
+    a scroll can't be resumed from a point, only restarted from the beginning
+    (which is exactly what opening again does, and no rows have been yielded
+    yet at this stage)."""
+    for attempt in range(_SCROLL_EXISTS_MAX_RETRIES + 1):
+        try:
+            return _intercom_get(session, "/companies/scroll")
+        except HTTPError as exc:
+            if _is_scroll_exists(exc) and attempt < _SCROLL_EXISTS_MAX_RETRIES:
+                logger.warning(
+                    "intercom_companies_scroll_exists_retry",
+                    attempt=attempt + 1,
+                    backoff_seconds=_SCROLL_EXISTS_BACKOFF_SECONDS,
+                )
+                time.sleep(_SCROLL_EXISTS_BACKOFF_SECONDS)
+                continue
+            raise
+    # Unreachable: the final attempt either returns or re-raises above.
+    raise AssertionError("unreachable")
+
+
 def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
     """Walk every company via `GET /companies/scroll` (full refresh).
 
@@ -267,12 +320,14 @@ def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
     please use scroll API`. The Scroll API has no such ceiling: each response
     carries a `scroll_param` to feed into the next request, and the walk ends
     when `data` comes back empty (the scroll param then expires). Only one
-    scroll can be open per workspace at a time — fine here, since this is the
-    sole scroll user and a schema never syncs concurrently with itself."""
+    scroll can be open per workspace at a time, so the initial open backs off
+    past a stale `scroll_exists` lock (see `_open_companies_scroll`)."""
     scroll_param: str | None = None
     while True:
-        params = {"scroll_param": scroll_param} if scroll_param else None
-        payload = _intercom_get(session, "/companies/scroll", params=params)
+        if scroll_param is None:
+            payload = _open_companies_scroll(session)
+        else:
+            payload = _intercom_get(session, "/companies/scroll", params={"scroll_param": scroll_param})
         data = payload.get("data") or []
         if not data:
             return

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -21,6 +21,7 @@ from posthog.temporal.data_imports.sources.intercom.intercom import (
     _build_search_body,
     _company_segments_generator,
     _conversation_parts_generator,
+    _is_scroll_exists,
     _iter_companies,
     _make_intercom_session,
     get_resource,
@@ -41,6 +42,16 @@ def _make_response(json_body: Any, status_code: int = 200, text: str = "") -> Re
 def _endpoint(resource: Any) -> dict[str, Any]:
     # `EndpointResource["endpoint"]` is typed `str | Endpoint | None`; tests build dict endpoints.
     return cast(dict[str, Any], resource["endpoint"])
+
+
+SCROLL_EXISTS_BODY = {
+    "type": "error.list",
+    "errors": [{"code": "scroll_exists", "message": "scroll already exists for this workspace"}],
+}
+
+
+def _http_error(json_body: Any, status_code: int = 400, text: str = "") -> HTTPError:
+    return HTTPError(response=_make_response(json_body, status_code=status_code, text=text))
 
 
 class TestValidateCredentials:
@@ -372,6 +383,72 @@ class TestSubstreamGenerators:
         mock_session.get.side_effect = [_make_response({"data": [], "scroll_param": "s1"})]
 
         assert list(_iter_companies(mock_session)) == []
+        assert mock_session.get.call_count == 1
+
+
+class TestCompaniesScrollExists:
+    @pytest.mark.parametrize(
+        "body,status_code,expected",
+        [
+            (SCROLL_EXISTS_BODY, 400, True),
+            # A different 400 (e.g. a genuinely malformed request) is not the transient lock.
+            ({"type": "error.list", "errors": [{"code": "parameter_invalid"}]}, 400, False),
+            # Right code, wrong status — not the scroll lock.
+            (SCROLL_EXISTS_BODY, 404, False),
+            # No errors array at all.
+            ({"type": "error.list"}, 400, False),
+        ],
+    )
+    def test_is_scroll_exists(self, body: Any, status_code: int, expected: bool):
+        assert _is_scroll_exists(_http_error(body, status_code=status_code)) is expected
+
+    def test_is_scroll_exists_handles_non_json_body(self):
+        assert _is_scroll_exists(_http_error(None, status_code=400, text="<html>bad</html>")) is False
+
+    def test_iter_companies_retries_open_past_stale_scroll(self):
+        # A scroll left open by an interrupted/concurrent sync blocks the open with
+        # `400 scroll_exists` until it expires. Wait it out and retry the open
+        # rather than failing the whole sync.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response(SCROLL_EXISTS_BODY, status_code=400),
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": []}),
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep") as sleep:
+            companies = list(_iter_companies(mock_session))
+
+        assert [c["id"] for c in companies] == ["co1"]
+        sleep.assert_called_once_with(intercom_module._SCROLL_EXISTS_BACKOFF_SECONDS)
+        # The retried open carries no scroll_param — a scroll can only restart from
+        # the beginning, never resume.
+        assert mock_session.get.call_args_list[1].kwargs["params"] is None
+
+    def test_iter_companies_reraises_scroll_exists_after_max_retries(self):
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response(SCROLL_EXISTS_BODY, status_code=400)
+            for _ in range(intercom_module._SCROLL_EXISTS_MAX_RETRIES + 1)
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep"):
+            with pytest.raises(HTTPError):
+                list(_iter_companies(mock_session))
+
+        assert mock_session.get.call_count == intercom_module._SCROLL_EXISTS_MAX_RETRIES + 1
+
+    def test_iter_companies_does_not_retry_other_400(self):
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response({"type": "error.list", "errors": [{"code": "parameter_invalid"}]}, status_code=400),
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep") as sleep:
+            with pytest.raises(HTTPError):
+                list(_iter_companies(mock_session))
+
+        sleep.assert_not_called()
         assert mock_session.get.call_count == 1
 
 


### PR DESCRIPTION
## Problem

The Intercom data-warehouse import surfaced a recurring `HTTPError` in error tracking:

> `400 Client Error: Bad Request for url: https://api.intercom.io/companies/scroll`

raised in `posthog/temporal/data_imports/sources/intercom/intercom.py` at `_intercom_get`, on the call path `_company_segments_generator` → `_iter_companies` → `_intercom_get`.

The companies sync walks `GET /companies/scroll`. Intercom permits **only one open companies scroll per workspace** and expires an idle scroll after ~1 minute. When a scroll left behind by an interrupted or concurrent sync is still alive, opening a new one returns `400` with `{code: scroll_exists}`. This is a **transient, self-healing** condition — once the stale scroll expires, re-opening succeeds.

Our HTTP retry policy (`_INTERCOM_RETRY`, derived from the shared `DEFAULT_RETRY`) only retries `status_forcelist=(429, 500, 502, 503, 504)`. A `400` is never retried, so a single `scroll_exists` aborted the entire `companies` / `company_segments` sync, which then only recovered on the next scheduled run.

## Changes

- Detect Intercom's `scroll_exists` lock via the stable error `code` in the response body (not the volatile URL or message text) — `_is_scroll_exists`.
- When opening the companies scroll hits `scroll_exists`, wait out the ~1-minute expiry window and retry the open (`_open_companies_scroll`), capped at a small number of attempts so a genuinely stuck lock still surfaces. The retried open carries no `scroll_param`, since an Intercom scroll can only be restarted from the beginning, never resumed — and no rows have been yielded at that point, so restarting is safe.
- Any other `400` still fails fast.

This is **not** a `NonRetryableErrors` case: the error resolves on retry, so suppressing retries would be the opposite of the correct fix. It is also scoped to the companies scroll open — no change to the global retry policy.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `_is_scroll_exists` detection across `400 scroll_exists`, a different `400`, the right code on a non-400, a missing `errors` array, and a non-JSON body.
- `_iter_companies` retries the open past a stale `scroll_exists` and then yields companies, sleeping once and re-opening with no `scroll_param`.
- `_iter_companies` re-raises after exhausting the retry budget.
- `_iter_companies` does **not** retry an unrelated `400`.

`python -m pytest posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py` → 71 passed. `ruff check` / `ruff format` clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue for the Intercom source. Confirmed via the error-tracking MCP tools that the failure genuinely originates in this source's code (`_intercom_get` → `_iter_companies` → `_company_segments_generator` on `/companies/scroll`), and that the most recent events are `400`/`500` on the scroll endpoint. Researched the upstream behavior: `400 scroll_exists` is a documented one-scroll-per-workspace lock that other connectors (e.g. Airbyte) handle with backoff-and-retry, and it self-heals once the stale scroll expires. Chose a code fix (targeted backoff-retry on the scroll open) over `NonRetryableErrors`, since retrying is exactly what resolves the error. Followed the existing in-generator backoff precedent in this codebase (`brex`, `google_sheets`).
