### PR TITLE
fix(cli): resolve commit SHA from packed-refs when loose ref file is absent

### DIFF
--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -205,7 +205,7 @@ fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
         return Ok(head_content.trim().to_string());
     }
 
-    // Try to read the commit from the branch reference
+    // Try to read the commit from the branch reference (loose ref)
     let ref_path = git_dir.join("refs/heads").join(branch);
     if ref_path.exists() {
         let mut commit_id = String::new();
@@ -215,6 +215,28 @@ fn get_commit_sha(git_dir: &Path, branch: &str) -> Result<String> {
             .context("Failed to read branch reference file")?;
 
         return Ok(commit_id.trim().to_string());
+    }
+
+    // Fall back to packed-refs — Git packs loose refs into this file during
+    // garbage collection or clone, which is common on Windows and in CI.
+    // Format: "<sha> refs/heads/<branch>" (lines starting with '#' are comments)
+    let packed_refs_path = git_dir.join("packed-refs");
+    if packed_refs_path.exists() {
+        let contents = fs::read_to_string(&packed_refs_path)
+            .context("Failed to read packed-refs file")?;
+        let target = format!("refs/heads/{branch}");
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.starts_with('#') {
+                continue;
+            }
+            let mut parts = line.splitn(2, ' ');
+            if let (Some(sha), Some(refname)) = (parts.next(), parts.next()) {
+                if refname == target {
+                    return Ok(sha.to_string());
+                }
+            }
+        }
     }
 
     anyhow::bail!("Could not determine commit ID")

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -1,4 +1,4 @@
-use posthog_cli::utils::git::{get_git_info_from_env, get_remote_url, get_repo_name};
+use posthog_cli::utils::git::{get_git_info, get_git_info_from_env, get_remote_url, get_repo_name};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -19,6 +19,72 @@ fn make_git_dir_with_config(config_content: &str) -> PathBuf {
     let config_path = git_dir.join("config");
     fs::write(&config_path, config_content).expect("failed to write config");
     git_dir
+}
+
+fn make_git_dir(config_content: &str, head_content: &str) -> PathBuf {
+    let temp_root = std::env::temp_dir().join(format!("posthog_cli_git_test_{}", Uuid::now_v7()));
+    let git_dir = temp_root.join(".git");
+    fs::create_dir_all(&git_dir).expect("failed to create .git directory");
+    fs::write(git_dir.join("config"), config_content).expect("failed to write config");
+    fs::write(git_dir.join("HEAD"), head_content).expect("failed to write HEAD");
+    git_dir
+}
+
+#[test]
+fn test_get_commit_sha_from_loose_ref() {
+    let cfg = "[core]\n    repositoryformatversion = 0\n";
+    let git_dir = make_git_dir(cfg, "ref: refs/heads/main\n");
+    let refs_heads = git_dir.join("refs/heads");
+    fs::create_dir_all(&refs_heads).expect("failed to create refs/heads");
+    fs::write(refs_heads.join("main"), "abc123def456abc123def456abc123def456abc1\n")
+        .expect("failed to write loose ref");
+
+    let info = get_git_info(Some(git_dir.parent().unwrap().to_path_buf()))
+        .expect("get_git_info failed")
+        .expect("expected Some(GitInfo)");
+
+    assert_eq!(info.branch, "main");
+    assert_eq!(info.commit_id, "abc123def456abc123def456abc123def456abc1");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_commit_sha_from_packed_refs() {
+    let cfg = "[core]\n    repositoryformatversion = 0\n";
+    let git_dir = make_git_dir(cfg, "ref: refs/heads/main\n");
+    // No loose ref file — only packed-refs (common after gc or fresh clone on Windows)
+    let packed_refs = "# pack-refs with: peeled fully-peeled sorted\n\
+        deadbeefdeadbeefdeadbeefdeadbeefdeadbeef refs/heads/other\n\
+        cafebabecafebabecafebabecafebabecafebabe refs/heads/main\n";
+    fs::write(git_dir.join("packed-refs"), packed_refs).expect("failed to write packed-refs");
+
+    let info = get_git_info(Some(git_dir.parent().unwrap().to_path_buf()))
+        .expect("get_git_info failed")
+        .expect("expected Some(GitInfo)");
+
+    assert_eq!(info.branch, "main");
+    assert_eq!(info.commit_id, "cafebabecafebabecafebabecafebabecafebabe");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_commit_sha_loose_ref_takes_precedence_over_packed_refs() {
+    let cfg = "[core]\n    repositoryformatversion = 0\n";
+    let git_dir = make_git_dir(cfg, "ref: refs/heads/main\n");
+    let refs_heads = git_dir.join("refs/heads");
+    fs::create_dir_all(&refs_heads).expect("failed to create refs/heads");
+    fs::write(refs_heads.join("main"), "1111111111111111111111111111111111111111\n")
+        .expect("failed to write loose ref");
+    // packed-refs has a different (stale) SHA for the same branch
+    let packed_refs = "cafebabecafebabecafebabecafebabecafebabe refs/heads/main\n";
+    fs::write(git_dir.join("packed-refs"), packed_refs).expect("failed to write packed-refs");
+
+    let info = get_git_info(Some(git_dir.parent().unwrap().to_path_buf()))
+        .expect("get_git_info failed")
+        .expect("expected Some(GitInfo)");
+
+    assert_eq!(info.commit_id, "1111111111111111111111111111111111111111");
+    let _ = fs::remove_dir_all(git_dir.parent().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
get_commit_sha in cli/src/utils/git.rs only looks at loose ref files. On Windows, Git packs refs more aggressively so the loose file often doesn't exist, and the CLI fails with "Could not determine commit ID" in a valid repo.

Added a fallback that parses .git/packed-refs when the loose ref isn't found. Loose refs still take priority.

Closes #62070