### PR TITLE
fix(bigquery): lift gRPC message-size limit on storage read channel

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -72,6 +72,19 @@ BIGQUERY_STORAGE_HOST = "bigquerystorage.googleapis.com"
 # so it must stay free of volatile data (urls, ids, timestamps).
 BIGQUERY_TOKEN_RESPONSE_ERROR = "BigQuery OAuth token endpoint returned an unexpected response"
 
+# gRPC channel options for the Storage Read API channel. The Storage Read API
+# can return `ReadRowsResponse` messages larger than gRPC's default 4 MiB
+# receive limit (wide rows, large Arrow batches), which surfaces as
+# `ResourceExhausted: CLIENT: Received message larger than max`. The generated
+# `BigQueryReadGrpcTransport` applies these same options when it builds its own
+# channel, but because we build the channel ourselves (to inject the tracked
+# interceptors) and pass it in as `channel=`, that default path is skipped — so
+# we must set them here to match. `-1` means unlimited, mirroring the client.
+BIGQUERY_STORAGE_GRPC_CHANNEL_OPTIONS = [
+    ("grpc.max_send_message_length", -1),
+    ("grpc.max_receive_message_length", -1),
+]
+
 
 class BigQueryTokenRefreshError(Exception):
     """Raised when the service-account OAuth token endpoint returns a non-JSON-object 200.
@@ -206,7 +219,11 @@ def bigquery_storage_read_client(
     # via `create_channel(credentials=...)`. This routes the Storage Read API's
     # create_read_session (unary) + read_rows (server-streaming) RPCs through our
     # logging / metrics / sample-capture pipeline.
-    channel = BigQueryReadGrpcTransport.create_channel(host=BIGQUERY_STORAGE_HOST, credentials=credentials)
+    channel = BigQueryReadGrpcTransport.create_channel(
+        host=BIGQUERY_STORAGE_HOST,
+        credentials=credentials,
+        options=BIGQUERY_STORAGE_GRPC_CHANNEL_OPTIONS,
+    )
     tracked_channel = make_tracked_channel(channel, host=BIGQUERY_STORAGE_HOST)
     transport = BigQueryReadGrpcTransport(channel=tracked_channel)
 

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -18,6 +18,7 @@ from posthog.temporal.data_imports.sources.bigquery.bigquery import (
     _resolve_project_id,
     _resolve_query_project,
     _resolve_region,
+    bigquery_storage_read_client,
     delete_all_temp_destination_tables,
     validate_bigquery_credentials,
 )
@@ -594,3 +595,27 @@ def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
 
     assert any(pattern in error_msg for pattern in non_retryable_errors)
+
+
+def test_bigquery_storage_read_client_raises_grpc_message_size_limit():
+    """The manually-built Storage Read channel must lift gRPC's default 4 MiB receive
+    limit, otherwise large `ReadRowsResponse` messages raise `ResourceExhausted`."""
+    base = "posthog.temporal.data_imports.sources.bigquery.bigquery"
+    with (
+        mock.patch(f"{base}.service_account"),
+        mock.patch(f"{base}.BigQueryReadGrpcTransport") as mock_transport,
+        mock.patch(f"{base}.make_tracked_channel", side_effect=lambda channel, host: channel),
+        mock.patch(f"{base}.bigquery_storage"),
+    ):
+        with bigquery_storage_read_client(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ):
+            pass
+
+    options = dict(mock_transport.create_channel.call_args.kwargs["options"])
+    assert options["grpc.max_receive_message_length"] == -1
+    assert options["grpc.max_send_message_length"] == -1

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -597,7 +597,7 @@ def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     assert any(pattern in error_msg for pattern in non_retryable_errors)
 
 
-def test_bigquery_storage_read_client_raises_grpc_message_size_limit():
+def test_bigquery_storage_read_client_lifts_grpc_message_size_limit():
     """The manually-built Storage Read channel must lift gRPC's default 4 MiB receive
     limit, otherwise large `ReadRowsResponse` messages raise `ResourceExhausted`."""
     base = "posthog.temporal.data_imports.sources.bigquery.bigquery"


### PR DESCRIPTION
## Problem

BigQuery data-warehouse imports were failing with `ResourceExhausted: CLIENT: Received message larger than max (… vs. 4194304)` raised from the Storage Read API client in `posthog/temporal/data_imports/sources/bigquery/bigquery.py` (`get_rows`).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ea9d2-d1cb-7cb0-9079-86f4e73f79db

`4194304` is gRPC's default 4 MiB max-receive-message length. The BigQuery Storage Read API can legitimately return `ReadRowsResponse` Arrow messages larger than that (wide rows / large batches), so the read crashes.

## Changes

Root cause: the generated `BigQueryReadGrpcTransport` builds its own channel with `options=[("grpc.max_send_message_length", -1), ("grpc.max_receive_message_length", -1)]` (unlimited). But our `bigquery_storage_read_client` builds the channel *itself* (to inject the tracked logging/metrics interceptors) and passes it in as `channel=`. When a channel instance is supplied, the transport's `__init__` sets `self._grpc_channel = channel` and **skips** the branch that applies those unlimited options — so our channel was left on gRPC's 4 MiB default.

This is not a user/upstream error: it's our manually-built channel diverging from the client's defaults. The standard Google client never hits this.

Fix: pass the same options to `create_channel` so our channel matches the client's defaults. Added a `BIGQUERY_STORAGE_GRPC_CHANNEL_OPTIONS` constant and a regression test asserting the options reach `create_channel`.

## How did you test this code?

I am an agent. I did not perform manual testing against live BigQuery. Automated tests run:

- `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` — 21 passed.
- Verified the new regression test (`test_bigquery_storage_read_client_raises_grpc_message_size_limit`) **fails** when the fix is reverted (`KeyError: 'options'`) and **passes** with it.
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BigQuery import source. Used the PostHog error-tracking MCP tools to pull the stack trace and a representative event, confirming the top in-app frame was `get_rows` in the BigQuery source. Read the generated `google-cloud-bigquery-storage` transport to confirm the default client applies unlimited gRPC message-length options and that our custom-channel path bypasses them. Chose to mirror the client's `-1` (unlimited) options rather than pick an arbitrary cap, since the Storage Read API server already bounds response sizes. Scoped strictly to the storage read channel — no retry-policy or pipeline changes.
