### PR TITLE
feat(logs): make the log transformer HogWatcher-aware

### DIFF
--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -1728,6 +1728,7 @@ describe('LogsIngestionConsumer', () => {
                 messageBudgetMs: 100,
                 batchBudgetMs: 2000,
                 maxErrorLogsPerFunctionPerMessage: 3,
+                hogWatcherSampleRate: 0,
             })
         }
 

--- a/nodejs/src/logs-ingestion/transformations/logs-transformer.service.test.ts
+++ b/nodejs/src/logs-ingestion/transformations/logs-transformer.service.test.ts
@@ -1,5 +1,6 @@
 import { HogFunctionManagerService } from '../../cdp/services/managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from '../../cdp/services/monitoring/hog-function-monitoring.service'
+import { HogWatcherService, HogWatcherState } from '../../cdp/services/monitoring/hog-watcher.service'
 import { compileHog } from '../../cdp/templates/compiler'
 import { HogFunctionType } from '../../cdp/types'
 import type { LogRecord } from '../log-record-avro'
@@ -83,6 +84,7 @@ describe('LogsTransformerService', () => {
             messageBudgetMs: 50,
             batchBudgetMs: 2000,
             maxErrorLogsPerFunctionPerMessage: 3,
+            hogWatcherSampleRate: 0,
         }
         service = new LogsTransformerService(manager as any, monitoring as any, config)
     })
@@ -349,5 +351,67 @@ describe('LogsTransformerService', () => {
     it('flush delegates to the monitoring service', async () => {
         await service.flush()
         expect(monitoring.flush).toHaveBeenCalled()
+    })
+
+    describe('HogWatcher integration', () => {
+        const createMockWatcher = (): jest.Mocked<
+            Pick<HogWatcherService, 'getEffectiveStates' | 'observeAggregatedResults'>
+        > =>
+            ({
+                getEffectiveStates: jest.fn().mockResolvedValue({}),
+                observeAggregatedResults: jest.fn().mockResolvedValue(undefined),
+            }) as any
+
+        const withWatcher = (watcher: any, sampleRate: number): LogsTransformerService =>
+            new LogsTransformerService(
+                manager as any,
+                monitoring as any,
+                { ...config, hogWatcherSampleRate: sampleRate },
+                watcher
+            )
+
+        it('never touches the watcher when the sample rate is 0', async () => {
+            const watcher = createMockWatcher()
+            service = withWatcher(watcher, 0)
+            setFunctions([await createFunction('return record')])
+
+            await service.transformRecords(TEAM_ID, [createRecord()])
+
+            expect(watcher.getEffectiveStates).not.toHaveBeenCalled()
+            expect(watcher.observeAggregatedResults).not.toHaveBeenCalled()
+        })
+
+        it('reports one aggregated observation per function when sampled', async () => {
+            const watcher = createMockWatcher()
+            service = withWatcher(watcher, 1)
+            const fn = await createFunction('return record')
+            setFunctions([fn])
+
+            await service.transformRecords(TEAM_ID, [createRecord(), createRecord()])
+
+            expect(watcher.observeAggregatedResults).toHaveBeenCalledTimes(1)
+            const observations = watcher.observeAggregatedResults.mock.calls[0][0]
+            expect(observations).toHaveLength(1)
+            expect(observations[0].hogFunction.id).toEqual(fn.id)
+            expect(observations[0].totalDurationMs).toBeGreaterThanOrEqual(0)
+        })
+
+        it('skips functions the watcher has disabled and records a metric', async () => {
+            const watcher = createMockWatcher()
+            const fn = await createFunction('return null') // would drop every record if it ran
+            watcher.getEffectiveStates.mockResolvedValue({ [fn.id]: { state: HogWatcherState.disabled, tokens: 0 } })
+            service = withWatcher(watcher, 1)
+            setFunctions([fn])
+
+            const records = [createRecord(), createRecord()]
+            const { recordsDropped } = await service.transformRecords(TEAM_ID, records)
+
+            expect(recordsDropped).toEqual(0)
+            expect(records).toHaveLength(2)
+            expect(watcher.observeAggregatedResults).not.toHaveBeenCalled()
+            expect(queuedMetrics()).toContainEqual(
+                expect.objectContaining({ metric_name: 'disabled_permanently', app_source_id: fn.id, count: 2 })
+            )
+        })
     })
 })

