### PR TITLE
feat(capture-v1): add processing duration histogram

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
+use std::time::Instant;
+
 use chrono::{DateTime, Utc};
+use metrics::histogram;
 use uuid::Uuid;
 
 use super::constants::{
@@ -47,6 +50,7 @@ pub async fn process_batch(
     context: &mut Context,
     batch: Batch,
 ) -> Result<BatchResponse, Error> {
+    let processing_start = Instant::now();
     crate::ctx_log!(Level::INFO, context, "process_batch called");
 
     validate_batch(&batch)?;
@@ -87,6 +91,12 @@ pub async fn process_batch(
     if let Some(ref limiter) = state.global_rate_limiter_token_distinctid {
         apply_token_distinct_id_limits(limiter, context, &mut events).await;
     }
+
+    histogram!(
+        "capture_v1_processing_duration_seconds",
+        "path" => context.path,
+    )
+    .record(processing_start.elapsed().as_secs_f64());
 
     // Publish to v1 sink, merge results, build response
     let sink_router = state


### PR DESCRIPTION
## Summary
- Adds `capture_v1_processing_duration_seconds` histogram
- Measures wall-time from batch entry through validation/overflow/prep, up to (not including) the sink publish call
- Stacked on #62816, #62817, #62818 — completes the latency decomposition for the v1 produce path

## Metric details
- Labels: `path` (matches existing sink metrics)
- Covers: `validate_batch` + `validate_events` + `apply_event_restrictions` + `apply_overflow_stamping` + event-ref collection
- Excludes: sink publish + ack drain (already covered by `enqueue_duration` and `ack_duration`)

## Test plan
- [ ] CI passes (fmt, clippy, tests)
- [ ] Deploy to dev, confirm metric appears in Prometheus with expected path labels