### PR TITLE
fix(clickhouse): treat HTTP 404 from data-warehouse source as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -157,6 +157,14 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "No route to host": None,
             "certificate verify failed": None,
             "SSL: WRONG_VERSION_NUMBER": None,
+            # clickhouse-connect's HTTP driver got a 404 back while opening the
+            # connection ("HTTPDriver for <url> returned response code 404").
+            # The host responded but isn't serving the ClickHouse HTTP interface
+            # on that path — typically a tunnel/proxy pointing at the wrong
+            # service or an offline endpoint. A real ClickHouse server never
+            # answers queries with 404, so retrying can't recover. We match only
+            # 404, not transient gateway codes (502/503/504), which stay retryable.
+            "returned response code 404": "We reached your ClickHouse host but it returned a 404, so it isn't serving the ClickHouse HTTP interface on that host/port. Please check the host, port, and HTTPS setting (and any tunnel or proxy in front of it).",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `Int32` → `Int64`) after
             # the destination table was created with the narrower type. Delta Lake can't widen

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -522,6 +522,7 @@ class TestClickHouseSourceNonRetryableErrors:
             "Could not resolve the ClickHouse host",
             "Connection refused",
             "certificate verify failed",
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 404",
         ],
     )
     def test_permanent_errors_are_non_retryable(self, source, error_msg):
@@ -535,6 +536,9 @@ class TestClickHouseSourceNonRetryableErrors:
             "Code: 159. DB::Exception: Timeout exceeded",  # query timeout — could be retried
             "Code: 999. DB::Exception: Keeper exception",  # transient zookeeper-style errors
             "Code: 209. DB::Exception: Socket timeout",
+            # Transient gateway errors must stay retryable — only 404 is permanent.
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 502",
+            "HTTPDriver for https://example.ngrok-free.dev:443 returned response code 503",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse import source is repeatedly failing and retrying on a permanent error surfaced by error tracking:

> `DatabaseError: HTTPDriver for https://<host>:443 returned response code 404`

Stack: `clickhouse/source.py::get_schemas` → `clickhouse/clickhouse.py::get_schemas` → `_get_client` → clickhouse-connect's `create_client`. The driver does a probe request when opening the connection; a `404` back means the configured host/port responded but isn't serving the ClickHouse HTTP interface on that path — typically a tunnel/proxy pointing at the wrong service, or an offline endpoint. A real ClickHouse server never answers queries with `404`.

Because nothing on our side can recover this, the schema-discovery activity keeps retrying and re-firing the same exception (observed as a tight cluster of identical occurrences in error tracking).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ea0c3-86ec-78e3-b085-6a8ab3a9d77e

## Changes

- Add `returned response code 404` to `ClickHouseSource.get_non_retryable_errors()` with a user-facing message guiding the customer to check host/port/HTTPS and any tunnel or proxy in front of their ClickHouse.
- Match is scoped to **404 only**. Transient gateway codes (`502`/`503`/`504`) are intentionally left retryable, since those are usually momentary upstream issues. The substring chosen is the stable, low-false-positive part of the message — the URL and host are volatile and excluded.

## How did you test this code?

I'm an agent. I ran the automated tests; I did not do manual testing.

- Extended the existing parameterized `TestClickHouseSourceNonRetryableErrors` cases: a `404` message under permanent/non-retryable, and `502`/`503` messages under transient/retryable (guards against over-matching).
- `pytest posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py` — 139 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the ClickHouse data-warehouse source. Confirmed via the PostHog error-tracking MCP tools that the failure genuinely originates in `posthog/temporal/data_imports/sources/clickhouse/` (the serialized thread-pool variables in the event mention unrelated activities, but the actual call path is the ClickHouse `get_schemas` → `_get_client` chain).

Decision: user/upstream config error, not a code bug. The HTTP `404` is a persistent property of the customer's endpoint, so retrying can't help → extend `NonRetryableErrors`, mirroring the Stripe source pattern. Deliberately scoped to `404` rather than all `4xx`/`5xx` so transient gateway errors stay retryable.

Tools used: Claude Code with the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`).
