### PR TITLE
feat(mcp): add inject_mcp_intents dev sandbox script

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1039,3 +1039,7 @@ environment:
         bin_script: send-dev-metrics.sh
         description: 'Send a synthetic OTLP counter/gauge/histogram through the metrics ingest chain'
         hidden: true
+    inject_mcp_intents:
+        bin_script: inject_mcp_intents.py
+        description: 'Used when developing MCP Analytics locally and trying to load some intents'
+        hidden: true


### PR DESCRIPTION
Adds a new hidden CLI command `inject_mcp_intents` that runs `inject_mcp_intents.py`, intended for local development of MCP Analytics to load intents.