### PR TITLE
fix(trends): hide moving-average overlay when its series is toggled off

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.test.ts
@@ -231,6 +231,15 @@ describe('trendsChartTransforms', () => {
                 expect(out.movingAverage).toEqual([{ seriesKey: 'a', window: 3 }])
             })
 
+            it('skips hidden results so a toggled-off series has no MA overlay', () => {
+                const out = buildDerivedConfigs([makeResult({ id: 'a' }), makeResult({ id: 'b' })], {
+                    showMovingAverage: true,
+                    movingAverageIntervals: 3,
+                    getHidden: (r) => r.id === 'b',
+                })
+                expect(out.movingAverage).toEqual([{ seriesKey: 'a', window: 3 }])
+            })
+
             it('omits movingAverage when movingAverageIntervals is undefined', () => {
                 expect(buildDerivedConfigs([makeResult()], { showMovingAverage: true }).movingAverage).toBeUndefined()
             })
@@ -326,6 +335,15 @@ describe('trendsChartTransforms', () => {
                     movingAverageIntervals: 3,
                 })
                 expect(out.comparisonOf).toEqual({ '1': '1', '1-ma': '1' })
+            })
+
+            it('omits the MA-of-previous key when the previous result is hidden', () => {
+                const out = buildDerivedConfigs([makeResult({ id: 1, compare: true, compare_label: 'previous' })], {
+                    showMovingAverage: true,
+                    movingAverageIntervals: 3,
+                    getHidden: () => true,
+                })
+                expect(out.comparisonOf).toEqual({ '1': '1' })
             })
 
             it('omits the MA-of-previous key when the result is too short for an MA series', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -124,6 +124,7 @@ export function buildDerivedConfigs<R extends TrendsResultLike>(
     if (includeMa) {
         const window = opts.movingAverageIntervals as number
         out.movingAverage = results
+            .filter((r) => !opts.getHidden?.(r))
             .filter((r) => r.data.length >= window)
             .map((r) => ({ seriesKey: String(r.id), window }))
     }
@@ -156,7 +157,7 @@ export function buildDerivedConfigs<R extends TrendsResultLike>(
             // Self-map: applyComparisonDimming only checks key presence; the paired primary
             // id isn't carried on TrendsResultLike.
             comparisonOf[key] = key
-            if (includeMa && r.data.length >= (opts.movingAverageIntervals as number)) {
+            if (includeMa && !opts.getHidden?.(r) && r.data.length >= (opts.movingAverageIntervals as number)) {
                 comparisonOf[movingAverageKey(key)] = key
             }
         }


### PR DESCRIPTION
## Problem

In a Trends line chart rendered by the new quill-charts renderer (`TrendsLineChart`, behind the `product-analytics-hog-charts-trends` feature flag), enabling **Moving average** and then unchecking a series in the legend hid the series' main line but left its moving-average overlay line on the chart. The overlay should disappear together with its series.

This is a customer-reported regression specific to the new renderer (support ticket #60214). The legacy Chart.js `ActionsLineGraph` handles it correctly because it builds the MA overlay as a clone of the parent dataset, so the overlay inherits the hide.

## Changes

In `buildDerivedConfigs` (`products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts`), the moving-average config was built from all results with no visibility check, while the sibling `showTrendLines` block in the same function already skips hidden series via `getHidden`. That asymmetry was the bug.

- Filter hidden series out of `out.movingAverage`, mirroring the trend-lines block.
- Apply the same `getHidden` guard to the `comparisonOf[movingAverageKey(...)]` registration, so a hidden compare-to-previous series doesn't leave a dangling comparison-dimming entry for an overlay that no longer renders. The primary self-map entry is left untouched, so base compare-to-previous dimming for visible series is preserved.

Scoped intentionally to the app-level transform rather than the shared `@posthog/quill-charts` package: the fix matches the existing trend-lines mechanism already in this function, keeping the blast radius to one product file.

_Frontend change — verified visually on a local instance (screenshot in the PR thread): with two of three series toggled off in the legend, only the visible series keeps its dashed moving-average overlay._

## How did you test this code?

I'm an agent (PostHog Code). Testing performed:

- **Automated:** added two unit tests to `trendsChartTransforms.test.ts` — one asserting a hidden series produces no `movingAverage` entry, one asserting the MA-of-previous `comparisonOf` key is dropped for a hidden compare-previous series. Ran the full file: **56 passed** (`hogli test .../trendsChartTransforms.test.ts`).
- **Manual (by the human driver):** verified on a local instance with a 3-series daily Trends line chart and a 7-day moving average — toggling a series off in the legend now removes both its line and its MA overlay, and re-checking restores both.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed initially in a separate Claude Code session (root-cause write-up handed off), then re-verified against current `master`, implemented, and tested in PostHog Code. Tools used: Read/Edit/Bash/Grep, the `code-reviewer` subagent (reviewed the diff, approved with no critical issues), and a local ClickHouse/Postgres inspection to build a representative test insight from the Hedgebox demo data.

Key decision: fix at the app transform layer (filter hidden series) rather than propagating an `excluded` flag through the shared quill MA series builder. The shared package has the same asymmetry — CI series propagate `excluded`, MA series don't — but the trend-lines path in this same function already solves it by app-level filtering, so matching that keeps the change minimal and consistent without touching shared chart code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

