### PR TITLE
chore(toolbox-cli): fix import sort in telemetry.py

### DIFF
--- a/tools/infra-scripts/clitools/toolbox/telemetry.py
+++ b/tools/infra-scripts/clitools/toolbox/telemetry.py
@@ -81,7 +81,9 @@ def capture_invocation(distinct_id: str, properties: dict) -> None:
     try:
         # Imported lazily so a missing SDK degrades to a no-op instead of breaking
         # the import of this module. Install with `pip install -r requirements.txt`.
-        from posthog import Posthog  # type: ignore[import-not-found]  # noqa: PLC0415 — optional dep, kept off the import path
+        from posthog import (
+            Posthog,  # type: ignore[import-not-found]  # noqa: PLC0415 — optional dep, kept off the import path
+        )
 
         resolved_distinct_id = distinct_id or "unknown"
         client = Posthog(project_api_key=api_key, host=host)


### PR DESCRIPTION
## Problem

`ruff check .` (the repo-wide lint CI job) is failing on master with `I001 Import block is un-sorted or un-formatted` in `tools/infra-scripts/clitools/toolbox/telemetry.py`. This turns lint red for **every** open PR, since CI runs the PR merged with master.

The lazy `from posthog import Posthog` import (added in #63638) carries an inline `# type: ignore[import-not-found]` plus a justified `# noqa: PLC0415` comment, which pushes the line past the length limit — so ruff wants to reformat it.

## Changes

Applied ruff's autofix: wrap the single import in parentheses so the import block formats cleanly. No behavior change — purely the formatter's preferred layout. `ruff check .` is green afterward.

## How did you test this code?

I'm an agent (Claude Code, driven by @andrewm4894). Ran `ruff check .` locally on a branch off latest `origin/master`: fails before the change (the I001 above), passes after ("All checks passed!"). No runtime behavior is affected — it's an import-formatting-only change to a CLI telemetry helper.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @andrewm4894 hit this as a master-wide lint failure blocking an unrelated PR (#63912) and asked to clear it at the root.

Authored with Claude Code. Diagnosed that the failure was pre-existing on `origin/master` (not the unrelated signals PR whose CI surfaced it), branched from `origin/master`, applied `ruff check --fix`, and verified `ruff check .` is clean. Kept to the minimal autofix rather than restructuring the import or its noqa justification.
