### PR TITLE
perf(capture-v1): drop queue-full retry + parallel kafka batch prep

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "opentelemetry_sdk 0.22.1",
  "prost 0.13.5",
  "rand 0.8.5",
+ "rayon",
  "rdkafka",
  "redis",
  "reqwest 0.12.28",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -38,6 +38,7 @@ opentelemetry-proto = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
+rayon = "1.11.0"
 rdkafka = { workspace = true }
 redis = { workspace = true }
 serde = { workspace = true }

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -438,20 +438,20 @@ corresponds 1:1 to a published event.
   └──────────────────────────┬───────────────────────────────────────┘
                              │
   ┌──────────────────────────▼───────────────────────────────────────┐
-  │ Phase 1: Enqueue (sequential, per-partition ordering preserved)  │
+  │ Phase 1: Prepare (serial < 8, else parallel) then serial enqueue │
   │                                                                 │
-  │   for each event:                                               │
+  │   prep each event (parallel on rayon pool for big batches):     │
   │     ├── should_publish()? → skip if false                       │
   │     ├── topic_for(destination)? → skip if Drop/None             │
-  │     ├── serialize_into(ctx, payload_buf)                        │
-  │     ├── event.headers(ctx) → CapturedEventHeaders               │
-  │     ├── event.partition_key(ctx, key_buf)                       │
-  │     ├── effective_partition_key(key, headers, dest) → key/None  │
-  │     ├── CapturedEventHeaders → OwnedHeaders (via From)          │
+  │     ├── serialize_into → owned payload                          │
+  │     ├── headers(ctx) + partition_key(ctx); null key per policy  │
+  │     └── build owned ProduceRecord (Err → serialization result)  │
+  │   sort prepared records by input index                          │
+  │   enqueue SERIALLY in input order (ordering invariant):         │
   │     └── producer.send(ProduceRecord)                            │
   │           ├── Ok(ack_future) → push to FuturesUnordered         │
-  │           ├── Err(QueueFull) + retries left → sleep, retry      │
-  │           └── Err(final) → results.push(KafkaResult err)        │
+  │           └── Err(e) → results.push(KafkaResult err)            │
+  │                 (QueueFull → RetriableError; no app-level retry) │
   └──────────────────────────┬───────────────────────────────────────┘
                              │
   ┌──────────────────────────▼───────────────────────────────────────┐
@@ -490,17 +490,29 @@ corresponds 1:1 to a published event.
                      Vec<Box<dyn SinkResult>>
 ```
 
-### Phase 1 — Enqueue
+### Phase 1 — Prepare + enqueue
 
-Events are sent sequentially to preserve per-partition ordering. Two
-reusable `String` buffers (`payload_buf`, `key_buf`) are cleared and
-rewritten each iteration, amortizing allocations to zero after the first
-event.
+Each event is first **prepared**: `serialize_into` produces an owned
+payload, `partition_key`/`headers` build the key and headers, and an owned
+`ProduceRecord` is assembled (`prepare_one`). Prep runs serially for
+batches below `SCATTER_GATHER_MIN_BATCH` (8) and in parallel on a
+dedicated, bounded rayon pool (under `block_in_place`) at or above it — v0
+proved this scatter-gather is a net win at batch scale. Prepared records
+carry their input index and are sorted back into input order before a
+strictly **serial enqueue** loop, which preserves per-partition on-wire
+ordering (librdkafka orders by `send_result` call order). A prep-pool panic
+is caught, counted (`capture_v1_kafka_prep_panic_total`), and fails the
+batch as retriable; `prepare_one` is panic-free by construction. Prep and
+enqueue wall-times are recorded separately
+(`capture_v1_kafka_serialize_duration_seconds`,
+`capture_v1_kafka_enqueue_duration_seconds`).
 
-If `producer.send()` returns `QueueFull`, the sink retries up to
-`enqueue_retry_max` times with `enqueue_poll_ms` pauses. This gives
-rdkafka's background thread time to drain in-flight deliveries. Metrics
-track recovery vs exhaustion via `capture_v1_kafka_queue_full_retries_total`.
+If `producer.send()` fails, the result is surfaced immediately as a
+`KafkaResult` error and the event is not enqueued. `QueueFull` is treated
+like any other retriable produce error (`Outcome::RetriableError` →
+`EventResult::Retry`), matching v0: there is no app-level enqueue retry
+loop. Backpressure is handled by librdkafka's own producer queue plus the
+client-side retry on a retriable response.
 
 After serialization and header construction, `effective_partition_key()`
 (`kafka/sink.rs`) decides whether the partition key should be nulled.
@@ -673,8 +685,6 @@ only needs to specify hosts and topics.
 | `retry_backoff_max_ms` | `1000` | `retry.backoff.max.ms` | Upper bound on exponential retry backoff |
 | `socket_send_buffer_bytes` | `0` | `socket.send.buffer.bytes` | TCP send buffer size; 0 = OS default |
 | `socket_receive_buffer_bytes` | `0` | `socket.receive.buffer.bytes` | TCP receive buffer size; 0 = OS default |
-| `enqueue_retry_max` | `3` | _(application-level)_ | QueueFull backpressure retries |
-| `enqueue_poll_ms` | `33` | _(application-level)_ | Pause between QueueFull retries |
 | `topic_main` | _(required)_ | — | Analytics main topic |
 | `topic_historical` | _(required)_ | — | Historical migration topic |
 | `topic_overflow` | _(required)_ | — | Overflow topic |
@@ -766,16 +776,23 @@ Constructed by `KafkaProducer::new(sink, &KafkaConfig, handle, capture_mode)`:
 ```rust
 pub struct ProduceRecord<'a> {
     pub topic: &'a str,
-    pub key: Option<&'a str>,
-    pub payload: &'a str,
+    pub key: Option<String>,
+    pub payload: String,
     pub headers: OwnedHeaders,
 }
 ```
 
+`topic` borrows either a config `String` (built-in destinations) or
+`Destination::Custom(String)` — both outlive the prep+enqueue scope so
+borrowing avoids a per-event clone. `payload` and `key` are owned because
+each event's serialized bytes must coexist across the batch (prerequisite
+for parallel prep).
+
 `send()` converts this to a `FutureRecord` and calls `send_result()`.
 On success it returns a `SendHandle` wrapping rdkafka's `DeliveryFuture`.
-On failure it returns the `ProduceRecord` back to the caller (enabling
-the QueueFull retry loop without reallocating the message).
+On failure it returns the `ProduceRecord` back to the caller alongside the
+`ProduceError`; the sink discards it and surfaces the error immediately
+(QueueFull included — see Phase 1).
 
 `SendHandle` implements `Future` and maps rdkafka delivery outcomes:
 
@@ -905,8 +922,10 @@ request-level context (`path`, `attempt`).
 |---|---|---|---|
 | `capture_v1_kafka_publish_total` | counter | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Every event outcome (success, error, timeout, reject) |
 | `capture_v1_kafka_ack_duration_seconds` | histogram | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Per-event broker-ack latency (successful send → ack resolution), including `outcome="timeout"` for acks that miss `produce_timeout` |
-| `capture_v1_kafka_enqueue_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+") | Per-batch enqueue wall-time (the `enqueue_events` call), isolated from broker-ack latency |
-| `capture_v1_kafka_queue_full_retries_total` | counter | `mode`, `cluster`, `result` | QueueFull retry (`result` = `recovered` or `exhausted`) |
+| `capture_v1_kafka_serialize_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+") | Per-batch prep wall-time (serialize + record build), serial or parallel |
+| `capture_v1_kafka_enqueue_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+") | Per-batch serial enqueue-loop wall-time, isolated from broker-ack latency |
+| `capture_v1_kafka_prep_panic_total` | counter | `mode`, `cluster` | Parallel prep pool panicked (batch failed retriable); should stay 0 |
+| `capture_v1_kafka_prep_pool_inflight` | gauge | _(none — shared pool)_ | Concurrent `publish_batch` calls inside the parallel prep pool (saturation proxy) |
 
 Cardinality note: the `destination` label is bounded at 9 values
 (`Destination::as_tag()` collapses all `Custom(_)` topics to `custom`)
