### PR TITLE
feat(cdp): add starter templates for log transformations

### DIFF
--- a/nodejs/src/cdp/templates/_transformations/transformation-templates.test.ts
+++ b/nodejs/src/cdp/templates/_transformations/transformation-templates.test.ts
@@ -1,11 +1,16 @@
 import { HogFunctionTemplate } from '~/cdp/types'
 
-import { HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS, HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED } from '../index'
+import {
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+    HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
+} from '../index'
 
 describe('Transformation templates', () => {
     const allTransformationTemplates: HogFunctionTemplate[] = [
         ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
         ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+        ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
     ]
 
     it('should have free property set to true for all transformation templates', () => {

--- a/nodejs/src/cdp/templates/_transformations_log/default/default.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/default/default.template.ts
@@ -1,0 +1,26 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-default',
+    name: 'Custom log transformation',
+    description: 'Start from scratch. Mutate the log record and return it, or return null to drop it.',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+// Runs on every log record for your project.
+//
+// 'record' fields you can change: body, attributes, resource_attributes, severity_text
+// 'record' fields that are read-only: severity_number, service_name, event_name,
+//          timestamp, observed_timestamp, trace_id, span_id
+//
+// Return the record to keep it (optionally mutated), or return null to drop it.
+// Note: severity_text is lowercased before this runs — compare against 'error', 'info', etc.
+
+return record
+`,
+    inputs_schema: [],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/drop-by-severity/drop-by-severity.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/drop-by-severity/drop-by-severity.template.ts
@@ -1,0 +1,34 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-drop-by-severity',
+    name: 'Drop logs by severity',
+    description: 'Drop noisy log records at the configured severity levels (for example debug and trace).',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+// severity_text is lowercased upstream, so normalise the configured list too.
+let drop := splitByString(',', lower(inputs.severitiesToDrop))
+for (let _, s in drop) {
+    if (record.severity_text == trim(s)) {
+        return null
+    }
+}
+return record
+`,
+    inputs_schema: [
+        {
+            key: 'severitiesToDrop',
+            type: 'string',
+            label: 'Severities to drop',
+            description: 'Comma-separated severity levels to drop, e.g. "debug,trace". Case-insensitive.',
+            default: 'debug,trace',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/pii-scrub/pii-scrub.template.ts
@@ -1,0 +1,51 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-pii-scrub',
+    name: 'Scrub PII from log bodies',
+    description: 'Redact emails, API keys, and bearer tokens from the log body using regular expressions.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+let r := record
+if (r.body == null) {
+    return r
+}
+
+// Character classes ([.] [ ]) keep these readable — no backslash escaping needed.
+// Non-capturing groups (?:...) so the whole match is redacted, not a sub-group.
+let patterns := [
+    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z]{2,}',
+    '(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{8,}',
+    '[Bb]earer[ ]+[A-Za-z0-9._-]{10,}'
+]
+
+for (let _, pattern in patterns) {
+    let found := extractRegex(r.body, pattern)
+    // Each replaceAll clears one distinct match; guard caps work per record.
+    let guard := 0
+    while (notEmpty(found) and guard < 100) {
+        r.body := replaceAll(r.body, found, inputs.replacement)
+        found := extractRegex(r.body, pattern)
+        guard := guard + 1
+    }
+}
+
+return r
+`,
+    inputs_schema: [
+        {
+            key: 'replacement',
+            type: 'string',
+            label: 'Replacement text',
+            description: 'Replaces each matched value in the log body.',
+            default: '[REDACTED]',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/redact-attributes/redact-attributes.template.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/redact-attributes/redact-attributes.template.ts
@@ -1,0 +1,34 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'stable',
+    type: 'transformation_log',
+    id: 'template-log-transformation-redact-attributes',
+    name: 'Hash log attributes',
+    description: 'Replace the values of the configured log attributes with a SHA-256 hash to protect PII.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+let r := record
+for (let _, key in splitByString(',', inputs.attributeKeys)) {
+    let k := trim(key)
+    if (notEmpty(k) and notEmpty(r.attributes[k])) {
+        r.attributes[k] := sha256Hex(r.attributes[k])
+    }
+}
+return r
+`,
+    inputs_schema: [
+        {
+            key: 'attributeKeys',
+            type: 'string',
+            label: 'Attribute keys to hash',
+            description: 'Comma-separated attribute keys whose values are replaced with a SHA-256 hash.',
+            default: 'user.email,user.id',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
+++ b/nodejs/src/cdp/templates/_transformations_log/transformation-log-templates.test.ts
@@ -1,0 +1,128 @@
+import type { LogRecord } from '../../../logs-ingestion/log-record-avro'
+import {
+    LogTransformationOutcome,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+} from '../../../logs-ingestion/transformations/hog-log-exec'
+import { compileHog } from '../compiler'
+import { template as logDefaultTemplate } from './default/default.template'
+import { template as logDropBySeverityTemplate } from './drop-by-severity/drop-by-severity.template'
+import { template as logPiiScrubTemplate } from './pii-scrub/pii-scrub.template'
+import { template as logRedactAttributesTemplate } from './redact-attributes/redact-attributes.template'
+
+jest.setTimeout(30_000)
+
+const PROJECT = { id: 1, name: 'test', url: 'http://localhost:8010/project/1' }
+
+const createRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+    uuid: '0197a3f2-1111-7000-8000-000000000001',
+    trace_id: null,
+    span_id: null,
+    trace_flags: 0,
+    timestamp: 1_780_000_000_000_000_000,
+    observed_timestamp: 1_780_000_000_000_000_000,
+    body: 'user jane@example.com logged in',
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'auth-api',
+    resource_attributes: { 'k8s.namespace.name': 'auth' },
+    instrumentation_scope: 'auth.sessions',
+    event_name: null,
+    attributes: { 'http.method': 'POST' },
+    bytes_uncompressed: 120,
+    ...overrides,
+})
+
+const run = async (
+    code: string,
+    record: LogRecord,
+    inputs: Record<string, unknown> = {}
+): Promise<{ outcome: LogTransformationOutcome; record: LogRecord }> => {
+    const bytecode = await compileHog(code)
+    const globals = buildLogRecordGlobals(record, PROJECT, inputs)
+    const outcome = executeLogTransformation(bytecode, record, globals, {})
+    return { outcome, record }
+}
+
+describe('transformation_log templates', () => {
+    describe('default', () => {
+        it('returns the record unchanged', async () => {
+            const { outcome, record } = await run(logDefaultTemplate.code, createRecord())
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toEqual('user jane@example.com logged in')
+        })
+    })
+
+    describe('pii-scrub', () => {
+        it('redacts emails, API keys, and bearer tokens from the body', async () => {
+            const body = 'login jane@example.com key sk_live_abcdef123456 auth Bearer abcdef012345 done'
+            const { outcome, record } = await run(logPiiScrubTemplate.code, createRecord({ body }), {
+                replacement: '[REDACTED]',
+            })
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toEqual('login [REDACTED] key [REDACTED] auth [REDACTED] done')
+        })
+
+        it('honors a custom replacement value', async () => {
+            const { record } = await run(logPiiScrubTemplate.code, createRecord({ body: 'x jane@example.com y' }), {
+                replacement: '***',
+            })
+            expect(record.body).toEqual('x *** y')
+        })
+
+        it('leaves a null body untouched', async () => {
+            const { outcome, record } = await run(logPiiScrubTemplate.code, createRecord({ body: null }), {
+                replacement: '[REDACTED]',
+            })
+            expect(outcome.status).toEqual('mutated')
+            expect(record.body).toBeNull()
+        })
+    })
+
+    describe('drop-by-severity', () => {
+        it('drops a configured severity', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'debug' }), {
+                severitiesToDrop: 'debug,trace',
+            })
+            expect(outcome.status).toEqual('dropped')
+        })
+
+        it('keeps severities not in the list', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'error' }), {
+                severitiesToDrop: 'debug,trace',
+            })
+            expect(outcome.status).toEqual('mutated')
+        })
+
+        it('matches case-insensitively against the lowercased severity', async () => {
+            const { outcome } = await run(logDropBySeverityTemplate.code, createRecord({ severity_text: 'debug' }), {
+                severitiesToDrop: 'DEBUG',
+            })
+            expect(outcome.status).toEqual('dropped')
+        })
+    })
+
+    describe('redact-attributes', () => {
+        it('replaces configured attribute values with a sha256 hash', async () => {
+            const { outcome, record } = await run(
+                logRedactAttributesTemplate.code,
+                createRecord({ attributes: { user_email: 'jane@example.com', keep: 'me' } }),
+                { attributeKeys: 'user_email' }
+            )
+            expect(outcome.status).toEqual('mutated')
+            const attributes = record.attributes ?? {}
+            expect(attributes.user_email).toMatch(/^[a-f0-9]{64}$/)
+            expect(attributes.keep).toEqual('me')
+        })
+
+        it('ignores attribute keys that are not present', async () => {
+            const { outcome, record } = await run(
+                logRedactAttributesTemplate.code,
+                createRecord({ attributes: { keep: 'me' } }),
+                { attributeKeys: 'user_email,user.id' }
+            )
+            expect(outcome.status).toEqual('mutated')
+            expect(record.attributes).toEqual({ keep: 'me' })
+        })
+    })
+})

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -44,6 +44,10 @@ import { template as piiHashingTemplate } from './_transformations/pii-hashing/p
 import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { template as urlMaskingTemplate } from './_transformations/url-masking/url-masking.template'
 import { template as urlNormalizationTemplate } from './_transformations/url-normalization/url-normalization.template'
