### PR TITLE
chore(ci): add PR freshness check with per-PR staleness budgets

### DIFF
--- a/.github/workflows/ci-pr-freshness.yml
+++ b/.github/workflows/ci-pr-freshness.yml
@@ -46,9 +46,14 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
 
             - name: Checkout freshness tool
+              # Always run the tool from master — hardcoded so a pull_request from
+              # a branch can't supply a tampered freshness.py that exfiltrates the
+              # app token / Anthropic key. The tool acts on PRs via the API, so it
+              # never needs the PR branch's working tree.
               if: steps.app-token.outputs.token != ''
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  ref: master
                   sparse-checkout: tools/pr-freshness
                   sparse-checkout-cone-mode: false
 
@@ -69,4 +74,11 @@ jobs:
                   # freshness falls back to a flat default budget — no hard dep.
                   ANTHROPIC_API_KEY: ${{ secrets.STAMPHOG_ANTHROPIC_API_KEY }}
                   PR_FRESHNESS_MODEL: claude-haiku-4-5
-              run: uv run tools/pr-freshness/freshness.py
+              run: |
+                  # Bootstrap guard: the tool is checked out from master, so until
+                  # this lands on master the file is absent — no-op rather than fail.
+                  if [ ! -f tools/pr-freshness/freshness.py ]; then
+                    echo "freshness tool not on master yet — skipping"
+                    exit 0
+                  fi
+                  uv run tools/pr-freshness/freshness.py

