### PR TITLE
perf(replay): batch synthetic playlist watched-count lookups

### DIFF
--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -64,6 +64,11 @@ CURRENT_USER_VIEWED_CHUNK_SIZE = 5000
 # building the cross-playlist watched lookup. Prevents a single oversized cached
 # entry from dominating memory.
 MAX_SAVED_FILTER_SESSION_IDS_PER_PLAYLIST = 1000
+# Cap on how many of a synthetic playlist's session_ids we materialize for the
+# watched-status intersection. The displayed count comes from count_session_ids
+# (accurate); only watched_count is approximate beyond this cap, bounding the
+# memory a single very large synthetic can consume during the batched lookup.
+SYNTHETIC_WATCHED_SAMPLE_LIMIT = 10000
 
 
 class SessionRecordingPlaylistPagination(LimitOffsetPagination):
@@ -144,31 +149,9 @@ def count_saved_filters(playlist: SessionRecordingPlaylist, user: User, team: Te
     }
 
 
-def count_synthetic_playlist(
-    playlist: SessionRecordingPlaylist, user: User, team: Team
-) -> dict[str, int | bool | None]:
-    """Count recordings in a synthetic playlist using efficient database-level counting"""
-    synthetic_def = get_synthetic_playlist(playlist.short_id)
-    if not synthetic_def:
-        return {
-            "count": None,
-            "has_more": None,
-            "watched_count": None,
-            "increased": None,
-            "last_refreshed_at": None,
-        }
-
-    # Use the count function for efficient database-level counting
-    count = synthetic_def.count_session_ids(team, user)
-
-    # For watched_count, we still need to load session IDs since we're checking user-specific viewed status
-    # But only if count > 0
-    if count > 0:
-        session_ids = synthetic_def.get_session_ids(team, user)
-        watched_count = len(current_user_viewed(session_ids, user, team))
-    else:
-        watched_count = 0
-
+def _synthetic_counts(count: int, watched_count: int) -> dict[str, int | bool | None]:
+    """Shared shape for a synthetic playlist's counts, used by both the batched
+    precompute and the per-playlist fallback so the two can't drift."""
     return {
         "count": count if count > 0 else None,
         "has_more": False,  # We don't paginate synthetic playlists (yet)
@@ -178,7 +161,29 @@ def count_synthetic_playlist(
     }
 
 
-def _empty_saved_filters_counts() -> dict[str, int | bool | None]:
+def count_synthetic_playlist(
+    playlist: SessionRecordingPlaylist, user: User, team: Team
+) -> dict[str, int | bool | None]:
+    """Count recordings in a synthetic playlist using efficient database-level counting"""
+    synthetic_def = get_synthetic_playlist(playlist.short_id)
+    if not synthetic_def:
+        return _empty_recordings_counts()
+
+    count = synthetic_def.count_session_ids(team, user)
+
+    # For watched_count we need the session ids, but only when there are any. Bound the
+    # read so a very large synthetic can't dominate memory — watched_count is then a
+    # lower bound, the same trade the batched precompute path makes.
+    if count > 0:
+        session_ids = synthetic_def.get_session_ids(team, user, limit=SYNTHETIC_WATCHED_SAMPLE_LIMIT)
+        watched_count = len(current_user_viewed(session_ids, user, team))
+    else:
+        watched_count = 0
+
+    return _synthetic_counts(count, watched_count)
+
+
+def _empty_recordings_counts() -> dict[str, int | bool | None]:
     return {
         "count": None,
         "has_more": None,
@@ -232,7 +237,7 @@ def _attach_empty_recordings_counts(playlists: list[SessionRecordingPlaylist]) -
                 "watched_count": None,
             }
         if not hasattr(playlist, "_prefetched_saved_filters_count"):
-            playlist._prefetched_saved_filters_count = _empty_saved_filters_counts()  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+            playlist._prefetched_saved_filters_count = _empty_recordings_counts()  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
 
 
 def precompute_recordings_counts(playlists: list[SessionRecordingPlaylist], user: User, team: Team) -> None:
@@ -337,8 +342,54 @@ def precompute_recordings_counts(playlists: list[SessionRecordingPlaylist], user
         playlist._prefetched_saved_filters_count = (  # type: ignore[attr-defined]
             _saved_filters_counts_from_data(data, viewed_session_ids)
             if data is not None
-            else _empty_saved_filters_counts()
+            else _empty_recordings_counts()
         )
+
+
+def precompute_synthetic_recordings_counts(playlists: list[SessionRecordingPlaylist], user: User, team: Team) -> None:
+    """Batch the watched-count lookups for a page of synthetic playlists.
+
+    The per-playlist path (count_synthetic_playlist) issues one current_user_viewed
+    query per synthetic collection, which is O(N) Postgres round-trips for a list
+    response. Here we collapse those viewed-status lookups into a single chunked
+    query and attach the results as `_prefetched_synthetic_count` for the serializer.
+
+    Counts come from count_session_ids (accurate); the ids materialized for the
+    watched-status intersection are bounded by SYNTHETIC_WATCHED_SAMPLE_LIMIT so a
+    very large synthetic can't dominate memory.
+
+    Non-synthetic playlists are skipped — they use precompute_recordings_counts.
+    """
+    synthetic_playlists = [p for p in playlists if getattr(p, "_is_synthetic", False)]
+    if not synthetic_playlists:
+        return
+
+    # short_id -> count; None marks a short_id with no synthetic definition.
+    counts_by_short_id: dict[str, int | None] = {}
+    sample_ids_by_short_id: dict[str, list[str]] = {}
+    all_session_ids: set[str] = set()
+    for playlist in synthetic_playlists:
+        synthetic_def = get_synthetic_playlist(playlist.short_id)
+        if synthetic_def is None:
+            counts_by_short_id[playlist.short_id] = None
+            continue
+        count = synthetic_def.count_session_ids(team, user)
+        counts_by_short_id[playlist.short_id] = count
+        if count > 0:
+            sample_ids = synthetic_def.get_session_ids(team, user, limit=SYNTHETIC_WATCHED_SAMPLE_LIMIT)
+            sample_ids_by_short_id[playlist.short_id] = sample_ids
+            all_session_ids.update(sample_ids)
+
+    viewed_session_ids = _batch_current_user_viewed(all_session_ids, user, team)
+
+    for playlist in synthetic_playlists:
+        count = counts_by_short_id[playlist.short_id]
+        if count is None:
+            playlist._prefetched_synthetic_count = _empty_recordings_counts()  # type: ignore[attr-defined]
+            continue
+        sample_ids = sample_ids_by_short_id.get(playlist.short_id, [])
+        watched_count = len(set(sample_ids) & viewed_session_ids)
+        playlist._prefetched_synthetic_count = _synthetic_counts(count, watched_count)  # type: ignore[attr-defined]
 
 
 def log_playlist_activity(
@@ -448,7 +499,7 @@ class SessionRecordingPlaylistSerializer(serializers.ModelSerializer, UserAccess
 
     def get_recordings_counts(self, playlist: SessionRecordingPlaylist) -> dict[str, dict[str, int | bool | None]]:
         recordings_counts: dict[str, dict[str, int | bool | None]] = {
-            "saved_filters": _empty_saved_filters_counts(),
+            "saved_filters": _empty_recordings_counts(),
             "collection": {
                 "count": None,
                 "watched_count": None,
@@ -461,7 +512,11 @@ class SessionRecordingPlaylistSerializer(serializers.ModelSerializer, UserAccess
 
             # Handle synthetic playlists differently
             if getattr(playlist, "_is_synthetic", False):
-                recordings_counts["collection"] = count_synthetic_playlist(playlist, user, team)
+                prefetched_synthetic = getattr(playlist, "_prefetched_synthetic_count", None)
+                if prefetched_synthetic is not None:
+                    recordings_counts["collection"] = prefetched_synthetic
+                else:
+                    recordings_counts["collection"] = count_synthetic_playlist(playlist, user, team)
             else:
                 prefetched_collection = getattr(playlist, "_prefetched_collection_count", None)
                 if prefetched_collection is not None:
@@ -647,6 +702,18 @@ class SessionRecordingPlaylistViewSet(
             )
             posthoganalytics.capture_exception(e)
             _attach_empty_recordings_counts(combined)
+
+        # Batch the synthetic playlists' watched-count lookups. On failure the
+        # serializer falls back to the per-playlist count_synthetic_playlist path.
+        try:
+            precompute_synthetic_recordings_counts(combined, cast(User, request.user), self.team)
+        except Exception as e:
+            logger.exception(
+                "playlist_synthetic_recordings_counts_precompute_failed",
+                team_id=self.team.id,
+                page_size=len(combined),
+            )
+            posthoganalytics.capture_exception(e)
 
         serializer = self.get_serializer(combined, many=True)
 

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -383,13 +383,13 @@ def precompute_synthetic_recordings_counts(playlists: list[SessionRecordingPlayl
     viewed_session_ids = _batch_current_user_viewed(all_session_ids, user, team)
 
     for playlist in synthetic_playlists:
-        count = counts_by_short_id[playlist.short_id]
-        if count is None:
+        playlist_count = counts_by_short_id[playlist.short_id]
+        if playlist_count is None:
             playlist._prefetched_synthetic_count = _empty_recordings_counts()  # type: ignore[attr-defined]
             continue
         sample_ids = sample_ids_by_short_id.get(playlist.short_id, [])
         watched_count = len(set(sample_ids) & viewed_session_ids)
-        playlist._prefetched_synthetic_count = _synthetic_counts(count, watched_count)  # type: ignore[attr-defined]
+        playlist._prefetched_synthetic_count = _synthetic_counts(playlist_count, watched_count)  # type: ignore[attr-defined]
 
 
 def log_playlist_activity(

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -64,11 +64,6 @@ CURRENT_USER_VIEWED_CHUNK_SIZE = 5000
 # building the cross-playlist watched lookup. Prevents a single oversized cached
 # entry from dominating memory.
 MAX_SAVED_FILTER_SESSION_IDS_PER_PLAYLIST = 1000
-# Cap on how many of a synthetic playlist's session_ids we materialize for the
-# watched-status intersection. The displayed count comes from count_session_ids
-# (accurate); only watched_count is approximate beyond this cap, bounding the
-# memory a single very large synthetic can consume during the batched lookup.
-SYNTHETIC_WATCHED_SAMPLE_LIMIT = 10000
 
 
 class SessionRecordingPlaylistPagination(LimitOffsetPagination):
@@ -171,11 +166,9 @@ def count_synthetic_playlist(
 
     count = synthetic_def.count_session_ids(team, user)
 
-    # For watched_count we need the session ids, but only when there are any. Bound the
-    # read so a very large synthetic can't dominate memory — watched_count is then a
-    # lower bound, the same trade the batched precompute path makes.
+    # For watched_count we still need the session ids, but only when there are any.
     if count > 0:
-        session_ids = synthetic_def.get_session_ids(team, user, limit=SYNTHETIC_WATCHED_SAMPLE_LIMIT)
+        session_ids = synthetic_def.get_session_ids(team, user)
         watched_count = len(current_user_viewed(session_ids, user, team))
     else:
         watched_count = 0
@@ -351,12 +344,9 @@ def precompute_synthetic_recordings_counts(playlists: list[SessionRecordingPlayl
 
     The per-playlist path (count_synthetic_playlist) issues one current_user_viewed
     query per synthetic collection, which is O(N) Postgres round-trips for a list
-    response. Here we collapse those viewed-status lookups into a single chunked
-    query and attach the results as `_prefetched_synthetic_count` for the serializer.
-
-    Counts come from count_session_ids (accurate); the ids materialized for the
-    watched-status intersection are bounded by SYNTHETIC_WATCHED_SAMPLE_LIMIT so a
-    very large synthetic can't dominate memory.
+    response. Here we read each source's session ids once (their length is the
+    count) and collapse the viewed-status lookups into a single chunked query,
+    attaching the results as `_prefetched_synthetic_count` for the serializer.
 
     Non-synthetic playlists are skipped — they use precompute_recordings_counts.
     """
@@ -364,32 +354,26 @@ def precompute_synthetic_recordings_counts(playlists: list[SessionRecordingPlayl
     if not synthetic_playlists:
         return
 
-    # short_id -> count; None marks a short_id with no synthetic definition.
-    counts_by_short_id: dict[str, int | None] = {}
-    sample_ids_by_short_id: dict[str, list[str]] = {}
+    # A short_id absent from this map had no synthetic definition.
+    session_ids_by_short_id: dict[str, list[str]] = {}
     all_session_ids: set[str] = set()
     for playlist in synthetic_playlists:
         synthetic_def = get_synthetic_playlist(playlist.short_id)
         if synthetic_def is None:
-            counts_by_short_id[playlist.short_id] = None
             continue
-        count = synthetic_def.count_session_ids(team, user)
-        counts_by_short_id[playlist.short_id] = count
-        if count > 0:
-            sample_ids = synthetic_def.get_session_ids(team, user, limit=SYNTHETIC_WATCHED_SAMPLE_LIMIT)
-            sample_ids_by_short_id[playlist.short_id] = sample_ids
-            all_session_ids.update(sample_ids)
+        session_ids = synthetic_def.get_session_ids(team, user)
+        session_ids_by_short_id[playlist.short_id] = session_ids
+        all_session_ids.update(session_ids)
 
     viewed_session_ids = _batch_current_user_viewed(all_session_ids, user, team)
 
     for playlist in synthetic_playlists:
-        playlist_count = counts_by_short_id[playlist.short_id]
-        if playlist_count is None:
+        if playlist.short_id not in session_ids_by_short_id:
             playlist._prefetched_synthetic_count = _empty_recordings_counts()  # type: ignore[attr-defined]
             continue
-        sample_ids = sample_ids_by_short_id.get(playlist.short_id, [])
-        watched_count = len(set(sample_ids) & viewed_session_ids)
-        playlist._prefetched_synthetic_count = _synthetic_counts(playlist_count, watched_count)  # type: ignore[attr-defined]
+        session_ids = session_ids_by_short_id[playlist.short_id]
+        watched_count = len(set(session_ids) & viewed_session_ids)
+        playlist._prefetched_synthetic_count = _synthetic_counts(len(session_ids), watched_count)  # type: ignore[attr-defined]
 
 
 def log_playlist_activity(

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -954,53 +954,57 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.24
   '''
-  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
+  SELECT COUNT(*) AS "__count"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999)
-  ORDER BY "posthog_sessionrecordingviewed"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.25
   '''
-  SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
-  FROM "posthog_comment"
-  WHERE (NOT "posthog_comment"."deleted"
-         AND "posthog_comment"."scope" = 'Replay'
-         AND "posthog_comment"."team_id" = 99999
-         AND NOT ("posthog_comment"."item_id" IS NULL))
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
+     FROM "posthog_comment"
+     WHERE (NOT "posthog_comment"."deleted"
+            AND "posthog_comment"."scope" = 'Replay'
+            AND "posthog_comment"."team_id" = 99999
+            AND NOT ("posthog_comment"."item_id" IS NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.26
   '''
-  SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
-  FROM "posthog_sharingconfiguration"
-  WHERE ("posthog_sharingconfiguration"."enabled"
-         AND "posthog_sharingconfiguration"."team_id" = 99999
-         AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
+     FROM "posthog_sharingconfiguration"
+     WHERE ("posthog_sharingconfiguration"."enabled"
+            AND "posthog_sharingconfiguration"."team_id" = 99999
+            AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.27
   '''
-  SELECT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
-  FROM "posthog_exportedasset"
-  WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
-          OR "posthog_exportedasset"."expires_after" IS NULL)
-         AND "posthog_exportedasset"."team_id" = 99999
-         AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
-         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
-         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
-                  AND "posthog_exportedasset"."export_context" IS NOT NULL))
-  ORDER BY "posthog_exportedasset"."created_at" DESC
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
+     FROM "posthog_exportedasset"
+     WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
+             OR "posthog_exportedasset"."expires_after" IS NULL)
+            AND "posthog_exportedasset"."team_id" = 99999
+            AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
+            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
+            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
+                     AND "posthog_exportedasset"."export_context" IS NOT NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.28
   '''
-  SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id",
-                  "ee_single_session_summary"."created_at"
-  FROM "ee_single_session_summary"
-  WHERE "ee_single_session_summary"."team_id" = 99999
-  ORDER BY "ee_single_session_summary"."created_at" DESC
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
+     FROM "ee_single_session_summary"
+     WHERE "ee_single_session_summary"."team_id" = 99999) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.29
@@ -1723,53 +1727,57 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.40
   '''
-  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
+  SELECT COUNT(*) AS "__count"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999)
-  ORDER BY "posthog_sessionrecordingviewed"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.41
   '''
-  SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
-  FROM "posthog_comment"
-  WHERE (NOT "posthog_comment"."deleted"
-         AND "posthog_comment"."scope" = 'Replay'
-         AND "posthog_comment"."team_id" = 99999
-         AND NOT ("posthog_comment"."item_id" IS NULL))
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
+     FROM "posthog_comment"
+     WHERE (NOT "posthog_comment"."deleted"
+            AND "posthog_comment"."scope" = 'Replay'
+            AND "posthog_comment"."team_id" = 99999
+            AND NOT ("posthog_comment"."item_id" IS NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.42
   '''
-  SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
-  FROM "posthog_sharingconfiguration"
-  WHERE ("posthog_sharingconfiguration"."enabled"
-         AND "posthog_sharingconfiguration"."team_id" = 99999
-         AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
+     FROM "posthog_sharingconfiguration"
+     WHERE ("posthog_sharingconfiguration"."enabled"
+            AND "posthog_sharingconfiguration"."team_id" = 99999
+            AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.43
   '''
-  SELECT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
-  FROM "posthog_exportedasset"
-  WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
-          OR "posthog_exportedasset"."expires_after" IS NULL)
-         AND "posthog_exportedasset"."team_id" = 99999
-         AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
-         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
-         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
-                  AND "posthog_exportedasset"."export_context" IS NOT NULL))
-  ORDER BY "posthog_exportedasset"."created_at" DESC
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
+     FROM "posthog_exportedasset"
+     WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
+             OR "posthog_exportedasset"."expires_after" IS NULL)
+            AND "posthog_exportedasset"."team_id" = 99999
+            AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
+            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
+            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
+                     AND "posthog_exportedasset"."export_context" IS NOT NULL))) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.44
   '''
-  SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id",
-                  "ee_single_session_summary"."created_at"
-  FROM "ee_single_session_summary"
-  WHERE "ee_single_session_summary"."team_id" = 99999
-  ORDER BY "ee_single_session_summary"."created_at" DESC
+  SELECT COUNT(*)
+  FROM
+    (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
+     FROM "ee_single_session_summary"
+     WHERE "ee_single_session_summary"."team_id" = 99999) subquery
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.5

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -954,57 +954,53 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.24
   '''
-  SELECT COUNT(*) AS "__count"
+  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999)
+  ORDER BY "posthog_sessionrecordingviewed"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.25
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
-     FROM "posthog_comment"
-     WHERE (NOT "posthog_comment"."deleted"
-            AND "posthog_comment"."scope" = 'Replay'
-            AND "posthog_comment"."team_id" = 99999
-            AND NOT ("posthog_comment"."item_id" IS NULL))) subquery
+  SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
+  FROM "posthog_comment"
+  WHERE (NOT "posthog_comment"."deleted"
+         AND "posthog_comment"."scope" = 'Replay'
+         AND "posthog_comment"."team_id" = 99999
+         AND NOT ("posthog_comment"."item_id" IS NULL))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.26
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
-     FROM "posthog_sharingconfiguration"
-     WHERE ("posthog_sharingconfiguration"."enabled"
-            AND "posthog_sharingconfiguration"."team_id" = 99999
-            AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))) subquery
+  SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
+  FROM "posthog_sharingconfiguration"
+  WHERE ("posthog_sharingconfiguration"."enabled"
+         AND "posthog_sharingconfiguration"."team_id" = 99999
+         AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.27
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
-     FROM "posthog_exportedasset"
-     WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
-             OR "posthog_exportedasset"."expires_after" IS NULL)
-            AND "posthog_exportedasset"."team_id" = 99999
-            AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
-            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
-            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
-                     AND "posthog_exportedasset"."export_context" IS NOT NULL))) subquery
+  SELECT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
+  FROM "posthog_exportedasset"
+  WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
+          OR "posthog_exportedasset"."expires_after" IS NULL)
+         AND "posthog_exportedasset"."team_id" = 99999
+         AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
+         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
+         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
+                  AND "posthog_exportedasset"."export_context" IS NOT NULL))
+  ORDER BY "posthog_exportedasset"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.28
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
-     FROM "ee_single_session_summary"
-     WHERE "ee_single_session_summary"."team_id" = 99999) subquery
+  SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id",
+                  "ee_single_session_summary"."created_at"
+  FROM "ee_single_session_summary"
+  WHERE "ee_single_session_summary"."team_id" = 99999
+  ORDER BY "ee_single_session_summary"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.29
@@ -1727,57 +1723,53 @@
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.40
   '''
-  SELECT COUNT(*) AS "__count"
+  SELECT "posthog_sessionrecordingviewed"."session_id" AS "session_id"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999)
+  ORDER BY "posthog_sessionrecordingviewed"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.41
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
-     FROM "posthog_comment"
-     WHERE (NOT "posthog_comment"."deleted"
-            AND "posthog_comment"."scope" = 'Replay'
-            AND "posthog_comment"."team_id" = 99999
-            AND NOT ("posthog_comment"."item_id" IS NULL))) subquery
+  SELECT DISTINCT "posthog_comment"."item_id" AS "item_id"
+  FROM "posthog_comment"
+  WHERE (NOT "posthog_comment"."deleted"
+         AND "posthog_comment"."scope" = 'Replay'
+         AND "posthog_comment"."team_id" = 99999
+         AND NOT ("posthog_comment"."item_id" IS NULL))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.42
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
-     FROM "posthog_sharingconfiguration"
-     WHERE ("posthog_sharingconfiguration"."enabled"
-            AND "posthog_sharingconfiguration"."team_id" = 99999
-            AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))) subquery
+  SELECT DISTINCT "posthog_sharingconfiguration"."recording_id" AS "recording__session_id"
+  FROM "posthog_sharingconfiguration"
+  WHERE ("posthog_sharingconfiguration"."enabled"
+         AND "posthog_sharingconfiguration"."team_id" = 99999
+         AND NOT ("posthog_sharingconfiguration"."recording_id" IS NULL))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.43
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
-     FROM "posthog_exportedasset"
-     WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
-             OR "posthog_exportedasset"."expires_after" IS NULL)
-            AND "posthog_exportedasset"."team_id" = 99999
-            AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
-            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
-            AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
-                     AND "posthog_exportedasset"."export_context" IS NOT NULL))) subquery
+  SELECT ("posthog_exportedasset"."export_context" -> 'session_recording_id') AS "export_context__session_recording_id"
+  FROM "posthog_exportedasset"
+  WHERE (("posthog_exportedasset"."expires_after" >= '2025-01-01 12:00:00+00:00'::timestamptz
+          OR "posthog_exportedasset"."expires_after" IS NULL)
+         AND "posthog_exportedasset"."team_id" = 99999
+         AND "posthog_exportedasset"."export_context" ? 'session_recording_id'
+         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') IS NULL)
+         AND NOT (("posthog_exportedasset"."export_context" -> 'session_recording_id') = '""'::jsonb
+                  AND "posthog_exportedasset"."export_context" IS NOT NULL))
+  ORDER BY "posthog_exportedasset"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.44
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id"
-     FROM "ee_single_session_summary"
-     WHERE "ee_single_session_summary"."team_id" = 99999) subquery
+  SELECT DISTINCT "ee_single_session_summary"."session_id" AS "session_id",
+                  "ee_single_session_summary"."created_at"
+  FROM "ee_single_session_summary"
+  WHERE "ee_single_session_summary"."team_id" = 99999
+  ORDER BY "ee_single_session_summary"."created_at" DESC
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.5

--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -32,7 +32,7 @@ from posthog.session_recordings.session_recording_playlist_api import (
     PLAYLIST_COUNT_REDIS_PREFIX,
     PLAYLIST_LIST_MAX_LIMIT,
     _attach_empty_recordings_counts,
-    _empty_saved_filters_counts,
+    _empty_recordings_counts,
     precompute_recordings_counts,
 )
 from posthog.session_recordings.synthetic_playlists import ExpiringPlaylistSource
@@ -1379,7 +1379,7 @@ class TestPrecomputeRecordingsCounts(APIBaseTest):
 
         precompute_recordings_counts([playlist], self.user, self.team)
 
-        assert playlist._prefetched_saved_filters_count == _empty_saved_filters_counts()  # type: ignore[attr-defined]
+        assert playlist._prefetched_saved_filters_count == _empty_recordings_counts()  # type: ignore[attr-defined]
 
     def test_redis_mget_failure_degrades_without_raising(self) -> None:
         playlist = self._make_playlist("redis down")
@@ -1392,7 +1392,7 @@ class TestPrecomputeRecordingsCounts(APIBaseTest):
             precompute_recordings_counts([playlist], self.user, self.team)
 
         assert playlist._prefetched_collection_count == {"count": None, "watched_count": 0}  # type: ignore[attr-defined]
-        assert playlist._prefetched_saved_filters_count == _empty_saved_filters_counts()  # type: ignore[attr-defined]
+        assert playlist._prefetched_saved_filters_count == _empty_recordings_counts()  # type: ignore[attr-defined]
 
     def test_does_not_read_items_from_other_team(self) -> None:
         # Defense-in-depth: even if a caller misuses the helper by passing a
@@ -1440,7 +1440,7 @@ class TestPrecomputeRecordingsCounts(APIBaseTest):
             assert playlist._prefetched_collection_count == expected_collection_count  # type: ignore[attr-defined]
 
         if expect_saved_filters_default:
-            assert playlist._prefetched_saved_filters_count == _empty_saved_filters_counts()  # type: ignore[attr-defined]
+            assert playlist._prefetched_saved_filters_count == _empty_recordings_counts()  # type: ignore[attr-defined]
 
     def test_list_clamps_limit_query_param_to_max(self) -> None:
         # Sanity-check the pagination cap — requesting limit=99999 must cap at the configured max.

--- a/posthog/session_recordings/test/test_synthetic_playlists.py
+++ b/posthog/session_recordings/test/test_synthetic_playlists.py
@@ -14,6 +14,7 @@ from posthog.models import Comment, SessionRecordingPlaylist
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.utils import uuid7
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
+from posthog.session_recordings.session_recording_api import current_user_viewed
 from posthog.session_recordings.synthetic_playlists import ExpiringPlaylistSource, FrustrationSignalsPlaylistSource
 
 from products.exports.backend.models.exported_asset import ExportedAsset
@@ -87,6 +88,30 @@ class TestSyntheticPlaylists(APIBaseTest):
         assert session_ids == ["expiring-soon"]
         # count + get_session_ids + recount share a single cached scan
         assert mock_query.call_count == 1
+
+    def test_synthetic_watched_counts_are_batched(self) -> None:
+        cache.clear()
+
+        SessionRecordingViewed.objects.create(team=self.team, user=self.user, session_id="watched-1")
+        SessionRecordingViewed.objects.create(team=self.team, user=self.user, session_id="watched-2")
+        Comment.objects.create(team=self.team, created_by=self.user, content="c", scope="Replay", item_id="commented-1")
+
+        with patch(
+            "posthog.session_recordings.session_recording_playlist_api.current_user_viewed",
+            wraps=current_user_viewed,
+        ) as mock_viewed:
+            response_data = self._get_playlists_response()
+
+        # multiple non-empty synthetics share a single batched watched-status lookup
+        assert mock_viewed.call_count == 1
+
+        by_short_id = {p["short_id"]: p["recordings_counts"]["collection"] for p in response_data["results"]}
+        # watch-history's two sessions are both viewed
+        assert by_short_id["synthetic-watch-history"]["count"] == 2
+        assert by_short_id["synthetic-watch-history"]["watched_count"] == 2
+        # the commented session was not viewed — proves ids don't leak across synthetics
+        assert by_short_id["synthetic-commented"]["count"] == 1
+        assert by_short_id["synthetic-commented"]["watched_count"] == 0
 
     def test_retrieve_synthetic_playlist(self) -> None:
         playlist = self._get_synthetic_playlist("synthetic-watch-history")


### PR DESCRIPTION
## Problem

Synthetic playlists were skipped by the list endpoint's count precompute, so each one ran its own count query plus a per-playlist `current_user_viewed` lookup during serialization — O(N) Postgres round-trips for a single list page that renders ~6-7 synthetic collections.

This is part of the server-side cost on the list endpoint that backs the `/replay/playlists` page (LCP p75 in the "poor" band).

## Changes

Add `precompute_synthetic_recordings_counts`: read each source's session ids once (their length is the count — verified equal to the existing `count_session_ids` for every source) and collapse all watched-status lookups into a single chunked query, attaching the result for the serializer to consume. Falls back to the per-playlist path on error.

Top of a 4-PR stack improving `/replay/playlists` performance.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only:

- Added `test_synthetic_watched_counts_are_batched`: multiple non-empty synthetics share a single batched watched-status lookup, with correct counts.
- Updated the `test_filters_playlist_by_type` Postgres query snapshot (per-synthetic `COUNT` replaced by a single `get_session_ids` read each).
- Full `test_session_recording_playlist.py` and `test_synthetic_playlists.py` suites pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Last of four landed improvements from a `/replay/playlists` LCP investigation. The key insight: the serializer already loaded all session ids for the watched count whenever a synthetic had any items, so folding count+ids into one read and batching the viewed-status lookups is behaviour-preserving while removing per-synthetic round-trips. Built with PostHog Code (Claude Opus).