@@ -1204,8 +1223,6 @@ Builder options include:
 | `ack_delay(d)` | Simulate slow acks / timeouts |
 | `not_ready()` | Producer health gate fails |
 | `with_liveness(deadline, poll)` | Custom liveness timing for health tests |
-| `enqueue_retry_max(n)` | QueueFull retry budget |
-| `enqueue_poll_ms(ms)` | QueueFull retry pause |
 
 ### Analytics event serialization tests
 

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -522,6 +522,23 @@ for latency measurement.
 Polling them inline in a single task is strictly cheaper than spawning
 real tokio tasks.
 
+#### Single batch deadline vs per-event deadline (head-of-line coupling)
+
+The deadline is **per batch**, not per event: `deadline = now +
+produce_timeout` is computed once, after the whole batch is enqueued, and
+every event in the batch shares it. Because enqueue is fast and serial, the
+last event's clock starts only marginally after the first's, so per-event
+`sent_at` (recorded for the ack-latency histogram) and the shared deadline
+stay close in practice.
+
+A per-event deadline (`sent_at + produce_timeout`, now feasible since WS3a
+threads `sent_at` through) would decouple a slow head-of-line event from the
+rest of the batch. It is **deliberately deferred**: the current model is
+simpler, matches v0, and `capture_v1_kafka_ack_duration_seconds` (per-event,
+including `outcome="timeout"`) now makes any head-of-line coupling directly
+observable. Revisit only if load-test tails (WS7) show the shared deadline
+materially penalizing fast events behind a slow one.
+
 ### Phase 3 — Sweep
 
 Any keys in `enqueued_keys` not present in `resolved_keys` after the
@@ -870,7 +887,9 @@ request.
 | `capture_v1_kafka_producer_queue_utilization` | gauge | `cluster`, `mode` | `stats()` (`msg_cnt / msg_max`) |
 | `capture_v1_kafka_batch_size_bytes_avg` | gauge | `cluster`, `mode`, `topic` | `stats()` |
 | `capture_v1_kafka_broker_connected` | gauge | `cluster`, `mode`, `broker` | `stats()` |
-| `capture_v1_kafka_broker_rtt_us` | gauge | `cluster`, `mode`, `quantile`, `broker` | `stats()` (p50 and p99) |
+| `capture_v1_kafka_broker_rtt_us` | gauge | `cluster`, `mode`, `quantile`, `broker` | `stats()` (full window: `min`/`avg`/`max`/`stddev`/`p50`/`p90`/`p95`/`p99`) |
+| `capture_v1_kafka_broker_int_latency_us` | gauge | `cluster`, `mode`, `quantile`, `broker` | `stats()` — time in producer internal queue (full window) |
+| `capture_v1_kafka_broker_outbuf_latency_us` | gauge | `cluster`, `mode`, `quantile`, `broker` | `stats()` — time in broker output buffer (full window) |
 | `capture_v1_kafka_broker_tx_errors_total` | counter | `cluster`, `mode`, `broker` | `stats()` via `.absolute()` |
 | `capture_v1_kafka_broker_rx_errors_total` | counter | `cluster`, `mode`, `broker` | `stats()` via `.absolute()` |
 
@@ -885,7 +904,8 @@ request-level context (`path`, `attempt`).
 | Metric | Type | Labels | When |
 |---|---|---|---|
 | `capture_v1_kafka_publish_total` | counter | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Every event outcome (success, error, timeout, reject) |