--- a/.github/workflows/ci-pr-freshness.yml
+++ b/.github/workflows/ci-pr-freshness.yml
@@ -1,0 +1,72 @@
+name: PR freshness
+
+# Stamps a "PR freshness" check on open PRs that turns red once a PR has gone
+# untouched for longer than a per-PR staleness budget. The scheduled run is what
+# makes the check go red as a PR ages without a push; the pull_request trigger
+# stamps a freshly-pushed PR immediately. The budget is assigned by a cheap LLM
+# from the PR's content and cached on the head SHA, so the cron does only clock
+# arithmetic. See tools/pr-freshness/freshness.py. Advisory until "PR freshness"
+# is added to branch protection's required checks.
+
+on:
+    schedule:
+        # Every 6h — at most 6h of slop on the staleness budgets.
+        - cron: '17 */6 * * *'
+    pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: pr-freshness-${{ github.event_name }}-${{ github.event.pull_request.number || 'all' }}
+    # Cancel superseded PR runs on a new push, but let a scheduled full sweep of
+    # all open PRs always run to completion.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    freshness:
+        name: Stamp PR freshness check
+        # Fork PRs can't mint the app token (secrets are withheld from
+        # fork-triggered runs); the scheduled run re-stamps them instead.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        steps:
+            - name: Get app token
+              id: app-token
+              # continue-on-error: stamping freshness is auxiliary — a transient
+              # token-mint failure must not redden this workflow. On failure the
+              # token output is empty and the steps below are skipped.
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
+
+            - name: Checkout freshness tool
+              if: steps.app-token.outputs.token != ''
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: tools/pr-freshness
+                  sparse-checkout-cone-mode: false
+
+            - name: Install uv
+              if: steps.app-token.outputs.token != ''
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: false
+
+            - name: Evaluate and stamp PR freshness
+              if: steps.app-token.outputs.token != ''
+              env:
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+                  REPO: ${{ github.repository }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  # Dedicated CI Anthropic key (shared with stamphog). If absent,
+                  # freshness falls back to a flat default budget — no hard dep.
+                  ANTHROPIC_API_KEY: ${{ secrets.STAMPHOG_ANTHROPIC_API_KEY }}
+                  PR_FRESHNESS_MODEL: claude-haiku-4-5
+              run: uv run tools/pr-freshness/freshness.py

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,13 +1,15 @@
 name: Script tests
 
-# Unit tests for the helper scripts in .github/scripts that gate CI decisions
-# (e.g. schema-impact narrowing). Without this, a regression in the narrowing
-# logic could silently skip affected product tests.
+# Unit tests for small CI helper scripts/tools (.github/scripts and select
+# tools/) that gate or drive CI decisions — e.g. schema-impact narrowing and the
+# PR freshness budget logic. Without this, a regression in those pure functions
+# would be invisible (the tools' own workflows don't run their unit tests).
 on:
     pull_request:
         paths:
             - .github/scripts/**
             - .github/workflows/ci-scripts.yml
+            - tools/pr-freshness/**
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -35,7 +37,7 @@ jobs:
                   python-version-file: pyproject.toml
 
             - name: Install pytest
-              run: python -m pip install --quiet pytest
+              run: python -m pip install --quiet pytest parameterized
 
             # `-c /dev/null` skips the repo pytest.ini (its --reuse-db addopt needs
             # pytest-django, which we don't install here).
@@ -51,3 +53,6 @@ jobs:
 
             - name: Rate-limit monitor tests (Node)
               run: node --test .github/scripts/monitor-github-rate-limit.test.js
+
+            - name: PR freshness tests (Python)
+              run: python -m pytest tools/pr-freshness/test_freshness.py -v -c /dev/null -p no:cacheprovider

--- a/tools/pr-freshness/freshness.py
+++ b/tools/pr-freshness/freshness.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["anthropic", "PyGithub"]
+# ///
+# ruff: noqa: T201
+"""Stamp a "PR freshness" check on open PRs, with a per-PR staleness budget.
+
+A green CI on a PR that is hundreds of commits behind a fast-moving master is a
+lie — it ran against a merge-base that no longer resembles master. This check
+turns red once a PR has gone untouched for longer than its budget, nudging the
+author to push/rebase (which re-runs CI against current code and clears it).
+
+The budget is *per PR*, not a flat threshold: a cheap LLM reads the file list,
+title, and description and estimates how coupled the PR is to fast-moving shared
+surface (a repo-wide linter touches cold files but couples to everything, so it
+rots fast; a docs tweak couples to nothing). That judgment is content-driven, so
+it only needs to run when the content changes — i.e. on a new head commit. We
+cache the result in the check's own summary marker, keyed to the head SHA, so a
+six-hourly cron just does clock arithmetic against the stored deadline and never
+re-invokes the model on an unchanged PR. A new push is a new SHA, which has no
+marker, so the budget (and the clock) are recomputed once and renewed.
+
+Fail open everywhere: no model, an outage, or a bad response falls back to a
+default budget rather than blocking a merge. Staleness is a soft safeguard.
+
+`classify_freshness`, `tier_to_hours`, the marker codec, and `build_prompt` are
+pure and unit-tested; everything touching GitHub or Anthropic is isolated below.
+"""
+
+import os
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+
+CHECK_NAME = "PR freshness"
+DEFAULT_MODEL = "claude-haiku-4-5"
+
+# Tier → hours of budget. The LLM picks a tier; the hours live here so the
+# thresholds can be tuned without re-prompting. `default` is the fail-open
+# budget used whenever the model is unavailable or unsure.
+TIER_HOURS = {
+    "hot": 2,
+    "normal": 12,
+    "isolated": 48,
+    "default": 48,
+}
+
+# Bound the prompt: paths and body are the signal, but a 500-file PR or a giant
+# description shouldn't blow up the token count.
+MAX_FILES_IN_PROMPT = 100
+MAX_BODY_CHARS = 2000
+
+_MARKER_RE = re.compile(
+    r"<!--\s*pr-freshness:v1\s+tier=(?P<tier>\S+)\s+budget_hours=(?P<hours>\d+)\s+deadline=(?P<deadline>\S+)\s*-->"
+)
+
+
+def tier_to_hours(tier: str) -> int:
+    return TIER_HOURS.get(tier, TIER_HOURS["default"])
+
+
+def parse_tier(text: str) -> str:
+    """Map a model reply to a known tier, defaulting if it doesn't name one."""
+    lowered = text.lower()
+    for tier in ("hot", "isolated", "normal"):
+        if tier in lowered:
+            return tier
+    return "default"
+
+
+def format_marker(tier: str, budget_hours: int, deadline_iso: str) -> str:
+    return f"<!-- pr-freshness:v1 tier={tier} budget_hours={budget_hours} deadline={deadline_iso} -->"
+
+
+def parse_marker(summary: str | None) -> dict | None:
+    """Read a previously-stamped budget back out of a check summary, if present."""
+    match = _MARKER_RE.search(summary or "")
+    if match is None:
+        return None
+    return {
+        "tier": match.group("tier"),
+        "budget_hours": int(match.group("hours")),
+        "deadline": match.group("deadline"),
+    }
+
+
+def classify_freshness(now: datetime, deadline: datetime, tier: str, budget_hours: int) -> tuple[str, str, str]:
+    """Pure verdict from the clock: red once now is past the stored deadline."""
+    if now > deadline:
+        overdue = int((now - deadline).total_seconds() // 3600)
+        return (
+            "failure",
+            f"❌ Stale — {overdue}h past its {budget_hours}h freshness budget (tier: {tier})",
+            "This PR hasn't moved in a while, so its green CI may have run against a merge-base now far "
+            "behind `master`. Push or rebase onto the latest `master` to re-run CI against current code "
+            "and clear this check.",
+        )
+    remaining = int((deadline - now).total_seconds() // 3600)
+    return (
+        "success",
+        f"✅ Fresh — ~{remaining}h of its {budget_hours}h freshness budget remain (tier: {tier})",
+        f"This PR is within its {budget_hours}h freshness budget. The budget reflects how coupled the PR "
+        "looks to fast-moving `master` surface; pushing or rebasing renews it.",
+    )
+
+
+def build_prompt(title: str, body: str, files: list[str]) -> tuple[str, str]:
+    """System + user messages for the one-shot tier classification."""
+    system = (
+        "You estimate how soon a GitHub pull request's passing CI becomes untrustworthy as its target "
+        "branch (`master`) keeps moving. The risk is coupling to fast-moving shared surface, NOT how "
+        "often the PR's own files change. Classify into exactly one tier:\n"
+        "- hot: couples to fast-moving shared surface — widely-imported modules, base classes, core "
+        "types, schemas, migrations, CI/build config, or repo-wide tooling like linters or codemods. "
+        "master is likely to change something it depends on soon.\n"
+        "- normal: a typical feature or bug fix scoped to one product area.\n"
+        "- isolated: docs, tests-only, generated files, or a self-contained corner unlikely to be "
+        "affected by master churn.\n"
+        "Reply with exactly one word: hot, normal, or isolated."
+    )
+    shown_files = files[:MAX_FILES_IN_PROMPT]
+    extra = len(files) - len(shown_files)
+    file_block = "\n".join(shown_files)
+    if extra > 0:
+        file_block += f"\n…and {extra} more files"
+    user = (
+        f"Title: {title}\n\n"
+        f"Description:\n{(body or '').strip()[:MAX_BODY_CHARS] or '(none)'}\n\n"
+        f"Changed files:\n{file_block or '(none)'}"
+    )
+    return system, user
+
+
+def classify_tier(title: str, body: str, files: list[str], *, model: str, api_key: str | None) -> str:
+    """One-shot LLM tier classification. Fails open to `default` on any problem."""
+    if not api_key:
+        return "default"
+    try:
+        import anthropic  # noqa: PLC0415 — heavy optional dep, only loaded when a budget must be computed
+
+        client = anthropic.Anthropic(api_key=api_key)
+        system, user = build_prompt(title, body, files)
+        response = client.messages.create(
+            model=model,
+            max_tokens=16,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        text = "".join(block.text for block in response.content if block.type == "text")
+        return parse_tier(text)
+    except Exception as exc:
+        print(f"[freshness] LLM classification failed, using default budget: {exc}", file=sys.stderr)
+        return "default"
+
+
+def _find_existing_check(repo, sha: str):
+    """The most recent freshness check on this head SHA, or None."""
+    check_runs = repo.get_commit(sha).get_check_runs(check_name=CHECK_NAME)
+    return next(iter(check_runs), None)
+
+
+def _upsert_check(repo, sha: str, existing, conclusion: str, title: str, summary: str) -> None:
+    output = {"title": title, "summary": summary}
+    completed_at = datetime.now(UTC)
+    if existing is not None:
+        existing.edit(status="completed", conclusion=conclusion, completed_at=completed_at, output=output)
+        return
+    repo.create_check_run(
+        name=CHECK_NAME,
+        head_sha=sha,
+        status="completed",
+        conclusion=conclusion,
+        completed_at=completed_at,
+        output=output,
+    )
+
+
+def _evaluate_pr(repo, pr, now: datetime, *, model: str, api_key: str | None) -> str:
+    sha = pr.head.sha
+    existing = _find_existing_check(repo, sha)
+
+    marker = parse_marker(existing.output.summary if existing and existing.output else None)
+    if marker is not None:
+        # Budget already computed for this head SHA — reuse it, no LLM call.
+        tier = marker["tier"]
+        budget_hours = marker["budget_hours"]
+        deadline = datetime.fromisoformat(marker["deadline"])
+    else:
+        files = [f.filename for f in pr.get_files()]
+        tier = classify_tier(pr.title or "", pr.body or "", files, model=model, api_key=api_key)
+        budget_hours = tier_to_hours(tier)
+        deadline = now + timedelta(hours=budget_hours)
+
+    conclusion, title, body = classify_freshness(now, deadline, tier, budget_hours)
+    summary = f"{format_marker(tier, budget_hours, deadline.isoformat())}\n\n{body}"
+    _upsert_check(repo, sha, existing, conclusion, title, summary)
+    return conclusion
+
+
+def main() -> None:
+    repo_name = os.environ["REPO"]
+    token = os.environ["GITHUB_TOKEN"]
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    model = os.environ.get("PR_FRESHNESS_MODEL", DEFAULT_MODEL)
+    pr_number = os.environ.get("PR_NUMBER")
+
+    from github import Auth, Github  # noqa: PLC0415 — heavy optional dep, kept off the import path for unit tests
+
+    github = Github(auth=Auth.Token(token))
+    repo = github.get_repo(repo_name)
+
+    if pr_number:
+        prs = [repo.get_pull(int(pr_number))]
+    else:
+        prs = list(repo.get_pulls(state="open"))
+
+    now = datetime.now(UTC)
+    stale = 0
+    for pr in prs:
+        if pr.draft:
+            print(f"#{pr.number}: draft — skipping")
+            continue
+        try:
+            conclusion = _evaluate_pr(repo, pr, now, model=model, api_key=api_key)
+        except Exception as exc:
+            # One bad PR must not abort the sweep of the rest.
+            print(f"#{pr.number}: error — {exc}", file=sys.stderr)
+            continue
+        if conclusion == "failure":
+            stale += 1
+        print(f"#{pr.number}: {conclusion}")
+
+    print(f"Done — {stale} stale PR(s) of {len(prs)} evaluated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pr-freshness/freshness.py
+++ b/tools/pr-freshness/freshness.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["anthropic", "PyGithub"]
+# dependencies = [
+#     "anthropic==0.109.2",
+#     "PyGithub==2.9.1",
+# ]
 # ///
 # ruff: noqa: T201
 """Stamp a "PR freshness" check on open PRs, with a per-PR staleness budget.

--- a/tools/pr-freshness/freshness.py
+++ b/tools/pr-freshness/freshness.py
@@ -54,6 +54,7 @@ MAX_BODY_CHARS = 2000
 _MARKER_RE = re.compile(
     r"<!--\s*pr-freshness:v1\s+tier=(?P<tier>\S+)\s+budget_hours=(?P<hours>\d+)\s+deadline=(?P<deadline>\S+)\s*-->"
 )
+_TIER_RE = re.compile(r"\b(hot|normal|isolated)\b")
 
 
 def tier_to_hours(tier: str) -> int:
@@ -61,12 +62,14 @@ def tier_to_hours(tier: str) -> int:
 
 
 def parse_tier(text: str) -> str:
-    """Map a model reply to a known tier, defaulting if it doesn't name one."""
-    lowered = text.lower()
-    for tier in ("hot", "isolated", "normal"):
-        if tier in lowered:
-            return tier
-    return "default"
+    """Map a model reply to a known tier, defaulting if it doesn't name exactly one.
+
+    Whole-word matching avoids incidental substrings, and a reply that names
+    several tiers (e.g. "not hot, normal") is treated as ambiguous → default
+    rather than silently picking one.
+    """
+    found = set(_TIER_RE.findall(text.lower()))
+    return found.pop() if len(found) == 1 else "default"
 
 
 def format_marker(tier: str, budget_hours: int, deadline_iso: str) -> str:
@@ -74,14 +77,23 @@ def format_marker(tier: str, budget_hours: int, deadline_iso: str) -> str:
 
 
 def parse_marker(summary: str | None) -> dict | None:
-    """Read a previously-stamped budget back out of a check summary, if present."""
+    """Read a previously-stamped budget back out of a check summary.
+
+    Returns None for an absent *or* malformed marker (older format, unparseable
+    deadline) so the caller recomputes the budget rather than skipping the PR on
+    a bad marker.
+    """
     match = _MARKER_RE.search(summary or "")
     if match is None:
+        return None
+    try:
+        deadline = datetime.fromisoformat(match.group("deadline"))
+    except ValueError:
         return None
     return {
         "tier": match.group("tier"),
         "budget_hours": int(match.group("hours")),
-        "deadline": match.group("deadline"),
+        "deadline": deadline,
     }
 
 
@@ -185,7 +197,7 @@ def _evaluate_pr(repo, pr, now: datetime, *, model: str, api_key: str | None) ->
         # Budget already computed for this head SHA — reuse it, no LLM call.
         tier = marker["tier"]
         budget_hours = marker["budget_hours"]
-        deadline = datetime.fromisoformat(marker["deadline"])
+        deadline = marker["deadline"]
     else:
         files = [f.filename for f in pr.get_files()]
         tier = classify_tier(pr.title or "", pr.body or "", files, model=model, api_key=api_key)
@@ -210,14 +222,13 @@ def main() -> None:
     github = Github(auth=Auth.Token(token))
     repo = github.get_repo(repo_name)
 
-    if pr_number:
-        prs = [repo.get_pull(int(pr_number))]
-    else:
-        prs = list(repo.get_pulls(state="open"))
+    # Iterate the paginated list lazily — don't materialize every open PR up front.
+    prs = [repo.get_pull(int(pr_number))] if pr_number else repo.get_pulls(state="open")
 
     now = datetime.now(UTC)
-    stale = 0
+    seen = evaluated = stale = 0
     for pr in prs:
+        seen += 1
         if pr.draft:
             print(f"#{pr.number}: draft — skipping")
             continue
@@ -227,11 +238,12 @@ def main() -> None:
             # One bad PR must not abort the sweep of the rest.
             print(f"#{pr.number}: error — {exc}", file=sys.stderr)
             continue
+        evaluated += 1
         if conclusion == "failure":
             stale += 1
         print(f"#{pr.number}: {conclusion}")
 
-    print(f"Done — {stale} stale PR(s) of {len(prs)} evaluated")
+    print(f"Done — {stale} stale of {evaluated} evaluated ({seen} open PR(s) seen)")
 
 
 if __name__ == "__main__":

--- a/tools/pr-freshness/test_freshness.py
+++ b/tools/pr-freshness/test_freshness.py
@@ -1,0 +1,74 @@
+from datetime import UTC, datetime, timedelta
+
+from freshness import build_prompt, classify_freshness, format_marker, parse_marker, parse_tier, tier_to_hours
+from parameterized import parameterized
+
+NOW = datetime(2026, 6, 16, 12, 0, 0, tzinfo=UTC)
+
+
+@parameterized.expand(
+    [
+        ("hot", 2),
+        ("normal", 12),
+        ("isolated", 48),
+        ("default", 48),
+        ("nonsense", 48),
+    ]
+)
+def test_tier_to_hours(tier, expected):
+    assert tier_to_hours(tier) == expected
+
+
+@parameterized.expand(
+    [
+        ("bare word", "normal", "normal"),
+        ("uppercase", "HOT", "hot"),
+        ("with reasoning", "I'd say isolated since it's docs", "isolated"),
+        ("unknown", "maybe medium?", "default"),
+        ("empty", "", "default"),
+    ]
+)
+def test_parse_tier(_name, text, expected):
+    assert parse_tier(text) == expected
+
+
+def test_marker_roundtrip():
+    deadline = "2026-06-18T08:00:00+00:00"
+    marker = format_marker("normal", 48, deadline)
+    parsed = parse_marker(f"some summary text\n{marker}\nmore text")
+    assert parsed == {"tier": "normal", "budget_hours": 48, "deadline": deadline}
+
+
+def test_parse_marker_absent():
+    assert parse_marker("no marker here") is None
+    assert parse_marker(None) is None
+
+
+@parameterized.expand(
+    [
+        ("within budget", 10, "success"),
+        ("just inside", 1, "success"),
+        ("just past", -1, "failure"),
+        ("long overdue", -200, "failure"),
+    ]
+)
+def test_classify_freshness(_name, hours_until_deadline, expected_conclusion):
+    deadline = NOW + timedelta(hours=hours_until_deadline)
+    conclusion, title, _summary = classify_freshness(NOW, deadline, "normal", 48)
+    assert conclusion == expected_conclusion
+    assert "48h" in title
+
+
+def test_build_prompt_includes_signal():
+    system, user = build_prompt("Add repo-wide linter", "Catches every nuance on master", ["tools/lint.py"])
+    assert "hot" in system and "isolated" in system
+    assert "Add repo-wide linter" in user
+    assert "tools/lint.py" in user
+
+
+def test_build_prompt_truncates_file_list():
+    files = [f"src/file_{i}.py" for i in range(150)]
+    _system, user = build_prompt("title", "body", files)
+    assert "src/file_0.py" in user
+    assert "and 50 more files" in user
+    assert "src/file_149.py" not in user

--- a/tools/pr-freshness/test_freshness.py
+++ b/tools/pr-freshness/test_freshness.py
@@ -24,6 +24,7 @@ def test_tier_to_hours(tier, expected):
         ("bare word", "normal", "normal"),
         ("uppercase", "HOT", "hot"),
         ("with reasoning", "I'd say isolated since it's docs", "isolated"),
+        ("ambiguous multiple tiers", "not hot, normal", "default"),
         ("unknown", "maybe medium?", "default"),
         ("empty", "", "default"),
     ]
@@ -32,16 +33,28 @@ def test_parse_tier(_name, text, expected):
     assert parse_tier(text) == expected
 
 
-def test_marker_roundtrip():
-    deadline = "2026-06-18T08:00:00+00:00"
-    marker = format_marker("normal", 48, deadline)
-    parsed = parse_marker(f"some summary text\n{marker}\nmore text")
-    assert parsed == {"tier": "normal", "budget_hours": 48, "deadline": deadline}
+@parameterized.expand(
+    [
+        ("hot", 2, "2026-06-18T08:00:00+00:00"),
+        ("normal", 12, "2026-06-17T00:00:00+00:00"),
+        ("isolated", 48, "2026-06-20T12:00:00+00:00"),
+    ]
+)
+def test_marker_roundtrip(tier, hours, deadline_iso):
+    parsed = parse_marker(f"some summary text\n{format_marker(tier, hours, deadline_iso)}\nmore text")
+    assert parsed == {"tier": tier, "budget_hours": hours, "deadline": datetime.fromisoformat(deadline_iso)}
 
 
-def test_parse_marker_absent():
-    assert parse_marker("no marker here") is None
-    assert parse_marker(None) is None
+@parameterized.expand(
+    [
+        ("no marker", "no marker here"),
+        ("none", None),
+        ("empty", ""),
+        ("malformed deadline", "<!-- pr-freshness:v1 tier=normal budget_hours=12 deadline=not-a-date -->"),
+    ]
+)
+def test_parse_marker_absent_or_invalid(_name, summary):
+    assert parse_marker(summary) is None
 
 
 @parameterized.expand(


### PR DESCRIPTION
## Problem

Green CI on a PR that is hundreds of commits behind a fast-moving `master` is unreliable — it ran against a merge-base that no longer resembles the current state. We need a mechanism to nudge authors to rebase stale PRs so CI re-runs against current code.

A flat staleness threshold doesn't work well: a repo-wide linter touches many files but couples to everything (rots fast), while a docs tweak couples to nothing (can age longer). The budget should be content-driven.

## Changes

Added a new PR freshness check that:

- **Per-PR budgets**: Uses Claude Haiku to classify each PR's coupling to fast-moving shared surface (hot/normal/isolated) and assigns a staleness budget (2h/12h/48h respectively)
- **Efficient caching**: Caches the budget in the check's summary, keyed to the head SHA, so a 6-hourly cron only does clock arithmetic — no re-invocation of the model on unchanged PRs
- **Fail-open design**: Falls back to a default budget if the model is unavailable, an outage occurs, or a response is malformed — staleness is a soft safeguard, not a hard blocker
- **Dual triggers**: Runs on PR push (to stamp fresh PRs immediately) and on a 6-hourly schedule (to age existing PRs and turn them red once the budget expires)

### Files added

- `tools/pr-freshness/freshness.py`: Main script with pure functions (`classify_freshness`, `tier_to_hours`, marker codec, `build_prompt`) and GitHub/Anthropic integration
- `tools/pr-freshness/test_freshness.py`: Unit tests for all pure functions
- `.github/workflows/ci-pr-freshness.yml`: Workflow that runs the check on PR events and a schedule

The check is advisory until added to branch protection's required checks.

## How did you test this code?

Added comprehensive unit tests covering:
- Tier-to-hours mapping (including unknown tiers falling back to default)
- LLM response parsing (bare words, uppercase, reasoning, unknown responses)
- Marker encoding/decoding roundtrips
- Freshness classification (within budget, just inside, just past, long overdue)
- Prompt building (signal inclusion, file list truncation)

All tests pass. The pure functions are isolated and testable; GitHub and Anthropic integration is wrapped in exception handlers that degrade gracefully.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR implements a PR freshness check system designed to keep long-lived PRs in sync with a fast-moving `master` branch. The implementation prioritizes:

- **Pure, testable logic**: Tier classification, budget calculation, and freshness verdict are pure functions with no side effects, making them easy to unit test and reason about
- **Fail-open resilience**: Any failure in LLM classification, GitHub API calls, or Anthropic API calls falls back to sensible defaults rather than blocking merges
- **Efficient caching**: The budget is computed once per head SHA and cached in the check summary, so the 6-hourly cron does only clock arithmetic
- **Content-driven budgets**: The LLM reads the PR's title, description, and file list to estimate coupling to fast-moving shared surface, rather than using a flat threshold

The workflow uses a GitHub App token (minted from secrets) to ensure the check can be stamped on fork PRs via the scheduled run, and includes proper concurrency controls to avoid redundant work.

https://claude.ai/code/session_01Rt4SCWYCrjGpAq9Y6BD4vW