### PR TITLE
fix(insights): refresh sql insight view on update without a result

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -315,6 +315,18 @@ describe('insightDataLogic', () => {
                 theInsightLogic.actions.setInsight({ query: q }, { overrideQuery: false })
             }).toNotHaveDispatchedActions(['setQuery'])
         })
+        it('re-runs the query when overriding without a result', async () => {
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ query: q }, { overrideQuery: true })
+            }).toDispatchActions(['setQuery', 'loadData'])
+        })
+        it('uses the handed-in result instead of re-running when one is provided', async () => {
+            await expectLogic(theInsightDataLogic, () => {
+                theInsightLogic.actions.setInsight({ query: q, result: [{ count: 1 }] }, { overrideQuery: true })
+            })
+                .toDispatchActions(['setQuery', 'setInsightData'])
+                .toNotHaveDispatchedActions(['loadData'])
+        })
     })
 
     describe('dashboard tile: cached insight with no chart data yet', () => {

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -297,6 +297,11 @@ export const insightDataLogic = kea<insightDataLogicType>([
 
             if (result) {
                 actions.setInsightData({ ...values.insightData, result })
+            } else if (query) {
+                // No precomputed result (e.g. a SQL editor PATCH response carries none) — re-run
+                // the query so the view doesn't keep rendering the pre-edit response.
+                const source = isInsightVizNode(query) || isDataVisualizationNode(query) ? query.source : query
+                actions.loadData(isHogQLQuery(source) ? 'force_blocking' : 'force_async')
             }
         },
         loadInsightSuccess: ({ insight }) => {


### PR DESCRIPTION
## Problem

When you edit an existing SQL insight in the SQL editor and click "Update insight", the view keeps showing the pre-edit results until you reload the page. The PATCH response for a query-based insight carries no computed `result`, and `insightDataLogic`'s `setInsight` listener only refreshed the displayed data when a `result` was present — so `dataNodeLogic`'s response (what the SQL viz renders) was never re-run.

## Changes

- In `insightDataLogic`'s `setInsight` listener, when the query is overridden but no `result` is handed in, re-run the query from source instead of leaving the stale response in place.
- Pick the load mode the same way `afterMount` does: `force_blocking` for HogQL sources, `force_async` otherwise.
- Add two tests: overriding without a result dispatches `loadData`; overriding with a result dispatches `setInsightData` and does not re-run.

## How did you test this code?

I'm an agent. I added and ran the `insightDataLogic` jest tests for the `setInsight` listener (the new "re-runs the query when overriding without a result" and "uses the handed-in result instead of re-running" cases, plus the existing block) — all pass. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The user asked me to review a prior branch's fix for this bug, which used a module-level `Map` to hand the editor's result across to the insight scene. Tracing the data flow showed the real root cause was the `setInsight` listener skipping the data refresh when no `result` was present — so the proper fix is a few lines in `insightDataLogic`, at the layer where the bug lives. We branched fresh off `origin/master` and dropped the cross-scene handoff entirely (a changed query is a clean server cache miss, and the editor's own run warms that cache, so the normal async load returns correct data on its own).