### PR TITLE
perf(capture-v1): reshape Event trait to owned-return API

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -358,8 +358,6 @@ fn apply_historical_rerouting(
 }
 
 fn apply_overflow_stamping(limiter: &OverflowLimiter, ctx: &Context, events: &mut [WrappedEvent]) {
-    let mut buf = String::with_capacity(128);
-
     for event in events.iter_mut() {
         if event.destination != Destination::AnalyticsMain {
             continue;
@@ -368,10 +366,9 @@ fn apply_overflow_stamping(limiter: &OverflowLimiter, ctx: &Context, events: &mu
             continue;
         }
 
-        buf.clear();
-        event.partition_key(ctx, &mut buf);
+        let key = event.partition_key(ctx);
 
-        match limiter.is_limited(&buf) {
+        match limiter.is_limited(&key) {
             OverflowLimiterResult::ForceLimited => {
                 event.destination = Destination::Overflow;
                 // Disables person processing AND nulls partition key at sink.

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -189,8 +189,9 @@ impl SinkEvent for WrappedEvent {
         }
     }
 
-    fn partition_key(&self, ctx: &Context, buf: &mut String) {
+    fn partition_key(&self, ctx: &Context) -> String {
         use std::fmt::Write;
+        let mut buf = String::with_capacity(128);
         match (
             self.event.options.cookieless_mode == Some(true),
             ctx.capture_internal,
@@ -205,9 +206,10 @@ impl SinkEvent for WrappedEvent {
                 let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
             }
         }
+        buf
     }
 
-    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
+    fn serialize(&self, ctx: &Context) -> anyhow::Result<String> {
         let spliced = self.build_spliced_properties(ctx)?;
         let properties: &RawValue = spliced.as_deref().unwrap_or(&self.event.properties);
         let ingestion_data = IngestionData {
@@ -228,7 +230,7 @@ impl SinkEvent for WrappedEvent {
             &ip
         };
         let timestamp = self.adjusted_timestamp.ok_or_else(|| {
-            anyhow::anyhow!("serialize_into called on event without adjusted_timestamp")
+            anyhow::anyhow!("serialize called on event without adjusted_timestamp")
         })?;
         let now = ctx
             .server_received_at
@@ -247,9 +249,10 @@ impl SinkEvent for WrappedEvent {
             historical_migration: ctx.historical_migration,
         };
 
-        serde_json::to_string(&ie)
-            .map(|s| buf.push_str(&s))
-            .map_err(|e| anyhow::anyhow!("serializing IngestionEvent: {e:#}"))
+        let mut buf = String::with_capacity(data.len() + 512);
+        serde_json::to_writer(StringWriter(&mut buf), &ie)
+            .map_err(|e| anyhow::anyhow!("serializing IngestionEvent: {e:#}"))?;
+        Ok(buf)
     }
 }
 
@@ -362,7 +365,7 @@ impl HasEventName for WrappedEvent {
     }
 }
 
-/// The Kafka payload produced by `WrappedEvent::serialize_into`.
+/// The Kafka payload produced by `WrappedEvent::serialize`.
 ///
 /// Field order matches `CapturedEvent` from `common_types` so that serde's
 /// derived `Serialize` emits JSON keys in the same order as v0. Serde
@@ -370,7 +373,7 @@ impl HasEventName for WrappedEvent {
 ///
 /// Borrows from `WrappedEvent` and `Context` to avoid per-event heap
 /// allocations -- the struct is created, serialized, and dropped within
-/// a single `serialize_into` call.
+/// a single `serialize` call.
 #[derive(Debug, Serialize)]
 pub struct IngestionEvent<'a> {
     pub uuid: Uuid,
@@ -929,20 +932,11 @@ mod tests {
         assert!(h.historical_migration.is_none());
     }
 
-    fn partition_key_str(ev: &WrappedEvent, ctx: &Context) -> String {
-        let mut buf = String::new();
-        ev.partition_key(ctx, &mut buf);
-        buf
-    }
-
     #[test]
     fn partition_key_normal_mode() {
         let ctx = test_utils::test_context();
         let ev = ok_wrapped("$pageview", "user-42");
-        assert_eq!(
-            partition_key_str(&ev, &ctx),
-            format!("{}:user-42", ctx.api_token)
-        );
+        assert_eq!(ev.partition_key(&ctx), format!("{}:user-42", ctx.api_token));
     }
 
     #[test]
@@ -951,7 +945,7 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.event.options.cookieless_mode = Some(true);
         assert_eq!(
-            partition_key_str(&ev, &ctx),
+            ev.partition_key(&ctx),
             format!("{}:{}", ctx.api_token, ctx.client_ip)
         );
     }
@@ -963,7 +957,7 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.event.options.cookieless_mode = Some(true);
         assert_eq!(
-            partition_key_str(&ev, &ctx),
+            ev.partition_key(&ctx),
             format!("{}:127.0.0.1", ctx.api_token)
         );
     }
@@ -982,7 +976,7 @@ mod tests {
         ev.force_disable_person_processing = true;
         ev.destination = Destination::AnalyticsMain;
         assert_eq!(
-            partition_key_str(&ev, &ctx),
+            ev.partition_key(&ctx),
             format!("{}:user-42", ctx.api_token),
             "partition_key() is unconditional; sink applies null-key policy"
         );
@@ -1015,7 +1009,7 @@ mod tests {
         assert!(!ev.has_property("unknown_key"));
     }
 
-    // --- serialize_into ---
+    // --- serialize ---
 
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -1074,10 +1068,7 @@ mod tests {
         wrapped: &WrappedEvent,
         ctx: &crate::v1::context::Context,
     ) -> (CapturedEvent, RawEvent) {
-        let mut buf = String::new();
-        wrapped
-            .serialize_into(ctx, &mut buf)
-            .expect("serialize_into failed");
+        let buf = wrapped.serialize(ctx).expect("serialize failed");
         let captured: CapturedEvent =
             serde_json::from_str(&buf).expect("v1 output must deserialize as CapturedEvent");
         let data: RawEvent =
@@ -1086,12 +1077,11 @@ mod tests {
     }
 
     #[test]
-    fn serialize_into_fails_without_adjusted_timestamp() {
+    fn serialize_fails_without_adjusted_timestamp() {
         let mut ev = pageview_event();
         ev.adjusted_timestamp = None;
         let ctx = serialize_ctx();
-        let mut buf = String::new();
-        let err = ev.serialize_into(&ctx, &mut buf).unwrap_err();
+        let err = ev.serialize(&ctx).unwrap_err();
         assert!(
             err.to_string().contains("adjusted_timestamp"),
             "error should mention adjusted_timestamp: {err}"
@@ -1205,8 +1195,7 @@ mod tests {
         let headers = wrapped.headers(&ctx);
         assert_eq!(headers.distinct_id.as_deref(), Some("user-42"));
 
-        let mut key = String::new();
-        wrapped.partition_key(&ctx, &mut key);
+        let key = wrapped.partition_key(&ctx);
         assert_eq!(key, format!("{}:user-42", ctx.api_token));
     }
 
@@ -1434,8 +1423,7 @@ mod tests {
         let wrapped = pageview_event();
         assert_eq!(wrapped.event.options.cookieless_mode, Some(false));
         let ctx = serialize_ctx();
-        let mut buf = String::new();
-        wrapped.serialize_into(&ctx, &mut buf).unwrap();
+        let buf = wrapped.serialize(&ctx).unwrap();
         let val: Value = serde_json::from_str(&buf).unwrap();
         assert!(
             val.get("is_cookieless_mode").is_none(),
@@ -1456,8 +1444,7 @@ mod tests {
     fn serialize_historical_migration_false_skipped() {
         let wrapped = pageview_event();
         let ctx = serialize_ctx();
-        let mut buf = String::new();
-        wrapped.serialize_into(&ctx, &mut buf).unwrap();
+        let buf = wrapped.serialize(&ctx).unwrap();
         let val: Value = serde_json::from_str(&buf).unwrap();
         assert!(
             val.get("historical_migration").is_none(),
@@ -1608,8 +1595,7 @@ mod tests {
         };
 
         let ctx = serialize_ctx();
-        let mut buf = String::new();
-        let err = wrapped.serialize_into(&ctx, &mut buf).unwrap_err();
+        let err = wrapped.serialize(&ctx).unwrap_err();
         assert!(
             err.to_string().contains("must be a JSON object"),
             "expected object guard, got: {err}"
@@ -1775,9 +1761,8 @@ mod tests {
     fn partition_key_parity_normal() {
         let ctx = serialize_ctx();
         let ev = realistic_pageview("user-42");
-        let mut buf = String::new();
-        ev.partition_key(&ctx, &mut buf);
-        assert_eq!(buf, format!("{}:user-42", ctx.api_token));
+        let key = ev.partition_key(&ctx);
+        assert_eq!(key, format!("{}:user-42", ctx.api_token));
     }
 
     #[test]
@@ -1785,9 +1770,8 @@ mod tests {
         let ctx = serialize_ctx();
         let mut ev = realistic_pageview("user-42");
         ev.event.options.cookieless_mode = Some(true);
-        let mut buf = String::new();
-        ev.partition_key(&ctx, &mut buf);
-        assert_eq!(buf, format!("{}:{}", ctx.api_token, ctx.client_ip));
+        let key = ev.partition_key(&ctx);
+        assert_eq!(key, format!("{}:{}", ctx.api_token, ctx.client_ip));
     }
 
     #[test]
@@ -1796,10 +1780,9 @@ mod tests {
         let ev = realistic_pageview("user-42")
             .with_force_disable_person_processing(true)
             .with_destination(Destination::AnalyticsMain);
-        let mut buf = String::new();
-        ev.partition_key(&ctx, &mut buf);
+        let key = ev.partition_key(&ctx);
         assert_eq!(
-            buf,
+            key,
             format!("{}:user-42", ctx.api_token),
             "partition_key() is unconditional; sink applies null-key policy"
         );

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -210,8 +210,8 @@ pub trait Event: Send + Sync {
     fn should_publish(&self) -> bool;
     fn destination(&self) -> &Destination;
     fn headers(&self, ctx: &Context) -> CapturedEventHeaders;
-    fn partition_key(&self, ctx: &Context, buf: &mut String);
-    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()>;
+    fn partition_key(&self, ctx: &Context) -> String;
+    fn serialize(&self, ctx: &Context) -> anyhow::Result<String>;
 }
 ```
 
@@ -227,26 +227,25 @@ The analytics capture endpoint's `WrappedEvent` implements this trait
 Other capture endpoints (e.g. session replay, exceptions) provide
 their own `Event` implementations without changing any sink code.
 
-### Buffer-reuse pattern
+### Owned-return pattern
 
-`partition_key` and `serialize_into` write into caller-owned
-`String` buffers that are cleared between events. This eliminates
-per-event allocations after the first iteration — the buffers grow to
-high-water mark and stay there for the entire batch.
+`partition_key` and `serialize` each return an owned `String`. This
+enables parallel preparation (each event's output is independent) and
+simplifies the API at the cost of one allocation per event per field.
+`serialize` uses `serde_json::to_writer` with a pre-sized buffer
+(`data.len() + 512`) to minimize reallocation.
 
 ```text
   ┌──────────────────────────────────────────────┐
   │ publish_batch                                │
   │                                              │
-  │   payload_buf = String::with_capacity(4096)  │
-  │   key_buf     = String::with_capacity(128)   │
+  │   for event in events (parallel if large):   │
+  │       payload = event.serialize(ctx)?        │
+  │       key     = event.partition_key(ctx)     │
+  │       → ProduceRecord { topic, key, payload }│
   │                                              │
-  │   for event in events:                       │
-  │       payload_buf.clear()   ◄─ no alloc      │
-  │       key_buf.clear()       ◄─ no alloc      │
-  │       event.serialize_into(ctx, &payload_buf) │
-  │       event.partition_key(ctx, &key_buf)      │
-  │       producer.send(...)                     │
+  │   for record in prepared (serial):           │
+  │       producer.send(record)                  │
   └──────────────────────────────────────────────┘
 ```
 
@@ -356,7 +355,7 @@ Captures every failure mode within a single configured sink:
 | Variant | Outcome | When |
 |---|---|---|
 | `SinkUnavailable` | `RetriableError` | Producer health gate failed |
-| `SerializationFailed(String)` | `FatalError` | `serialize_into` returned `Err` |
+| `SerializationFailed(String)` | `FatalError` | `serialize` returned `Err` |
 | `Produce(ProduceError)` | Depends on `ProduceError::is_retriable()` | rdkafka send or delivery error |
 | `Timeout` | `Timeout` | Ack not received within `produce_timeout` |
 | `TaskPanicked` | `RetriableError` | Ack task panicked (should not happen with `FuturesUnordered`) |
@@ -443,7 +442,7 @@ corresponds 1:1 to a published event.
   │   prep each event (parallel on rayon pool for big batches):     │
   │     ├── should_publish()? → skip if false                       │
   │     ├── topic_for(destination)? → skip if Drop/None             │
-  │     ├── serialize_into → owned payload                          │
+  │     ├── serialize(ctx) → owned payload                          │
   │     ├── headers(ctx) + partition_key(ctx); null key per policy  │
   │     └── build owned ProduceRecord (Err → serialization result)  │
   │   sort prepared records by input index                          │
@@ -492,7 +491,7 @@ corresponds 1:1 to a published event.
 
 ### Phase 1 — Prepare + enqueue
 
-Each event is first **prepared**: `serialize_into` produces an owned
+Each event is first **prepared**: `serialize` produces an owned
 payload, `partition_key`/`headers` build the key and headers, and an owned
 `ProduceRecord` is assembled (`prepare_one`). Prep runs serially for
 batches below `SCATTER_GATHER_MIN_BATCH` (8) and in parallel on a
@@ -514,9 +513,9 @@ like any other retriable produce error (`Outcome::RetriableError` →
 loop. Backpressure is handled by librdkafka's own producer queue plus the
 client-side retry on a retriable response.
 
-After serialization and header construction, `effective_partition_key()`
+After serialization and header construction, `should_null_partition_key()`
 (`kafka/sink.rs`) decides whether the partition key should be nulled.
-Events always write a key via `partition_key()`; the sink nulls it when
+Events always produce a key via `partition_key()`; the sink nulls it when
 `force_disable_person_processing` is set and the destination is
 `AnalyticsMain` or `Overflow`. In that case `None` is passed to rdkafka
 so it round-robins; passing `Some("")` would hash to a single
@@ -1012,12 +1011,12 @@ keeping the Sink trait unaware of topic names.
 Partition key construction is split between the `Event` implementation
 and the sink:
 
-1. **`Event::partition_key(ctx, buf)`** always writes a key into the
-   buffer. For analytics events (`WrappedEvent`):
+1. **`Event::partition_key(ctx)`** always returns a key. For analytics
+   events (`WrappedEvent`):
 
 ```text
   ┌───────────────────────────────────────────────────┐
-  │ partition_key(ctx, buf)                            │
+  │ partition_key(ctx) -> String                       │
   │                                                    │
   │   cookieless_mode?                                 │
   │   ├── yes, capture_internal → "token:127.0.0.1"   │
@@ -1026,20 +1025,20 @@ and the sink:
   └───────────────────────────────────────────────────┘
 ```
 
-2. **`effective_partition_key()`** (`kafka/sink.rs`) decides whether
+2. **`should_null_partition_key()`** (`kafka/sink.rs`) decides whether
    the key should be nulled before sending to the producer:
 
 ```rust
-fn effective_partition_key<'a>(
-    key_buf: &'a str,
+fn should_null_partition_key(
     force_disable_person_processing: bool,
     destination: &Destination,
-) -> Option<&'a str>
+) -> bool
 ```
 
-   If `force_disable_person_processing` is set and the destination is
-   `AnalyticsMain` or `Overflow`, the function returns `None`. Otherwise
-   it returns `Some(key_buf)`.
+   Returns `true` when `force_disable_person_processing` is set and the
+   destination is `AnalyticsMain` or `Overflow`. When true, the sink
+   passes `None` as the key; otherwise it moves the owned `String` from
+   `partition_key()` directly into `ProduceRecord.key`.
 
 Key design choices:
 
@@ -1095,7 +1094,7 @@ expect.
   │  destination: Destination│
   │  force_disable_*        │
   └───────────┬─────────────┘
-              │ serialize_into(ctx, buf)
+              │ serialize(ctx) -> String
               ▼
   ┌──────────────────────────────┐
   │  IngestionEvent (Kafka msg)  │
@@ -1170,7 +1169,7 @@ Fields intentionally omitted vs the legacy `RawEvent`:
 ### IP redaction
 
 `capture_internal` requests (PostHog's own telemetry) have their IP
-redacted to `127.0.0.1` in both `serialize_into` (the `ip` field on
+redacted to `127.0.0.1` in both `serialize` (the `ip` field on
 `IngestionEvent`) and `partition_key` (cookieless mode).
 
 ---
@@ -1228,7 +1227,7 @@ Builder options include:
 
 `v1::analytics::types` has a comprehensive test suite validating:
 
-- **Round-trip parity**: `WrappedEvent::serialize_into` output
+- **Round-trip parity**: `WrappedEvent::serialize` output
   deserializes as `common_types::CapturedEvent` + `RawEvent`, verifying
   field-by-field compatibility with legacy capture.
 - **Property injection**: all option fields are correctly injected into

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -27,11 +27,11 @@ pub trait Event: Send + Sync {
     /// `common_types`).
     fn headers(&self, ctx: &Context) -> CapturedEventHeaders;
 
-    /// Write the partition key for this event into `buf`.
-    /// Always writes unconditionally -- the sink decides whether to use it
-    /// or null it based on routing policy (e.g. force_disable_person_processing).
-    fn partition_key(&self, ctx: &Context, buf: &mut String);
+    /// Return the partition key for this event.
+    /// The sink decides whether to use it or null it based on routing policy
+    /// (e.g. force_disable_person_processing).
+    fn partition_key(&self, ctx: &Context) -> String;
 
-    /// Serialize the event payload into a caller-provided buffer.
-    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()>;
+    /// Serialize the event payload and return the JSON string.
+    fn serialize(&self, ctx: &Context) -> anyhow::Result<String>;
 }

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -85,24 +85,18 @@ type PrepOutcome<'a> = Result<Prepared<'a>, Box<dyn SinkResult>>;
 /// attached (`prep_outcome` wraps this into a `Prepared`). `None` = skipped.
 type ReadyRecord<'a> = (Uuid, &'static str, ProduceRecord<'a>);
 
-/// Null the partition key when person processing is force-disabled for
-/// Main/Overflow destinations — spreads load across partitions instead of
-/// hotspotting on a single token:distinct_id pair.
-fn effective_partition_key<'a>(
-    key_buf: &'a str,
+/// Returns true when the partition key should be nulled — i.e. when person
+/// processing is force-disabled for Main/Overflow destinations, spreading
+/// load across partitions instead of hotspotting on a single key.
+fn should_null_partition_key(
     force_disable_person_processing: bool,
     destination: &Destination,
-) -> Option<&'a str> {
-    if force_disable_person_processing
+) -> bool {
+    force_disable_person_processing
         && matches!(
             destination,
             Destination::AnalyticsMain | Destination::Overflow
         )
-    {
-        None
-    } else {
-        Some(key_buf)
-    }
 }
 
 /// Shared label values for metrics emitted within a single `publish_batch` call.
@@ -228,45 +222,47 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
             None => return Ok(None),
         };
 
-        let mut payload = String::with_capacity(4096);
-        if let Err(e) = event.serialize_into(ctx, &mut payload) {
-            crate::ctx_log!(
-                Level::ERROR,
-                ctx,
-                sink = labels.sink,
-                event_uuid = %uuid,
-                error = %e,
-                "event serialization failed, dropping event"
-            );
-            counter!(
-                "capture_v1_kafka_publish_total",
-                "mode" => labels.mode,
-                "cluster" => labels.sink,
-                "outcome" => Outcome::FatalError.as_tag(),
-                "path" => labels.path,
-                "attempt" => labels.attempt,
-                "destination" => dest_tag,
-            )
-            .increment(1);
-            return Err(Box::new(KafkaResult::err(
-                uuid,
-                KafkaSinkError::SerializationFailed(format!("{e:#}")),
-                enqueued_at,
-            )));
-        }
+        let payload = match event.serialize(ctx) {
+            Ok(p) => p,
+            Err(e) => {
+                crate::ctx_log!(
+                    Level::ERROR,
+                    ctx,
+                    sink = labels.sink,
+                    event_uuid = %uuid,
+                    error = %e,
+                    "event serialization failed, dropping event"
+                );
+                counter!(
+                    "capture_v1_kafka_publish_total",
+                    "mode" => labels.mode,
+                    "cluster" => labels.sink,
+                    "outcome" => Outcome::FatalError.as_tag(),
+                    "path" => labels.path,
+                    "attempt" => labels.attempt,
+                    "destination" => dest_tag,
+                )
+                .increment(1);
+                return Err(Box::new(KafkaResult::err(
+                    uuid,
+                    KafkaSinkError::SerializationFailed(format!("{e:#}")),
+                    enqueued_at,
+                )));
+            }
+        };
 
         let captured_headers = event.headers(ctx);
 
-        let mut key_buf = String::with_capacity(128);
-        event.partition_key(ctx, &mut key_buf);
-        let key = effective_partition_key(
-            &key_buf,
+        let key = if should_null_partition_key(
             captured_headers
                 .force_disable_person_processing
                 .unwrap_or(false),
             event.destination(),
-        )
-        .map(str::to_owned);
+        ) {
+            None
+        } else {
+            Some(event.partition_key(ctx))
+        };
 
         let headers: rdkafka::message::OwnedHeaders = captured_headers.into();
 
@@ -727,23 +723,19 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
 }
 
 #[cfg(test)]
-mod effective_partition_key_tests {
+mod should_null_partition_key_tests {
     use super::*;
     use rstest::rstest;
 
     #[rstest]
-    #[case::main_disabled(true, Destination::AnalyticsMain, None)]
-    #[case::overflow_disabled(true, Destination::Overflow, None)]
-    #[case::dlq_disabled(true, Destination::Dlq, Some("k"))]
-    #[case::historical_disabled(true, Destination::AnalyticsHistorical, Some("k"))]
-    #[case::custom_disabled(true, Destination::Custom("t".into()), Some("k"))]
-    #[case::main_not_disabled(false, Destination::AnalyticsMain, Some("k"))]
-    fn policy(
-        #[case] force_disable: bool,
-        #[case] dest: Destination,
-        #[case] expected: Option<&str>,
-    ) {
-        assert_eq!(effective_partition_key("k", force_disable, &dest), expected);
+    #[case::main_disabled(true, Destination::AnalyticsMain, true)]
+    #[case::overflow_disabled(true, Destination::Overflow, true)]
+    #[case::dlq_disabled(true, Destination::Dlq, false)]
+    #[case::historical_disabled(true, Destination::AnalyticsHistorical, false)]
+    #[case::custom_disabled(true, Destination::Custom("t".into()), false)]
+    #[case::main_not_disabled(false, Destination::AnalyticsMain, false)]
+    fn policy(#[case] force_disable: bool, #[case] dest: Destination, #[case] expected: bool) {
+        assert_eq!(should_null_partition_key(force_disable, &dest), expected);
     }
 }
 

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -109,18 +109,13 @@ impl Event for FakeEvent {
         self.event_headers.clone()
     }
 
-    fn partition_key(&self, _ctx: &Context, buf: &mut String) {
-        if let Some(k) = &self.partition_key {
-            buf.push_str(k);
-        }
+    fn partition_key(&self, _ctx: &Context) -> String {
+        self.partition_key.clone().unwrap_or_default()
     }
 
-    fn serialize_into(&self, _ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
+    fn serialize(&self, _ctx: &Context) -> anyhow::Result<String> {
         match &self.payload {
-            Ok(p) => {
-                buf.push_str(p);
-                Ok(())
-            }
+            Ok(p) => Ok(p.clone()),
             Err(e) => Err(anyhow::anyhow!(e.clone())),
         }
     }

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -179,13 +179,11 @@ mod tests {
                 content_encoding: None,
             }
         }
-        fn partition_key(&self, _ctx: &Context, buf: &mut String) {
-            use std::fmt::Write;
-            let _ = write!(buf, "key:{}", self.uuid());
+        fn partition_key(&self, _ctx: &Context) -> String {
+            format!("key:{}", self.uuid())
         }
-        fn serialize_into(&self, _ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
-            buf.push_str(r#"{"event":"test"}"#);
-            Ok(())
+        fn serialize(&self, _ctx: &Context) -> anyhow::Result<String> {
+            Ok(r#"{"event":"test"}"#.to_string())
         }
     }
 

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -390,10 +390,7 @@ pub fn assert_round_trip(
 ) -> (common_types::CapturedEvent, common_types::RawEvent) {
     use crate::v1::sinks::event::Event as SinkEvent;
 
-    let mut buf = String::new();
-    wrapped
-        .serialize_into(ctx, &mut buf)
-        .expect("serialize_into failed");
+    let buf = wrapped.serialize(ctx).expect("serialize failed");
     let captured: common_types::CapturedEvent =
         serde_json::from_str(&buf).expect("v1 output must deserialize as CapturedEvent");
     let data: common_types::RawEvent =


### PR DESCRIPTION
Stacked on #63867.

- Reshape `Event` trait: `serialize_into(&mut buf)` → `serialize() -> Result<String>`
- `partition_key(&mut buf)` → `partition_key() -> String`
- `WrappedEvent::serialize` now uses `serde_json::to_writer` + pre-sized buffer
- Eliminates shared scratch buffers; prep is fully parallel-safe without lifetime gymnastics
- Updates all implementors (WrappedEvent, FakeEvent, router), call sites, and tests