### PR TITLE
chore(data-imports): fix flaky postgres chunk-size timeout test

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1451,24 +1451,30 @@ class TestGetTableChunkSize:
             assert cursor.fetchone()[0] == 1
 
     @pytest.mark.django_db
-    def test_statement_timeout_falls_back_without_poisoning_transaction(self):
+    def test_statement_timeout_falls_back_without_poisoning_connection(self, autocommit_pg_connection):
         # The estimation query wraps the sample in octet_length(t::text), which can exceed the
         # source's statement_timeout on tables whose rows trigger slow validator functions. A
         # cancelled probe must degrade to DEFAULT_CHUNK_SIZE, not crash the whole import — the
         # streaming read loop has its own dedicated QueryCanceled handling.
+        #
+        # Discovery runs under autocommit (see postgres_source), so each probe is its own
+        # transaction: a statement_timeout cancellation ends only that statement and leaves the
+        # connection usable for later probes — there are no per-probe savepoints anymore.
+        # Session-scoped timeout because LOCAL has no transaction to bind to under autocommit.
         logger = structlog.get_logger()
 
-        with django_connection.cursor() as dj_cursor:
+        with autocommit_pg_connection.cursor() as cursor:
             # Tight timeout + a deliberately slow probe reproduces a real QueryCanceled.
-            dj_cursor.execute("SET LOCAL statement_timeout = '100ms'")
+            cursor.execute("SET statement_timeout = '100ms'")
             inner_query = sql.SQL("SELECT pg_sleep(3) AS c").format()
 
-            chunk_size = _get_table_chunk_size(cast(Any, dj_cursor), inner_query, logger)
+            chunk_size = _get_table_chunk_size(cast(Any, cursor), inner_query, logger)
             assert chunk_size == DEFAULT_CHUNK_SIZE
 
-            # Savepoint rollback leaves the connection usable for the rest of setup.
-            dj_cursor.execute("SELECT 1")
-            assert dj_cursor.fetchone()[0] == 1
+            # Clear the tight timeout so the sanity check isn't itself at risk on a slow runner.
+            cursor.execute("SET statement_timeout = 0")
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()[0] == 1
 
 
 class TestGetRowsToSync:


### PR DESCRIPTION
## Problem

`TestGetTableChunkSize::test_statement_timeout_falls_back_without_poisoning_transaction` is flaky on master, failing unrelated PRs (e.g. it broke CI on a hogql-only change).

The test ran the chunk-size probe on the shared **transactional** `django_connection` with `SET LOCAL statement_timeout`. But `_get_table_chunk_size` no longer keeps per-probe savepoints — discovery was refactored to run under **autocommit** (`postgres.py` *"Replaces the per-probe savepoints"*). The function catches the `QueryCanceled` and falls back to `DEFAULT_CHUNK_SIZE` but never rolls back, so on a transactional connection the cancelled probe leaves the transaction in an aborted state and the follow-up `SELECT 1` raises `InFailedSqlTransaction`. The test only passed when the shared connection happened to already be in autocommit mode (leaked from another test / ordering) — hence the flakiness. The `# Savepoint rollback...` comment was stale.

## Changes

Run the probe on the existing `autocommit_pg_connection` fixture with a session-scoped `statement_timeout`, exactly mirroring how discovery connects in production and matching the two sibling isolation tests (`test_failing_probe_isolated_by_autocommit`, `test_failing_count_isolated_by_autocommit`). Under autocommit a statement-timeout cancellation ends only that statement and leaves the connection usable, which is the property under test.

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the suite here — the test requires a live Postgres and the sandbox has no DB reachable. I confirmed `ruff check` passes on the file and that the rewrite mirrors the two sibling tests that already pass reliably with the same fixture. CI will exercise the test against a real database.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a CI failure flagged from a Slack thread. Traced the failing job to a data-imports test unrelated to the reporting PR, identified that the probe's transaction-poisoning recovery depends on the connection's autocommit state (which the production code now guarantees but the test did not), and aligned the test with the production code path and its sibling tests rather than re-adding savepoints to production code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1781605741863449)*
