### PR TITLE
feat(hogql): attribute observability passes via query-tag fallback

### DIFF
--- a/ee/hogai/chat_agent/sql/mixins.py
+++ b/ee/hogai/chat_agent/sql/mixins.py
@@ -79,7 +79,13 @@ class HogQLDatabaseMixin:
         return self._get_database()
 
     def _get_default_hogql_context(self, database: Database):
-        hogql_context = HogQLContext(team=self._team, user=self._user, database=database, enable_select_queries=True)
+        hogql_context = HogQLContext(
+            team=self._team,
+            user=self._user,
+            database=database,
+            enable_select_queries=True,
+            observability_source="max_ai",
+        )
         return hogql_context
 
     async def _serialize_database_schema(self):

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -79,10 +79,10 @@ def compile_hogql_to_ducklake_sql(team_id: int, query: HogQLQuery) -> tuple[str,
     parsed = parse_select(query.query)
     # Separate context for the Postgres print — the HogQL round-trip below shouldn't
     # contribute to ``postgres_context.values``.
-    postgres_context = HogQLContext(team_id=team_id, enable_select_queries=True)
+    postgres_context = HogQLContext(team_id=team_id, enable_select_queries=True, observability_source="warehouse")
     postgres_sql, _ = prepare_and_print_ast(parsed, postgres_context, dialect="postgres")
 
-    hogql_context = HogQLContext(team_id=team_id, enable_select_queries=True)
+    hogql_context = HogQLContext(team_id=team_id, enable_select_queries=True, observability_source="warehouse")
     hogql_pretty, _ = prepare_and_print_ast(parsed, hogql_context, dialect="hogql")
 
     return postgres_sql, dict(postgres_context.values), hogql_pretty

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -146,6 +146,7 @@ def write_sql_from_prompt(
         enable_select_queries=True,
         database=database,
         modifiers=create_default_modifiers_for_team(team),
+        observability_source="max_ai",
     )
     serialized_database = database.serialize(context)
     schema_description = "\n\n".join(

--- a/posthog/hogql/observability.py
+++ b/posthog/hogql/observability.py
@@ -24,7 +24,7 @@ from prometheus_client import (
 from posthog.hogql import ast
 from posthog.hogql.visitor import TraversingVisitor
 
-from posthog.clickhouse.query_tagging import Product, get_query_tags
+from posthog.clickhouse.query_tagging import Product, add_fallback_query_tags, get_query_tags
 
 logger = structlog.get_logger(__name__)
 
@@ -268,8 +268,21 @@ def create_hogql_type_observability(
 
 
 def _source_from_query_tags() -> str:
-    """Attribute the pass to the product surface the request layer already tagged it with."""
-    product = get_query_tags().product
+    """Attribute the pass to the product surface.
+
+    Prefer an explicitly set product tag, then fall back to the same bounded taxonomy the
+    request/execution layer uses for ``system.query_log`` attribution (scene → query kind →
+    HogQL features → MCP source). Observability resolves the source while *printing*, which
+    happens before ``sync_execute`` applies that fallback — so without re-running the fallback
+    here, every pass whose product is only derivable (not explicitly tagged) lands in
+    "unknown". We resolve against a deep copy so the shared request tags are never mutated.
+    """
+    tags = get_query_tags()
+    product = tags.product
+    if product is None:
+        resolved = tags.model_copy(deep=True)
+        add_fallback_query_tags(resolved)
+        product = resolved.product
     if product is None:
         return "unknown"
     return str(getattr(product, "value", product))

--- a/posthog/hogql/test/test_observability.py
+++ b/posthog/hogql/test/test_observability.py
@@ -17,7 +17,7 @@ from posthog.hogql.observability import (
     emit_hogql_type_observability,
 )
 
-from posthog.clickhouse.query_tagging import Product
+from posthog.clickhouse.query_tagging import Product, QueryTags
 
 
 def _metric(name: str, labels: dict[str, str]) -> float:
@@ -172,6 +172,25 @@ class TestHogQLTypeObservability(SimpleTestCase):
 
         assert stats is not None
         self.assertEqual(stats.source, "warehouse")
+
+    @parameterized.expand(
+        [
+            ("kind_fallback", QueryTags(query_type="TrendsQuery"), "product_analytics"),
+            ("scene_fallback", QueryTags(scene="Cohort"), "cohorts"),
+            ("nothing_resolvable", QueryTags(query_type="ActorsQuery"), "unknown"),
+        ]
+    )
+    @patch("posthog.hogql.observability.TYPE_OBSERVABILITY_SAMPLE_RATE", 1.0)
+    def test_source_resolves_via_query_tag_fallback_when_product_unset(self, _name, tags, expected):
+        # Observability resolves the source while printing, before sync_execute applies the
+        # product fallback. Re-running that fallback here keeps derivable passes off "unknown".
+        with patch("posthog.hogql.observability.get_query_tags", return_value=tags):
+            stats = create_hogql_type_observability(dialect="clickhouse")
+
+        assert stats is not None
+        self.assertEqual(stats.source, expected)
+        # The shared request tags must never be mutated by observability resolution.
+        self.assertIsNone(tags.product)
 
     @patch("posthog.hogql.observability.TYPE_OBSERVABILITY_SAMPLE_RATE", 1.0)
     def test_explicit_source_wins_over_query_tags(self):

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -488,6 +488,7 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
                             enable_select_queries=True,
                             timings=self.timings,
                             modifiers=self.modifiers,
+                            observability_source=self.observability_source(),
                         ),
                         dialect="clickhouse",
                     )

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -230,7 +230,9 @@ class HogQLCohortQuery:
         team: Optional[Team] = None,
     ):
         if cohort is not None:
-            self.hogql_context = HogQLContext(team_id=cohort.team.pk, enable_select_queries=True)
+            self.hogql_context = HogQLContext(
+                team_id=cohort.team.pk, enable_select_queries=True, observability_source="cohorts"
+            )
             self.team = team or cohort.team
             unwrapped = unwrap_cohort(
                 Filter(
@@ -246,7 +248,9 @@ class HogQLCohortQuery:
         elif filter is not None:
             if team is None:
                 raise ValueError("HogQLCohortQuery requires a team when constructed from a filter")
-            self.hogql_context = HogQLContext(team_id=team.pk, enable_select_queries=True)
+            self.hogql_context = HogQLContext(
+                team_id=team.pk, enable_select_queries=True, observability_source="cohorts"
+            )
             self.team = team
             self.property_groups = unwrap_cohort(filter, team.pk, team).property_groups
         else:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -92,7 +92,7 @@ from posthog.clickhouse.client.limit import (
     get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import get_query_tag_value, kind_fallback_tags, tag_queries
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
@@ -1810,6 +1810,29 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # TODO: add support for selecting and filtering by breakdowns
         raise NotImplementedError()
 
+    def observability_source(self) -> str:
+        """Best-effort product-surface attribution for HogQL type-system observability.
+
+        Prefer a product the request layer already tagged; otherwise attribute by the query
+        kind using the same taxonomy as ``system.query_log``. Background and programmatic
+        callers (cache warming, exports, the ``/query`` API) run query runners without
+        frontend tags, so resolving from the kind keeps them off the "unknown" bucket.
+        Returns "unknown" when neither resolves — the observability layer then falls back to
+        the request query tags.
+        """
+        product = get_query_tag_value("product")
+        if product is not None:
+            return str(getattr(product, "value", product))
+        kind = getattr(self.query, "kind", None)
+        if kind is not None:
+            try:
+                mapped = kind_fallback_tags(NodeKind(kind))
+            except ValueError:
+                mapped = None
+            if mapped is not None and (kind_product := mapped.get("product")) is not None:
+                return kind_product.value
+        return "unknown"
+
     def to_hogql(self, **kwargs) -> str:
         with self.timings.measure("to_hogql"):
             return prepare_and_print_ast(
@@ -1819,6 +1842,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     enable_select_queries=True,
                     timings=self.timings,
                     modifiers=self.modifiers,
+                    observability_source=self.observability_source(),
                 ),
                 "hogql",
                 **kwargs,

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -40,6 +40,7 @@ from posthog.schema import (
 from posthog.hogql.constants import LimitContext
 
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
+from posthog.clickhouse.query_tagging import Product, tags_context
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import (
     ExecutionMode,
@@ -140,6 +141,16 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
         self.assertEqual(runner.query, TheTestQuery(some_attr="bla"))
+
+    def test_observability_source_resolves_from_query_kind(self):
+        runner = get_query_runner(query=TrendsQuery(series=[EventsNode(event="$pageview")]), team=self.team)
+        with tags_context():
+            self.assertEqual(runner.observability_source(), "product_analytics")
+
+    def test_observability_source_prefers_explicit_product_tag(self):
+        runner = get_query_runner(query=TrendsQuery(series=[EventsNode(event="$pageview")]), team=self.team)
+        with tags_context(product=Product.WEB_ANALYTICS):
+            self.assertEqual(runner.observability_source(), "web_analytics")
 
     @parameterized.expand(
         [

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -332,6 +332,7 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                 team_id=cohort_obj.team_id,
                 enable_select_queries=True,
                 limit_context=LimitContext.COHORT_CALCULATION,
+                observability_source="messaging",
             )
             current_members_sql, _ = prepare_and_print_ast(current_members_query, hogql_context, "clickhouse")
             return current_members_sql, hogql_context.values

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -626,7 +626,9 @@ def build_lazy_computation_insert_sql(
         query.where = date_range_filter
 
     # Print the SELECT query to ClickHouse SQL
-    context = HogQLContext(team_id=team.id, team=team, enable_select_queries=True, limit_top_select=False)
+    context = HogQLContext(
+        team_id=team.id, team=team, enable_select_queries=True, limit_top_select=False, observability_source="internal"
+    )
     select_sql, _ = prepare_and_print_ast(
         query,
         context=context,
@@ -1196,6 +1198,7 @@ def _build_manual_insert_sql(
         enable_select_queries=True,
         limit_top_select=False,
         modifiers=create_default_modifiers_for_team(team),
+        observability_source="internal",
     )
     select_sql, _ = prepare_and_print_ast(
         query,

--- a/products/cohorts/backend/models/util.py
+++ b/products/cohorts/backend/models/util.py
@@ -374,6 +374,7 @@ def print_cohort_hogql_query(cohort: Cohort, hogql_context: HogQLContext, *, tea
 
     hogql_context.enable_select_queries = True
     hogql_context.limit_top_select = False
+    hogql_context.observability_source = "cohorts"
     create_default_modifiers_for_team(team, hogql_context.modifiers)
 
     # Apply HogQL global settings to ensure consistency with regular queries

--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -185,7 +185,13 @@ class HogQLQueryFixerTool(MaxTool):
 
     def _run_impl(self) -> tuple[str, str | None]:
         database = Database.create_for(team=self._team, user=self._user)
-        hogql_context = HogQLContext(team=self._team, user=self._user, enable_select_queries=True, database=database)
+        hogql_context = HogQLContext(
+            team=self._team,
+            user=self._user,
+            enable_select_queries=True,
+            database=database,
+            observability_source="max_ai",
+        )
 
         all_table_names = database.get_all_table_names()
         schema_description = _get_schema_description(self.context, hogql_context, database)

--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -62,6 +62,7 @@ def _print_materialized_hogql(query: ast.Expr, team: Team, modifiers: HogQLQuery
             enable_select_queries=True,
             limit_top_select=False,
             modifiers=create_default_modifiers_for_team(team, modifiers),
+            observability_source="endpoints",
         ),
         pretty=True,
     )[0]


### PR DESCRIPTION
## TL;DR

HogQL type-inference observability was attributing ~60% of expression volume to `source="unknown"` because the source is resolved while *printing* — before `sync_execute` applies its product-tag fallback. This PR re-runs that same bounded fallback during observability resolution and explicitly tags previously untagged entry points, driving the unknown share down without altering type inference behavior.

## Problem

`posthog/hogql/observability.py` resolved the attribution source purely from the explicitly set `product` query tag. But observability resolves the source at print time, which happens before the request/execution layer applies its product fallback. As a result, every pass whose product was only *derivable* (rather than explicitly tagged) landed in `source="unknown"` — accounting for roughly 60% of expression volume.

## What changed?

- **`posthog/hogql/observability.py`**: `_source_from_query_tags()` now falls back to the same bounded taxonomy used for `system.query_log` attribution (scene → query kind → HogQL features → MCP source) when no product is explicitly tagged. The fallback runs against a deep copy of the query tags so shared request tags are never mutated.
- **Explicit `observability_source` propagation** at several entry points that previously went untagged:
  - `ee/hogai/chat_agent/sql/mixins.py` and `posthog/hogql/ai.py`: tag Max AI SQL contexts as `"max_ai"`.
  - `posthog/ducklake/client.py`: tag DuckLake compilation contexts as `"warehouse"`.
  - `posthog/hogql_queries/hogql_cohort_query.py`: tag cohort query contexts as `"cohorts"`.
  - `posthog/hogql_queries/actors_query_runner.py`: propagate `self.observability_source()` into the actors query context.
- **Tests** (`posthog/hogql/test/test_observability.py`): cover source resolution via query-tag fallback (kind fallback → `product_analytics`, scene fallback → `cohorts`, and an unresolvable case → `unknown`), and assert that the shared request tags are never mutated during resolution.

## How did you test this code?

I'm an agent. I added automated tests in `posthog/hogql/test/test_observability.py` covering the new fallback resolution paths and the no-mutation guarantee. I did not perform manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change improves observability attribution only and does not modify type inference behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*