-| `capture_v1_kafka_ack_duration_seconds` | histogram | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Successful ack only |
+| `capture_v1_kafka_ack_duration_seconds` | histogram | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Per-event broker-ack latency (successful send → ack resolution), including `outcome="timeout"` for acks that miss `produce_timeout` |
+| `capture_v1_kafka_enqueue_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+") | Per-batch enqueue wall-time (the `enqueue_events` call), isolated from broker-ack latency |
 | `capture_v1_kafka_queue_full_retries_total` | counter | `mode`, `cluster`, `result` | QueueFull retry (`result` = `recovered` or `exhausted`) |
 
 Cardinality note: the `destination` label is bounded at 9 values

--- a/rust/capture/src/v1/sinks/kafka/config.rs
+++ b/rust/capture/src/v1/sinks/kafka/config.rs
@@ -94,16 +94,6 @@ pub struct Config {
     #[envconfig(default = "0")]
     pub socket_receive_buffer_bytes: u32,
 
-    // -- QueueFull backpressure --
-    /// Max enqueue retry attempts when rdkafka returns QueueFull.
-    /// 0 = no retries (immediate failure, pre-backpressure behavior).
-    #[envconfig(default = "3")]
-    pub enqueue_retry_max: u32,
-    /// Pause between QueueFull retry attempts (ms). Gives rdkafka's
-    /// background poller time to drain in-flight deliveries.
-    #[envconfig(default = "33")]
-    pub enqueue_poll_ms: u32,
-
     // -- Topics (all required -- envconfig errors if any are missing) --
     pub topic_main: String,
     pub topic_historical: String,
@@ -218,8 +208,6 @@ mod tests {
         env.insert("METADATA_MAX_AGE_MS".into(), "30000".into());
         env.insert("SOCKET_TIMEOUT_MS".into(), "30000".into());
         env.insert("STATISTICS_INTERVAL_MS".into(), "5000".into());
-        env.insert("ENQUEUE_RETRY_MAX".into(), "5".into());
-        env.insert("ENQUEUE_POLL_MS".into(), "50".into());
         env.insert("PARTITIONER".into(), "consistent_random".into());
         env.insert("MAX_RETRIES".into(), "6".into());
         env.insert("MAX_IN_FLIGHT_REQUESTS".into(), "500000".into());
@@ -248,8 +236,6 @@ mod tests {
         assert_eq!(cfg.metadata_max_age_ms, 30000);
         assert_eq!(cfg.socket_timeout_ms, 30000);
         assert_eq!(cfg.statistics_interval_ms, 5000);
-        assert_eq!(cfg.enqueue_retry_max, 5);
-        assert_eq!(cfg.enqueue_poll_ms, 50);
         assert_eq!(cfg.partitioner, "consistent_random");
         assert_eq!(cfg.max_retries, 6);
         assert_eq!(cfg.max_in_flight_requests, 500000);
@@ -282,8 +268,6 @@ mod tests {
         assert_eq!(cfg.metadata_max_age_ms, 15000);
         assert_eq!(cfg.socket_timeout_ms, 5000);
         assert_eq!(cfg.statistics_interval_ms, 10000);
-        assert_eq!(cfg.enqueue_retry_max, 3);
-        assert_eq!(cfg.enqueue_poll_ms, 33);
         assert_eq!(cfg.partitioner, "murmur2_random");
         assert_eq!(cfg.max_retries, 4);
         assert_eq!(cfg.max_in_flight_requests, 1000000);

--- a/rust/capture/src/v1/sinks/kafka/context.rs
+++ b/rust/capture/src/v1/sinks/kafka/context.rs
@@ -9,6 +9,36 @@ use crate::v1::sinks::SinkName;
 
 const BROKER_STATE_UP: &str = "UP";
 
+/// Emit min/avg/max/stddev + p50/p90/p95/p99 gauges for an rdkafka window
+/// stat, tagged by `quantile` and `broker`.
+fn emit_window_stats(
+    metric: &'static str,
+    w: &rdkafka::statistics::Window,
+    sink: &'static str,
+    mode: &'static str,
+    broker: &Arc<str>,
+) {
+    for (quantile, value) in [
+        ("min", w.min),
+        ("avg", w.avg),
+        ("max", w.max),
+        ("stddev", w.stddev),
+        ("p50", w.p50),
+        ("p90", w.p90),
+        ("p95", w.p95),
+        ("p99", w.p99),
+    ] {
+        gauge!(
+            metric,
+            "cluster" => sink,
+            "mode" => mode,
+            "quantile" => quantile,
+            "broker" => Arc::clone(broker),
+        )
+        .set(value as f64);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // KafkaContext
 // ---------------------------------------------------------------------------
@@ -101,15 +131,29 @@ impl rdkafka::ClientContext for KafkaContext {
             } else {
                 0.0
             });
+            // Broker round-trip latency.
             if let Some(rtt) = &bs.rtt {
-                gauge!("capture_v1_kafka_broker_rtt_us",
-                    "cluster" => sink, "mode" => mode,
-                    "quantile" => "p50", "broker" => Arc::clone(&id))
-                .set(rtt.p50 as f64);
-                gauge!("capture_v1_kafka_broker_rtt_us",
-                    "cluster" => sink, "mode" => mode,
-                    "quantile" => "p99", "broker" => Arc::clone(&id))
-                .set(rtt.p99 as f64);
+                emit_window_stats("capture_v1_kafka_broker_rtt_us", rtt, sink, mode, &id);
+            }
+            // Internal queue time (linger + backlog).
+            if let Some(int_latency) = &bs.int_latency {
+                emit_window_stats(
+                    "capture_v1_kafka_broker_int_latency_us",
+                    int_latency,
+                    sink,
+                    mode,
+                    &id,
+                );
+            }
+            // Output buffer time before wire send.
+            if let Some(outbuf_latency) = &bs.outbuf_latency {
+                emit_window_stats(
+                    "capture_v1_kafka_broker_outbuf_latency_us",
+                    outbuf_latency,
+                    sink,
+                    mode,
+                    &id,
+                );
             }
             counter!("capture_v1_kafka_broker_tx_errors_total",
                 "cluster" => sink, "mode" => mode, "broker" => Arc::clone(&id))

--- a/rust/capture/src/v1/sinks/kafka/mock.rs
+++ b/rust/capture/src/v1/sinks/kafka/mock.rs
@@ -20,22 +20,12 @@ pub struct OwnedProduceRecord {
     pub payload: String,
 }
 
-impl<'a> From<ProduceRecord<'a>> for OwnedProduceRecord {
-    fn from(r: ProduceRecord<'a>) -> Self {
-        Self {
-            topic: r.topic.to_owned(),
-            key: r.key.map(str::to_owned),
-            payload: r.payload.to_owned(),
-        }
-    }
-}
-
 impl<'a> From<&ProduceRecord<'a>> for OwnedProduceRecord {
     fn from(r: &ProduceRecord<'a>) -> Self {
         Self {
             topic: r.topic.to_owned(),
-            key: r.key.map(str::to_owned),
-            payload: r.payload.to_owned(),
+            key: r.key.clone(),
+            payload: r.payload.clone(),
         }
     }
 }

--- a/rust/capture/src/v1/sinks/kafka/producer.rs
+++ b/rust/capture/src/v1/sinks/kafka/producer.rs
@@ -47,15 +47,6 @@ impl ProduceError {
         }
     }
 
-    pub fn is_queue_full(&self) -> bool {
-        matches!(
-            self,
-            Self::Kafka {
-                code: RDKafkaErrorCode::QueueFull,
-            }
-        )
-    }
-
     /// Stable, low-cardinality tag for metrics and log aggregation.
     pub fn as_tag(&self) -> &'static str {
         match self {
@@ -70,11 +61,14 @@ impl ProduceError {
 // ProduceRecord
 // ---------------------------------------------------------------------------
 
+/// Produce record with a borrowed topic and owned payload/key.
+/// Topic borrows a config or `Destination::Custom` string that outlives the
+/// batch; payload/key are owned so events coexist across parallel prep.
 #[derive(Debug)]
 pub struct ProduceRecord<'a> {
     pub topic: &'a str,
-    pub key: Option<&'a str>,
-    pub payload: &'a str,
+    pub key: Option<String>,
+    pub payload: String,
     pub headers: OwnedHeaders,
 }
 
@@ -229,23 +223,35 @@ impl super::KafkaProducerTrait for KafkaProducer {
         &self,
         record: ProduceRecord<'a>,
     ) -> Result<SendHandle, (ProduceError, ProduceRecord<'a>)> {
-        match self.inner.send_result(FutureRecord {
-            topic: record.topic,
-            payload: Some(record.payload),
+        let ProduceRecord {
+            topic,
+            key,
+            payload,
+            headers,
+        } = record;
+
+        let future_record = FutureRecord {
+            topic,
+            payload: Some(payload.as_str()),
             partition: None,
-            key: record.key,
+            key: key.as_deref(),
             timestamp: None,
-            headers: Some(record.headers),
-        }) {
+            headers: Some(headers),
+        };
+
+        match self.inner.send_result(future_record) {
             Ok(future) => Ok(SendHandle { inner: future }),
             Err((e, returned)) => {
-                let returned_record = ProduceRecord {
-                    topic: returned.topic,
-                    key: returned.key,
-                    payload: returned.payload.unwrap_or(""),
-                    headers: returned.headers.unwrap_or_else(OwnedHeaders::new),
-                };
-                Err((produce_error_from_kafka(e), returned_record))
+                let headers = returned.headers.unwrap_or_else(OwnedHeaders::new);
+                Err((
+                    produce_error_from_kafka(e),
+                    ProduceRecord {
+                        topic,
+                        key,
+                        payload,
+                        headers,
+                    },
+                ))
             }
         }
     }

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -136,6 +136,7 @@ type AckFuture = Pin<
                     Uuid,
                     &'static str,
                     DateTime<Utc>,
+                    Duration,
                     Result<(), super::producer::ProduceError>,
                 ),
             > + Send,
@@ -156,7 +157,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
         enqueued_at: DateTime<Utc>,
         results: &mut Vec<Box<dyn SinkResult>>,
         pending: &mut FuturesUnordered<AckFuture>,
-        enqueued_keys: &mut Vec<(Uuid, &'static str)>,
+        enqueued_keys: &mut Vec<(Uuid, &'static str, Instant)>,
     ) {
         let mut payload_buf = String::with_capacity(4096);
         let mut key_buf = String::with_capacity(128);
@@ -243,10 +244,12 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                             )
                             .increment(1);
                         }
-                        enqueued_keys.push((uuid, dest_tag));
+                        let sent_at = Instant::now();
+                        enqueued_keys.push((uuid, dest_tag, sent_at));
                         pending.push(Box::pin(async move {
                             let result = ack_future.await;
-                            (uuid, dest_tag, Utc::now(), result)
+                            let ack_latency = sent_at.elapsed();
+                            (uuid, dest_tag, Utc::now(), ack_latency, result)
                         }));
                         break;
                     }
@@ -304,7 +307,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
 
         loop {
             match tokio::time::timeout_at(deadline, pending.next()).await {
-                Ok(Some((uuid, dest_tag, completed_at, ack))) => {
+                Ok(Some((uuid, dest_tag, completed_at, ack_latency, ack))) => {
                     resolved_keys.insert(uuid);
 
                     let outcome_tag = match &ack {
@@ -329,19 +332,18 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                     )
                     .increment(1);
 
-                    let elapsed = completed_at.signed_duration_since(enqueued_at);
-                    if let Ok(secs) = elapsed.to_std() {
-                        histogram!(
-                            "capture_v1_kafka_ack_duration_seconds",
-                            "mode" => labels.mode,
-                            "cluster" => labels.sink,
-                            "outcome" => outcome_tag,
-                            "path" => labels.path,
-                            "attempt" => labels.attempt,
-                            "destination" => dest_tag,
-                        )
-                        .record(secs.as_secs_f64());
-                    }
+                    // Per-event broker-ack latency (send → ack), isolated from
+                    // batch enqueue wall-time.
+                    histogram!(
+                        "capture_v1_kafka_ack_duration_seconds",
+                        "mode" => labels.mode,
+                        "cluster" => labels.sink,
+                        "outcome" => outcome_tag,
+                        "path" => labels.path,
+                        "attempt" => labels.attempt,
+                        "destination" => dest_tag,
+                    )
+                    .record(ack_latency.as_secs_f64());
 
                     match ack {
                         Ok(()) => results.push(Box::new(
@@ -365,20 +367,20 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
     fn collect_timeouts(
         labels: &MetricLabels,
         enqueued_at: DateTime<Utc>,
-        enqueued_keys: Vec<(Uuid, &'static str)>,
+        enqueued_keys: Vec<(Uuid, &'static str, Instant)>,
         resolved_keys: &HashSet<Uuid>,
         results: &mut Vec<Box<dyn SinkResult>>,
     ) {
         let timed_out: Vec<_> = enqueued_keys
             .into_iter()
-            .filter(|(k, _)| !resolved_keys.contains(k))
+            .filter(|(k, _, _)| !resolved_keys.contains(k))
             .collect();
         if timed_out.is_empty() {
             return;
         }
         let mut by_dest: std::collections::HashMap<&'static str, u64> =
             std::collections::HashMap::new();
-        for (_, dest_tag) in &timed_out {
+        for (_, dest_tag, _) in &timed_out {
             *by_dest.entry(dest_tag).or_default() += 1;
         }
         for (dest_tag, count) in &by_dest {
@@ -394,7 +396,19 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
             .increment(*count);
         }
         let gave_up_at = Utc::now();
-        for (uuid, _) in timed_out {
+        for (uuid, dest_tag, sent_at) in timed_out {
+            // Record timed-out acks so the latency tail (>= produce_timeout)
+            // is visible rather than silently dropped.
+            histogram!(
+                "capture_v1_kafka_ack_duration_seconds",
+                "mode" => labels.mode,
+                "cluster" => labels.sink,
+                "outcome" => Outcome::Timeout.as_tag(),
+                "path" => labels.path,
+                "attempt" => labels.attempt,
+                "destination" => dest_tag,
+            )
+            .record(sent_at.elapsed().as_secs_f64());
             results.push(Box::new(
                 KafkaResult::err(uuid, KafkaSinkError::Timeout, enqueued_at)
                     .with_completed_at(gave_up_at),
@@ -435,8 +449,10 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
         let enqueued_at = Utc::now();
         let mut results: Vec<Box<dyn SinkResult>> = Vec::new();
         let mut pending: FuturesUnordered<AckFuture> = FuturesUnordered::new();
-        let mut enqueued_keys: Vec<(Uuid, &'static str)> = Vec::new();
+        let mut enqueued_keys: Vec<(Uuid, &'static str, Instant)> = Vec::new();
 
+        // Enqueue wall-time, isolated from per-event broker-ack latency.
+        let enqueue_start = Instant::now();
         self.enqueue_events(
             ctx,
             events,
@@ -447,6 +463,14 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
             &mut enqueued_keys,
         )
         .await;
+        histogram!(
+            "capture_v1_kafka_enqueue_duration_seconds",
+            "mode" => labels.mode,
+            "cluster" => labels.sink,
+            "path" => labels.path,
+            "attempt" => labels.attempt,
+        )
+        .record(enqueue_start.elapsed().as_secs_f64());
 
         let resolved_keys = self
             .drain_acks(&labels, enqueued_at, &mut results, &mut pending)

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -1,14 +1,16 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use metrics::{counter, histogram};
+use metrics::{counter, gauge, histogram};
+use rayon::prelude::*;
 use tracing::Level;
 use uuid::Uuid;
 
@@ -22,6 +24,66 @@ use crate::v1::sinks::{Config, SinkName};
 use super::producer::ProduceRecord;
 use super::types::{KafkaResult, KafkaSinkError};
 use super::KafkaProducerTrait;
+
+/// Minimum batch size for parallel prep on the rayon pool; smaller batches
+/// stay serial because scatter-gather overhead exceeds per-event savings.
+pub(crate) const SCATTER_GATHER_MIN_BATCH: usize = 8;
+
+/// Fixed prep pool size — bounded to avoid oversubscribing the cgroup.
+const PREP_POOL_THREADS: usize = 4;
+
+/// In-flight prep batches — saturation proxy since rayon doesn't expose
+/// queue depth. Values sustained above `PREP_POOL_THREADS` = oversubscribed.
+static PREP_POOL_INFLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+/// Shared rayon pool for parallel batch prep, built once on first use.
+fn prep_pool() -> &'static rayon::ThreadPool {
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(PREP_POOL_THREADS)
+            .thread_name(|i| format!("v1-kafka-prep-{i}"))
+            .build()
+            .expect("failed to build v1 kafka prep thread pool")
+    })
+}
+
+/// RAII guard for `PREP_POOL_INFLIGHT` — gauge updated on enter and drop.
+struct PrepPoolGuard;
+
+impl PrepPoolGuard {
+    fn enter() -> Self {
+        let inflight = PREP_POOL_INFLIGHT.fetch_add(1, Ordering::Relaxed) + 1;
+        gauge!("capture_v1_kafka_prep_pool_inflight").set(inflight as f64);
+        Self
+    }
+}
+
+impl Drop for PrepPoolGuard {
+    fn drop(&mut self) {
+        let inflight = PREP_POOL_INFLIGHT
+            .fetch_sub(1, Ordering::Relaxed)
+            .saturating_sub(1);
+        gauge!("capture_v1_kafka_prep_pool_inflight").set(inflight as f64);
+    }
+}
+
+/// Enqueue-ready event with its input index for restoring order after
+/// parallel prep.
+struct Prepared<'a> {
+    idx: usize,
+    uuid: Uuid,
+    dest_tag: &'static str,
+    record: ProduceRecord<'a>,
+}
+
+/// `Ok(Prepared)` = enqueue-ready, `Err(result)` = serialization failure.
+/// Skipped events are filtered to `None` upstream.
+type PrepOutcome<'a> = Result<Prepared<'a>, Box<dyn SinkResult>>;
+
+/// Output of `prepare_one`: an enqueue-ready record before its batch index is
+/// attached (`prep_outcome` wraps this into a `Prepared`). `None` = skipped.
+type ReadyRecord<'a> = (Uuid, &'static str, ProduceRecord<'a>);
 
 /// Null the partition key when person processing is force-disabled for
 /// Main/Overflow destinations — spreads load across partitions instead of
@@ -144,150 +206,287 @@ type AckFuture = Pin<
 >;
 
 impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
-    /// Phase 1: serialize and enqueue events to the producer sequentially,
-    /// preserving per-partition ordering. Returns early results for
-    /// serialization / send failures and collects ack futures for events
-    /// that were successfully enqueued.
-    #[allow(clippy::too_many_arguments)]
-    async fn enqueue_events(
+    /// Serialize one event into a `ProduceRecord`. Returns `Ok(None)` for
+    /// skipped/dropped events, `Err` for serialization failures.
+    /// Safe to call concurrently (reads only, panic-free by construction).
+    fn prepare_one<'a>(
+        &'a self,
+        ctx: &Context,
+        event: &'a (dyn Event + Send + Sync),
+        labels: &MetricLabels,
+        enqueued_at: DateTime<Utc>,
+    ) -> Result<Option<ReadyRecord<'a>>, Box<dyn SinkResult>> {
+        if !event.should_publish() {
+            return Ok(None);
+        }
+
+        let uuid = event.uuid();
+        let dest_tag = event.destination().as_tag();
+
+        let topic = match self.config.kafka.topic_for(event.destination()) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let mut payload = String::with_capacity(4096);
+        if let Err(e) = event.serialize_into(ctx, &mut payload) {
+            crate::ctx_log!(
+                Level::ERROR,
+                ctx,
+                sink = labels.sink,
+                event_uuid = %uuid,
+                error = %e,
+                "event serialization failed, dropping event"
+            );
+            counter!(
+                "capture_v1_kafka_publish_total",
+                "mode" => labels.mode,
+                "cluster" => labels.sink,
+                "outcome" => Outcome::FatalError.as_tag(),
+                "path" => labels.path,
+                "attempt" => labels.attempt,
+                "destination" => dest_tag,
+            )
+            .increment(1);
+            return Err(Box::new(KafkaResult::err(
+                uuid,
+                KafkaSinkError::SerializationFailed(format!("{e:#}")),
+                enqueued_at,
+            )));
+        }
+
+        let captured_headers = event.headers(ctx);
+
+        let mut key_buf = String::with_capacity(128);
+        event.partition_key(ctx, &mut key_buf);
+        let key = effective_partition_key(
+            &key_buf,
+            captured_headers
+                .force_disable_person_processing
+                .unwrap_or(false),
+            event.destination(),
+        )
+        .map(str::to_owned);
+
+        let headers: rdkafka::message::OwnedHeaders = captured_headers.into();
+
+        Ok(Some((
+            uuid,
+            dest_tag,
+            ProduceRecord {
+                topic,
+                key,
+                payload,
+                headers,
+            },
+        )))
+    }
+
+    /// Stamp input index onto a prepared event; folds skips into `None`.
+    fn prep_outcome<'a>(
+        &'a self,
+        idx: usize,
+        ctx: &Context,
+        event: &'a (dyn Event + Send + Sync),
+        labels: &MetricLabels,
+        enqueued_at: DateTime<Utc>,
+    ) -> Option<PrepOutcome<'a>> {
+        match self.prepare_one(ctx, event, labels, enqueued_at) {
+            Ok(Some((uuid, dest_tag, record))) => Some(Ok(Prepared {
+                idx,
+                uuid,
+                dest_tag,
+                record,
+            })),
+            Ok(None) => None,
+            Err(early) => Some(Err(early)),
+        }
+    }
+
+    /// Parallel prep on the rayon pool. Returns `None` on prep-task panic
+    /// (defensive — `prepare_one` is panic-free by construction).
+    fn prepare_parallel<'a>(
+        &'a self,
+        ctx: &Context,
+        events: &'a [&'a (dyn Event + Send + Sync)],
+        labels: &MetricLabels,
+        enqueued_at: DateTime<Utc>,
+    ) -> Option<Vec<PrepOutcome<'a>>> {
+        let _guard = PrepPoolGuard::enter();
+        let pool = prep_pool();
+        // Yield tokio worker; catch_unwind converts panic into batch failure.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tokio::task::block_in_place(|| {
+                pool.install(|| {
+                    events
+                        .par_iter()
+                        .enumerate()
+                        .filter_map(|(idx, event)| {
+                            self.prep_outcome(idx, ctx, *event, labels, enqueued_at)
+                        })
+                        .collect::<Vec<PrepOutcome<'a>>>()
+                })
+            })
+        }));
+
+        match outcome {
+            Ok(outcomes) => Some(outcomes),
+            Err(_) => {
+                counter!(
+                    "capture_v1_kafka_prep_panic_total",
+                    "mode" => labels.mode,
+                    "cluster" => labels.sink,
+                )
+                .increment(1);
+                None
+            }
+        }
+    }
+
+    /// Fail entire batch as retriable on prep-pool panic.
+    fn fail_batch_prep_panic(
         &self,
         ctx: &Context,
         events: &[&(dyn Event + Send + Sync)],
         labels: &MetricLabels,
         enqueued_at: DateTime<Utc>,
         results: &mut Vec<Box<dyn SinkResult>>,
+    ) {
+        crate::ctx_log!(
+            Level::ERROR,
+            ctx,
+            sink = labels.sink,
+            mode = labels.mode,
+            "parallel batch prep panicked — failing batch as retriable"
+        );
+        for event in events {
+            if !event.should_publish() || self.config.kafka.topic_for(event.destination()).is_none()
+            {
+                continue;
+            }
+            let dest_tag = event.destination().as_tag();
+            counter!(
+                "capture_v1_kafka_publish_total",
+                "mode" => labels.mode,
+                "cluster" => labels.sink,
+                "outcome" => Outcome::RetriableError.as_tag(),
+                "path" => labels.path,
+                "attempt" => labels.attempt,
+                "destination" => dest_tag,
+            )
+            .increment(1);
+            results.push(Box::new(KafkaResult::err(
+                event.uuid(),
+                KafkaSinkError::TaskPanicked,
+                enqueued_at,
+            )));
+        }
+    }
+
+    /// Prepare + enqueue the batch. Prep is parallel for large batches;
+    /// enqueue is always serial to preserve per-partition ordering.
+    #[allow(clippy::too_many_arguments)]
+    async fn enqueue_events<'a>(
+        &'a self,
+        ctx: &Context,
+        events: &'a [&'a (dyn Event + Send + Sync)],
+        labels: &MetricLabels,
+        enqueued_at: DateTime<Utc>,
+        results: &mut Vec<Box<dyn SinkResult>>,
         pending: &mut FuturesUnordered<AckFuture>,
         enqueued_keys: &mut Vec<(Uuid, &'static str, Instant)>,
     ) {
-        let mut payload_buf = String::with_capacity(4096);
-        let mut key_buf = String::with_capacity(128);
-
-        for event in events {
-            if !event.should_publish() {
-                continue;
-            }
-
-            let uuid = event.uuid();
-            let dest_tag = event.destination().as_tag();
-
-            let topic = match self.config.kafka.topic_for(event.destination()) {
-                Some(t) => t,
-                None => continue,
-            };
-
-            payload_buf.clear();
-            if let Err(e) = event.serialize_into(ctx, &mut payload_buf) {
-                crate::ctx_log!(
-                    Level::ERROR,
-                    ctx,
-                    sink = labels.sink,
-                    event_uuid = %uuid,
-                    error = %e,
-                    "event serialization failed, dropping event"
-                );
-                counter!(
-                    "capture_v1_kafka_publish_total",
-                    "mode" => labels.mode,
-                    "cluster" => labels.sink,
-                    "outcome" => Outcome::FatalError.as_tag(),
-                    "path" => labels.path,
-                    "attempt" => labels.attempt,
-                    "destination" => dest_tag,
-                )
-                .increment(1);
-                results.push(Box::new(KafkaResult::err(
-                    uuid,
-                    KafkaSinkError::SerializationFailed(format!("{e:#}")),
-                    enqueued_at,
-                )));
-                continue;
-            }
-
-            let captured_headers = event.headers(ctx);
-
-            key_buf.clear();
-            event.partition_key(ctx, &mut key_buf);
-            let key = effective_partition_key(
-                &key_buf,
-                captured_headers
-                    .force_disable_person_processing
-                    .unwrap_or(false),
-                event.destination(),
-            );
-
-            let headers: rdkafka::message::OwnedHeaders = captured_headers.into();
-
-            let mut record = ProduceRecord {
-                topic,
-                key,
-                payload: &payload_buf,
-                headers,
-            };
-
-            let enqueue_retry_max = self.config.kafka.enqueue_retry_max;
-            let enqueue_poll = Duration::from_millis(self.config.kafka.enqueue_poll_ms as u64);
-            let mut hit_queue_full = false;
-
-            for enqueue_attempt in 0..=enqueue_retry_max {
-                if enqueue_attempt > 0 {
-                    tokio::time::sleep(enqueue_poll).await;
+        // -- Prep phase: serialize + build records (parallel for big batches) --
+        let serialize_start = Instant::now();
+        let outcomes: Vec<PrepOutcome<'a>> = if events.len() >= SCATTER_GATHER_MIN_BATCH {
+            match self.prepare_parallel(ctx, events, labels, enqueued_at) {
+                Some(outcomes) => outcomes,
+                None => {
+                    // Prep panic — fail whole batch retriably, skip enqueue.
+                    self.fail_batch_prep_panic(ctx, events, labels, enqueued_at, results);
+                    histogram!(
+                        "capture_v1_kafka_serialize_duration_seconds",
+                        "mode" => labels.mode,
+                        "cluster" => labels.sink,
+                        "path" => labels.path,
+                        "attempt" => labels.attempt,
+                    )
+                    .record(serialize_start.elapsed().as_secs_f64());
+                    return;
                 }
+            }
+        } else {
+            events
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, event)| self.prep_outcome(idx, ctx, *event, labels, enqueued_at))
+                .collect()
+        };
 
-                match self.producer.send(record) {
-                    Ok(ack_future) => {
-                        if hit_queue_full {
-                            counter!(
-                                "capture_v1_kafka_queue_full_retries_total",
-                                "mode" => labels.mode,
-                                "cluster" => labels.sink,
-                                "result" => "recovered",
-                            )
-                            .increment(1);
-                        }
-                        let sent_at = Instant::now();
-                        enqueued_keys.push((uuid, dest_tag, sent_at));
-                        pending.push(Box::pin(async move {
-                            let result = ack_future.await;
-                            let ack_latency = sent_at.elapsed();
-                            (uuid, dest_tag, Utc::now(), ack_latency, result)
-                        }));
-                        break;
-                    }
-                    Err((e, returned_record))
-                        if e.is_queue_full() && enqueue_attempt < enqueue_retry_max =>
-                    {
-                        hit_queue_full = true;
-                        record = returned_record;
-                        continue;
-                    }
-                    Err((e, _)) => {
-                        if hit_queue_full || e.is_queue_full() {
-                            counter!(
-                                "capture_v1_kafka_queue_full_retries_total",
-                                "mode" => labels.mode,
-                                "cluster" => labels.sink,
-                                "result" => "exhausted",
-                            )
-                            .increment(1);
-                        }
-                        let sink_err = KafkaSinkError::Produce(e);
-                        let outcome = sink_err.outcome();
-                        counter!(
-                            "capture_v1_kafka_publish_total",
-                            "mode" => labels.mode,
-                            "cluster" => labels.sink,
-                            "outcome" => outcome.as_tag(),
-                            "path" => labels.path,
-                            "attempt" => labels.attempt,
-                            "destination" => dest_tag,
-                        )
-                        .increment(1);
-                        results.push(Box::new(KafkaResult::err(uuid, sink_err, enqueued_at)));
-                        break;
-                    }
+        let mut prepared: Vec<Prepared<'a>> = Vec::with_capacity(outcomes.len());
+        for outcome in outcomes {
+            match outcome {
+                Ok(p) => prepared.push(p),
+                Err(early) => results.push(early),
+            }
+        }
+        // Restore input order for serial enqueue (no-op for serial prep path,
+        // required after parallel prep to preserve per-partition ordering).
+        prepared.sort_unstable_by_key(|p| p.idx);
+        histogram!(
+            "capture_v1_kafka_serialize_duration_seconds",
+            "mode" => labels.mode,
+            "cluster" => labels.sink,
+            "path" => labels.path,
+            "attempt" => labels.attempt,
+        )
+        .record(serialize_start.elapsed().as_secs_f64());
+
+        // -- Enqueue phase: serial, original event order (ordering invariant) --
+        let enqueue_start = Instant::now();
+        for Prepared {
+            idx: _,
+            uuid,
+            dest_tag,
+            record,
+        } in prepared
+        {
+            // QueueFull → RetriableError immediately; no app-level retry loop.
+            match self.producer.send(record) {
+                Ok(ack_future) => {
+                    let sent_at = Instant::now();
+                    enqueued_keys.push((uuid, dest_tag, sent_at));
+                    pending.push(Box::pin(async move {
+                        let result = ack_future.await;
+                        let ack_latency = sent_at.elapsed();
+                        (uuid, dest_tag, Utc::now(), ack_latency, result)
+                    }));
+                }
+                Err((e, _)) => {
+                    let sink_err = KafkaSinkError::Produce(e);
+                    let outcome = sink_err.outcome();
+                    counter!(
+                        "capture_v1_kafka_publish_total",
+                        "mode" => labels.mode,
+                        "cluster" => labels.sink,
+                        "outcome" => outcome.as_tag(),
+                        "path" => labels.path,
+                        "attempt" => labels.attempt,
+                        "destination" => dest_tag,
+                    )
+                    .increment(1);
+                    results.push(Box::new(KafkaResult::err(uuid, sink_err, enqueued_at)));
                 }
             }
         }
+        histogram!(
+            "capture_v1_kafka_enqueue_duration_seconds",
+            "mode" => labels.mode,
+            "cluster" => labels.sink,
+            "path" => labels.path,
+            "attempt" => labels.attempt,
+        )
+        .record(enqueue_start.elapsed().as_secs_f64());
     }
 
     /// Phase 2: drain ack futures with a per-sink deadline. Dropping remaining
@@ -451,8 +650,7 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
         let mut pending: FuturesUnordered<AckFuture> = FuturesUnordered::new();
         let mut enqueued_keys: Vec<(Uuid, &'static str, Instant)> = Vec::new();
 
-        // Enqueue wall-time, isolated from per-event broker-ack latency.
-        let enqueue_start = Instant::now();
+        // Prep + enqueue (metrics emitted inside).
         self.enqueue_events(
             ctx,
             events,
@@ -463,14 +661,6 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
             &mut enqueued_keys,
         )
         .await;
-        histogram!(
-            "capture_v1_kafka_enqueue_duration_seconds",
-            "mode" => labels.mode,
-            "cluster" => labels.sink,
-            "path" => labels.path,
-            "attempt" => labels.attempt,
-        )
-        .record(enqueue_start.elapsed().as_secs_f64());
 
         let resolved_keys = self
             .drain_acks(&labels, enqueued_at, &mut results, &mut pending)

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -17,7 +17,7 @@ use crate::v1::test_utils::{self, WrappedEventMut};
 
 use super::mock::MockProducer;
 use super::producer::ProduceError;
-use super::sink::KafkaSink;
+use super::sink::{KafkaSink, SCATTER_GATHER_MIN_BATCH};
 
 /// All-None CapturedEventHeaders for stubbing FakeEvent. `CapturedEventHeaders`
 /// does not derive `Default` in common_types; keep the literal here so the
@@ -152,8 +152,6 @@ impl TestHarness {
             ack_delay: None,
             not_ready: false,
             liveness: None,
-            enqueue_retry_max: None,
-            enqueue_poll_ms: None,
         }
     }
 }
@@ -166,8 +164,6 @@ struct HarnessBuilder {
     ack_delay: Option<Duration>,
     not_ready: bool,
     liveness: Option<(Duration, Duration)>,
-    enqueue_retry_max: Option<u32>,
-    enqueue_poll_ms: Option<u32>,
 }
 
 impl HarnessBuilder {
@@ -203,16 +199,6 @@ impl HarnessBuilder {
 
     fn with_liveness(mut self, deadline: Duration, poll_interval: Duration) -> Self {
         self.liveness = Some((deadline, poll_interval));
-        self
-    }
-
-    fn enqueue_retry_max(mut self, n: u32) -> Self {
-        self.enqueue_retry_max = Some(n);
-        self
-    }
-
-    fn enqueue_poll_ms(mut self, ms: u32) -> Self {
-        self.enqueue_poll_ms = Some(ms);
         self
     }
 
@@ -255,13 +241,7 @@ impl HarnessBuilder {
 
         let producer = Arc::new(mock);
 
-        let mut kafka_config = crate::v1::test_utils::test_kafka_config();
-        if let Some(n) = self.enqueue_retry_max {
-            kafka_config.enqueue_retry_max = n;
-        }
-        if let Some(ms) = self.enqueue_poll_ms {
-            kafka_config.enqueue_poll_ms = ms;
-        }
+        let kafka_config = crate::v1::test_utils::test_kafka_config();
 
         let config = Config {
             produce_timeout: self.produce_timeout,
@@ -383,7 +363,6 @@ async fn send_error_retriable_queue_full() {
         .send_error(|| ProduceError::Kafka {
             code: RDKafkaErrorCode::QueueFull,
         })
-        .enqueue_retry_max(0)
         .build();
     let event = FakeEvent::ok("evt-1");
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
@@ -392,81 +371,6 @@ async fn send_error_retriable_queue_full() {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].key(), event.parsed_uuid);
-    assert_eq!(results[0].outcome(), Outcome::RetriableError);
-    assert_eq!(results[0].cause(), Some("queue_full"));
-    assert_eq!(h.producer.record_count(), 0);
-}
-
-// ---------------------------------------------------------------------------
-// 5b. QueueFull retry succeeds after drain
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn queue_full_retry_succeeds_after_drain() {
-    let h = TestHarness::builder()
-        .send_error(|| ProduceError::Kafka {
-            code: RDKafkaErrorCode::QueueFull,
-        })
-        .send_error_count(2)
-        .enqueue_retry_max(3)
-        .enqueue_poll_ms(1)
-        .build();
-    let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].key(), event.parsed_uuid);
-    assert_eq!(results[0].outcome(), Outcome::Success);
-    assert_eq!(h.producer.record_count(), 1);
-}
-
-// ---------------------------------------------------------------------------
-// 5c. QueueFull retry exhausted
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn queue_full_retry_exhausted() {
-    let h = TestHarness::builder()
-        .send_error(|| ProduceError::Kafka {
-            code: RDKafkaErrorCode::QueueFull,
-        })
-        .enqueue_retry_max(2)
-        .enqueue_poll_ms(1)
-        .build();
-    let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].key(), event.parsed_uuid);
-    assert_eq!(results[0].outcome(), Outcome::RetriableError);
-    assert_eq!(results[0].cause(), Some("queue_full"));
-    assert_eq!(h.producer.record_count(), 0);
-}
-
-// ---------------------------------------------------------------------------
-// 5d. QueueFull retry disabled (enqueue_retry_max = 0)
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn queue_full_retry_zero_max_disables_retry() {
-    let h = TestHarness::builder()
-        .send_error(|| ProduceError::Kafka {
-            code: RDKafkaErrorCode::QueueFull,
-        })
-        .send_error_count(1)
-        .enqueue_retry_max(0)
-        .enqueue_poll_ms(1)
-        .build();
-    let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 1);
     assert_eq!(results[0].outcome(), Outcome::RetriableError);
     assert_eq!(results[0].cause(), Some("queue_full"));
     assert_eq!(h.producer.record_count(), 0);
@@ -806,11 +710,9 @@ fn health_harness(mode: &FailureMode) -> TestHarness {
             b = b.ack_delay(Duration::from_secs(10));
         }
         FailureMode::SendError => {
-            b = b
-                .send_error(|| ProduceError::Kafka {
-                    code: RDKafkaErrorCode::QueueFull,
-                })
-                .enqueue_retry_max(0);
+            b = b.send_error(|| ProduceError::Kafka {
+                code: RDKafkaErrorCode::QueueFull,
+            });
         }
         FailureMode::AckError => {
             b = b.ack_error(|| ProduceError::DeliveryCancelled);
@@ -1093,7 +995,6 @@ async fn mixed_send_error_and_ack_error_in_batch() {
             code: RDKafkaErrorCode::QueueFull,
         })
         .send_error_count(1)
-        .enqueue_retry_max(0)
         .ack_error(|| ProduceError::DeliveryCancelled)
         .build();
     let e1 = FakeEvent::ok("evt-1");
@@ -1132,7 +1033,6 @@ async fn partial_timeout_with_send_error() {
             code: RDKafkaErrorCode::QueueFull,
         })
         .send_error_count(1)
-        .enqueue_retry_max(0)
         .ack_delay(Duration::from_secs(60))
         .produce_timeout(Duration::from_millis(50))
         .build();
@@ -1327,5 +1227,141 @@ async fn realistic_force_disable_pp_null_partition_key() {
     assert_eq!(results[0].outcome(), Outcome::Success);
     h.producer.with_records(|records| {
         assert!(records[0].key.is_none());
+    });
+}
+
+// ===========================================================================
+// Parallel batch prep (scatter-gather)
+//
+// Batches >= SCATTER_GATHER_MIN_BATCH prep in parallel; enqueue stays serial.
+// multi_thread flavor required for block_in_place.
+// ===========================================================================
+
+/// N events with distinct, order-revealing partition keys (`phc_test:evt-NNN`).
+fn ordered_events(n: usize) -> Vec<FakeEvent> {
+    (0..n)
+        .map(|i| FakeEvent::ok(&format!("evt-{i:03}")))
+        .collect()
+}
+
+fn as_dyn(events: &[FakeEvent]) -> Vec<&(dyn Event + Send + Sync)> {
+    let mut refs: Vec<&(dyn Event + Send + Sync)> = Vec::with_capacity(events.len());
+    for e in events {
+        refs.push(e);
+    }
+    refs
+}
+
+/// Below-threshold batches stay serial and preserve input order.
+#[tokio::test]
+async fn serial_prep_below_threshold_preserves_order() {
+    let n = SCATTER_GATHER_MIN_BATCH - 1;
+    let h = TestHarness::new();
+    let owned = ordered_events(n);
+    let events = as_dyn(&owned);
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), n);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+    assert_eq!(h.producer.record_count(), n);
+    h.producer.with_records(|records| {
+        let keys: Vec<&str> = records.iter().map(|r| r.key.as_deref().unwrap()).collect();
+        let expected: Vec<String> = (0..n).map(|i| format!("phc_test:evt-{i:03}")).collect();
+        assert_eq!(
+            keys,
+            expected.iter().map(String::as_str).collect::<Vec<_>>()
+        );
+    });
+}
+
+/// At-threshold batches take the parallel path; all events succeed and
+/// enqueue order matches input order.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_prep_at_threshold_all_succeed() {
+    let n = SCATTER_GATHER_MIN_BATCH;
+    let h = TestHarness::new();
+    let owned = ordered_events(n);
+    let events = as_dyn(&owned);
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), n);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+    assert_eq!(h.producer.record_count(), n);
+    h.producer.with_records(|records| {
+        let keys: Vec<&str> = records.iter().map(|r| r.key.as_deref().unwrap()).collect();
+        let expected: Vec<String> = (0..n).map(|i| format!("phc_test:evt-{i:03}")).collect();
+        assert_eq!(
+            keys,
+            expected.iter().map(String::as_str).collect::<Vec<_>>()
+        );
+    });
+}
+
+/// Above-threshold parallel prep preserves input (= serial) enqueue order.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_prep_above_threshold_preserves_order_and_outcomes() {
+    let n = SCATTER_GATHER_MIN_BATCH + 4;
+    let h = TestHarness::new();
+    let owned = ordered_events(n);
+    let events = as_dyn(&owned);
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), n);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+    assert_eq!(h.producer.record_count(), n);
+    h.producer.with_records(|records| {
+        let keys: Vec<&str> = records.iter().map(|r| r.key.as_deref().unwrap()).collect();
+        let expected: Vec<String> = (0..n).map(|i| format!("phc_test:evt-{i:03}")).collect();
+        assert_eq!(
+            keys,
+            expected.iter().map(String::as_str).collect::<Vec<_>>()
+        );
+    });
+}
+
+/// A mid-batch serialization failure on the parallel path drops only that
+/// event (FatalError) and preserves order + outcomes for the rest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_prep_mid_batch_serialization_failure_drops_only_that_event() {
+    let n = SCATTER_GATHER_MIN_BATCH + 2;
+    let bad_idx = n / 2;
+    let h = TestHarness::new();
+    let mut owned = ordered_events(n);
+    owned[bad_idx] = FakeEvent::ok(&format!("evt-{bad_idx:03}")).with_payload(Err("boom".into()));
+    let events = as_dyn(&owned);
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), n);
+    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
+    for (i, ev) in owned.iter().enumerate() {
+        let r = by_key[&ev.parsed_uuid];
+        if i == bad_idx {
+            assert_eq!(r.outcome(), Outcome::FatalError);
+            assert_eq!(r.cause(), Some("serialization_failed"));
+        } else {
+            assert_eq!(r.outcome(), Outcome::Success);
+        }
+    }
+    assert_eq!(h.producer.record_count(), n - 1);
+    h.producer.with_records(|records| {
+        let keys: Vec<&str> = records.iter().map(|r| r.key.as_deref().unwrap()).collect();
+        let expected: Vec<String> = (0..n)
+            .filter(|&i| i != bad_idx)
+            .map(|i| format!("phc_test:evt-{i:03}"))
+            .collect();
+        assert_eq!(
+            keys,
+            expected.iter().map(String::as_str).collect::<Vec<_>>()
+        );
     });
 }

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -739,6 +739,37 @@ async fn batch_summary_with_timeouts() {
     assert_eq!(summary.errors.get("timeout").copied(), Some(2));
 }
 
+// ---------------------------------------------------------------------------
+// Slow-ack path: acks resolve within produce_timeout → all events succeed.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn slow_ack_within_timeout_batch_all_succeed() {
+    let h = TestHarness::builder()
+        .ack_delay(Duration::from_millis(20))
+        .produce_timeout(Duration::from_secs(30))
+        .build();
+    let e1 = FakeEvent::ok("evt-1");
+    let e2 = FakeEvent::ok("evt-2");
+    let e3 = FakeEvent::ok("evt-3");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 3);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+        assert!(r.cause().is_none());
+        assert!(r.elapsed().is_some());
+    }
+    assert_eq!(h.producer.record_count(), 3);
+
+    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
+    assert!(by_key.contains_key(&e1.parsed_uuid));
+    assert!(by_key.contains_key(&e2.parsed_uuid));
+    assert!(by_key.contains_key(&e3.parsed_uuid));
+}
+
 // ===========================================================================
 // Health heartbeat tests
 //


### PR DESCRIPTION
## What

Two produce-path changes for v0 parity and throughput. Stacked on #63866.

- remove the in-process QueueFull retry loop
- prepare batches in parallel, then enqueue serially

## QueueFull retry removal

- QueueFull is now an immediate retriable error (same as v0)
- backpressure is handled by librdkafka's own queue + the client retry, not an app-level sleep loop
- drops the `enqueue_retry_max` / `enqueue_poll_ms` config and the dead `queue_full_retries_total` metric

## Parallel batch prep

- `ProduceRecord` now owns its fields so a whole batch can be prepared up front
- serialize + build records on a bounded rayon pool (4 threads) for batches >= 8, else stay serial
- enqueue stays strictly serial in input order, so per-partition ordering is preserved
- prep-pool panics fail the batch as retriable and are counted; the per-event prep path is panic-free
- new metrics: `serialize_duration`, `prep_panic_total`, `prep_pool_inflight`

## Why

- v0 already proved scatter-gather prep is a clear win at batch scale
- the retry loop diverged from v0 and just absorbed bursts that should surface as retriable

## Test plan

- [ ] kafka sink tests pass (queue-full now asserts immediate retriable)
- [ ] new below/at/above-threshold tests confirm parallel path == serial path (order + outcomes)
- [ ] mid-batch serialization failure drops only that event
- [ ] watch prep_pool_inflight / prep_panic_total after deploy