--- a/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
+++ b/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
@@ -3,6 +3,7 @@ import { Counter, Histogram } from 'prom-client'
 
 import { HogFunctionManagerService } from '../../cdp/services/managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from '../../cdp/services/monitoring/hog-function-monitoring.service'
+import { HogWatcherService, HogWatcherState } from '../../cdp/services/monitoring/hog-watcher.service'
 import { HogFunctionType, LogEntry } from '../../cdp/types'
 import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
 import { logger } from '../../utils/logger'
@@ -18,7 +19,7 @@ import {
 export const transformationRecordsCounter = new Counter({
     name: 'logs_ingestion_transformations_records_total',
     help: 'Per-record log transformation outcomes',
-    labelNames: ['result'], // succeeded | failed | dropped | budget_skipped
+    labelNames: ['result'], // succeeded | failed | dropped | budget_skipped | watcher_disabled
 })
 
 export const transformationVmDurationHistogram = new Histogram({
@@ -48,6 +49,9 @@ export interface LogsTransformerConfig {
     batchBudgetMs: number
     /** Max failed invocations whose print/error logs are captured, per function per message */
     maxErrorLogsPerFunctionPerMessage: number
+    /** Fraction of messages on which HogWatcher state is read and aggregate cost reported.
+     * 0 disables the watcher entirely (no Redis reads, no observations). */
+    hogWatcherSampleRate: number
 }
 
 /** Tracks cumulative VM time across all messages of one consumer batch. */
@@ -94,7 +98,8 @@ export class LogsTransformerService {
     constructor(
         private hogFunctionManager: HogFunctionManagerService,
         private monitoring: HogFunctionMonitoringService,
-        private config: LogsTransformerConfig
+        private config: LogsTransformerConfig,
+        private hogWatcher?: HogWatcherService
     ) {}
 
     public startBatch(): TransformationBatchBudget {
@@ -121,8 +126,18 @@ export class LogsTransformerService {
         let recordsDropped = 0
 
         const functionsByTeam = await this.hogFunctionManager.getHogFunctionsForTeams([teamId], ['transformation_log'])
-        const functions = functionsByTeam[teamId] ?? []
-        if (functions.length === 0 || records.length === 0) {
+        const allFunctions = functionsByTeam[teamId] ?? []
+        if (allFunctions.length === 0 || records.length === 0) {
+            return { recordsDropped, recordsDroppedByFunctionId }
+        }
+
+        // On a sampled message the watcher reads state (to skip disabled functions) and, at the
+        // end, receives the aggregate cost. A sample rate of 0 means no Redis traffic at all.
+        const runWatcher = !!this.hogWatcher && Math.random() < this.config.hogWatcherSampleRate
+        const functions = runWatcher
+            ? await this.dropWatcherDisabled(teamId, allFunctions, records.length)
+            : allFunctions
+        if (functions.length === 0) {
             return { recordsDropped, recordsDroppedByFunctionId }
         }
 
@@ -196,8 +211,65 @@ export class LogsTransformerService {
 
         transformationVmDurationHistogram.observe(messageVmMs / 1000)
         this.queueAggregates(teamId, aggregates)
+        if (runWatcher) {
+            this.reportToWatcher(functions, aggregates)
+        }
 
         return { recordsDropped, recordsDroppedByFunctionId }
+    }
+
+    /** Reads watcher state once per message and removes functions it has disabled. */
+    private async dropWatcherDisabled(
+        teamId: number,
+        functions: HogFunctionType[],
+        recordCount: number
+    ): Promise<HogFunctionType[]> {
+        if (!this.hogWatcher) {
+            return functions
+        }
+        const states = await this.hogWatcher.getEffectiveStates(functions.map((fn) => fn.id))
+        const active: HogFunctionType[] = []
+        for (const fn of functions) {
+            if (states[fn.id]?.state === HogWatcherState.disabled) {
+                transformationRecordsCounter.inc({ result: 'watcher_disabled' }, recordCount)
+                this.monitoring.queueAppMetric(
+                    {
+                        team_id: teamId,
+                        app_source_id: fn.id,
+                        metric_kind: 'failure',
+                        metric_name: 'disabled_permanently',
+                        count: recordCount,
+                    },
+                    'hog_function'
+                )
+            } else {
+                active.push(fn)
+            }
+        }
+        return active
+    }
+
+    /** Reports one aggregated VM-time observation per function for this message. Fire-and-forget. */
+    private reportToWatcher(functions: HogFunctionType[], aggregates: Map<string, FunctionAggregates>): void {
+        if (!this.hogWatcher) {
+            return
+        }
+        const byId = new Map(functions.map((fn) => [fn.id, fn]))
+        const observations: { hogFunction: HogFunctionType; totalDurationMs: number }[] = []
+        for (const [functionId, agg] of aggregates) {
+            const hogFunction = byId.get(functionId)
+            // A 0ms aggregate still costs nothing, but reporting it keeps token refill honest.
+            if (hogFunction) {
+                observations.push({ hogFunction, totalDurationMs: agg.totalDurationMs })
+            }
+        }
+        if (observations.length > 0) {
+            this.hogWatcher.observeAggregatedResults(observations).catch((error) => {
+                logger.warn('⚠️', '[logs-transformer] HogWatcher observeAggregatedResults failed', {
+                    error: String(error),
+                })
+            })
+        }
     }
 
     /** Runs every function in execution order against one record. Returns true if dropped. */

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -135,6 +135,9 @@ export class IngestionLogsServer implements NodeServer {
             messageBudgetMs: this.config.LOGS_TRANSFORMATIONS_MESSAGE_BUDGET_MS,
             batchBudgetMs: this.config.LOGS_TRANSFORMATIONS_BATCH_BUDGET_MS,
             maxErrorLogsPerFunctionPerMessage: this.config.LOGS_TRANSFORMATIONS_MAX_ERROR_LOGS_PER_FUNCTION,
+            // 0 keeps the watcher dormant (no Redis traffic). The HogWatcher instance and a
+            // configurable sample rate are wired into this server in a follow-up.
+            hogWatcherSampleRate: 0,
         })
 
         // 4. Logs ingestion consumer


### PR DESCRIPTION
## Problem

A pathological log transformation should be degradable per-team, but the transformer had no connection to HogWatcher.

## Changes

`LogsTransformerService` now takes an optional HogWatcher. On a sampled message it reads effective state once (skipping functions the watcher has disabled, with a `disabled_permanently` metric) and, after processing, reports one aggregated VM-time observation per function via `observeAggregatedResults`. The whole interaction is gated by `hogWatcherSampleRate` — `0` means no Redis traffic at all, matching the events watcher's sampling rollout. The server passes sample rate `0` and no watcher instance for now, so this is inert in production; constructing the real logs-tuned watcher (its own CDP redis pool and careful stop ordering) is a focused follow-up.

## How did you test this code?

Agent-authored. Automated and green: `LogsTransformerService` suite (17 tests) including 3 new ones for the disabled-skip, the aggregated observe, and the sample-rate-0 no-op path (mock watcher), node typecheck.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the work.

PR 6 of the 6-PR follow-up stack (06 → 10b). Deliberately inert until the live watcher wiring (the redis-lifecycle area that caused an earlier server-stop hang on the base stack, so it gets its own PR). Built with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
