### PR TITLE
feat(agent-platform): approval detail panel with embedded session

### DIFF
--- a/products/agent_platform/packages/agent-chat/src/fixtures/approvals.ts
+++ b/products/agent_platform/packages/agent-chat/src/fixtures/approvals.ts
@@ -1,0 +1,203 @@
+/**
+ * Sample approval-gated tool calls for stories and mocked console reads.
+ *
+ * Shape mirrors the Django `AgentApprovalRequestApi` field set (see
+ * `products/agent_platform/services/agent-console/src/generated/
+ * agent-platform.api.schemas.ts`) so stories exercise the same apiClient
+ * mappers as production. Each fixture's `session_id` points at a real
+ * session fixture so the approval detail's Session tab renders the
+ * conversation that proposed the call.
+ */
+
+import { incidentTriager, releaseConcierge, weeklyDigest } from './agents'
+
+export type ApprovalStateFixture =
+    | 'queued'
+    | 'approving'
+    | 'dispatched'
+    | 'dispatched_failed'
+    | 'rejected'
+    | 'expired'
+
+export interface AgentApprovalRequestFixture {
+    id: string
+    session_id: string
+    application_id: string
+    team_id: number
+    revision_id: string
+    turn: number
+    tool_call_id: string
+    tool_name: string
+    proposed_args: Record<string, unknown>
+    decided_args: Record<string, unknown> | null
+    assistant_message: Record<string, unknown>
+    approver_scope: Record<string, unknown>
+    state: ApprovalStateFixture
+    decision_by: string | null
+    decision_at: string | null
+    decision_reason: string | null
+    dispatch_outcome: Record<string, unknown> | null
+    created_at: string
+    expires_at: string
+}
+
+/** Queued, editable — the agent wants to open a hotfix PR. Backs the Slack-triggered release session. */
+export const queuedPrApproval: AgentApprovalRequestFixture = {
+    id: '01998a01-3333-7000-8000-000000000001',
+    session_id: '01998a01-2222-7000-8000-000000000102', // releaseAwaitingSession
+    application_id: releaseConcierge.id,
+    team_id: 2,
+    revision_id: releaseConcierge.live_revision!,
+    turn: 1,
+    tool_call_id: 'fleet-call-1',
+    tool_name: 'github.pull_request_open',
+    proposed_args: { repo: 'posthog/posthog', base: 'release/2.40', head: 'hotfix/tz-2.40' },
+    decided_args: null,
+    assistant_message: {
+        role: 'assistant',
+        content: [
+            {
+                type: 'thinking',
+                thinking: 'The timezone fix is isolated to one module and has a test. Opening against the release branch is the right move, but pushing to a protected branch is gated — surfacing for approval.',
+            },
+            {
+                type: 'text',
+                text: 'Patch is ready. Opening a PR against `release/2.40` — needs your approval to push.',
+            },
+        ],
+    },
+    approver_scope: { approvers: ['session_owner'], allow_edit: true, allow_agent_approver: false },
+    state: 'queued',
+    decision_by: null,
+    decision_at: null,
+    decision_reason: null,
+    dispatch_outcome: null,
+    created_at: '2026-05-28T15:38:30Z',
+    expires_at: '2026-05-29T15:38:30Z',
+}
+
+/** Queued, NOT editable — a destructive call the spec dispatches verbatim. */
+export const queuedTeamDeleteApproval: AgentApprovalRequestFixture = {
+    id: '01998a01-3333-7000-8000-000000000002',
+    session_id: '01998a01-2222-7000-8000-000000000103', // triagerStreamingSession
+    application_id: incidentTriager.id,
+    team_id: 2,
+    revision_id: incidentTriager.live_revision!,
+    turn: 2,
+    tool_call_id: 'triage-call-7',
+    tool_name: '@posthog/feature-flag-disable',
+    proposed_args: { flag_key: 'new-ingest-path', reason: 'p99 regression in prod-eu' },
+    decided_args: null,
+    assistant_message: {
+        role: 'assistant',
+        content: [
+            {
+                type: 'text',
+                text: 'The new ingest path correlates with the p99 spike. I recommend disabling the `new-ingest-path` flag to roll back. This is gated — approve to apply.',
+            },
+        ],
+    },
+    approver_scope: { approvers: ['oncall'], allow_edit: false, allow_agent_approver: false },
+    state: 'queued',
+    decision_by: null,
+    decision_at: null,
+    decision_reason: null,
+    dispatch_outcome: null,
+    created_at: '2026-05-28T15:53:10Z',
+    expires_at: '2026-05-28T17:53:10Z',
+}
+
+/** Approved + dispatched successfully, with approver edits applied. */
+export const dispatchedApproval: AgentApprovalRequestFixture = {
+    id: '01998a01-3333-7000-8000-000000000003',
+    session_id: '01998a01-2222-7000-8000-000000000101', // releaseStreamingSession
+    application_id: releaseConcierge.id,
+    team_id: 2,
+    revision_id: releaseConcierge.live_revision!,
+    turn: 3,
+    tool_call_id: 'fleet-call-9',
+    tool_name: 'github.pull_request_merge',
+    proposed_args: { repo: 'posthog/posthog', pull_number: 41201, merge_method: 'squash' },
+    decided_args: { repo: 'posthog/posthog', pull_number: 41201, merge_method: 'rebase' },
+    assistant_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Checks are green. Ready to merge the v2.41 changelog PR.' }],
+    },
+    approver_scope: { approvers: ['session_owner'], allow_edit: true, allow_agent_approver: false },
+    state: 'dispatched',
+    decision_by: '01998a01-9999-7000-8000-0000000000a1',
+    decision_at: '2026-05-28T15:48:02Z',
+    decision_reason: 'Prefer rebase to keep release history linear.',
+    dispatch_outcome: { result: { merged: true, sha: 'd34db33fc0ffee1234567890abcdef0987654321' } },
+    created_at: '2026-05-28T15:47:30Z',
+    expires_at: '2026-05-28T17:47:30Z',
+}
+
+/** Approver said no. */
+export const rejectedApproval: AgentApprovalRequestFixture = {
+    id: '01998a01-3333-7000-8000-000000000004',
+    session_id: '01998a01-2222-7000-8000-0000000007d2', // weeklyDigest chat test run
+    application_id: weeklyDigest.id,
+    team_id: 2,
+    revision_id: weeklyDigest.live_revision!,
+    turn: 4,
+    tool_call_id: 'digest-call-3',
+    tool_name: '@posthog/slack-post-message',
+    proposed_args: { channel: '#product-eng', text: 'Draft digest — please review before Monday.' },
+    decided_args: null,
+    assistant_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Digest draft is ready. Posting to #product-eng for review.' }],
+    },
+    approver_scope: { approvers: ['session_owner'], allow_edit: true, allow_agent_approver: false },
+    state: 'rejected',
+    decision_by: '01998a01-9999-7000-8000-0000000000a1',
+    decision_at: '2026-05-28T16:02:11Z',
+    decision_reason: 'This is a test run — don’t post to the real channel.',
+    dispatch_outcome: null,
+    created_at: '2026-05-28T16:01:40Z',
+    expires_at: '2026-05-28T18:01:40Z',
+}
+
+/** Approved, but the tool threw when it ran. */
+export const dispatchedFailedApproval: AgentApprovalRequestFixture = {
+    id: '01998a01-3333-7000-8000-000000000005',
+    session_id: '01998a01-2222-7000-8000-0000000007d3', // weeklyDigest failed run
+    application_id: weeklyDigest.id,
+    team_id: 2,
+    revision_id: weeklyDigest.live_revision!,
+    turn: 2,
+    tool_call_id: 'digest-call-8',
+    tool_name: 'github.pull_request_open',
+    proposed_args: { repo: 'posthog/posthog', base: 'master', head: 'digest/skill-tweak' },
+    decided_args: null,
+    assistant_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Opening a PR with the updated digest skill.' }],
+    },
+    approver_scope: { approvers: ['session_owner'], allow_edit: true, allow_agent_approver: false },
+    state: 'dispatched_failed',
+    decision_by: '01998a01-9999-7000-8000-0000000000a1',
+    decision_at: '2026-05-28T16:20:05Z',
+    decision_reason: null,
+    dispatch_outcome: { error: 'GitHub API 422: head branch `digest/skill-tweak` does not exist.' },
+    created_at: '2026-05-28T16:19:50Z',
+    expires_at: '2026-05-28T18:19:50Z',
+}
+
+/** All approvals across the fleet, newest first. */
+export const fleetApprovals: AgentApprovalRequestFixture[] = [
+    queuedTeamDeleteApproval,
+    dispatchedFailedApproval,
+    rejectedApproval,
+    dispatchedApproval,
+    queuedPrApproval,
+]
+
+export function listApprovalsForAgentFixture(applicationId: string): AgentApprovalRequestFixture[] {
+    return fleetApprovals.filter((a) => a.application_id === applicationId)
+}
+
+export function getApprovalFixture(id: string): AgentApprovalRequestFixture | null {
+    return fleetApprovals.find((a) => a.id === id) ?? null
+}

