### PR TITLE
fix(postgres): treat missing-table partition probe as non-capturing noise

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1443,6 +1443,15 @@ def _get_partition_settings(
         cursor.execute(query)
     except psycopg.errors.QueryCanceled:
         raise
+    except psycopg.errors.UndefinedTable as e:
+        # The selected table was dropped or renamed in the source between schema discovery and
+        # this best-effort partition-sizing probe. That's a user/upstream condition we already
+        # tolerate here (return None -> no partitioning), and the real extraction query — which
+        # shares this FROM clause — hits the same missing relation and surfaces it through the
+        # normal non-retryable path ("does not exist"). Capturing it here too would only flood
+        # error tracking with handled duplicates, so mirror `_get_rows_to_sync` and log at debug.
+        logger.debug(f"_get_partition_settings: table does not exist, returning None: {e}")
+        return None
     except Exception as e:
         # A read replica can cancel this best-effort sizing query with a recovery conflict; it's
         # transient (the row-streaming reader retries it in-process) and expected on replicas, so

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1840,6 +1840,22 @@ class TestGetPartitionSettings:
             assert result is not None
             assert result.partition_size > 0
 
+    def test_missing_table_falls_back_to_none_without_capturing(self):
+        # The selected table was dropped/renamed before this best-effort probe, so psycopg raises
+        # UndefinedTable (42P01). The real extraction query surfaces "does not exist" through the
+        # non-retryable path, so this helper must degrade quietly (None) instead of flooding error
+        # tracking with a handled duplicate.
+        logger = structlog.get_logger()
+
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = psycopg.errors.UndefinedTable('relation "public.store_source" does not exist')
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+            result = _get_partition_settings(cast(Any, cursor), "public", "store_source", logger, is_partitioned=False)
+
+        assert result is None
+        mock_capture.assert_not_called()
+
     def test_reuses_passed_is_partitioned_flag(self):
         # When the caller already knows the table is partitioned, skip re-detecting it.
         logger = structlog.get_logger()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `UndefinedTable` issue from the Postgres data-warehouse import source:

> `relation "public.store_source" does not exist`
> `LINE 6: FROM "public"."store_source"`

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019ecd5d-1455-74c3-af57-be980bee4021) — captured via `posthog-python`, top in-app frame `_get_partition_settings` in `posthog/temporal/data_imports/sources/postgres/postgres.py`.

The selected table was dropped or renamed in the source database between schema discovery and sync. That is a **user/upstream condition**, not a bug in our query — and the pipeline already handles it correctly: `"does not exist"` is in the source's `NonRetryableErrors`, so the real extraction stops retrying with an actionable message.

The noise comes from a *best-effort* helper. `_get_partition_settings` runs a `pg_table_size`/`COUNT(*)` probe to size Delta partitions. Its fallback `except` clause already degrades gracefully (returns `None` → no partitioning), but it *also* called `capture_exception(e)` on every error — including this missing-table case. So a condition we already tolerate gets reported to error tracking as a handled duplicate of the failure the real read already classifies.

## Changes

Add an `except psycopg.errors.UndefinedTable` branch to `_get_partition_settings` that logs at debug and returns `None` **without** capturing. The probe shares its `FROM` clause with the real extraction query, so any genuine table-level problem still resurfaces there and flows through the normal non-retryable path. This mirrors the sibling `_get_rows_to_sync` helper, which deliberately does not capture handled user/upstream conditions for the same documented reason. Genuinely unexpected errors are still captured via the existing generic `except`.

Matching on the `psycopg.errors.UndefinedTable` exception type (SQLSTATE `42P01`) is stable and low-false-positive — no reliance on volatile message text, table names, or ids.

Scope is deliberately narrow: no change to retry policy, `NonRetryableErrors`, or the extraction path.

## How did you test this code?

I'm an agent (Claude Code). Automated test only — I did not run a live sync.

- Added a regression test `TestGetPartitionSettings::test_missing_table_falls_back_to_none_without_capturing` that drives `_get_partition_settings` with a cursor raising `UndefinedTable` and asserts it returns `None` and `capture_exception` is **not** called. Confirmed it fails before the fix's intent (capture would fire) and passes after.
- Ran the hermetic (non-DB) tests in `TestGetPartitionSettings` — pass. The DB-backed tests in the class require a Postgres test database not available in this sandbox.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged the error-tracking issue with the PostHog MCP, traced the stack to `_get_partition_settings` line 1400, and confirmed the `except` there captures-and-handles rather than crashes. Decided this is a noisy capture of a user/upstream condition (table dropped/renamed) rather than a new `NonRetryableErrors` entry — `"does not exist"` is already non-retryable, and the established in-file pattern (`_get_rows_to_sync`, `_rls_active_from_conn`) is to not flood error tracking with handled duplicates. Chose to suppress capture only for the specific `UndefinedTable` type so genuine partition-sizing bugs stay visible.
