### PR TITLE
fix(postgres): retry standby recovery conflicts during table setup

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -71,6 +71,11 @@ SYSTEM_POSTGRES_SCHEMAS = ["information_schema", "pg_catalog", "pg_toast"]
 # default statement_timeout on the source role.
 SYNC_STATEMENT_TIMEOUT_MS = 1000 * 60 * 10  # 10 mins
 
+# How many times the metadata-gathering phase reconnects and retries when a hot-standby
+# recovery conflict terminates the setup connection. Past this the conflict is treated as
+# sustained and surfaced as the non-retryable "successive SerializationFailure errors" abort.
+_MAX_SETUP_RECOVERY_CONFLICT_RETRIES = 10
+
 
 def source_requires_ssl(source: ExternalDataSource, source_config: Any = None) -> bool:
     """Return whether this source must connect over SSL/TLS.
@@ -1780,219 +1785,253 @@ def postgres_source(
     effective_sslmode = _get_sslmode(require_ssl)
 
     with tunnel() as (host, port):
-        try:
-            connection = psycopg.connect(
-                host=host,
-                port=port,
-                dbname=database,
-                user=user,
-                password=password,
-                sslmode=effective_sslmode,
-                connect_timeout=15,
-                sslrootcert="/tmp/no.txt",
-                sslcert="/tmp/no.txt",
-                sslkey="/tmp/no.txt",
-                keepalives=1,
-                keepalives_idle=30,
-                keepalives_interval=10,
-                keepalives_count=5,
-            )
-        except psycopg.OperationalError as e:
-            if require_ssl and "SSL" in str(e):
-                raise SSLRequiredError(
-                    "SSL/TLS connection is required but your database does not support it. "
-                    "Please enable SSL/TLS on your PostgreSQL server or contact your database administrator."
-                ) from e
-            raise
 
-        # Autocommit so each best-effort probe is its own transaction: one that fails — a
-        # read-replica recovery conflict on a slow COUNT(*), or syntax the source rejects like
-        # TABLESAMPLE on CockroachDB — can't poison the rest. Replaces the per-probe savepoints.
-        connection.autocommit = True
-
-        with connection:
-            with connection.cursor() as cursor:
-                logger.debug("Getting table types...")
-                # Only probe the actual data for numeric scale when a fresh delta column is
-                # about to be created — either a first-ever sync or a post-reset full scan
-                # (watermark cleared). On normal incremental syncs the delta column already
-                # exists, so probing would be a wasted full-table aggregation. Mirrors the
-                # `is_initial_sync or full_table_scan` gating used a few lines below for
-                # partitioned-table row estimation.
-                fresh_schema_being_created = is_initial_sync or db_incremental_field_last_value is None
-                full_table = _get_table(
-                    cursor,
-                    schema,
-                    table_name,
-                    logger,
-                    probe_unconstrained_numeric_scale=fresh_schema_being_created,
+        def _open_setup_connection() -> psycopg.Connection:
+            try:
+                conn = psycopg.connect(
+                    host=host,
+                    port=port,
+                    dbname=database,
+                    user=user,
+                    password=password,
+                    sslmode=effective_sslmode,
+                    connect_timeout=15,
+                    sslrootcert="/tmp/no.txt",
+                    sslcert="/tmp/no.txt",
+                    sslkey="/tmp/no.txt",
+                    keepalives=1,
+                    keepalives_idle=30,
+                    keepalives_interval=10,
+                    keepalives_count=5,
                 )
+            except psycopg.OperationalError as e:
+                if require_ssl and "SSL" in str(e):
+                    raise SSLRequiredError(
+                        "SSL/TLS connection is required but your database does not support it. "
+                        "Please enable SSL/TLS on your PostgreSQL server or contact your database administrator."
+                    ) from e
+                raise
 
-                # Session, not LOCAL: under autocommit a LOCAL timeout has no transaction to bind to.
-                cursor.execute(
-                    sql.SQL("SET statement_timeout = {timeout}").format(
-                        timeout=sql.Literal(1000 * 60 * 10)  # 10 mins
-                    )
-                )
+            # Autocommit so each best-effort probe is its own transaction: one that fails — a
+            # read-replica recovery conflict on a slow COUNT(*), or syntax the source rejects like
+            # TABLESAMPLE on CockroachDB — can't poison the rest. Replaces the per-probe savepoints.
+            conn.autocommit = True
+            return conn
 
-                try:
-                    logger.debug("Checking if source is a read replica...")
-                    using_read_replica = _is_read_replica(cursor)
-                    logger.debug(f"using_read_replica = {using_read_replica}")
-                    logger.debug("Getting primary keys...")
-                    primary_keys = _get_primary_keys(cursor, schema, table_name, logger)
-                    if primary_keys:
-                        logger.debug(f"Found primary keys: {primary_keys}")
+        # A hot-standby recovery conflict ("terminating connection due to conflict with recovery")
+        # terminates the whole connection mid-probe, so autocommit alone can't isolate it — every
+        # subsequent probe on the dead connection fails too. Reconnect and retry the metadata
+        # probes a bounded number of times with backoff, mirroring how the read loop recovers from
+        # the same conflict. Only once the conflicts are sustained do we raise the non-retryable
+        # "successive SerializationFailure errors" abort the read path already uses, rather than
+        # letting Temporal re-run setup straight back into the same wall.
+        setup_recovery_conflicts = 0
+        while True:
+            connection = _open_setup_connection()
+            try:
+                with connection:
+                    with connection.cursor() as cursor:
+                        logger.debug("Getting table types...")
+                        # Only probe the actual data for numeric scale when a fresh delta column is
+                        # about to be created — either a first-ever sync or a post-reset full scan
+                        # (watermark cleared). On normal incremental syncs the delta column already
+                        # exists, so probing would be a wasted full-table aggregation. Mirrors the
+                        # `is_initial_sync or full_table_scan` gating used a few lines below for
+                        # partitioned-table row estimation.
+                        fresh_schema_being_created = is_initial_sync or db_incremental_field_last_value is None
+                        full_table = _get_table(
+                            cursor,
+                            schema,
+                            table_name,
+                            logger,
+                            probe_unconstrained_numeric_scale=fresh_schema_being_created,
+                        )
 
-                    # Fallback on checking for an `id` field on the table. Resolve the PKs
-                    # before building queries so chunk-size sampling and the actual reader
-                    # project the same columns.
-                    used_id_pk_fallback = False
-                    if primary_keys is None and "id" in full_table:
-                        logger.debug("Falling back to ['id'] for primary keys...")
-                        primary_keys = ["id"]
-                        used_id_pk_fallback = True
+                        # Session, not LOCAL: under autocommit a LOCAL timeout has no transaction to bind to.
+                        cursor.execute(
+                            sql.SQL("SET statement_timeout = {timeout}").format(
+                                timeout=sql.Literal(1000 * 60 * 10)  # 10 mins
+                            )
+                        )
 
-                    # Project both the Arrow schema and the SELECT clause so the cursor's row shape
-                    # matches what downstream consumers expect.
-                    retained_columns: list[str] | None = None
-                    if enabled_columns is not None:
-                        retained_set: set[str] = set(enabled_columns)
-                        for pk in primary_keys or []:
-                            retained_set.add(pk)
-                        if incremental_field:
-                            retained_set.add(incremental_field)
-                        retained_columns = [column.name for column in full_table.columns if column.name in retained_set]
-                        # Mirror `compute_projected_columns` fallback to `SELECT *` so Arrow stays full-table.
-                        if not retained_columns:
-                            retained_columns = None
-
-                    table = _project_table_columns(full_table, retained_columns)
-                    logger.debug(f"Source schema: {table.to_arrow_schema()}")
-
-                    inner_query_with_limit = _build_query(
-                        schema,
-                        table_name,
-                        should_use_incremental_field,
-                        table.type,
-                        incremental_field,
-                        incremental_field_type,
-                        db_incremental_field_last_value,
-                        add_sampling=True,
-                        enabled_columns=enabled_columns,
-                        primary_keys=primary_keys,
-                    )
-
-                    count_query = _build_count_query(
-                        schema,
-                        table_name,
-                        should_use_incremental_field,
-                        incremental_field,
-                        incremental_field_type,
-                        db_incremental_field_last_value,
-                    )
-
-                    logger.debug("Checking if table is partitioned...")
-                    is_partitioned = False
-                    child_partitions: list = []
-                    try:
-                        is_partitioned = _is_partitioned_table(cursor, schema, table_name)
-                        if is_partitioned:
-                            child_partitions = list_child_partitions(cursor, schema, table_name)
-                    except Exception as e:
-                        logger.debug(f"Partition detection failed: {e}")
-                    logger.debug("Getting table chunk size...")
-                    if chunk_size_override is not None:
-                        chunk_size = chunk_size_override
-                        logger.debug(f"Using chunk_size_override: {chunk_size_override}")
-                    else:
-                        chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
-
-                    logger.debug("Getting rows to sync...")
-                    # For partitioned tables without an incremental cursor (initial
-                    # sync, re-sync, or non-incremental), use pg_class.reltuples
-                    # estimate to avoid scanning all partitions with a COUNT(*).
-                    # `is_initial_sync` only reflects the first-ever sync; a forced
-                    # re-sync keeps initial_sync_complete=True but still scans the
-                    # whole table, so we gate on the filter actually being a full
-                    # scan (no incremental cursor value).
-                    rows_to_sync: int | None = None
-                    full_table_scan = db_incremental_field_last_value is None
-                    if is_partitioned and (is_initial_sync or full_table_scan):
                         try:
+                            logger.debug("Checking if source is a read replica...")
+                            using_read_replica = _is_read_replica(cursor)
+                            logger.debug(f"using_read_replica = {using_read_replica}")
+                            logger.debug("Getting primary keys...")
+                            primary_keys = _get_primary_keys(cursor, schema, table_name, logger)
+                            if primary_keys:
+                                logger.debug(f"Found primary keys: {primary_keys}")
+
+                            # Fallback on checking for an `id` field on the table. Resolve the PKs
+                            # before building queries so chunk-size sampling and the actual reader
+                            # project the same columns.
+                            used_id_pk_fallback = False
+                            if primary_keys is None and "id" in full_table:
+                                logger.debug("Falling back to ['id'] for primary keys...")
+                                primary_keys = ["id"]
+                                used_id_pk_fallback = True
+
+                            # Project both the Arrow schema and the SELECT clause so the cursor's row shape
+                            # matches what downstream consumers expect.
+                            retained_columns: list[str] | None = None
+                            if enabled_columns is not None:
+                                retained_set: set[str] = set(enabled_columns)
+                                for pk in primary_keys or []:
+                                    retained_set.add(pk)
+                                if incremental_field:
+                                    retained_set.add(incremental_field)
+                                retained_columns = [
+                                    column.name for column in full_table.columns if column.name in retained_set
+                                ]
+                                # Mirror `compute_projected_columns` fallback to `SELECT *` so Arrow stays full-table.
+                                if not retained_columns:
+                                    retained_columns = None
+
+                            table = _project_table_columns(full_table, retained_columns)
+                            logger.debug(f"Source schema: {table.to_arrow_schema()}")
+
+                            inner_query_with_limit = _build_query(
+                                schema,
+                                table_name,
+                                should_use_incremental_field,
+                                table.type,
+                                incremental_field,
+                                incremental_field_type,
+                                db_incremental_field_last_value,
+                                add_sampling=True,
+                                enabled_columns=enabled_columns,
+                                primary_keys=primary_keys,
+                            )
+
+                            count_query = _build_count_query(
+                                schema,
+                                table_name,
+                                should_use_incremental_field,
+                                incremental_field,
+                                incremental_field_type,
+                                db_incremental_field_last_value,
+                            )
+
+                            logger.debug("Checking if table is partitioned...")
+                            is_partitioned = False
+                            child_partitions: list = []
+                            try:
+                                is_partitioned = _is_partitioned_table(cursor, schema, table_name)
+                                if is_partitioned:
+                                    child_partitions = list_child_partitions(cursor, schema, table_name)
+                            except Exception as e:
+                                logger.debug(f"Partition detection failed: {e}")
+                            logger.debug("Getting table chunk size...")
+                            if chunk_size_override is not None:
+                                chunk_size = chunk_size_override
+                                logger.debug(f"Using chunk_size_override: {chunk_size_override}")
+                            else:
+                                chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
+
+                            logger.debug("Getting rows to sync...")
+                            # For partitioned tables without an incremental cursor (initial
+                            # sync, re-sync, or non-incremental), use pg_class.reltuples
+                            # estimate to avoid scanning all partitions with a COUNT(*).
+                            # `is_initial_sync` only reflects the first-ever sync; a forced
+                            # re-sync keeps initial_sync_complete=True but still scans the
+                            # whole table, so we gate on the filter actually being a full
+                            # scan (no incremental cursor value).
+                            rows_to_sync: int | None = None
+                            full_table_scan = db_incremental_field_last_value is None
+                            if is_partitioned and (is_initial_sync or full_table_scan):
+                                try:
+                                    logger.debug(
+                                        f"Partitioned table detected (is_initial_sync={is_initial_sync}, "
+                                        f"full_table_scan={full_table_scan}), using estimated row count"
+                                    )
+                                    rows_to_sync = _get_estimated_row_count_for_partitioned_table(
+                                        cursor, schema, table_name, logger
+                                    )
+                                except Exception as e:
+                                    logger.debug(f"Estimated row count failed, falling back to exact count: {e}")
+                            if rows_to_sync is None:
+                                rows_to_sync = _get_rows_to_sync(cursor, count_query, logger)
+
+                            if _role_subject_to_rls(cursor, schema, table_name, logger):
+                                logger.warning(
+                                    f"Row-level security is active for the sync role on {schema}.{table_name} "
+                                    f"(rows visible to this sync: {rows_to_sync}). Grant the role BYPASSRLS "
+                                    f"or a permissive policy if it should see all rows."
+                                )
+
+                            logger.debug("Getting partition settings...")
+                            partition_settings = (
+                                _get_partition_settings(
+                                    cursor, schema, table_name, logger, is_partitioned=is_partitioned
+                                )
+                                if should_use_incremental_field
+                                else None
+                            )
+
+                            # Bounded date/numeric window chunking for partitioned parents keeps
+                            # each query small so statement_timeout stays comfortable and partition
+                            # pruning can drop empty partitions server-side. Non-partitioned tables
+                            # continue through the legacy single-cursor path below.
+                            use_window_chunking = (
+                                is_partitioned
+                                and should_use_incremental_field
+                                and is_supported_incremental_type_for_window(incremental_field_type)
+                            )
+                            # When the parent is range-partitioned on the incremental field, we can
+                            # query each child relation directly instead of routing through the parent
+                            # and forcing the planner to Append + sort across all children. One cursor
+                            # per child = no cross-partition merge sort, trivial pruning, and child-sized
+                            # query plans that fit comfortably under statement_timeout.
+                            use_per_partition_chunking = False
+                            if use_window_chunking and child_partitions:
+                                try:
+                                    partition_strategy = get_partition_strategy(cursor, schema, table_name)
+                                except Exception as e:
+                                    partition_strategy = None
+                                    logger.debug(f"Partition strategy detection failed: {e}")
+                                use_per_partition_chunking = (
+                                    partition_strategy is not None
+                                    and partition_strategy.strategy == "r"
+                                    and incremental_field is not None
+                                    and incremental_field in partition_strategy.key_columns
+                                )
                             logger.debug(
-                                f"Partitioned table detected (is_initial_sync={is_initial_sync}, "
-                                f"full_table_scan={full_table_scan}), using estimated row count"
+                                f"Postgres read strategy: use_window_chunking={use_window_chunking}, "
+                                f"use_per_partition_chunking={use_per_partition_chunking}, "
+                                f"child_partitions={len(child_partitions)}"
                             )
-                            rows_to_sync = _get_estimated_row_count_for_partitioned_table(
-                                cursor, schema, table_name, logger
-                            )
-                        except Exception as e:
-                            logger.debug(f"Estimated row count failed, falling back to exact count: {e}")
-                    if rows_to_sync is None:
-                        rows_to_sync = _get_rows_to_sync(cursor, count_query, logger)
 
-                    if _role_subject_to_rls(cursor, schema, table_name, logger):
-                        logger.warning(
-                            f"Row-level security is active for the sync role on {schema}.{table_name} "
-                            f"(rows visible to this sync: {rows_to_sync}). Grant the role BYPASSRLS "
-                            f"or a permissive policy if it should see all rows."
-                        )
-
-                    logger.debug("Getting partition settings...")
-                    partition_settings = (
-                        _get_partition_settings(cursor, schema, table_name, logger, is_partitioned=is_partitioned)
-                        if should_use_incremental_field
-                        else None
-                    )
-
-                    # Bounded date/numeric window chunking for partitioned parents keeps
-                    # each query small so statement_timeout stays comfortable and partition
-                    # pruning can drop empty partitions server-side. Non-partitioned tables
-                    # continue through the legacy single-cursor path below.
-                    use_window_chunking = (
-                        is_partitioned
-                        and should_use_incremental_field
-                        and is_supported_incremental_type_for_window(incremental_field_type)
-                    )
-                    # When the parent is range-partitioned on the incremental field, we can
-                    # query each child relation directly instead of routing through the parent
-                    # and forcing the planner to Append + sort across all children. One cursor
-                    # per child = no cross-partition merge sort, trivial pruning, and child-sized
-                    # query plans that fit comfortably under statement_timeout.
-                    use_per_partition_chunking = False
-                    if use_window_chunking and child_partitions:
-                        try:
-                            partition_strategy = get_partition_strategy(cursor, schema, table_name)
-                        except Exception as e:
-                            partition_strategy = None
-                            logger.debug(f"Partition strategy detection failed: {e}")
-                        use_per_partition_chunking = (
-                            partition_strategy is not None
-                            and partition_strategy.strategy == "r"
-                            and incremental_field is not None
-                            and incremental_field in partition_strategy.key_columns
-                        )
-                    logger.debug(
-                        f"Postgres read strategy: use_window_chunking={use_window_chunking}, "
-                        f"use_per_partition_chunking={use_per_partition_chunking}, "
-                        f"child_partitions={len(child_partitions)}"
-                    )
-
-                    has_duplicate_primary_keys = False
-                    if used_id_pk_fallback:
-                        logger.debug("Checking duplicate primary keys...")
-                        has_duplicate_primary_keys = _has_duplicate_primary_keys(
-                            cursor, schema, table_name, primary_keys, logger
-                        )
-                except psycopg.errors.QueryCanceled:
-                    if should_use_incremental_field:
-                        raise QueryTimeoutException(
-                            f"10 min timeout statement reached. Please ensure your incremental field ({incremental_field}) has an appropriate index created"
-                        )
+                            has_duplicate_primary_keys = False
+                            if used_id_pk_fallback:
+                                logger.debug("Checking duplicate primary keys...")
+                                has_duplicate_primary_keys = _has_duplicate_primary_keys(
+                                    cursor, schema, table_name, primary_keys, logger
+                                )
+                        except psycopg.errors.QueryCanceled:
+                            if should_use_incremental_field:
+                                raise QueryTimeoutException(
+                                    f"10 min timeout statement reached. Please ensure your incremental field ({incremental_field}) has an appropriate index created"
+                                )
+                            raise
+                        except Exception:
+                            raise
+                break
+            except psycopg.errors.SerializationFailure as e:
+                if "conflict with recovery" not in "".join(e.args):
                     raise
-                except Exception:
-                    raise
+                # Connection is dead; close defensively before reconnecting.
+                _safe_close_connection(connection)
+                setup_recovery_conflicts += 1
+                if setup_recovery_conflicts >= _MAX_SETUP_RECOVERY_CONFLICT_RETRIES:
+                    raise Exception(
+                        f"Hit {setup_recovery_conflicts} successive SerializationFailure errors. Aborting."
+                    ) from e
+                logger.debug(
+                    f"SerializationFailure during table setup ({e}). Reconnecting and retrying "
+                    f"(attempt {setup_recovery_conflicts}/{_MAX_SETUP_RECOVERY_CONFLICT_RETRIES})"
+                )
+                time.sleep(min(2 * setup_recovery_conflicts, 30))
 
     def get_rows(chunk_size: int) -> Iterator[Any]:
         arrow_schema = table.to_arrow_schema()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, cast
 
@@ -37,6 +38,7 @@ from posthog.temporal.data_imports.sources.postgres.partitioned_tables import (
     should_preserve_asc_sort,
 )
 from posthog.temporal.data_imports.sources.postgres.postgres import (
+    _MAX_SETUP_RECOVERY_CONFLICT_RETRIES,
     SSL_REQUIRED_AFTER_DATE,
     JsonAsStringLoader,
     PostgresDiscoveredSchema,
@@ -69,6 +71,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     get_leading_index_columns,
     get_postgres_row_count,
     get_schemas,
+    postgres_source,
 )
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 
@@ -192,6 +195,8 @@ class TestPostgresSourceNonRetryableErrors:
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",
+            # The connection-terminating variant is retried by the setup phase the same way.
+            "terminating connection due to conflict with recovery",
             # The connection-dropped abort is a separate, genuinely transient condition.
             "Hit 10 successive connection-dropped errors. Aborting.",
         ],
@@ -200,6 +205,73 @@ class TestPostgresSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Transient error should remain retryable: {error_msg}"
+
+
+class TestPostgresSourceSetupRecoveryConflictRetry:
+    @staticmethod
+    @contextmanager
+    def _tunnel():
+        yield ("localhost", 5432)
+
+    def _make_failing_connection(self, error: BaseException) -> mock.MagicMock:
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = error
+        cursor_cm = mock.MagicMock()
+        cursor_cm.__enter__.return_value = cursor
+        cursor_cm.__exit__.return_value = False
+        connection = mock.MagicMock()
+        connection.closed = False
+        connection.cursor.return_value = cursor_cm
+        connection.__enter__.return_value = connection
+        # Must return falsy so the raised error propagates out of the `with` block.
+        connection.__exit__.return_value = False
+        return connection
+
+    def _call_postgres_source(self):
+        return postgres_source(
+            tunnel=self._tunnel,
+            user="u",
+            password="p",
+            database="db",
+            sslmode="prefer",
+            schema="public",
+            table_names=["t"],
+            should_use_incremental_field=False,
+            logger=structlog.get_logger(),
+            db_incremental_field_last_value=None,
+        )
+
+    def test_sustained_recovery_conflict_during_setup_aborts_non_retryably(self):
+        err = psycopg.errors.SerializationFailure("terminating connection due to conflict with recovery")
+        connection = self._make_failing_connection(err)
+
+        with patch(
+            "posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            return_value=connection,
+        ) as connect_mock:
+            with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+                with pytest.raises(Exception) as exc_info:
+                    self._call_postgres_source()
+
+        # Exhausting the in-process retries surfaces the message wired into NonRetryableErrors.
+        assert "successive SerializationFailure errors. Aborting." in str(exc_info.value)
+        # Each retry reconnects, so connect is called once per attempt.
+        assert connect_mock.call_count == _MAX_SETUP_RECOVERY_CONFLICT_RETRIES
+
+    def test_non_recovery_serialization_failure_during_setup_is_not_retried(self):
+        # A serialization failure unrelated to standby recovery must propagate immediately —
+        # the retry is scoped strictly to "conflict with recovery".
+        err = psycopg.errors.SerializationFailure("could not serialize access due to concurrent update")
+        connection = self._make_failing_connection(err)
+
+        with patch(
+            "posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            return_value=connection,
+        ) as connect_mock:
+            with pytest.raises(psycopg.errors.SerializationFailure):
+                self._call_postgres_source()
+
+        assert connect_mock.call_count == 1
 
 
 class TestIsConnectionDroppedError:


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `SerializationFailure: terminating connection due to conflict with recovery` originating in the Postgres data-warehouse import source (`posthog/temporal/data_imports/sources/postgres/`). The stack confirms it is raised inside `postgres_source` during the metadata-gathering phase that runs before streaming rows (table-type lookup, primary keys, `COUNT(*)`, chunk-size sampling, partition probes).

This is a Postgres hot-standby recovery conflict: when a source database is a read replica, its recovery process can kill a query — and in the connection-terminating variant, the entire backend connection — because the primary's WAL needs to remove row versions or relation locks the reader still holds. The error's own HINT (`In a moment you should be able to reconnect to the database and repeat your command.`) confirms it is transient and that reconnecting and retrying should succeed.

The setup phase ran all of its probes on a single connection with no in-process retry, so a single transient conflict that terminated the connection propagated as a raw, retryable error and failed the whole import activity. It has been firing steadily across many affected sources.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ce078-bbe9-7ab1-8e99-6f0b2ee41962

## Changes

The read loop (`offset_chunking`) already recovers from the same class of conflict — it matches `"conflict with recovery"`, reconnects, retries with backoff, and only gives up *non-retryably* (`"successive SerializationFailure errors. Aborting."`, already in `NonRetryableErrors`) once the conflict is sustained.

This applies the same resilience to the setup phase:

- Wrap the connect + metadata-probe block in a bounded retry loop. On a `SerializationFailure` whose message contains `"conflict with recovery"`, the dead connection is closed, a fresh connection is opened, and the probes re-run with linear backoff (capped at 30s).
- After `_MAX_SETUP_RECOVERY_CONFLICT_RETRIES` (10) successive conflicts, raise the existing non-retryable `"successive SerializationFailure errors. Aborting."` message so a sustained conflict surfaces an actionable error instead of looping Temporal back into the same wall.
- The match is scoped strictly to `"conflict with recovery"`; any other `SerializationFailure` propagates immediately. A single transient blip stays retryable — it is **not** added to `NonRetryableErrors`.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated tests; I did not perform manual testing.

- New `TestPostgresSourceSetupRecoveryConflictRetry`:
  - a sustained `terminating connection due to conflict with recovery` during setup reconnects once per attempt and aborts with the non-retryable message after the retry budget is exhausted;
  - a non-recovery `SerializationFailure` propagates immediately without retrying (no over-broad matching).
- Extended `TestPostgresSourceNonRetryableErrors` to assert the raw `terminating connection due to conflict with recovery` message stays retryable.
- Ran the full `test_postgres.py` suite: all logic tests pass; the only non-passing tests are pre-existing ones that require a live Postgres database, which is unavailable in this environment (they error on connection, unrelated to this change).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Used Claude Code with the PostHog MCP error-tracking tools to confirm the issue, pull the full stack trace and a representative event, and verify the failure originates in `postgres_source`'s setup phase (not in serialized log context).

Decision: this is a fixable fragility, not a user/upstream error. The conflict is transient (the error HINT says reconnect-and-retry works), so adding it to `NonRetryableErrors` would wrongly stop retrying a recoverable condition. The existing design already retries this exact conflict class in-process in the read loop and only treats the *sustained* case as non-retryable; the setup phase was simply missing that handling. The fix mirrors the established pattern and reuses the existing non-retryable abort message rather than introducing a new abstraction.
