### PR TITLE
feat(reminders): add account settings UI to manage reminders

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1437,9 +1437,9 @@ snapshots:
     components-search--product-recents-and-starred--light:
         hash: v1.k794b7964.97e5efb2d91954a33994531f9fb4155d70c96a987db440c00b9bd43e6afde390.-UG32lAwfVJScsWobbnwUM-3Qp44xLXG15beaTHHFMw
     components-search--searching--dark:
-        hash: v1.k794b7964.f0e56a57f1bdb7d34e9e68a0e9ced473902ae9beddd97b26f7184b795127f215.wN1lnsrv9ZDAJIaGrOUHsMSj9Gfnicme3H4-eUxLgmw
+        hash: v1.k794b7964.2b6565645158a1c2b48cdda980298e6564fbb38cd76cb8230a0ff1cc726a6c73.O6ohcLvjdauxqx9m1PA4MXuHqGkca2NCzdfXpKQtyAU
     components-search--searching--light:
-        hash: v1.k794b7964.e2659797213acb028fc90d590bebe63fcb382a0ac77e2ed4b6f1f902fd6f8fbb.f3TaxvHdCb5R1Rry3CTRr57swQ1qudTLZQPUFcn-x-c
+        hash: v1.k794b7964.03b211d4ef749cff4115a5fd03754d0e12a073f95f4181967b5b88f4fdfb88de.-VoIleDr1-4soYmj9g6HASQTd9zm1IUlbjfEEl6J9Mc
     components-sentencelist--full-sentence--dark:
         hash: v1.k794b7964.2bc693d15a56feae37ff7691155712fee3f9c0590cf5fac3f52911ee5a0cbfeb.w4Q-a1Ll26AC29zPLkyqCUoPWfXbCI71OjbaxNRU2Oc
     components-sentencelist--full-sentence--light:

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -160,6 +160,7 @@ import { PasskeySettings } from './user/PasskeySettings'
 import { PersonalAPIKeys } from './user/PersonalAPIKeys'
 import { PersonalIntegrations } from './user/PersonalIntegrations'
 import { RealtimeNotificationPreferences } from './user/RealtimeNotificationPreferences'
+import { Reminders } from './user/Reminders'
 import { SidebarAutoSuggestSetting } from './user/SidebarProductSettings'
 import { ThemeSwitcher } from './user/ThemeSwitcher'
 import { TwoFactorSettings } from './user/TwoFactorSettings'
