### PR TITLE
chore(mcp): suppress intentional cross-team unscoped in seed script

### DIFF
--- a/bin/inject_mcp_intents.py
+++ b/bin/inject_mcp_intents.py
@@ -123,6 +123,7 @@ def main() -> None:
     updated = 0
     for session_id in qs.values_list("id", flat=True):
         intent = rng.choice(pool)
+        # nosemgrep: idor-lookup-without-team -- local-dev seed script intentionally spans all teams
         MCPSession.objects.unscoped().filter(id=session_id).update(intent=intent)
         updated += 1
         if updated % 100 == 0:


### PR DESCRIPTION
## Problem

`ci-security`'s `semgrep-python` check is red on master. That blocks the "Semgrep Checks Pass" gate on every open PR. The single blocking finding is `idor-lookup-without-team` at `bin/inject_mcp_intents.py:126`:

```python
MCPSession.objects.unscoped().filter(id=session_id).update(intent=intent)
```

This is a false positive here. `inject_mcp_intents.py` is a local-dev seed script. Its `--team-id` argument is optional and defaults to all teams, so `.unscoped()` is deliberate. The IDOR rule targets request-path code, not seed tooling.

The code and the rule are both unchanged. Only the file path moved. The script was added at `scripts/inject_mcp_intents.py` in #59705 (commit 17203f0). #63855 (commit f3453a3) renamed `scripts/` to `bin/`. `semgrep-python` in `ci-security.yaml` scans `bin/` but not `scripts/`, so the move exposed the pre-existing `MCPSession.objects.unscoped()` call to the scanner and turned master red.

## Changes

Add an inline `# nosemgrep: idor-lookup-without-team` suppression with a short reason on line 126. Only line 126 is flagged; the rule does not match line 106's `.unscoped()`.

## How did you test this code?

Ran the same scanner CI uses, against the flagged file:

```
docker run --rm -v "$PWD:/src" -w /src semgrep/semgrep:1.163.0 \
  semgrep --config .semgrep/rules --error bin/inject_mcp_intents.py
```

Before the change: 1 finding (1 blocking). After: 0 findings.