### PR TITLE
fix(charts): guard SSR text measurement and cap compact-number suffix

### DIFF
--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -68,7 +68,7 @@ Charts fill their container and need a parent with real dimensions — a `0`-hei
 - `ValueLabels` formatter gets `(value, seriesIndex, dataIndex, context)`; in percent layouts `value` is a 0–1 fraction — use `context.rawValue` for the original.
 - `Legend` is presentational: pass `items`, `onItemClick`, `hiddenKeys` — filtering series is the caller's state. `LegendItem.secondaryLabel` shows muted trailing text (e.g. a slope chart's per-series change).
 - `SlopeChart` config: `showSeriesLabels` (name beside each end point; steepest line wins label collisions), `showStartLabels`/`showEndLabels` (defaults overridable per series via `meta.showStartLabel`/`showEndLabel`), `legend` (`{ show, position }`, rows carry the formatted change), `valueFormatter`/`deltaFormatter`. The value axis is hidden by default — the start/end labels are the readout.
-- y-axis `format`: `numeric | short | percentage | percentage_scaled | currency | duration | duration-ms`, plus `prefix`/`suffix`.
+- y-axis `format`: `numeric | short | percentage | percentage_scaled | currency | duration | duration_ms`, plus `prefix`/`suffix`.
 
 ## Maintenance
 

--- a/packages/quill/packages/charts/src/charts/SlopeChart/SlopeChart.tsx
+++ b/packages/quill/packages/charts/src/charts/SlopeChart/SlopeChart.tsx
@@ -12,7 +12,7 @@ import type {
     TooltipContext,
     ValueDomain,
 } from '../../core/types'
-import { FONT_FAMILY, measureLabelWidth } from '../../utils/text-measure'
+import { measureLabelWidth } from '../../utils/text-measure'
 import { LineChart } from '../LineChart/LineChart'
 import {
     defaultDeltaFormatter,
@@ -23,12 +23,12 @@ import {
     type SlopeSeriesMeta,
 } from './slope-data'
 import { slopeLegendItems } from './slope-legend'
+import { SLOPE_LABEL_FONT } from './SlopeLabel'
 import { SlopeSeriesLabels } from './SlopeSeriesLabels'
 import { SlopeValueLabels } from './SlopeValueLabels'
 
 export type { SlopeSeriesMeta } from './slope-data'
 
-const LABEL_FONT = `600 12px ${FONT_FAMILY}`
 const VALUE_GAP = 8
 const NAME_GAP = 8
 const EDGE_PAD = 8
@@ -84,7 +84,7 @@ export function SlopeChart<Meta = SlopeSeriesMeta>({ onError, ...rest }: SlopeCh
 }
 
 function maxLabelWidth(texts: string[]): number {
-    return texts.reduce((max, t) => Math.max(max, measureLabelWidth(t, LABEL_FONT)), 0)
+    return texts.reduce((max, t) => Math.max(max, measureLabelWidth(t, SLOPE_LABEL_FONT)), 0)
 }
 
 function SlopeChartInner<Meta = SlopeSeriesMeta>({

--- a/packages/quill/packages/charts/src/utils/format.test.ts
+++ b/packages/quill/packages/charts/src/utils/format.test.ts
@@ -92,6 +92,7 @@ describe('format helpers', () => {
             ['negative thousands', -1500, `-1.5${NBSP}K`],
             ['rounded to 3 sig figs', 12345, `12.3${NBSP}K`],
             ['zero', 0, '0'],
+            ['caps at largest suffix instead of rendering undefined', 1e27, `1000${NBSP}Y`],
         ] as const)('%s', (_, value, expected) => {
             expect(compactNumber(value)).toBe(expected)
         })

--- a/packages/quill/packages/charts/src/utils/format.ts
+++ b/packages/quill/packages/charts/src/utils/format.ts
@@ -109,7 +109,8 @@ export function compactNumber(value: number | null): string {
     }
     value = parseFloat(value.toPrecision(3))
     let magnitude = 0
-    while (Math.abs(value) >= 1000) {
+    const maxMagnitude = COMPACT_NUMBER_MAGNITUDES.length - 1
+    while (Math.abs(value) >= 1000 && magnitude < maxMagnitude) {
         magnitude++
         value /= 1000
     }

--- a/packages/quill/packages/charts/src/utils/text-measure.ts
+++ b/packages/quill/packages/charts/src/utils/text-measure.ts
@@ -15,6 +15,10 @@ export const MAX_CATEGORY_LABEL_WIDTH = 160
 
 let measureCtx: CanvasRenderingContext2D | null = null
 export function getTextMeasureCtx(): CanvasRenderingContext2D | null {
+    // No DOM under SSR — callers fall back to a character-width estimate.
+    if (typeof document === 'undefined') {
+        return null
+    }
     if (!measureCtx) {
         measureCtx = document.createElement('canvas').getContext('2d')
     }


### PR DESCRIPTION
## Problem

A handful of small, independent correctness and maintainability issues surfaced by a fresh audit of `@posthog/quill-charts` (follow-up to #63486, #63488, #63874):

- `getTextMeasureCtx` calls `document.createElement('canvas')` with no DOM guard. Its docstring promises a character-width fallback "when the canvas context is unavailable (SSR)", but under SSR `document` is undefined and the call throws a `ReferenceError` first. `measureLabelWidth` runs on the render path (axis margins, slope/pie/axis-title labels), so any labelled chart breaks during a server render.
- `compactNumber` increments its magnitude index past the end of the suffix array for very large inputs, rendering the literal string `undefined` (e.g. a `short`-format y-tick at extreme scale).
- `SlopeChart` redefines the slope label font string instead of reusing the exported `SLOPE_LABEL_FONT`, so the reserved label gutter and the drawn label can silently drift if one changes.
- The charts AGENTS guide documents the y-axis duration token as `duration-ms`; the real union value is `duration_ms`.

## Changes

- **SSR guard** in `getTextMeasureCtx` — returns `null` when `document` is undefined, so callers fall back to the documented character-width estimate.
- **Cap `compactNumber`** at the largest available magnitude suffix (`Y`), so values ≥ 1e27 format as `1000 Y` rather than `1 undefined`. Regression test added.
- **De-duplicate the slope label font** — `SlopeChart` imports `SLOPE_LABEL_FONT` from `SlopeLabel`.
- **Doc fix** — `duration-ms` → `duration_ms` in `packages/quill/packages/charts/AGENTS.md`.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I ran locally:

- `oxlint` on all changed files — 0 errors (1 pre-existing unrelated warning in `format.test.ts`).
- `tsc --noEmit` — changed source files typecheck clean.
- Jest: `format`, `text-measure`, and `SlopeChart` suites — 83 tests pass, including the new `compactNumber` overflow case.

The SSR guard is a defensive `typeof document` check; I did not stand up a server-render harness to exercise it (jsdom always defines `document`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @sampennington. These are the "quick win" findings from a fresh four-track re-audit of the charts package (the original review doc was lost to an environment reset, so the audit was regenerated against current code). Deliberately scoped to high-confidence, low-risk fixes. Deferred from the same audit for separate decisions: applying `valuePadding` on log/percent bar axes (visual change, needs eyes-on verification), adding the missing `stack-pills`/`resolve-bar-hover` test suites, the `frontend/src/lib/statistics.ts` re-export consolidation, and trimming leaked internal-mechanism type exports.