### PR TITLE
chore(slack): log when the legacy image unfurl path is invoked

### DIFF
--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -71,6 +71,17 @@ def _handle_slack_event(event_payload: Any) -> None:
 
             # With both the integration and the resource we are good to go!!
 
+            # Usage breadcrumb: this legacy Celery-backed image unfurl is believed superseded by the
+            # metadata-only products/slack_app unfurl. It renders a PNG via the EXPORTS Celery queue,
+            # which has no in-container Chromium (removed) and no BROWSERLESS_CDP_URL — so a real hit
+            # here both proves the path is live AND would fail to render. Logged at warning so it's
+            # impossible to miss while we decide whether to keep/retire it.
+            logger.warning(
+                "slack_legacy_image_unfurl.invoked",
+                team_id=team_id,
+                share_token=share_token,
+            )
+
             insights, assets = generate_assets(sharing_config, 1)
 
             if assets:

--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -79,7 +79,7 @@ def _handle_slack_event(event_payload: Any) -> None:
             logger.warning(
                 "slack_legacy_image_unfurl.invoked",
                 team_id=team_id,
-                share_token=share_token,
+                sharing_configuration_id=sharing_config.id,
             )
 
             insights, assets = generate_assets(sharing_config, 1)


### PR DESCRIPTION
## Summary

Adds a loud (`warning`) usage log when the **legacy** Slack link image-unfurl path actually runs, so we can confirm whether it's still in use before retiring it / removing the browser env from the EXPORTS Celery worker.

## Why now

This legacy unfurl (`ee/api/integration.py` `slack/events` → `ee/tasks/slack._handle_slack_event` → `generate_assets`) renders a **PNG via the EXPORTS Celery queue** (`posthog-worker-django` "longrunning" worker). That worker has **no `BROWSERLESS_CDP_URL`**, and with the local Chromium now removed from the image (#62825), a real hit here would **fail to render**. It appears superseded by the metadata-only `products/slack_app` unfurl, but we couldn't prove it's dead from request logs alone:

- Endpoint `/api/integrations/slack/events` gets traffic, but the only logged hits (14d) are rejected junk (403/405/CSRF) from a scanner — successful 200 events are silent.
- `export_format="image/png"` on the Celery worker: 0 in 30d (but render-log reliability on that worker is uncertain).

This log fires on the **success path**, right before `generate_assets`, so any genuine invocation is unmissable.

## Watch query

```logql
{app=~"posthog-.*django.*"} | json | __error__="" | msg="slack_legacy_image_unfurl.invoked"
```

If this stays empty for a week → path is dead → safe to drop the browser env from the worker (and eventually delete the legacy unfurl stack). If it fires → the path is live and needs `BROWSERLESS_CDP_URL` (charts #12154) before #62825's chromium removal reaches it.
