### PR TITLE
fix(agent-platform): bind chat session ownership to the resolved agent

### DIFF
--- a/.semgrep/devex-rules/agent-ingress-scoped-session-fetch.yaml
+++ b/.semgrep/devex-rules/agent-ingress-scoped-session-fetch.yaml
@@ -1,0 +1,28 @@
+rules:
+    - id: agent-ingress-scoped-session-fetch
+      message: |
+          Trigger handlers must fetch sessions through `getOwnedSession(ctx, sessionId)`
+          (`products/agent_platform/services/agent-ingress/src/triggers/session-access.ts`),
+          not `queue.get(...)` directly.
+
+          A `session_id` on a request is client-supplied, and for public agents every
+          principal is `{ kind: 'anonymous' }` — so the handler must scope the session to
+          the resolved agent (`application_id`). `queue.get` returns a session for ANY
+          agent and the ownership check fails open if forgotten — that's the cross-tenant
+          gap that hit `/send` `/listen` `/cancel` `/client_tool_result`, `/mcp/stream`,
+          and the Slack interactivity handler. `getOwnedSession` routes through
+          `queue.getForApplication`, which scopes in SQL.
+
+          If you genuinely need an unscoped fetch (you almost never do in a request
+          handler), suppress with
+          `// nosemgrep: agent-ingress-scoped-session-fetch -- <reason>`.
+      languages: [typescript]
+      severity: ERROR
+      patterns:
+          - pattern: $Q.queue.get($ID)
+      paths:
+          include:
+              - products/agent_platform/services/agent-ingress/src/triggers/**/*.ts
+          exclude:
+              - products/agent_platform/services/agent-ingress/src/triggers/session-access.ts
+              - products/agent_platform/services/agent-ingress/src/triggers/**/*.test.ts

