### PR TITLE
fix(mcp): advertise only OAuth scopes the live auth server grants

### DIFF
--- a/services/mcp/src/hono/public-routes.ts
+++ b/services/mcp/src/hono/public-routes.ts
@@ -1,8 +1,8 @@
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { Hono } from 'hono'
 
+import { getLiveAdvertisedOAuthScopes } from '@/lib/authorization-server-scopes'
 import { buildRedirectUrl, getPublicUrl, matchAuthServerRedirect } from '@/lib/routing'
-import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
 
 import type { Lifecycle } from './app'
 import { AUTH_REDIRECT_PATHS, getAuthorizationServerUrl, MCP_DOCS_URL } from './constants'
@@ -46,18 +46,19 @@ function readyzHandler(redis: RedisWithPing, lifecycle: Lifecycle) {
 // resource path. The resource URL the metadata advertises has to match what
 // the client connected on, so we derive it from the request rather than
 // hard-coding the host.
-const wellKnownHandler = (c: HonoCtx): Response => {
+const wellKnownHandler = async (c: HonoCtx): Promise<Response> => {
     const url = new URL(c.req.url)
     const resourcePath = url.pathname.slice(WELL_KNOWN_PREFIX.length) || '/'
     const resourceUrl = getPublicUrl(c.req.raw)
     resourceUrl.pathname = resourcePath
     resourceUrl.search = ''
 
+    const authorizationServerUrl = getAuthorizationServerUrl()
     return c.json(
         {
             resource: resourceUrl.toString().replace(/\/$/, ''),
-            authorization_servers: [getAuthorizationServerUrl()],
-            scopes_supported: getAdvertisedOAuthScopes(),
+            authorization_servers: [authorizationServerUrl],
+            scopes_supported: await getLiveAdvertisedOAuthScopes(authorizationServerUrl),
             bearer_methods_supported: ['header'],
         },
         200,

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -1,3 +1,4 @@
+import { getLiveAdvertisedOAuthScopes } from '@/lib/authorization-server-scopes'
 import { MCP_DOCS_URL, getAuthorizationServerUrl } from '@/lib/constants'
 import { isIdJagAccessToken } from '@/lib/id-jag'
 import { RequestLogger, withLogging } from '@/lib/logging'
@@ -5,7 +6,6 @@ import { extractClientInfoFromBody } from '@/lib/mcp-client-info'
 import { RequestProperties } from '@/lib/request-properties'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { extractBearerToken, hash, parseMcpMode, sanitizeHeaderValue } from '@/lib/utils'
-import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
 import type { CloudRegion } from '@/tools/types'
 
 import { proxyToHono, resolveProxyRegion } from './proxy'
@@ -168,7 +168,7 @@ const handleRequest = async (
             JSON.stringify({
                 resource: resourceUrl.toString().replace(/\/$/, ''),
                 authorization_servers: [authorizationServer],
-                scopes_supported: getAdvertisedOAuthScopes(),
+                scopes_supported: await getLiveAdvertisedOAuthScopes(authorizationServer),
                 bearer_methods_supported: ['header'],
             }),
             {

--- a/services/mcp/src/lib/authorization-server-scopes.ts
+++ b/services/mcp/src/lib/authorization-server-scopes.ts
@@ -1,0 +1,101 @@
+import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
+
+// RFC 8414 metadata document, served by the PostHog authorization server (and
+// fronted by oauth.posthog.com for cloud). Its `scopes_supported` is the live
+// grantable set from the running Django pods — `get_oauth_scopes_supported()`.
+const AS_METADATA_PATH = '/.well-known/oauth-authorization-server'
+
+// Refresh fast enough that a scope newly recognised by the AS shows up in our
+// advertised list within minutes of the Django deploy completing, slow enough
+// that we don't fetch on every metadata request.
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+// The metadata route is unauthenticated and hit by clients mid sign-in, so a
+// slow AS must never wedge it — bail quickly and fall back to the static list.
+const FETCH_TIMEOUT_MS = 1500
+
+interface CacheEntry {
+    scopes: Set<string>
+    fetchedAt: number
+}
+
+// Keyed by authorization-server URL so US and EU (and self-hosted) caches don't
+// clobber each other. Module-level: persists across requests in the long-lived
+// Node process and within a reused Workers isolate; best-effort either way.
+const cache = new Map<string, CacheEntry>()
+
+async function fetchAuthorizationServerScopes(authorizationServerUrl: string): Promise<Set<string> | undefined> {
+    const metadataUrl = new URL(AS_METADATA_PATH, authorizationServerUrl).toString()
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+        const res = await fetch(metadataUrl, {
+            signal: controller.signal,
+            headers: { Accept: 'application/json' },
+        })
+        if (!res.ok) {
+            return undefined
+        }
+        const body = (await res.json()) as { scopes_supported?: unknown }
+        if (!Array.isArray(body.scopes_supported)) {
+            return undefined
+        }
+        const scopes = body.scopes_supported.filter((scope): scope is string => typeof scope === 'string')
+        // An empty list almost certainly means a malformed/partial response, not
+        // an AS that genuinely grants nothing — treat it as a miss so we fall
+        // back rather than advertise an empty `scopes_supported`.
+        return scopes.length > 0 ? new Set(scopes) : undefined
+    } catch {
+        // Network error, timeout/abort, or non-JSON body — caller falls back.
+        return undefined
+    } finally {
+        clearTimeout(timeout)
+    }
+}
+
+async function getAuthorizationServerScopes(authorizationServerUrl: string): Promise<Set<string> | undefined> {
+    const now = Date.now()
+    const cached = cache.get(authorizationServerUrl)
+    if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+        return cached.scopes
+    }
+
+    const fetched = await fetchAuthorizationServerScopes(authorizationServerUrl)
+    if (fetched) {
+        cache.set(authorizationServerUrl, { scopes: fetched, fetchedAt: now })
+        return fetched
+    }
+
+    // Fetch failed: prefer a stale cache over nothing, else signal "no live data".
+    return cached?.scopes
+}
+
+/**
+ * Scopes to publish as `scopes_supported`, intersected with the scopes the live
+ * authorization server actually recognises right now.
+ *
+ * `getAdvertisedOAuthScopes()` is baked into the MCP image at build time, so a
+ * scope added in a single PR reaches the MCP and the Django authorization server
+ * through two independently-rolled deploys. If the MCP rolls out first it would
+ * advertise a scope the AS doesn't yet know, and spec-compliant clients that
+ * trust the advertised list get `invalid_scope` at `/authorize` until Django
+ * catches up — which is exactly the deploy-skew outage this guards against.
+ *
+ * Filtering against the AS's own live `scopes_supported` closes that window: we
+ * never advertise a resource scope the running AS can't grant. Identity scopes
+ * (no `:`) always ride along. On any fetch failure we fall back to the static
+ * list, so the worst case is the previous behaviour, never worse.
+ */
+export async function getLiveAdvertisedOAuthScopes(authorizationServerUrl: string): Promise<readonly string[]> {
+    const advertised = getAdvertisedOAuthScopes()
+    const live = await getAuthorizationServerScopes(authorizationServerUrl)
+    if (!live) {
+        return advertised
+    }
+    return advertised.filter((scope) => !scope.includes(':') || live.has(scope))
+}
+
+/** Test-only: drop the cached AS scopes so cases don't bleed into each other. */
+export function resetAuthorizationServerScopesCacheForTests(): void {
+    cache.clear()
+}

--- a/services/mcp/tests/hono/app-routes.test.ts
+++ b/services/mcp/tests/hono/app-routes.test.ts
@@ -3,6 +3,8 @@ import type { Mock } from 'vitest'
 
 import { createApp } from '@/hono/app'
 import type { RedisLike } from '@/hono/cache/RedisCache'
+import { resetAuthorizationServerScopesCacheForTests } from '@/lib/authorization-server-scopes'
+import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
 
@@ -40,6 +42,25 @@ describe('Hono App Routes', () => {
 
     beforeEach(() => {
         mockRedis = createMockRedis()
+        // The protected-resource metadata handler fetches the authorization
+        // server's live `scopes_supported` to filter what it advertises. Stub
+        // it to the full advertised set (intersection is a no-op) and reset the
+        // cache so cases stay hermetic and don't hit the network.
+        resetAuthorizationServerScopesCacheForTests()
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    ({
+                        ok: true,
+                        json: async () => ({ scopes_supported: getAdvertisedOAuthScopes() }),
+                    }) as unknown as Response
+            )
+        )
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
     })
 
     describe('GET /', () => {
@@ -153,6 +174,34 @@ describe('Hono App Routes', () => {
             const { app } = createApp(mockRedis)
             const res = await app.request('/.well-known/oauth-protected-resource/mcp')
             expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600')
+        })
+
+        it('should not advertise a scope the live authorization server does not recognise', async () => {
+            // Deploy-skew guard: when the AS metadata omits a scope (Django hasn't
+            // rolled out the new scope yet), the MCP must not advertise it, or
+            // spec-compliant clients hit `invalid_scope` at /authorize.
+            const advertised = getAdvertisedOAuthScopes()
+            const droppedScope = advertised.find((scope) => scope.includes(':')) as string
+            resetAuthorizationServerScopesCacheForTests()
+            vi.stubGlobal(
+                'fetch',
+                vi.fn(
+                    async () =>
+                        ({
+                            ok: true,
+                            json: async () => ({
+                                scopes_supported: advertised.filter((scope) => scope !== droppedScope),
+                            }),
+                        }) as unknown as Response
+                )
+            )
+
+            const { app } = createApp(mockRedis)
+            const res = await app.request('/.well-known/oauth-protected-resource/mcp')
+            const body = (await res.json()) as Record<string, any>
+
+            expect(body.scopes_supported).not.toContain(droppedScope)
+            expect(body.scopes_supported).toContain('openid')
         })
     })
 

--- a/services/mcp/tests/unit/authorization-server-scopes.test.ts
+++ b/services/mcp/tests/unit/authorization-server-scopes.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+    getLiveAdvertisedOAuthScopes,
+    resetAuthorizationServerScopesCacheForTests,
+} from '@/lib/authorization-server-scopes'
+import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
+
+const AS_URL = 'https://oauth.posthog.test'
+
+const jsonResponse = (body: unknown): Response => ({ ok: true, json: async () => body }) as unknown as Response
+
+const advertised = getAdvertisedOAuthScopes()
+const identityScopes = advertised.filter((scope) => !scope.includes(':'))
+const firstResourceScope = advertised.find((scope) => scope.includes(':')) as string
+
+describe('getLiveAdvertisedOAuthScopes', () => {
+    beforeEach(() => {
+        resetAuthorizationServerScopesCacheForTests()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('drops a resource scope the live authorization server does not recognise', async () => {
+        // Simulate the deploy-skew window: the MCP image advertises a scope the
+        // AS doesn't know yet. The AS metadata omits it, so we must not publish it.
+        const live = advertised.filter((scope) => scope !== firstResourceScope)
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => jsonResponse({ scopes_supported: live }))
+        )
+
+        const result = await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        expect(result).not.toContain(firstResourceScope)
+        for (const scope of live) {
+            expect(result).toContain(scope)
+        }
+    })
+
+    it('always keeps identity scopes even when the AS omits them', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => jsonResponse({ scopes_supported: ['dashboard:read'] }))
+        )
+
+        const result = await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        const missing = identityScopes.filter((scope) => !result.includes(scope))
+        expect(missing).toEqual([])
+    })
+
+    it('falls back to the full static list when the fetch rejects', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => {
+                throw new Error('network down')
+            })
+        )
+
+        const result = await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        expect([...result]).toEqual([...advertised])
+    })
+
+    it('falls back to the static list on a non-200 response', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({ ok: false, json: async () => ({}) }) as unknown as Response)
+        )
+
+        const result = await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        expect([...result]).toEqual([...advertised])
+    })
+
+    it('falls back to the static list when scopes_supported is empty or malformed', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => jsonResponse({ scopes_supported: [] }))
+        )
+
+        const result = await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        expect([...result]).toEqual([...advertised])
+    })
+
+    it('caches the live list and does not refetch within the TTL', async () => {
+        const fetchMock = vi.fn(async () => jsonResponse({ scopes_supported: advertised }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        await getLiveAdvertisedOAuthScopes(AS_URL)
+        await getLiveAdvertisedOAuthScopes(AS_URL)
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Problem

Overnight we saw a spike in `oauth_authorization_rejected` (`reason: invalid_scope`) for MCP sign-ins, with `rejected_scopes` containing `agents:read` / `agents:write`.

Root cause is deploy skew. The MCP publishes its `scopes_supported` from a **build-time** generated list (`oauth-scopes.generated.ts`), while the Django authorization server recognizes scopes from its own image. A scope added in a single PR (#62616 added `agents:*`) reaches the two services on independent deploy cadences. When the MCP rolled out first, it advertised `agents:*` before Django recognized them, so spec-compliant clients that trust the advertised list requested those scopes at `/authorize` and got `invalid_scope` until Django caught up. The events died out once the Django deploy completed.

## Changes

The MCP now defers to the live authorization server instead of trusting its static build-time copy:

- New `getLiveAdvertisedOAuthScopes()` fetches the AS's live `scopes_supported` from `/.well-known/oauth-authorization-server` (cached per region, short timeout) and publishes the **intersection** of the static advertised list with what the AS currently recognizes. Identity scopes (`openid`/`profile`/`email`) always ride along; on any fetch failure it falls back to the static list, so the worst case is the previous behavior — never worse.
- Both protected-resource metadata handlers (Hono `public-routes.ts` and the Workers `index.ts`) use it.

Net effect: the MCP can never advertise a resource scope the running AS can't grant, closing this deploy-skew window automatically for every future scope — no deploy-ordering discipline required.

A small residual remains during the AS's *own* rolling deploy (a single pod can report a new scope before all pods accept it). Making Django narrow-instead-of-reject at `/authorize` would close that too and can be a follow-up.

## How did you test this code?

- New unit suite `tests/unit/authorization-server-scopes.test.ts` (6 cases): intersection drops unknown scopes, identity scopes always kept, graceful fallback on reject / non-200 / empty body, caching within TTL.
- New handler assertion in `tests/hono/app-routes.test.ts` ("does not advertise a scope the live AS does not recognise"); full Hono route suite (38) and Workers metadata suite (8, exercising the fallback path) pass.
- `tsc --noEmit` clean for the changed files; oxlint / oxfmt clean.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## 🤖 LLM context

Authored with Claude Code while investigating a Slack report of MCP auth failures. The diagnosis traced the `oauth_authorization_rejected` spike to deploy skew between the MCP's build-time `scopes_supported` and the Django authorization server's recognized scope set after `agents:*` was added in #62616. This implements the chosen remediation (MCP intersects its advertised scopes with the AS's live `/.well-known/oauth-authorization-server` list), picked over the Django narrow-on-authorize and deploy-ordering alternatives.