@@ -1968,6 +1969,20 @@ export const SETTINGS_MAP: SettingSection[] = [
                     'Your personal GitHub integrations for repo access, code attribution, and pull request authorship. You can connect multiple GitHub accounts or organizations.',
                 component: <PersonalIntegrations />,
                 keywords: ['github', 'integration', 'repos', 'identity', 'link', 'code', 'personal'],
+            },
+        ],
+    },
+    {
+        level: 'user',
+        id: 'user-reminders',
+        title: 'Reminders',
+        settings: [
+            {
+                id: 'reminders',
+                title: 'Reminders',
+                description: 'Schedule one-off or recurring nudges that notify you in-app when they are due.',
+                component: <Reminders />,
+                keywords: ['reminder', 'notification', 'schedule', 'recurring', 'cron'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -80,6 +80,7 @@ export type SettingSectionId =
     | 'user-feature-previews'
     | 'user-notifications'
     | 'user-personal-integrations'
+    | 'user-reminders'
     | 'user-danger-zone'
     // Standalone
     | 'mcp-servers'
@@ -208,6 +209,7 @@ export type SettingId =
     | 'personal-api-keys'
     | 'personal-integrations'
     | 'persons-join-mode'
+    | 'reminders'
     | 'persons-on-events'
     | 'posthog-mcp-configure'
     | 'project-delete'

--- a/frontend/src/scenes/settings/user/Reminders.tsx
+++ b/frontend/src/scenes/settings/user/Reminders.tsx
@@ -1,0 +1,269 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { IconPencil, IconPlus, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTable, LemonTag } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
+import { capitalizeFirstLetter, timeZoneLabel } from 'lib/utils'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { ReminderApi, ReminderStatusEnumApi } from 'products/reminders/frontend/generated/api.schemas'
+
+import { remindersLogic } from './remindersLogic'
+
+const RECURRENCE_OPTIONS = [
+    { value: 'daily', label: 'Daily' },
+    { value: 'weekly', label: 'Weekly' },
+    { value: 'monthly', label: 'Monthly' },
+    { value: 'yearly', label: 'Yearly' },
+]
+
+const STATUS_TAG_TYPE: Record<ReminderStatusEnumApi, 'primary' | 'muted' | 'danger'> = {
+    active: 'primary',
+    completed: 'muted',
+    errored: 'danger',
+}
+
+function scheduleSummary(reminder: ReminderApi): string {
+    if (reminder.cron_expression) {
+        return `Cron: ${reminder.cron_expression}`
+    }
+    if (reminder.recurrence_interval) {
+        return capitalizeFirstLetter(reminder.recurrence_interval)
+    }
+    return 'One-off'
+}
+
+function ReminderModal(): JSX.Element {
+    const { editingReminderId, reminderForm, isReminderFormSubmitting, isScheduleEditable } = useValues(remindersLogic)
+    const { setEditingReminderId, submitReminderForm } = useActions(remindersLogic)
+    const { currentOrganization } = useValues(organizationLogic)
+    const { preflight } = useValues(preflightLogic)
+
+    const isOpen = editingReminderId !== null
+    const isCreating = editingReminderId === 'new'
+
+    const projectOptions = [
+        { value: null, label: 'Organization-wide (no project)' },
+        ...(currentOrganization?.teams ?? []).map((team) => ({ value: team.id, label: team.name })),
+    ]
+    const timezoneOptions = Object.entries(preflight?.available_timezones ?? {}).map(([tz, offset]) => ({
+        key: tz,
+        label: timeZoneLabel(tz, offset),
+    }))
+
+    return (
+        <LemonModal
+            isOpen={isOpen}
+            onClose={() => setEditingReminderId(null)}
+            title={isCreating ? 'New reminder' : 'Edit reminder'}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={() => setEditingReminderId(null)}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={submitReminderForm}
+                        loading={isReminderFormSubmitting}
+                        data-attr="save-reminder"
+                    >
+                        {isCreating ? 'Create reminder' : 'Save'}
+                    </LemonButton>
+                </>
+            }
+        >
+            <Form logic={remindersLogic} formKey="reminderForm" className="deprecated-space-y-4">
+                <LemonField name="title" label="Title">
+                    <LemonInput placeholder="Review the activation dashboard" maxLength={255} autoFocus />
+                </LemonField>
+                <LemonField name="message" label="Message" info="Optional longer text shown in the notification.">
+                    <LemonTextArea placeholder="Optional details" minRows={2} />
+                </LemonField>
+                <LemonField name="team" label="Project">
+                    {({ value, onChange }) => (
+                        <LemonSelect value={value} onChange={onChange} options={projectOptions} fullWidth />
+                    )}
+                </LemonField>
+
+                <LemonField name="scheduleType" label="Schedule">
+                    {({ value, onChange }) => (
+                        <LemonSegmentedButton
+                            value={value}
+                            onChange={onChange}
+                            disabledReason={!isScheduleEditable ? 'This reminder has already fired' : undefined}
+                            options={[
+                                { value: 'one-off', label: 'One-off' },
+                                { value: 'repeats', label: 'Repeats' },
+                                { value: 'advanced', label: 'Advanced' },
+                            ]}
+                            fullWidth
+                        />
+                    )}
+                </LemonField>
+
+                {reminderForm.scheduleType === 'one-off' && (
+                    <LemonField name="scheduled_at" label="Fires at">
+                        {({ value, onChange }) => (
+                            <LemonCalendarSelectInput
+                                value={value ? dayjs(value) : null}
+                                onChange={(date) => onChange(date ? date.toISOString() : null)}
+                                granularity="minute"
+                                placeholder="Select date and time"
+                                disabled={!isScheduleEditable}
+                            />
+                        )}
+                    </LemonField>
+                )}
+
+                {reminderForm.scheduleType === 'repeats' && (
+                    <LemonField name="recurrence_interval" label="Repeats every">
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={onChange}
+                                options={RECURRENCE_OPTIONS}
+                                placeholder="Select an interval"
+                                disabled={!isScheduleEditable}
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                )}
+
+                {reminderForm.scheduleType === 'advanced' && (
+                    <LemonField
+                        name="cron_expression"
+                        label="Cron expression"
+                        info="5-field cron, max 4 fires per day."
+                    >
+                        <LemonInput placeholder="0 9 * * 1" disabled={!isScheduleEditable} />
+                    </LemonField>
+                )}
+
+                {reminderForm.scheduleType !== 'one-off' && (
+                    <LemonField name="end_date" label="Ends" info="Optional. The reminder stops after this time.">
+                        {({ value, onChange }) => (
+                            <LemonCalendarSelectInput
+                                value={value ? dayjs(value) : null}
+                                onChange={(date) => onChange(date ? date.toISOString() : null)}
+                                granularity="minute"
+                                placeholder="No end date"
+                                clearable
+                                disabled={!isScheduleEditable}
+                            />
+                        )}
+                    </LemonField>
+                )}
+
+                <LemonField name="timezone" label="Time zone">
+                    {({ value, onChange }) => (
+                        <LemonInputSelect
+                            mode="single"
+                            value={[value]}
+                            onChange={([newTimezone]) => onChange(newTimezone)}
+                            options={timezoneOptions}
+                            placeholder="Select a time zone"
+                            disabled={!isScheduleEditable}
+                            virtualized
+                        />
+                    )}
+                </LemonField>
+            </Form>
+        </LemonModal>
+    )
+}
+
+export function Reminders(): JSX.Element {
+    const { reminders, remindersLoading } = useValues(remindersLogic)
+    const { setEditingReminderId, deleteReminder } = useActions(remindersLogic)
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div>
+                <LemonButton
+                    type="primary"
+                    icon={<IconPlus />}
+                    onClick={() => setEditingReminderId('new')}
+                    data-attr="new-reminder"
+                >
+                    New reminder
+                </LemonButton>
+            </div>
+
+            <LemonTable
+                loading={remindersLoading}
+                dataSource={reminders}
+                rowKey="id"
+                emptyState="No reminders yet. Create one to get a nudge when it's due."
+                columns={[
+                    {
+                        title: 'Title',
+                        dataIndex: 'title',
+                        render: (_, reminder) => <span className="font-semibold">{reminder.title}</span>,
+                    },
+                    {
+                        title: 'Schedule',
+                        render: (_, reminder) => scheduleSummary(reminder),
+                    },
+                    {
+                        title: 'Next fire',
+                        render: (_, reminder) =>
+                            reminder.next_fire_at ? <TZLabel time={reminder.next_fire_at} /> : '—',
+                    },
+                    {
+                        title: 'Status',
+                        render: (_, reminder) => (
+                            <LemonTag type={STATUS_TAG_TYPE[reminder.status]}>
+                                {capitalizeFirstLetter(reminder.status)}
+                            </LemonTag>
+                        ),
+                    },
+                    {
+                        title: '',
+                        width: 0,
+                        render: (_, reminder) => (
+                            <div className="flex gap-1 justify-end">
+                                <LemonButton
+                                    size="small"
+                                    icon={<IconPencil />}
+                                    tooltip="Edit"
+                                    onClick={() => setEditingReminderId(reminder.id)}
+                                />
+                                <LemonButton
+                                    size="small"
+                                    status="danger"
+                                    icon={<IconTrash />}
+                                    tooltip="Delete"
+                                    onClick={() =>
+                                        LemonDialog.open({
+                                            title: 'Delete reminder?',
+                                            description: `"${reminder.title}" will be permanently deleted.`,
+                                            primaryButton: {
+                                                children: 'Delete',
+                                                status: 'danger',
+                                                onClick: () => deleteReminder(reminder.id),
+                                            },
+                                            secondaryButton: { children: 'Cancel' },
+                                        })
+                                    }
+                                />
+                            </div>
+                        ),
+                    },
+                ]}
+            />
+
+            <ReminderModal />
+        </div>
+    )
+}

--- a/frontend/src/scenes/settings/user/Reminders.tsx
+++ b/frontend/src/scenes/settings/user/Reminders.tsx
@@ -12,7 +12,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
-import { capitalizeFirstLetter, timeZoneLabel } from 'lib/utils'
+import { capitalizeFirstLetter } from 'lib/utils/strings'
+import { timeZoneLabel } from 'lib/utils/timezones'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -119,7 +120,9 @@ function ReminderModal(): JSX.Element {
                                 onChange={(date) => onChange(date ? date.toISOString() : null)}
                                 granularity="minute"
                                 placeholder="Select date and time"
-                                disabled={!isScheduleEditable}
+                                buttonProps={{
+                                    disabledReason: !isScheduleEditable ? 'This reminder has already fired' : undefined,
+                                }}
                             />
                         )}
                     </LemonField>
@@ -159,7 +162,9 @@ function ReminderModal(): JSX.Element {
                                 granularity="minute"
                                 placeholder="No end date"
                                 clearable
-                                disabled={!isScheduleEditable}
+                                buttonProps={{
+                                    disabledReason: !isScheduleEditable ? 'This reminder has already fired' : undefined,
+                                }}
                             />
                         )}
                     </LemonField>

