### PR TITLE
feat(logs): add a transformations tab to the logs scene

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -17,6 +17,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
 import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
 import { LogsSqlEditor } from 'products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor'
+import { LogsTransformations } from 'products/logs/frontend/components/LogsTransformations/LogsTransformations'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
@@ -93,12 +94,14 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
     const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
+    const showTransformations = useFeatureFlag('LOGS_TRANSFORMATIONS')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
         ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
+        ...(showTransformations ? [{ key: 'transformations' as const, label: 'Transformations' }] : []),
         { key: 'configuration', label: 'Configuration' },
     ]
 
@@ -150,6 +153,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             )}
             {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
             {activeTab === 'sql' && showSqlView && <LogsSqlEditor id={LOGS_SCENE_VIEWER_ID} />}
+            {activeTab === 'transformations' && showTransformations && <LogsTransformations />}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}

--- a/products/logs/frontend/components/LogsTransformations/LogsTransformations.tsx
+++ b/products/logs/frontend/components/LogsTransformations/LogsTransformations.tsx
@@ -1,0 +1,28 @@
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
+import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
+
+const LOGS_TRANSFORMATIONS_LOGIC_KEY = 'logs-transformations'
+
+export function LogsTransformations(): JSX.Element {
+    return (
+        <SceneContent>
+            <LemonBanner type="info" dismissKey="logs-transformations-beta-banner" className="mb-3">
+                Transformations run on every log record as it is ingested. Use them to mutate, redact, or drop records.
+                They run in order, and a transformation that returns null drops the record.
+            </LemonBanner>
+            <SceneSection title="Transformations" description="Modify or drop log records as they are ingested.">
+                <HogFunctionList logicKey={LOGS_TRANSFORMATIONS_LOGIC_KEY} type="transformation_log" />
+            </SceneSection>
+            <SceneDivider />
+            <SceneSection title="Create a new transformation">
+                <HogFunctionTemplateList type="transformation_log" hideComingSoonByDefault />
+            </SceneSection>
+        </SceneContent>
+    )
+}

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -39,8 +39,15 @@ export const getLogsSqlEditorTabId = (id: string): string => `logs-sql-editor-${
 // A static id would persist across projects in the same browser, leaking one project's pinned log payloads into another.
 export const LOGS_SCENE_VIEWER_ID = `logs-scene-${window.POSTHOG_APP_CONTEXT?.current_team?.id ?? 'unknown'}`
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'sql', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'transformations' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = [
+    'viewer',
+    'services',
+    'alerts',
+    'sql',
+    'transformations',
+    'configuration',
+]
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 const resolveActiveTabFromParams = (params: Params): LogsSceneActiveTab | null => {


### PR DESCRIPTION
## Problem

Log transformations had no home in the logs product — you could only reach them through the data-pipeline scenes built for events.

## Changes

A new **Transformations** tab in the logs scene, behind the `logs-transformations` feature flag. It lists the team's `transformation_log` functions and offers the starter templates to create new ones, reusing the shared `HogFunctionList` and `HogFunctionTemplateList` components. The tab is hidden unless the flag is on, so this is inert until rollout; editing/testing happen in the hog function editor wired up in the previous PR.

## How did you test this code?

Agent-authored. Automated and green: `logsSceneLogic` tests (21), frontend typecheck.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work.

PR 4 of the 6-PR follow-up stack (06 → 10b). There's an open design question (raised by Daniel) about whether the whole editor should move into this tab as a logs-native surface; this PR ships the reuse-the-shared-components version. Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
