### PR TITLE
fix(linkedin_ads): refresh stale db connection before integration read

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
@@ -3,6 +3,8 @@ import datetime as dt
 import collections.abc
 from dataclasses import dataclass
 
+from django.db import close_old_connections
+
 import pyarrow as pa
 import structlog
 from structlog.types import FilteringBoundLogger
@@ -100,6 +102,12 @@ def get_schemas() -> dict[str, LinkedinAdsSchema]:
 
 def linkedin_ads_client(config: LinkedinAdsSourceConfig, team_id: int) -> LinkedinAdsClient:
     """Initialize a LinkedIn Ads client with provided config."""
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it — drop any stale connection first, else
+    # the read surfaces as `OperationalError: the connection is closed`.
+    close_old_connections()
     integration = Integration.objects.get(id=config.linkedin_ads_integration_id, team_id=team_id)
     if not integration.access_token:
         raise ValueError("LinkedIn Ads integration does not have an access token")

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py
@@ -361,6 +361,32 @@ class TestLinkedinAdsClientFunction:
         with pytest.raises(ValueError, match="LinkedIn Ads integration does not have an access token"):
             linkedin_ads_client(config, team_id=789)
 
+    def test_linkedin_ads_client_refreshes_stale_db_connection_before_query(self, mock_integration_model, monkeypatch):
+        # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+        # Django connection may have been closed server-side, surfacing as
+        # `OperationalError: the connection is closed`. We must drop the stale
+        # connection before querying, so the read happens on a fresh connection.
+        calls: list[str] = []
+
+        monkeypatch.setattr(
+            "posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.close_old_connections",
+            lambda: calls.append("close_old_connections"),
+        )
+
+        mock_integration = mock.MagicMock()
+        mock_integration.access_token = "token"
+
+        def fake_get(*args, **kwargs):
+            calls.append("Integration.objects.get")
+            return mock_integration
+
+        mock_integration_model.objects.get.side_effect = fake_get
+
+        config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=123, account_id="456")
+        linkedin_ads_client(config, team_id=789)
+
+        assert calls == ["close_old_connections", "Integration.objects.get"]
+
 
 @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.linkedin_ads.linkedin_ads_client")
 class TestLinkedinAdsSource:


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError: the connection is closed` originating in the `linkedin_ads` data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ce16a-451d-7673-a7ff-9f4aba8754d5)).

The stack trace lands in `linkedin_ads.py` at the `Integration.objects.get(...)` ORM read inside `linkedin_ads_client()`:

```
posthog/temporal/data_imports/pipelines/pipeline/pipeline.py:93   (worker thread)
posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py:137  client = linkedin_ads_client(...)
posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py:111  Integration.objects.get(...)
django/db/.../base.py → psycopg → OperationalError: the connection is closed
```

The client is built **lazily inside `get_rows`**, which runs on a pipeline worker thread. The pooled Django DB connection on that thread can be closed server-side after sitting idle for minutes, so the very first ORM read of the run fails.

This is not a LinkedIn upstream/credentials error and it is not a per-call transient that retrying blindly fixes well — it is a stale-connection bug in our code, the same one already fixed in the Google Search Console source (`_credentials` calls `close_old_connections()` for exactly this reason).

## Changes

- `linkedin_ads_client()` now calls `close_old_connections()` before `Integration.objects.get(...)`, dropping any stale pooled connection so the read happens on a fresh one.
- Added a regression test asserting `close_old_connections()` is invoked before the integration query.

Scoped strictly to this source — no change to retry policy or `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I ran the automated tests only:

- `posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_ads.py` — full file, 31 passed, including the new `test_linkedin_ads_client_refreshes_stale_db_connection_before_query`.
- `ruff check` / `ruff format --check` clean on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's full stack trace via the PostHog MCP error-tracking tools and confirmed the failing frame is our `Integration.objects.get(...)` read, not LinkedIn's API. Found the same `OperationalError: the connection is closed` class already handled in the Google Search Console source and mirrored that fix (`close_old_connections()` before the lazy ORM read on the worker thread) rather than touching retry policy or `NonRetryableErrors`. Tool used: Claude Code with the PostHog MCP server.
