### PR TITLE
fix(mongodb): treat server-selection timeouts as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -51,13 +51,19 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             "AuthenticationFailed": auth_failed_msg,
             "Authentication failed": auth_failed_msg,
             "SSL handshake failed": None,
-            # pymongo raises ServerSelectionTimeoutError ("No servers found yet" / "No replica set
-            # members found yet") when it can't reach any cluster node for the whole selection
-            # timeout. On a managed cluster this is a persistent connectivity problem — the worker
-            # IP isn't allowlisted, or the cluster is paused/decommissioned — not a momentary blip
-            # (a mid-sync outage surfaces differently), so retrying the job won't recover it.
-            "No servers found yet": _MONGO_UNREACHABLE_MESSAGE,
-            "No replica set members found yet": _MONGO_UNREACHABLE_MESSAGE,
+            # pymongo raises ServerSelectionTimeoutError when it can't select a usable cluster node
+            # for the whole selection timeout. The reason varies — "No servers found yet" / "No
+            # replica set members found yet" when nothing was ever discovered, or a per-server
+            # "<host>: connection closed ... error=AutoReconnect(...)" when a host resolves but every
+            # connection attempt is dropped for the entire window. All of these carry the
+            # "Topology Description:" suffix that only ServerSelectionTimeoutError emits, so we key
+            # off that single marker. On a managed cluster this is a persistent connectivity problem
+            # — the worker IP isn't allowlisted, the cluster is paused/decommissioned, or the
+            # connection string points at an endpoint the driver can't speak to — not a momentary
+            # blip, so retrying the job won't recover it. A transient mid-sync drop surfaces
+            # differently (a bare AutoReconnect / NetworkTimeout with no topology description) and
+            # stays retryable.
+            "Topology Description:": _MONGO_UNREACHABLE_MESSAGE,
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -337,12 +337,26 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
-            # Cluster unreachable for the whole selection timeout — persistent connectivity issue.
+            # ServerSelectionTimeoutError variants — cluster unreachable for the whole selection
+            # timeout. All carry the "Topology Description:" suffix regardless of the per-reason text.
             ("no_servers", "No servers found yet, Timeout: 5.0s, Topology Description: ..."),
             (
                 "no_replica_set_members",
                 "No replica set members found yet, Timeout: 10.0s, Topology Description: "
                 "<TopologyDescription topology_type: ReplicaSetNoPrimary>",
+            ),
+            # Host resolves but every connection attempt is closed for the whole window — the driver
+            # never identifies the server (topology_type: Unknown) and wraps the per-server
+            # AutoReconnect. Persistent connectivity/config problem, not a momentary blip.
+            (
+                "connection_closed_selection_timeout",
+                "cluster0.example.mongodb.net:27017: connection closed (configured timeouts: "
+                "socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms), Timeout: 10.0s, "
+                "Topology Description: <TopologyDescription id: abc, topology_type: Unknown, "
+                "servers: [<ServerDescription ('cluster0.example.mongodb.net', 27017) "
+                "server_type: Unknown, rtt: None, error=AutoReconnect('cluster0.example.mongodb.net:"
+                "27017: connection closed (configured timeouts: socketTimeoutMS: 20000.0ms, "
+                "connectTimeoutMS: 20000.0ms)')>]>",
             ),
         ]
     )
@@ -355,6 +369,14 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         [
             ("connection_reset", "connection closed"),
             ("network_timeout", "NetworkTimeout: timed out reading from socket"),
+            # A mid-sync AutoReconnect carries the "(configured timeouts: ...)" suffix but no
+            # topology description — it's a momentary drop the driver can recover from, so it must
+            # not be caught by the "Topology Description:" server-selection matcher.
+            (
+                "mid_sync_auto_reconnect",
+                "cluster0.example.mongodb.net:27017: connection closed (configured timeouts: "
+                "socketTimeoutMS: 20000.0ms, connectTimeoutMS: 20000.0ms)",
+            ),
         ]
     )
     def test_transient_errors_are_retryable(self, _name, error_msg):
