### PR TITLE
fix(agent-platform): pin http-request/web-fetch to http(s) schemes

### DIFF
--- a/products/agent_platform/services/agent-tools/src/tools/http-request.v1.test.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/http-request.v1.test.ts
@@ -243,6 +243,17 @@ describe('@posthog/http-request', () => {
             await expect(httpRequestV1.run({ url: 'not a url' }, makeCtx({ http }))).rejects.toThrow(/invalid_url/)
         })
 
+        it('rejects non-http(s) schemes before fetching', async () => {
+            const fetch = vi.fn(async () => {
+                throw new Error('should not be called')
+            })
+            const http = { fetch } as unknown as HttpFetcher
+            await expect(httpRequestV1.run({ url: 'file:///etc/passwd' }, makeCtx({ http }))).rejects.toThrow(
+                /unsupported_url_scheme/
+            )
+            expect(fetch).not.toHaveBeenCalled()
+        })
+
         it('surfaces fetch failures as http_request_failed', async () => {
             const http: HttpFetcher = {
                 fetch: vi.fn(async () => {

--- a/products/agent_platform/services/agent-tools/src/tools/http-request.v1.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/http-request.v1.ts
@@ -28,6 +28,8 @@
 
 import { defineNativeTool, type ToolContext, Type } from '@posthog/agent-shared'
 
+import { parseFetchableUrl } from './http-url'
+
 const SECRET_REF = /\$\{([A-Z][A-Z0-9_]*)\}/g
 
 /**
@@ -162,13 +164,10 @@ export const httpRequestV1 = defineNativeTool({
         const maxBytes = args.max_response_bytes ?? DEFAULT_MAX_RESPONSE_BYTES
         const timeoutMs = args.timeout_ms ?? DEFAULT_TIMEOUT_MS
 
-        // Sanity check the URL parses; the runtime fetch would throw anyway,
-        // but a clear error here helps the model retry.
-        try {
-            new URL(url)
-        } catch {
-            throw new Error(`invalid_url: ${url}`)
-        }
+        // Validate the URL parses and uses an http/https scheme. SSRF host
+        // filtering is smokescreen's job; this guards the scheme so a model
+        // can't point the tool at file://, gopher://, etc.
+        parseFetchableUrl(url)
 
         const controller = new AbortController()
         const abortTimer = setTimeout(() => controller.abort(), timeoutMs)

--- a/products/agent_platform/services/agent-tools/src/tools/http-url.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/http-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared URL validation for the agent-facing HTTP tools (`@posthog/http-request`,
+ * `@posthog/web-fetch`).
+ *
+ * SSRF (host/IP filtering) is enforced at the egress hop by smokescreen, but
+ * that only governs WHERE a request can go — not the scheme. `new URL()` alone
+ * happily parses `file://`, `gopher://`, `data:`, etc., and whether those are
+ * refused depends on undici's incidental behaviour rather than an explicit
+ * app guard. Pin the scheme to http/https here so a model-supplied URL can't
+ * reach a non-HTTP fetch surface. Mirrors the explicit `https:` check the MCP
+ * transport already enforces in `mcp-clients.ts`.
+ */
+const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
+
+/**
+ * Parse `url` and require an http/https scheme. Throws a model-readable error
+ * (`invalid_url` / `unsupported_url_scheme`) the agent can retry against.
+ */
+export function parseFetchableUrl(url: string): URL {
+    let parsed: URL
+    try {
+        parsed = new URL(url)
+    } catch {
+        throw new Error(`invalid_url: ${url}`)
+    }
+    if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+        throw new Error(`unsupported_url_scheme: ${parsed.protocol} (only http/https are allowed)`)
+    }
+    return parsed
+}

--- a/products/agent_platform/services/agent-tools/src/tools/web-fetch.v1.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/web-fetch.v1.ts
@@ -1,5 +1,7 @@
 import { defineNativeTool, Type } from '@posthog/agent-shared'
 
+import { parseFetchableUrl } from './http-url'
+
 export const webFetchV1 = defineNativeTool({
     id: '@posthog/web-fetch',
     description:
@@ -18,6 +20,9 @@ export const webFetchV1 = defineNativeTool({
     cost_hint: 'medium',
     async run(args, ctx) {
         const maxBytes = args.max_bytes ?? 1_000_000
+        // Pin the scheme to http/https before fetching (SSRF host filtering is
+        // smokescreen's job at the egress hop).
+        parseFetchableUrl(args.url)
         const res = await ctx.http.fetch(args.url, { method: 'GET' })
         const text = await res.text()
         return {

--- a/products/agent_platform/services/agent-tools/src/tools/web.v1.test.ts
+++ b/products/agent_platform/services/agent-tools/src/tools/web.v1.test.ts
@@ -41,6 +41,16 @@ describe('@posthog/web-fetch', () => {
         const out = await webFetchV1.run({ url: 'https://example.com', max_bytes: 100 }, makeCtx({ http }))
         expect(out.body.length).toBe(100)
     })
+
+    it('rejects non-http(s) schemes before fetching', async () => {
+        const fetch = vi.fn()
+        const http = { fetch } as unknown as HttpFetcher
+        await expect(webFetchV1.run({ url: 'file:///etc/passwd' }, makeCtx({ http }))).rejects.toThrow(
+            /unsupported_url_scheme/
+        )
+        await expect(webFetchV1.run({ url: 'gopher://x' }, makeCtx({ http }))).rejects.toThrow(/unsupported_url_scheme/)
+        expect(fetch).not.toHaveBeenCalled()
+    })
 })
 
 describe('@posthog/web-search', () => {


### PR DESCRIPTION
## Problem

Threat model finding **F10** (TB-2, MEDIUM). The agent-facing HTTP tools (`@posthog/http-request`, `@posthog/web-fetch`) validated model-supplied URLs with `new URL()` only — `web-fetch` did no validation at all. Refusal of `file://`, `gopher://`, `data:`, etc. relied on undici's incidental behaviour, not an explicit app guard. By contrast the MCP transport (`mcp-clients.ts`) explicitly enforces `https:`.

## Changes

- New shared `parseFetchableUrl()` helper that parses the URL and pins the scheme to `http`/`https`, throwing a model-readable `invalid_url` / `unsupported_url_scheme` otherwise.
- `http-request.v1.ts` now routes its URL check through the helper; `web-fetch.v1.ts` gains the check it previously lacked (before the fetch is dispatched).
- Tests: both tools reject `file://` / `gopher://` without ever calling `fetch`.

SSRF host/IP filtering remains enforced at the egress hop by smokescreen — this only governs the scheme.

## Scope note — F6 deferred

The threat model paired F10 with **F6** (credential exfil: `${SECRET}` substituted into URL/headers/body with no secret↔host binding). F6's proper fix needs a per-secret **host allowlist authored in the spec**, which ripples into the Django JSON-schema mirror and OpenAPI/Orval codegen. Per discussion with Ben, that's split into a follow-up so this PR stays proportionate to the scheme fix; F10 lands now.

## How did you test this code?

I'm an agent. Automated tests I ran:

- `vitest run src/tools/web.v1.test.ts src/tools/http-request.v1.test.ts` — 25 passed, including the new scheme-rejection cases.
- `oxlint` + `tsc --noEmit` on agent-tools — clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation, and chose to ship F10 now and defer F6's host-binding.