--- a/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
@@ -551,16 +551,19 @@ describe('ingress HTTP server (path mode)', () => {
         const sid = create.body.session_id as string
 
         // Every write/stream path on agent B must refuse A's session as not-found.
-        const sendB = await request(app).post('/agents/agent-b/send').send({ session_id: sid, message: 'pwn' })
-        expect(sendB.status).toBe(404)
-        const cancelB = await request(app).post('/agents/agent-b/cancel').send({ session_id: sid })
-        expect(cancelB.status).toBe(404)
-        const listenB = await request(app).get('/agents/agent-b/listen').query({ session_id: sid })
-        expect(listenB.status).toBe(404)
-        const ctrB = await request(app)
-            .post('/agents/agent-b/client_tool_result')
-            .send({ session_id: sid, call_id: 'c1', result: {} })
-        expect(ctrB.status).toBe(404)
+        const crossAgentCases: Array<() => Promise<{ status: number }>> = [
+            () => request(app).post('/agents/agent-b/send').send({ session_id: sid, message: 'pwn' }),
+            () => request(app).post('/agents/agent-b/cancel').send({ session_id: sid }),
+            () => request(app).get('/agents/agent-b/listen').query({ session_id: sid }),
+            () =>
+                request(app)
+                    .post('/agents/agent-b/client_tool_result')
+                    .send({ session_id: sid, call_id: 'c1', result: {} }),
+            () => request(app).get('/agents/agent-b/mcp/stream').query({ session_id: sid }),
+        ]
+        for (const makeRequest of crossAgentCases) {
+            expect((await makeRequest()).status).toBe(404)
+        }
 
         // The owning agent still drives its own session.
         const sendA = await request(app).post('/agents/agent-a/send').send({ session_id: sid, message: 'ok' })

--- a/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
@@ -538,6 +538,35 @@ describe('ingress HTTP server (path mode)', () => {
         expect(init.body.result.serverInfo.name).toBe('agent:gated')
     })
 
+    it('cross-agent session access is 404 — a session id from agent A cannot be driven via agent B', async () => {
+        const { revisions, app } = mk()
+        // Two public agents in the same team → distinct application_ids. Both
+        // store the anonymous principal, so `principalsMatch` alone would let a
+        // leaked session id be driven through either agent's endpoints. The
+        // `application_id` binding closes that cross-tenant path.
+        await seedApp(revisions, 'agent-a')
+        await seedApp(revisions, 'agent-b')
+        const create = await request(app).post('/agents/agent-a/run').send({ message: 'hi' })
+        expect(create.status).toBe(200)
+        const sid = create.body.session_id as string
+
+        // Every write/stream path on agent B must refuse A's session as not-found.
+        const sendB = await request(app).post('/agents/agent-b/send').send({ session_id: sid, message: 'pwn' })
+        expect(sendB.status).toBe(404)
+        const cancelB = await request(app).post('/agents/agent-b/cancel').send({ session_id: sid })
+        expect(cancelB.status).toBe(404)
+        const listenB = await request(app).get('/agents/agent-b/listen').query({ session_id: sid })
+        expect(listenB.status).toBe(404)
+        const ctrB = await request(app)
+            .post('/agents/agent-b/client_tool_result')
+            .send({ session_id: sid, call_id: 'c1', result: {} })
+        expect(ctrB.status).toBe(404)
+
+        // The owning agent still drives its own session.
+        const sendA = await request(app).post('/agents/agent-a/send').send({ session_id: sid, message: 'ok' })
+        expect(sendA.status).toBe(200)
+    })
+
     it('GET /mcp/connect-info advertises a public agent with no headers', async () => {
         const { revisions, app } = mk()
         await seedApp(revisions, 'public-agent')

--- a/products/agent_platform/services/agent-ingress/src/routing/server.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/server.ts
@@ -6,6 +6,7 @@
 
 import express, { Express, Request, Response } from 'express'
 import type { Pool } from 'pg'
+import { z } from 'zod'
 
 import type { IdentityStore, IntegrationStore, SecretResolver } from '@posthog/agent-shared'
 import { createLogger, RevisionStore, SessionQueue, triggerAuthConfig } from '@posthog/agent-shared'
@@ -202,13 +203,21 @@ export function buildApp(opts: BuildAppOpts): Express {
                 const triggerAuth = specTrigger ? triggerAuthConfig(specTrigger) : null
                 return {
                     type: m.type,
-                    routes: m.routes.map((r) => ({
-                        method: r.method,
-                        path: r.path,
-                        ...(r.bodySchema ? { bodySchema: r.bodySchema } : {}),
-                        ...(r.querySchema ? { querySchema: r.querySchema } : {}),
-                        auth: resolveRouteAuth(r.auth, triggerAuth),
-                    })),
+                    routes: m.routes.map((r) => {
+                        // A route's `schema` (zod) drives both runtime parsing and the
+                        // published shape — body for POST, query for GET. Bespoke-parse
+                        // triggers (MCP, Slack) publish via the raw `bodySchema`/`querySchema`.
+                        const schemaJson = r.schema ? z.toJSONSchema(r.schema) : undefined
+                        const bodySchema = r.method === 'POST' ? (schemaJson ?? r.bodySchema) : r.bodySchema
+                        const querySchema = r.method === 'GET' ? (schemaJson ?? r.querySchema) : r.querySchema
+                        return {
+                            method: r.method,
+                            path: r.path,
+                            ...(bodySchema ? { bodySchema } : {}),
+                            ...(querySchema ? { querySchema } : {}),
+                            auth: resolveRouteAuth(r.auth, triggerAuth),
+                        }
+                    }),
                 }
             })
             res.json({

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
@@ -14,7 +14,7 @@
 import { Response } from 'express'
 import { z } from 'zod'
 
-import { buildClientToolResultMarker } from '@posthog/agent-shared'
+import { AgentSession, buildClientToolResultMarker } from '@posthog/agent-shared'
 
 import { buildElevationResponse, principalDisplay, recordElevationRequest, requireAclAccess } from '../enqueue/acl'
 import { enqueueOrResume } from '../enqueue/enqueue'
@@ -25,7 +25,7 @@ import {
     ChatRunBodySchema,
     ChatSendBodySchema,
 } from './chat.schemas'
-import type { AuthedRouteCtx, TriggerModule } from './types'
+import type { AuthedRouteCtx, RouteCtx, TriggerModule } from './types'
 
 /**
  * Turn a zod error into the structured 400 body. Same shape as the janitor's
@@ -33,6 +33,22 @@ import type { AuthedRouteCtx, TriggerModule } from './types'
  */
 function badRequest(res: Response, err: z.ZodError): void {
     res.status(400).json({ error: 'invalid_body', issues: err.issues })
+}
+
+/**
+ * Fetch a session by client-supplied id, but only if it belongs to the agent
+ * this request resolved to. A mismatch reads as "not found" — a session id is
+ * a bare UUID, and for public agents every principal is `{kind:'anonymous'}`,
+ * so `principalsMatch` alone would let a leaked id be driven through *any*
+ * public agent's endpoint (cross-tenant). Binding to `resolved.application.id`
+ * closes that, and doesn't reveal the session exists under another agent.
+ */
+async function sessionForResolvedApp(ctx: RouteCtx, sessionId: string): Promise<AgentSession | null> {
+    const session = await ctx.deps.queue.get(sessionId)
+    if (!session || session.application_id !== ctx.resolved.application.id) {
+        return null
+    }
+    return session
 }
 
 async function runHandler(ctx: AuthedRouteCtx): Promise<void> {
@@ -85,7 +101,7 @@ async function sendHandler(ctx: AuthedRouteCtx): Promise<void> {
         return
     }
     const { session_id: sessionId, message, client_tool_result } = parsed.data
-    const existing = await deps.queue.get(sessionId)
+    const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -167,7 +183,7 @@ async function cancelHandler(ctx: AuthedRouteCtx): Promise<void> {
         return
     }
     const { session_id: sessionId } = parsed.data
-    const existing = await deps.queue.get(sessionId)
+    const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -193,7 +209,7 @@ async function listenHandler(ctx: AuthedRouteCtx): Promise<void> {
         return
     }
     const { session_id: sessionId } = parsed.data
-    const existing = await deps.queue.get(sessionId)
+    const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -223,7 +239,7 @@ async function clientToolResultHandler(ctx: AuthedRouteCtx): Promise<void> {
         return
     }
     const { session_id: sessionId, call_id, result, error } = parsed.data
-    const existing = await deps.queue.get(sessionId)
+    const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'no_session' })
         return

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
@@ -11,7 +11,6 @@
  * (ACL) on the principal the guard produced.
  */
 
-import { Response } from 'express'
 import { z } from 'zod'
 
 import { AgentSession, buildClientToolResultMarker } from '@posthog/agent-shared'
@@ -25,15 +24,7 @@ import {
     ChatRunBodySchema,
     ChatSendBodySchema,
 } from './chat.schemas'
-import type { AuthedRouteCtx, RouteCtx, TriggerModule } from './types'
-
-/**
- * Turn a zod error into the structured 400 body. Same shape as the janitor's
- * validation responses so callers (curl, MCP, tests) parse it uniformly.
- */
-function badRequest(res: Response, err: z.ZodError): void {
-    res.status(400).json({ error: 'invalid_body', issues: err.issues })
-}
+import { defineRoute, type AuthedRouteCtx, type RouteCtx, type TriggerModule } from './types'
 
 /**
  * Fetch a session by client-supplied id, but only if it belongs to the agent
@@ -51,14 +42,9 @@ async function sessionForResolvedApp(ctx: RouteCtx, sessionId: string): Promise<
     return session
 }
 
-async function runHandler(ctx: AuthedRouteCtx): Promise<void> {
-    const { req, res, deps, resolved } = ctx
-    const parsed = ChatRunBodySchema.safeParse(req.body)
-    if (!parsed.success) {
-        badRequest(res, parsed.error)
-        return
-    }
-    const { message, external_key: externalKey = null } = parsed.data
+async function runHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatRunBodySchema>>): Promise<void> {
+    const { res, deps, resolved } = ctx
+    const { message, external_key: externalKey = null } = ctx.parsed
     const sessionPrincipal = ctx.principal
     const outcome = await enqueueOrResume(
         { queue: deps.queue },
@@ -93,14 +79,9 @@ async function runHandler(ctx: AuthedRouteCtx): Promise<void> {
     })
 }
 
-async function sendHandler(ctx: AuthedRouteCtx): Promise<void> {
-    const { req, res, deps, resolved } = ctx
-    const parsed = ChatSendBodySchema.safeParse(req.body)
-    if (!parsed.success) {
-        badRequest(res, parsed.error)
-        return
-    }
-    const { session_id: sessionId, message, client_tool_result } = parsed.data
+async function sendHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatSendBodySchema>>): Promise<void> {
+    const { res, deps, resolved } = ctx
+    const { session_id: sessionId, message, client_tool_result } = ctx.parsed
     const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
@@ -175,14 +156,9 @@ async function sendHandler(ctx: AuthedRouteCtx): Promise<void> {
     res.json({ ok: true })
 }
 
-async function cancelHandler(ctx: AuthedRouteCtx): Promise<void> {
-    const { req, res, deps } = ctx
-    const parsed = ChatCancelBodySchema.safeParse(req.body)
-    if (!parsed.success) {
-        badRequest(res, parsed.error)
-        return
-    }
-    const { session_id: sessionId } = parsed.data
+async function cancelHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatCancelBodySchema>>): Promise<void> {
+    const { res, deps } = ctx
+    const { session_id: sessionId } = ctx.parsed
     const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
@@ -201,14 +177,9 @@ async function cancelHandler(ctx: AuthedRouteCtx): Promise<void> {
     res.json({ ok: true, state: 'cancelled' })
 }
 
-async function listenHandler(ctx: AuthedRouteCtx): Promise<void> {
+async function listenHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatListenQuerySchema>>): Promise<void> {
     const { req, res, deps } = ctx
-    const parsed = ChatListenQuerySchema.safeParse(req.query)
-    if (!parsed.success) {
-        badRequest(res, parsed.error)
-        return
-    }
-    const { session_id: sessionId } = parsed.data
+    const { session_id: sessionId } = ctx.parsed
     const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
@@ -231,14 +202,11 @@ async function listenHandler(ctx: AuthedRouteCtx): Promise<void> {
     req.on('close', () => unsubscribe())
 }
 
-async function clientToolResultHandler(ctx: AuthedRouteCtx): Promise<void> {
-    const { req, res, deps } = ctx
-    const parsed = ChatClientToolResultBodySchema.safeParse(req.body)
-    if (!parsed.success) {
-        badRequest(res, parsed.error)
-        return
-    }
-    const { session_id: sessionId, call_id, result, error } = parsed.data
+async function clientToolResultHandler(
+    ctx: AuthedRouteCtx<z.infer<typeof ChatClientToolResultBodySchema>>
+): Promise<void> {
+    const { res, deps } = ctx
+    const { session_id: sessionId, call_id, result, error } = ctx.parsed
     const existing = await sessionForResolvedApp(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'no_session' })
@@ -266,40 +234,40 @@ async function clientToolResultHandler(ctx: AuthedRouteCtx): Promise<void> {
 export const chatTrigger: TriggerModule = {
     type: 'chat',
     routes: [
-        {
+        defineRoute({
             method: 'POST',
             path: '/run',
-            bodySchema: z.toJSONSchema(ChatRunBodySchema),
             auth: 'agent_spec',
+            schema: ChatRunBodySchema,
             handler: runHandler,
-        },
-        {
+        }),
+        defineRoute({
             method: 'POST',
             path: '/send',
-            bodySchema: z.toJSONSchema(ChatSendBodySchema),
             auth: 'agent_spec',
+            schema: ChatSendBodySchema,
             handler: sendHandler,
-        },
-        {
+        }),
+        defineRoute({
             method: 'POST',
             path: '/cancel',
-            bodySchema: z.toJSONSchema(ChatCancelBodySchema),
             auth: 'agent_spec',
+            schema: ChatCancelBodySchema,
             handler: cancelHandler,
-        },
-        {
+        }),
+        defineRoute({
             method: 'GET',
             path: '/listen',
-            querySchema: z.toJSONSchema(ChatListenQuerySchema),
             auth: 'agent_spec',
+            schema: ChatListenQuerySchema,
             handler: listenHandler,
-        },
-        {
+        }),
+        defineRoute({
             method: 'POST',
             path: '/client_tool_result',
-            bodySchema: z.toJSONSchema(ChatClientToolResultBodySchema),
             auth: 'agent_spec',
+            schema: ChatClientToolResultBodySchema,
             handler: clientToolResultHandler,
-        },
+        }),
     ],
 }

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
@@ -13,7 +13,7 @@
 
 import { z } from 'zod'
 
-import { AgentSession, buildClientToolResultMarker } from '@posthog/agent-shared'
+import { buildClientToolResultMarker } from '@posthog/agent-shared'
 
 import { buildElevationResponse, principalDisplay, recordElevationRequest, requireAclAccess } from '../enqueue/acl'
 import { enqueueOrResume } from '../enqueue/enqueue'
@@ -24,23 +24,8 @@ import {
     ChatRunBodySchema,
     ChatSendBodySchema,
 } from './chat.schemas'
-import { defineRoute, type AuthedRouteCtx, type RouteCtx, type TriggerModule } from './types'
-
-/**
- * Fetch a session by client-supplied id, but only if it belongs to the agent
- * this request resolved to. A mismatch reads as "not found" — a session id is
- * a bare UUID, and for public agents every principal is `{kind:'anonymous'}`,
- * so `principalsMatch` alone would let a leaked id be driven through *any*
- * public agent's endpoint (cross-tenant). Binding to `resolved.application.id`
- * closes that, and doesn't reveal the session exists under another agent.
- */
-async function sessionForResolvedApp(ctx: RouteCtx, sessionId: string): Promise<AgentSession | null> {
-    const session = await ctx.deps.queue.get(sessionId)
-    if (!session || session.application_id !== ctx.resolved.application.id) {
-        return null
-    }
-    return session
-}
+import { getOwnedSession } from './session-access'
+import { defineRoute, type AuthedRouteCtx, type TriggerModule } from './types'
 
 async function runHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatRunBodySchema>>): Promise<void> {
     const { res, deps, resolved } = ctx
@@ -82,7 +67,7 @@ async function runHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatRunBodySchema>>
 async function sendHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatSendBodySchema>>): Promise<void> {
     const { res, deps, resolved } = ctx
     const { session_id: sessionId, message, client_tool_result } = ctx.parsed
-    const existing = await sessionForResolvedApp(ctx, sessionId)
+    const existing = await getOwnedSession(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -159,7 +144,7 @@ async function sendHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatSendBodySchema
 async function cancelHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatCancelBodySchema>>): Promise<void> {
     const { res, deps } = ctx
     const { session_id: sessionId } = ctx.parsed
-    const existing = await sessionForResolvedApp(ctx, sessionId)
+    const existing = await getOwnedSession(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -180,7 +165,7 @@ async function cancelHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatCancelBodySc
 async function listenHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatListenQuerySchema>>): Promise<void> {
     const { req, res, deps } = ctx
     const { session_id: sessionId } = ctx.parsed
-    const existing = await sessionForResolvedApp(ctx, sessionId)
+    const existing = await getOwnedSession(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
@@ -207,7 +192,7 @@ async function clientToolResultHandler(
 ): Promise<void> {
     const { res, deps } = ctx
     const { session_id: sessionId, call_id, result, error } = ctx.parsed
-    const existing = await sessionForResolvedApp(ctx, sessionId)
+    const existing = await getOwnedSession(ctx, sessionId)
     if (!existing) {
         res.status(404).json({ error: 'no_session' })
         return

--- a/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
@@ -329,7 +329,11 @@ async function mcpStreamHandler(ctx: AuthedRouteCtx): Promise<void> {
     }
     const { session_id: sessionId } = parsed.data
     const existing = await deps.queue.get(sessionId)
-    if (!existing) {
+    // Bind the session to the resolved agent before anything else — a leaked
+    // anonymous session UUID must not be subscribable via another public
+    // agent's /mcp/stream (same cross-tenant guard as the chat handlers and the
+    // tools/call + resources/read paths above). Mismatch reads as not-found.
+    if (!existing || existing.application_id !== ctx.resolved.application.id) {
         res.status(404).json({ error: 'session_not_found' })
         return
     }

--- a/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/mcp.ts
@@ -51,6 +51,7 @@ import { buildElevationResponse, principalDisplay, recordElevationRequest, requi
 import { principalsMatch } from '../enqueue/auth'
 import { enqueueOrResume } from '../enqueue/enqueue'
 import { McpRequestBodySchema, McpStreamQuerySchema } from './mcp.schemas'
+import { getOwnedSession } from './session-access'
 import type { AuthedRouteCtx, CustomAuthRouteCtx, RouteCtx, TriggerDeps, TriggerModule } from './types'
 
 interface McpRequest {
@@ -161,12 +162,8 @@ async function mcpHandler(ctx: CustomAuthRouteCtx): Promise<void> {
             if (continuationId) {
                 // Continuation path: append to an existing session, matching the
                 // strict-principal contract chat/send already enforces.
-                const existing = await deps.queue.get(continuationId)
+                const existing = await getOwnedSession(ctx, continuationId)
                 if (!existing) {
-                    res.json(errReply(RPC_INVALID_PARAMS, 'session_not_found'))
-                    return
-                }
-                if (existing.application_id !== resolved.application.id) {
                     res.json(errReply(RPC_INVALID_PARAMS, 'session_not_found'))
                     return
                 }
@@ -285,8 +282,8 @@ async function mcpHandler(ctx: CustomAuthRouteCtx): Promise<void> {
                 return
             }
             const sessionId = uri.slice(SESSION_URI_PREFIX.length)
-            const session = await deps.queue.get(sessionId)
-            if (!session || session.application_id !== resolved.application.id) {
+            const session = await getOwnedSession(ctx, sessionId)
+            if (!session) {
                 res.json(errReply(RPC_INVALID_PARAMS, 'session_not_found'))
                 return
             }
@@ -328,12 +325,11 @@ async function mcpStreamHandler(ctx: AuthedRouteCtx): Promise<void> {
         return
     }
     const { session_id: sessionId } = parsed.data
-    const existing = await deps.queue.get(sessionId)
-    // Bind the session to the resolved agent before anything else — a leaked
-    // anonymous session UUID must not be subscribable via another public
-    // agent's /mcp/stream (same cross-tenant guard as the chat handlers and the
-    // tools/call + resources/read paths above). Mismatch reads as not-found.
-    if (!existing || existing.application_id !== ctx.resolved.application.id) {
+    // Scope the session to the resolved agent — a leaked anonymous session UUID
+    // must not be subscribable via another public agent's /mcp/stream. Mismatch
+    // reads as not-found.
+    const existing = await getOwnedSession(ctx, sessionId)
+    if (!existing) {
         res.status(404).json({ error: 'session_not_found' })
         return
     }

--- a/products/agent_platform/services/agent-ingress/src/triggers/mount.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/mount.ts
@@ -15,7 +15,15 @@ import { asyncHandler } from '../routing/http-utils'
 import { ResolvedAgent } from '../routing/resolver'
 import { hasTrigger, resolveAgent } from './resolve'
 import { verifySlackSignature } from './slack-signature'
-import type { RouteCtx, TriggerDeps, TriggerModule, TriggerRoute, TriggerType } from './types'
+import type {
+    AuthedRouteCtx,
+    CustomAuthRouteCtx,
+    RouteCtx,
+    TriggerDeps,
+    TriggerModule,
+    TriggerRoute,
+    TriggerType,
+} from './types'
 
 /** Build an Express router that mounts every route of a module behind its guard. */
 export function mountTrigger(deps: TriggerDeps, module: TriggerModule): Router {
@@ -52,12 +60,16 @@ async function runGuardedRoute(
         }
         return
     }
-    const base: RouteCtx = { req, res, deps, resolved }
+    const base: RouteCtx = { req, res, deps, resolved, parsed: undefined }
 
+    // Resolve the auth-specific context (or respond + return on failure). The
+    // body/query parse happens after this, so a malformed payload never short-
+    // circuits the auth gate.
+    let ctx: RouteCtx | AuthedRouteCtx | CustomAuthRouteCtx
     switch (route.auth) {
         case 'public': {
-            await route.handler(base)
-            return
+            ctx = base
+            break
         }
         case 'slack_signing': {
             if (!hasTrigger(resolved, type)) {
@@ -76,8 +88,8 @@ async function runGuardedRoute(
                 res.status(401).json({ error: 'invalid_signature' })
                 return
             }
-            await route.handler(base)
-            return
+            ctx = base
+            break
         }
         case 'custom': {
             const authConfig = authConfigFor(resolved, type)
@@ -85,13 +97,13 @@ async function runGuardedRoute(
                 res.status(404).json({ error: `no_${type}_trigger` })
                 return
             }
-            await route.handler({
+            ctx = {
                 ...base,
                 authConfig,
                 authorize: () =>
                     authorize(req, resolved.application, authConfig, deps.authProvider ?? PUBLIC_ONLY_AUTH_PROVIDER),
-            })
-            return
+            }
+            break
         }
         case 'agent_spec': {
             const authConfig = authConfigFor(resolved, type)
@@ -109,8 +121,22 @@ async function runGuardedRoute(
                 res.status(auth.status).json({ error: auth.reason })
                 return
             }
-            await route.handler({ ...base, authConfig, principal: auth.principal, credentials: auth.credentials })
-            return
+            ctx = { ...base, authConfig, principal: auth.principal, credentials: auth.credentials }
+            break
         }
     }
+
+    // Validate the declared payload schema (body for POST, query for GET) and
+    // hand the handler a typed `ctx.parsed`. Centralized here so no handler can
+    // skip validation or drift from its declared schema.
+    if (route.schema) {
+        const source = route.method === 'GET' ? req.query : req.body
+        const result = route.schema.safeParse(source)
+        if (!result.success) {
+            res.status(400).json({ error: 'invalid_body', issues: result.error.issues })
+            return
+        }
+        ctx.parsed = result.data
+    }
+    await route.handler(ctx as never)
 }

--- a/products/agent_platform/services/agent-ingress/src/triggers/session-access.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/session-access.ts
@@ -1,0 +1,27 @@
+/**
+ * Tenant-safe session fetch for trigger handlers.
+ *
+ * A `session_id` on a request is client-supplied, and for public agents every
+ * principal is `{ kind: 'anonymous' }` — so `principalsMatch` alone can't tell
+ * agent A's session from agent B's. Every handler that loads a session by id
+ * must therefore scope it to the agent the request resolved to. That check is
+ * easy to forget and fails open (a found row is returned regardless of tenant),
+ * which is exactly the gap that bit `/send` `/listen` `/cancel`
+ * `/client_tool_result`, `/mcp/stream`, and the Slack interactivity handler.
+ *
+ * `getOwnedSession` is the single sanctioned way to do it: it routes through
+ * `queue.getForApplication`, which scopes in SQL, and returns `null` on both
+ * "no such session" and "belongs to another agent" so callers can't
+ * distinguish the two (no cross-tenant existence leak). A semgrep rule
+ * (`.semgrep/devex-rules/agent-ingress-scoped-session-fetch.yaml`) forbids raw
+ * `queue.get(...)` elsewhere in `triggers/` so a new handler can't reintroduce
+ * the gap.
+ */
+
+import type { AgentSession } from '@posthog/agent-shared'
+
+import type { RouteCtx } from './types'
+
+export async function getOwnedSession(ctx: RouteCtx, sessionId: string): Promise<AgentSession | null> {
+    return ctx.deps.queue.getForApplication(sessionId, ctx.resolved.application.id)
+}

--- a/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
@@ -23,6 +23,7 @@ import { applyElevationDecline, applyElevationGrant, authorizeGrant } from '../e
 import { enqueueOrResume } from '../enqueue/enqueue'
 import { verifySlackSignature } from './slack-signature'
 import { SlackEventBodySchema } from './slack.schemas'
+import { getOwnedSession } from './session-access'
 import type { RouteCtx, TriggerDeps, TriggerModule } from './types'
 
 // Re-exported for backwards compatibility — the guard (mount.ts) is the
@@ -294,7 +295,10 @@ async function slackInteractivityHandler(ctx: RouteCtx): Promise<void> {
         return
     }
     const { sessionId, requestId, decision } = decoded
-    const session = await deps.queue.get(sessionId)
+    // The sessionId is decoded from the (attacker-influenceable) Slack action
+    // value — scope it to the resolved agent so an elevation decision can't be
+    // applied to another agent's session. Mismatch reads as not-found.
+    const session = await getOwnedSession(ctx, sessionId)
     if (!session) {
         res.status(404).json({ error: 'session_not_found' })
         return

--- a/products/agent_platform/services/agent-ingress/src/triggers/types.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/types.ts
@@ -19,6 +19,7 @@
 
 import type { Request, Response } from 'express'
 import type { Pool } from 'pg'
+import type { z } from 'zod'
 
 import type {
     AuthConfig,
@@ -93,23 +94,32 @@ export type TriggerType = Trigger['type']
  */
 export type RouteAuthKind = 'agent_spec' | 'custom' | 'slack_signing' | 'public'
 
-/** Context every route handler receives. The agent is always resolved. */
-export interface RouteCtx {
+/**
+ * Context every route handler receives. The agent is always resolved.
+ *
+ * `parsed` is the request payload validated against the route's `schema` (body
+ * for POST, query for GET) — the mount layer parses + 400s before the handler
+ * runs, so handlers read `ctx.parsed` directly instead of re-validating. It's
+ * typed via the `P` parameter (set by `defineRoute`); `unknown` for routes that
+ * declare no `schema`.
+ */
+export interface RouteCtx<P = unknown> {
     req: Request
     res: Response
     deps: TriggerDeps
     resolved: ResolvedAgent
+    parsed: P
 }
 
 /** `agent_spec` routes: the guard authenticated the caller before the handler ran. */
-export interface AuthedRouteCtx extends RouteCtx {
+export interface AuthedRouteCtx<P = unknown> extends RouteCtx<P> {
     authConfig: AuthConfig
     principal: SessionPrincipal
     credentials: CredentialMap
 }
 
 /** `custom` routes: agent + authConfig resolved; the handler authorizes on demand. */
-export interface CustomAuthRouteCtx extends RouteCtx {
+export interface CustomAuthRouteCtx<P = unknown> extends RouteCtx<P> {
     authConfig: AuthConfig
     /** Run the agent's auth gate (per JSON-RPC method, etc.). */
     authorize(): Promise<VerifyResult>
@@ -119,10 +129,19 @@ interface RouteCommon {
     method: 'GET' | 'POST'
     /** Path relative to the agent mount (e.g. `/run`, `/slack/events`). */
     path: string
-    /** JSON Schema for the request body. POST routes only. Omit when the
-     *  trigger genuinely accepts arbitrary payloads (e.g. webhook). */
+    /**
+     * Zod schema for the request payload — body for POST, query for GET. When
+     * set, the mount layer validates the payload after auth, responds 400
+     * (`{ error: 'invalid_body', issues }`) on failure, and hands the handler a
+     * typed `ctx.parsed`. Also published (via `z.toJSONSchema`) on `/schemas`.
+     * Use `defineRoute` so `ctx.parsed` is inferred from this schema.
+     */
+    schema?: z.ZodType
+    /** Publish-only JSON Schema, for triggers that parse the body themselves
+     *  with a bespoke error contract (MCP JSON-RPC, Slack envelopes). Mutually
+     *  exclusive with `schema` — prefer `schema` for plain 400-on-invalid routes. */
     bodySchema?: object
-    /** JSON Schema for the query string. GET routes that read params. */
+    /** Publish-only JSON Schema for the query string (bespoke-parse GET routes). */
     querySchema?: object
 }
 
@@ -142,4 +161,31 @@ export interface TriggerModule {
     type: TriggerType
     /** Routes this trigger owns — drives mounting, guards, and `/schemas`. */
     routes: TriggerRoute[]
+}
+
+/** The context an `auth` kind yields, carrying the parsed payload type `P`. */
+type CtxForAuth<A extends RouteAuthKind, P> = A extends 'agent_spec'
+    ? AuthedRouteCtx<P>
+    : A extends 'custom'
+      ? CustomAuthRouteCtx<P>
+      : RouteCtx<P>
+
+/**
+ * Define a route, tying its `schema` to the handler's `ctx.parsed` type. The
+ * mount layer validates the payload (after auth) and the handler receives it
+ * pre-parsed and typed — so a handler can't read an unvalidated body or drift
+ * from the declared schema. Omit `schema` for routes with no payload (or for
+ * bespoke-parse triggers using `bodySchema`/`querySchema`), in which case
+ * `ctx.parsed` is `unknown`.
+ */
+export function defineRoute<A extends RouteAuthKind, S extends z.ZodType | undefined = undefined>(def: {
+    method: 'GET' | 'POST'
+    path: string
+    auth: A
+    schema?: S
+    bodySchema?: object
+    querySchema?: object
+    handler: (ctx: CtxForAuth<A, S extends z.ZodType ? z.infer<S> : unknown>) => Promise<void>
+}): TriggerRoute {
+    return def as unknown as TriggerRoute
 }

--- a/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/webhook.ts
@@ -9,23 +9,19 @@
 
 import { Request } from 'express'
 import { createHash } from 'node:crypto'
-import { z } from 'zod'
+import type { z } from 'zod'
 
 import { principalDisplay } from '../enqueue/acl'
 import { enqueueOrResume } from '../enqueue/enqueue'
-import type { AuthedRouteCtx, TriggerModule } from './types'
+import { defineRoute, type AuthedRouteCtx, type TriggerModule } from './types'
 import { WebhookBodySchema } from './webhook.schemas'
 
-async function webhookHandler(ctx: AuthedRouteCtx): Promise<void> {
+async function webhookHandler(ctx: AuthedRouteCtx<z.infer<typeof WebhookBodySchema>>): Promise<void> {
     const { req, res, deps, resolved } = ctx
-    const parsed = WebhookBodySchema.safeParse(req.body)
-    if (!parsed.success) {
-        res.status(400).json({ error: 'invalid_body', issues: parsed.error.issues })
-        return
-    }
+    const body = ctx.parsed
     const externalKeyHeader = req.headers['x-external-key']
     const externalKey = typeof externalKeyHeader === 'string' ? externalKeyHeader : null
-    const idempotencyKey = extractProviderIdempotencyKey(req, parsed.data)
+    const idempotencyKey = extractProviderIdempotencyKey(req, body)
     const sessionPrincipal = ctx.principal
     const outcome = await enqueueOrResume(
         { queue: deps.queue },
@@ -36,7 +32,7 @@ async function webhookHandler(ctx: AuthedRouteCtx): Promise<void> {
             idempotencyKey,
             seed: {
                 role: 'user',
-                content: JSON.stringify(parsed.data),
+                content: JSON.stringify(body),
                 timestamp: Date.now(),
                 sender: sessionPrincipal,
             },
@@ -101,12 +97,12 @@ function extractProviderIdempotencyKey(req: Request, parsedBody: unknown): strin
 export const webhookTrigger: TriggerModule = {
     type: 'webhook',
     routes: [
-        {
+        defineRoute({
             method: 'POST',
             path: '/webhook',
-            bodySchema: z.toJSONSchema(WebhookBodySchema),
             auth: 'agent_spec',
+            schema: WebhookBodySchema,
             handler: webhookHandler,
-        },
+        }),
     ],
 }

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
@@ -410,6 +410,64 @@ maybeDescribe('Postgres impls (real PG)', () => {
         expect((await queue.get(sessionId))!.id).toBe(sessionId)
     })
 
+    it('agent_session carries the indexes the hot session lookups rely on', async () => {
+        if (!reachable) {
+            return
+        }
+        const { rows } = await pool.query<{ indexname: string; indexdef: string }>(
+            `SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'agent_session'`
+        )
+        const defs = rows.map((r) => r.indexdef)
+        const has = (re: RegExp): boolean => defs.some((d) => re.test(d))
+        // getForApplication resolves via the primary key on id.
+        expect(has(/UNIQUE INDEX .*agent_session_pkey.* \(id\)/)).toBe(true)
+        // findByExternalKey — (application_id, external_key), partial on non-null.
+        expect(has(/\(application_id, external_key\)[\s\S]*WHERE \(external_key IS NOT NULL\)/)).toBe(true)
+        // findByIdempotencyKey — unique (application_id, idempotency_key), partial.
+        expect(
+            has(/UNIQUE INDEX[\s\S]*\(application_id, idempotency_key\)[\s\S]*WHERE \(idempotency_key IS NOT NULL\)/)
+        ).toBe(true)
+    })
+
+    it('the hot session lookups plan as index scans, not seq scans', async () => {
+        if (!reachable) {
+            return
+        }
+        const appId = randomUUID()
+        const sid = randomUUID()
+        // EXPLAIN (no ANALYZE) plans without touching rows. Forcing seqscan off
+        // proves each predicate is index-supported against the real schema — on a
+        // small table the planner would otherwise pick a seq scan by cost.
+        const client = await pool.connect()
+        try {
+            await client.query('SET enable_seqscan = off')
+            const explain = async (sql: string): Promise<string> => {
+                const r = await client.query<{ 'QUERY PLAN': string }>(`EXPLAIN ${sql}`)
+                return r.rows.map((row) => row['QUERY PLAN']).join('\n')
+            }
+            // getForApplication
+            const getPlan = await explain(
+                `SELECT * FROM agent_session WHERE id = '${sid}' AND application_id = '${appId}'`
+            )
+            expect(getPlan).toMatch(/Index Scan using agent_session_pkey/)
+            expect(getPlan).not.toMatch(/Seq Scan on agent_session/)
+            // findByExternalKey
+            const extPlan = await explain(
+                `SELECT * FROM agent_session WHERE application_id = '${appId}' AND external_key = 'slack:C1' ORDER BY updated_at DESC LIMIT 1`
+            )
+            expect(extPlan).toMatch(/Index Scan.*agent_sess_extkey_idx/)
+            expect(extPlan).not.toMatch(/Seq Scan on agent_session/)
+            // findByIdempotencyKey
+            const idemPlan = await explain(
+                `SELECT * FROM agent_session WHERE application_id = '${appId}' AND idempotency_key = 'k1'`
+            )
+            expect(idemPlan).toMatch(/Index Scan.*agent_session_idempotency_key_unique/)
+            expect(idemPlan).not.toMatch(/Seq Scan on agent_session/)
+        } finally {
+            client.release()
+        }
+    })
+
     it('PgSessionQueue.reapStuckRunning bumps retry_count and poison-pills past threshold', async () => {
         if (!reachable) {
             return

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
@@ -367,6 +367,49 @@ maybeDescribe('Postgres impls (real PG)', () => {
         expect(missing).toBeNull()
     })
 
+    it('getForApplication scopes by (id, application_id) — null for another application', async () => {
+        if (!reachable) {
+            return
+        }
+        const queue = new PgSessionQueue(pool)
+        const revisions = new PgRevisionStore(pool)
+        const app = await revisions.createApplication({ team_id: 1, slug: 'owner', name: 'Owner', description: '' })
+        const other = await revisions.createApplication({ team_id: 1, slug: 'other', name: 'Other', description: '' })
+        const rev = await revisions.createRevision({
+            application_id: app.id,
+            parent_revision_id: null,
+            created_by_id: null,
+            bundle_uri: 's3://x/',
+            spec: AgentSpecSchema.parse({ model: 'x' }),
+        })
+        const sessionId = '33333333-3333-3333-3333-333333333333'
+        await queue.enqueue({
+            id: sessionId,
+            application_id: app.id,
+            revision_id: rev.id,
+            team_id: 1,
+            external_key: null,
+            idempotency_key: null,
+            trigger_metadata: null,
+            state: 'queued',
+            conversation: [],
+            pending_inputs: [],
+            principal: null,
+            retry_count: 0,
+            usage_total: { ...EMPTY_USAGE_TOTAL },
+            acl: [],
+            pending_elevation_requests: [],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        })
+        // Owning application resolves it; a different application (even in the
+        // same team) sees null — the cross-tenant guard lives in the SQL filter.
+        expect((await queue.getForApplication(sessionId, app.id))!.id).toBe(sessionId)
+        expect(await queue.getForApplication(sessionId, other.id)).toBeNull()
+        // Plain get is unscoped (trusted internal callers only).
+        expect((await queue.get(sessionId))!.id).toBe(sessionId)
+    })
+
     it('PgSessionQueue.reapStuckRunning bumps retry_count and poison-pills past threshold', async () => {
         if (!reachable) {
             return

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-queue.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-queue.ts
@@ -227,6 +227,17 @@ export class PgSessionQueue implements SessionQueue {
         return rowToSession(r.rows[0])
     }
 
+    async getForApplication(sessionId: string, applicationId: string): Promise<AgentSession | null> {
+        const r = await this.pool.query<DbRow>(
+            `SELECT ${SELECT_COLS} FROM agent_session WHERE id = $1 AND application_id = $2`,
+            [sessionId, applicationId]
+        )
+        if (r.rowCount === 0) {
+            return null
+        }
+        return rowToSession(r.rows[0])
+    }
+
     async findByIdempotencyKey(applicationId: string, idempotencyKey: string): Promise<AgentSession | null> {
         // Unique index on (application_id, idempotency_key) guarantees at most
         // one row matches — no ORDER BY / LIMIT needed for correctness, but

--- a/products/agent_platform/services/agent-shared/src/persistence/queue.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/queue.ts
@@ -68,6 +68,17 @@ export interface SessionQueue extends SessionInputsStore {
      */
     appendPendingElevationRequest(sessionId: string, req: PendingElevationRequest): Promise<void>
     get(sessionId: string): Promise<AgentSession | null>
+    /**
+     * Like `get`, but scoped to one application — returns null when the session
+     * doesn't exist OR belongs to a different application. This is the
+     * tenant-safe read for request handlers, where `sessionId` is
+     * client-supplied: a leaked id from another agent must not resolve. The
+     * filter is in SQL (`id = $1 AND application_id = $2`), so the scoping holds
+     * even if a caller forgets to compare afterwards. Ingress handlers reach it
+     * via `getOwnedSession(ctx, id)`; plain `get` stays for trusted internal
+     * callers (runner claim loop, sweep) that legitimately fetch by id alone.
+     */
+    getForApplication(sessionId: string, applicationId: string): Promise<AgentSession | null>
     /** Find an existing session matching (application_id, external_key). */
     findByExternalKey(applicationId: string, externalKey: string): Promise<AgentSession | null>
     /**


### PR DESCRIPTION
## Problem

Two related issues in the ingress trigger/router layer:

1. **Cross-tenant session confusion (security, HIGH).** The chat `/send`, `/cancel`, `/listen`, and `/client_tool_result` handlers fetch a session by client-supplied `session_id` and gate only on `requireAclAccess`. For **public agents**, both the stored and incoming principals are `{ kind: 'anonymous' }`, and `principalsMatch(anonymous, anonymous)` is unconditionally `true` — and the handlers never check the session belongs to the agent the request resolved to. So a leaked anonymous session UUID for **team A's** public agent could be read, advanced, cancelled, or fed forged tool results through **any** public agent's endpoint, across the tenant boundary. (Threat-model finding F2.)

2. **Repeated, forgettable body-parsing boilerplate.** Every chat/webhook handler opened with the same `safeParse(req.body)` + 400 dance before doing anything, and the parsed payload type wasn't carried onto the handler context — so each handler re-validated by hand and a new handler could silently forget to.

## Changes

**1. Bind session ownership to the resolved agent.** A `sessionForResolvedApp(ctx, sessionId)` helper fetches the session only when `session.application_id === ctx.resolved.application.id`; all four chat handlers route their fetch through it. A mismatch returns the handler's existing 404 — indistinguishable from a genuinely-missing session, so it doesn't reveal the session exists under another agent. Hardens every principal path, not just anonymous; the ACL/principal check still runs afterward.

**2. Centralize payload parsing in the router.** Routes now declare a zod `schema` via a new `defineRoute` helper; the mount layer validates the payload **after auth** (body for POST, query for GET), responds `400 { error: 'invalid_body', issues }` on failure, and hands the handler a typed `ctx.parsed`. The same schema is published on `/schemas`, so a route can't advertise one shape and parse another, and a handler can't read an unvalidated body. Chat and webhook adopt it; MCP (JSON-RPC error contract) and Slack (challenge / multi-envelope) keep parsing themselves via the publish-only `bodySchema`/`querySchema` fields.

Not addressed here (tracked separately): the same missing binding on the Slack interactivity handler, and the structural fix of scoping the persistence-layer single-row reads by `application_id` / `team_id` (F11).

## How did you test this code?

I'm an agent (Claude Code). No manual testing. Automated, run against the local Postgres/Redis stack:

- Added an integration test in `agent-ingress/src/routing/server.test.ts`: seeds two public agents in the same team, starts an anonymous session on agent A, and asserts `/send`, `/cancel`, `/listen`, `/client_tool_result` on **agent B** all 404 for A's session id, while agent A still drives its own session (200).
- Full `agent-ingress` suite green (**113 tests**) — covering the `/schemas` published-shape assertions and the existing 400-on-invalid-body cases, which now flow through the centralized parser unchanged. `typescript:check` and `oxlint` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @benjackwhite, starting from threat-model finding F2 (cross-tenant session confusion on public agents). While in the chat handlers, the session-binding fix surfaced the repeated parse boilerplate, so a second commit lifts payload validation into the router.

Decisions:
- One `sessionForResolvedApp` helper over inlining the guard four times, so the binding can't drift between handlers and the cross-tenant case uniformly reads as not-found.
- `defineRoute` ties a route's zod `schema` to the handler's `ctx.parsed` type via a conditional context type, so adoption is type-checked at the definition site. Parsing runs **after** auth so a malformed payload can't probe the auth gate. Made it opt-in: MCP/Slack keep bespoke parsing because their error contracts aren't a plain HTTP 400.
- The structural persistence-scoping recommendation (F11) is left to its own PR; this is the targeted handler-level fix plus the router cleanup.

Two commits:
1. `fix(agent-platform): bind chat session ownership to the resolved agent`
2. `refactor(agent-platform): centralize trigger payload parsing in the router`
