### PR TITLE
chore: move inject_mcp_intents.py to bin/ and make executable

### DIFF
--- a/bin/inject_mcp_intents.py
+++ b/bin/inject_mcp_intents.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Inject synthetic intents on MCPSession rows for local clustering tests.
 
 Bypasses OpenAI by picking from a curated pool of phrasings grouped into
@@ -9,7 +11,7 @@ checkout-failure spike", multiple phrasings of "confirm a flag rollout", etc.
 — so clustering has clear signal to detect.
 
 Usage:
-  flox activate -- python scripts/inject_mcp_intents.py [--team-id N] [--seed N]
+  bin/inject_mcp_intents.py [--team-id N] [--seed N]
 """
 
 import os

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1039,3 +1039,7 @@ environment:
         bin_script: send-dev-metrics.sh
         description: 'Send a synthetic OTLP counter/gauge/histogram through the metrics ingest chain'
         hidden: true
+    inject_mcp_intents:
+        bin_script: inject_mcp_intents.py
+        description: 'Used when developing MCP Analytics locally and trying to load some intents'
+        hidden: true


### PR DESCRIPTION
Moves `inject_mcp_intents.py` from `scripts/` to `bin/`, adds a shebang line, and updates the usage instructions so the script can be invoked directly without prefixing `python`.