### PR TITLE
feat(logs): support log transformations in the hog function editor

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -359,6 +359,7 @@ export const FEATURE_FLAGS = {
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
+    LOGS_TRANSFORMATIONS: 'logs-transformations', // owner: #team-logs
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MARKDOWN_NOTEBOOKS: 'markdown-notebooks', // owner: #team-platform-features, enables Markdown notebooks upgrade path
     MARKETING_ANALYTICS_AI: 'marketing-analytics-ai', // owner: @jabahamondes #team-web-analytics

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -51,6 +51,7 @@ export type HogFunctionSceneTab = (typeof HOG_FUNCTION_SCENE_TABS)[number]
 
 const HogFunctionSceneMapping: Partial<Record<HogFunctionTypeType, { scene: Scene; url: () => string }>> = {
     transformation: { scene: Scene.Transformations, url: urls.transformations },
+    transformation_log: { scene: Scene.Logs, url: urls.logs },
     destination: { scene: Scene.Destinations, url: urls.destinations },
     site_destination: { scene: Scene.Destinations, url: urls.destinations },
     source_webhook: { scene: Scene.Sources, url: urls.sources },
@@ -239,7 +240,10 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
                     return [
                         {
                             key: sceneMapping.scene,
-                            name: `${capitalizeFirstLetter(type).replace('_', ' ')}s`,
+                            name:
+                                type === 'transformation_log'
+                                    ? 'Log transformations'
+                                    : `${capitalizeFirstLetter(type).replace('_', ' ')}s`,
                             path: id ? sceneMapping.url() : urls.dataPipelinesNew(type as DataPipelinesNewSceneKind),
                             iconType: 'data_pipeline',
                         },
@@ -435,7 +439,12 @@ export function HogFunctionScene(): JSX.Element {
                   key: 'logs',
                   content: <HogFunctionLogs />,
               },
-        type === 'site_app' || type === 'site_destination' || type === 'internal_destination'
+        // Log transformations test against a sample record (inline, in Configuration), not historical
+        // events — so skip the events-based testing tab the same way internal destinations do.
+        type === 'site_app' ||
+        type === 'site_destination' ||
+        type === 'internal_destination' ||
+        type === 'transformation_log'
             ? null
             : {
                   label: 'Testing',

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -156,12 +156,16 @@ export function HogFunctionConfiguration({
                                             disabled={loading}
                                             bordered
                                             fullWidth
-                                            label="Enable destination"
+                                            label={type === 'transformation_log' ? 'Enable' : 'Enable destination'}
                                             tooltip={
                                                 <>
-                                                    {value
-                                                        ? 'Enabled. Events will be processed.'
-                                                        : 'Disabled. Events will not be processed.'}
+                                                    {type === 'transformation_log'
+                                                        ? value
+                                                            ? 'Enabled. Log records will be processed.'
+                                                            : 'Disabled. Log records will not be processed.'
+                                                        : value
+                                                          ? 'Enabled. Events will be processed.'
+                                                          : 'Disabled. Events will not be processed.'}
                                                 </>
                                             }
                                         />
@@ -181,9 +185,19 @@ export function HogFunctionConfiguration({
                             {mightDropEvents && (
                                 <div>
                                     <LemonBanner type="info">
-                                        <b>Warning:</b> This transformation can filter out events, dropping them
-                                        irreversibly. Make sure to double check your configuration, and use filters to
-                                        limit the events that this transformation is applied to.
+                                        {type === 'transformation_log' ? (
+                                            <>
+                                                <b>Warning:</b> This transformation can drop log records irreversibly
+                                                (any record it returns null for is discarded). Double check your code
+                                                before enabling.
+                                            </>
+                                        ) : (
+                                            <>
+                                                <b>Warning:</b> This transformation can filter out events, dropping them
+                                                irreversibly. Make sure to double check your configuration, and use
+                                                filters to limit the events that this transformation is applied to.
+                                            </>
+                                        )}
                                     </LemonBanner>
                                 </div>
                             )}

--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
@@ -202,7 +202,10 @@ export function HogFunctionTest(): JSX.Element {
                             <span>Testing</span>
                         </h2>
                         {inactive ? (
-                            <p>Click here to test your function with an example {isDataWarehouse ? 'row' : 'event'}</p>
+                            <p>
+                                Click here to test your function with an example{' '}
+                                {isDataWarehouse ? 'row' : type === 'transformation_log' ? 'record' : 'event'}
+                            </p>
                         ) : null}
                     </div>
 
@@ -375,7 +378,8 @@ export function HogFunctionTest(): JSX.Element {
                                           : 'Error'}
                                 </LemonBanner>
 
-                                {type === 'transformation' && testResult.status !== 'error' ? (
+                                {(type === 'transformation' || type === 'transformation_log') &&
+                                testResult.status !== 'error' ? (
                                     <>
                                         <div className="flex gap-2 justify-between items-center">
                                             <LemonLabel>Transformation result</LemonLabel>
@@ -392,14 +396,19 @@ export function HogFunctionTest(): JSX.Element {
                                                 />
                                             )}
                                         </div>
-                                        <p>Below you can see the event after the transformation has been applied.</p>
+                                        <p>
+                                            Below you can see the {type === 'transformation_log' ? 'record' : 'event'}{' '}
+                                            after the transformation has been applied.
+                                        </p>
                                         {testResult.result ? (
                                             <>
                                                 {!sortedTestsResult?.hasDiff && (
                                                     <LemonBanner type="info">
                                                         {testResult.status === 'skipped'
                                                             ? 'The event was not modified as it did not match the filter criteria.'
-                                                            : 'The event was unmodified by the transformation.'}
+                                                            : `The ${
+                                                                  type === 'transformation_log' ? 'record' : 'event'
+                                                              } was unmodified by the transformation.`}
                                                     </LemonBanner>
                                                 )}
                                                 <CodeEditorResizeable

--- a/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/HogFunctionCode.tsx
@@ -95,8 +95,9 @@ export function HogFunctionCode(): JSX.Element {
                             ) : null}
                             {mightDropEvents && (
                                 <LemonBanner type="warning" className="mt-2">
-                                    <b>Warning:</b> Returning null or undefined will drop the event. If this is
-                                    unintentional, return the event object instead.
+                                    <b>Warning:</b> Returning null or undefined will drop the{' '}
+                                    {type === 'transformation_log' ? 'record' : 'event'}. If this is unintentional,
+                                    return the {type === 'transformation_log' ? 'record' : 'event'} object instead.
                                 </LemonBanner>
                             )}
                             {type === 'source_webhook' && (

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.test.ts
@@ -183,4 +183,36 @@ describe('hogFunctionConfigurationLogic', () => {
             }).toDispatchActions(['upsertHogFunction', 'submitConfigurationSuccess'])
         })
     })
+
+    describe('log transformation', () => {
+        const LOG_TEMPLATE: HogFunctionTemplateType = {
+            free: true,
+            status: 'stable',
+            id: 'template-log-transformation-default',
+            type: 'transformation_log',
+            name: 'Custom log transformation',
+            description: 'Start from scratch.',
+            code: 'return record',
+            code_language: 'hog',
+            inputs_schema: [],
+            filters: null,
+            masking: null,
+            icon_url: '/static/hedgehog/builder-hog-01.png',
+        }
+
+        beforeEach(() => {
+            initKeaTests()
+            mockApi.getTemplate.mockReturnValue(Promise.resolve(LOG_TEMPLATE))
+            logic = hogFunctionConfigurationLogic({ templateId: 'test' })
+            logic.mount()
+        })
+
+        it('seeds the inline tester with a sample record, not an event', async () => {
+            await expectLogic(logic).toDispatchActions(['loadTemplate', 'loadTemplateSuccess'])
+            const globals = logic.values.exampleInvocationGlobals
+            expect(globals.record).toBeTruthy()
+            expect(globals.record?.body).toContain('GET /api/users')
+            expect(globals.event).toBeUndefined()
+        })
+    })
 })

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -105,7 +105,7 @@ const NEW_FUNCTION_TEMPLATE: HogFunctionTemplateType = {
     status: 'stable',
 }
 
-export const TYPES_WITH_GLOBALS: HogFunctionTypeType[] = ['transformation', 'destination']
+export const TYPES_WITH_GLOBALS: HogFunctionTypeType[] = ['transformation', 'transformation_log', 'destination']
 export const TYPES_WITH_REAL_EVENTS: HogFunctionTypeType[] = ['destination', 'site_destination', 'transformation']
 export const TYPES_WITH_VOLUME_WARNING: HogFunctionTypeType[] = ['destination', 'site_destination']
 
@@ -113,7 +113,24 @@ const TYPE_TO_PRODUCT_KEY: Partial<Record<HogFunctionTypeType, ProductKey>> = {
     destination: ProductKey.PIPELINE_DESTINATIONS,
     site_destination: ProductKey.PIPELINE_DESTINATIONS,
     transformation: ProductKey.PIPELINE_TRANSFORMATIONS,
+    transformation_log: ProductKey.LOGS,
     site_app: ProductKey.SITE_APPS,
+}
+
+// Sample record shown in the log transformation testing UI (no events table to sample from).
+const EXAMPLE_LOG_RECORD: NonNullable<CyclotronJobInvocationGlobals['record']> = {
+    body: 'GET /api/users 200 in 42ms user=jane@example.com',
+    attributes: { 'http.method': 'GET', 'http.status_code': '200' },
+    resource_attributes: { 'service.name': 'api', 'k8s.namespace.name': 'production' },
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'api',
+    instrumentation_scope: 'http.server',
+    event_name: null,
+    timestamp: 1780000000000000000,
+    observed_timestamp: 1780000000000000000,
+    trace_id: null,
+    span_id: null,
 }
 
 export function sanitizeInputs(
@@ -740,9 +757,11 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                             ? 'Web scripts'
                             : type === 'transformation'
                               ? 'Transformations'
-                              : type === 'source_webhook'
-                                ? 'Sources'
-                                : 'Destinations'
+                              : type === 'transformation_log'
+                                ? 'Log transformations'
+                                : type === 'source_webhook'
+                                  ? 'Sources'
+                                  : 'Destinations'
                     payload._create_in_folder = `Unfiled/${typeFolder}`
                 }
                 await asyncActions.upsertHogFunction(payload as HogFunctionConfigurationType)
@@ -839,6 +858,18 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         exampleInvocationGlobals: [
             (s) => [s.configuration, s.currentProject, s.groupTypes, s.contextId, s.survey],
             (configuration, currentProject, groupTypes, contextId, survey): CyclotronJobInvocationGlobals => {
+                // Log transformations are seeded with a sample record (no event), so the inline
+                // tester shows something useful to run against instead of an empty object.
+                if (configuration?.type === 'transformation_log') {
+                    return {
+                        project: {
+                            id: currentProject?.id ?? 0,
+                            name: currentProject?.name ?? '',
+                            url: `${window.location.origin}/project/${currentProject?.id}`,
+                        },
+                        record: EXAMPLE_LOG_RECORD,
+                    } as CyclotronJobInvocationGlobals
+                }
                 const currentUrl = window.location.href.split('#')[0]
                 const eventId = uuid()
                 const personId = uuid()
@@ -982,6 +1013,17 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     return {
                         project: baseGlobals.project,
                         event: baseGlobals.event,
+                        inputs,
+                    }
+                }
+
+                // Log transformations receive `project` and `record` at runtime (see
+                // buildLogRecordGlobals). There is no event table to sample from, so show a
+                // representative record the user can edit.
+                if (configuration.type === 'transformation_log') {
+                    return {
+                        project: baseGlobals.project,
+                        record: EXAMPLE_LOG_RECORD,
                         inputs,
                     }
                 }
@@ -1224,7 +1266,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         mightDropEvents: [
             (s) => [s.configuration, s.type],
             (configuration, type) => {
-                if (type !== 'transformation') {
+                if (type !== 'transformation' && type !== 'transformation_log') {
                     return false
                 }
                 const hogCode = configuration.hog || ''
@@ -1292,14 +1334,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     return false
                 }
 
-                return ['source_webhook', 'transformation', 'destination'].includes(type)
+                return ['source_webhook', 'transformation', 'transformation_log', 'destination'].includes(type)
             },
         ],
 
         showTesting: [
             (s) => [s.type],
             (type) => {
-                return ['destination', 'internal_destination', 'transformation'].includes(type)
+                return ['destination', 'internal_destination', 'transformation', 'transformation_log'].includes(type)
             },
         ],
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionTestLogic.tsx
@@ -185,6 +185,9 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 const event = convertToTransformationEvent(globals.event)
                 // Strip down to just the real values
                 actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
+            } else if (values.type === 'transformation_log') {
+                // Log transformations edit the record directly
+                actions.setTestInvocationValue('globals', JSON.stringify(globals.record ?? {}, null, 2))
             } else {
                 actions.setTestInvocationValue('globals', JSON.stringify(globals, null, 2))
             }
@@ -323,13 +326,13 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 configuration.template_id = values.templateId
                 configuration.hog = values.currentHogCode
 
-                // Transformations have a simpler UI just showing the event so we need to map it back to the event
+                // Transformations have a simpler UI just showing the event/record so we map it back
                 const globals =
                     values.type === 'transformation'
-                        ? {
-                              event: parsedData,
-                          }
-                        : parsedData
+                        ? { event: parsedData }
+                        : values.type === 'transformation_log'
+                          ? { record: parsedData }
+                          : parsedData
 
                 try {
                     const res = await api.hogFunctions.createTestInvocation(props.id ?? 'new', {
@@ -367,13 +370,20 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 output: string
                 hasDiff: boolean
             } | null => {
-                if (!testResult || configuration.type !== 'transformation') {
+                if (
+                    !testResult ||
+                    (configuration.type !== 'transformation' && configuration.type !== 'transformation_log')
+                ) {
                     return null
                 }
 
-                const rawInput = convertFromTransformationEvent(
-                    convertToTransformationEvent(JSON.parse(testInvocation.globals))
-                )
+                // Log transformations edit the record directly; events round-trip through the event shape
+                const rawInput =
+                    configuration.type === 'transformation_log'
+                        ? JSON.parse(testInvocation.globals)
+                        : convertFromTransformationEvent(
+                              convertToTransformationEvent(JSON.parse(testInvocation.globals))
+                          )
 
                 const input = JSON.stringify(rawInput, null, 2)
                 const output = JSON.stringify(testResult.result, null, 2)

--- a/frontend/src/scenes/hog-functions/hog-function-utils.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.ts
@@ -7,5 +7,8 @@ export function humanizeHogFunctionType(type: HogFunctionTypeType, plural: boole
     if (type === 'site_app') {
         return 'Web script' + (plural ? 's' : '')
     }
+    if (type === 'transformation_log') {
+        return 'log transformation' + (plural ? 's' : '')
+    }
     return type.replaceAll('_', ' ') + (plural ? 's' : '')
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6809,6 +6809,7 @@ export type HogFunctionTypeType =
     | 'site_destination'
     | 'site_app'
     | 'transformation'
+    | 'transformation_log'
 
 export type HogFunctionType = {
     id: string
@@ -6969,6 +6970,21 @@ export type CyclotronJobInvocationGlobals = {
         body: Record<string, any>
         headers: Record<string, string>
         ip?: string
+    }
+    // Only applies to log transformations (see buildLogRecordGlobals)
+    record?: {
+        body: string | null
+        attributes: Record<string, string>
+        resource_attributes: Record<string, string>
+        severity_text: string | null
+        severity_number: number | null
+        service_name: string | null
+        instrumentation_scope: string | null
+        event_name: string | null
+        timestamp: number | null
+        observed_timestamp: number | null
+        trace_id: string | null
+        span_id: string | null
     }
     // For HogFlows, workflow-level variables
     variables?: Record<string, any>


### PR DESCRIPTION
## Problem

The shared hog function editor was built for event transformations and assumed an `event` everywhere. Log transformations operate on a log `record`, so the editor needed to understand the new type — and the borrowed-from-events surface showed event-shaped UI and copy that was wrong for logs.

## Changes

Wire `transformation_log` into the shared configuration/testing machinery, all type-aware so event behavior is unchanged:

- type union + `LOGS_TRANSFORMATIONS` feature flag
- config logic: globals, product key, `canEditSource`, `showTesting`, `mightDropEvents`, a sample `record` to test against, the create-folder
- testing: the editor shows/edits the log record directly (no event wrapping), submits it as `{ record }`, and renders the before/after record diff
- scene mapping + breadcrumb back to the logs surface
- a proactive sweep of the shared components: the events-based Testing tab is hidden for the type (the inline record tester covers it), and the drop warnings, enable toggle, placeholder, and breadcrumb now say "record"/"log"

## How did you test this code?

Agent-authored. Automated and green: frontend typecheck (after regenerating kea types), `hogFunctionConfigurationLogic` logic tests including a new test asserting the inline tester seeds a record (not an event). A three-agent read-only sweep confirmed every other type-gate (filters, mappings, backfills, sparkline/volume, autocomplete globals) already excludes/includes the type correctly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work and drove the validation that surfaced several of these editor gaps.

PR 3 of the 6-PR follow-up stack (06 → 10b). The logs-product surface that links here is PR 4 (09). Gated by the `logs-transformations` flag. Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
