### PR TITLE
fix(agent-platform): fail closed at config-load for required service config

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/config.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/config.test.ts
@@ -1,14 +1,41 @@
 import { AgentIngressConfigSchema, loadAgentIngressConfig } from './config'
 
+// Minimal prod env satisfying every `requiredInProd` field; a test can omit one
+// and assert it's what trips the loader.
+const PROD_REQUIRED = {
+    AGENT_INTERNAL_SIGNING_KEY: 'prod-signing-key',
+    // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+    REDIS_URL: 'redis://prod-redis:6379',
+    HTTPS_PROXY: 'http://smokescreen:4750',
+    ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00',
+    POSTHOG_API_BASE_URL: 'https://app.example.com',
+}
+
 describe('loadAgentIngressConfig', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
     it('returns defaults for an empty env', () => {
         const cfg = loadAgentIngressConfig({})
         expect(cfg.port).toBe(8080)
         expect(cfg.routingMode).toBe('path')
         expect(cfg.pathPrefix).toBe('/agents')
-        expect(cfg.internalSigningKey).toBeUndefined()
+        // Dev default — backs the preview-token gate + posthog_internal mode locally.
+        expect(cfg.internalSigningKey).toBe('dev-internal-signing-key-do-not-use-in-prod')
         expect(cfg.publicUrl).toBeUndefined()
         expect(cfg.logLevel).toBe('info')
+    })
+
+    it('fails closed at config-load in prod when AGENT_INTERNAL_SIGNING_KEY is unset', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        const { AGENT_INTERNAL_SIGNING_KEY: _omit, ...rest } = PROD_REQUIRED
+        expect(() => loadAgentIngressConfig(rest)).toThrow(/AGENT_INTERNAL_SIGNING_KEY/)
+    })
+
+    it('fails closed at config-load in prod when REDIS_URL / HTTPS_PROXY are unset', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        expect(() => loadAgentIngressConfig({ AGENT_INTERNAL_SIGNING_KEY: 'k' })).toThrow(/REDIS_URL|HTTPS_PROXY/)
     })
 
     it('publicUrl comes from AGENT_INGRESS_PUBLIC_URL', () => {

--- a/products/agent_platform/services/agent-ingress/src/config.ts
+++ b/products/agent_platform/services/agent-ingress/src/config.ts
@@ -8,10 +8,38 @@
 
 import { z } from 'zod'
 
-import { extendEnvKeyMap, loadConfigFromEnv, PLATFORM_ENV_KEY_MAP, PlatformConfigSchema } from '@posthog/agent-shared'
+import {
+    DEV_ENCRYPTION_KEY,
+    DEV_INTERNAL_SIGNING_KEY,
+    DEV_POSTHOG_API_BASE_URL,
+    DEV_REDIS_URL,
+    extendEnvKeyMap,
+    loadConfigFromEnv,
+    PLATFORM_ENV_KEY_MAP,
+    PlatformConfigSchema,
+    requiredInProd,
+    requiredInProdUnsetInDev,
+} from '@posthog/agent-shared'
 
 export const AgentIngressConfigSchema = PlatformConfigSchema.extend({
     port: z.coerce.number().int().positive().default(8080).describe('HTTP listen port.'),
+    // /listen SSE subscribes to the bus; HTTPS_PROXY routes outbound (Slack bridge,
+    // PostHog introspect) through smokescreen. Both required in prod, enforced here
+    // rather than via boot guards in index.ts.
+    redisUrl: requiredInProd(DEV_REDIS_URL, 'REDIS_URL', { url: true }).describe(
+        'SessionEventBus backing for cross-host /listen SSE. Required in prod; dev defaults to local Redis.'
+    ),
+    httpsProxy: requiredInProdUnsetInDev('HTTPS_PROXY', { url: true }).describe(
+        'Outbound HTTP proxy (smokescreen) for Slack bridge + PostHog introspect. Required in prod; unset in dev (fetches go direct).'
+    ),
+    // EncryptedFields (Slack bot-token + credential broker) throws on empty keys;
+    // the introspector needs the API base. Required in prod, enforced at config-load.
+    encryptionSaltKeys: requiredInProd(DEV_ENCRYPTION_KEY, 'ENCRYPTION_SALT_KEYS').describe(
+        'Comma-separated UTF-8 Fernet keys (match Django EncryptedTextField). Required in prod; deterministic dev default.'
+    ),
+    posthogApiBaseUrl: requiredInProd(DEV_POSTHOG_API_BASE_URL, 'POSTHOG_API_BASE_URL', { url: true }).describe(
+        'PostHog API the oauth/pat verifiers introspect against. Required in prod; dev defaults to localhost:8010.'
+    ),
     routingMode: z
         .enum(['path', 'domain'])
         .default('path')
@@ -26,12 +54,9 @@ export const AgentIngressConfigSchema = PlatformConfigSchema.extend({
         .string()
         .default('/agents')
         .describe('URL prefix in path mode (default `/agents`). Slug comes immediately after.'),
-    internalSigningKey: z
-        .string()
-        .optional()
-        .describe(
-            "HMAC signing key shared with Django and the janitor (must match Django's `AGENT_INTERNAL_SIGNING_KEY`). Verifies x-agent-preview-token on non-live invokes (aud = agent-ingress.preview). Unset → preview gate bypassed (dev / harness only)."
-        ),
+    internalSigningKey: requiredInProd(DEV_INTERNAL_SIGNING_KEY, 'AGENT_INTERNAL_SIGNING_KEY').describe(
+        "HMAC signing key shared with Django and the janitor (must match Django's `AGENT_INTERNAL_SIGNING_KEY`). Backs the x-agent-preview-token gate (aud = agent-ingress.preview) and the posthog_internal auth mode. Required in prod, dev default for local running."
+    ),
     publicUrl: z
         .string()
         .optional()

--- a/products/agent_platform/services/agent-ingress/src/index.ts
+++ b/products/agent_platform/services/agent-ingress/src/index.ts
@@ -20,7 +20,6 @@ import {
     EncryptedFields,
     HttpClient,
     installProcessHandlers,
-    isDev,
     PgCredentialBroker,
     PgIdentityStore,
     PgIntegrationStore,
@@ -42,35 +41,13 @@ async function main(): Promise<void> {
     const posthogDb = createAgentPool(config.posthogDbUrl)
     const agentDb = createAgentPool(config.agentDbUrl)
 
-    // SSE /listen is the consumer side of the same bus the runner publishes
-    // to. REDIS_URL is required — without cross-host fan-out, /listen on
-    // ingress pod A would silently miss events from runner pod B. Fail
-    // closed at boot rather than serving a /listen that returns nothing.
-    if (!config.redisUrl) {
-        throw new Error(
-            'REDIS_URL must be set — ingress /listen SSE needs the SessionEventBus subscribe side. Wire valkey-agent-platform via the chart.'
-        )
-    }
+    // REDIS_URL (cross-host /listen bus), HTTPS_PROXY (smokescreen — Slack bridge
+    // + PostHog introspect), and AGENT_INTERNAL_SIGNING_KEY (preview-token gate +
+    // posthog_internal mode) are all required in prod and enforced at config-load
+    // (config.ts: dev defaults, fail closed in prod) — no boot guards needed here.
     const bus = new RedisSessionEventBus({ url: config.redisUrl })
     await bus.connect()
 
-    // Outbound HTTP — Slack identity bridge + PostHog API introspect both
-    // dispatch through here. In prod `config.httpsProxy` points at
-    // smokescreen so outbound calls match the runner's posture. Fail-fast
-    // in non-dev when unset rather than silently bypassing the proxy.
-    if (!config.httpsProxy && !isDev()) {
-        throw new Error(
-            'HTTPS_PROXY must be set — outbound fetches must route through smokescreen in prod. Wire `httpProxy.enabled: true` in the chart.'
-        )
-    }
-    // The internal signing key backs both the preview-token gate and the
-    // `posthog_internal` auth verifier — required in prod, fail-fast rather than
-    // booting with that mode silently disabled.
-    if (!config.internalSigningKey && !isDev()) {
-        throw new Error(
-            'AGENT_INTERNAL_SIGNING_KEY must be set — it backs the preview-token gate and the posthog_internal auth mode.'
-        )
-    }
     const http = new HttpClient({ proxyUrl: config.httpsProxy })
 
     // Slack → PostHog user bridge needs the integration store to fetch the
@@ -102,7 +79,7 @@ async function main(): Promise<void> {
             introspector,
             jwtSecretResolver: secretResolver,
             sharedSecretResolver: secretResolver,
-            internalSecret: config.internalSigningKey ?? '',
+            internalSecret: config.internalSigningKey,
         }),
     }
     // Encrypted-at-rest credential broker (separate row per session,

--- a/products/agent_platform/services/agent-janitor/src/config.test.ts
+++ b/products/agent_platform/services/agent-janitor/src/config.test.ts
@@ -1,13 +1,40 @@
 import { AgentJanitorConfigSchema, loadAgentJanitorConfig } from './config'
 
+// Minimal prod env that satisfies every `requiredInProd` field, so a test can
+// omit exactly one and assert it's the thing that trips the loader.
+const PROD_REQUIRED = {
+    AGENT_INTERNAL_SIGNING_KEY: 'prod-signing-key',
+    AGENT_BUNDLE_S3_BUCKET: 'prod-bundles',
+    AGENT_MEMORY_S3_BUCKET: 'prod-memory',
+    AGENT_MEMORY_S3_ENDPOINT: 'https://s3.example.com',
+}
+
 describe('loadAgentJanitorConfig', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
     it('returns defaults for an empty env', () => {
         const cfg = loadAgentJanitorConfig({})
         expect(cfg.port).toBe(8082)
         expect(cfg.maxRetries).toBe(3)
         expect(cfg.logLevel).toBe('info')
-        expect(cfg.internalSigningKey).toBeUndefined()
+        // Dev default — gates RPC auth locally without forcing every dev to set it.
+        expect(cfg.internalSigningKey).toBe('dev-internal-signing-key-do-not-use-in-prod')
         expect(cfg.posthogDbUrl).toContain('postgres://')
+    })
+
+    it('fails closed at config-load in prod when AGENT_INTERNAL_SIGNING_KEY is unset', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        const { AGENT_INTERNAL_SIGNING_KEY: _omit, ...rest } = PROD_REQUIRED
+        expect(() => loadAgentJanitorConfig(rest)).toThrow(/AGENT_INTERNAL_SIGNING_KEY/)
+    })
+
+    it('loads in prod when every required field is set', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        const cfg = loadAgentJanitorConfig(PROD_REQUIRED)
+        expect(cfg.internalSigningKey).toBe('prod-signing-key')
+        expect(cfg.bundleS3Bucket).toBe('prod-bundles')
     })
 
     it('coerces numeric env strings without leaking NaN', () => {

--- a/products/agent_platform/services/agent-janitor/src/config.ts
+++ b/products/agent_platform/services/agent-janitor/src/config.ts
@@ -11,11 +11,13 @@
 import { z } from 'zod'
 
 import {
+    DEV_INTERNAL_SIGNING_KEY,
     extendEnvKeyMap,
     isDev,
     loadConfigFromEnv,
     PLATFORM_ENV_KEY_MAP,
     PlatformConfigSchema,
+    requiredInProd,
 } from '@posthog/agent-shared'
 
 const ONE_MINUTE_MS = 60_000
@@ -33,12 +35,9 @@ const DEV_S3_SECRET_ACCESS_KEY = 'any'
 
 export const AgentJanitorConfigSchema = PlatformConfigSchema.extend({
     port: z.coerce.number().int().positive().default(8082).describe('HTTP listen port.'),
-    internalSigningKey: z
-        .string()
-        .optional()
-        .describe(
-            "Shared HMAC signing key (must match Django's `AGENT_INTERNAL_SIGNING_KEY`). Verifies the audience-bound JWT Django sends as `x-internal-secret` (aud = `agent-janitor.rpc`). Required in prod for any endpoint other than `/healthz`."
-        ),
+    internalSigningKey: requiredInProd(DEV_INTERNAL_SIGNING_KEY, 'AGENT_INTERNAL_SIGNING_KEY').describe(
+        "Shared HMAC signing key (must match Django's `AGENT_INTERNAL_SIGNING_KEY`). Verifies the audience-bound JWT Django sends as `x-internal-secret` (aud = `agent-janitor.rpc`). Gates every endpoint other than `/healthz` — required in prod, dev default for local running."
+    ),
     stuckRunningMs: z.coerce
         .number()
         .int()
@@ -88,20 +87,13 @@ export const AgentJanitorConfigSchema = PlatformConfigSchema.extend({
                 'provider SDK and marks the row terminated. Default 10 minutes = 2x stuck-running ' +
                 'threshold, so a healthy session re-queue + resume cycle doesnt race the reaper.'
         ),
-    memoryS3Endpoint: z
-        .string()
-        .url()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_ENDPOINT : undefined))
-        .describe(
-            'S3-compatible endpoint for memory file storage. Dev defaults to local SeaweedFS; prod unset disables the /memory/* routes (503).'
-        ),
+    memoryS3Endpoint: requiredInProd(DEV_S3_ENDPOINT, 'AGENT_MEMORY_S3_ENDPOINT', { url: true }).describe(
+        'S3-compatible endpoint for memory file storage. Dev defaults to local SeaweedFS; required in prod — the janitor refuses to start without memory storage.'
+    ),
     memoryS3Region: z.string().default('us-east-1').describe('Region for the memory bucket.'),
-    memoryS3Bucket: z
-        .string()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_BUCKET : undefined))
-        .describe('Bucket holding agent memory files. Dev defaults to the SeaweedFS `posthog` bucket.'),
+    memoryS3Bucket: requiredInProd(DEV_S3_BUCKET, 'AGENT_MEMORY_S3_BUCKET').describe(
+        'Bucket holding agent memory files. Dev defaults to the SeaweedFS `posthog` bucket; required in prod.'
+    ),
     memoryS3Prefix: z.string().default('agent_memory').describe('Per-deployment key prefix inside the bucket.'),
     memoryS3AccessKeyId: z
         .string()
@@ -131,13 +123,9 @@ export const AgentJanitorConfigSchema = PlatformConfigSchema.extend({
             'S3-compatible endpoint for agent-bundle storage. Dev defaults to local SeaweedFS; prod unset means SDK regional default.'
         ),
     bundleS3Region: z.string().default('us-east-1').describe('Region for the bundle bucket.'),
-    bundleS3Bucket: z
-        .string()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_BUCKET : undefined))
-        .describe(
-            'Bucket holding agent bundles (per-revision compiled code + spec + skills). Dev defaults to the SeaweedFS `posthog` bucket; prod must set explicitly or the janitor fails closed at boot.'
-        ),
+    bundleS3Bucket: requiredInProd(DEV_S3_BUCKET, 'AGENT_BUNDLE_S3_BUCKET').describe(
+        'Bucket holding agent bundles (per-revision compiled code + spec + skills). Dev defaults to the SeaweedFS `posthog` bucket; required in prod — the janitor fails closed at boot without it.'
+    ),
     bundleS3Prefix: z.string().default('agent_bundles').describe('Per-deployment key prefix inside the bucket.'),
     bundleS3AccessKeyId: z
         .string()

--- a/products/agent_platform/services/agent-janitor/src/index.ts
+++ b/products/agent_platform/services/agent-janitor/src/index.ts
@@ -46,16 +46,10 @@ async function main(): Promise<void> {
     installProcessHandlers(log)
     const config = loadAgentJanitorConfig()
 
-    // S3 bundle storage is required — the authoring API publishes new
-    // revisions through this store. Fail-fast at boot rather than 503-ing
-    // every bundle CRUD call individually. Endpoint is optional — unset
-    // means "use the AWS SDK's regional default" (prod path); SeaweedFS in
-    // dev sets it explicitly.
-    if (!config.bundleS3Bucket) {
-        throw new Error(
-            'AGENT_BUNDLE_S3_BUCKET must be set — the janitor cannot serve bundle endpoints without storage.'
-        )
-    }
+    // S3 bundle storage is required (enforced on `bundleS3Bucket` in config —
+    // dev default, fails closed at config-load in prod). Endpoint is optional:
+    // unset means "use the AWS SDK's regional default" (prod path); SeaweedFS
+    // in dev sets it explicitly.
     const bundleS3 = new S3Client({
         endpoint: config.bundleS3Endpoint,
         region: config.bundleS3Region,
@@ -114,13 +108,8 @@ async function main(): Promise<void> {
         },
     }
     // S3-backed memory store. Required everywhere — no optional fallback that
-    // returns 503. Dev wires SeaweedFS via `hogli start` and the platform
-    // config dev defaults; prod must set bucket + endpoint explicitly.
-    if (!config.memoryS3Bucket || !config.memoryS3Endpoint) {
-        throw new Error(
-            'AGENT_MEMORY_S3_BUCKET and AGENT_MEMORY_S3_ENDPOINT must both be set — janitor refuses to start without memory storage. Dev: SeaweedFS via `hogli start`. Prod: real S3 / equivalent.'
-        )
-    }
+    // returns 503. Bucket + endpoint are enforced in config (dev defaults via
+    // SeaweedFS / `hogli start`; fail closed at config-load in prod).
     const memoryS3 = new S3Client({
         endpoint: config.memoryS3Endpoint,
         region: config.memoryS3Region,

--- a/products/agent_platform/services/agent-runner/src/config.test.ts
+++ b/products/agent_platform/services/agent-runner/src/config.test.ts
@@ -1,5 +1,18 @@
 import { AgentRunnerConfigSchema, defaultApiKeyFromConfig, loadAgentRunnerConfig } from './config'
 
+// Minimal prod env satisfying every `requiredInProd` field, so prod tests can
+// load the config and assert the remaining (still-optional) fields.
+const PROD_REQUIRED = {
+    // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+    REDIS_URL: 'redis://prod-redis:6379',
+    HTTPS_PROXY: 'http://smokescreen:4750',
+    ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00',
+    POSTHOG_API_BASE_URL: 'https://app.example.com',
+    AGENT_MEMORY_S3_ENDPOINT: 'https://s3.example.com',
+    AGENT_MEMORY_S3_BUCKET: 'prod-memory',
+    AGENT_BUNDLE_S3_BUCKET: 'prod-bundles',
+}
+
 describe('loadAgentRunnerConfig', () => {
     afterEach(() => {
         vi.unstubAllEnvs()
@@ -7,15 +20,19 @@ describe('loadAgentRunnerConfig', () => {
 
     it('returns prod-safe defaults when NODE_ENV=production', () => {
         vi.stubEnv('NODE_ENV', 'production')
-        const cfg = loadAgentRunnerConfig({})
+        const cfg = loadAgentRunnerConfig(PROD_REQUIRED)
         expect(cfg.maxConcurrency).toBe(8)
         expect(cfg.useAiGateway).toBe(false)
         expect(cfg.aiGatewayUrl).toBe('http://ai-gateway/v1')
-        expect(cfg.encryptionSaltKeys).toBe('')
+        expect(cfg.encryptionSaltKeys).toBe('00beef0000beef0000beef0000beef00')
         expect(cfg.logLevel).toBe('info')
-        // S3 fields fall back to undefined in prod — fail-fast at boot lives in index.ts.
-        expect(cfg.bundleS3Bucket).toBeUndefined()
-        expect(cfg.memoryS3Bucket).toBeUndefined()
+        expect(cfg.bundleS3Bucket).toBe('prod-bundles')
+        expect(cfg.memoryS3Bucket).toBe('prod-memory')
+    })
+
+    it('fails closed at config-load in prod when required infra env is unset', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        expect(() => loadAgentRunnerConfig({})).toThrow(/REDIS_URL|HTTPS_PROXY|AGENT_(MEMORY|BUNDLE)_S3/)
     })
 
     it('exposes dev SeaweedFS defaults when NODE_ENV is not production', () => {
@@ -33,7 +50,7 @@ describe('loadAgentRunnerConfig', () => {
 
     it('leaves sandboxBackend unset in prod so selectSandboxPool fails fast at boot', () => {
         vi.stubEnv('NODE_ENV', 'production')
-        const cfg = loadAgentRunnerConfig({})
+        const cfg = loadAgentRunnerConfig(PROD_REQUIRED)
         expect(cfg.sandboxBackend).toBeUndefined()
     })
 
@@ -49,7 +66,7 @@ describe('loadAgentRunnerConfig', () => {
 
     it('leaves sandboxHostImage unset in prod so SANDBOX_HOST_IMAGE must be set explicitly', () => {
         vi.stubEnv('NODE_ENV', 'production')
-        const cfg = loadAgentRunnerConfig({})
+        const cfg = loadAgentRunnerConfig(PROD_REQUIRED)
         expect(cfg.sandboxHostImage).toBeUndefined()
     })
 

--- a/products/agent_platform/services/agent-runner/src/config.ts
+++ b/products/agent_platform/services/agent-runner/src/config.ts
@@ -9,11 +9,16 @@
 import { z } from 'zod'
 
 import {
+    DEV_ENCRYPTION_KEY,
+    DEV_POSTHOG_API_BASE_URL,
+    DEV_REDIS_URL,
     extendEnvKeyMap,
     isDev,
     loadConfigFromEnv,
     PLATFORM_ENV_KEY_MAP,
     PlatformConfigSchema,
+    requiredInProd,
+    requiredInProdUnsetInDev,
 } from '@posthog/agent-shared'
 
 // Dev SeaweedFS defaults — the PostHog dev stack pre-creates the `posthog`
@@ -28,6 +33,22 @@ const DEV_S3_ACCESS_KEY_ID = 'any'
 const DEV_S3_SECRET_ACCESS_KEY = 'any'
 
 export const AgentRunnerConfigSchema = PlatformConfigSchema.extend({
+    // Bus (publishes lifecycle events) + smokescreen (tool/gateway/MCP egress) are
+    // required in prod, enforced at config-load rather than via boot guards.
+    redisUrl: requiredInProd(DEV_REDIS_URL, 'REDIS_URL', { url: true }).describe(
+        'SessionEventBus the runner publishes lifecycle events to. Required in prod; dev defaults to local Redis.'
+    ),
+    httpsProxy: requiredInProdUnsetInDev('HTTPS_PROXY', { url: true }).describe(
+        'Outbound HTTP proxy (smokescreen) for tool / gateway / MCP egress. Required in prod; unset in dev (fetches go direct).'
+    ),
+    // EncryptedFields (encrypted_env + credential broker) throws on empty keys; tools
+    // need the API base. Required in prod, enforced at config-load.
+    encryptionSaltKeys: requiredInProd(DEV_ENCRYPTION_KEY, 'ENCRYPTION_SALT_KEYS').describe(
+        'Comma-separated UTF-8 Fernet keys (match Django EncryptedTextField). Required in prod; deterministic dev default.'
+    ),
+    posthogApiBaseUrl: requiredInProd(DEV_POSTHOG_API_BASE_URL, 'POSTHOG_API_BASE_URL', { url: true }).describe(
+        'PostHog API base forwarded onto ToolContext for native tools. Required in prod; dev defaults to localhost:8010.'
+    ),
     maxConcurrency: z.coerce.number().int().positive().default(8).describe('In-flight sessions per worker process.'),
     healthPort: z.coerce
         .number()
@@ -83,23 +104,16 @@ export const AgentRunnerConfigSchema = PlatformConfigSchema.extend({
         .describe(
             'Base URL of the agent console. Used to build clickable approval links (`<base>/approvals?request=<id>`) surfaced to the model on a gated tool call. Dev defaults to the local console (`:3040`); prod sets the deployed host via the chart. Unset in prod → relative links (still clickable in-console, not in Slack).'
         ),
-    memoryS3Endpoint: z
-        .string()
-        .url()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_ENDPOINT : undefined))
-        .describe(
-            'S3-compatible endpoint for agent-memory file storage. Required everywhere — runner refuses to start without it. Dev defaults to local SeaweedFS via `hogli start`.'
-        ),
+    memoryS3Endpoint: requiredInProd(DEV_S3_ENDPOINT, 'AGENT_MEMORY_S3_ENDPOINT', { url: true }).describe(
+        'S3-compatible endpoint for agent-memory file storage. Required everywhere — runner refuses to start without it (fail closed at config-load in prod). Dev defaults to local SeaweedFS via `hogli start`.'
+    ),
     memoryS3Region: z
         .string()
         .default('us-east-1')
         .describe('Region for the memory bucket. SeaweedFS ignores; real S3 honours.'),
-    memoryS3Bucket: z
-        .string()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_BUCKET : undefined))
-        .describe('Bucket holding agent memory files. Dev defaults to the SeaweedFS `posthog` bucket.'),
+    memoryS3Bucket: requiredInProd(DEV_S3_BUCKET, 'AGENT_MEMORY_S3_BUCKET').describe(
+        'Bucket holding agent memory files. Dev defaults to the SeaweedFS `posthog` bucket; required in prod.'
+    ),
     memoryS3Prefix: z
         .string()
         .default('agent_memory')
@@ -135,13 +149,9 @@ export const AgentRunnerConfigSchema = PlatformConfigSchema.extend({
         .string()
         .default('us-east-1')
         .describe('Region for the bundle bucket. SeaweedFS ignores; real S3 honours.'),
-    bundleS3Bucket: z
-        .string()
-        .optional()
-        .transform((v): string | undefined => v ?? (isDev() ? DEV_S3_BUCKET : undefined))
-        .describe(
-            'Bucket holding agent bundles (per-revision compiled code + spec + skills). Dev defaults to the SeaweedFS `posthog` bucket; prod must set explicitly or the runner fails closed at boot.'
-        ),
+    bundleS3Bucket: requiredInProd(DEV_S3_BUCKET, 'AGENT_BUNDLE_S3_BUCKET').describe(
+        'Bucket holding agent bundles (per-revision compiled code + spec + skills). Dev defaults to the SeaweedFS `posthog` bucket; required in prod — the runner fails closed at config-load without it.'
+    ),
     bundleS3Prefix: z
         .string()
         .default('agent_bundles')

--- a/products/agent_platform/services/agent-runner/src/index.ts
+++ b/products/agent_platform/services/agent-runner/src/index.ts
@@ -79,26 +79,15 @@ async function main(): Promise<void> {
     }
 
     // Outbound HTTP — every tool fetch, gateway fetch, and MCP transport
-    // dispatches through here. In prod `config.httpsProxy` points at
-    // smokescreen so author-supplied URLs (web-fetch, http-request,
-    // external MCPs) get SSRF protection. Fail-fast in non-dev when unset
-    // rather than silently bypassing the proxy.
-    if (!config.httpsProxy && !isDev()) {
-        throw new Error(
-            'HTTPS_PROXY must be set — outbound fetches must route through smokescreen in prod. Wire `httpProxy.enabled: true` in the chart.'
-        )
-    }
+    // dispatches through here. In prod `config.httpsProxy` points at smokescreen
+    // so author-supplied URLs (web-fetch, http-request, external MCPs) get SSRF
+    // protection; required in prod, enforced at config-load (config.ts).
     const http = new HttpClient({ proxyUrl: config.httpsProxy })
 
-    // S3 bundle storage is required — sessions need to load the revision's
-    // compiled code + spec + skills at start. Fail-fast at boot rather than
-    // silently no-oping per-session and confusing the operator with a wall
-    // of `session.bundle_missing` failures. Endpoint is optional — unset
-    // means "use the AWS SDK's regional default" (prod path); SeaweedFS in
+    // S3 bundle storage is required (enforced on `bundleS3Bucket` in config —
+    // dev default, fail closed at config-load in prod). Endpoint is optional:
+    // unset means "use the AWS SDK's regional default" (prod path); SeaweedFS in
     // dev sets it explicitly.
-    if (!config.bundleS3Bucket) {
-        throw new Error('AGENT_BUNDLE_S3_BUCKET must be set — the runner cannot start sessions without bundle storage.')
-    }
     const bundleS3 = new S3Client({
         endpoint: config.bundleS3Endpoint,
         region: config.bundleS3Region,
@@ -146,15 +135,9 @@ async function main(): Promise<void> {
         return integrations.resolveForSpec(session.team_id, kinds)
     }
 
-    // Cross-process event bus. REDIS_URL is required — ingress /listen on
-    // host A subscribes to events the runner publishes on host B via the
-    // same Redis. Fail closed at boot if unset rather than silently
-    // noop-publishing (the previous fallback behavior).
-    if (!config.redisUrl) {
-        throw new Error(
-            'REDIS_URL must be set — runner cannot publish session lifecycle events without it. Wire valkey-agent-platform via the chart.'
-        )
-    }
+    // Cross-process event bus. REDIS_URL is required — ingress /listen on host A
+    // subscribes to events the runner publishes on host B via the same Redis.
+    // Required in prod, enforced at config-load (config.ts).
     const bus = new RedisSessionEventBus({ url: config.redisUrl })
     await bus.connect()
 
@@ -216,15 +199,9 @@ async function main(): Promise<void> {
 
     // Agent memory: S3-backed file store. Required everywhere — the runner
     // refuses to boot without it so the `@posthog/memory-*` + `@posthog/table-*`
-    // tools always work the same way in dev as in prod. Dev gets a default
-    // pointing at SeaweedFS (provisioned by `hogli start`); prod must wire its
-    // bucket + endpoint via env. No more `memory_store_unavailable` surfacing
-    // to the model on a misconfigured dev box.
-    if (!config.memoryS3Bucket || !config.memoryS3Endpoint) {
-        throw new Error(
-            'AGENT_MEMORY_S3_BUCKET and AGENT_MEMORY_S3_ENDPOINT must both be set — the runner refuses to start without memory storage. Dev: SeaweedFS via `hogli start` (defaults wired in `agent-shared/src/config/platform.ts`). Prod: real S3 / equivalent.'
-        )
-    }
+    // tools always work the same way in dev as in prod. Bucket + endpoint are
+    // enforced in config (dev defaults via SeaweedFS / `hogli start`; fail closed
+    // at config-load in prod).
     const memoryS3 = new S3Client({
         endpoint: config.memoryS3Endpoint,
         region: config.memoryS3Region,

--- a/products/agent_platform/services/agent-shared/src/config/platform.test.ts
+++ b/products/agent_platform/services/agent-shared/src/config/platform.test.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod'
 
-import { extendEnvKeyMap, loadConfigFromEnv, PLATFORM_ENV_KEY_MAP, PlatformConfigSchema } from './platform'
+import {
+    extendEnvKeyMap,
+    loadConfigFromEnv,
+    PLATFORM_ENV_KEY_MAP,
+    PlatformConfigSchema,
+    requiredInProd,
+    requiredInProdUnsetInDev,
+} from './platform'
 
 describe('PlatformConfigSchema', () => {
     afterEach(() => {
@@ -29,6 +36,49 @@ describe('PlatformConfigSchema', () => {
         for (const [key, field] of Object.entries(PlatformConfigSchema.shape)) {
             expect((field as { description?: string }).description, `missing .describe() for ${key}`).toBeTruthy()
         }
+    })
+})
+
+describe('requiredInProd', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    const Schema = z.object({ key: requiredInProd('dev-default', 'MY_KEY') })
+
+    it('uses the dev default when unset in dev', () => {
+        expect(Schema.parse({}).key).toBe('dev-default')
+    })
+
+    it('uses the provided value when set', () => {
+        expect(Schema.parse({ key: 'explicit' }).key).toBe('explicit')
+    })
+
+    it('fails closed at parse time when unset in prod', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        expect(() => Schema.parse({})).toThrow(/MY_KEY/)
+    })
+
+    it('validates url format when opts.url is set', () => {
+        const UrlSchema = z.object({ u: requiredInProd('http://localhost:1', 'MY_URL', { url: true }) })
+        expect(() => UrlSchema.parse({ u: 'not-a-url' })).toThrow()
+    })
+})
+
+describe('requiredInProdUnsetInDev', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    const Schema = z.object({ proxy: requiredInProdUnsetInDev('MY_PROXY', { url: true }) })
+
+    it('is undefined when unset in dev', () => {
+        expect(Schema.parse({}).proxy).toBeUndefined()
+    })
+
+    it('fails closed at parse time when unset in prod', () => {
+        vi.stubEnv('NODE_ENV', 'production')
+        expect(() => Schema.parse({})).toThrow(/MY_PROXY/)
     })
 })
 

--- a/products/agent_platform/services/agent-shared/src/config/platform.ts
+++ b/products/agent_platform/services/agent-shared/src/config/platform.ts
@@ -47,9 +47,70 @@ export function isDev(env: NodeJS.ProcessEnv = process.env): boolean {
  * unset fails closed (empty key → encryption-requiring components
  * refuse to start).
  */
-const DEV_ENCRYPTION_KEY = '00beef0000beef0000beef0000beef00'
+export const DEV_ENCRYPTION_KEY = '00beef0000beef0000beef0000beef00'
 
-const DEV_POSTHOG_API_BASE_URL = 'http://localhost:8010'
+export const DEV_POSTHOG_API_BASE_URL = 'http://localhost:8010'
+
+// Dev fallback only — prod entrypoints fail closed without an explicit REDIS_URL.
+// nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+export const DEV_REDIS_URL = 'redis://localhost:6379'
+
+/**
+ * Dev-only shared HMAC key for the internal service JWT. Must match
+ * `.env.development`'s `AGENT_INTERNAL_SIGNING_KEY` so Django, ingress, and the
+ * janitor all sign/verify with the same key in local dev. **Never used in
+ * production** — gated behind `isDev()` by `requiredInProd`.
+ */
+export const DEV_INTERNAL_SIGNING_KEY = 'dev-internal-signing-key-do-not-use-in-prod'
+
+/**
+ * A config string that is genuinely required in prod but has an ergonomic dev
+ * default. Resolves to `devDefault` when `isDev()`, and **fails at config-load**
+ * (throws via `schema.parse`) when unset in prod. The output type is a plain
+ * `string` — no `| undefined` — so downstream code never has to null-check or
+ * re-assert the value with a scattered `if (!x) throw` boot guard. Use this
+ * instead of `.optional()` for values the service cannot function without.
+ */
+export function requiredInProd(
+    devDefault: string,
+    envHint: string,
+    opts?: { url?: boolean }
+): z.ZodType<string, string | undefined> {
+    const base = opts?.url ? z.string().url() : z.string()
+    return base.optional().transform((v, ctx): string => {
+        if (v) {
+            return v
+        }
+        if (isDev()) {
+            return devDefault
+        }
+        ctx.addIssue({ code: 'custom', message: `${envHint} must be set in production.` })
+        return z.NEVER
+    })
+}
+
+/**
+ * Like {@link requiredInProd}, but the value is legitimately absent in dev
+ * (e.g. `HTTPS_PROXY` — local fetches go direct). Required in prod (fails at
+ * config-load when unset), `undefined` in dev. Use instead of `.optional()` +
+ * an `if (!x && !isDev()) throw` boot guard.
+ */
+export function requiredInProdUnsetInDev(
+    envHint: string,
+    opts?: { url?: boolean }
+): z.ZodType<string | undefined, string | undefined> {
+    const base = opts?.url ? z.string().url() : z.string()
+    return base.optional().transform((v, ctx): string | undefined => {
+        if (v) {
+            return v
+        }
+        if (isDev()) {
+            return undefined
+        }
+        ctx.addIssue({ code: 'custom', message: `${envHint} must be set in production.` })
+        return z.NEVER
+    })
+}
 
 export const PlatformConfigSchema = z.object({
     posthogDbUrl: z
@@ -68,9 +129,9 @@ export const PlatformConfigSchema = z.object({
         .string()
         .url()
         .optional()
-        // Dev fallback only — prod entrypoints fail closed without an explicit REDIS_URL.
-        // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
-        .transform((v): string | undefined => v ?? (isDev() ? 'redis://localhost:6379' : undefined))
+        // Base stays optional: services that use the bus (ingress, runner) tighten this to
+        // `requiredInProd(DEV_REDIS_URL, ...)`; the janitor never touches Redis.
+        .transform((v): string | undefined => v ?? (isDev() ? DEV_REDIS_URL : undefined))
         .describe(
             'SessionEventBus backing for cross-host /listen SSE — runner publishes lifecycle events here, ingress subscribes. Required in prod (entrypoints fail closed without it); defaults to a local dev Redis URL when NODE_ENV != production. Provisioned by terraform/modules/agent-platform/valkey_serverless and surfaced into the chart via the posthog-app `valkey:` map (REDIS_WRITER_URL → REDIS_URL).'
         ),


### PR DESCRIPTION
## Problem

The janitor mounts its internal RPC auth middleware only when `AGENT_INTERNAL_SIGNING_KEY` is set ([`server.ts`](https://github.com/PostHog/posthog/blob/ass/products/agent_platform/services/agent-janitor/src/server.ts)), but the config field was `.optional()` with **no boot guard**. A missing or mistyped env var would silently boot the janitor with auth disabled on every privileged endpoint (bundle CRUD, freeze, approvals, cross-team memory) — with no log or health signal. The ingress had an explicit boot guard for the same key; the janitor did not. This was flagged as a HIGH finding in the agent-platform v2 threat model.

More broadly, several genuinely-required service config values were modelled as `.optional()` + a scattered `if (!config.x) throw` boot guard (or, for `encryptionSaltKeys` / `posthogApiBaseUrl`, a `.default('')` that fails later at first use). The requirement lived far from the schema and was easy to omit — exactly what happened with the janitor key.

## Changes

Introduce two helpers in `agent-shared` and make required service config fail closed **at config-load** instead of via boot guards / downstream throws:

- `requiredInProd(devDefault, envHint, { url? })` → `string`: resolves a dev default locally, throws at `loadConfig` time in prod when unset.
- `requiredInProdUnsetInDev(envHint, { url? })` → `string | undefined`: for values legitimately absent in dev (`HTTPS_PROXY`).

The requirement is applied **per service** (via `PlatformConfigSchema.extend(...)` override) only for the fields each service actually consumes, so the janitor isn't forced to carry redis/proxy/encryption/api-base it never uses. The base schema fields stay optional. No charts change is needed — every service requires exactly what its old boot guard already enforced, and each was already provisioned the relevant env.

| Field | janitor | ingress | runner |
|---|---|---|---|
| `internalSigningKey` | ✅ (was the missing guard) | ✅ | — |
| `redisUrl` | — | ✅ | ✅ |
| `httpsProxy` | — | ✅ | ✅ |
| `encryptionSaltKeys` | — | ✅ | ✅ |
| `posthogApiBaseUrl` | — | ✅ | ✅ |
| `bundleS3Bucket` / `memoryS3Bucket` / `memoryS3Endpoint` | ✅ | — | ✅ |

The corresponding boot guards in each service's `index.ts` are removed. The legitimate *inverse* guard (`devMcpBearerToken` — throws if set in prod) is kept. `sandboxBackend` / `sandboxHostImage` remain as-is (enum; already fail fast at boot via `selectSandboxPool`).

## How did you test this code?

I'm an agent (Claude Code). I did not do manual/runtime testing. Automated checks I ran locally across `agent-shared`, `agent-janitor`, `agent-ingress`, `agent-runner`:

- `typescript:check` — clean on all four.
- `oxlint` — 0 errors, no new warnings vs baseline.
- Config test suites — green, including **new fail-closed-in-prod tests** that assert each service throws at config-load when a required env is unset (the janitor signing-key one directly covers the original finding), plus dev-default and prod-loads-when-set cases. Added direct unit tests for both helpers in `platform.test.ts`.

Pre-existing `agent-janitor/src/server.test.ts` failures are environmental (require a live Postgres) and are unchanged by this PR — confirmed identical with the diff stashed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @benjackwhite, starting from corroboration of the agent-platform v2 threat model's HIGH finding F1 (janitor auth fails open when the signing key is unset).

The directive evolved from "add the janitor boot guard" to "make required config genuinely required at the schema level with a dev default, and remove these optional+guard error cases wherever they appear in the agent-* services." Key decisions:

- **Schema-level over boot guard.** The signing key now resolves to a shared dev default (matching `.env.development`) locally and throws at config-load in prod, so the output type is a non-optional `string` and `server.ts` can no longer be reached with auth off.
- **Per-service requirement, not base-schema.** Hoisting the requirement into the shared `PlatformConfigSchema` would force the runner/janitor to require credentials they neither use nor are provisioned. Instead the shared *helpers* live in `agent-shared` and each service overrides only the fields it consumes — keeping least-privilege and avoiding any charts change.
- **Scope.** Swept every `if (!config.x) throw` boot guard plus the two `.default('')`-then-throw-downstream fields. Left `sandboxBackend`/`sandboxHostImage` (enum, already boot-failing) out.
