### PR TITLE
fix(data-imports): honor Sentry rate-limit-reset header in rest client backoff

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -1,6 +1,8 @@
 import copy
 import logging
 from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 
 from requests import Request, Response, Session
@@ -24,13 +26,54 @@ class RESTClientRetryableError(Exception):
         self.retry_after = retry_after
 
 
+# Upper bound on how long we'll honor a server-provided retry delay, so a
+# misreported header can't stall a worker for an unbounded amount of time.
+MAX_RETRY_AFTER_SECONDS = 300.0
+
+
+def _parse_retry_after(response: Response) -> Optional[float]:
+    """Best-effort retry delay (seconds) from a rate-limited / erroring response.
+
+    Honors the standard ``Retry-After`` header (delta-seconds or HTTP-date)
+    first. When it's absent, falls back to Sentry's ``X-Sentry-Rate-Limit-Reset``
+    (a UNIX epoch timestamp): Sentry's API signals its rate-limit window with
+    that header rather than ``Retry-After``, and Sentry's flat / fan-out
+    endpoints (e.g. ``project_users``) sync through this generic client, so
+    without it a 429 backs off on the short exponential fallback and exhausts
+    retries while still rate-limited. Capped at ``MAX_RETRY_AFTER_SECONDS``.
+    """
+    retry_after_header = response.headers.get("Retry-After")
+    if retry_after_header:
+        try:
+            return min(float(retry_after_header), MAX_RETRY_AFTER_SECONDS)
+        except ValueError:
+            try:
+                dt = parsedate_to_datetime(retry_after_header)
+            except (TypeError, ValueError):
+                return None
+            return min(max(0.0, (dt - datetime.now(UTC)).total_seconds()), MAX_RETRY_AFTER_SECONDS)
+
+    reset_header = response.headers.get("X-Sentry-Rate-Limit-Reset")
+    if reset_header:
+        try:
+            reset_epoch = int(reset_header)
+        except ValueError:
+            return None
+        wait_seconds = reset_epoch - int(datetime.now(UTC).timestamp())
+        if wait_seconds <= 0:
+            return None
+        return min(float(wait_seconds), MAX_RETRY_AFTER_SECONDS)
+
+    return None
+
+
 def _retry_wait_seconds(state: RetryCallState) -> float:
     fallback = min(2 ** (state.attempt_number - 1), 60)
     if state.outcome is None or not state.outcome.failed:
         return float(fallback)
     exc = state.outcome.exception()
     if isinstance(exc, RESTClientRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, 300.0)
+        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
     return float(fallback)
 
 
@@ -127,26 +170,9 @@ class RESTClient:
         response = self.session.send(prepared)
 
         if response.status_code == 429 or response.status_code >= 500:
-            retry_after: Optional[float] = None
-            retry_after_header = response.headers.get("Retry-After")
-            if retry_after_header:
-                try:
-                    retry_after = min(float(retry_after_header), 300.0)
-                except ValueError:
-                    import datetime
-                    from email.utils import parsedate_to_datetime
-
-                    try:
-                        dt = parsedate_to_datetime(retry_after_header)
-                        retry_after = min(
-                            max(0.0, (dt - datetime.datetime.now(datetime.UTC)).total_seconds()),
-                            300.0,
-                        )
-                    except Exception:
-                        pass
             raise RESTClientRetryableError(
                 f"HTTP {response.status_code} for {response.url}",
-                retry_after=retry_after,
+                retry_after=_parse_retry_after(response),
             )
 
         response_hooks = hooks.get("response", [])

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -9,7 +10,12 @@ from requests import Response
 from posthog.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from posthog.temporal.data_imports.sources.common.rest_source.exceptions import IgnoreResponseException
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator, SinglePagePaginator
-from posthog.temporal.data_imports.sources.common.rest_source.rest_client import RESTClient, RESTClientRetryableError
+from posthog.temporal.data_imports.sources.common.rest_source.rest_client import (
+    MAX_RETRY_AFTER_SECONDS,
+    RESTClient,
+    RESTClientRetryableError,
+    _parse_retry_after,
+)
 
 
 def _make_response(json_body: Any, status_code: int = 200) -> Response:
