### PR TITLE
fix(redshift): stop best-effort EXPLAIN from poisoning discovery queries

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -20,6 +20,7 @@ import pyarrow as pa
 import structlog
 from psycopg import sql
 from psycopg.adapt import Loader
+from psycopg.pq import TransactionStatus
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
@@ -222,6 +223,9 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
     logger.debug(f"Running EXPLAIN on {query.as_string()}")
 
     try:
+        # Debug-only, best-effort: Redshift can't EXPLAIN queries against leader-node-only system
+        # views such as `svv_table_info` (they fail with `UndefinedColumn: column "t" does not
+        # exist in t`), so swallow failures rather than reporting an expected, non-actionable error.
         query_with_explain = sql.SQL("EXPLAIN {}").format(query)
         cursor.execute(query_with_explain)
         rows = cursor.fetchall()
@@ -231,8 +235,16 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
                 explain_result += f"\n{col}"
         logger.debug(f"EXPLAIN result: {explain_result}")
     except Exception as e:
-        capture_exception(e)
         logger.debug(f"EXPLAIN raised an exception: {e}")
+        # A failed EXPLAIN aborts the surrounding transaction, and Redshift has no savepoints to
+        # scope it. Roll back the aborted transaction so the caller's real query — which runs on
+        # the same connection right after this probe — isn't killed by `InFailedSqlTransaction`.
+        # Every caller runs read-only discovery queries, so there is no pending work to lose.
+        try:
+            if cursor.connection.info.transaction_status == TransactionStatus.INERROR:
+                cursor.connection.rollback()
+        except Exception:
+            pass
 
 
 class RedshiftColumn(Column):

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -1,7 +1,9 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import psycopg
 from psycopg import sql
+from psycopg.pq import TransactionStatus
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.pipelines.pipeline.utils import TemporaryFileSizeExceedsLimitException
@@ -11,6 +13,7 @@ from posthog.temporal.data_imports.sources.redshift.redshift import (
     RedshiftColumn,
     RedshiftImplementation,
     _build_query,
+    _explain_query,
     filter_redshift_incremental_fields,
 )
 from posthog.temporal.data_imports.sources.redshift.source import _REDSHIFT_IMPLEMENTATION, RedshiftSource
@@ -259,6 +262,81 @@ class TestFetchTableStats:
     def test_returns_none_on_exception(self, impl, cursor, logger):
         cursor.execute.side_effect = RuntimeError("boom")
         assert impl.fetch_table_stats(cursor, "public", "t", logger) is None
+
+    def test_failed_explain_does_not_poison_real_query(self, impl, logger):
+        # Reproduces the reported incident: EXPLAIN on `svv_table_info` fails (Redshift can't
+        # EXPLAIN leader-node-only system views), aborting the transaction. Without recovery the
+        # real stats query would then die with `InFailedSqlTransaction` and stats would be lost.
+        cursor = _fake_poisoning_cursor(real_query_result=(2, 100))
+
+        with patch("posthog.temporal.data_imports.sources.redshift.redshift.capture_exception") as mock_capture:
+            stats = impl.fetch_table_stats(cursor, "public", "t", logger)
+
+        assert stats == TableStats(table_size_bytes=2 * 1024 * 1024, row_count=100)
+        cursor.connection.rollback.assert_called_once()
+        mock_capture.assert_not_called()
+
+
+def _fake_poisoning_cursor(real_query_result):
+    """A cursor mock whose EXPLAIN fails and aborts the transaction, mirroring Redshift.
+
+    The real (non-EXPLAIN) query only succeeds once the aborted transaction has been rolled
+    back — exactly the behaviour `_explain_query` must restore.
+    """
+    cursor = MagicMock()
+    state = {"poisoned": False}
+
+    def execute(stmt, *args, **kwargs):
+        text = stmt.as_string() if hasattr(stmt, "as_string") else str(stmt)
+        if text.strip().upper().startswith("EXPLAIN"):
+            state["poisoned"] = True
+            cursor.connection.info.transaction_status = TransactionStatus.INERROR
+            raise psycopg.errors.UndefinedColumn('column "t" does not exist in t')
+        if state["poisoned"]:
+            raise psycopg.errors.InFailedSqlTransaction("current transaction is aborted")
+        return cursor
+
+    def rollback():
+        state["poisoned"] = False
+        cursor.connection.info.transaction_status = TransactionStatus.IDLE
+
+    cursor.execute.side_effect = execute
+    cursor.connection.rollback.side_effect = rollback
+    cursor.connection.info.transaction_status = TransactionStatus.IDLE
+    cursor.fetchone.return_value = real_query_result
+    return cursor
+
+
+class TestExplainQuery:
+    def test_swallows_explain_failure_without_reporting(self, logger):
+        # EXPLAIN failures are expected for system views and non-actionable, so they must not be
+        # reported to error tracking (this is the source of the reported noise).
+        cursor = MagicMock()
+        cursor.execute.side_effect = psycopg.errors.UndefinedColumn('column "t" does not exist in t')
+        cursor.connection.info.transaction_status = TransactionStatus.IDLE
+
+        with patch("posthog.temporal.data_imports.sources.redshift.redshift.capture_exception") as mock_capture:
+            _explain_query(cursor, sql.SQL("SELECT 1 FROM svv_table_info").format(), logger)
+
+        mock_capture.assert_not_called()
+
+    def test_rolls_back_aborted_transaction(self, logger):
+        cursor = MagicMock()
+        cursor.execute.side_effect = psycopg.errors.UndefinedColumn('column "t" does not exist in t')
+        cursor.connection.info.transaction_status = TransactionStatus.INERROR
+
+        _explain_query(cursor, sql.SQL("SELECT 1 FROM svv_table_info").format(), logger)
+
+        cursor.connection.rollback.assert_called_once()
+
+    def test_does_not_roll_back_when_transaction_healthy(self, logger):
+        cursor = MagicMock()
+        cursor.execute.side_effect = psycopg.errors.UndefinedColumn('column "t" does not exist in t')
+        cursor.connection.info.transaction_status = TransactionStatus.IDLE
+
+        _explain_query(cursor, sql.SQL("SELECT 1 FROM svv_table_info").format(), logger)
+
+        cursor.connection.rollback.assert_not_called()
 
 
 class TestFetchAverageRowSize:


