### PR TITLE
fix(agent-platform): lock down custom-tool sandbox egress

### DIFF
--- a/products/agent_platform/services/agent-runner/src/config.ts
+++ b/products/agent_platform/services/agent-runner/src/config.ts
@@ -214,6 +214,13 @@ export const AgentRunnerConfigSchema = PlatformConfigSchema.extend({
         .describe(
             'Modal region pin (e.g. `us-east`, `eu-west`). Defaults to whatever `resolveRegion()` derives from `CLOUD_DEPLOYMENT` inside the Modal pool when unset.'
         ),
+    sandboxOutboundCidrAllowlist: z
+        .string()
+        .optional()
+        .transform((v): string[] => (v ? v.split(',').map((s) => s.trim()).filter(Boolean) : []))
+        .describe(
+            'Comma-separated CIDRs the Modal custom-tool sandbox may reach outbound. Empty (default) → the sandbox has NO outbound internet (Modal `block_network`). Custom tools compute and return; the runner makes any egress through smokescreen. Set only if a custom tool genuinely needs direct egress to a known range.'
+        ),
 })
 
 export type AgentRunnerConfig = z.infer<typeof AgentRunnerConfigSchema>
@@ -250,6 +257,7 @@ const ENV_KEY_MAP = extendEnvKeyMap<AgentRunnerConfig>(PLATFORM_ENV_KEY_MAP, {
     SANDBOX_HOST_IMAGE: 'sandboxHostImage',
     SANDBOX_DOCKER_IMAGE: 'sandboxDockerImage',
     SANDBOX_MODAL_IMAGE: 'sandboxModalImage',
+    SANDBOX_OUTBOUND_CIDR_ALLOWLIST: 'sandboxOutboundCidrAllowlist',
     MODAL_APP_NAME: 'modalAppName',
     MODAL_REGION: 'modalRegion',
 })

--- a/products/agent_platform/services/agent-runner/src/index.ts
+++ b/products/agent_platform/services/agent-runner/src/index.ts
@@ -273,6 +273,7 @@ async function main(): Promise<void> {
             sandboxModalImage: config.sandboxModalImage,
             modalAppName: config.modalAppName,
             modalRegion: config.modalRegion,
+            sandboxOutboundCidrAllowlist: config.sandboxOutboundCidrAllowlist,
         }),
         sandboxInstances: new PgSandboxInstanceStore(agentDb),
         broker: new SecretBroker(),

--- a/products/agent_platform/services/agent-sandbox-host/src/dispatch.js
+++ b/products/agent_platform/services/agent-sandbox-host/src/dispatch.js
@@ -21,8 +21,12 @@
  *   }
  *
  * `ctx` exposes:
- *   - secrets.ref(name)  → opaque nonce string the runner substitutes at
- *     egress (the sandbox never sees raw secret values).
+ *   - secrets.ref(name)  → opaque per-session nonce string. The raw secret
+ *     never enters the sandbox, and the sandbox has no outbound network
+ *     (block_network / --network=none), so a nonce cannot be exfiltrated.
+ *     NOTE: runner-side nonce→value substitution at egress is not yet wired —
+ *     a returned nonce won't resolve to the real secret today. Tools should
+ *     return values for the runner to act on, not attempt their own egress.
  *   - log(level, msg, meta?)
  *
  * Nonces are read from /workdir/nonces.json once at startup. Re-read on each