@@ -306,3 +312,74 @@ class TestRESTClient:
         assert pages == [[{"id": 1}]]
         assert mock_session.send.call_count == 2
         mock_sleep.assert_called_once_with(90.0)
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.datetime")
+    @patch("tenacity.nap.time.sleep")
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
+    def test_send_request_respects_sentry_rate_limit_reset_header(self, MockSession, mock_sleep, mock_datetime) -> None:
+        # Sentry signals its rate-limit window via ``X-Sentry-Rate-Limit-Reset``
+        # (an epoch timestamp) rather than ``Retry-After``; its fan-out endpoints
+        # sync through this generic client, so the client must honor it.
+        now = datetime(2026, 3, 6, 12, 0, 0, tzinfo=UTC)
+        mock_datetime.now.return_value = now
+
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        rate_limited = _make_response({"error": "rate limited"}, status_code=429)
+        rate_limited.url = "https://sentry.io/api/0/projects/org/proj/users/"
+        rate_limited.headers["X-Sentry-Rate-Limit-Reset"] = str(int(now.timestamp()) + 45)
+        ok = _make_response({"results": [{"id": 1}]})
+
+        mock_session.send.side_effect = [rate_limited, ok]
+
+        client = RESTClient(base_url="https://sentry.io")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+        mock_sleep.assert_called_once_with(45.0)
+
+    @patch("tenacity.nap.time.sleep")
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session")
+    def test_send_request_prefers_retry_after_over_sentry_reset_header(self, MockSession, mock_sleep) -> None:
+        # ``Retry-After`` is the standard, so it wins when both headers are present.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        rate_limited = _make_response({"error": "rate limited"}, status_code=429)
+        rate_limited.url = "https://sentry.io/api/0/projects/org/proj/users/"
+        rate_limited.headers["Retry-After"] = "12"
+        rate_limited.headers["X-Sentry-Rate-Limit-Reset"] = "9999999999"
+        ok = _make_response({"results": [{"id": 1}]})
+
+        mock_session.send.side_effect = [rate_limited, ok]
+
+        client = RESTClient(base_url="https://sentry.io")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        mock_sleep.assert_called_once_with(12.0)
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.datetime")
+    def test_parse_retry_after_caps_sentry_reset_header(self, mock_datetime) -> None:
+        # A reset far in the future must be clamped to MAX_RETRY_AFTER_SECONDS.
+        now = datetime(2026, 3, 6, 12, 0, 0, tzinfo=UTC)
+        mock_datetime.now.return_value = now
+
+        response = _make_response({"error": "rate limited"}, status_code=429)
+        response.headers["X-Sentry-Rate-Limit-Reset"] = str(int(now.timestamp()) + 10_000)
+
+        assert _parse_retry_after(response) == MAX_RETRY_AFTER_SECONDS
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.datetime")
+    def test_parse_retry_after_ignores_already_elapsed_sentry_reset(self, mock_datetime) -> None:
+        now = datetime(2026, 3, 6, 12, 0, 0, tzinfo=UTC)
+        mock_datetime.now.return_value = now
+
+        response = _make_response({"error": "rate limited"}, status_code=429)
+        response.headers["X-Sentry-Rate-Limit-Reset"] = str(int(now.timestamp()) - 5)
+
+        assert _parse_retry_after(response) is None


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `RESTClientRetryableError: HTTP 429` raised from the shared data-imports REST client (`posthog/temporal/data_imports/sources/common/rest_source/rest_client.py`). The issue is active and high-volume — thousands of occurrences over the last 30 days, still firing today.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019dd0d3-5c51-7fd2-af99-1320a21f4766

The failing requests are Sentry-source syncs of fan-out endpoints (e.g. `/projects/{org}/{project}/users/`). These endpoints route through the **generic** `rest_source` client, whose 429 backoff only reads the standard `Retry-After` header. Sentry's API does not send `Retry-After` — it signals its rate-limit window with `X-Sentry-Rate-Limit-Reset` (a UNIX epoch timestamp). With `Retry-After` absent, the generic client fell back to a short exponential backoff (~1+2+4+8s ≈ 15s across 5 attempts), exhausted its retries while the customer was still rate-limited, and re-raised the error.

This is a transient upstream rate-limit, not a credential/config failure, so it should **stay retryable** — it does not belong in `NonRetryableErrors`. The fix is to back off for the duration the upstream actually told us to wait.

The Sentry source's own dedicated client (`sentry/sentry.py`) already honors `X-Sentry-Rate-Limit-Reset`, but the flat/fan-out endpoints bypass it by using the generic client — so the same source had inconsistent backoff depending on the endpoint.

## Changes

- `rest_client.py`: extracted retry-delay parsing into `_parse_retry_after()`. It honors the standard `Retry-After` header (delta-seconds or HTTP-date) first, and falls back to `X-Sentry-Rate-Limit-Reset` (epoch seconds) when `Retry-After` is absent. The result is capped at a shared `MAX_RETRY_AFTER_SECONDS` (300s) so a misreported header can't stall a worker.
- This also removed a pre-existing inline `import datetime` from inside `_send_request` by lifting the imports to module level.
- No change to retry counts, retryable status codes, or the global pipeline retry policy. Non-Sentry sources never emit `X-Sentry-Rate-Limit-Reset`, so their behavior is unchanged.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests; I did not perform manual testing.

New regression tests in `tests/test_rest_client.py`:
- backs off for the `X-Sentry-Rate-Limit-Reset` window on a 429, then succeeds
- `Retry-After` still wins when both headers are present
- the reset-derived wait is capped at `MAX_RETRY_AFTER_SECONDS`
- an already-elapsed reset is ignored (falls back to exponential)

Ran locally:
- `pytest posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py` — 19 passed
- `pytest posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py` — 53 passed (no regression)
- `ruff check` + `ruff format --check` on both changed files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue end to end with Claude Code. Pulled the issue, stack trace, and representative events via the PostHog MCP tools, traced the failure to the generic `rest_source` client's 429 backoff, and confirmed the affected requests are Sentry fan-out endpoints (`project_users`) that route through the generic client rather than Sentry's own retry path.

Decision: a 429 is a transient upstream rate-limit, so adding it to `NonRetryableErrors` would be wrong (it would permanently pause syncs on a temporary limit). Instead fixed the backoff to honor the reset window the upstream advertises, mirroring the existing `sentry/sentry.py` logic. Scoped strictly to the parsing helper — no change to retry counts or global retry policy.
