### PR TITLE
feat: Add export nudge to Web Analytics

### DIFF
--- a/common/tailwind/tailwind.config.js
+++ b/common/tailwind/tailwind.config.js
@@ -649,6 +649,7 @@ const config = {
                 'fade-out-delayed': 'fade-out-delayed 5s ease-out forwards',
                 // Quick horizontal shake
                 shake: 'shake 0.5s ease-in-out',
+                'slide-in-right': 'slide-in-right 0.28s cubic-bezier(0.16, 1, 0.3, 1)',
             },
             keyframes: {
                 'pulse-glow': {
@@ -669,6 +670,10 @@ const config = {
                     '40%': { transform: 'translateX(3px)' },
                     '60%': { transform: 'translateX(-2px)' },
                     '80%': { transform: 'translateX(2px)' },
+                },
+                'slide-in-right': {
+                    '0%': { opacity: '0', transform: 'translateX(calc(100% + 1.5rem))' },
+                    '100%': { opacity: '1', transform: 'translateX(0)' },
                 },
             },
             colors: {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -513,7 +513,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_PRECOMPUTE_TOGGLE: 'web-analytics-precompute-toggle', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
-    WEB_ANALYTICS_SHARE_NUDGE: 'web-analytics-share-nudge', // owner: @pauldambra #team-web-analytics multivariate=control,banner,prompt,button
+    WEB_ANALYTICS_SHARE_NUDGE_V2: 'web-analytics-share-nudge-v2', // owner: @jordanm-posthog #team-web-analytics multivariate=control,control_b,banner,export
     WEB_ANALYTICS_TILE_HEADER_V2: 'web-analytics-tile-header-v2', // owner: @jordanm-posthog #team-web-analytics multivariate=control,test
     WEB_ANALYTICS_TILE_SKELETONS: 'web-analytics-tile-skeletons', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_TILE_TOGGLES: 'web-analytics-tile-toggles', // owner: @lricoy #team-web-analytics

--- a/frontend/src/scenes/web-analytics/ShareNudgePrompt.tsx
+++ b/frontend/src/scenes/web-analytics/ShareNudgePrompt.tsx
@@ -8,33 +8,36 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { shareNudgeLogic } from 'scenes/web-analytics/shareNudgeLogic'
 
 export function ShareNudgePrompt(): JSX.Element | null {
-    const { promptVisible, promptAnchor } = useValues(shareNudgeLogic)
+    const { promptVisible, promptSource } = useValues(shareNudgeLogic)
     const { dismissForSession } = useActions(shareNudgeLogic)
 
-    if (!promptVisible || !promptAnchor) {
+    if (!promptVisible) {
         return null
     }
 
-    const left = Math.min(promptAnchor.x, window.innerWidth - 300)
-    const top = Math.min(promptAnchor.y + 8, window.innerHeight - 120)
-
     const handleShare = (): void => {
         void copyToClipboard(window.location.href, 'link to share')
-        posthog.capture('web analytics share link copied', { source: 'intent_prompt' })
+        posthog.capture('web analytics share link copied', { source: promptSource })
         dismissForSession()
     }
 
     return (
         <div
-            className="z-top fixed flex items-center gap-2 rounded border bg-surface-primary p-2 shadow-md"
-            style={{ left, top, maxWidth: 280 }}
+            className="animate-slide-in-right z-top fixed inset-y-0 right-6 my-auto flex h-fit w-[340px] max-w-[calc(100vw-2rem)] flex-col gap-2 rounded-lg border bg-surface-primary p-4 shadow-lg"
             data-attr="web-analytics-share-nudge-prompt"
         >
-            <span className="text-sm">Share this with a colleague?</span>
-            <LemonButton type="primary" size="xsmall" icon={<IconShare />} onClick={handleShare}>
-                Copy link
-            </LemonButton>
-            <LemonButton size="xsmall" icon={<IconX />} tooltip="Dismiss" onClick={dismissForSession} />
+            <div className="flex items-start justify-between gap-2">
+                <h4 className="m-0 text-base font-semibold">Share this view with a colleague</h4>
+                <LemonButton size="xsmall" icon={<IconX />} tooltip="Dismiss" onClick={dismissForSession} />
+            </div>
+            <p className="m-0 text-sm text-muted">
+                Web analytics is better with your team. Send this exact view so they see what you see.
+            </p>
+            <div className="flex">
+                <LemonButton type="primary" icon={<IconShare />} onClick={handleShare}>
+                    Copy link
+                </LemonButton>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsExport.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsExport.tsx
@@ -1,5 +1,9 @@
+import { useActions } from 'kea'
+
 import { IconCopy } from '@posthog/icons'
 import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
+
+import { shareNudgeLogic } from 'scenes/web-analytics/shareNudgeLogic'
 
 import { QuerySchema } from '~/queries/schema/schema-general'
 import { ExporterFormat, InsightLogicProps } from '~/types'
@@ -14,6 +18,7 @@ interface WebAnalyticsExportProps {
 
 export function WebAnalyticsExport({ query, insightProps }: WebAnalyticsExportProps): JSX.Element | null {
     const adapter = useWebTileExportAdapter(query, insightProps)
+    const { exportTriggered } = useActions(shareNudgeLogic)
 
     if (!adapter) {
         return null
@@ -22,6 +27,7 @@ export function WebAnalyticsExport({ query, insightProps }: WebAnalyticsExportPr
     const handleCopy = (format: ExporterFormat): void => {
         const tableData = adapter.toTableData()
         exportTableData(tableData, format)
+        exportTriggered()
     }
 
     return (

--- a/frontend/src/scenes/web-analytics/shareNudgeLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/shareNudgeLogic.test.ts
@@ -1,0 +1,141 @@
+import { MOCK_DEFAULT_ORGANIZATION } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { shareNudgeLogic } from './shareNudgeLogic'
+
+jest.mock('posthog-js')
+
+const FLAG = FEATURE_FLAGS.WEB_ANALYTICS_SHARE_NUDGE_V2
+
+function setVariant(variant: string): void {
+    featureFlagLogic.actions.setFeatureFlags([], { [FLAG]: variant })
+}
+
+function setMemberCount(memberCount: number): void {
+    organizationLogic.actions.loadCurrentOrganizationSuccess({
+        ...MOCK_DEFAULT_ORGANIZATION,
+        member_count: memberCount,
+    })
+}
+
+function capturesOf(event: string): any[][] {
+    return (posthog.capture as jest.Mock).mock.calls.filter(([name]) => name === event)
+}
+
+describe('shareNudgeLogic', () => {
+    let logic: ReturnType<typeof shareNudgeLogic.build>
+    let randomSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        initKeaTests()
+        featureFlagLogic.mount()
+        randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0)
+        ;(posthog.capture as jest.Mock).mockClear()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        featureFlagLogic.unmount()
+        jest.restoreAllMocks()
+    })
+
+    function mount(variant: string): void {
+        setVariant(variant)
+        logic = shareNudgeLogic()
+        logic.mount()
+        ;(posthog.capture as jest.Mock).mockClear()
+    }
+
+    it('shows the export prompt when variant is "export" and the probability gate passes', () => {
+        randomSpy.mockReturnValue(0.1)
+        mount('export')
+
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(true)
+        expect(logic.values.promptSource).toBe('export_prompt')
+        expect(capturesOf('web analytics share nudge prompt shown')).toEqual([
+            ['web analytics share nudge prompt shown', { source: 'export_prompt' }],
+        ])
+    })
+
+    it('does not show the prompt when the probability gate fails', () => {
+        randomSpy.mockReturnValue(0.9)
+        mount('export')
+
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(false)
+        expect(capturesOf('web analytics share nudge prompt shown')).toHaveLength(0)
+    })
+
+    it.each([['banner'], ['control'], ['control_b']])('does not show the prompt for the "%s" variant', (variant) => {
+        randomSpy.mockReturnValue(0)
+        mount(variant)
+
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(false)
+    })
+
+    it('does not show the prompt for a solo org even on the "export" variant', () => {
+        randomSpy.mockReturnValue(0)
+        setMemberCount(1)
+        mount('export')
+
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(false)
+    })
+
+    it('does not show the prompt when not enrolled in the flag', () => {
+        randomSpy.mockReturnValue(0)
+        featureFlagLogic.actions.setFeatureFlags([], {})
+        logic = shareNudgeLogic()
+        logic.mount()
+
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(false)
+    })
+
+    it('does not show the prompt once dismissed for the session', () => {
+        randomSpy.mockReturnValue(0)
+        mount('export')
+
+        logic.actions.dismissForSession()
+        logic.actions.exportTriggered()
+
+        expect(logic.values.promptVisible).toBe(false)
+    })
+
+    it('dismissForSession hides an open export prompt', async () => {
+        randomSpy.mockReturnValue(0)
+        mount('export')
+
+        logic.actions.exportTriggered()
+        expect(logic.values.promptVisible).toBe(true)
+
+        await expectLogic(logic, () => {
+            logic.actions.dismissForSession()
+        }).toMatchValues({ promptVisible: false, sessionDismissed: true })
+    })
+
+    it('captures the exposure event once for the "export" variant', () => {
+        setVariant('export')
+        logic = shareNudgeLogic()
+        logic.mount()
+
+        expect(capturesOf('web analytics share nudge exposed')).toEqual([
+            ['web analytics share nudge exposed', { variant: 'export' }],
+        ])
+    })
+})

--- a/frontend/src/scenes/web-analytics/shareNudgeLogic.ts
+++ b/frontend/src/scenes/web-analytics/shareNudgeLogic.ts
@@ -8,14 +8,10 @@ import { organizationLogic } from 'scenes/organizationLogic'
 
 import type { shareNudgeLogicType } from './shareNudgeLogicType'
 
-const FLAG = FEATURE_FLAGS.WEB_ANALYTICS_SHARE_NUDGE
+const FLAG = FEATURE_FLAGS.WEB_ANALYTICS_SHARE_NUDGE_V2
 const DASHBOARD_SELECTOR = '[data-attr="web-analytics-dashboard"]'
 const HOVER_DWELL_MS = 2500
-
-export interface PromptAnchor {
-    x: number
-    y: number
-}
+const EXPORT_PROMPT_PROBABILITY = 0.25
 
 export const shareNudgeLogic = kea<shareNudgeLogicType>([
     path(['scenes', 'web-analytics', 'shareNudgeLogic']),
@@ -23,8 +19,9 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
         values: [organizationLogic, ['currentOrganization'], featureFlagLogic, ['featureFlags']],
     })),
     actions({
-        showPrompt: (anchor: PromptAnchor) => ({ anchor }),
+        showPrompt: (source: string) => ({ source }),
         dismissForSession: true,
+        exportTriggered: true,
     }),
     reducers({
         promptVisible: [
@@ -34,10 +31,10 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
                 dismissForSession: () => false,
             },
         ],
-        promptAnchor: [
-            null as PromptAnchor | null,
+        promptSource: [
+            null as string | null,
             {
-                showPrompt: (_, { anchor }) => anchor,
+                showPrompt: (_, { source }) => source,
             },
         ],
         sessionDismissed: [
@@ -65,10 +62,20 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
         ],
         emphasizeShareButton: [(s) => [s.variant], (variant): boolean => variant === 'button'],
         intentPromptEnabled: [(s) => [s.variant], (variant): boolean => variant === 'prompt'],
+        exportPromptEnabled: [(s) => [s.variant], (variant): boolean => variant === 'export'],
     }),
-    listeners(() => ({
-        showPrompt: () => {
-            posthog.capture('web analytics share nudge prompt shown')
+    listeners(({ values, actions }) => ({
+        showPrompt: ({ source }) => {
+            posthog.capture('web analytics share nudge prompt shown', { source })
+        },
+        exportTriggered: () => {
+            if (!values.exportPromptEnabled || values.sessionDismissed) {
+                return
+            }
+            if (Math.random() >= EXPORT_PROMPT_PROBABILITY) {
+                return
+            }
+            actions.showPrompt('export_prompt')
         },
     })),
     subscriptions(({ values, actions, cache }) => ({
@@ -100,8 +107,7 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
                     if (!container || !container.contains(selection.anchorNode)) {
                         return
                     }
-                    const rect = selection.getRangeAt(0).getBoundingClientRect()
-                    actions.showPrompt({ x: rect.left, y: rect.bottom })
+                    actions.showPrompt('intent_prompt')
                 }
 
                 const onMouseMove = (event: MouseEvent): void => {
@@ -110,12 +116,10 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
                         cache.disposables.dispose('shareNudgeHoverDwell')
                         return
                     }
-                    const x = event.clientX
-                    const y = event.clientY
                     cache.disposables.add(() => {
                         const timer = setTimeout(() => {
                             if (shouldTrigger()) {
-                                actions.showPrompt({ x, y })
+                                actions.showPrompt('intent_prompt')
                             }
                         }, HOVER_DWELL_MS)
                         return () => clearTimeout(timer)

--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
@@ -20,6 +20,7 @@ import {
 import { ExporterFormat, InsightLogicProps } from '~/types'
 
 import { TileId, WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
+import { shareNudgeLogic } from './shareNudgeLogic'
 import {
     CalendarHeatmapAdapter,
     ExportAdapter,
@@ -96,6 +97,7 @@ export function useWebTileOverflowMenuItems({
 }: UseWebTileOverflowMenuItemsArgs): LemonMenuItem[] {
     const effectiveInsightProps = insightProps ?? NO_ACTIVE_TAB_INSIGHT_PROPS
     const { openModal } = useActions(webAnalyticsModalLogic)
+    const { exportTriggered } = useActions(shareNudgeLogic)
     const adapter = useWebTileExportAdapter(query, effectiveInsightProps)
 
     return useMemo(() => {
@@ -114,6 +116,7 @@ export function useWebTileOverflowMenuItems({
                         return
                     }
                     exportTableData(adapter.toTableData(), ExporterFormat.CSV)
+                    exportTriggered()
                 },
             },
             {
@@ -146,7 +149,7 @@ export function useWebTileOverflowMenuItems({
         }
 
         return items
-    }, [tileId, tabId, query, canOpenModal, openModal, adapter, extraMenuItems])
+    }, [tileId, tabId, query, canOpenModal, openModal, adapter, extraMenuItems, exportTriggered])
 }
 
 export type WebTileOpenInsightProps = Required<Pick<LemonButtonProps, 'to' | 'onClick'>>


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
Not sure the best way to get users to invite their co-workers to Web Analytics.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Try an on-share nudge! Maybe it will work... maybe it won't. Let's find out.

https://github.com/user-attachments/assets/e413a5ac-a8d1-44d0-9c62-f5be57c6741c



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally clicked around
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
