### PR TITLE
fix(funnels): show conversion % for every breakdown in trends tooltip

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.test.tsx
@@ -61,6 +61,24 @@ describe('FunnelLineChart', () => {
             expect(tooltip.textContent).toContain('Spike')
             expect(tooltip.textContent).toContain('Bramble')
         })
+
+        it('shows each breakdown row’s conversion percentage in the tooltip, not a dash', async () => {
+            // Funnel-trends results carry no `order`, so every breakdown series must collapse onto
+            // the single value column. A regression here renders `–` for all but the first row.
+            renderInsight({
+                query: buildFunnelsQuery({
+                    breakdownFilter: { breakdown: 'hedgehog', breakdown_type: 'event' },
+                }),
+                featureFlags: HOG_CHARTS_FUNNEL_FLAG,
+            })
+
+            await chart.clickAtIndex(2)
+            const tooltip = await waitForHogChartTooltip()
+            // At index 2: Spike data[2]=50, Bramble data[2]=30, both shown as percentages.
+            expect(tooltip.textContent).toContain('50%')
+            expect(tooltip.textContent).toContain('30%')
+            expect(tooltip.textContent).not.toContain('–')
+        })
     })
 
     describe('click → persons modal', () => {

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useMountedLogic } from 'kea'
+
+import type { Series, TooltipContext } from '@posthog/quill-charts'
+
+import { cohortsModel } from '~/models/cohortsModel'
+import type { BreakdownFilter } from '~/queries/schema/schema-general'
+
+import type { FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
+import { FunnelLineTooltip } from './FunnelLineTooltip'
+
+// Five-day window matching the mocked date, so the pinned tooltip resolves a stable header.
+const DAYS = ['2022-03-08', '2022-03-09', '2022-03-10', '2022-03-11', '2022-03-12']
+const DATA_INDEX = 4
+
+// The funnel-trends API returns one conversion series per breakdown value with NO `order`
+// field, so `meta.order` is undefined at runtime (despite the `number` type). Constructing
+// the meta the same way keeps the story faithful: it exercises FunnelLineTooltip's
+// `meta.order ?? …` fallback exactly as production does. A regression that orders series by
+// index makes InsightTooltip render `–` for every row except the first.
+function funnelSeries(label: string, data: number[], breakdown?: string[]): Series<FunnelSeriesMeta> {
+    return {
+        key: label,
+        label,
+        data,
+        meta: { days: DAYS, breakdown_value: breakdown, label } as FunnelSeriesMeta,
+    }
+}
+
+function tooltipContext(
+    entries: { series: Series<FunnelSeriesMeta>; value: number; color: string }[]
+): TooltipContext<FunnelSeriesMeta> {
+    return {
+        dataIndex: DATA_INDEX,
+        label: DAYS[DATA_INDEX],
+        seriesData: entries,
+        position: { x: 0, y: 0 },
+        hoverPosition: null,
+        canvasBounds: new DOMRect(),
+        isPinned: true,
+        onUnpin: () => {},
+    }
+}
+
+const BREAKDOWN_FILTER: BreakdownFilter = { breakdown: '$browser', breakdown_type: 'event' }
+
+type Story = StoryObj<typeof FunnelLineTooltip>
+
+const meta: Meta<typeof FunnelLineTooltip> = {
+    title: 'Insights/FunnelLineTooltip',
+    component: FunnelLineTooltip,
+    parameters: {
+        layout: 'centered',
+        mockDate: '2022-03-12',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+    render: (props) => {
+        useMountedLogic(cohortsModel)
+        return <FunnelLineTooltip {...props} />
+    },
+}
+export default meta
+
+// Single conversion series with no breakdown, so the tooltip shows one "Conversion" row.
+export const SingleSeries: Story = {
+    args: {
+        context: tooltipContext([
+            { series: funnelSeries('Conversion', [10, 25, 40, 60, 50]), value: 50, color: '#1d4aff' },
+        ]),
+    },
+}
+
+// Regression guard: a broken-down funnel-trends tooltip must show every breakdown's
+// conversion percentage. Before the order fix, only the first row showed a value and the
+// rest rendered `–`.
+export const Breakdown: Story = {
+    args: {
+        breakdownFilter: BREAKDOWN_FILTER,
+        context: tooltipContext([
+            { series: funnelSeries('Chrome', [10, 25, 40, 60, 72], ['Chrome']), value: 72, color: '#1d4aff' },
+            { series: funnelSeries('Firefox', [5, 12, 20, 30, 48], ['Firefox']), value: 48, color: '#f7a501' },
+            { series: funnelSeries('Safari', [2, 6, 14, 22, 31], ['Safari']), value: 31, color: '#42827e' },
+            { series: funnelSeries('Edge', [1, 3, 7, 12, 19], ['Edge']), value: 19, color: '#b62b82' },
+        ]),
+    },
+}

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.tsx
@@ -40,7 +40,11 @@ export function FunnelLineTooltip({
                     id: idx,
                     dataIndex: context.dataIndex,
                     datasetIndex: idx,
-                    order: meta.order ?? idx,
+                    // Funnel-trends results carry no `order` (one conversion series per breakdown), so
+                    // every series belongs to the single value column. Falling back to `idx` makes
+                    // InsightTooltip's `find(s => s.order === colIdx)` miss for all but the first
+                    // breakdown row, rendering `–`. Default to 0, mirroring the legacy LineGraph path.
+                    order: meta.order ?? 0,
                     label: entry.series.label,
                     color: entry.color,
                     count: entry.value,

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineTooltip.tsx
@@ -40,10 +40,6 @@ export function FunnelLineTooltip({
                     id: idx,
                     dataIndex: context.dataIndex,
                     datasetIndex: idx,
-                    // Funnel-trends results carry no `order` (one conversion series per breakdown), so
-                    // every series belongs to the single value column. Falling back to `idx` makes
-                    // InsightTooltip's `find(s => s.order === colIdx)` miss for all but the first
-                    // breakdown row, rendering `–`. Default to 0, mirroring the legacy LineGraph path.
                     order: meta.order ?? 0,
                     label: entry.series.label,
                     color: entry.color,


### PR DESCRIPTION
## Problem

In a funnel insight set to **Historical trends** with a breakdown, the pinned/hover tooltip showed the actual conversion percentage for only the first breakdown series and rendered a dash (`–`) for every other series. It reads as though the other breakdowns have no data when they actually do.

This only affects users on the `product-analytics-hog-charts-funnel` feature flag (the new hog-charts funnel chart). The legacy chart path was unaffected.

## Changes

Funnel historical-trends results carry no `order` field (the backend returns one conversion series per breakdown value). `FunnelLineTooltip` built each tooltip row's `order` as `meta.order ?? idx`, so the missing `order` fell through to the series index (`0, 1, 2, …`). `InsightTooltip`'s column-per-series layout then looked each row up by `order === colIdx` (with a `colIdx` of `0`), which matched only the first breakdown row and left every other row with no value, rendering `–`.

The fix defaults the order to `0` so every funnel-trends series collapses onto the single value column, mirroring the behavior the legacy `LineGraph` tooltip path already had.

It also adds a `FunnelLineTooltip` Storybook story (`Breakdown`) that renders the tooltip with breakdown series carrying no `order`, exercising the breakdown column-collapse directly in visual regression. A future regression to the per-row `–` bug will change the snapshot without anyone needing to hover a live chart.

## How did you test this code?

I'm an agent (PostHog Code). These are the automated checks I actually ran; I did **not** perform manual browser testing.

- Added a jest regression test in `FunnelLineChart.test.tsx` that pins the breakdown tooltip and asserts every breakdown row shows its percentage (not `–`). It is a genuine guard: with the fix reverted it fails, capturing exactly the reported output (`Spike●50%Bramble–`); with the fix it passes. The full `FunnelLineChart.test.tsx` suite is green (16 passed).
- Added the `FunnelLineTooltip` visual-regression story; the rendered tooltip will surface in this PR's Visual Review run (no committed PNGs — CI captures and uploads them).

I have no manual screenshots to attach. The `Breakdown` story is the visual reference and will appear in Visual Review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by @xljones.

Authored with PostHog Code (Claude Opus 4.8). I traced the data flow from the funnel-trends backend serializer (`funnel_trends.py` `_format_single_summary`, which omits `order`) through `funnelDataLogic.indexedSteps`, `FunnelLineTooltip`, and `InsightTooltip`'s `invertDataSource` / column lookup to pin the root cause.

I considered fixing it inside `InsightTooltip` (rejected: its `–` placeholder is correct for genuine multi-event trends gaps) and at the transform layer (`normalizeStep`), and chose the one-line tooltip fallback because it is the narrowest change at the exact point the wrong value is produced and it matches the already-correct legacy path. The follow-up commits (visual-regression story, comment removal) were split out at the reviewer's request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
