### PR TITLE
fix(postgres): use unnamed client cursor in offset-chunking recovery

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -2087,7 +2087,13 @@ def postgres_source(
                             connection = get_connection()
                             connection.autocommit = True
 
-                        with connection.cursor() as cursor:
+                        # Use psycopg.Cursor directly to bypass cursor_factory: on a
+                        # non-read-replica source it is ServerCursor (set in get_rows),
+                        # which requires a `name` and makes an unnamed connection.cursor()
+                        # raise "ServerCursor.__init__() missing 1 required positional
+                        # argument: 'name'". This LIMIT/OFFSET fetchall path wants an
+                        # unnamed client cursor.
+                        with psycopg.Cursor(connection) as cursor:
                             query_with_limit = cast(
                                 LiteralString, f"{query.as_string()} LIMIT {chunk_size} OFFSET {offset}"
                             )

--- a/posthog/temporal/tests/data_imports/test_postgres_source.py
+++ b/posthog/temporal/tests/data_imports/test_postgres_source.py
@@ -199,6 +199,70 @@ async def test_postgres_source_full_refresh(
     assert res.results == TEST_DATA
 
 
+@pytest.fixture
+def external_data_schema_incremental(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
+    schema = ExternalDataSchema.objects.create(
+        name=POSTGRES_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="incremental",
+        sync_type_config={
+            "incremental_field": "id",
+            "incremental_field_type": "integer",
+            "incremental_field_last_value": None,
+        },
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_source_recovers_from_dropped_connection_via_offset_chunking(
+    team,
+    postgres_source_table: AsyncCursor[TupleRow],
+    external_data_source: ExternalDataSource,
+    external_data_schema_incremental: ExternalDataSchema,
+):
+    """A non-read-replica source streams rows through a named ServerCursor. When the
+    upstream connection is culled mid-stream it surfaces as a "server conn crashed?"
+    ProtocolViolation, and the sync recovers by resuming through offset chunking.
+
+    Regression: offset chunking opened its cursor with connection.cursor(), which
+    inherited the ServerCursor cursor_factory and raised "ServerCursor.__init__()
+    missing 1 required positional argument: 'name'", so the recovery itself crashed
+    instead of completing the sync.
+    """
+    table_name = f"postgres_{POSTGRES_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    real_fetchmany = psycopg.ServerCursor.fetchmany
+    state = {"tripped": False}
+
+    def flaky_fetchmany(self, *args, **kwargs):
+        # Trip once on the initial server-cursor stream to mimic the source culling the
+        # backend mid-fetch, then let the offset-chunking fallback (a plain Cursor) read
+        # normally. ServerCursor is only used by the streaming read path, so this targets
+        # exactly the fetch that triggers the connection-dropped recovery.
+        if not state["tripped"]:
+            state["tripped"] = True
+            raise psycopg.errors.ProtocolViolation("server conn crashed?")
+        return real_fetchmany(self, *args, **kwargs)
+
+    with mock.patch.object(psycopg.ServerCursor, "fetchmany", flaky_fetchmany):
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental,
+            table_name=table_name,
+            expected_rows_synced=expected_num_rows,
+            expected_total_rows=expected_num_rows,
+            expected_columns=["id", "name", "email", "created_at", "big_int", "int_range", "num_range", "tstz_range"],
+        )
+
+    assert state["tripped"], "expected the streaming server cursor to hit the simulated connection drop"
+    assert res.results == TEST_DATA
+
+
 def test_postgresql__source_config_loads():
     job_inputs = {
         "host": "host.com",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an active, recurring crash on the Postgres data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019e6ec0-1a82-7ea2-9ac1-a94cdb20f9ed)). It presents as `ProtocolViolation: server conn crashed?`, but the exception chain shows the real failure is a `TypeError: ServerCursor.__init__() missing 1 required positional argument: 'name'` raised inside the connection-drop recovery path.

The sequence:

1. A non-read-replica source streams rows through a **named** `ServerCursor` (the streaming connection is opened with `cursor_factory=psycopg.ServerCursor`).
2. The upstream connection gets culled mid-stream (idle cull / failover / PgBouncer), surfacing as a `ProtocolViolation: server conn crashed?`.
3. For incremental syncs this is caught and the sync resumes through `offset_chunking` (a `LIMIT`/`OFFSET` loop in autocommit).
4. `offset_chunking` opened its cursor with `connection.cursor()` — with no `name`. Because the connection still carries the `ServerCursor` factory, psycopg tried to build a `ServerCursor` without a `name` and raised `TypeError`.

So a transient, recoverable connection drop was turned into a hard crash of the recovery path itself.

## Changes

`offset_chunking` now builds its cursor via `psycopg.Cursor(connection)`, which bypasses the connection's `cursor_factory`. This matches the existing `setup_cursor` a few lines above in the same function, which already uses `psycopg.Cursor(connection)` for exactly this reason. The fix applies to both the initial connection and the reopen-after-close branch, since the cursor is always created through this call.

This is a fixable bug in our code (the recovery path was unreachable-by-design for read-replica sources where the factory is `None`, but reachable for the non-replica connection-drop case where the factory is `ServerCursor`), not a user/upstream error — so it is **not** a `NonRetryableErrors` change.

## How did you test this code?

I'm an agent (Claude Code). I added an integration regression test, `test_postgres_source_recovers_from_dropped_connection_via_offset_chunking`, which:

- runs an **incremental** sync against the Docker Postgres (non-partitioned table → legacy server-cursor path, the path that carries the bug),
- patches `psycopg.ServerCursor.fetchmany` to raise `ProtocolViolation("server conn crashed?")` once on the initial stream, then read normally, and
- asserts the sync completes and returns all rows.

Before the fix this fails with the `TypeError` (the run never reaches `COMPLETED`); after the fix the offset-chunking fallback completes the sync.

I ran `ruff check` and `ruff format --check` on both changed files (pass). I could **not** run the integration test in this environment — it requires the Docker Postgres/MinIO/Temporal stack, which isn't available here — so it will be exercised in CI.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used Claude Code with the PostHog MCP error-tracking tools to confirm the issue (302 occurrences, still firing) and pull the full exception chain, then read the source under `posthog/temporal/data_imports/sources/postgres/`. The chained `ProtocolViolation` → `TypeError` made the root cause clear: the recovery path inherited the `ServerCursor` factory and called `cursor()` unnamed. Chose the minimal fix that mirrors the established `psycopg.Cursor(connection)` pattern already present in the same function over introducing a new helper.
