### PR TITLE
feat(charts): allow hiding individual data points from the tooltip

### DIFF
--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -41,6 +41,7 @@ const series: Series[] = [
 - `key` (React key + stacking identity), `label` (legend/tooltip), `data` are required.
 - Line-only options: `points`, `stroke.pattern` (dashes/projections), `fill.opacity` / `fill.gradient` (area), `fill.lowerData` (ribbon).
 - `yAxisId` scales a series against a second axis; `meta` carries arbitrary data into tooltips.
+- `visibility.tooltip` hides a series from the tooltip: `false` hides the whole series; a `(boolean | null)[]` hides individual points by data index (e.g. `[true, false, true]`). Hidden points still render on the line and contribute to tooltip anchoring. `visibility.excluded` removes a series entirely; `visibility.valueLabel` hides it from the `ValueLabels` overlay.
 
 ## Sizing
 

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { isTooltipHiddenAt } from '../../core/interaction'
 import type { TooltipContext } from '../../core/types'
 import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 import type { BoxPlotAdaptedMeta } from './BoxPlot'
@@ -41,7 +42,7 @@ export function BoxPlotTooltip<Meta = unknown>({
 
     const entries: { key: string; color: string; label: string; datum: BoxPlotDatum }[] = []
     for (const seriesEntry of ctx.seriesData) {
-        if (seriesEntry.series.visibility?.tooltip === false) {
+        if (isTooltipHiddenAt(seriesEntry.series, ctx.dataIndex)) {
             continue
         }
         const datum = seriesEntry.series.meta?.datums?.[ctx.dataIndex]

--- a/packages/quill/packages/charts/src/core/interaction.test.ts
+++ b/packages/quill/packages/charts/src/core/interaction.test.ts
@@ -188,6 +188,37 @@ describe('hog-charts interaction', () => {
             expect(result?.seriesData.map((d) => d.series.key)).toEqual(['present'])
         })
 
+        it('excludes only the points where visibility.tooltip[dataIndex] is false, per series', () => {
+            const shown = makeSeries({ key: 'shown', data: [10, 10] })
+            // hidden at index 0, shown at index 1
+            const perPoint = makeSeries({ key: 'pp', data: [50, 50], visibility: { tooltip: [false, true] } })
+            const yScale = (v: number): number => ({ 10: 80, 50: 5 })[v] ?? 0
+
+            const atZero = buildTooltipContext(
+                0,
+                [shown, perPoint],
+                ['a', 'b'],
+                xConst,
+                yScale,
+                fakeCanvasBounds,
+                defaultResolveValue
+            )
+            // 'pp' is hidden from the tooltip at index 0 but still anchors position (min pixel = 5)
+            expect(atZero?.seriesData.map((d) => d.series.key)).toEqual(['shown'])
+            expect(atZero?.position.y).toBe(5)
+
+            const atOne = buildTooltipContext(
+                1,
+                [shown, perPoint],
+                ['a', 'b'],
+                xConst,
+                yScale,
+                fakeCanvasBounds,
+                defaultResolveValue
+            )
+            expect(atOne?.seriesData.map((d) => d.series.key)).toEqual(['shown', 'pp'])
+        })
+
         it('includes correct pixel position from xScale and minimum yScale output', () => {
             const s1 = makeSeries({ key: 's1', data: [10] })
             const s2 = makeSeries({ key: 's2', data: [50] })

--- a/packages/quill/packages/charts/src/core/interaction.ts
+++ b/packages/quill/packages/charts/src/core/interaction.ts
@@ -7,10 +7,21 @@ import type {
     PointClickData,
     ResolvedSeries,
     ResolveValueFn,
+    Series,
     TooltipContext,
     YAxisScale,
 } from './types'
 import { DEFAULT_Y_AXIS_ID } from './types'
+
+/** Whether a series' value at `dataIndex` is hidden from the tooltip. Honors both forms of
+ *  `visibility.tooltip`: a boolean toggles the whole series, an array toggles individual points. */
+export function isTooltipHiddenAt(series: Pick<Series, 'visibility'>, dataIndex: number): boolean {
+    const tooltip = series.visibility?.tooltip
+    if (tooltip === false) {
+        return true
+    }
+    return Array.isArray(tooltip) && tooltip[dataIndex] === false
+}
 
 export interface LabelPosition {
     x: number
@@ -105,7 +116,7 @@ export function buildTooltipContext<Meta = unknown>(
         // A gap (`data[i]` non-finite) draws no point/bar, so don't fabricate a `0` row for it —
         // skip it the same way the renderer does.
         const rawValue = s.data[dataIndex]
-        if (s.visibility?.tooltip !== false && rawValue != null && isFinite(rawValue)) {
+        if (!isTooltipHiddenAt(s, dataIndex) && rawValue != null && isFinite(rawValue)) {
             // A per-bar series carries each bar's identity in `bars[i]` — surface it so the tooltip
             // reads the right color/meta/label rather than the shared series-level ones.
             const bar = s.bars?.[dataIndex]

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -84,8 +84,11 @@ export interface Series<Meta = unknown> {
     visibility?: {
         /** Fully exclude the series — no rendering, no scale contribution, no tooltip, no hit-testing. */
         excluded?: boolean
-        /** Whether the series appears in the tooltip's seriesData. Defaults to true. */
-        tooltip?: boolean
+        /** Whether the series appears in the tooltip's seriesData. Defaults to true. A boolean toggles
+         *  the whole series; an array toggles individual points, indexed by data index (sparse — a
+         *  missing/`null`/`true` entry shows that point, `false` hides it). A hidden point still renders
+         *  on the line and contributes to scales and tooltip anchoring. */
+        tooltip?: boolean | (boolean | null)[]
         /** Whether the ValueLabels overlay draws a label for this series. Defaults to true. */
         valueLabel?: boolean
     }


### PR DESCRIPTION
## Problem

`@posthog/quill-charts` could hide a whole series from the tooltip via `visibility.tooltip: false`, but there was no way to hide a single data point on a series — `data` is a flat `number[]` with no per-point options.

## Changes

- `visibility.tooltip` on a `Series` now accepts a per-point `(boolean | null)[]` in addition to a whole-series `boolean`. An array entry of `false` hides that point's row from the tooltip; missing/`null`/`true` shows it.
- A hidden point still renders on the line and still contributes to tooltip anchoring — same semantics as the series-level flag.
- Added a shared `isTooltipHiddenAt(series, dataIndex)` helper in `core/interaction.ts` and used it at both tooltip read sites (`buildTooltipContext` and `BoxPlotTooltip`) so the boolean and array forms are handled in one place.
- Documented the behavior in the charts `AGENTS.md` (Series shape section).

## How did you test this code?

I'm an agent — no manual testing. Ran the charts unit tests:

- `interaction.test.ts` — 37 pass, including a new case covering per-point `tooltip: [false, true]` (hidden at index 0, shown at index 1, still anchoring position).
- `BoxPlot/*` — 41 pass (the other tooltip read site I touched).

Did not run a project-wide typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The work started as a question about whether quill-charts had a hide-from-tooltip option, then became a request to extend it to individual points.

Considered three API shapes: (A) overload the existing `visibility.tooltip` to also accept a per-point array, (B) a separate parallel array like the bar charts' `bars[]`, and (C) making `data` hold per-point objects. Chose A at the author's direction — it keeps the same field name and path as the series level and is the most contained change (only the two tooltip read sites change). C was rejected as a large, invasive refactor touching every renderer, scale, and hit-test path.

Note: `master` had concurrently gained gap-skipping (null/NaN points) in `buildTooltipContext`; this branch merges both behaviors in the same conditional.