### PR TITLE
feat(slack-app): add channels:manage to SlackIntegrationScopeInReview

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39908,7 +39908,7 @@
             "type": "string"
         },
         "SlackIntegrationScopeInReview": {
-            "enum": ["assistant:write", "im:history", "mpim:read"],
+            "enum": ["assistant:write", "channels:manage", "im:history", "mpim:read"],
             "type": "string"
         },
         "SlashCommandName": {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5304,6 +5304,7 @@ export const SLACK_INTEGRATION_SCOPES = Object.values(SlackIntegrationScope)
 // `invalid_scope`. Move entries into SlackIntegrationScope once Slack approves the public app.
 export enum SlackIntegrationScopeInReview {
     ASSISTANT_WRITE = 'assistant:write',
+    CHANNELS_MANAGE = 'channels:manage',
     IM_HISTORY = 'im:history',
     MPIM_READ = 'mpim:read',
 }

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2583,6 +2583,7 @@ class SlackIntegrationScope(StrEnum):
 
 class SlackIntegrationScopeInReview(StrEnum):
     ASSISTANT_WRITE = "assistant:write"
+    CHANNELS_MANAGE = "channels:manage"
     IM_HISTORY = "im:history"
     MPIM_READ = "mpim:read"
 


### PR DESCRIPTION
## Problem

The PostHog Slack app manifest lists `channels:manage` but the OAuth flow doesn't request it, so we can't exercise it on the DEV instance while the public app is still in review.

## Changes

Add `CHANNELS_MANAGE = 'channels:manage'` to `SlackIntegrationScopeInReview` in `frontend/src/types.ts` and regenerate `schema.json` / `schema_enums.py` via `hogli build:schema`.

## How did you test this code?

Agent-authored. Verified the enum propagated through codegen; no behavior changes outside DEV until the public app is approved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta pointed at `SlackIntegrationScopeInReview`. Claude Code edited the source enum, regenerated the schema, and opened the draft PR.