### PR TITLE
refactor(session-replay): harden ffmpeg input handling in rasterizer

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
@@ -215,6 +215,38 @@ describe('config', () => {
                 expect(config.trimFrameLimit).toBe(24)
             })
         })
+
+        describe('ffmpeg argument safety', () => {
+            it.each([
+                { field: 'trim', value: Infinity },
+                { field: 'trim', value: '10 -i /etc/passwd' },
+                { field: 'trim', value: 'not-a-number' },
+                { field: 'playback_speed', value: Infinity },
+                { field: 'playback_speed', value: '8 -vf evil' },
+                { field: 'playback_speed', value: 'NaN' },
+                { field: 'recording_fps', value: Infinity },
+                { field: 'recording_fps', value: '24; rm -rf /' },
+                { field: 'recording_fps', value: 'abc' },
+            ])('throws on non-finite $field=$value before it reaches an ffmpeg arg', ({ field, value }) => {
+                expect(() => buildCaptureConfig(baseInput({ [field]: value as any }))).toThrow(
+                    'must be a finite number'
+                )
+            })
+
+            it('emits the -t value as a single numeric token (no embedded flags)', () => {
+                const config = buildCaptureConfig(baseInput({ trim: 60 }))
+                const tOpt = config.ffmpegOutputOpts.find((o) => o.startsWith('-t'))
+                // Exactly two space-separated tokens → fluent-ffmpeg passes ['-t', '60'],
+                // so an attacker can never split the value into extra ffmpeg arguments.
+                expect(tOpt!.split(' ')).toEqual(['-t', '60'])
+            })
+
+            it('interpolates speed/fps as bare numbers into the filtergraph', () => {
+                const config = buildCaptureConfig(baseInput({ playback_speed: 8, recording_fps: 24 }))
+                expect(config.ffmpegVideoFilters).toContain('setpts=8*PTS')
+                expect(config.ffmpegVideoFilters).toContain('fps=24')
+            })
+        })
     })
 
     describe('buildPlayerConfig', () => {

--- a/nodejs/src/session-replay/recording-rasterizer/capture/config.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/config.ts
@@ -6,6 +6,19 @@ import { CaptureConfig, RasterizeRecordingInput } from '../types'
 const DEFAULT_PLAYBACK_SPEED = 4
 const DEFAULT_FPS = 24
 
+// Coerce a value interpolated into an ffmpeg option (`-t`) or filter (`setpts=`, `fps=`) to a
+// finite number. ffmpeg is spawned without a shell, but a non-finite/non-numeric value reaching
+// here (e.g. from a future caller that skips upstream validation) could still land in the option
+// list or filtergraph as a raw string. Throwing keeps interpolation injection-proof regardless of
+// the caller: a finite number stringifies to [0-9.eE+-] only — no spaces or filter metacharacters.
+function toFiniteNumber(value: unknown, field: string): number {
+    const n = Number(value)
+    if (!Number.isFinite(n)) {
+        throw new RasterizationError(`${field} must be a finite number, got: ${String(value)}`, false, 'INVALID_INPUT')
+    }
+    return n
+}
+
 export function validateInput(input: RasterizeRecordingInput): void {
     if (!input.session_id) {
         throw new RasterizationError('session_id is required', false, 'INVALID_INPUT')
@@ -47,8 +60,11 @@ export function validateInput(input: RasterizeRecordingInput): void {
 }
 
 export function buildCaptureConfig(input: RasterizeRecordingInput): CaptureConfig {
-    const playbackSpeed = input.playback_speed || DEFAULT_PLAYBACK_SPEED
-    const outputFps = input.recording_fps || DEFAULT_FPS
+    const playbackSpeed = input.playback_speed
+        ? toFiniteNumber(input.playback_speed, 'playback_speed')
+        : DEFAULT_PLAYBACK_SPEED
+    const outputFps = input.recording_fps ? toFiniteNumber(input.recording_fps, 'recording_fps') : DEFAULT_FPS
+    const trim = input.trim ? toFiniteNumber(input.trim, 'trim') : undefined
     // e.g. 3fps output × 8x speed = 24fps capture → setpts stretches 8x → 3fps
     const captureFps = outputFps * playbackSpeed
     const outputFormat = input.output_format || 'mp4'
@@ -59,8 +75,8 @@ export function buildCaptureConfig(input: RasterizeRecordingInput): CaptureConfi
             : outputFormat === 'gif'
               ? ['-f gif', '-c:v gif', '-loop', '0']
               : ['-f mp4', '-c:v libx264', '-preset veryfast', '-crf 23', '-pix_fmt yuv420p', '-movflags +faststart']
-    if (input.trim) {
-        ffmpegOutputOpts.push(`-t ${input.trim}`)
+    if (trim) {
+        ffmpegOutputOpts.push(`-t ${trim}`)
     }
 
     const ffmpegVideoFilters: string[] = []
@@ -92,8 +108,8 @@ export function buildCaptureConfig(input: RasterizeRecordingInput): CaptureConfi
         captureFps,
         outputFps,
         playbackSpeed,
-        trim: input.trim,
-        trimFrameLimit: input.trim ? input.trim * outputFps : Infinity,
+        trim,
+        trimFrameLimit: trim ? trim * outputFps : Infinity,
         maxVirtualTimeMs: input.max_virtual_time ? input.max_virtual_time * 1000 : Infinity,
         outputFormat,
         ffmpegOutputOpts,

--- a/posthog/temporal/session_replay/rasterize_recording/activities/rasterize.py
+++ b/posthog/temporal/session_replay/rasterize_recording/activities/rasterize.py
@@ -58,6 +58,14 @@ def build_rasterization_input(exported_asset_id: int) -> BuildRasterizationResul
     # 1x for short clips so output plays in real time; 4x for full sessions to cap file size.
     default_speed = 1 if (duration is not None and duration <= 5) else 4
     playback_speed = ctx.get("playback_speed", default_speed)
+    recording_fps = ctx.get("recording_fps", 24)
+    # Cap the render rate so a large fps × speed product can't exhaust the shared rasterizer pool.
+    # Upper bound only: positivity is enforced in the Node validateInput, and fractional
+    # slow-motion speeds (< 1) are valid.
+    if playback_speed is not None:
+        playback_speed = min(360.0, float(playback_speed))
+    if recording_fps is not None:
+        recording_fps = min(60, int(recording_fps))
 
     activity_input = RasterizationActivityInput(
         team_id=asset.team_id,
@@ -65,7 +73,7 @@ def build_rasterization_input(exported_asset_id: int) -> BuildRasterizationResul
         s3_bucket=settings.OBJECT_STORAGE_BUCKET,
         s3_key_prefix=s3_key_prefix,
         playback_speed=playback_speed,
-        recording_fps=ctx.get("recording_fps", 24),
+        recording_fps=recording_fps,
         trim=ctx.get("trim"),
         show_metadata_footer=ctx.get("show_metadata_footer", False),
         viewport_width=viewport_width,

--- a/posthog/temporal/tests/session_replay/rasterize_recording/test_activities.py
+++ b/posthog/temporal/tests/session_replay/rasterize_recording/test_activities.py
@@ -253,6 +253,39 @@ class TestBuildRasterizationInput:
         assert result.activity_input is not None
         assert getattr(result.activity_input, field) == expected_value
 
+    @parameterized.expand(
+        [
+            ("in_range", 24, 24),
+            ("at_cap", 60, 60),
+            ("above_cap", 1000, 60),
+            ("absurd", 100_000, 60),
+        ]
+    )
+    def test_recording_fps_capped(self, _name, recording_fps, expected_fps):
+        asset = _make_asset(pk=50, export_context={"session_recording_id": "s1", "recording_fps": recording_fps})
+        patches, _ = _patches(asset)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            result = build_rasterization_input(50)
+        assert result.activity_input is not None
+        assert result.activity_input.recording_fps == expected_fps
+
+    @parameterized.expand(
+        [
+            ("slow_motion_preserved", 0.5, 0.5),
+            ("default_in_range", 4, 4),
+            ("at_cap", 360, 360),
+            ("above_cap", 1000, 360),
+            ("absurd", 99_999, 360),
+        ]
+    )
+    def test_playback_speed_capped(self, _name, playback_speed, expected_speed):
+        asset = _make_asset(pk=50, export_context={"session_recording_id": "s1", "playback_speed": playback_speed})
+        patches, _ = _patches(asset)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            result = build_rasterization_input(50)
+        assert result.activity_input is not None
+        assert result.activity_input.playback_speed == expected_speed
+
 
 class TestBuildRasterizationCache:
     def _ctx_with_render(self, fingerprint: str, **overrides) -> dict:


### PR DESCRIPTION
## Problem

The session-replay rasterizer renders a user's session recording in headless Chromium and encodes the captured frames into mp4/webm/gif with ffmpeg (via `puppeteer-capture` → `fluent-ffmpeg`). A few encoding parameters — `trim`, `playback_speed`, `recording_fps` — originate from the user-supplied `export_context` on the export API and are interpolated into ffmpeg options/filters (`-t`, `setpts=`, `fps=`).

ffmpeg has a long history of argument- and input-parsing CVEs, so we want a hard guarantee that **only well-typed numeric values can ever reach its command line**, and that the render rate a single request can demand is bounded.

An audit found no exploitable injection today: ffmpeg is spawned without a shell, and the Pydantic activity-input model coerces these fields to numbers before they leave Python. These changes are **defense-in-depth** so that guarantee no longer rests on a single upstream layer — if a future caller skips that validation, the boundary still holds.

## Changes

- **Coerce numeric params at the point of interpolation** (`config.ts`): `trim` / `playback_speed` / `recording_fps` now pass through a `toFiniteNumber` helper that throws on any non-finite or non-numeric value before it becomes part of an ffmpeg arg or filter. A finite number stringifies without spaces or filter/shell metacharacters, so it cannot split into extra args or alter the filtergraph.
- **Cap the render rate** (`rasterize.py`): clamp `recording_fps` ≤ 60 and `playback_speed` ≤ 360 (upper bound only) when building the rasterization activity input, mirroring the existing viewport clamp. This bounds the worst-case capture rate (`fps × speed`) so it can't exhaust the shared rasterizer pool. Positivity stays enforced downstream, and fractional slow-motion speeds (< 1) are preserved.

No change to how ffmpeg is spawned, the `image2pipe` frame input, output paths, or the S3 key prefix.

## How did you test this code?

I'm an agent (Claude Code) — automated tests only, no manual testing. Tests were written failing-first, then made green:

- `config.test.ts`: `buildCaptureConfig` throws on non-finite `trim`/`playback_speed`/`recording_fps` (incl. payloads like `10 -i /etc/passwd`), plus regressions that `-t`/`setpts`/`fps` stay bare numerics — 63/63 pass.
- `rasterize_recording/test_activities.py`: parametrized caps — in-range, at-cap, above-cap, and slow-motion preserved — 50/50 pass.
- ruff, prettier, eslint, and `tsc --noEmit` clean on the changed files (pre-commit hooks ran on both commits).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; no docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus). Work began as a security audit of the rasterizer's ffmpeg usage, which concluded there was no exploitable injection (no shell; Pydantic numeric gate; fixed `image2pipe` input with no user file paths, protocols, or demuxers). At the author's request, implemented the two defense-in-depth hardenings the audit surfaced.
- Decisions: capped only the **upper** bound on fps/speed so valid fractional slow-motion speeds keep working; kept the existing ffmpeg option string formats so coercion is transparent for valid input; placed the clamp in `build_rasterization_input` to match the existing viewport-clamp pattern rather than duplicating it in the Node layer.
