### PR TITLE
feat(funnels): restore compare labels + prototype anchored bins for ttc

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -293,7 +293,15 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                 lambda timings: self._run_time_to_convert_bounds(previous_funnel, timings),
             ]
         )
-        boundaries = compute_shared_bin_boundaries(current_bounds, previous_bounds, self.context.funnelsFilter.binCount)
+        if self._team_flag_funnels_compare_anchor_bins():
+            # Prototype binning: anchor on the current period alone, so the x-axis matches the
+            # no-compare view. The previous period is bucketed into those boundaries; conversions
+            # outside the current range fall off the histogram (their average is still reported).
+            boundaries = compute_shared_bin_boundaries(current_bounds, None, self.context.funnelsFilter.binCount)
+        else:
+            boundaries = compute_shared_bin_boundaries(
+                current_bounds, previous_bounds, self.context.funnelsFilter.binCount
+            )
 
         current_result, previous_result = self._run_in_parallel(
             [
@@ -400,6 +408,28 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
     def _team_flag_funnels_compare(self) -> bool:
         return posthoganalytics.feature_enabled(
             "product-analytics-funnels-compare",
+            str(self.team.uuid),
+            groups={
+                "organization": str(self.team.organization_id),
+                "project": str(self.team.id),
+            },
+            group_properties={
+                "organization": {"id": str(self.team.organization_id)},
+                "project": {"id": str(self.team.id)},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def _team_flag_funnels_compare_anchor_bins(self) -> bool:
+        """Prototype gate for the alternative TIME_TO_CONVERT compare binning strategy.
+
+        When enabled, both periods are bucketed on the *current* period's bin boundaries (matching
+        the no-compare view) instead of the union of both periods. Lets us A/B the two approaches
+        per team; defaults off (flag absent) to the union behaviour.
+        """
+        return posthoganalytics.feature_enabled(
+            "product-analytics-funnels-compare-anchor-bins",
             str(self.team.uuid),
             groups={
                 "organization": str(self.team.organization_id),

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
@@ -667,8 +667,18 @@ class TestFunnelTimeToConvertCompare(ClickhouseTestMixin, APIBaseTest):
             compareFilter=CompareFilter(compare=compare, compare_to=compare_to),
         )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_returns_two_histograms_on_shared_bins(self, _feature_enabled):
+    @staticmethod
+    def _only_flags(*enabled_flags: str):
+        """Build a `feature_enabled` side effect that returns True only for the listed flags.
+
+        Keeps the union vs anchor binning prototype independently controllable instead of flipping
+        every flag at once with a blanket `return_value=True`.
+        """
+        return lambda flag, *args, **kwargs: flag in enabled_flags
+
+    @patch("posthoganalytics.feature_enabled")
+    def test_compare_returns_two_histograms_on_shared_bins(self, mock_feature_enabled):
+        mock_feature_enabled.side_effect = self._only_flags("product-analytics-funnels-compare")
         # Current window 2021-06-07..06-13: one 600 s conversion.
         # Default previous window 2021-05-31..06-06: one 3600 s conversion.
         journeys_for(
@@ -703,4 +713,46 @@ class TestFunnelTimeToConvertCompare(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual([count for _, count in previous["bins"]], [0, 0, 1])
 
         self.assertEqual(current["average_conversion_time"], 600)
+        self.assertEqual(previous["average_conversion_time"], 3600)
+
+    @patch("posthoganalytics.feature_enabled")
+    def test_compare_anchors_bins_on_current_period_when_flagged(self, mock_feature_enabled):
+        # Prototype: with the anchor flag on, bins come from the current period alone.
+        mock_feature_enabled.side_effect = self._only_flags(
+            "product-analytics-funnels-compare",
+            "product-analytics-funnels-compare-anchor-bins",
+        )
+        # Same data as the shared-bin test: current 600 s conversion, previous 3600 s conversion.
+        journeys_for(
+            {
+                "current_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10, 0, 0)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 10, 10, 0)},
+                ],
+                "previous_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 1, 10, 0, 0)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 1, 11, 0, 0)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
+
+        current = next(r for r in results if r["compare_label"] == "current")
+        previous = next(r for r in results if r["compare_label"] == "previous")
+
+        # Boundaries are derived from the current period's single 600 s conversion (range collapses
+        # to one fallback-width bin), NOT the union [600, 3600] — that's the no-compare x-axis.
+        current_boundaries = [b[0] for b in current["bins"]]
+        previous_boundaries = [b[0] for b in previous["bins"]]
+        self.assertEqual(current_boundaries, previous_boundaries)
+        self.assertEqual(current_boundaries, [600, 660])
+
+        # Current 600 s conversion still lands in the first bin.
+        self.assertEqual([count for _, count in current["bins"]], [1, 0])
+        # The previous 3600 s conversion is outside the current-anchored range, so it drops out of
+        # the histogram — the documented trade-off of anchoring on the current period.
+        self.assertEqual([count for _, count in previous["bins"]], [0, 0])
+        # The average is computed over the full timings, so it still reflects the clipped conversion.
         self.assertEqual(previous["average_conversion_time"], 3600)

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -76,13 +76,14 @@ export function FunnelHistogramChart(): JSX.Element | null {
             dataAttr="funnel-histogram"
             onError={handleChartError}
         >
-            {/* Per-bar percentage labels only read cleanly with a single series; the grouped
-                compare view relies on tooltips (which label each period) instead. */}
-            {!isComparing && (
-                <ValueLabels
-                    valueFormatter={(_value, _seriesIndex, dataIndex) => histogramData.barLabels[dataIndex] ?? ''}
-                />
-            )}
+            {/* Each bar is labelled with its own period's share. In the grouped compare view the
+                overlay anchors per-bar (via the series key), so `seriesIndex` selects the matching
+                period's labels; dense bin counts may drop colliding labels (overlay handles that). */}
+            <ValueLabels
+                valueFormatter={(_value, seriesIndex, dataIndex) =>
+                    histogramData.barLabels[seriesIndex]?.[dataIndex] ?? ''
+                }
+            />
         </BarChart>
     )
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/funnelHistogramTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/funnelHistogramTransforms.test.ts
@@ -37,10 +37,10 @@ describe('buildFunnelHistogramData', () => {
         expect(labels).toEqual(['0s', '1m', '2m'])
     })
 
-    it('carries the per-bin percentage labels', () => {
+    it('carries the per-bin percentage labels for the single series', () => {
         const { barLabels } = buildFunnelHistogramData(bins)
 
-        expect(barLabels).toEqual(['60%', '30%', '10%'])
+        expect(barLabels).toEqual([['60%', '30%', '10%']])
     })
 
     it('applies the provided series color', () => {
@@ -59,7 +59,7 @@ describe('buildFunnelHistogramData', () => {
         const { series, labels, barLabels } = buildFunnelHistogramData([])
 
         expect(labels).toEqual([])
-        expect(barLabels).toEqual([])
+        expect(barLabels).toEqual([[]])
         expect(series[0].data).toEqual([])
     })
 
@@ -79,6 +79,18 @@ describe('buildFunnelHistogramData', () => {
         expect(series[1].color).toBe('#cccccc')
         // Shared bins: labels come from the (current) period's boundaries.
         expect(labels).toEqual(['0s', '1m', '2m'])
+    })
+
+    it('keeps each period’s percentage labels on its own series row when comparing', () => {
+        const { barLabels } = buildFunnelHistogramData(bins, {
+            color: '#1d4aff',
+            previous: { data: previousBins, color: '#cccccc' },
+        })
+
+        expect(barLabels).toEqual([
+            ['60%', '30%', '10%'],
+            ['40%', '50%', '10%'],
+        ])
     })
 
     it('stays single-series when no previous period is provided', () => {

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/funnelHistogramTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/funnelHistogramTransforms.ts
@@ -16,8 +16,9 @@ export interface FunnelHistogramData {
     series: Series[]
     /** Category labels — the lower bound of each duration bin, one per bar. */
     labels: string[]
-    /** Per-bar percentage label (share of total conversions), indexed to match `labels`. */
-    barLabels: string[]
+    /** Per-bar percentage label, keyed `barLabels[seriesIndex][dataIndex]` — one row per emitted
+     * series so grouped (compare) bars can label each period's own bar with its own share. */
+    barLabels: string[][]
 }
 
 /** Maps the funnel time-to-convert bins onto categorical hog-charts bar series.
@@ -37,6 +38,9 @@ export function buildFunnelHistogramData(
             color: options?.color,
         },
     ]
+    // Each series carries its own percentage labels (share of that period's conversions) so the
+    // value-label overlay can anchor the right label on each bar in the grouped compare view.
+    const barLabels: string[][] = [histogramGraphData.map((datum) => datum.label)]
 
     if (options?.previous) {
         series.push({
@@ -45,11 +49,12 @@ export function buildFunnelHistogramData(
             data: options.previous.data.map((datum) => datum.count),
             color: options.previous.color,
         })
+        barLabels.push(options.previous.data.map((datum) => datum.label))
     }
 
     return {
         labels: histogramGraphData.map((datum) => humanFriendlyDuration(datum.bin0, { maxUnits: 2 })),
-        barLabels: histogramGraphData.map((datum) => datum.label),
+        barLabels,
         series,
     }
 }


### PR DESCRIPTION
## Problem

Two follow-ups to the funnel TIME_TO_CONVERT compare work in #60157, both raised while reviewing it:

1. **Missing percentage labels.** The single-period histogram shows a percentage on top of each bar; the grouped compare view dropped them entirely. (And since tooltips are disabled in this chart, the compare view had _no_ per-bar readout at all — only bar height.)
2. **Bins differ from the no-compare view.** Compare computes bins over the *union* of both periods (sum of sample counts for the bin count, combined min/max for the range), so turning compare on changes the current period's x-axis. That's inherent to sharing an axis — but whether the current period's bins should stay stable is a genuine product decision worth being able to evaluate.

This PR is stacked on top of #60157 (`claude/brave-bose-423aab`).

## Changes

**1. Restore per-bar percentage labels in compare (fix)**

The value-label overlay already supports grouped bars — it anchors each label on its own bar via the series key (added in #58192). The only missing piece was per-series label data:

- `FunnelHistogramData.barLabels` becomes `string[][]`, keyed `[seriesIndex][dataIndex]`, so each period carries its own share labels.
- The `ValueLabels` formatter selects the matching period's labels by `seriesIndex`, and the overlay is no longer gated off when comparing.

Each bar now shows its own period's share of conversions. With dense bin counts the overlay's collision avoidance drops overlapping labels (same behavior as the single-series view).

**2. Prototype: current-period-anchored binning (feat, flag-gated)**

Adds an alternative binning strategy behind a new flag, `product-analytics-funnels-compare-anchor-bins`, so the two approaches can be compared per team:

| | Boundaries | Current period x-axis | Previous-period outliers |
|---|---|---|---|
| **Union** (default, today) | `min/max` + `cbrt(samples)` over both periods | changes when compare is toggled | always shown |
| **Anchored** (flag on) | current period alone (= no-compare view) | stable | clipped if outside current range (average still reported) |

Implementation reuses the existing, tested `compute_shared_bin_boundaries(current, None, …)` — no new bin math. Defaults off (flag absent → union behavior unchanged). To evaluate, create the flag and enable it for a team.

## How did you test this code?

I'm an agent (PostHog Code, Claude Opus 4.8). Automated tests I actually ran:

- **Frontend (jest, passing):** `funnelHistogramTransforms.test.ts` — updated the `barLabels` shape expectations and added a compare case asserting each period keeps its own label row; `funnelDataLogic.test.ts` (61 tests) still green.
- **Backend (pytest + ClickHouse, passing):** `TestFunnelTimeToConvertCompare` — updated the existing shared-bins test to gate the flag mock precisely (so it stays on the union path) and added `test_compare_anchors_bins_on_current_period_when_flagged`, which asserts the anchored x-axis (`[600, 660]`) and documents the previous-period clipping trade-off. Both pass individually (the local run is slow — ClickHouse cold start).
- **Types/lint:** `tsc` clean for the changed files (the only errors are pre-existing stale-kea-typegen in unrelated products); `ruff` + lint-staged `ty check` clean.

I did not run the app manually.

**Note for the reviewer:** the Storybook `FunnelHistogramChart--Compare` visual baseline will change (labels now render), so the visual-regression check will flag it and the baseline needs regenerating — I couldn't regenerate it locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated two questions about #60157 and implemented the follow-ups. Key decisions:

- **Labels:** confirmed via the chart library that grouped per-bar labels are supported (`ValueLabels.tsx` anchors by series key), so the original "relies on tooltips" rationale didn't hold (tooltips are off here). Went with per-series `barLabels` rather than re-deriving shares from band totals, since the percentages are already computed per period in `funnelDataLogic`.
- **Binning:** implemented the alternative as a flag-gated prototype rather than a replacement, so the team can A/B it. Reused the existing bin helper with `previous=None` so there's no second copy of the bin math to keep in sync.

Tools: PostHog Code (Claude Opus 4.8).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
