### PR TITLE
fix(postgres): surface dropped connection during metadata discovery instead of masked commit error

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -183,6 +183,26 @@ def _is_connection_dropped_error(error: BaseException) -> bool:
     return False
 
 
+def _raise_if_setup_connection_broken(connection: psycopg.Connection) -> None:
+    """Surface a connection dropped during metadata discovery as a retryable error.
+
+    The best-effort probes run during `postgres_source` setup (`_explain_query`,
+    `_get_table_chunk_size`, and the numeric-scale probe in `_get_table`) isolate their
+    queries in `connection.transaction(savepoint_name=...)`. When the upstream
+    connection drops mid-probe, psycopg's `Transaction.__exit__` skips its savepoint
+    teardown — it early-returns whenever the connection is no longer OK — leaving the
+    connection's transaction-nesting counter incremented. The surrounding helpers then
+    swallow the follow-up "connection closed" errors, so discovery finishes "successfully"
+    and the implicit commit in the enclosing `with connection:` raises a misleading
+    `ProgrammingError: Explicit commit() forbidden within a Transaction context`, burying
+    the real cause. Detect the broken connection first and raise the actual
+    dropped-connection error (transient, so it stays retryable) — the activity then retries
+    on a fresh connection instead of failing on a self-inflicted commit error.
+    """
+    if connection.broken:
+        raise psycopg.OperationalError("connection to server was lost during table metadata discovery")
+
+
 def _connect_with_dropped_retry(
     connect: Callable[[], psycopg.Connection],
     logger: FilteringBoundLogger,
@@ -2256,6 +2276,14 @@ def postgres_source(
                             raise
                         except Exception:
                             raise
+
+                    # If a transient drop killed the connection during one of the best-effort
+                    # savepoint probes above, the implicit commit on `with connection:` exit would
+                    # otherwise raise a misleading "Explicit commit() forbidden within a Transaction
+                    # context" (psycopg leaves the transaction-nesting counter incremented when it
+                    # tears a savepoint down on a no-longer-OK connection). Surface the real,
+                    # retryable dropped-connection error instead.
+                    _raise_if_setup_connection_broken(connection)
                 break
             except psycopg.errors.SerializationFailure as e:
                 if "conflict with recovery" not in "".join(e.args):

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -72,6 +72,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _is_read_replica,
     _is_unsupported_function_error,
     _normalize_function_names,
+    _raise_if_setup_connection_broken,
     _rls_active_from_conn,
     _role_subject_to_rls,
     _statement_timeout_as_non_retryable,
@@ -567,6 +568,32 @@ class TestIsConnectionDroppedError:
     )
     def test_unrelated_errors_are_not_detected(self, error):
         assert _is_connection_dropped_error(error) is False
+
+
+class TestRaiseIfSetupConnectionBroken:
+    """A connection dropped mid-discovery must surface as a retryable error, not the masked
+    `ProgrammingError: Explicit commit() forbidden within a Transaction context` that psycopg's
+    implicit `with connection:` exit-commit raises when a savepoint teardown leaks the
+    transaction-nesting counter on a no-longer-OK connection."""
+
+    def test_broken_connection_raises_retryable_dropped_error(self):
+        connection = mock.MagicMock()
+        connection.broken = True
+
+        with pytest.raises(psycopg.OperationalError) as exc_info:
+            _raise_if_setup_connection_broken(cast(Any, connection))
+
+        # Classified as a transient drop, so the activity keeps retrying...
+        assert _is_connection_dropped_error(exc_info.value) is True
+        # ...and the message is not matched by any NonRetryableErrors substring.
+        message = str(exc_info.value)
+        assert not any(key in message for key in PostgresSource().get_non_retryable_errors())
+
+    def test_healthy_connection_is_a_noop(self):
+        connection = mock.MagicMock()
+        connection.broken = False
+
+        assert _raise_if_setup_connection_broken(cast(Any, connection)) is None
 
 
 class TestConnectWithDroppedRetry:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -593,7 +593,8 @@ class TestRaiseIfSetupConnectionBroken:
         connection = mock.MagicMock()
         connection.broken = False
 
-        assert _raise_if_setup_connection_broken(cast(Any, connection)) is None
+        # A healthy connection must not raise.
+        _raise_if_setup_connection_broken(cast(Any, connection))
 
 
 class TestConnectWithDroppedRetry:


### PR DESCRIPTION
## Problem

Postgres (and Postgres-backed sources like Supabase) data-warehouse imports were failing in large volume with a confusing, self-inflicted error surfaced by error tracking:

> `ProgrammingError: Explicit commit() forbidden within a Transaction context. (Transaction will be automatically committed on successful exit from context.)`

The stack pointed into `posthog/temporal/data_imports/sources/postgres/postgres.py` (`postgres_source`, called from `source.py:source_for_pipeline`), with psycopg's `wait_c` as the deepest frame.

Root cause: during `postgres_source` setup, several read-only probes (`_explain_query`, `_get_table_chunk_size`, and the numeric-scale probe in `_get_table`) isolate their queries in `connection.transaction(savepoint_name=...)`. When the upstream connection drops mid-probe, psycopg's `Transaction.__exit__` skips its savepoint teardown — it early-returns whenever the connection is no longer OK — leaving the connection's transaction-nesting counter incremented. The surrounding best-effort helpers then swallow the follow-up dead-connection errors, so discovery finishes "successfully" and the implicit `commit()` on `with connection:` exit raises the misleading `ProgrammingError`, burying the real cause. Affected sources showed classic transient drops (`[INERROR]` connections behind connection poolers / managed Postgres).

## Changes

- Add `_raise_if_setup_connection_broken(connection)` and call it just before the setup `with connection:` block exits.
- If the connection broke during discovery, raise the real, retryable dropped-connection error (`connection to server was lost during table metadata discovery`) instead of letting the implicit exit-commit raise the masked `ProgrammingError`.

This is a transient infrastructure drop, so it is deliberately **kept retryable** — it is *not* added to `NonRetryableErrors`. The raised message is classified as a transient drop by `_is_connection_dropped_error` and is not matched by any `NonRetryableErrors` substring, so the activity retries on a fresh connection (which re-runs discovery and gets correct metadata, rather than silently proceeding with bogus counts).

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not perform manual testing.

- New `TestRaiseIfSetupConnectionBroken` (in `test_postgres.py`): asserts a broken connection raises a `psycopg.OperationalError` that is classified as a transient drop and is *not* matched by `NonRetryableErrors`, and that a healthy connection is a no-op.
- Re-ran the adjacent connection-handling suites (`TestIsConnectionDroppedError`, `TestConnectWithDroppedRetry`, `TestPostgresSourceNonRetryableErrors`) — all pass.
- `ruff check` and `ruff format --check` clean on both changed files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Postgres data-warehouse import source. Investigated the live issue (full stack trace, representative events, frequency, affected source types) via the PostHog error-tracking tools, then traced the call path into `postgres_source` and read psycopg's `Connection.__exit__` / `Transaction.__exit__` / `_commit_gen` to confirm the exact mechanism: the leaked transaction-nesting counter from a savepoint torn down on a no-longer-OK connection, turning a transient drop into a misleading commit error.

Decision: treated this as a fixable bug (masking), not a `NonRetryableErrors` change — the underlying drop is transient infrastructure and must stay retryable. Considered swapping `with connection:` for `_safe_close_connection` teardown, but that would silently proceed with bogus discovery metadata; raising the real retryable error forces a clean retry instead. Kept the change scoped to a single guard helper plus its call site.