@@ -366,8 +388,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         [
             ("code_name", "AuthenticationFailed", "password"),
             ("message", "Authentication failed", "password"),
-            ("unreachable_no_servers", "No servers found yet", "allowlist"),
-            ("unreachable_no_replica_set", "No replica set members found yet", "allowlist"),
+            ("unreachable_topology", "Topology Description:", "allowlist"),
         ]
     )
     def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a high-volume, long-running `ServerSelectionTimeoutError` from the MongoDB data-warehouse import source (52k+ occurrences over three months, never recovering). The failure originates in our code at `posthog/temporal/data_imports/sources/mongodb/mongo.py` `get_schemas` (`db.list_collection_names(...)`), reached via the schema-discovery activity.

The exception message looks like:

```
<host>:27017: connection closed (configured timeouts: socketTimeoutMS: 20000.0ms,
connectTimeoutMS: 20000.0ms), Timeout: 10.0s, Topology Description:
<TopologyDescription id: ..., topology_type: Unknown, servers: [<ServerDescription
(...) server_type: Unknown, rtt: None, error=AutoReconnect('...connection closed...')>]>
```

pymongo could not select a usable cluster node for the **entire** server-selection window: the host resolves, but every connection attempt is closed (`topology_type` stays `Unknown`). On a managed cluster this is a persistent reachability/config problem — the worker IP isn't allowlisted, the cluster is paused/decommissioned, or the connection string points at an endpoint the driver can't speak to. Retrying the job can't recover it, so it should stop retrying and surface a clear message to the user.

The source already treated `ServerSelectionTimeoutError` as non-retryable, but only via the literal prefixes `"No servers found yet"` / `"No replica set members found yet"`, which don't cover the connection-closed/`AutoReconnect` variant. Notably the error-tracking issue groups both variants under one issue — they're the same failure mode with different per-reason text.

## Changes

- Generalized the two specific server-selection-timeout matchers in `MongoDBSource.get_non_retryable_errors` into a single `"Topology Description:"` matcher. That substring is present in **every** `ServerSelectionTimeoutError` message (regardless of the per-reason text) and is **absent** from the transient mid-operation drops the source deliberately keeps retryable (a bare `AutoReconnect` / `NetworkTimeout` carries no topology description). It maps to the existing user-facing "could not reach your cluster / check allowlist" message.
- Updated tests: added a regression case using the exact reported connection-closed message; the existing `No servers found yet` / `No replica set members found yet` cases still match (they contain the topology suffix); hardened the retryable test with a realistic mid-sync `AutoReconnect` (which carries the `(configured timeouts: ...)` suffix but no topology description) to prove it stays retryable.

This is a transient-vs-persistent distinction: a bare connection drop mid-sync remains retryable; a connection failure that exhausts the whole server-selection window does not.

## How did you test this code?

I'm an agent. I ran the automated tests only — no manual testing.

- `pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py` — 47 passed, including the updated `TestMongoDBNonRetryableErrors` (12 cases).
- `ruff check` and `ruff format --check` on both changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to confirm the issue: pulled the stack trace (confirmed the top in-app frame is in the MongoDB source's `get_schemas`), exception type, representative events, and that it has persisted continuously at high volume.

Decision: this is an upstream/config error, not transient infra and not a code bug. A `ServerSelectionTimeoutError` means selection failed for the entire window — a persistent connectivity wall the pipeline can't retry past. Considered keying off the connection-closed text directly but rejected it: a real transient mid-operation drop also carries the same `(configured timeouts: ...)` suffix, so matching on it would risk swallowing genuinely retryable failures (which the source explicitly keeps retryable). The `"Topology Description:"` marker cleanly distinguishes the persistent server-selection case from transient drops and subsumes the two pre-existing matchers, so they were consolidated.
