### PR TITLE
fix(replay): don't show '100% with any matching' banner when sample rate is the default

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -37,13 +37,14 @@ function AnyWith100SamplingWarning({
     const { urlTriggerConfig, eventTriggerConfig } = useValues(replayTriggersLogic)
 
     const matchType = currentTeam?.session_recording_trigger_match_type_config || 'all'
-    const sampleRate = toDisplaySampleRate(currentTeam?.session_recording_sample_rate)
+    const storedSampleRate = currentTeam?.session_recording_sample_rate
+    const sampleRate = toDisplaySampleRate(storedSampleRate)
     const hasOtherCondition =
         (urlTriggerConfig?.length ?? 0) > 0 ||
         (eventTriggerConfig?.length ?? 0) > 0 ||
         !!currentTeam?.session_recording_linked_flag
 
-    if (matchType !== 'any' || sampleRate !== 100 || !hasOtherCondition) {
+    if (matchType !== 'any' || sampleRate !== 100 || storedSampleRate == null || !hasOtherCondition) {
         return null
     }
 
@@ -242,6 +243,8 @@ function Sampling(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
 
+    const storedSampleRate = currentTeam?.session_recording_sample_rate
+
     return (
         <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING}>
             <div className="flex flex-col gap-2">
@@ -254,9 +257,10 @@ function Sampling(): JSX.Element {
                             ios={{ version: '3.42.0' }}
                             reactNative={{ version: '4.37.0' }}
                         />
+                        {storedSampleRate == null && <span className="text-muted font-normal"> (default)</span>}
                     </LemonLabel>
                     <IngestionControls.SamplingTrigger
-                        initialSampleRate={toDisplaySampleRate(currentTeam?.session_recording_sample_rate)}
+                        initialSampleRate={toDisplaySampleRate(storedSampleRate)}
                         onChange={(v) => updateCurrentTeam({ session_recording_sample_rate: v.toString() })}
                     />
                 </div>
@@ -269,7 +273,8 @@ function Sampling(): JSX.Element {
 function MobileSampling(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
 
-    const sampleRate = toDisplaySampleRate(currentTeam?.session_recording_sample_rate)
+    const storedSampleRate = currentTeam?.session_recording_sample_rate
+    const sampleRate = toDisplaySampleRate(storedSampleRate)
 
     return (
         <div className="flex flex-col gap-2">
@@ -283,7 +288,9 @@ function MobileSampling(): JSX.Element {
                     />
                 </LemonLabel>
                 <Tooltip title="Sample rate is shared across web and mobile. Change it on the Web tab.">
-                    <span className="text-muted font-semibold">{sampleRate}%</span>
+                    <span className="text-muted font-semibold">
+                        {sampleRate}%{storedSampleRate == null && <span className="font-normal"> (default)</span>}
+                    </span>
                 </Tooltip>
             </div>
             <p className="text-muted-alt">


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

sigh  
when the sampling rate has never been set its actually "null" and the frontend translates that to 100%  
but this problem only manifests when its 100%

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

account for "null" sampling rate for this warning banner

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->