### PR TITLE
feat(cdp): test-invocation and rearrange for log transformations

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -30,6 +30,7 @@ import { CdpApi } from './cdp-api'
 import { CdpConsumerBaseDeps } from './consumers/cdp-base.consumer'
 import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/posthog-filter-out-plugin/template'
 import { BASE_REDIS_KEY, HogWatcherState } from './services/monitoring/hog-watcher.service'
+import { compileHog } from './templates/compiler'
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 
 describe('CDP API', () => {
@@ -608,6 +609,112 @@ describe('CDP API', () => {
             expect(res.status).toEqual(200)
             expect(res.body.logs.map((log: any) => log.message)).toMatchInlineSnapshot(`[]`)
             expect(res.body.result).toMatchInlineSnapshot(`null`)
+        })
+    })
+
+    describe('log transformations', () => {
+        let configuration: HogFunctionType
+
+        const logRecordGlobals = {
+            record: {
+                body: 'login ok password=hunter2',
+                severity_text: 'info',
+                severity_number: 9,
+                service_name: 'payments-api',
+                attributes: { 'http.method': 'POST' },
+                resource_attributes: { 'k8s.namespace.name': 'payments' },
+            },
+        }
+
+        beforeEach(async () => {
+            const hog = `
+                let r := record
+                if (r.severity_text == 'debug') {
+                    return null
+                }
+                if (r.body != null) {
+                    r.body := replaceAll(r.body, inputs.needle, '[REDACTED]')
+                }
+                r.attributes.transformed := 'true'
+                return r
+            `
+            configuration = createHogFunction({
+                type: 'transformation_log',
+                name: 'Test log transformation',
+                team_id: team.id,
+                enabled: true,
+                hog,
+                bytecode: await compileHog(hog),
+                inputs: { needle: { value: 'hunter2' } },
+            })
+        })
+
+        it('transforms a mock log record', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({ globals: logRecordGlobals, configuration })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.errors).toEqual([])
+            expect(res.body.result.body).toEqual('login ok password=[REDACTED]')
+            expect(res.body.result.severity_text).toEqual('info')
+            expect(res.body.result.attributes).toEqual({ 'http.method': 'POST', transformed: 'true' })
+        })
+
+        it('returns null result when the record is dropped', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: { record: { ...logRecordGlobals.record, severity_text: 'debug' } },
+                    configuration,
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.result).toEqual(null)
+            expect(res.body.logs.map((log: any) => log.message)).toContain('Record dropped by transformation.')
+        })
+
+        it('returns 400 when the record global is missing', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({ globals: {}, configuration })
+
+            expect(res.status).toEqual(400)
+            expect(res.body.error).toEqual('Missing record')
+        })
+
+        it('reports a malformed return value as an error', async () => {
+            // Returning a non-record, non-null value is a customer mistake the endpoint must surface
+            const hog = `return 42`
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: logRecordGlobals,
+                    configuration: { ...configuration, hog, bytecode: await compileHog(hog) },
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('error')
+            expect(res.body.errors.length).toBeGreaterThan(0)
+        })
+
+        it('captures print output from the transformation', async () => {
+            const hog = `
+                print('inspecting', record.service_name)
+                return record
+            `
+            const res = await supertest(app)
+                .post(`/api/projects/${team.id}/hog_functions/new/invocations`)
+                .send({
+                    globals: logRecordGlobals,
+                    configuration: { ...configuration, hog, bytecode: await compileHog(hog) },
+                })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('success')
+            expect(res.body.logs.map((log: any) => log.message)).toContain('inspecting, payments-api')
         })
     })
 

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -4,6 +4,13 @@ import express from 'ultimate-express'
 import { ModifiedRequest } from '~/api/router'
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { LogRecord } from '../logs-ingestion/log-record-avro'
+import {
+    DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+    resolveLogTransformationInputs,
+} from '../logs-ingestion/transformations/hog-log-exec'
 import {
     HealthCheckResult,
     HealthCheckResultError,
@@ -355,7 +362,15 @@ export class CdpApi {
                 ? convertToHogFunctionInvocationGlobals(clickhouse_event, team, this.config.SITE_URL)
                 : globals
 
-            if (!globals || !globals.event) {
+            const functionType: string | undefined = configuration?.type ?? hogFunction?.type
+
+            if (functionType === 'transformation_log') {
+                // Log transformations run against a log record, not an event
+                if (!globals?.record || typeof globals.record !== 'object') {
+                    res.status(400).json({ error: 'Missing record' })
+                    return
+                }
+            } else if (!globals || !globals.event) {
                 res.status(400).json({ error: 'Missing event' })
                 return
             }
@@ -478,6 +493,97 @@ export class CdpApi {
                 res.json({
                     result: result,
                     status: errors.length > 0 ? 'error' : wasSkipped ? 'skipped' : 'success',
+                    errors: errors.map((e) => String(e)),
+                    logs: logs,
+                })
+            } else if (compoundConfiguration.type === 'transformation_log') {
+                const mock = globals.record as Record<string, unknown>
+
+                const toStringMap = (value: unknown): Record<string, string> => {
+                    const map: Record<string, string> = {}
+                    if (value && typeof value === 'object' && !Array.isArray(value)) {
+                        for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+                            if (entry !== null && entry !== undefined) {
+                                map[key] = typeof entry === 'string' ? entry : JSON.stringify(entry)
+                            }
+                        }
+                    }
+                    return map
+                }
+
+                // Mock log record from the request; trace/span ids stay null (they are
+                // read-only in transformations and not meaningful for a test run).
+                const record: LogRecord = {
+                    uuid: invocationID,
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: typeof mock.timestamp === 'number' ? mock.timestamp : DateTime.now().toMillis() * 1e6,
+                    observed_timestamp: typeof mock.observed_timestamp === 'number' ? mock.observed_timestamp : null,
+                    body: typeof mock.body === 'string' ? mock.body : null,
+                    severity_text: typeof mock.severity_text === 'string' ? mock.severity_text : null,
+                    severity_number: typeof mock.severity_number === 'number' ? mock.severity_number : null,
+                    service_name: typeof mock.service_name === 'string' ? mock.service_name : null,
+                    resource_attributes: toStringMap(mock.resource_attributes),
+                    instrumentation_scope:
+                        typeof mock.instrumentation_scope === 'string' ? mock.instrumentation_scope : null,
+                    event_name: typeof mock.event_name === 'string' ? mock.event_name : null,
+                    attributes: toStringMap(mock.attributes),
+                    bytes_uncompressed: null,
+                }
+
+                const hogGlobals = buildLogRecordGlobals(record, triggerGlobals.project, {})
+
+                try {
+                    hogGlobals.inputs = resolveLogTransformationInputs(
+                        compoundConfiguration,
+                        hogGlobals,
+                        DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS
+                    )
+                } catch (e) {
+                    return res.json({
+                        result: null,
+                        status: 'error',
+                        errors: [String(e)],
+                        logs,
+                    })
+                }
+
+                const sensitiveValues = Object.values(compoundConfiguration.encrypted_inputs ?? {})
+                    .map((input) => input?.value)
+                    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+
+                const outcome = executeLogTransformation(compoundConfiguration.bytecode, record, hogGlobals, {
+                    sensitiveValues,
+                })
+
+                logs = logs.concat(
+                    outcome.logs.map((message) => ({
+                        level: 'info' as const,
+                        timestamp: DateTime.now(),
+                        message,
+                    }))
+                )
+
+                if (outcome.status === 'failed') {
+                    errors.push(outcome.error)
+                } else if (outcome.status === 'dropped') {
+                    logs.push({
+                        level: 'info',
+                        timestamp: DateTime.now(),
+                        message: 'Record dropped by transformation.',
+                    })
+                }
+
+                // Same record shape the function saw (hex ids, string maps) — null when dropped
+                result =
+                    outcome.status === 'dropped'
+                        ? null
+                        : buildLogRecordGlobals(record, triggerGlobals.project, {}).record
+
+                res.json({
+                    result: result,
+                    status: errors.length > 0 ? 'error' : 'success',
                     errors: errors.map((e) => String(e)),
                     logs: logs,
                 })

--- a/nodejs/src/logs-ingestion/transformations/hog-log-exec.ts
+++ b/nodejs/src/logs-ingestion/transformations/hog-log-exec.ts
@@ -1,5 +1,6 @@
 import { convertHogToJS } from '@posthog/hogvm'
 
+import type { HogFunctionType } from '../../cdp/types'
 import { sanitizeLogMessage } from '../../cdp/utils'
 import { execHogImmediate } from '../../cdp/utils/hog-exec'
 import type { LogRecord } from '../log-record-avro'
@@ -150,6 +151,43 @@ export function applyTransformResult(record: LogRecord, execResult: unknown): 'm
     }
 
     return 'mutated'
+}
+
+/**
+ * Resolves a function's input values against log globals. Inputs may reference earlier
+ * inputs, so resolution happens in declared order; hog-templated inputs execute their
+ * compiled bytecode with the accumulated `inputs` visible.
+ *
+ * Throws on the first unresolvable input — callers decide the failure policy
+ * (the pipeline fails open per record; the test-invocation API surfaces the error).
+ */
+export function resolveLogTransformationInputs(
+    fn: Pick<HogFunctionType, 'inputs' | 'encrypted_inputs'>,
+    globals: Omit<LogTransformationGlobals, 'inputs'>,
+    timeoutMs: number
+): Record<string, unknown> {
+    const inputs: Record<string, unknown> = {}
+    const allInputs = { ...fn.inputs, ...fn.encrypted_inputs }
+
+    const entries = Object.entries(allInputs).sort(([, a], [, b]) => (a?.order ?? -1) - (b?.order ?? -1))
+
+    for (const [key, input] of entries) {
+        if (input?.bytecode && (input.templating ?? 'hog') === 'hog') {
+            const { execResult, error } = execHogImmediate(input.bytecode, {
+                globals: { ...globals, inputs },
+                timeout: timeoutMs,
+                maxAsyncSteps: 0,
+            })
+            if (error || execResult?.error || !execResult?.finished) {
+                throw new Error(`Could not resolve input '${key}': ${error ?? execResult?.error}`)
+            }
+            inputs[key] = execResult.result
+        } else {
+            inputs[key] = input?.value
+        }
+    }
+
+    return inputs
 }
 
 export interface ExecuteLogTransformationOptions {

--- a/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
+++ b/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
@@ -4,12 +4,16 @@ import { Counter, Histogram } from 'prom-client'
 import { HogFunctionManagerService } from '../../cdp/services/managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from '../../cdp/services/monitoring/hog-function-monitoring.service'
 import { HogFunctionType, LogEntry } from '../../cdp/types'
-import { execHogImmediate } from '../../cdp/utils/hog-exec'
 import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
 import { logger } from '../../utils/logger'
 import { UUIDT } from '../../utils/utils'
 import type { LogRecord } from '../log-record-avro'
-import { LogTransformationGlobals, buildLogRecordGlobals, executeLogTransformation } from './hog-log-exec'
+import {
+    LogTransformationGlobals,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+    resolveLogTransformationInputs,
+} from './hog-log-exec'
 
 export const transformationRecordsCounter = new Counter({
     name: 'logs_ingestion_transformations_records_total',
@@ -294,29 +298,7 @@ export class LogsTransformerService {
     }
 
     private resolveInputsUncached(fn: HogFunctionType, globals: LogTransformationGlobals): Record<string, unknown> {
-        const inputs: Record<string, unknown> = {}
-        const allInputs = { ...fn.inputs, ...fn.encrypted_inputs }
-
-        // Inputs can reference earlier inputs, so resolve in declared order
-        const entries = Object.entries(allInputs).sort(([, a], [, b]) => (a?.order ?? -1) - (b?.order ?? -1))
-
-        for (const [key, input] of entries) {
-            if (input?.bytecode && (input.templating ?? 'hog') === 'hog') {
-                const { execResult, error } = execHogImmediate(input.bytecode, {
-                    globals: { ...globals, inputs },
-                    timeout: this.config.hogTimeoutMs,
-                    maxAsyncSteps: 0,
-                })
-                if (error || execResult?.error || !execResult?.finished) {
-                    throw new Error(`Could not resolve input '${key}': ${error ?? execResult?.error}`)
-                }
-                inputs[key] = execResult.result
-            } else {
-                inputs[key] = input?.value
-            }
-        }
-
-        return inputs
+        return resolveLogTransformationInputs(fn, globals, this.config.hogTimeoutMs)
     }
 
     private getSensitiveValues(fn: HogFunctionType, cache: Map<string, string[]>): string[] {

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -689,7 +689,7 @@ class HogFunctionViewSet(
             functions = {
                 str(f.id): f
                 for f in HogFunction.objects.filter(
-                    id__in=function_ids, team=team, type="transformation", deleted=False
+                    id__in=function_ids, team=team, type__in=TYPES_WITH_EXECUTION_ORDER, deleted=False
                 )
             }
 
@@ -697,6 +697,12 @@ class HogFunctionViewSet(
             missing_ids = set(function_ids) - set(functions.keys())
             if missing_ids:
                 raise exceptions.ValidationError(f"HogFunction with id {missing_ids.pop()} does not exist")
+
+            # execution_order is scoped per type, so one rearrange request must stay within one type
+            types = {f.type for f in functions.values()}
+            if len(types) > 1:
+                raise exceptions.ValidationError("Cannot rearrange functions of different types in one request")
+            hog_type = types.pop()
 
             # Update orders and create activity logs
             from django.contrib.auth.models import AnonymousUser
@@ -739,7 +745,7 @@ class HogFunctionViewSet(
                     function.save(update_fields=["execution_order", "updated_at"])
 
         # Get final ordered list in a single query
-        transformations = HogFunction.objects.filter(team=team, type="transformation", deleted=False).order_by(
+        transformations = HogFunction.objects.filter(team=team, type=hog_type, deleted=False).order_by(
             "execution_order"
         )
 

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -2703,3 +2703,32 @@ class TestLogTransformationAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
             inputs={"svc": {"value": "service = {record.service_name}"}},
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_rearrange_log_transformations(self):
+        first = self._create_log_transformation(name="A", enabled=True).json()
+        second = self._create_log_transformation(name="B", enabled=True).json()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/rearrange/",
+            data={"orders": {first["id"]: 2, second["id"]: 1}},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        results = response.json()
+        assert [f["id"] for f in results] == [second["id"], first["id"]]
+        assert [f["execution_order"] for f in results] == [1, 2]
+
+    def test_rearrange_rejects_mixed_types(self):
+        log_function = self._create_log_transformation(name="A", enabled=True).json()
+        event_function = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={"name": "Event transformation", "type": "transformation", "hog": "return event"},
+        ).json()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/rearrange/",
+            data={"orders": {log_function["id"]: 1, event_function["id"]: 2}},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "different types" in response.json()["detail"]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -437,7 +437,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -445,7 +445,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -788,7 +788,7 @@
                 "type": {
                     "anyOf": [
                         {
-                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                             "enum": [
                                 "destination",
                                 "site_destination",
@@ -796,7 +796,8 @@
                                 "source_webhook",
                                 "warehouse_source_webhook",
                                 "site_app",
-                                "transformation"
+                                "transformation",
+                                "transformation_log"
                             ],
                             "type": "string"
                         },
@@ -804,7 +805,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
                 },
                 "updated_at": {
                     "format": "date-time",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -441,7 +441,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -449,7 +449,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },
@@ -457,7 +458,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
         }
     },
     "required": ["id"],


### PR DESCRIPTION
## Problem

The `transformation_log` type (log transformations, base stack #63374–#63378) had no way to dry-run a function before enabling it, and the reorder endpoint silently no-opped for the type.

## Changes

- **Test invocation** — `/hog_functions/:id/invocations` now accepts a log-record global, runs the function through the shared log execution primitives, and returns the mutated record (or `null` when dropped) plus captured `print()` output. Same response shape destinations/transformations use, so the editor's testing UI works unchanged.
- **Rearrange** — the reorder endpoint hardcoded `type="transformation"`, so reordering log transformations did nothing. It now filters by `TYPES_WITH_EXECUTION_ORDER` and rejects mixed-type requests, keeping per-type `execution_order` independent.
- `resolveLogTransformationInputs` is lifted into `hog-log-exec` so the consumer service and the invocation API share one input-resolution path.

## How did you test this code?

Agent-authored, no manual testing claimed. Automated and green: 5 node invocation tests in `cdp-api.test.ts` (real express app + hub), 2 pytest rearrange tests, node typecheck.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work.

PR 1 of a 6-PR follow-up stack (06 → 10b) on top of the base log-transformations stack (#63374–#63378). This one is the API parity that the editor's Testing tab depends on. Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
