### PR TITLE
fix(postgres): fall back to default chunk size on estimation timeout

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1302,9 +1302,16 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
         )
 
         return chunk_size
-    except psycopg.errors.QueryCanceled:
-        raise
     except Exception as e:
+        # Best-effort: any failure (including a statement_timeout / QueryCanceled) falls back to
+        # DEFAULT_CHUNK_SIZE. The estimation query wraps the sample in `octet_length(t::text)`,
+        # which serializes every column to text and so evaluates generated columns and check/domain
+        # validator functions — making it strictly more expensive than the real chunked `SELECT *`
+        # extraction. A timeout here therefore says nothing about whether extraction will succeed,
+        # and the savepoint above keeps the connection usable. The streaming read loop has its own
+        # dedicated QueryCanceled handling (`_statement_timeout_as_non_retryable`), so re-raising the
+        # cancellation here would only bypass that path and leak a raw, retryable QueryCanceled that
+        # Temporal re-attempts forever on tables this query can never complete on.
         logger.debug(f"_get_table_chunk_size: Error: {e}. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}", exc_info=e)
 
         return DEFAULT_CHUNK_SIZE

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1340,6 +1340,26 @@ class TestGetTableChunkSize:
             dj_cursor.execute("SELECT 1")
             assert dj_cursor.fetchone()[0] == 1
 
+    @pytest.mark.django_db
+    def test_statement_timeout_falls_back_without_poisoning_transaction(self):
+        # The estimation query wraps the sample in octet_length(t::text), which can exceed the
+        # source's statement_timeout on tables whose rows trigger slow validator functions. A
+        # cancelled probe must degrade to DEFAULT_CHUNK_SIZE, not crash the whole import — the
+        # streaming read loop has its own dedicated QueryCanceled handling.
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            # Tight timeout + a deliberately slow probe reproduces a real QueryCanceled.
+            dj_cursor.execute("SET LOCAL statement_timeout = '100ms'")
+            inner_query = sql.SQL("SELECT pg_sleep(3) AS c").format()
+
+            chunk_size = _get_table_chunk_size(cast(Any, dj_cursor), inner_query, logger)
+            assert chunk_size == DEFAULT_CHUNK_SIZE
+
+            # Savepoint rollback leaves the connection usable for the rest of setup.
+            dj_cursor.execute("SELECT 1")
+            assert dj_cursor.fetchone()[0] == 1
+
 
 class TestGetRowsToSync:
     @pytest.mark.django_db


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports were failing with an unrecoverable, endlessly-retried error:

- **Exception:** `QueryCanceled` — `canceling statement due to statement timeout`
- **Raise site:** `posthog/temporal/data_imports/sources/postgres/postgres.py` in `_get_table_chunk_size`
- **Error tracking issue:** https://us.posthog.com/project/2/error_tracking/019e9f41-6a33-7f13-b4e6-c2e791dbdb2a

The verified stack runs `source_for_pipeline` → `postgres_source` → `_get_table_chunk_size`, and the surfaced Temporal activity attempt counter was in the six figures — the activity had been retried into oblivion, failing the same way every time.

`_get_table_chunk_size` estimates a per-row byte size to pick a chunk size, using a probe that wraps the sampled rows in `octet_length(t::text)`. Casting each row to text forces full-row serialization, which evaluates generated columns and check/domain validator functions. The issue's exception `CONTEXT` shows exactly this: a customer PL/pgSQL validator function being invoked during the cast. That makes the probe **strictly more expensive than the real chunked `SELECT *` extraction**, so it can exceed the source database's `statement_timeout` even on tables that would otherwise sync fine.

The function is best-effort by design — its own comment notes that failures fall back to `DEFAULT_CHUNK_SIZE` and a savepoint keeps the transaction clean — but it re-raised `psycopg.errors.QueryCanceled` *before* the generic `except Exception` fallback. That leaked a raw, retryable `QueryCanceled` straight out of the import activity, bypassing the streaming read loop's dedicated timeout handling (`_statement_timeout_as_non_retryable`, which maps incremental-sync timeouts to an actionable non-retryable error). Temporal then re-attempted the same doomed query indefinitely.

## Changes

This is a **fixable bug (missing graceful-skip)**, not a user/upstream condition:

- A statement timeout is transient/config-dependent, so adding it to `NonRetryableErrors` would be wrong (and would permanently fail tables that are perfectly syncable with a default chunk size).
- The chunk-size estimation is purely an optimization with a sane default.

The fix removes the `except psycopg.errors.QueryCanceled: raise` short-circuit in `_get_table_chunk_size` so a cancelled probe degrades to `DEFAULT_CHUNK_SIZE`, exactly like every other probe failure. The savepoint already in place keeps the connection usable for the rest of setup. The change is scoped to this one function — `_get_rows_to_sync` (whose count query shares its FROM/WHERE with the real extraction, so a cancel there genuinely predicts trouble) and the streaming read loop's `QueryCanceled` handling are left untouched.

## How did you test this code?

I'm an agent. Automated tests only — no manual testing.

- Added `TestGetTableChunkSize::test_statement_timeout_falls_back_without_poisoning_transaction`, which sets a tight `statement_timeout`, runs a deliberately slow probe to produce a real `QueryCanceled`, and asserts the helper returns `DEFAULT_CHUNK_SIZE` and the connection stays usable afterwards. This mirrors the existing `test_failing_probe_falls_back_without_poisoning_transaction`.
- The new test is `@pytest.mark.django_db` and needs a live Postgres, which wasn't available in my environment; it runs in CI. I verified the existing non-DB tests in the file still pass (`TestPostgresSourceNonRetryableErrors`, `TestStatementTimeoutAsNonRetryable` — 25 tests), ran `ruff check` / `ruff format --check` clean, and confirmed the control flow change locally: `QueryCanceled` subclasses `Exception`, so removing the re-raise routes it into the existing `DEFAULT_CHUNK_SIZE` fallback.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Used the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the verified stack trace and confirm the failure originates in this source's code, then read the import pipeline to understand the call path.

Decision trail: considered treating the statement timeout as non-retryable (rejected — timeouts are transient/config-dependent and the probe is a non-essential optimization), and considered narrowing the re-raise to only recovery-conflict cancellations (rejected as unnecessary — the streaming loop already owns extraction-time timeout classification, and a probe cancel is never representative because of the `t::text` wrapper). Settled on the minimal graceful-skip that matches the function's documented best-effort contract.
