### PR TITLE
perf(replay): don't load recordings query on the collections tab

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -188,6 +188,18 @@ function Warnings(): JSX.Element {
     )
 }
 
+// Keeps the recordings logic mounted for the scene's lifetime so its state survives tab
+// switches. Rendered only on the Home tab so landing on Collections/Templates does not mount
+// it — which would otherwise fire a wasted loadSessionRecordings ClickHouse query on load.
+function AttachScenePlaylistLogic({
+    playlistLogicProps,
+}: {
+    playlistLogicProps: SessionRecordingPlaylistLogicProps
+}): null {
+    useAttachedLogic(sessionRecordingsPlaylistLogic(playlistLogicProps), sessionReplaySceneLogic())
+    return null
+}
+
 function MainPanel(): JSX.Element {
     const { tab } = useValues(sessionReplaySceneLogic)
     const isRedesignEnabled = useFeatureFlag('REPLAY_UI_REDESIGN_2026', 'test')
@@ -197,8 +209,6 @@ function MainPanel(): JSX.Element {
         updateSearchParams: true,
     }
 
-    useAttachedLogic(sessionRecordingsPlaylistLogic(playlistLogicProps), sessionReplaySceneLogic())
-
     return (
         <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow')}>
             <Warnings />
@@ -207,6 +217,7 @@ function MainPanel(): JSX.Element {
                 <Spinner />
             ) : tab === ReplayTabs.Home ? (
                 <div className="SessionRecordingPlaylistHeightWrapper grow">
+                    <AttachScenePlaylistLogic playlistLogicProps={playlistLogicProps} />
                     {isRedesignEnabled ? (
                         <SessionRecordingsPlaylistRedesign {...playlistLogicProps} />
                     ) : (


### PR DESCRIPTION
## Problem

Landing on `/replay/playlists` (the Collections tab) mounted `sessionRecordingsPlaylistLogic` unconditionally via `useAttachedLogic` on the scene logic. That logic's `afterMount` fires a `loadSessionRecordings` ClickHouse query — which is for the Recordings tab, not Collections. So opening the Collections (or Templates) tab kicked off a wasted recordings query that competed with the actual page load.

## Changes

Move the `useAttachedLogic` call into a small child component rendered only on the Home (Recordings) tab. The logic still persists across tab switches once Recordings has been visited, but is never mounted if the user only opens Collections or Templates.

No visual change — this only affects which kea logic mounts.

Part of a 4-PR stack improving `/replay/playlists` performance.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks only:

- `tsc` type-checks clean for the changed file (the only errors on the base are pre-existing missing-typegen artifacts in unrelated areas).
- The behavioural outcome — no recordings query on the Collections tab — is observable in the network panel / ClickHouse query log. A React mount-by-tab unit test would require rendering the whole scene and was judged too brittle for the value; relying on the network/query-log signal instead.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of five improvements found while investigating poor LCP on `/replay/playlists` (see the rest of the stack). This is the only frontend lever: the scene was eagerly mounting the recordings logic regardless of tab. Kept the cross-tab persistence behaviour intact by gating the attach on the Home tab rather than removing it. Built with PostHog Code (Claude Opus).
