### PR TITLE
chore(data-warehouse): exempt warehouse source changes from stamphog auth gate

### DIFF
--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -374,17 +374,19 @@ def test_only(categories: dict[str, int]) -> bool:
 
 # ── Deny / allow detection ───────────────────────────────────────
 
-# Data warehouse import sources. Every SaaS connector under here performs an
-# auth/OAuth/credential handshake, so connector code and PR titles legitimately
+# Path prefixes exempt from the `auth` deny category. Code under these trees
+# performs auth/OAuth/credential handshakes as part of its normal job — e.g.
+# every data warehouse import connector — so the code and PR titles legitimately
 # mention auth, oauth, token, login, etc. without touching the auth *system*.
-# The `auth` deny is exempted for this tree (see detect_deny_categories) so it
-# doesn't force T2-never on essentially every source PR. Other deny categories
-# (crypto/secrets, migrations, …) still apply.
-DATA_WAREHOUSE_SOURCE_PREFIX = "posthog/temporal/data_imports/sources/"
+# Without this, the `auth` deny would force T2-never on essentially every such
+# PR. Other deny categories (crypto/secrets, migrations, …) still apply. Add new
+# exempt trees here rather than special-casing in detect_deny_categories.
+AUTH_EXEMPT_PATH_PREFIXES = ("posthog/temporal/data_imports/sources/",)
 
 
-def _is_data_warehouse_source(path: str) -> bool:
-    return path.lower().startswith(DATA_WAREHOUSE_SOURCE_PREFIX)
+def _is_auth_exempt_path(path: str) -> bool:
+    low = path.lower()
+    return any(low.startswith(prefix) for prefix in AUTH_EXEMPT_PATH_PREFIXES)
 
 
 def detect_deny_categories(files: list[str], subject: str, ignored_files: set[str] | None = None) -> list[str]:
