### PR TITLE
chore(charts): prune dead exports and add CI-band visual guard

### DIFF
--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
@@ -267,6 +267,36 @@ export const CombinedOverlays: Story = {
     },
 }
 
+/** Confidence band whose lower bound dips below zero — the y-axis must widen to
+ *  include it rather than clipping at the data minimum. Visual guard for the
+ *  band-aware domain (lowerData folded into the value range). */
+export const ConfidenceBandBelowZero: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const color = theme.colors[0]
+        const data = [6, 4, 8, 5, 9, 4, 7]
+        // Hand-built wide band so the lower edge crosses zero on several points.
+        const lower = [1, -2, 3, -1, 4, -3, 2]
+        const upper = [11, 10, 13, 11, 14, 11, 12]
+        const series: Series[] = [
+            { key: 'visits', label: 'Visits', color, data, points: { radius: 3 } },
+            {
+                key: 'visits__ci',
+                label: 'Visits (CI)',
+                color,
+                data: upper,
+                fill: { opacity: 0.2, lowerData: lower },
+                visibility: { tooltip: false, valueLabel: false },
+            },
+        ]
+        return (
+            <Stage width={560} height={320}>
+                <LineChart series={series} labels={DAYS} config={BASIC} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
 /** Single series spanning a few orders of magnitude — locks in log-axis tick generation. */
 export const LogScale: Story = {
     render: () => {

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -23,7 +23,7 @@ export type { MetricCardProps, ChangeColor, MetricChange } from './components/Me
 export { Chart } from './core/Chart'
 export type { ChartProps } from './core/Chart'
 export { ChartErrorBoundary } from './core/ChartErrorBoundary'
-export { RadialChart, RADIAL_MARGINS } from './core/RadialChart'
+export { RadialChart } from './core/RadialChart'
 export type { RadialChartProps, RadialLayoutBuilder } from './core/RadialChart'
 export { DEFAULT_MARGINS } from './core/hooks/useChartMargins'
 
@@ -102,7 +102,7 @@ export type { ThemeFromCssOptions } from './core/theme'
 // Built-in tooltip (for reference or extension)
 export { DefaultTooltip } from './overlays/DefaultTooltip'
 // Shared tooltip surface — reuse to build custom tooltips with the quill look
-export { TooltipSurface, TooltipSwatch, TOOLTIP_FALLBACK_BG, TOOLTIP_FALLBACK_COLOR } from './overlays/TooltipSurface'
+export { TooltipSurface, TooltipSwatch } from './overlays/TooltipSurface'
 
 // Optional overlays
 export { ReferenceLine, ReferenceLines } from './overlays/ReferenceLine'
@@ -128,7 +128,7 @@ export type { AnomalyMarker } from './overlays/AnomalyPointsLayer'
 export { movingAverageKey } from './charts/TimeSeriesLineChart/utils/derived-series'
 
 // Timeseries utils
-export { createXAxisTickCallback, parseDateForAxis } from './utils/dates'
+export { createXAxisTickCallback } from './utils/dates'
 export type { TimeInterval } from './utils/dates'
 export { buildYTickFormatter } from './utils/y-formatters'
 export type { YAxisFormat, YFormatterConfig } from './utils/y-formatters'

--- a/packages/quill/packages/charts/src/overlays/AnomalyPointsLayer.test.tsx
+++ b/packages/quill/packages/charts/src/overlays/AnomalyPointsLayer.test.tsx
@@ -74,15 +74,13 @@ describe('AnomalyPointsLayer', () => {
         expect(dot.style.left).toBe('395px')
     })
 
-    it('skips a marker whose label is unknown to the x-scale', () => {
+    it.each([
         // dataIndex 9 is out of the labels array → no x pixel.
-        const { container } = renderInChart(<AnomalyPointsLayer markers={[marker({ dataIndex: 9 })]} />)
-        expect(dots(container)).toHaveLength(0)
-    })
-
-    it('skips a marker whose y value falls outside the plot bounds', () => {
+        ['label unknown to the x-scale', marker({ dataIndex: 9 })],
         // value 500 → yScale(500) = 368 - 1760 = well above plotTop, out of bounds.
-        const { container } = renderInChart(<AnomalyPointsLayer markers={[marker({ value: 500 })]} />)
+        ['y value outside the plot bounds', marker({ value: 500 })],
+    ])('skips a marker with %s', (_label, m) => {
+        const { container } = renderInChart(<AnomalyPointsLayer markers={[m]} />)
         expect(dots(container)).toHaveLength(0)
     })
 


### PR DESCRIPTION
## Problem

Follow-up cleanup on `@posthog/quill-charts` after the two merged correctness PRs (#63486, #63488). Two loose ends remained while the package is still beta and its export surface is cheap to trim:

- Four symbols were re-exported from the package barrel but have no consumers outside the charts package — dead surface that would otherwise become part of the frozen public API.
- The band-aware y-domain fix from #63486 (folding `fill.lowerData` into the value range) had only a unit-level regression test. The charts render to canvas, so the visual-regression guard for that fix is a Storybook story — and none existed for a band whose lower bound dips below zero.

## Changes

- **Prune dead barrel exports** from `index.ts`: `RADIAL_MARGINS`, `TOOLTIP_FALLBACK_BG`, `TOOLTIP_FALLBACK_COLOR`, `parseDateForAxis`. Each symbol stays defined and exported in its own source module for internal use (e.g. `PieChart.test.tsx` imports `RADIAL_MARGINS` directly from `core/RadialChart`) — only the public re-export is removed. `TooltipSwatch` is **kept**: it has one external consumer, so the audit was wrong to flag it.
- **Add the `ConfidenceBandBelowZero` LineChart story** — a confidence band with a hand-built lower edge that crosses zero on several points. The y-axis must widen to include the sub-zero bound instead of clipping at the data minimum, giving the #63486 fix a visual-regression guard.
- **Parameterize** the two `AnomalyPointsLayer` skip-cases into a single `it.each` block (the review suggestion on #63488 that didn't make it in before merge).

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual/visual testing — the new story is a fixture for the existing visual-regression pipeline to capture. Automated checks I actually ran locally:

- `oxlint` on all three changed files — 0 warnings, 0 errors.
- `tsc --noEmit` — the two non-test changed files typecheck clean (`index.ts`, `LineChart.stories.tsx`).
- Jest: LineChart + PieChart suites (91 tests) and AnomalyPointsLayer suite (9 tests) all pass after building `@posthog/quill-tokens`.
- Verified via grep that no test or external file imports the removed symbols from the barrel.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @sampennington as a follow-up to the charts audit work. This is the "P7 cleanup" slice of that review: dead-export pruning plus a visual guard for the one merged bug-fix that produces a visible pixel difference. Statistics-helper de-duplication (`charts/utils/statistics.ts` vs `frontend/src/lib/statistics.ts`) was deliberately left out — the charts package is meant to be standalone/publishable, so the duplication may be intentional and warrants a separate decision rather than a reflexive merge.