### PR TITLE
chore(ci): gate agent image build/deploy behind CD_DEPLOY_ENABLED

### DIFF
--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -14,6 +14,8 @@ on:
     push:
         branches:
             - 'master'
+            # Kept while the agent platform integrates on `ass` and deploys from
+            # it for testing. Drop at the master cutover (then deploy is master-only).
             - 'ass'
 
 concurrency:
@@ -72,7 +74,7 @@ jobs:
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.agent_files == 'true') ||
             github.event_name == 'merge_group' ||
             github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && needs.changes.outputs.agent_files == 'true')
+            (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && needs.changes.outputs.agent_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
         timeout-minutes: 30
         permissions:
@@ -140,7 +142,7 @@ jobs:
                   context: ${{ matrix.context }}
                   buildx-fallback: false
                   project: ${{ matrix.depot_project }}
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: ${{ matrix.dockerfile }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
@@ -262,7 +264,7 @@ jobs:
     deploy:
         name: Deploy ${{ matrix.image }}
         needs: build
-        if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && github.event_name == 'push'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && github.event_name == 'push'
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         # One dispatch per image, not per Helm release. The charts side keys


### PR DESCRIPTION
## Problem

`ci-agent-container.yml` always pushed its images (`push: true`) and dispatched a `commit_state_update` to `PostHog/charts` (a production deploy) gated **only** on a push to `master` or `ass`. `CD_DEPLOY_ENABLED` appeared nowhere and there was no `repository_owner` check — so there's no kill-switch, contrary to the repo's `gating-production-deploys` convention (every sibling image+deploy workflow gates on `repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'`). Threat-model finding F4.

## Changes

- **Build push step** now pushes on `pull_request` / `merge_group` (validation) or when `CD_DEPLOY_ENABLED` — so a master/`ass` push only pushes images when the deploy var is on.
- **Build job's push arm** and the **deploy job** both gate on `repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'`.
- **`ass` is intentionally kept** as a build/deploy trigger: the agent platform still integrates on `ass` and is deployed from it for testing. The gating now makes those `ass` deploys honour the same kill-switch (and shuts forks out). The `ass` refs should be dropped at the master cutover so deploy becomes master-only — noted in the commit.

PR validation for in-flight branches is unaffected (it runs via the `pull_request` trigger, whose `if` arm is unchanged).

## How did you test this code?

I'm an agent (Claude Code). CI-config change, no runtime test. Verified the workflow YAML parses; the gating expressions are copied verbatim from the sibling pattern (`cd-mcp-image.yml`, `ci-nodejs-container.yml`). actionlint wasn't available in the sandbox (offline), so this relies on the YAML parse + pattern match — worth an `actionlint` pass in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @benjackwhite, from threat-model finding F4. Followed the `gating-production-deploys` skill. Initial pass removed `ass` entirely (the threat-model's end state); per direction, kept `ass` as a trigger because the platform currently integrates and test-deploys from `ass` — the gating still applies, and dropping `ass` is deferred to the master cutover.