--- a/products/agent_platform/services/agent-shared/src/sandbox/sandbox-docker.ts
+++ b/products/agent_platform/services/agent-shared/src/sandbox/sandbox-docker.ts
@@ -134,7 +134,15 @@ export class DockerSandboxPool implements SandboxPool {
             'run',
             '-d',
             '--rm',
+            // Untrusted-ish author tool code. No network (custom tools compute +
+            // return; the runner egresses). Drop all caps, cap PIDs and memory
+            // so a runaway / fork-bomb tool can't exhaust the host. The /workdir
+            // bind mount stays writable (dispatch reads tools + writes results).
             '--network=none',
+            '--cap-drop=ALL',
+            '--security-opt=no-new-privileges',
+            '--pids-limit=512',
+            '--memory=512m',
             '-v',
             `${workDir}:/workdir`,
             this.image,

--- a/products/agent_platform/services/agent-shared/src/sandbox/sandbox-modal-unit.test.ts
+++ b/products/agent_platform/services/agent-shared/src/sandbox/sandbox-modal-unit.test.ts
@@ -12,7 +12,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AcquireOpts } from './sandbox'
-import { ModalSandboxPool, resolveRegion } from './sandbox-modal'
+import { ModalSandboxPool, resolveEgressOpts, resolveRegion } from './sandbox-modal'
 
 const ACQUIRE_INPUT: AcquireOpts = {
     sessionId: 'unit-test-session',
@@ -175,5 +175,51 @@ describe('ModalSandboxPool: client-init failure recovery', () => {
         const sandbox = await pool.acquireForSession(ACQUIRE_INPUT)
         expect(sandbox.providerSandboxId).toBe('sb-unit-test-handle')
         expect(clientCtor).toHaveBeenCalledTimes(2)
+    })
+
+    it('resolveEgressOpts default-denies, allowlists when CIDRs are given', () => {
+        // No allowlist → block all outbound (the secure default).
+        expect(resolveEgressOpts()).toEqual({ blockNetwork: true })
+        expect(resolveEgressOpts([])).toEqual({ blockNetwork: true })
+        // Allowlist → pass it through, and DON'T also set blockNetwork (Modal
+        // rejects the two together).
+        expect(resolveEgressOpts(['10.0.0.0/8', '192.168.0.0/16'])).toEqual({
+            outboundCidrAllowlist: ['10.0.0.0/8', '192.168.0.0/16'],
+        })
+    })
+
+    async function captureCreateOpts(poolOpts: { outboundCidrAllowlist?: string[] }): Promise<Record<string, unknown>> {
+        const createMock = vi.fn().mockResolvedValue({
+            sandboxId: 'sb-egress-test',
+            filesystem: {
+                makeDirectory: vi.fn().mockResolvedValue(undefined),
+                writeText: vi.fn().mockResolvedValue(undefined),
+            },
+            poll: vi.fn().mockResolvedValue(null),
+            terminate: vi.fn().mockResolvedValue(undefined),
+        })
+        vi.doMock('modal', () => ({
+            ModalClient: vi.fn(() => ({
+                apps: { fromName: vi.fn().mockResolvedValue({}) },
+                images: { fromRegistry: vi.fn().mockReturnValue({}) },
+                sandboxes: { create: createMock },
+            })),
+        }))
+        const pool = new ModalSandboxPool({ appName: 'unit-test-app', ...poolOpts })
+        await pool.acquireForSession(ACQUIRE_INPUT)
+        // create(app, image, opts) — opts is the third arg.
+        return createMock.mock.calls[0][2] as Record<string, unknown>
+    }
+
+    it('sandboxes.create blocks the network by default (no allowlist)', async () => {
+        const opts = await captureCreateOpts({})
+        expect(opts.blockNetwork).toBe(true)
+        expect(opts).not.toHaveProperty('outboundCidrAllowlist')
+    })
+
+    it('sandboxes.create uses the configured CIDR allowlist instead of blocking', async () => {
+        const opts = await captureCreateOpts({ outboundCidrAllowlist: ['10.1.0.0/16'] })
+        expect(opts.outboundCidrAllowlist).toEqual(['10.1.0.0/16'])
+        expect(opts).not.toHaveProperty('blockNetwork')
     })
 })

--- a/products/agent_platform/services/agent-shared/src/sandbox/sandbox-modal.ts
+++ b/products/agent_platform/services/agent-shared/src/sandbox/sandbox-modal.ts
@@ -26,6 +26,14 @@
  * The Modal sandbox idles waiting for `exec()` calls — no foreground command
  * is set. `timeoutMs` upper-bounds the session lifetime so a wedged session
  * doesn't leak compute.
