### PR TITLE
fix(agent-platform): enforce team match in posthog auth verifier

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/enqueue/verifiers.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/enqueue/verifiers.test.ts
@@ -31,7 +31,14 @@ const APP: AgentApplication = {
 
 const introspector: PosthogIdentityIntrospector = {
     async introspect(bearer) {
-        return bearer === 'good-token' ? { uuid: 'u1', email: 'u1@test', team: { id: 7 } } : null
+        if (bearer === 'good-token') {
+            return { uuid: 'u1', email: 'u1@test', team: { id: 7 } }
+        }
+        // A valid bearer whose active team is NOT the agent's owning team (7).
+        if (bearer === 'other-team-token') {
+            return { uuid: 'u2', email: 'u2@test', team: { id: 99 } }
+        }
+        return null
     },
 }
 
@@ -77,6 +84,15 @@ describe('buildDefaultVerifiers', () => {
             status: 401,
         })
         expect(await v.verify(req({}), { type: 'posthog', scopes: [] }, APP)).toMatchObject({ ok: false, status: 0 })
+    })
+
+    it('posthog mode: valid bearer from a different team → 403 (no cross-team access)', async () => {
+        const res = await posthogVerifier(introspector).verify(
+            req({ authorization: 'Bearer other-team-token' }),
+            { type: 'posthog', scopes: [] },
+            APP
+        )
+        expect(res).toMatchObject({ ok: false, status: 403, reason: 'wrong_team' })
     })
 
     it('shared_secret: matches resolved encrypted_env secret, 401 on mismatch, 500 when unset', async () => {

--- a/products/agent_platform/services/agent-ingress/src/enqueue/verifiers.ts
+++ b/products/agent_platform/services/agent-ingress/src/enqueue/verifiers.ts
@@ -93,11 +93,16 @@ function posthogPrincipalFrom(me: PosthogMeResponse): SessionPrincipal {
  * PostHog credential verifier. Accepts a bearer (Personal API key today, OAuth
  * later) and validates it against `/api/users/@me/`. Produces a `posthog`
  * principal + a `posthog_api` credential for tools.
+ *
+ * The bearer only proves "is a valid PostHog user somewhere" — it carries no
+ * tenant binding of its own. We therefore require the user's active team to
+ * match the agent's owning team (`application.team_id`); otherwise any valid
+ * bearer from any org would pass a `posthog`-gated agent (cross-team-open).
  */
 export function posthogVerifier(introspector: PosthogIdentityIntrospector): AuthVerifier {
     return {
         modeType: 'posthog',
-        async verify(req: Request, _mode: AuthMode, _app: AgentApplication): Promise<VerifyResult> {
+        async verify(req: Request, _mode: AuthMode, application: AgentApplication): Promise<VerifyResult> {
             const bearer = readBearer(req)
             if (!bearer) {
                 return { ok: false, status: 0, reason: 'skip' }
@@ -105,6 +110,12 @@ export function posthogVerifier(introspector: PosthogIdentityIntrospector): Auth
             const me = await introspector.introspect(bearer)
             if (!me) {
                 return { ok: false, status: 401, reason: 'invalid_token' }
+            }
+            // Tenant gate: the verified user must belong to the agent's team.
+            // `me.team?.id` is the user's active project; a stranger from
+            // another org is rejected even with a valid bearer.
+            if (me.team?.id !== application.team_id) {
+                return { ok: false, status: 403, reason: 'wrong_team' }
             }
             const credentials: CredentialMap = {
                 posthog_api: { kind: 'posthog_bearer', token: bearer },


### PR DESCRIPTION
## Problem

Threat model finding **F7** (TB-1, MEDIUM). The `posthog` auth mode accepts any valid PostHog bearer (Personal API key today, OAuth later) and validates it against `/api/users/@me/`, but the verifier never compared the resolved user's team to the agent's owning team. The session is created under the agent's team, but the *actor* could be a stranger from another organization — any valid bearer passed a `posthog`-gated agent regardless of tenant.

The `application` argument was already threaded into the verifier (`_app`) but was unused.

## Changes

- `posthogVerifier` now requires `me.team?.id === application.team_id`. A valid bearer whose active team is not the agent's owning team is rejected with `403 wrong_team`.
- Added a regression test: a valid bearer for a different team is denied.

The `posthog` mode carries no cross-team opt-in flag, so this is a hard tenant gate. Other verifiers (`shared_secret`, `posthog_internal`) already stamp `application.team_id` directly onto the principal; this brings `posthog` in line.

## How did you test this code?

I'm an agent. Automated tests I ran:

- `vitest run src/enqueue/verifiers.test.ts` — 6 passed (including the new cross-team denial case).
- `oxlint` and `tsc --noEmit` on the ingress package — clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this work as part of the agent-platform threat-model remediation.

One of a series of PRs working through the threat-model findings on the `ass` branch. Scoped to the single verifier per the finding notes. The fix uses the already-available `application.team_id` rather than introducing new config.
