### PR TITLE
chore: instruct agents to open draft PRs before slow local checks - closed as PH code opened PR in wrong repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ Pass the description straight to the `body` argument of the PR-creation tool (th
 - Description should be lowercase and not end with a period
 - Keep the first line under 72 characters
 
+### Opening a pull request
+
+When the user asks you to open a PR — especially a draft — commit the work to a branch and open the PR _first_, then run any verification (or let CI do it). Do not gate PR creation on slow local checks such as a full `tsc`, jest, or a fresh dependency install: a draft PR is a safety net, not a reward for green checks, and committing early is what makes the work durable if the session ends unexpectedly before the checks finish. If the user says to skip checks or "just open the PR", do so immediately without further local verification.
+
 ### Pushing to remote
 
 Pushes trigger CI, which burns runner credits. Refrain from pushing unless explicitly instructed or until the task is complete — batch local commits and push once at the end rather than after every change. If you're mid-task or iterating, keep work local.


### PR DESCRIPTION
## Problem

Agent sessions have hit a failure mode where PR creation was gated behind slow local verification (a full-frontend `tsc`, jest, or a fresh dependency install). The checks never finished within the session, so the PR was never opened — and because the work lived only in the working tree (uncommitted), it was lost when the sandbox was reclaimed before the checks completed.

## Changes

Adds an "Opening a pull request" convention to `AGENTS.md` (symlinked as `CLAUDE.md`, so it loads into every agent session for every contributor):

- When asked to open a PR — especially a draft — commit to a branch and open the PR _first_, then verify (or let CI verify).
- Don't gate PR creation on slow local checks; a draft PR is a safety net, not a reward for green checks, and committing early is what makes work durable if the session ends unexpectedly.
- Honor explicit "skip checks / just open the PR" requests immediately.

This is a docs/instructions-only change. It's the appropriate automation tier here (per the repo's own ordering) because session conduct — when to commit vs. verify — can't be enforced by a linter or commit hook.

## How did you test this code?

I'm an agent (Claude Code). This is a Markdown instructions change with no code paths to exercise, so there are no automated tests to run. Verified the `CLAUDE.md → AGENTS.md` symlink so the guidance reaches every agent, and confirmed the rendered section reads correctly in the diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by Marcel Poelker. This came out of a post-mortem on a prior session where a draft PR was never created: PR creation had been sequenced after a long-running full-frontend type check, and the uncommitted work was lost when the sandbox was torn down without a snapshot. The fix encodes the behavioral half of that post-mortem (open the draft PR before slow checks; commit early for durability). The two infrastructure halves — snapshot/auto-commit uncommitted work before sandbox teardown, and the GitHub token embedded in the `origin` remote URL — are out of scope here and handed off to the team separately.