+ *
+ * Egress: the sandbox runs untrusted-ish author-supplied tool code, which by
+ * design computes and returns — it does not reach out (the runner makes any
+ * outbound call, through smokescreen). So we default-deny the sandbox's
+ * outbound internet (`blockNetwork`), closing the open-egress exfil vector. An
+ * operator can open specific CIDRs via `outboundCidrAllowlist` if a custom tool
+ * ever genuinely needs direct egress. Modal's control plane (exec / filesystem)
+ * is unaffected — that isn't the sandbox's own internet egress.
  */
 
 import type { App, Image, ModalClient as ModalClientType, Sandbox as ModalSandboxHandle } from 'modal'
@@ -100,6 +108,27 @@ interface ModalSandboxPoolOpts {
      * unset. Default 512.
      */
     defaultMemoryMiB?: number
+    /**
+     * CIDRs the sandbox is allowed to reach outbound. Empty / unset →
+     * `blockNetwork: true` (the secure default — see the module docstring).
+     * Set only to open specific egress for a custom-tool use case.
+     */
+    outboundCidrAllowlist?: string[]
+}
+
+/**
+ * The Modal egress policy for the sandbox. Default-deny (`blockNetwork`) unless
+ * an operator supplied a CIDR allowlist. `blockNetwork` and `outboundCidrAllowlist`
+ * are mutually exclusive in the Modal SDK, so this returns exactly one.
+ * Exported for unit tests.
+ */
+export function resolveEgressOpts(
+    outboundCidrAllowlist?: string[]
+): { blockNetwork: true } | { outboundCidrAllowlist: string[] } {
+    if (outboundCidrAllowlist && outboundCidrAllowlist.length > 0) {
+        return { outboundCidrAllowlist }
+    }
+    return { blockNetwork: true }
 }
 
 interface ModalSandboxState {
@@ -255,6 +284,8 @@ export class ModalSandboxPool implements SandboxPool {
                 cpuLimit: cpu,
                 memoryMiB,
                 memoryLimitMiB: memoryMiB,
+                // Default-deny outbound internet (or the configured allowlist).
+                ...resolveEgressOpts(this.opts.outboundCidrAllowlist),
                 tags: {
                     posthog_session_id: opts.sessionId,
                     posthog_team_id: String(opts.teamId),

--- a/products/agent_platform/services/agent-shared/src/sandbox/sandbox-selector.ts
+++ b/products/agent_platform/services/agent-shared/src/sandbox/sandbox-selector.ts
@@ -29,6 +29,8 @@ export interface SandboxSelectionConfig {
     modalAppName?: string
     /** Modal region pin (e.g. `us-east`, `eu-west`). */
     modalRegion?: string
+    /** CIDRs the Modal sandbox may reach outbound. Empty → no egress (block_network). */
+    sandboxOutboundCidrAllowlist?: string[]
 }
 
 export function selectSandboxPool(config: SandboxSelectionConfig): SandboxPool {
@@ -49,6 +51,7 @@ export function selectSandboxPool(config: SandboxSelectionConfig): SandboxPool {
                 appName: config.modalAppName,
                 image: resolveImage(config.sandboxModalImage),
                 region: config.modalRegion,
+                outboundCidrAllowlist: config.sandboxOutboundCidrAllowlist,
             })
     }
 }

--- a/products/agent_platform/services/agent-shared/src/sandbox/secret-broker.ts
+++ b/products/agent_platform/services/agent-shared/src/sandbox/secret-broker.ts
@@ -1,8 +1,14 @@
 /**
  * Per-session nonce broker. Custom tools receive opaque nonces, never raw
- * secret values. The sandbox runtime substitutes nonces back to values when
- * the tool actually reaches out — handled inside the Modal/Docker boundary
- * in prod, and via `ctx.secrets.value(name)` in the in-process pool.
+ * secret values — the secret stays in the runner.
+ *
+ * `substitute`/`scrub` are the intended egress seam (swap a nonce back to its
+ * value when the *runner* makes an outbound call on a tool's behalf), but that
+ * seam is NOT wired yet — they're currently unused. Until it is, a nonce never
+ * resolves to its secret outside this process, and the sandbox is run with no
+ * outbound network (Modal `block_network` / Docker `--network=none`), so a
+ * nonce can't leave the sandbox either. The in-process pool resolves nonces via
+ * `ctx.secrets.value(name)` as a test-only escape hatch.
  *
  * Lifetime is session-scoped: nonces expire when the sandbox is released.
  */


### PR DESCRIPTION
## Problem

The Modal sandbox that runs author-supplied **custom-tool code** was created with no egress restriction — Modal sandboxes default to full outbound internet — so untrusted-ish code had open network access (SSRF to internal services / cloud IMDS, free data exfil). The documented safeguard — opaque secret *nonces* "substituted at egress" — was never actually wired (`SecretBroker.substitute`/`scrub` are unused), so it offered no protection. Threat-model finding **F3** (HIGH).

## Changes

Custom tools are designed to **compute and return** — the runner makes any outbound call on their behalf (through smokescreen). So the sandbox needs no direct egress, and we default-deny it:

- **Modal pool** (`sandbox-modal.ts`): `resolveEgressOpts` returns `blockNetwork: true` by default, or `outboundCidrAllowlist` when CIDRs are configured. Plumbed runner config → `selectSandboxPool` → pool. New `SANDBOX_OUTBOUND_CIDR_ALLOWLIST` (comma-separated; empty = no egress). Modal's control plane (exec / filesystem) is **not** the sandbox's own internet egress, so it's unaffected.
- **Docker pool** (`sandbox-docker.ts`, local dev — already `--network=none`): hardened with `--cap-drop=ALL`, `--security-opt=no-new-privileges`, `--pids-limit=512`, `--memory=512m`.
- **Nonce docs corrected** (`dispatch.js`, `secret-broker.ts`): the raw secret never enters the sandbox; the runner-side nonce→value substitution seam is **not yet wired** (a returned nonce won't resolve to the secret today); and the sandbox now has no outbound network — so a nonce can't be exfiltrated regardless. No more claiming a safeguard that isn't there.

The Python `modal` SDK exposes a domain allowlist; the **node** SDK (used here) exposes CIDR allowlist / `blockNetwork`, hence the CIDR-based knob.

## How did you test this code?

I'm an agent (Claude Code). Automated, run locally:

- New unit tests (`sandbox-modal-unit.test.ts`): `resolveEgressOpts` default-denies / allowlists; and mocking the Modal client, `sandboxes.create` is called with `blockNetwork: true` by default and `outboundCidrAllowlist` when configured (mutually exclusive).
- The **Docker pool e2e test actually launched a container with the new hardening flags and passed** — so `--cap-drop=ALL` / `--security-opt=no-new-privileges` / `--pids-limit` / `--memory` are validated against the real sandbox-host image.
- `typescript:check` + `oxlint` clean on `agent-shared` and `agent-runner`; runner config tests green (incl. the new env var).

⚠️ **Not validated against real Modal** (no creds in the sandbox): the `blockNetwork: true` default is unit-validated at the `create`-args level. Worth a one-off real-Modal smoke test that exec/filesystem still work under `blockNetwork` before relying on it in prod (it should — that's control-plane, not sandbox egress). If anything regresses, set `SANDBOX_OUTBOUND_CIDR_ALLOWLIST` as an escape hatch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @benjackwhite, from threat-model finding F3.

Decisions:
- **Default-deny, not configurable-default-open.** The threat model wants default-deny and the custom-tool model (compute + return; runner egresses) means the sandbox legitimately needs no outbound — confirmed by the custom-tool test, which returns a value rather than fetching. CIDR allowlist is the escape hatch.
- **CIDR, not domain allowlist** — that's what the node `modal` SDK supports (the Python SDK's domain allowlist isn't available here).
- **Did not wire the nonce egress-substitution seam** — that's a feature, not a security fix; instead corrected the docs so nothing claims a safeguard that doesn't exist, and the egress block makes the exfil vector moot regardless.
- Flagged the real-Modal validation gap rather than asserting prod-readiness I couldn't verify.
