### PR TITLE
fix(postgres): use client cursor in offset_chunking recovery path

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1524,24 +1524,28 @@ class TestGetTableChunkSize:
             assert cursor.fetchone()[0] == 1
 
     @pytest.mark.django_db
-    def test_statement_timeout_falls_back_without_poisoning_transaction(self):
+    def test_statement_timeout_falls_back_without_poisoning_transaction(self, autocommit_pg_connection):
         # The estimation query wraps the sample in octet_length(t::text), which can exceed the
         # source's statement_timeout on tables whose rows trigger slow validator functions. A
         # cancelled probe must degrade to DEFAULT_CHUNK_SIZE, not crash the whole import — the
         # streaming read loop has its own dedicated QueryCanceled handling.
         logger = structlog.get_logger()
 
-        with django_connection.cursor() as dj_cursor:
+        # Probe on an autocommit connection, mirroring how the real source runs estimation
+        # (`get_connection` sets `connection.autocommit = True`). statement_timeout is set at the
+        # session level rather than via SET LOCAL, which would need a surrounding transaction.
+        with autocommit_pg_connection.cursor() as cursor:
             # Tight timeout + a deliberately slow probe reproduces a real QueryCanceled.
-            dj_cursor.execute("SET LOCAL statement_timeout = '100ms'")
+            cursor.execute("SET statement_timeout = '100ms'")
             inner_query = sql.SQL("SELECT pg_sleep(3) AS c").format()
 
-            chunk_size = _get_table_chunk_size(cast(Any, dj_cursor), inner_query, logger)
+            chunk_size = _get_table_chunk_size(cast(Any, cursor), inner_query, logger)
             assert chunk_size == DEFAULT_CHUNK_SIZE
 
-            # Savepoint rollback leaves the connection usable for the rest of setup.
-            dj_cursor.execute("SELECT 1")
-            assert dj_cursor.fetchone()[0] == 1
+            # Autocommit isolates the cancelled probe in its own transaction, leaving the
+            # connection usable for the rest of setup.
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()[0] == 1
 
 
 class TestGetRowsToSync:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, cast
@@ -3338,7 +3339,7 @@ class TestOffsetChunkingServerCursorFallback:
 
             # Without the fix this raises `ServerCursor.__init__() missing 1 required
             # positional argument: 'name'`; with it, offset_chunking yields every row.
-            tables = list(response.items())
+            tables = list(cast(Iterable[Any], response.items()))
             assert sum(t.num_rows for t in tables) == 5
         finally:
             with setup_conn.cursor() as cur:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3268,3 +3268,79 @@ class TestRlsActiveFromConnErrorHandling:
             result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
         assert result == {}
         capture_mock.assert_called_once()
+
+
+class TestOffsetChunkingServerCursorFallback:
+    """Regression: the connection-dropped fallback must not crash on a ServerCursor factory.
+
+    On a non-read-replica source, `postgres_source.get_connection` sets the connection's
+    `cursor_factory` to `psycopg.ServerCursor`. When the server-cursor streaming path hits a
+    transient connection drop (e.g. `OperationalError: consuming input failed: SSL SYSCALL
+    error: EOF detected`), it falls back to `offset_chunking`, which opened an *unnamed*
+    `connection.cursor()` — raising `ServerCursor.__init__() missing 1 required positional
+    argument: 'name'` and crashing the very recovery it was supposed to perform.
+    """
+
+    @pytest.mark.django_db(transaction=True)
+    def test_recovers_via_offset_chunking_on_server_cursor_connection(self, monkeypatch):
+        sd = django_connection.settings_dict
+        conn_kwargs: dict[str, Any] = {
+            "host": sd["HOST"] or None,
+            "port": sd["PORT"] or None,
+            "dbname": sd["NAME"],
+            "user": sd["USER"] or None,
+            "password": sd["PASSWORD"] or None,
+        }
+        table = "test_offset_chunking_dropfix"
+
+        # Create + populate the table over a committed connection so the fresh connections
+        # `postgres_source` opens (discovery + streaming) can see the rows.
+        setup_conn = psycopg.connect(autocommit=True, **conn_kwargs)
+        try:
+            with setup_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {table}")
+                cur.execute(f"CREATE TABLE {table} (id BIGINT PRIMARY KEY, val TEXT)")
+                cur.execute(f"INSERT INTO {table} (id, val) SELECT g, 'row-' || g FROM generate_series(1, 5) g")
+
+            # Force the primary server-cursor path to fail with a connection-dropped error so
+            # the offset_chunking fallback runs. We patch the *method* on the real ServerCursor
+            # class (not the `psycopg.ServerCursor` attribute) on purpose: the named-cursor path
+            # resolves through `Connection.server_cursor_factory`, which is bound to the real
+            # class, so reassigning the attribute would leave the named cursor untouched and the
+            # drop would never fire. offset_chunking pages with a plain client cursor
+            # (`psycopg.Cursor`), so it stays unaffected by this patch.
+            def _raise_dropped(self, *args, **kwargs):
+                raise psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected")
+
+            monkeypatch.setattr(psycopg.ServerCursor, "execute", _raise_dropped)
+            # The cursor was never DECLAREd, so skip the server-side CLOSE round trip that would
+            # otherwise error and mask the injected failure on __exit__.
+            monkeypatch.setattr(psycopg.ServerCursor, "close", lambda self: None)
+
+            @contextmanager
+            def _tunnel_cm():
+                yield (conn_kwargs["host"], conn_kwargs["port"])
+
+            response = postgres_source(
+                tunnel=lambda: _tunnel_cm(),
+                user=conn_kwargs["user"],
+                password=conn_kwargs["password"],
+                database=conn_kwargs["dbname"],
+                sslmode="prefer",
+                schema="public",
+                table_names=[table],
+                should_use_incremental_field=True,
+                logger=structlog.get_logger(),
+                db_incremental_field_last_value=0,
+                incremental_field="id",
+                incremental_field_type=IncrementalFieldType.Integer,
+            )
+
+            # Without the fix this raises `ServerCursor.__init__() missing 1 required
+            # positional argument: 'name'`; with it, offset_chunking yields every row.
+            tables = list(response.items())
+            assert sum(t.num_rows for t in tables) == 5
+        finally:
+            with setup_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {table}")
+            setup_conn.close()


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports were crashing during their own transient-failure recovery. Error tracking surfaced an `OperationalError: consuming input failed: SSL SYSCALL error: EOF detected` (also `... SSL connection has been closed unexpectedly`) originating in `offset_chunking` in `posthog/temporal/data_imports/sources/postgres/postgres.py`, ~33 occurrences across multiple syncs over the past two weeks.