--- a/frontend/src/scenes/settings/user/Reminders.tsx
+++ b/frontend/src/scenes/settings/user/Reminders.tsx
@@ -170,7 +170,7 @@ function ReminderModal(): JSX.Element {
                         <LemonInputSelect
                             mode="single"
                             value={[value]}
-                            onChange={([newTimezone]) => onChange(newTimezone)}
+                            onChange={(newTimezones) => newTimezones[0] && onChange(newTimezones[0])}
                             options={timezoneOptions}
                             placeholder="Select a time zone"
                             disabled={!isScheduleEditable}

--- a/frontend/src/scenes/settings/user/Reminders.tsx
+++ b/frontend/src/scenes/settings/user/Reminders.tsx
@@ -13,9 +13,6 @@ import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
-import { timeZoneLabel } from 'lib/utils/timezones'
-import { organizationLogic } from 'scenes/organizationLogic'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import { ReminderApi, ReminderStatusEnumApi } from 'products/reminders/frontend/generated/api.schemas'
 
@@ -45,22 +42,18 @@ function scheduleSummary(reminder: ReminderApi): string {
 }
 
 function ReminderModal(): JSX.Element {
-    const { editingReminderId, reminderForm, isReminderFormSubmitting, isScheduleEditable } = useValues(remindersLogic)
+    const {
+        editingReminderId,
+        reminderForm,
+        isReminderFormSubmitting,
+        isScheduleEditable,
+        projectOptions,
+        timezoneOptions,
+    } = useValues(remindersLogic)
     const { setEditingReminderId, submitReminderForm } = useActions(remindersLogic)
-    const { currentOrganization } = useValues(organizationLogic)
-    const { preflight } = useValues(preflightLogic)
 
     const isOpen = editingReminderId !== null
     const isCreating = editingReminderId === 'new'
-
-    const projectOptions = [
-        { value: null, label: 'Organization-wide (no project)' },
-        ...(currentOrganization?.teams ?? []).map((team) => ({ value: team.id, label: team.name })),
-    ]
-    const timezoneOptions = Object.entries(preflight?.available_timezones ?? {}).map(([tz, offset]) => ({
-        key: tz,
-        label: timeZoneLabel(tz, offset),
-    }))
 
     return (
         <LemonModal

--- a/frontend/src/scenes/settings/user/remindersLogic.ts
+++ b/frontend/src/scenes/settings/user/remindersLogic.ts
@@ -1,0 +1,185 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
+
+import { dayjs } from 'lib/dayjs'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import {
+    remindersCreate,
+    remindersDestroy,
+    remindersList,
+    remindersPartialUpdate,
+} from 'products/reminders/frontend/generated/api'
+import { RecurrenceIntervalEnumApi, ReminderApi } from 'products/reminders/frontend/generated/api.schemas'
+
+import type { remindersLogicType } from './remindersLogicType'
+
+export type ReminderScheduleType = 'one-off' | 'repeats' | 'advanced'
+
+export interface ReminderFormValues {
+    title: string
+    message: string
+    team: number | null
+    scheduleType: ReminderScheduleType
+    scheduled_at: string | null
+    recurrence_interval: RecurrenceIntervalEnumApi | null
+    cron_expression: string | null
+    timezone: string
+    end_date: string | null
+}
+
+// Sentinel id used while creating a brand-new reminder (mirrors the personalAPIKeysLogic pattern).
+const NEW = 'new'
+
+function scheduleTypeForReminder(reminder: ReminderApi): ReminderScheduleType {
+    if (reminder.cron_expression) {
+        return 'advanced'
+    }
+    if (reminder.recurrence_interval) {
+        return 'repeats'
+    }
+    return 'one-off'
+}
+
+export const remindersLogic = kea<remindersLogicType>([
+    path(['scenes', 'settings', 'user', 'remindersLogic']),
+    connect(() => ({
+        values: [organizationLogic, ['currentOrganization'], teamLogic, ['timezone']],
+    })),
+    actions({
+        setEditingReminderId: (id: string | null) => ({ id }),
+    }),
+    reducers({
+        editingReminderId: [
+            null as string | null,
+            {
+                setEditingReminderId: (_, { id }) => id,
+            },
+        ],
+    }),
+    loaders(({ values }) => ({
+        reminders: [
+            [] as ReminderApi[],
+            {
+                loadReminders: async () => {
+                    const response = await remindersList()
+                    return response.results
+                },
+                deleteReminder: async (id: string) => {
+                    await remindersDestroy(id)
+                    return values.reminders.filter((reminder) => reminder.id !== id)
+                },
+            },
+        ],
+    })),
+    forms(({ values, actions }) => ({
+        reminderForm: {
+            defaults: {
+                title: '',
+                message: '',
+                team: null,
+                scheduleType: 'one-off',
+                scheduled_at: null,
+                recurrence_interval: null,
+                cron_expression: null,
+                timezone: values.timezone || 'UTC',
+                end_date: null,
+            } as ReminderFormValues,
+            errors: ({
+                title,
+                scheduleType,
+                scheduled_at,
+                recurrence_interval,
+                cron_expression,
+            }: ReminderFormValues) => ({
+                title: !title?.trim() ? 'A title is required' : undefined,
+                scheduled_at:
+                    scheduleType !== 'one-off'
+                        ? undefined
+                        : !scheduled_at
+                          ? 'Pick when this reminder should fire'
+                          : values.isScheduleEditable && dayjs(scheduled_at).isBefore(dayjs())
+                            ? 'The time must be in the future'
+                            : undefined,
+                recurrence_interval:
+                    scheduleType === 'repeats' && !recurrence_interval ? 'Choose how often it repeats' : undefined,
+                cron_expression:
+                    scheduleType === 'advanced' && !cron_expression?.trim() ? 'Enter a cron expression' : undefined,
+            }),
+            submit: async (formValues) => {
+                const organization = values.currentOrganization?.id
+                if (!organization) {
+                    return
+                }
+                const payload = {
+                    organization,
+                    team: formValues.team,
+                    title: formValues.title.trim(),
+                    message: formValues.message?.trim() || '',
+                    timezone: formValues.timezone,
+                    scheduled_at: formValues.scheduleType === 'one-off' ? formValues.scheduled_at : null,
+                    recurrence_interval: formValues.scheduleType === 'repeats' ? formValues.recurrence_interval : null,
+                    cron_expression: formValues.scheduleType === 'advanced' ? formValues.cron_expression : null,
+                    end_date: formValues.scheduleType === 'one-off' ? null : formValues.end_date,
+                }
+                const editingId = values.editingReminderId
+                try {
+                    if (editingId && editingId !== NEW) {
+                        await remindersPartialUpdate(editingId, payload)
+                        lemonToast.success('Reminder updated')
+                    } else {
+                        await remindersCreate(payload)
+                        lemonToast.success('Reminder created')
+                    }
+                } catch (error: any) {
+                    lemonToast.error(error?.data?.detail || error?.detail || 'Could not save the reminder')
+                    return
+                }
+                actions.setEditingReminderId(null)
+                actions.loadReminders()
+            },
+        },
+    })),
+    selectors({
+        editingReminder: [
+            (s) => [s.editingReminderId, s.reminders],
+            (editingReminderId, reminders): ReminderApi | null =>
+                editingReminderId && editingReminderId !== NEW
+                    ? (reminders.find((reminder) => reminder.id === editingReminderId) ?? null)
+                    : null,
+        ],
+        isScheduleEditable: [
+            (s) => [s.editingReminderId, s.editingReminder],
+            (editingReminderId, editingReminder): boolean =>
+                editingReminderId === NEW || editingReminder?.status === 'active',
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        setEditingReminderId: ({ id }) => {
+            if (!id) {
+                return
+            }
+            const reminder = id === NEW ? null : values.reminders.find((r) => r.id === id)
+            actions.resetReminderForm({
+                title: reminder?.title ?? '',
+                message: reminder?.message ?? '',
+                team: reminder?.team ?? null,
+                scheduleType: reminder ? scheduleTypeForReminder(reminder) : 'one-off',
+                scheduled_at: reminder?.scheduled_at ?? null,
+                recurrence_interval: (reminder?.recurrence_interval as RecurrenceIntervalEnumApi) || null,
+                cron_expression: reminder?.cron_expression ?? null,
+                timezone: reminder?.timezone || values.timezone || 'UTC',
+                end_date: reminder?.end_date ?? null,
+            })
+        },
+        deleteReminderSuccess: () => {
+            lemonToast.success('Reminder deleted')
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadReminders()
+    }),
+])

--- a/frontend/src/scenes/settings/user/remindersLogic.ts
+++ b/frontend/src/scenes/settings/user/remindersLogic.ts
@@ -26,7 +26,7 @@ export interface ReminderFormValues {
     scheduleType: ReminderScheduleType
     scheduled_at: string | null
     recurrence_interval: RecurrenceIntervalEnumApi | null
-    cron_expression: string | null
+    cron_expression: string
     timezone: string
     end_date: string | null
 }
@@ -84,7 +84,7 @@ export const remindersLogic = kea<remindersLogicType>([
                 scheduleType: 'one-off',
                 scheduled_at: null,
                 recurrence_interval: null,
-                cron_expression: null,
+                cron_expression: '',
                 timezone: values.timezone || 'UTC',
                 end_date: null,
             } as ReminderFormValues,
@@ -170,7 +170,7 @@ export const remindersLogic = kea<remindersLogicType>([
                 scheduleType: reminder ? scheduleTypeForReminder(reminder) : 'one-off',
                 scheduled_at: reminder?.scheduled_at ?? null,
                 recurrence_interval: (reminder?.recurrence_interval as RecurrenceIntervalEnumApi) || null,
-                cron_expression: reminder?.cron_expression ?? null,
+                cron_expression: reminder?.cron_expression ?? '',
                 timezone: reminder?.timezone || values.timezone || 'UTC',
                 end_date: reminder?.end_date ?? null,
             })

--- a/frontend/src/scenes/settings/user/remindersLogic.ts
+++ b/frontend/src/scenes/settings/user/remindersLogic.ts
@@ -5,7 +5,6 @@ import { loaders } from 'kea-loaders'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { organizationLogic } from 'scenes/organizationLogic'
-import { teamLogic } from 'scenes/teamLogic'
 
 import {
     remindersCreate,
@@ -34,6 +33,15 @@ export interface ReminderFormValues {
 // Sentinel id used while creating a brand-new reminder (mirrors the personalAPIKeysLogic pattern).
 const NEW = 'new'
 
+// Personal reminders default to the user's own timezone, not the project's.
+function getLocalTimezone(): string {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+    } catch {
+        return 'UTC'
+    }
+}
+
 function scheduleTypeForReminder(reminder: ReminderApi): ReminderScheduleType {
     if (reminder.cron_expression) {
         return 'advanced'
@@ -47,7 +55,7 @@ function scheduleTypeForReminder(reminder: ReminderApi): ReminderScheduleType {
 export const remindersLogic = kea<remindersLogicType>([
     path(['scenes', 'settings', 'user', 'remindersLogic']),
     connect(() => ({
-        values: [organizationLogic, ['currentOrganization'], teamLogic, ['timezone']],
+        values: [organizationLogic, ['currentOrganization']],
     })),
     actions({
         setEditingReminderId: (id: string | null) => ({ id }),
@@ -85,7 +93,7 @@ export const remindersLogic = kea<remindersLogicType>([
                 scheduled_at: null,
                 recurrence_interval: null,
                 cron_expression: '',
-                timezone: values.timezone || 'UTC',
+                timezone: getLocalTimezone(),
                 end_date: null,
             } as ReminderFormValues,
             errors: ({
@@ -171,7 +179,7 @@ export const remindersLogic = kea<remindersLogicType>([
                 scheduled_at: reminder?.scheduled_at ?? null,
                 recurrence_interval: (reminder?.recurrence_interval as RecurrenceIntervalEnumApi) || null,
                 cron_expression: reminder?.cron_expression ?? '',
-                timezone: reminder?.timezone || values.timezone || 'UTC',
+                timezone: reminder?.timezone || getLocalTimezone(),
                 end_date: reminder?.end_date ?? null,
             })
         },

--- a/frontend/src/scenes/settings/user/remindersLogic.ts
+++ b/frontend/src/scenes/settings/user/remindersLogic.ts
@@ -4,7 +4,9 @@ import { loaders } from 'kea-loaders'
 
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { timeZoneLabel } from 'lib/utils/timezones'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import {
     remindersCreate,
@@ -55,7 +57,7 @@ function scheduleTypeForReminder(reminder: ReminderApi): ReminderScheduleType {
 export const remindersLogic = kea<remindersLogicType>([
     path(['scenes', 'settings', 'user', 'remindersLogic']),
     connect(() => ({
-        values: [organizationLogic, ['currentOrganization']],
+        values: [organizationLogic, ['currentOrganization'], preflightLogic, ['preflight']],
     })),
     actions({
         setEditingReminderId: (id: string | null) => ({ id }),
@@ -163,6 +165,21 @@ export const remindersLogic = kea<remindersLogicType>([
             (s) => [s.editingReminderId, s.editingReminder],
             (editingReminderId, editingReminder): boolean =>
                 editingReminderId === NEW || editingReminder?.status === 'active',
+        ],
+        projectOptions: [
+            (s) => [s.currentOrganization],
+            (currentOrganization): { value: number | null; label: string }[] => [
+                { value: null, label: 'Organization-wide (no project)' },
+                ...(currentOrganization?.teams ?? []).map((team) => ({ value: team.id, label: team.name })),
+            ],
+        ],
+        timezoneOptions: [
+            (s) => [s.preflight],
+            (preflight): { key: string; label: string }[] =>
+                Object.entries(preflight?.available_timezones ?? {}).map(([tz, offset]) => ({
+                    key: tz,
+                    label: timeZoneLabel(tz, offset),
+                })),
         ],
     }),
     listeners(({ actions, values }) => ({


### PR DESCRIPTION
## Problem

Reminders could only be created through MCP / PostHog AI — there was no in-app way for a user to see or manage the reminders they own.

## Changes

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f576ba47-5dbb-44c8-b890-1064e7b20fc8" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/63c11c6f-02d6-4611-8681-9cc094f5dec0" />


- Add a Reminders page under Account settings to list, create, edit, and delete your reminders
- Support one-off, recurring (daily/weekly/monthly/yearly), and cron schedules via a segmented control
- Show each reminder's schedule, next fire time, and status; default to the current organization with an optional project
- Reuse the existing settings, table, and modal-form patterns and bind to the generated reminders API types — no handwritten types

> [!IMPORTANT]
> Stacked on #63579 (reminders backend + MCP surface) — merge that first.

## How did you test this code?

- Manually verified end-to-end with Playwright: create/edit/delete for one-off, recurring, and cron, plus validation (empty fields, past time, and an over-frequent cron rejected server-side)
- No automated tests added in this PR
- Agent-authored; only the manual checks above were run

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?