--- a/products/agent_platform/packages/agent-chat/src/fixtures/index.ts
+++ b/products/agent_platform/packages/agent-chat/src/fixtures/index.ts
@@ -9,6 +9,7 @@
  */
 
 export * from './agents'
+export * from './approvals'
 export * from './bundles'
 export * from './logs'
 export * from './scripts'

--- a/products/agent_platform/services/agent-console/.storybook/mocks/handlers.ts
+++ b/products/agent_platform/services/agent-console/.storybook/mocks/handlers.ts
@@ -16,10 +16,13 @@ import type { Turn } from '@posthog/agent-chat'
 import {
     getAgentBySlugStore,
     getAgentStatsStore,
+    getApprovalStore,
     getBundleRawStore,
     getFleetStatsStore,
     getSessionStore,
+    listAgentApprovalsStore,
     listAgentsStore,
+    listFleetApprovalsStore,
     listLiveSessionsStore,
     listLogsForSessionStore,
     listRevisionsStore,
@@ -195,5 +198,36 @@ export const handlers = [
 
     http.get(`${PROJECT_PREFIX}/agent_fleet/live_sessions/`, () => {
         return HttpResponse.json({ results: listLiveSessionsStore() })
+    }),
+
+    /* Approvals — fleet inbox + per-agent tab + single-request detail.
+     * Mirrors the admin-only read surface in `backend/presentation/views.py`. */
+    http.get(`${PROJECT_PREFIX}/agent_fleet/approvals/`, () => {
+        return HttpResponse.json({ results: listFleetApprovalsStore() })
+    }),
+
+    http.get(`${PROJECT_PREFIX}/agent_applications/:slug/approvals/`, ({ params }) => {
+        const slug = params.slug as string
+        if (!getAgentBySlugStore(slug)) {
+            return HttpResponse.json({ error: 'not_found' }, { status: 404 })
+        }
+        return HttpResponse.json({ results: listAgentApprovalsStore(slug) })
+    }),
+
+    http.get(`${PROJECT_PREFIX}/agent_applications/:slug/approvals/:id/`, ({ params }) => {
+        const approval = getApprovalStore(params.slug as string, params.id as string)
+        if (!approval) {
+            return HttpResponse.json({ error: 'approval_not_found' }, { status: 404 })
+        }
+        return HttpResponse.json(approval)
+    }),
+
+    /* The one write the console issues. Mocked so the approve / reject flow
+     * completes in stories; the store is read-only, so a decided row keeps
+     * its fixture state on refetch (see the decided-state fixtures for those
+     * outcomes). Janitor flips the real row + writes the wake marker. */
+    http.post(`${PROJECT_PREFIX}/agent_applications/:slug/approvals/:id/decide/`, async ({ request }) => {
+        const body = (await request.json().catch(() => ({}))) as { decision?: string }
+        return HttpResponse.json({ ok: true, state: body.decision === 'reject' ? 'rejected' : 'approving' })
     }),
 ]

--- a/products/agent_platform/services/agent-console/.storybook/mocks/store.ts
+++ b/products/agent_platform/services/agent-console/.storybook/mocks/store.ts
@@ -19,7 +19,10 @@ import {
     agentsWithArchived,
     fleetLiveSessions,
     fleetStats,
+    fleetApprovals,
     getAgentStatsFixture,
+    getApprovalFixture,
+    listApprovalsForAgentFixture,
     listLogsForSessionFixture,
     listSessionsForAgentFixture,
     weeklyDigest,
@@ -28,6 +31,7 @@ import {
 } from '@posthog/agent-chat/fixtures'
 import type {
     AgentApplicationFixture,
+    AgentApprovalRequestFixture,
     AgentRevisionFixture,
     AgentStats,
     FleetStats,
@@ -101,6 +105,24 @@ export function getFleetStatsStore(): FleetStats {
 
 export function listLiveSessionsStore(): ChatSession[] {
     return fleetLiveSessions
+}
+
+export function listFleetApprovalsStore(): AgentApprovalRequestFixture[] {
+    return fleetApprovals
+}
+
+export function listAgentApprovalsStore(slug: string): AgentApprovalRequestFixture[] {
+    const agent = getAgentBySlugStore(slug)
+    return agent ? listApprovalsForAgentFixture(agent.id) : []
+}
+
+export function getApprovalStore(slug: string, id: string): AgentApprovalRequestFixture | null {
+    const agent = getAgentBySlugStore(slug)
+    if (!agent) {
+        return null
+    }
+    const approval = getApprovalFixture(id)
+    return approval && approval.application_id === agent.id ? approval : null
 }
 
 function baseBundleForApplication(applicationId: string): typeof weeklyDigestBundle {

--- a/products/agent_platform/services/agent-console/app/agents/[slug]/approvals/approvals-client.tsx
+++ b/products/agent_platform/services/agent-console/app/agents/[slug]/approvals/approvals-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useMemo } from 'react'
 
 import { useAgent } from '@/components/agent-context'
 import { ApprovalDetail } from '@/components/ApprovalDetail'
@@ -15,13 +16,29 @@ const POLL_MS = 10_000
 export function ApprovalsSegment(): React.ReactElement {
     const agent = useAgent()
     const teamId = useSessionTeamId()!
-    const [selectedId, setSelectedId] = useState<string | null>(null)
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const selectedId = searchParams?.get('request') ?? null
 
     useSetDockPage({ kind: 'agent', agent: { id: agent.id, name: agent.name, slug: agent.slug } })
 
     const approvals = useResource(() => listAgentApprovals(teamId, agent.slug), [teamId, agent.slug], {
         pollMs: POLL_MS,
     })
+
+    const select = useCallback(
+        (id: string | null) => {
+            const params = new URLSearchParams(searchParams?.toString() ?? '')
+            if (id) {
+                params.set('request', id)
+            } else {
+                params.delete('request')
+            }
+            const qs = params.toString()
+            router.push(`/agents/${agent.slug}/approvals${qs ? `?${qs}` : ''}`, { scroll: false })
+        },
+        [agent.slug, router, searchParams]
+    )
 
     const errorMessage = useMemo(() => {
         const e = approvals.error
@@ -40,37 +57,52 @@ export function ApprovalsSegment(): React.ReactElement {
     )
 
     const rows = approvals.data ?? []
+    const errorBanner = errorMessage ? (
+        <div className="shrink-0 rounded-md border border-destructive-foreground/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+            {errorMessage}
+        </div>
+    ) : null
+
+    const list = (
+        <ApprovalsList
+            approvals={rows}
+            agentsById={agentsById}
+            showAgentColumn={false}
+            selectedApprovalId={selectedId}
+            onOpenApproval={select}
+        />
+    )
+
+    // Nothing selected → list takes the whole centered column.
+    if (!selectedId) {
+        return (
+            <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 px-6 pb-6 pt-4">
+                {errorBanner}
+                {approvals.loading && rows.length === 0 ? (
+                    <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+                        Loading approvals…
+                    </div>
+                ) : (
+                    list
+                )}
+            </div>
+        )
+    }
 
     return (
-        <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 px-6 pb-6 pt-4">
-            {errorMessage ? (
-                <div className="rounded-md border border-destructive-foreground/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
-                    {errorMessage}
-                </div>
-            ) : null}
-            {approvals.loading && rows.length === 0 ? (
-                <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-                    Loading approvals…
-                </div>
-            ) : (
-                <ApprovalsList
-                    approvals={rows}
-                    agentsById={agentsById}
-                    showAgentColumn={false}
-                    selectedApprovalId={selectedId}
-                    onOpenApproval={setSelectedId}
+        <div className="grid h-full grid-cols-[minmax(280px,360px)_minmax(0,1fr)] divide-x divide-border">
+            <aside className="flex min-h-0 flex-col overflow-y-auto px-3 py-3">
+                {errorBanner}
+                {list}
+            </aside>
+            <main className="min-h-0 overflow-hidden">
+                <ApprovalDetail
+                    approvalId={selectedId}
+                    agent={{ id: agent.id, name: agent.name, slug: agent.slug }}
+                    onClose={() => select(null)}
+                    onDecided={() => approvals.reload()}
                 />
-            )}
-            <ApprovalDetail
-                approvalId={selectedId}
-                agentSlug={agent.slug}
-                agentName={agent.name}
-                onClose={() => setSelectedId(null)}
-                onDecided={() => {
-                    setSelectedId(null)
-                    approvals.reload()
-                }}
-            />
+            </main>
         </div>
     )
 }

--- a/products/agent_platform/services/agent-console/app/approvals/approvals-client.tsx
+++ b/products/agent_platform/services/agent-console/app/approvals/approvals-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useSearchParams } from 'next/navigation'
-import { useMemo } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useMemo } from 'react'
 
 import { useSetDockPage } from '@/components/dock-context'
 import { useSessionTeamId } from '@/components/session-context'
@@ -13,14 +13,30 @@ const POLL_MS = 10_000
 
 export function ApprovalsClient(): React.ReactElement {
     const teamId = useSessionTeamId()!
+    const router = useRouter()
+    const searchParams = useSearchParams()
     // Deep link from a gated tool call: `/approvals?request=<id>` opens that
     // approval's detail directly (the link the agent surfaces to the approver).
-    const requestId = useSearchParams()?.get('request') ?? null
+    const selectedId = searchParams?.get('request') ?? null
 
     useSetDockPage({ kind: 'agent-list' })
 
     const approvals = useResource(() => listFleetApprovals(teamId).catch(toApiError), [teamId], { pollMs: POLL_MS })
     const agents = useResource(() => listAgents(teamId).catch(() => []), [teamId])
+
+    const select = useCallback(
+        (id: string | null) => {
+            const params = new URLSearchParams(searchParams?.toString() ?? '')
+            if (id) {
+                params.set('request', id)
+            } else {
+                params.delete('request')
+            }
+            const qs = params.toString()
+            router.push(`/approvals${qs ? `?${qs}` : ''}`, { scroll: false })
+        },
+        [router, searchParams]
+    )
 
     const errorMessage = useMemo(() => {
         const e = approvals.error
@@ -40,7 +56,8 @@ export function ApprovalsClient(): React.ReactElement {
             loading={approvals.loading}
             error={errorMessage}
             onReload={approvals.reload}
-            initialSelectedId={requestId}
+            selectedId={selectedId}
+            onSelect={select}
         />
     )
 }

--- a/products/agent_platform/services/agent-console/src/components/ApprovalDetail.stories.tsx
+++ b/products/agent_platform/services/agent-console/src/components/ApprovalDetail.stories.tsx
@@ -1,0 +1,101 @@
+/**
+ * `<ApprovalDetail>` stories — the right pane of the approvals
+ * master-detail layout.
+ *
+ * The panel fetches the approval, its session, and its logs through
+ * `apiClient`, so each story wraps it in `<SessionProvider>` +
+ * `<SessionGate>` (resolves `teamId` from the mocked `/api/auth/me`) and
+ * relies on the MSW approval handlers in `.storybook/mocks/`. Switch to
+ * the **Session** tab to see the conversation that proposed the call.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import type { AgentApplicationFixture } from '@posthog/agent-chat/fixtures'
+import {
+    dispatchedApproval,
+    dispatchedFailedApproval,
+    incidentTriager,
+    queuedPrApproval,
+    queuedTeamDeleteApproval,
+    rejectedApproval,
+    releaseConcierge,
+    weeklyDigest,
+} from '@posthog/agent-chat/fixtures'
+
+import { SessionGate, SessionProvider } from '@/components/session-context'
+
+import { ApprovalDetail } from './ApprovalDetail'
+
+const toAgent = (a: AgentApplicationFixture): { id: string; name: string; slug: string } => ({
+    id: a.id,
+    name: a.name,
+    slug: a.slug,
+})
+
+const noop = (): void => undefined
+
+const meta: Meta<typeof ApprovalDetail> = {
+    title: 'Agent console components/Pages/Approval Detail',
+    component: ApprovalDetail,
+    parameters: { layout: 'fullscreen' },
+    decorators: [
+        (Story) => (
+            <SessionProvider>
+                <SessionGate>
+                    <div className="h-screen w-full max-w-3xl border-l border-border">
+                        <Story />
+                    </div>
+                </SessionGate>
+            </SessionProvider>
+        ),
+    ],
+}
+
+export default meta
+type Story = StoryObj<typeof ApprovalDetail>
+
+export const QueuedEditable: Story = {
+    args: {
+        approvalId: queuedPrApproval.id,
+        agent: toAgent(releaseConcierge),
+        onClose: noop,
+        onDecided: noop,
+    },
+}
+
+export const QueuedReadOnly: Story = {
+    args: {
+        approvalId: queuedTeamDeleteApproval.id,
+        agent: toAgent(incidentTriager),
+        onClose: noop,
+        onDecided: noop,
+    },
+}
+
+export const Dispatched: Story = {
+    args: {
+        approvalId: dispatchedApproval.id,
+        agent: toAgent(releaseConcierge),
+        onClose: noop,
+        onDecided: noop,
+    },
+}
+
+export const Rejected: Story = {
+    args: {
+        approvalId: rejectedApproval.id,
+        agent: toAgent(weeklyDigest),
+        onClose: noop,
+        onDecided: noop,
+    },
+}
+
+export const DispatchFailed: Story = {
+    args: {
+        approvalId: dispatchedFailedApproval.id,
+        agent: toAgent(weeklyDigest),
+        onClose: noop,
+        onDecided: noop,
+    },
+}

--- a/products/agent_platform/services/agent-console/src/components/ApprovalDetail.tsx
+++ b/products/agent_platform/services/agent-console/src/components/ApprovalDetail.tsx
@@ -1,174 +1,212 @@
 /**
- * `<ApprovalDetail />` — slide-out drawer rendering a single approval
- * request. Loaded lazily by id; parent owns open/close + which row is
- * selected.
+ * `<ApprovalDetail />` — embeddable detail panel for a single approval
+ * request. Lives in the right pane of the approvals master-detail layout
+ * (parent owns which row is selected via the `?request=` URL param).
  *
- * Decision controls only render when the row is still `queued`. The form
+ * Two tabs: **Approval** (model reasoning, proposed args, decision
+ * controls) and **Session** (the agent runtime session that proposed the
+ * gated call, rendered with the shared `<SessionDetail>` so the approver
+ * gets the full conversation + logs for context).
+ *
+ * Decision controls only render while the row is still `queued`. The form
  * disables submit while a request is in flight, surfaces server errors
  * inline, and on success calls `onDecided(state)` so the parent can
- * optimistically remove the row from the list.
+ * refetch the list. The panel stays open afterwards so the approver can
+ * watch the decided outcome (state, dispatch result) land via polling.
  */
 
-import { Loader2Icon, LockIcon } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { Loader2Icon, LockIcon, XIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
 
+import type { ChatSession } from '@posthog/agent-chat'
+import type { LogEntry } from '@posthog/agent-chat/fixtures'
 import {
     Badge,
     Button,
-    Drawer,
-    DrawerBackdrop,
-    DrawerClose,
-    DrawerContent,
-    DrawerDescription,
-    DrawerFooter,
-    DrawerHeader,
-    DrawerPortal,
-    DrawerTitle,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
     Textarea,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
 } from '@posthog/quill'
 
-import { ApiError, ApprovalRequest, decideApproval, DecideApprovalInput, getApproval } from '@/lib/apiClient'
+import { usePosthogBaseUrl, useSessionTeamId } from '@/components/session-context'
+import {
+    ApiError,
+    ApprovalRequest,
+    decideApproval,
+    DecideApprovalInput,
+    getApproval,
+    getSession,
+    listLogsForSession,
+} from '@/lib/apiClient'
+import { aiObservabilityTraceUrl } from '@/lib/posthogLinks'
+import { type ResourceState, useResource } from '@/lib/useResource'
+import { SessionDetail } from '@/screens/SessionDetail'
 
-import { useSessionTeamId } from './session-context'
+/** Sessions + approvals change while an agent is running, so the detail polls. */
+const POLL_MS = 10_000
+
+type Agent = { id: string; name: string; slug: string }
 
 export interface ApprovalDetailProps {
-    /** Closed when null; opens when set. */
+    /** Null renders nothing — the parent only mounts this when a row is selected. */
     approvalId: string | null
-    /** Used to build the API URL — every approval is scoped to one agent. */
-    agentSlug: string | null
-    /** Display name for the header. */
-    agentName?: string | null
+    /** The agent that owns this approval — used for the API URL and to hydrate its session. */
+    agent: Agent | null
+    /** Clears the host's `?request=` param. */
     onClose: () => void
-    /**
-     * Fires after a successful approve / reject so the parent list can
-     * remove the row optimistically and refetch.
-     */
+    /** Fires after a successful approve / reject so the parent list can refetch. */
     onDecided?: (next: 'approving' | 'rejected') => void
 }
 
 export function ApprovalDetail({
     approvalId,
-    agentSlug,
-    agentName,
+    agent,
     onClose,
     onDecided,
-}: ApprovalDetailProps): React.ReactElement {
-    return (
-        <Drawer open={approvalId !== null} onOpenChange={(open) => !open && onClose()}>
-            <DrawerPortal>
-                <DrawerBackdrop />
-                <DrawerContent className="!w-full !max-w-2xl">
-                    {approvalId && agentSlug ? (
-                        <DetailBody
-                            key={approvalId}
-                            approvalId={approvalId}
-                            agentSlug={agentSlug}
-                            agentName={agentName ?? null}
-                            onClose={onClose}
-                            onDecided={onDecided}
-                        />
-                    ) : null}
-                </DrawerContent>
-            </DrawerPortal>
-        </Drawer>
-    )
+}: ApprovalDetailProps): React.ReactElement | null {
+    if (!approvalId || !agent) {
+        return null
+    }
+    return <DetailBody key={approvalId} approvalId={approvalId} agent={agent} onClose={onClose} onDecided={onDecided} />
 }
 
 interface DetailBodyProps {
     approvalId: string
-    agentSlug: string
-    agentName: string | null
+    agent: Agent
     onClose: () => void
     onDecided?: (next: 'approving' | 'rejected') => void
 }
 
-function DetailBody({ approvalId, agentSlug, agentName, onClose, onDecided }: DetailBodyProps): React.ReactElement {
+function DetailBody({ approvalId, agent, onClose, onDecided }: DetailBodyProps): React.ReactElement {
     const teamId = useSessionTeamId()!
-    const [approval, setApproval] = useState<ApprovalRequest | null>(null)
-    const [loadError, setLoadError] = useState<string | null>(null)
 
-    useEffect(() => {
-        let cancelled = false
-        setApproval(null)
-        setLoadError(null)
-        ;(async () => {
-            try {
-                const row = await getApproval(teamId, agentSlug, approvalId)
-                if (!cancelled) {
-                    setApproval(row)
-                }
-            } catch (err) {
-                if (cancelled) {
-                    return
-                }
-                setLoadError(
-                    err instanceof ApiError && err.status === 404
-                        ? 'This approval no longer exists.'
-                        : err instanceof Error
-                          ? err.message
-                          : String(err)
-                )
-            }
-        })()
-        return () => {
-            cancelled = true
-        }
-    }, [teamId, agentSlug, approvalId])
+    const approvalRes = useResource(
+        () => getApproval(teamId, agent.slug, approvalId),
+        [teamId, agent.slug, approvalId],
+        { pollMs: POLL_MS }
+    )
+    const approval = approvalRes.data
+    const sessionId = approval?.session_id ?? null
 
-    if (loadError) {
+    const sessionRes = useResource(
+        () => (sessionId ? getSession(teamId, agent.slug, sessionId, agent).catch(() => null) : Promise.resolve(null)),
+        [teamId, agent.slug, sessionId, agent.id],
+        { pollMs: POLL_MS }
+    )
+    const logsRes = useResource(
+        () => (sessionId ? listLogsForSession(teamId, agent.slug, sessionId).catch(() => []) : Promise.resolve([])),
+        [teamId, agent.slug, sessionId],
+        { pollMs: POLL_MS }
+    )
+
+    if (approvalRes.error) {
+        const message =
+            approvalRes.error instanceof ApiError && approvalRes.error.status === 404
+                ? 'This approval no longer exists.'
+                : approvalRes.error.message
         return (
-            <>
-                <DrawerHeader>
-                    <DrawerTitle>Approval request</DrawerTitle>
-                    <DrawerDescription>Couldn't load this approval.</DrawerDescription>
-                </DrawerHeader>
-                <div className="px-6 py-4 text-sm text-destructive-foreground">{loadError}</div>
-                <DrawerFooter>
-                    <DrawerClose render={<Button variant="outline" type="button" onClick={onClose} />}>
-                        Close
-                    </DrawerClose>
-                </DrawerFooter>
-            </>
+            <PanelShell title="Approval request" onClose={onClose}>
+                <div className="px-4 py-4 text-sm text-destructive-foreground">{message}</div>
+            </PanelShell>
         )
     }
+
     if (!approval) {
         return (
-            <>
-                <DrawerHeader>
-                    <DrawerTitle>Loading approval…</DrawerTitle>
-                </DrawerHeader>
-                <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+            <PanelShell title="Loading approval…" onClose={onClose}>
+                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
                     <Loader2Icon className="h-4 w-4 animate-spin" />
                 </div>
-            </>
+            </PanelShell>
         )
     }
 
     return (
         <Loaded
             approval={approval}
-            agentSlug={agentSlug}
-            agentName={agentName}
+            agent={agent}
+            sessionState={sessionRes}
+            logs={logsRes.data ?? []}
             onClose={onClose}
             onDecided={onDecided}
+            reloadApproval={approvalRes.reload}
         />
+    )
+}
+
+/** Header chrome shared by the loading / error / loaded states. */
+function PanelShell({
+    title,
+    subtitle,
+    onClose,
+    children,
+}: {
+    title: React.ReactNode
+    subtitle?: React.ReactNode
+    onClose: () => void
+    children: React.ReactNode
+}): React.ReactElement {
+    return (
+        <div className="flex h-full min-h-0 flex-col">
+            <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2 text-sm">{title}</div>
+                    {subtitle ? <div className="mt-0.5 text-xs text-muted-foreground">{subtitle}</div> : null}
+                </div>
+                <Tooltip>
+                    <TooltipTrigger
+                        render={
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                aria-label="Close approval"
+                                className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                            >
+                                <XIcon className="h-4 w-4" />
+                            </button>
+                        }
+                    />
+                    <TooltipContent side="left">Close approval</TooltipContent>
+                </Tooltip>
+            </header>
+            {children}
+        </div>
     )
 }
 
 interface LoadedProps {
     approval: ApprovalRequest
-    agentSlug: string
-    agentName: string | null
+    agent: Agent
+    sessionState: ResourceState<ChatSession | null>
+    logs: LogEntry[]
     onClose: () => void
     onDecided?: (next: 'approving' | 'rejected') => void
+    reloadApproval: () => void
 }
 
-function Loaded({ approval, agentSlug, agentName, onClose, onDecided }: LoadedProps): React.ReactElement {
+type Pane = 'approval' | 'session'
+
+function Loaded({
+    approval,
+    agent,
+    sessionState,
+    logs,
+    onClose,
+    onDecided,
+    reloadApproval,
+}: LoadedProps): React.ReactElement {
     const teamId = useSessionTeamId()!
+    const posthogBaseUrl = usePosthogBaseUrl()
     const scope = approval.approver_scope as ApproverScope
     const allowEdit = scope?.allow_edit === true
     const isQueued = approval.state === 'queued'
 
+    const [pane, setPane] = useState<Pane>('approval')
     const [reason, setReason] = useState('')
     const [editMode, setEditMode] = useState(false)
     const [editedArgsText, setEditedArgsText] = useState<string>(() => JSON.stringify(approval.proposed_args, null, 2))
@@ -195,9 +233,10 @@ function Loaded({ approval, agentSlug, agentName, onClose, onDecided }: LoadedPr
         setSubmitting(decision)
         setServerError(null)
         try {
-            const res = await decideApproval(teamId, agentSlug, approval.id, body)
+            const res = await decideApproval(teamId, agent.slug, approval.id, body)
             onDecided?.(res.state)
-            onClose()
+            // Stay open and refetch so the approver sees the decided outcome land.
+            reloadApproval()
         } catch (err) {
             setServerError(err instanceof Error ? err.message : String(err))
         } finally {
@@ -205,144 +244,195 @@ function Loaded({ approval, agentSlug, agentName, onClose, onDecided }: LoadedPr
         }
     }
 
+    const sessionId = approval.session_id
+    const obsUrl = posthogBaseUrl && sessionId ? aiObservabilityTraceUrl(posthogBaseUrl, teamId, sessionId) : undefined
+
     return (
-        <>
-            <DrawerHeader>
-                <DrawerTitle className="flex items-center gap-2">
-                    <LockIcon className="h-4 w-4 text-muted-foreground" aria-hidden />
-                    <code className="font-mono text-sm">{approval.tool_name}</code>
-                    <StateBadge state={approval.state} />
-                </DrawerTitle>
-                <DrawerDescription>
-                    {agentName ? <span className="text-foreground">{agentName}</span> : null}
-                    {agentName ? <span className="px-1.5 text-muted-foreground/60">·</span> : null}
-                    <span>{relativeAge(approval.created_at)} ago</span>
-                    {isQueued ? (
-                        <>
-                            <span className="px-1.5 text-muted-foreground/60">·</span>
-                            <span>expires {relativeDelta(approval.expires_at)}</span>
-                        </>
-                    ) : null}
-                </DrawerDescription>
-            </DrawerHeader>
+        <div className="flex h-full min-h-0 flex-col">
+            <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2 text-sm">
+                        <LockIcon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <code className="truncate font-mono text-sm font-medium text-foreground">
+                            {approval.tool_name}
+                        </code>
+                        <StateBadge state={approval.state} />
+                    </div>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                        <span className="text-foreground">{agent.name}</span>
+                        <span className="px-1.5 text-muted-foreground/60">·</span>
+                        <span>{relativeAge(approval.created_at)} ago</span>
+                        {isQueued ? (
+                            <>
+                                <span className="px-1.5 text-muted-foreground/60">·</span>
+                                <span>expires {relativeDelta(approval.expires_at)}</span>
+                            </>
+                        ) : null}
+                    </div>
+                </div>
+                <Tooltip>
+                    <TooltipTrigger
+                        render={
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                aria-label="Close approval"
+                                className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                            >
+                                <XIcon className="h-4 w-4" />
+                            </button>
+                        }
+                    />
+                    <TooltipContent side="left">Close approval</TooltipContent>
+                </Tooltip>
+            </header>
 
-            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6 text-sm">
-                <AssistantSnapshot message={approval.assistant_message} />
+            <Tabs
+                value={pane}
+                onValueChange={(v) => setPane(v as Pane)}
+                className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden"
+            >
+                <div className="flex shrink-0 items-center border-b border-border px-4">
+                    <TabsList variant="line">
+                        <TabsTrigger value="approval">Approval</TabsTrigger>
+                        <TabsTrigger value="session">Session</TabsTrigger>
+                    </TabsList>
+                </div>
 
-                <Section title="Proposed arguments" hint="Frozen at intercept time.">
-                    <JsonView value={approval.proposed_args} />
-                </Section>
+                <TabsContent value="approval" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                    <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4 text-sm">
+                        <AssistantSnapshot message={approval.assistant_message} />
 
-                {!isQueued ? <DecidedFooter approval={approval} /> : null}
+                        <Section title="Proposed arguments" hint="Frozen at intercept time.">
+                            <JsonView value={approval.proposed_args} />
+                        </Section>
 
-                {isQueued ? (
-                    <Section title="Decision">
-                        <div className="space-y-3">
-                            {allowEdit ? (
-                                <div className="rounded-md border border-border bg-muted/20 p-3">
-                                    <label className="flex items-center gap-2 text-xs font-medium text-foreground">
-                                        <input
-                                            type="checkbox"
-                                            checked={editMode}
-                                            onChange={(e) => {
-                                                setEditMode(e.currentTarget.checked)
-                                                setArgsParseError(null)
-                                            }}
-                                            disabled={submitting !== null}
-                                        />
-                                        Approve with edits
-                                    </label>
-                                    {editMode ? (
-                                        <div className="mt-2 space-y-1.5">
-                                            <Textarea
-                                                value={editedArgsText}
-                                                onChange={(e) => {
-                                                    setEditedArgsText(e.currentTarget.value)
-                                                    setArgsParseError(null)
-                                                }}
-                                                rows={8}
-                                                spellCheck={false}
-                                                className="font-mono text-[0.75rem]"
-                                                disabled={submitting !== null}
-                                            />
-                                            <div className="flex items-center justify-between">
-                                                <Button
-                                                    type="button"
-                                                    variant="link-muted"
-                                                    size="sm"
-                                                    disabled={submitting !== null}
-                                                    onClick={() => {
-                                                        setEditedArgsText(
-                                                            JSON.stringify(approval.proposed_args, null, 2)
-                                                        )
+                        {!isQueued ? <DecidedFooter approval={approval} /> : null}
+
+                        {isQueued ? (
+                            <Section title="Decision">
+                                <div className="space-y-3">
+                                    {allowEdit ? (
+                                        <div className="rounded-md border border-border bg-muted/20 p-3">
+                                            <label className="flex items-center gap-2 text-xs font-medium text-foreground">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={editMode}
+                                                    onChange={(e) => {
+                                                        setEditMode(e.currentTarget.checked)
                                                         setArgsParseError(null)
                                                     }}
-                                                >
-                                                    Reset to proposed
-                                                </Button>
-                                                {argsParseError ? (
-                                                    <span className="text-[0.6875rem] text-destructive-foreground">
-                                                        {argsParseError}
-                                                    </span>
-                                                ) : null}
-                                            </div>
+                                                    disabled={submitting !== null}
+                                                />
+                                                Approve with edits
+                                            </label>
+                                            {editMode ? (
+                                                <div className="mt-2 space-y-1.5">
+                                                    <Textarea
+                                                        value={editedArgsText}
+                                                        onChange={(e) => {
+                                                            setEditedArgsText(e.currentTarget.value)
+                                                            setArgsParseError(null)
+                                                        }}
+                                                        rows={8}
+                                                        spellCheck={false}
+                                                        className="font-mono text-[0.75rem]"
+                                                        disabled={submitting !== null}
+                                                    />
+                                                    <div className="flex items-center justify-between">
+                                                        <Button
+                                                            type="button"
+                                                            variant="link-muted"
+                                                            size="sm"
+                                                            disabled={submitting !== null}
+                                                            onClick={() => {
+                                                                setEditedArgsText(
+                                                                    JSON.stringify(approval.proposed_args, null, 2)
+                                                                )
+                                                                setArgsParseError(null)
+                                                            }}
+                                                        >
+                                                            Reset to proposed
+                                                        </Button>
+                                                        {argsParseError ? (
+                                                            <span className="text-[0.6875rem] text-destructive-foreground">
+                                                                {argsParseError}
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
+                                                </div>
+                                            ) : null}
                                         </div>
+                                    ) : (
+                                        <p className="text-[0.6875rem] text-muted-foreground">
+                                            This tool's spec doesn't allow editing arguments — approval dispatches with
+                                            the model's exact args.
+                                        </p>
+                                    )}
+
+                                    <div className="space-y-1.5">
+                                        <label
+                                            className="text-xs font-medium text-foreground"
+                                            htmlFor="approval-reason"
+                                        >
+                                            Reason (optional)
+                                        </label>
+                                        <Textarea
+                                            id="approval-reason"
+                                            value={reason}
+                                            onChange={(e) => setReason(e.currentTarget.value)}
+                                            rows={2}
+                                            disabled={submitting !== null}
+                                            placeholder="Why are you approving / rejecting?"
+                                        />
+                                    </div>
+
+                                    {serverError ? (
+                                        <p className="text-xs text-destructive-foreground">{serverError}</p>
                                     ) : null}
                                 </div>
-                            ) : (
-                                <p className="text-[0.6875rem] text-muted-foreground">
-                                    This tool's spec doesn't allow editing arguments — approval dispatches with the
-                                    model's exact args.
-                                </p>
-                            )}
-
-                            <div className="space-y-1.5">
-                                <label className="text-xs font-medium text-foreground" htmlFor="approval-reason">
-                                    Reason (optional)
-                                </label>
-                                <Textarea
-                                    id="approval-reason"
-                                    value={reason}
-                                    onChange={(e) => setReason(e.currentTarget.value)}
-                                    rows={2}
-                                    disabled={submitting !== null}
-                                    placeholder="Why are you approving / rejecting?"
-                                />
-                            </div>
-
-                            {serverError ? <p className="text-xs text-destructive-foreground">{serverError}</p> : null}
-                        </div>
-                    </Section>
-                ) : null}
-            </div>
-
-            <DrawerFooter className="flex-row justify-between">
-                <DrawerClose render={<Button variant="outline" type="button" disabled={submitting !== null} />}>
-                    Close
-                </DrawerClose>
-                {isQueued ? (
-                    <div className="flex gap-2">
-                        <Button
-                            type="button"
-                            variant="outline"
-                            onClick={() => submit('reject')}
-                            disabled={submitting !== null}
-                            aria-busy={submitting === 'reject' ? 'true' : undefined}
-                        >
-                            {submitting === 'reject' ? 'Rejecting…' : 'Reject'}
-                        </Button>
-                        <Button
-                            type="button"
-                            onClick={() => submit('approve')}
-                            disabled={submitting !== null}
-                            aria-busy={submitting === 'approve' ? 'true' : undefined}
-                        >
-                            {submitting === 'approve' ? 'Approving…' : editMode ? 'Approve with edits' : 'Approve'}
-                        </Button>
+                            </Section>
+                        ) : null}
                     </div>
-                ) : null}
-            </DrawerFooter>
-        </>
+
+                    {isQueued ? (
+                        <div className="flex shrink-0 justify-end gap-2 border-t border-border px-4 py-3">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => submit('reject')}
+                                disabled={submitting !== null}
+                                aria-busy={submitting === 'reject' ? 'true' : undefined}
+                            >
+                                {submitting === 'reject' ? 'Rejecting…' : 'Reject'}
+                            </Button>
+                            <Button
+                                type="button"
+                                onClick={() => submit('approve')}
+                                disabled={submitting !== null}
+                                aria-busy={submitting === 'approve' ? 'true' : undefined}
+                            >
+                                {submitting === 'approve' ? 'Approving…' : editMode ? 'Approve with edits' : 'Approve'}
+                            </Button>
+                        </div>
+                    ) : null}
+                </TabsContent>
+
+                <TabsContent value="session" className="min-h-0 flex-1 overflow-hidden">
+                    {sessionState.data ? (
+                        <SessionDetail session={sessionState.data} logs={logs} aiObservabilityTraceUrl={obsUrl} />
+                    ) : sessionState.loading ? (
+                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                            <Loader2Icon className="h-4 w-4 animate-spin" />
+                        </div>
+                    ) : (
+                        <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+                            Couldn't load the session that proposed this call.
+                        </div>
+                    )}
+                </TabsContent>
+            </Tabs>
+        </div>
     )
 }
 

--- a/products/agent_platform/services/agent-console/src/components/ApprovalsList.stories.tsx
+++ b/products/agent_platform/services/agent-console/src/components/ApprovalsList.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { agents, fleetApprovals, releaseConcierge } from '@posthog/agent-chat/fixtures'
+
+import { type AgentLookup, ApprovalsList } from './ApprovalsList'
+
+const agentsById: AgentLookup = new Map(agents.map((a) => [a.id, { id: a.id, name: a.name, slug: a.slug }]))
+
+const meta: Meta<typeof ApprovalsList> = {
+    title: 'Agent console components/ApprovalsList',
+    component: ApprovalsList,
+    parameters: { layout: 'centered' },
+    decorators: [
+        (Story) => (
+            <div className="h-[640px] w-[860px]">
+                <Story />
+            </div>
+        ),
+    ],
+}
+
+export default meta
+type Story = StoryObj<typeof ApprovalsList>
+
+const onOpenApproval = (id: string): void => console.info('[mock] openApproval', id)
+
+export const Fleet: Story = {
+    args: { approvals: fleetApprovals, agentsById, showAgentColumn: true, onOpenApproval },
+}
+
+export const FleetWithSelection: Story = {
+    args: {
+        approvals: fleetApprovals,
+        agentsById,
+        showAgentColumn: true,
+        selectedApprovalId: fleetApprovals.find((a) => a.state === 'queued')?.id ?? null,
+        onOpenApproval,
+    },
+}
+
+export const PerAgent: Story = {
+    args: {
+        approvals: fleetApprovals.filter((a) => a.application_id === releaseConcierge.id),
+        agentsById: new Map([[releaseConcierge.id, releaseConcierge]]),
+        showAgentColumn: false,
+        onOpenApproval,
+    },
+}
+
+export const Empty: Story = {
+    args: { approvals: [], agentsById, showAgentColumn: true, onOpenApproval },
+}

--- a/products/agent_platform/services/agent-console/src/screens/Approvals.stories.tsx
+++ b/products/agent_platform/services/agent-console/src/screens/Approvals.stories.tsx
@@ -1,0 +1,69 @@
+/**
+ * `<Approvals>` stories — the fleet-wide approval inbox.
+ *
+ * The screen is presentation-only (selection is normally driven by the
+ * `?request=<id>` URL param); these stories wrap it in a tiny stateful
+ * harness so clicking a row opens the detail pane, mirroring the route
+ * client. The embedded `<ApprovalDetail>` fetches through `apiClient`, so
+ * the harness sits inside `<SessionProvider>` + `<SessionGate>` and relies
+ * on the MSW approval handlers in `.storybook/mocks/`.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { agents, fleetApprovals, queuedPrApproval } from '@posthog/agent-chat/fixtures'
+
+import { SessionGate, SessionProvider } from '@/components/session-context'
+
+import { Approvals, type ApprovalsProps } from './Approvals'
+
+type HarnessProps = Omit<ApprovalsProps, 'selectedId' | 'onSelect' | 'onReload'> & {
+    initialSelectedId?: string | null
+}
+
+function ApprovalsHarness({ initialSelectedId = null, ...rest }: HarnessProps): React.ReactElement {
+    const [selectedId, setSelectedId] = useState<string | null>(initialSelectedId)
+    return <Approvals {...rest} selectedId={selectedId} onSelect={setSelectedId} onReload={() => undefined} />
+}
+
+const meta: Meta<typeof ApprovalsHarness> = {
+    title: 'Agent console components/Pages/Approvals',
+    component: ApprovalsHarness,
+    parameters: { layout: 'fullscreen' },
+    decorators: [
+        (Story) => (
+            <SessionProvider>
+                <SessionGate>
+                    <div className="h-screen w-full">
+                        <Story />
+                    </div>
+                </SessionGate>
+            </SessionProvider>
+        ),
+    ],
+}
+
+export default meta
+type Story = StoryObj<typeof ApprovalsHarness>
+
+export const Inbox: Story = {
+    args: { approvals: fleetApprovals, agents, loading: false, error: null },
+}
+
+export const WithSelection: Story = {
+    args: { approvals: fleetApprovals, agents, loading: false, error: null, initialSelectedId: queuedPrApproval.id },
+}
+
+export const Empty: Story = {
+    args: { approvals: [], agents, loading: false, error: null },
+}
+
+export const AdminError: Story = {
+    args: {
+        approvals: [],
+        agents,
+        loading: false,
+        error: "Approvals are admin-only — your account doesn't have admin scope on this project.",
+    },
+}

--- a/products/agent_platform/services/agent-console/src/screens/Approvals.tsx
+++ b/products/agent_platform/services/agent-console/src/screens/Approvals.tsx
@@ -1,12 +1,14 @@
 /**
  * `<Approvals />` — fleet-wide approval inbox.
  *
- * Pure presentation: receives the list + agent lookup + drawer state from
- * the route client. Renders the page chrome and embeds `<ApprovalsList>`
- * + `<ApprovalDetail>`.
+ * Pure presentation: receives the list + agent lookup + selection from the
+ * route client (which owns the `?request=<id>` URL param). With nothing
+ * selected the list takes the full centered column; selecting a row splits
+ * into a master-detail grid (list on the left, `<ApprovalDetail>` on the
+ * right) mirroring the sessions tab.
  */
 
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import type { AgentApplicationFixture } from '@posthog/agent-chat/fixtures'
 
@@ -23,8 +25,10 @@ export interface ApprovalsProps {
     error: string | null
     /** Caller refetches the list after a successful decision. */
     onReload: () => void
-    /** Pre-select this approval on mount (deep link from `?request=<id>`). */
-    initialSelectedId?: string | null
+    /** Selected approval id, driven by the `?request=<id>` URL param. */
+    selectedId: string | null
+    /** Push / clear the `?request=<id>` URL param. */
+    onSelect: (id: string | null) => void
 }
 
 export function Approvals({
@@ -33,10 +37,9 @@ export function Approvals({
     loading,
     error,
     onReload,
-    initialSelectedId,
+    selectedId,
+    onSelect,
 }: ApprovalsProps): React.ReactElement {
-    const [selectedId, setSelectedId] = useState<string | null>(initialSelectedId ?? null)
-
     const agentsById = useMemo<AgentLookup>(() => {
         const m = new Map<string, { id: string; name: string; slug: string }>()
         for (const a of agents) {
@@ -51,47 +54,65 @@ export function Approvals({
     )
     const selectedAgent = selected ? (agentsById.get(selected.application_id) ?? null) : null
 
+    const header = (
+        <header className="flex shrink-0 items-end justify-between">
+            <div>
+                <h1 className="text-xl font-medium tracking-tight">Approvals</h1>
+                <p className="text-sm text-muted-foreground">
+                    Approval-gated tool calls across every agent in this project. Admin only.
+                </p>
+            </div>
+        </header>
+    )
+
+    const errorBanner = error ? (
+        <div className="shrink-0 rounded-md border border-destructive-foreground/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
+            {error}
+        </div>
+    ) : null
+
+    const list = (
+        <ApprovalsList
+            approvals={approvals}
+            agentsById={agentsById}
+            showAgentColumn
+            selectedApprovalId={selectedId}
+            onOpenApproval={onSelect}
+        />
+    )
+
+    // Nothing selected → list takes the whole centered column.
+    if (!selectedId) {
+        return (
+            <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 px-6 py-6">
+                {header}
+                {errorBanner}
+                {loading && approvals.length === 0 ? (
+                    <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+                        Loading approvals…
+                    </div>
+                ) : (
+                    list
+                )}
+            </div>
+        )
+    }
+
     return (
-        <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 px-6 py-6">
-            <header className="flex items-end justify-between">
-                <div>
-                    <h1 className="text-xl font-medium tracking-tight">Approvals</h1>
-                    <p className="text-sm text-muted-foreground">
-                        Approval-gated tool calls across every agent in this project. Admin only.
-                    </p>
-                </div>
-            </header>
-
-            {error ? (
-                <div className="rounded-md border border-destructive-foreground/30 bg-destructive/10 px-3 py-2 text-xs text-destructive-foreground">
-                    {error}
-                </div>
-            ) : null}
-
-            {loading && approvals.length === 0 ? (
-                <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-                    Loading approvals…
-                </div>
-            ) : (
-                <ApprovalsList
-                    approvals={approvals}
-                    agentsById={agentsById}
-                    showAgentColumn
-                    selectedApprovalId={selectedId}
-                    onOpenApproval={setSelectedId}
-                />
-            )}
-
-            <ApprovalDetail
-                approvalId={selectedId}
-                agentSlug={selectedAgent?.slug ?? null}
-                agentName={selectedAgent?.name ?? null}
-                onClose={() => setSelectedId(null)}
-                onDecided={() => {
-                    setSelectedId(null)
-                    onReload()
-                }}
-            />
+        <div className="flex h-full w-full flex-col gap-4 px-6 py-6">
+            {header}
+            {errorBanner}
+            <div className="grid min-h-0 flex-1 grid-cols-[minmax(280px,360px)_minmax(0,1fr)] divide-x divide-border overflow-hidden rounded-md border border-border">
+                <aside className="flex min-h-0 flex-col overflow-y-auto px-3 py-3">{list}</aside>
+                <main className="min-h-0 overflow-hidden">
+                    <ApprovalDetail
+                        approvalId={selectedId}
+                        agent={selectedAgent}
+                        onClose={() => onSelect(null)}
+                        onDecided={onReload}
+                    />
+                </main>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The agent-console approvals UI surfaced each approval-gated tool call in a slide-out drawer. The drawer overlaid the list, had no URL-addressable state, and showed the approval in isolation — an approver couldn't see the conversation that led the agent to propose the gated call, which is exactly the context needed to make a good decision.

## Changes

Replaces the drawer with a proper master-detail panel, mirroring how the sessions tab already works:

- **`ApprovalDetail`** is now an embeddable panel (no drawer chrome) with two tabs:
  - **Approval** — model reasoning, proposed args, and the decision controls (approve / reject, approve-with-edits, reason). The panel now stays open after a decision so the approver watches the dispatched/rejected outcome land via polling, instead of the drawer closing immediately.
  - **Session** — renders the agent runtime session that proposed the call by reusing the existing `SessionDetail` (conversation + logs), hydrated from the approval's `session_id`.
- Selection is driven by a `?request=<id>` URL param (bookmarkable) on both the **fleet** (`/approvals`) and **per-agent** (`/agents/<slug>/approvals`) surfaces. Nothing selected → centered list; selecting a row → list + detail grid.
- Adds approval **fixtures**, **MSW handlers**, and **Storybook stories** (`ApprovalsList`, `ApprovalDetail`, `Approvals`) covering every state — queued/editable, queued/read-only, dispatched, rejected, dispatch-failed — each linked to a real session fixture so the Session tab renders a conversation. This is the intended review surface.

No backend changes — purely the Next.js agent-console app plus shared fixtures.

## How did you test this code?

I'm an agent (Claude Code). I ran only automated checks — no manual browser testing:

- `tsc --noEmit` clean for `@posthog/agent-console` and `@posthog/agent-chat` (including a `.storybook`-inclusive pass for the mocks)
- `oxlint` clean (only pre-existing warnings in an unrelated file)
- `oxfmt` applied to all changed files
- `build-storybook` completes successfully — all stories, mocks, and imports bundle

To eyeball: `pnpm --filter @posthog/agent-console storybook` → "Agent console components / Pages / Approval Detail" and ".../Approvals".

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8) at Ben White's direction. The ask was to extend the approvals flow by removing the "rough" popup in favour of a detail view that can render the relevant session for context.

Two approval systems share the name in the repo; confirmed with the requester this targets the **agent-console** system (where approvals carry a `session_id`) and the chosen layout is a **master-detail panel** (not a separate route), to match the existing sessions tab.

Key decisions:
- Reused `SessionDetail` wholesale for the Session tab rather than duplicating its composition. This nests its Conversation/Logs tabs under the outer Approval/Session tabs — flagged for reviewer judgement vs. flattening to a single `Approval | Conversation | Logs` bar.
- Kept `getApproval` as the authoritative per-detail fetch (polling) rather than threading the list row through, and chained the session/logs fetch off the loaded approval's `session_id`.
- The Storybook decide POST mock returns success without mutating the read-only store; decided outcomes are shown via dedicated state fixtures.
