### PR TITLE
chore(flags): remove schedule-feature-flag-variants-update feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -463,7 +463,6 @@ export const FEATURE_FLAGS = {
     SCENE_ALERTS_LABEL_EXPERIMENT: 'scene-alerts-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,get-notified,monitor-changes,set-up-alert
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection
     SCENE_SUBSCRIBE_LABEL_EXPERIMENT: 'scene-subscribe-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,recurring-updates,scheduled-notifications,scheduled-reports
-    SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_ENFORCEMENT_REJECT: 'schema-enforcement-reject', // owner: @aspicer, gates the ability to set schema enforcement mode to "reject"
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer
     SEARCH_DEBOUNCE_ALL: 'search-debounce-all', // owner: @adamleithp #team-platform-ux

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -25,11 +25,9 @@ import {
 } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { hasFormErrors, shortTimeZone } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -456,7 +454,6 @@ export default function FeatureFlagSchedule(): JSX.Element {
         saveEdit,
     } = useActions(featureFlagScheduleEditLogic({ id: featureFlag.id ?? 'new' }))
     const { aggregationLabel } = useValues(groupsModel)
-    const { featureFlags } = useValues(enabledFeaturesLogic)
 
     const aggregationGroupTypeIndex = featureFlag.filters.aggregation_group_type_index
     const scheduleFilters = { ...schedulePayload.filters, aggregation_group_type_index: aggregationGroupTypeIndex }
@@ -472,11 +469,9 @@ export default function FeatureFlagSchedule(): JSX.Element {
 
     const supportsRecurring = RECURRING_SUPPORTED_OPERATIONS.has(scheduledChangeOperation)
 
-    // Available change type options (gate UpdateVariants behind feature flag)
+    // UpdateVariants is only available for multivariate flags
     const availableOptions = CHANGE_TYPE_OPTIONS.filter(
-        (opt) =>
-            opt.value !== ScheduledChangeOperationType.UpdateVariants ||
-            (featureFlags[FEATURE_FLAGS.SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE] && featureFlag.filters.multivariate)
+        (opt) => opt.value !== ScheduledChangeOperationType.UpdateVariants || featureFlag.filters.multivariate
     )
 
     return (
@@ -803,62 +798,51 @@ export default function FeatureFlagSchedule(): JSX.Element {
                             </div>
                         </div>
                     )}
-                    {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
-                        featureFlags[FEATURE_FLAGS.SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE] && (
-                            <div className="rounded border p-3">
-                                <FeatureFlagVariantsForm
-                                    variants={displayVariants}
-                                    payloads={displayPayloads}
-                                    onAddVariant={() => {
-                                        const { variants: currentVariants, payloads: currentPayloads } =
-                                            getScheduledVariantsPayloads(featureFlag, schedulePayload)
-                                        const newVariants = [
-                                            ...currentVariants,
-                                            { key: '', name: '', rollout_percentage: 0 },
-                                        ]
-                                        setSchedulePayload(null, null, null, newVariants, currentPayloads)
-                                    }}
-                                    onRemoveVariant={(index) => {
-                                        const { variants: currentVariants, payloads: currentPayloads } =
-                                            getScheduledVariantsPayloads(featureFlag, schedulePayload)
-                                        const newVariants = currentVariants.filter((_, i) => i !== index)
-                                        const newPayloads = { ...currentPayloads }
+                    {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants && (
+                        <div className="rounded border p-3">
+                            <FeatureFlagVariantsForm
+                                variants={displayVariants}
+                                payloads={displayPayloads}
+                                onAddVariant={() => {
+                                    const newVariants = [
+                                        ...displayVariants,
+                                        { key: '', name: '', rollout_percentage: 0 },
+                                    ]
+                                    setSchedulePayload(null, null, null, newVariants, displayPayloads)
+                                }}
+                                onRemoveVariant={(index) => {
+                                    const newVariants = displayVariants.filter((_, i) => i !== index)
+                                    const newPayloads = { ...displayPayloads }
+                                    delete newPayloads[index]
+                                    setSchedulePayload(null, null, null, newVariants, newPayloads)
+                                }}
+                                onDistributeEqually={() => {
+                                    const equalPercentage = Math.floor(100 / displayVariants.length)
+                                    const remainder = 100 - equalPercentage * displayVariants.length
+                                    const distributedVariants = displayVariants.map((variant, index) => ({
+                                        ...variant,
+                                        rollout_percentage: equalPercentage + (index === 0 ? remainder : 0),
+                                    }))
+                                    setSchedulePayload(null, null, null, distributedVariants, displayPayloads)
+                                }}
+                                onVariantChange={(index, field, value) => {
+                                    const newVariants = [...displayVariants]
+                                    newVariants[index] = { ...newVariants[index], [field]: value }
+                                    setSchedulePayload(null, null, null, newVariants, displayPayloads)
+                                }}
+                                onPayloadChange={(index, value) => {
+                                    const newPayloads = { ...displayPayloads }
+                                    if (value === undefined) {
                                         delete newPayloads[index]
-                                        setSchedulePayload(null, null, null, newVariants, newPayloads)
-                                    }}
-                                    onDistributeEqually={() => {
-                                        const { variants: currentVariants, payloads: currentPayloads } =
-                                            getScheduledVariantsPayloads(featureFlag, schedulePayload)
-                                        const equalPercentage = Math.floor(100 / currentVariants.length)
-                                        const remainder = 100 - equalPercentage * currentVariants.length
-                                        const distributedVariants = currentVariants.map((variant, index) => ({
-                                            ...variant,
-                                            rollout_percentage: equalPercentage + (index === 0 ? remainder : 0),
-                                        }))
-                                        setSchedulePayload(null, null, null, distributedVariants, currentPayloads)
-                                    }}
-                                    onVariantChange={(index, field, value) => {
-                                        const { variants: currentVariants, payloads: currentPayloads } =
-                                            getScheduledVariantsPayloads(featureFlag, schedulePayload)
-                                        const newVariants = [...currentVariants]
-                                        newVariants[index] = { ...newVariants[index], [field]: value }
-                                        setSchedulePayload(null, null, null, newVariants, currentPayloads)
-                                    }}
-                                    onPayloadChange={(index, value) => {
-                                        const { variants: currentVariants, payloads: currentPayloads } =
-                                            getScheduledVariantsPayloads(featureFlag, schedulePayload)
-                                        const newPayloads = { ...currentPayloads }
-                                        if (value === undefined) {
-                                            delete newPayloads[index]
-                                        } else {
-                                            newPayloads[index] = value
-                                        }
-                                        setSchedulePayload(null, null, null, currentVariants, newPayloads)
-                                    }}
-                                    variantErrors={variantErrors}
-                                />
-                            </div>
-                        )}
+                                    } else {
+                                        newPayloads[index] = value
+                                    }
+                                    setSchedulePayload(null, null, null, displayVariants, newPayloads)
+                                }}
+                                variantErrors={variantErrors}
+                            />
+                        </div>
+                    )}
 
                     {/* Warning for recurring variant updates */}
                     {isRecurring && scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants && (

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -798,59 +798,65 @@ export default function FeatureFlagSchedule(): JSX.Element {
                             </div>
                         </div>
                     )}
-                    {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants && (
-                        <div className="rounded border p-3">
-                            <FeatureFlagVariantsForm
-                                variants={displayVariants}
-                                payloads={displayPayloads}
-                                onAddVariant={() => {
-                                    const newVariants = [
-                                        ...displayVariants,
-                                        { key: '', name: '', rollout_percentage: 0 },
-                                    ]
-                                    setSchedulePayload(null, null, null, newVariants, displayPayloads)
-                                }}
-                                onRemoveVariant={(index) => {
-                                    const newVariants = displayVariants.filter((_, i) => i !== index)
-                                    const newPayloads = { ...displayPayloads }
-                                    delete newPayloads[index]
-                                    setSchedulePayload(null, null, null, newVariants, newPayloads)
-                                }}
-                                onDistributeEqually={() => {
-                                    const equalPercentage = Math.floor(100 / displayVariants.length)
-                                    const remainder = 100 - equalPercentage * displayVariants.length
-                                    const distributedVariants = displayVariants.map((variant, index) => ({
-                                        ...variant,
-                                        rollout_percentage: equalPercentage + (index === 0 ? remainder : 0),
-                                    }))
-                                    setSchedulePayload(null, null, null, distributedVariants, displayPayloads)
-                                }}
-                                onVariantChange={(index, field, value) => {
-                                    const newVariants = [...displayVariants]
-                                    newVariants[index] = { ...newVariants[index], [field]: value }
-                                    setSchedulePayload(null, null, null, newVariants, displayPayloads)
-                                }}
-                                onPayloadChange={(index, value) => {
-                                    const newPayloads = { ...displayPayloads }
-                                    if (value === undefined) {
+                    {scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
+                        !!featureFlag.filters.multivariate && (
+                            <div className="rounded border p-3">
+                                <FeatureFlagVariantsForm
+                                    variants={displayVariants}
+                                    payloads={displayPayloads}
+                                    onAddVariant={() => {
+                                        const newVariants = [
+                                            ...displayVariants,
+                                            { key: '', name: '', rollout_percentage: 0 },
+                                        ]
+                                        setSchedulePayload(null, null, null, newVariants, displayPayloads)
+                                    }}
+                                    onRemoveVariant={(index) => {
+                                        const newVariants = displayVariants.filter((_, i) => i !== index)
+                                        const newPayloads = { ...displayPayloads }
                                         delete newPayloads[index]
-                                    } else {
-                                        newPayloads[index] = value
-                                    }
-                                    setSchedulePayload(null, null, null, displayVariants, newPayloads)
-                                }}
-                                variantErrors={variantErrors}
-                            />
-                        </div>
-                    )}
+                                        setSchedulePayload(null, null, null, newVariants, newPayloads)
+                                    }}
+                                    onDistributeEqually={() => {
+                                        if (displayVariants.length === 0) {
+                                            return
+                                        }
+                                        const equalPercentage = Math.floor(100 / displayVariants.length)
+                                        const remainder = 100 - equalPercentage * displayVariants.length
+                                        const distributedVariants = displayVariants.map((variant, index) => ({
+                                            ...variant,
+                                            rollout_percentage: equalPercentage + (index === 0 ? remainder : 0),
+                                        }))
+                                        setSchedulePayload(null, null, null, distributedVariants, displayPayloads)
+                                    }}
+                                    onVariantChange={(index, field, value) => {
+                                        const newVariants = [...displayVariants]
+                                        newVariants[index] = { ...newVariants[index], [field]: value }
+                                        setSchedulePayload(null, null, null, newVariants, displayPayloads)
+                                    }}
+                                    onPayloadChange={(index, value) => {
+                                        const newPayloads = { ...displayPayloads }
+                                        if (value === undefined) {
+                                            delete newPayloads[index]
+                                        } else {
+                                            newPayloads[index] = value
+                                        }
+                                        setSchedulePayload(null, null, null, displayVariants, newPayloads)
+                                    }}
+                                    variantErrors={variantErrors}
+                                />
+                            </div>
+                        )}
 
                     {/* Warning for recurring variant updates */}
-                    {isRecurring && scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants && (
-                        <LemonBanner type="warning">
-                            This will reset variants to the configuration above on each recurrence. Any manual changes
-                            made between runs will be overwritten.
-                        </LemonBanner>
-                    )}
+                    {isRecurring &&
+                        scheduledChangeOperation === ScheduledChangeOperationType.UpdateVariants &&
+                        !!featureFlag.filters.multivariate && (
+                            <LemonBanner type="warning">
+                                This will reset variants to the configuration above on each recurrence. Any manual
+                                changes made between runs will be overwritten.
+                            </LemonBanner>
+                        )}
 
                     {/* Hint when creating a single recurring schedule with no other active schedules */}
                     {isRecurring && !schedulePreset && activeSchedules.length === 0 && (


### PR DESCRIPTION
## Problem

The `schedule-feature-flag-variants-update` feature flag has been fully rolled out. This PR removes it and enables the UpdateVariants schedule operation for all multivariate feature flags.

## Changes

- Removes the `SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE` constant from `constants.tsx`
- Removes the flag check from `FeatureFlagSchedule.tsx`, keeping only the multivariate condition as the gate for showing the UpdateVariants option
- Removes the `featureFlagLogic` import and `featureFlags` value that were only used for the flag check
- Simplifies the `FeatureFlagVariantsForm` callbacks to use the already-available `displayVariants`/`displayPayloads` directly instead of calling `getScheduledVariantsPayloads` inside each handler

## How did you test this code?

No new tests needed for a flag removal. The existing tests for `FeatureFlagSchedule` cover the UpdateVariants path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.