### PR TITLE
chore(cohorts): remove cohort-calculation-history feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -249,7 +249,6 @@ export const FEATURE_FLAGS = {
     CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-workflows
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp
     CDP_VERCEL_LOG_DRAIN: 'cdp-vercel-log-drain', // owner: #team-workflows-cdp
-    COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
     COHORT_INLINE_CALCULATION: 'inline-cohort-calculation', // owner: #team-analytics-platform, inlines fast dynamic cohort queries instead of using precomputed cohortpeople table
     COHORTS_TAXONOMIC_BASIC_LIST: 'cohorts-taxonomic-basic-list', // owner: @adamleith, picker sends ?basic=true to the cohorts list endpoint (trimmed payload: no filters/query/groups)
     CONDENSED_FILTER_BAR: 'condensed_filter_bar', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/cohorts/CohortCalculationHistory.tsx
+++ b/frontend/src/scenes/cohorts/CohortCalculationHistory.tsx
@@ -32,24 +32,12 @@ export function CohortCalculationHistory(props: CohortCalculationHistoryProps): 
     const cohortId = props.id && props.id !== 'new' ? parseInt(props.id) : 0
 
     const logic = cohortCalculationHistorySceneLogic({ cohortId })
-    const {
-        calculationHistory,
-        calculationHistoryResponseLoading,
-        cohort,
-        cohortMissing,
-        totalRecords,
-        page,
-        limit,
-        hasCalculationHistoryAccess,
-    } = useValues(logic)
+    const { calculationHistory, calculationHistoryResponseLoading, cohort, cohortMissing, totalRecords, page, limit } =
+        useValues(logic)
     const { setPage } = useActions(logic)
 
     if (!cohortId || cohortId <= 0) {
         return <div>Invalid cohort ID: {cohortId}. Please ensure you're visiting a valid cohort.</div>
-    }
-
-    if (!hasCalculationHistoryAccess) {
-        return <NotFound object="page" />
     }
 
     if (cohortMissing) {

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -258,7 +258,7 @@ export function CohortEdit({ id, attachTo }: CohortEditProps): JSX.Element {
                             </ButtonPrimitive>
                         )}
 
-                        {!cohort.is_static && featureFlags[FEATURE_FLAGS.COHORT_CALCULATION_HISTORY] && (
+                        {!cohort.is_static && (
                             <ButtonPrimitive
                                 onClick={() => router.actions.push(urls.cohortCalculationHistory(cohort.id))}
                                 disabledReasons={{

--- a/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
+++ b/frontend/src/scenes/cohorts/CohortSceneMenuBar.tsx
@@ -37,7 +37,6 @@ function CohortSceneMenuBarInner({ id }: { id?: CohortType['id'] }): JSX.Element
     const { cohort, cohortLoading } = useValues(logic)
     const { duplicateCohort, deleteCohort, restoreCohort } = useActions(logic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!cohort) {
         return null
@@ -77,7 +76,7 @@ function CohortSceneMenuBarInner({ id }: { id?: CohortType['id'] }): JSX.Element
                         Copy to another project
                     </SceneMenuBarItem>
                 )}
-                {!isNewCohort && !cohort.is_static && !!featureFlags[FEATURE_FLAGS.COHORT_CALCULATION_HISTORY] && (
+                {!isNewCohort && !cohort.is_static && (
                     <SceneMenuBarItem
                         onClick={() => router.actions.push(urls.cohortCalculationHistory(cohort.id))}
                         data-attr={`${RESOURCE_TYPE}-menubar-calculation-history`}

--- a/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.test.ts
@@ -2,9 +2,6 @@ import { api } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { mockCohort } from '~/test/mocks'
@@ -279,35 +276,6 @@ describe('cohortCalculationHistorySceneLogic', () => {
             }).toFinishAllListeners()
 
             expect(api.get).toHaveBeenLastCalledWith('api/cohort/789/calculation_history/?limit=25&offset=50')
-        })
-    })
-
-    describe('feature flag access control', () => {
-        it('should return true for hasCalculationHistoryAccess when feature flag is enabled', async () => {
-            await initLogic({ cohortId: 123 })
-
-            // Mock feature flags with COHORT_CALCULATION_HISTORY enabled
-            featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.COHORT_CALCULATION_HISTORY]: true })
-
-            expect(logic.values.hasCalculationHistoryAccess).toBe(true)
-        })
-
-        it('should return false for hasCalculationHistoryAccess when feature flag is disabled', async () => {
-            await initLogic({ cohortId: 123 })
-
-            // Mock feature flags with COHORT_CALCULATION_HISTORY disabled
-            featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.COHORT_CALCULATION_HISTORY]: false })
-
-            expect(logic.values.hasCalculationHistoryAccess).toBe(false)
-        })
-
-        it('should return false for hasCalculationHistoryAccess when feature flag is undefined', async () => {
-            await initLogic({ cohortId: 123 })
-
-            // Mock feature flags without COHORT_CALCULATION_HISTORY
-            featureFlagLogic.actions.setFeatureFlags([], {})
-
-            expect(logic.values.hasCalculationHistoryAccess).toBe(false)
         })
     })
 })

--- a/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortCalculationHistorySceneLogic.ts
@@ -1,9 +1,7 @@
-import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import type { cohortCalculationHistorySceneLogicType } from './cohortCalculationHistorySceneLogicType'
 
@@ -47,10 +45,6 @@ export const cohortCalculationHistorySceneLogic = kea<cohortCalculationHistorySc
     props({} as CohortCalculationHistorySceneLogicProps),
     key(({ cohortId }) => String(cohortId)),
     path((key) => ['scenes', 'cohorts', 'cohortCalculationHistorySceneLogic', key]),
-
-    connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
-    })),
 
     actions({
         setPage: (page: number) => ({ page }),
@@ -139,10 +133,6 @@ export const cohortCalculationHistorySceneLogic = kea<cohortCalculationHistorySc
         totalRecords: [
             (s) => [s.calculationHistoryResponse],
             (response: CohortCalculationHistoryResponse): number => response.count,
-        ],
-        hasCalculationHistoryAccess: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.COHORT_CALCULATION_HISTORY],
         ],
     }),
 


### PR DESCRIPTION
## Problem

The cohort calculation history feature is fully rolled out. The `cohort-calculation-history` flag gate can be removed.

## Changes

- Removes `COHORT_CALCULATION_HISTORY` from `FEATURE_FLAGS` in `constants.tsx`
- Removes the flag check from the calculation history button in `CohortEdit.tsx` and `CohortSceneMenuBar.tsx`
- Removes the flag-gated `<NotFound>` guard in `CohortCalculationHistory.tsx`
- Removes the `hasCalculationHistoryAccess` selector and `featureFlagLogic` connection from `cohortCalculationHistorySceneLogic.ts`
- Removes the flag access control tests from `cohortCalculationHistorySceneLogic.test.ts`
- Fixes the alphabetical position of `INSIGHT_SUBSCRIBE_PROMINENT_BUTTON` in `constants.tsx` (it was out of order from a prior merge)

## How did you test this code?

The existing tests in `cohortCalculationHistorySceneLogic.test.ts` cover pagination, data loading, and cohort lookup. The deleted tests covered the removed flag access control and are no longer relevant.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes needed.