### PR TITLE
fix(meta_ads): adapt entity-endpoint pagination to too-large 500s

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -264,15 +264,53 @@ def _iter_simple_pagination(
 
     On resume, the saved ``next_url`` is re-issued with a fresh ``access_token``
     injected at request time, so the initial request is skipped.
+
+    Like the stats path, this adapts to Meta's "reduce the amount of data" 500s
+    by shrinking the per-page ``limit`` (``PAGE_LIMIT_FALLBACK_SIZES``) and
+    retrying the same request. Entity endpoints (campaigns/adsets/ads) carry
+    heavy fields like ``targeting`` and ``creative``, so a default-sized page
+    can be too large for Meta to serve; without this fallback the whole sync
+    fails on those accounts. Retrying the same URL at a smaller limit never
+    re-emits already-yielded rows — the initial request has yielded nothing
+    yet, and a cursor points at the start of the next (not-yet-yielded) page.
     """
     access_token = params["access_token"]
+    current_limit = PAGE_LIMIT_FALLBACK_SIZES[0]
+
+    # None while on the initial request; set to the active ``paging.next``
+    # cursor once we start following pages. Used to retry-at-smaller-limit.
+    cursor_url: str | None = None
     if resume_config is not None and resume_config.next_url and resume_config.end_date is None:
-        response = _fetch_paging_url(resume_config.next_url, access_token)
-    else:
-        response = make_tracked_session().get(initial_url, params=params)
+        cursor_url = resume_config.next_url
+
+    def _issue() -> Response:
+        # Only rewrite the request once the limit has actually been shrunk, so
+        # healthy syncs keep their original request shape (saved cursor URLs and
+        # the caller's params already encode the default limit).
+        if cursor_url is not None:
+            url = (
+                _override_limit(cursor_url, current_limit)
+                if current_limit != PAGE_LIMIT_FALLBACK_SIZES[0]
+                else cursor_url
+            )
+            return _fetch_paging_url(url, access_token)
+        if current_limit != PAGE_LIMIT_FALLBACK_SIZES[0]:
+            return make_tracked_session().get(initial_url, params={**params, "limit": current_limit})
+        return make_tracked_session().get(initial_url, params=params)
+
+    response = _issue()
 
     while True:
         if response.status_code != 200:
+            # Too-much-data: shrink the page limit and retry the same request.
+            # Re-issuing the same URL/cursor at a smaller limit is safe — no
+            # already-yielded rows are re-emitted.
+            if _is_timeout_error(response):
+                smaller = _next_smaller_limit(current_limit)
+                if smaller is not None:
+                    current_limit = smaller
+                    response = _issue()
+                    continue
             _raise_meta_api_error(response)
 
         response_payload = response.json()
@@ -286,9 +324,9 @@ def _iter_simple_pagination(
         # the already-yielded page is not re-emitted (primary keys would dedupe it anyway).
         # Strip access_token from the URL before using it so we don't end up with a
         # duplicated `access_token` query param (requests merges `params=...` into the URL).
-        stripped_next_url = _strip_access_token(next_url)
-        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=stripped_next_url))
-        response = _fetch_paging_url(stripped_next_url, access_token)
+        cursor_url = _strip_access_token(next_url)
+        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=cursor_url))
+        response = _issue()
 
 
 def _iter_time_range_pagination(

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -46,8 +46,9 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
             "Ad account owner has NOT": None,
             "cannot be loaded due to missing permissions": None,
             # Meta returns this 500 when the requested query is too large for their backend to
-            # service. We already adaptively shrink stats chunks (30 → 7 → 1 day) and detect this
-            # message in `_is_timeout_error`; if it still escapes, retrying the whole job won't help.
+            # service. Both pagination paths adapt to it (stats chunks shrink 30 → 7 → 1 day, and
+            # both paths shrink the per-page limit 500 → 100 → 50); if it still escapes after those
+            # fallbacks are exhausted, retrying the whole job won't help.
             "Please reduce the amount of data you're asking for": None,
         }
 

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -192,6 +192,88 @@ class TestSimplePagination:
         assert mock_get.return_value.get.call_args_list[0].kwargs["params"] == {"access_token": "tok"}
 
 
+class TestSimplePaginationLimitFallback:
+    INITIAL_URL = "https://graph.facebook.com/v20/act_123/campaigns"
+    # Mirrors production params from `meta_ads_source`: a default page limit is always set.
+    PARAMS: dict[str, Any] = {"fields": "id,name", "limit": 500, "access_token": "tok"}
+    REDUCE_BODY: dict[str, Any] = {
+        "error": {"code": 1, "message": "Please reduce the amount of data you're asking for, then retry your request"}
+    }
+
+    def test_initial_too_much_data_retries_with_smaller_limit(self) -> None:
+        manager = _build_manager()
+        responses = [
+            # Initial request at the default limit is rejected as too large.
+            _mock_response(500, self.REDUCE_BODY),
+            # Retry at the next-smaller limit succeeds.
+            _mock_response(200, {"data": [{"id": "1"}], "paging": {}}),
+        ]
+
+        with mock.patch("posthog.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session") as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            batches = list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        assert batches == [[{"id": "1"}]]
+        # First attempt used the default 500 limit.
+        assert mock_get.return_value.get.call_args_list[0].args[0] == self.INITIAL_URL
+        assert mock_get.return_value.get.call_args_list[0].kwargs["params"]["limit"] == 500
+        # Retry re-issues the same initial URL with the limit reduced to the next rung (100).
+        assert mock_get.return_value.get.call_args_list[1].args[0] == self.INITIAL_URL
+        assert mock_get.return_value.get.call_args_list[1].kwargs["params"]["limit"] == 100
+
+    def test_cursor_too_much_data_retries_with_smaller_limit(self) -> None:
+        manager = _build_manager()
+        responses = [
+            # Page 1 succeeds and hands back a cursor.
+            _mock_response(
+                200,
+                {"data": [{"id": "1"}], "paging": {"next": "https://graph.facebook.com/v20/next?after=p1"}},
+            ),
+            # The cursor request is rejected as too large at the default limit.
+            _mock_response(500, self.REDUCE_BODY),
+            # Retry of the SAME cursor at a smaller limit succeeds; no more pages.
+            _mock_response(200, {"data": [{"id": "2"}], "paging": {}}),
+        ]
+
+        with mock.patch("posthog.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session") as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            batches = list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        assert batches == [[{"id": "1"}], [{"id": "2"}]]
+        # Cursor first tried without a limit override (still at the default).
+        assert mock_get.return_value.get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?after=p1"
+        # Retry uses the SAME cursor with the limit reduced to 100.
+        assert (
+            mock_get.return_value.get.call_args_list[2].args[0]
+            == "https://graph.facebook.com/v20/next?after=p1&limit=100"
+        )
+
+    def test_exhausting_limit_ladder_raises(self) -> None:
+        manager = _build_manager()
+        # Every rung in PAGE_LIMIT_FALLBACK_SIZES returns the too-much-data error.
+        responses = [_mock_response(500, self.REDUCE_BODY) for _ in PAGE_LIMIT_FALLBACK_SIZES]
+
+        with mock.patch("posthog.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session") as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            with pytest.raises(Exception, match="Meta API request failed: 500"):
+                list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        # One attempt per rung, then it gives up.
+        assert mock_get.return_value.get.call_count == len(PAGE_LIMIT_FALLBACK_SIZES)
+
+    def test_non_timeout_error_does_not_retry(self) -> None:
+        manager = _build_manager()
+        # Transient service error (code 2) — not a too-much-data error, so no limit fallback.
+        responses = [_mock_response(500, {"error": {"message": "Service temporarily unavailable", "code": 2}})]
+
+        with mock.patch("posthog.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session") as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            with pytest.raises(Exception, match="Meta API request failed: 500"):
+                list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
+
+        assert mock_get.return_value.get.call_count == 1
+
+
 class TestTimeRangePagination:
     URL = "https://graph.facebook.com/v20/act_1/insights"
     PARAMS: dict[str, Any] = {"fields": "ad_id", "limit": 500, "level": "ad", "access_token": "tok"}


### PR DESCRIPTION
## Problem

Meta's Graph API returns a 500 with `{"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}` when a request is too large to service.

The stats/insights pagination path already adapts to this by shrinking the per-page `limit`. But the **entity-endpoint path** (`_iter_simple_pagination`, used by `campaigns`, `adsets`, `ads`) had **no fallback at all** — it raised immediately on the first such response.

This message is also classified as **non-retryable** (`get_non_retryable_errors`), on the assumption that it only ever escapes *after* the stats path's adaptive chunk-shrinking. Error tracking shows that assumption is wrong: every sampled occurrence originates in `_iter_simple_pagination` (`meta_ads.py:438 → 276 → 254`), where nothing is ever shrunk. The result is that on large accounts the campaign/adset/ad tables fail outright and never sync, with no retry.

Observed in error tracking: [issue 019e970f-a417-7251-b52f-8480426f7476](https://us.posthog.com/project/2/error_tracking/019e970f-a417-7251-b52f-8480426f7476) (`Meta API request failed: 500 - {"error":{"code":1,"message":"Please reduce the amount of data you're asking for, then retry your request"}}`).

## Changes

Give `_iter_simple_pagination` the same adaptive page-limit fallback (`500 → 100 → 50`) the stats path already uses, reusing the existing `_is_timeout_error` / `_next_smaller_limit` / `_override_limit` helpers:

- On a too-much-data response, shrink the per-page `limit` and retry the **same** request (initial URL or cursor). Retrying the same URL/cursor at a smaller limit never re-emits already-yielded rows — the initial request has yielded nothing yet, and a cursor points at the start of the next (not-yet-yielded) page.
- Healthy syncs are unaffected: the request shape only changes once the limit is actually reduced.
- The non-retryable classification stays as a backstop for the genuinely terminal case where even the smallest limit (`50`) is still too large. Its comment is updated to reflect that both paths now adapt.

This is a fixable-bug fix, not a non-retryable widening: the message was already non-retryable, but the underlying entity-endpoint path never tried to recover.

## How did you test this code?

Automated tests only (I'm an agent — no manual testing performed). Added a `TestSimplePaginationLimitFallback` suite mirroring the existing stats-path fallback tests:

- initial request too-large → retries at smaller limit and succeeds
- cursor request too-large → retries the same cursor at a smaller limit
- exhausting the limit ladder → raises (one attempt per rung)
- a non-too-much-data error → raises immediately, no retry

Ran `pytest posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py` — 55 passed (4 new + all pre-existing, confirming no behavior change for healthy/resume cases). `ruff check` and `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the `meta_ads` data-warehouse source using the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm all sampled events originate in `_iter_simple_pagination`. Read the source to understand the two pagination paths.

Decision: the error message was *already* in `NonRetryableErrors`, so the simplest read would be "already handled — no-op." But the stack trace showed it escapes from the entity-endpoint path, which has no adaptive fallback — so marking it non-retryable just makes large accounts silently fail to sync those tables. Rejected widening/leaving non-retryable in favor of fixing the actual gap, mirroring the existing stats-path fallback so the data can sync, with the non-retryable entry kept as a backstop.