+import { template as logDefaultTemplate } from './_transformations_log/default/default.template'
+import { template as logDropBySeverityTemplate } from './_transformations_log/drop-by-severity/drop-by-severity.template'
+import { template as logPiiScrubTemplate } from './_transformations_log/pii-scrub/pii-scrub.template'
+import { template as logRedactAttributesTemplate } from './_transformations_log/redact-attributes/redact-attributes.template'
 
 export const HOG_FUNCTION_TEMPLATES_COMING_SOON: HogFunctionTemplate[] = allComingSoonTemplates
 
@@ -88,6 +92,13 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     filterPropertiesTemplate,
     hashPropertiesTemplate,
     urlNormalizationTemplate,
+]
+
+export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG: HogFunctionTemplate[] = [
+    logDefaultTemplate,
+    logPiiScrubTemplate,
+    logDropBySeverityTemplate,
+    logRedactAttributesTemplate,
 ]
 
 export const NATIVE_HOG_FUNCTIONS: (HogFunctionTemplate & NativeTemplate)[] = [nativeWebhookTemplate].map((plugin) => ({
@@ -139,6 +150,7 @@ export const HOG_FUNCTION_TEMPLATES: HogFunctionTemplate[] = [
     ...HOG_FUNCTION_TEMPLATES_DESTINATIONS_DEPRECATED,
     ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS,
     ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED,
+    ...HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_LOG,
     ...HOG_FUNCTION_TEMPLATES_SOURCES,
     ...HOG_FUNCTION_TEMPLATES_COMING_SOON,
     ...NATIVE_HOG_FUNCTIONS,

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -29,6 +29,7 @@ HogFunctionTemplateType = Literal[
     "warehouse_source_webhook",
     "site_app",
     "transformation",
+    "transformation_log",
 ]
 
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -437,7 +437,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -445,7 +445,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -788,7 +788,7 @@
                 "type": {
                     "anyOf": [
                         {
-                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                             "enum": [
                                 "destination",
                                 "site_destination",
@@ -796,7 +796,8 @@
                                 "source_webhook",
                                 "warehouse_source_webhook",
                                 "site_app",
-                                "transformation"
+                                "transformation",
+                                "transformation_log"
                             ],
                             "type": "string"
                         },
@@ -804,7 +805,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
                 },
                 "updated_at": {
                     "format": "date-time",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -441,7 +441,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -449,7 +449,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },
@@ -457,7 +458,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
         }
     },
     "required": ["id"],


### PR DESCRIPTION
## Problem

Creating a log transformation meant starting from a blank editor — no examples for the common cases (scrub PII, drop noisy severities, hash attributes).

## Changes

Four `transformation_log` templates in `nodejs/src/cdp/templates/_transformations_log/`:

- **default** — blank starter documenting the record fields, drop semantics, and the lowercase-severity gotcha.
- **pii-scrub** — redacts emails, API keys, and bearer tokens from the body via `extractRegex` + `replaceAll` (Hog has no regex-replace). Patterns use character classes and non-capturing groups to stay escape-free.
- **drop-by-severity** — drops a configurable, case-insensitive list of severities.
- **redact-attributes** — sha256-hashes the values of configured attribute keys.

Served from the existing `/api/hog_function_templates` node endpoint, so they sync to the DB and surface in the picker filtered by type. Adds `transformation_log` to the Python `HogFunctionTemplateType` literal.

## How did you test this code?

Agent-authored. Automated and green: 9 template tests compiling and executing each program against the real HogVM, node typecheck. Also verified each template compiles through the Python `compile_hog` sync path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work.

PR 2 of the 6-PR follow-up stack (06 → 10b). Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