### PR DESCRIPTION
## Problem

Error tracking surfaced a high-volume issue on the Redshift data-warehouse import source:

- **Exception:** `UndefinedColumn: column "t" does not exist in t`
- **Raised in:** `posthog/temporal/data_imports/sources/redshift/redshift.py` → `_explain_query`
- **Issue:** https://us.posthog.com/project/2/error_tracking/019c427e-324c-7130-9e85-70c2d755c32c

`_explain_query` is a debug-only probe that runs `EXPLAIN <query>` before each schema-discovery query and logs the plan. Redshift cannot `EXPLAIN` queries against leader-node-only system views such as `svv_table_info`, and rejects them with the cryptic `column "t" does not exist in t`.

This is our code being fragile, not a credential/config/upstream problem, so it's a fixable bug rather than something to mark non-retryable. It caused two issues:

1. The handled, fully expected failure was reported to error tracking via `capture_exception`, generating a large volume of non-actionable noise.
2. The connection isn't in autocommit mode and Redshift has no savepoints, so the failed `EXPLAIN` aborted the surrounding transaction. The *real* query that ran immediately after the probe (on the same connection) then died with `InFailedSqlTransaction`, so e.g. `fetch_table_stats` silently returned no stats (degrading partitioning).

## Changes

Treat the `EXPLAIN` probe as the debug-only, best-effort diagnostic it is — mirroring the sibling Postgres source, whose `_explain_query` already only logs at debug:

- Stop reporting the expected `EXPLAIN` failure to error tracking; log it at debug instead.
- Roll back the aborted transaction when the probe leaves it in an error state, so the caller's read-only discovery query runs cleanly on the same connection. (Redshift has no savepoints, and every `_explain_query` caller runs read-only discovery queries, so there's nothing to lose by rolling back.)

Scope is limited to the `_explain_query` helper — no retry-policy or connection-lifecycle changes.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests; I did not perform manual testing against a live Redshift cluster.

- `TestExplainQuery` — a failed `EXPLAIN` is swallowed without calling `capture_exception`, rolls back only when the transaction is `INERROR`, and leaves a healthy transaction untouched.
- `TestFetchTableStats::test_failed_explain_does_not_poison_real_query` — reproduces the incident with a fake cursor: the `EXPLAIN` aborts the transaction, and the real stats query only succeeds after the rollback. Fails on the previous behavior, passes now.

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py -q
# 79 passed
```

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue via the PostHog MCP tools: pulled the issue, stack trace, and a representative event (the failing query was an `EXPLAIN` on `svv_table_info`).
- Confirmed the failure originates in this source's `_explain_query`, then read the implementation and the recently-merged Postgres counterpart (which had already de-noised its own `_explain_query` and isolated discovery probes).
- Decided this is a fixable bug, not a non-retryable upstream error: the probe is our own diagnostic and was both noisy and actively breaking the real query. Rejected the minimal "just drop `capture_exception`" change because it would have shifted the noise to `InFailedSqlTransaction` from the poisoned transaction; added the rollback to fix the root cause while staying inside the one helper.