@@ -393,13 +395,13 @@ def detect_deny_categories(files: list[str], subject: str, ignored_files: set[st
     paths_lower = [f.lower() for f in files if f.lower() not in ignored_files_lower]
     subject_lower = subject.lower()
 
-    # Auth exemption for data warehouse sources: drop source paths from auth
-    # path-matching, and — when sources are involved — only let the PR title
-    # trip `auth` if a non-source file is also touched. PRs that don't touch
-    # the sources tree are evaluated exactly as before.
-    auth_paths = [p for p in paths_lower if not _is_data_warehouse_source(p)]
-    has_dwh_source = len(auth_paths) != len(paths_lower)
-    auth_title_eligible = (not has_dwh_source) or bool(auth_paths)
+    # Auth exemption for AUTH_EXEMPT_PATH_PREFIXES: drop exempt paths from auth
+    # path-matching, and — when any exempt path is in the change set — only let
+    # the PR title trip `auth` if a non-exempt file is also touched. PRs that
+    # touch no exempt paths are evaluated exactly as before.
+    auth_paths = [p for p in paths_lower if not _is_auth_exempt_path(p)]
+    has_exempt_path = len(auth_paths) != len(paths_lower)
+    auth_title_eligible = (not has_exempt_path) or bool(auth_paths)
 
     for category, scopes in DENY_PATTERNS.items():
         category_paths = auth_paths if category == "auth" else paths_lower

--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -374,6 +374,18 @@ def test_only(categories: dict[str, int]) -> bool:
 
 # ── Deny / allow detection ───────────────────────────────────────
 
+# Data warehouse import sources. Every SaaS connector under here performs an
+# auth/OAuth/credential handshake, so connector code and PR titles legitimately
+# mention auth, oauth, token, login, etc. without touching the auth *system*.
+# The `auth` deny is exempted for this tree (see detect_deny_categories) so it
+# doesn't force T2-never on essentially every source PR. Other deny categories
+# (crypto/secrets, migrations, …) still apply.
+DATA_WAREHOUSE_SOURCE_PREFIX = "posthog/temporal/data_imports/sources/"
+
+
+def _is_data_warehouse_source(path: str) -> bool:
+    return path.lower().startswith(DATA_WAREHOUSE_SOURCE_PREFIX)
+
 
 def detect_deny_categories(files: list[str], subject: str, ignored_files: set[str] | None = None) -> list[str]:
     hits: set[str] = set()
@@ -381,13 +393,23 @@ def detect_deny_categories(files: list[str], subject: str, ignored_files: set[st
     paths_lower = [f.lower() for f in files if f.lower() not in ignored_files_lower]
     subject_lower = subject.lower()
 
+    # Auth exemption for data warehouse sources: drop source paths from auth
+    # path-matching, and — when sources are involved — only let the PR title
+    # trip `auth` if a non-source file is also touched. PRs that don't touch
+    # the sources tree are evaluated exactly as before.
+    auth_paths = [p for p in paths_lower if not _is_data_warehouse_source(p)]
+    has_dwh_source = len(auth_paths) != len(paths_lower)
+    auth_title_eligible = (not has_dwh_source) or bool(auth_paths)
+
     for category, scopes in DENY_PATTERNS.items():
+        category_paths = auth_paths if category == "auth" else paths_lower
+        title_eligible = auth_title_eligible if category == "auth" else True
         found = False
         # "paths" patterns — only match against file paths
         for rx in scopes.get("paths", []):
             if found:
                 break
-            for p in paths_lower:
+            for p in category_paths:
                 if rx.search(p):
                     hits.add(category)
                     found = True
@@ -398,12 +420,12 @@ def detect_deny_categories(files: list[str], subject: str, ignored_files: set[st
         for path_rx, title_rx in scopes.get("any", []):
             if found:
                 break
-            for p in paths_lower:
+            for p in category_paths:
                 if path_rx.search(p):
                     hits.add(category)
                     found = True
                     break
-            if not found and title_rx.search(subject_lower):
+            if not found and title_eligible and title_rx.search(subject_lower):
                 hits.add(category)
                 found = True
     return sorted(hits)

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -228,20 +228,27 @@ def test_dwh_source_still_denies_non_auth_categories() -> None:
     assert "crypto_secrets" in result
 
 
-def test_dwh_source_mixed_with_real_auth_file_still_denies() -> None:
-    # A non-source auth file present means the auth gate must still fire.
-    files = [
-        "posthog/temporal/data_imports/sources/stripe/source.py",
-        "posthog/api/authentication.py",
-    ]
-    assert "auth" in detect_deny_categories(files, "fix: stripe auth and login flow")
-
-
-def test_dwh_source_mixed_title_only_auth_still_denies() -> None:
-    # Source file + an unrelated non-source file with an auth-y title: the
-    # title remains eligible because a non-source file is in the change set.
-    files = [
-        "posthog/temporal/data_imports/sources/stripe/source.py",
-        "posthog/api/foo.py",
-    ]
-    assert "auth" in detect_deny_categories(files, "fix: oauth login redirect")
+@pytest.mark.parametrize(
+    "files, subject",
+    [
+        pytest.param(
+            [
+                "posthog/temporal/data_imports/sources/stripe/source.py",
+                "posthog/api/authentication.py",
+            ],
+            "fix: stripe auth and login flow",
+            id="dwh-source-mixed-real-auth-file",
+        ),
+        pytest.param(
+            [
+                "posthog/temporal/data_imports/sources/stripe/source.py",
+                "posthog/api/foo.py",
+            ],
+            "fix: oauth login redirect",
+            id="dwh-source-mixed-unrelated-file-auth-title",
+        ),
+    ],
+)
+def test_dwh_source_mixed_still_denies(files: list[str], subject: str) -> None:
+    # Auth gate must still fire when any non-source file is in the change set.
+    assert "auth" in detect_deny_categories(files, subject)

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -188,3 +188,60 @@ def test_ignored_files_does_not_bypass_other_deny_list_files() -> None:
     ignored = {"posthog/migrations/1117_alter_integration_kind.py"}
 
     assert detect_deny_categories(files, "feat: integration field", ignored_files=ignored) == ["migrations"]
+
+
+# ── Data warehouse source auth exemption ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "files, subject",
+    [
+        pytest.param(
+            ["posthog/temporal/data_imports/sources/stripe/auth.py"],
+            "fix(stripe): refresh oauth token before sync",
+            id="dwh-source-auth-file-and-title",
+        ),
+        pytest.param(
+            ["posthog/temporal/data_imports/sources/postgres/source.py"],
+            "fix(postgres): treat invalid SSH tunnel auth as non-retryable",
+            id="dwh-source-auth-in-title-only",
+        ),
+        pytest.param(
+            [
+                "posthog/temporal/data_imports/sources/salesforce/source.py",
+                "posthog/temporal/data_imports/sources/salesforce/settings.py",
+            ],
+            "fix(salesforce): treat deleted oauth credential as non-retryable",
+            id="dwh-source-multi-file-oauth-credential",
+        ),
+    ],
+)
+def test_dwh_source_auth_exempt(files: list[str], subject: str) -> None:
+    assert "auth" not in detect_deny_categories(files, subject)
+
+
+def test_dwh_source_still_denies_non_auth_categories() -> None:
+    # Only `auth` is exempted — crypto/secrets still applies to source files.
+    files = ["posthog/temporal/data_imports/sources/stripe/api_key_store.py"]
+    result = detect_deny_categories(files, "feat(stripe): rotate api key")
+    assert "auth" not in result
+    assert "crypto_secrets" in result
+
+
+def test_dwh_source_mixed_with_real_auth_file_still_denies() -> None:
+    # A non-source auth file present means the auth gate must still fire.
+    files = [
+        "posthog/temporal/data_imports/sources/stripe/source.py",
+        "posthog/api/authentication.py",
+    ]
+    assert "auth" in detect_deny_categories(files, "fix: stripe auth and login flow")
+
+
+def test_dwh_source_mixed_title_only_auth_still_denies() -> None:
+    # Source file + an unrelated non-source file with an auth-y title: the
+    # title remains eligible because a non-source file is in the change set.
+    files = [
+        "posthog/temporal/data_imports/sources/stripe/source.py",
+        "posthog/api/foo.py",
+    ]
+    assert "auth" in detect_deny_categories(files, "fix: oauth login redirect")


### PR DESCRIPTION
## Problem

The stamphog PR-approval bot (`tools/pr-approval-agent/`) flags an `auth` deny category whenever a changed file path or PR title matches `auth`, `oauth`, `credential`, `token`, `login`, `password`, etc. Any deny-category hit forces the PR to tier `T2-never`, so the bot never auto-approves it.

Every data warehouse import connector under `posthog/temporal/data_imports/sources/` performs an auth / OAuth / credential handshake, so connector code and PR titles legitimately mention these terms without touching the auth *system*. The result is that essentially every warehouse-source PR (including the large batch of connector reliability fixes) trips the `auth` gate and can never be auto-approved, defeating the point of the bot for that area.

## Changes

Exempt the **`auth` category only** for changes under `posthog/temporal/data_imports/sources/`:

- Source paths no longer contribute `auth` path-matches.
- When sources are involved, an auth-y PR title only trips `auth` if a non-source file is also in the change set.

Fail-closed behavior is preserved:

- Only `auth` is exempted — `crypto_secrets` (e.g. `secret`, `api_key`, `.env`), `migrations`, and the other deny categories still apply to source files.
- A PR that also touches real auth code outside the sources tree (e.g. `posthog/api/authentication.py`) still fires the `auth` deny.
- PRs that don't touch the sources tree behave exactly as before.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated test suite only — no manual testing.

- Added 6 tests in `test_gates.py` covering: exempt source auth/oauth path and title cases, a multi-file oauth/credential source PR, `crypto_secrets` still firing on a source `api_key` file, and the two mixed-PR cases that must still deny.
- `python -m pytest test_gates.py` → 32 passed.
- `ruff check` / `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom asked to relax the stamphog auth gate for data warehouse source changes (and explicitly to make sure `oauth` was covered). Implemented in `gates.py` by scoping the exemption to the `auth` category and the `sources/` tree rather than globally ignoring those files, so crypto/secrets and migration gates still protect connector code. `oauth` is already one of the `auth` patterns, so it was covered by the category-level exemption — verified with a quick check and explicit tests rather than adding a separate pattern. Tool used: Claude Code.