The SSL EOF is a transient connection drop and is correctly classified as retryable — the streaming path falls back to `offset_chunking` to resume. But the recovery itself then crashed: the sampled events carry a *chained* `TypeError: ServerCursor.__init__() missing 1 required positional argument: 'name'`, raised while handling the original `OperationalError`.

Root cause: on a non-read-replica source, `get_connection` sets the connection's `cursor_factory` to `psycopg.ServerCursor`. `offset_chunking` opened an **unnamed** `connection.cursor()`, which instantiates that factory without the required `name` argument and raises `TypeError`. So the very code meant to recover from a dropped connection blew up instead. (The sibling fallbacks in `partitioned_tables.py` open *named* cursors, so they were unaffected; the `SerializationFailure` fallback only runs on read replicas, where the factory is a plain cursor — which is why this only bit the connection-dropped path on a primary.)

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e6f35-1f26-7580-82c1-82960b543d27

## Changes

Open a client-side cursor via `psycopg.Cursor(connection)` in `offset_chunking` instead of `connection.cursor()`. Offset chunking pages with `LIMIT`/`OFFSET` and wants a client cursor regardless of the connection's factory — this mirrors the existing `psycopg.Cursor(connection)` used for the `SET statement_timeout` cursor in `get_connection`, which already documents this exact ServerCursor pitfall.

This is a fix to our recovery code, not a retryability change: the SSL EOF stays retryable (it's transient infra), it was never added to `NonRetryableErrors`, and `"consuming input failed"` remains in the connection-dropped substrings so the fallback keeps triggering — it just no longer crashes.

## How did you test this code?

I'm an agent; I did not perform manual product testing. I added an automated regression test, `TestOffsetChunkingServerCursorFallback`, that drives `postgres_source` end-to-end against a real Postgres table on a `ServerCursor`-factory connection, forces the primary server-cursor path to raise the connection-dropped error, and asserts the `offset_chunking` fallback yields all rows.

I ran this test against a local Postgres instance (outside the normal pytest harness, since this environment lacks the ClickHouse/`sqlx` services the repo's `django_db` conftest requires):
- **With the fix:** the fallback recovers and returns all rows.
- **With the fix reverted:** it reproduces the exact production failure — `TypeError: ServerCursor.__init__() missing 1 required positional argument: 'name'` — confirming the test guards the regression.

`ruff check` and `ruff format` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, pull the full stack trace, and find the chained `TypeError` that revealed the real bug behind the transient `OperationalError`.

Decision: treat as a fixable bug rather than a non-retryable error. The triggering SSL EOF is transient infrastructure (must stay retryable), so the fix targets the recovery code that mishandled the connection's `ServerCursor` factory. Chose `psycopg.Cursor(connection)` to match the established pattern already used a few lines up in `get_connection`, keeping the change minimal and consistent rather than introducing a helper.
