### PR TITLE
feat(cdp): add HogWatcher.observeAggregatedResults for log transformations

### DIFF
--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -632,4 +632,53 @@ describe('HogWatcher', () => {
             )
         })
     })
+
+    describe('observeAggregatedResults', () => {
+        // Cost curve with the default config: lower=50ms, upper=550ms, cost=100.
+        it('charges no cost when the aggregate duration is below the lower bound', async () => {
+            await watcher.observeAggregatedResults([{ hogFunction, totalDurationMs: 50 }])
+            const state = await watcher.getPersistedState(hogFunctionId)
+            expect(watcherConfig.bucketSize - state.tokens).toEqual(0)
+        })
+
+        it('charges the full cost at the upper bound', async () => {
+            await watcher.observeAggregatedResults([{ hogFunction, totalDurationMs: 550 }])
+            const state = await watcher.getPersistedState(hogFunctionId)
+            expect(watcherConfig.bucketSize - state.tokens).toEqual(100)
+        })
+
+        it('scales cost with total VM time past the upper bound', async () => {
+            // (1050 - 50) / (550 - 50) = 2 → twice the max single-message cost
+            await watcher.observeAggregatedResults([{ hogFunction, totalDurationMs: 1050 }])
+            const state = await watcher.getPersistedState(hogFunctionId)
+            expect(watcherConfig.bucketSize - state.tokens).toEqual(200)
+        })
+
+        it('accumulates cost across observations for the same function', async () => {
+            await watcher.observeAggregatedResults([
+                { hogFunction, totalDurationMs: 300 },
+                { hogFunction, totalDurationMs: 300 },
+            ])
+            const state = await watcher.getPersistedState(hogFunctionId)
+            expect(watcherConfig.bucketSize - state.tokens).toEqual(100) // 50 + 50
+        })
+
+        it('marks a function degraded once its bucket drops to the threshold', async () => {
+            // cost 2000 leaves tokens at 8000 = 80% of the bucket → degraded
+            await watcher.observeAggregatedResults([{ hogFunction, totalDurationMs: 10050 }])
+            const state = await watcher.getPersistedState(hogFunctionId)
+            expect(state.tokens).toEqual(8000)
+            expect(state.state).toEqual(HogWatcherState.degraded)
+        })
+
+        it('charges each function independently', async () => {
+            const other = createHogFunction({ id: 'other-fn', team_id: 2 })
+            await watcher.observeAggregatedResults([
+                { hogFunction, totalDurationMs: 550 },
+                { hogFunction: other, totalDurationMs: 50 },
+            ])
+            expect(watcherConfig.bucketSize - (await watcher.getPersistedState(hogFunctionId)).tokens).toEqual(100)
+            expect(watcherConfig.bucketSize - (await watcher.getPersistedState('other-fn')).tokens).toEqual(0)
+        })
+    })
 })

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -53,6 +53,12 @@ export type HogWatcherFunctionState = {
     state: HogWatcherState
 }
 
+type FunctionCostEntry = {
+    hogFunction?: HogFunctionType
+    functionId: string
+    cost: number
+}
+
 const hogFunctionStateChange = new Counter({
     name: 'cdp_hog_function_state_change',
     help: 'Number of times a transformation state changed',
@@ -387,14 +393,7 @@ export class HogWatcherService {
     }
 
     public async observeResults(results: CyclotronJobInvocationResult[]): Promise<void> {
-        const functionCosts: Record<
-            CyclotronJobInvocation['functionId'],
-            {
-                hogFunction?: HogFunctionType
-                functionId: CyclotronJobInvocation['functionId']
-                cost: number
-            }
-        > = {}
+        const functionCosts: Record<CyclotronJobInvocation['functionId'], FunctionCostEntry> = {}
 
         results.forEach((result) => {
             if (!isHogFunctionResult(result)) {
@@ -423,8 +422,44 @@ export class HogWatcherService {
             functionCosts[result.invocation.functionId] = functionCost
         })
 
-        const functionCostEntries = Object.values(functionCosts)
+        await this.applyCostsAndTransitionStates(Object.values(functionCosts))
+    }
 
+    /**
+     * Per-(function, Kafka message) cost reporting for log transformations.
+     *
+     * The events path allocates one CyclotronJobInvocationResult per event; at log-record
+     * volumes that is prohibitive, so the logs transformer reports a single aggregated VM
+     * duration per function per message instead. Cost is derived from that aggregate via the
+     * same piecewise-linear curve (bounds come from this instance's config, so a logs-tuned
+     * HogWatcher charges on a logs-appropriate scale). Everything downstream — token bucket,
+     * state reads, transition rules — is shared with observeResults.
+     */
+    public async observeAggregatedResults(
+        observations: { hogFunction: HogFunctionType; totalDurationMs: number }[]
+    ): Promise<void> {
+        const functionCosts: Record<string, FunctionCostEntry> = {}
+        const costConfig = this.costsMapping.hog
+        if (!costConfig) {
+            return
+        }
+
+        for (const { hogFunction, totalDurationMs } of observations) {
+            const functionCost = functionCosts[hogFunction.id] ?? {
+                functionId: hogFunction.id,
+                cost: 0,
+                hogFunction,
+            }
+            const ratio =
+                Math.max(totalDurationMs - costConfig.lowerBound, 0) / (costConfig.upperBound - costConfig.lowerBound)
+            functionCost.cost += Math.round(costConfig.cost * ratio)
+            functionCosts[hogFunction.id] = functionCost
+        }
+
+        await this.applyCostsAndTransitionStates(Object.values(functionCosts))
+    }
+
+    private async applyCostsAndTransitionStates(functionCostEntries: FunctionCostEntry[]): Promise<void> {
         if (functionCostEntries.length === 0) {
             return
         }


### PR DESCRIPTION
## Problem

HogWatcher (the per-function circuit breaker) consumes one `CyclotronJobInvocationResult` per event. At log-record volumes (100k+/s for large teams) allocating a result object per record is prohibitive, so the logs transformer reports aggregated metrics per (function, Kafka message) — incompatible with the existing `observeResults`.

## Changes

`HogWatcherService.observeAggregatedResults({ hogFunction, totalDurationMs }[])` — derives cost from the aggregate VM duration via the same piecewise-linear curve (bounds come from the instance config, so a logs-tuned watcher charges on a logs scale) and shares the token bucket, state reads, and transition rules with `observeResults`. The shared tail is extracted into `applyCostsAndTransitionStates`; `observeResults` is unchanged in behavior. No wiring yet.

## How did you test this code?

Agent-authored. Automated and green: the full `hog-watcher.service` suite (35 tests, real Redis), including 6 new tests for the aggregate cost math, accumulation, the degraded-threshold transition, and per-function independence.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work, including the capacity analysis that informed the cost curve.

PR 5 of the 6-PR follow-up stack (06 → 10b). The consumer wiring is PR 6 (10b); making it live in the server is a documented follow-up. Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
