### PR TITLE
fix(agent-platform): harden slack signature ts + make elevation decisions atomic

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/enqueue/acl.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/enqueue/acl.test.ts
@@ -139,6 +139,26 @@ describe('applyElevationGrant', () => {
         expect(new Date(result.aclEntry.expires_at!).getTime()).toBeGreaterThan(Date.now())
     })
 
+    it('a second grant on the same request is rejected from committed DB state, not the stale snapshot', async () => {
+        // Replays the concurrent-double-apply scenario sequentially: both calls
+        // hold the same in-memory `session` snapshot where the request is still
+        // pending. The first commits the grant; the second must read the now
+        // -granted DB state (under the row lock) and refuse — otherwise it would
+        // append the proposed message into pending_inputs a second time.
+        const queue = new PgSessionQueue(pool)
+        const session = makeSession({ pending: [makePendingRequest({ content: 'bob says hi' })] })
+        await queue.enqueue(session)
+
+        await applyElevationGrant(queue, session, { requestId: 'req-1', granter: ALICE })
+        await expect(applyElevationGrant(queue, session, { requestId: 'req-1', granter: ALICE })).rejects.toThrow(
+            /not pending/
+        )
+
+        const after = await queue.get(session.id)
+        expect(after!.acl).toHaveLength(1)
+        expect(after!.pending_inputs).toHaveLength(1)
+    })
+
     it('throws when applied to a non-pending request (idempotency stop)', async () => {
         const queue = new PgSessionQueue(pool)
         const decided = { ...makePendingRequest(), state: 'granted' as const, decision_at: 'now', decision_by: ALICE }

--- a/products/agent_platform/services/agent-ingress/src/enqueue/acl.ts
+++ b/products/agent_platform/services/agent-ingress/src/enqueue/acl.ts
@@ -235,52 +235,34 @@ export interface ApplyGrantResult {
 /**
  * Apply a grant: add an ACL entry for the requester, mark the request
  * `granted`, replay the proposed message into `pending_inputs`, and re-queue
- * the session so the runner picks it up. Idempotency: re-applying the same
- * granted request short-circuits — caller can safely retry.
+ * the session so the runner picks it up.
+ *
+ * The transition runs atomically under a row lock in `decideElevationRequest`
+ * (re-reading the request state inside the transaction), so a concurrent or
+ * replayed grant can't apply twice — only the first caller lands the ACL entry
+ * and replays the message. A second attempt against an already-decided request
+ * throws (the Slack handler pre-checks `authorizeGrant`, so this stays a
+ * defensive guard).
  */
 export async function applyElevationGrant(
     queue: SessionQueue,
     session: AgentSession,
     input: ApplyGrantInput
 ): Promise<ApplyGrantResult> {
-    const requests = session.pending_elevation_requests ?? []
-    const request = requests.find((r) => r.id === input.requestId)
-    if (!request) {
-        throw new Error(`elevation request ${input.requestId} not found on session ${session.id}`)
-    }
-    if (request.state !== 'pending') {
-        throw new Error(`elevation request ${input.requestId} is ${request.state}, not pending`)
-    }
-
-    const now = new Date().toISOString()
-    const aclEntry: SessionAclEntry = {
-        principal: request.requester,
-        granted_by: input.granter,
-        granted_at: now,
-        expires_at:
-            input.expiresInMs != null && input.expiresInMs > 0
-                ? new Date(Date.now() + input.expiresInMs).toISOString()
-                : null,
-        reason: input.reason ?? null,
-        state: 'active',
-    }
-    const nextAcl = [...(session.acl ?? []), aclEntry]
-    const nextRequests = requests.map((r) =>
-        r.id === input.requestId ? { ...r, state: 'granted' as const, decision_at: now, decision_by: input.granter } : r
-    )
-
-    await queue.update(session.id, {
-        acl: nextAcl,
-        pending_elevation_requests: nextRequests,
+    const result = await queue.decideElevationRequest(session.id, {
+        requestId: input.requestId,
+        decision: 'grant',
+        decidedBy: input.granter,
+        expiresInMs: input.expiresInMs,
+        reason: input.reason,
     })
-    // Replay the requester's would-be message so the runner sees it on the
-    // next turn. Done after the ACL mutation so a crash between leaves the
-    // grant landed (the message will re-deliver next time anyway via the
-    // user's natural retry).
-    await queue.appendPendingInput(session.id, request.proposed_message)
-    await queue.update(session.id, { state: 'queued' })
-
-    return { request: nextRequests.find((r) => r.id === input.requestId)!, aclEntry }
+    if (!result.applied) {
+        if (result.reason === 'not_found') {
+            throw new Error(`elevation request ${input.requestId} not found on session ${session.id}`)
+        }
+        throw new Error(`elevation request ${input.requestId} is ${result.request?.state}, not pending`)
+    }
+    return { request: result.request, aclEntry: result.aclEntry! }
 }
 
 export interface ApplyDeclineInput {
@@ -291,27 +273,25 @@ export interface ApplyDeclineInput {
 
 /**
  * Apply a decline: mark the request `declined`, do not mutate the ACL, do
- * not advance the session. Idempotency mirrors `applyElevationGrant`.
+ * not advance the session. Atomic + idempotent via `decideElevationRequest`,
+ * mirroring `applyElevationGrant`.
  */
 export async function applyElevationDecline(
     queue: SessionQueue,
     session: AgentSession,
     input: ApplyDeclineInput
 ): Promise<PendingElevationRequest> {
-    const requests = session.pending_elevation_requests ?? []
-    const request = requests.find((r) => r.id === input.requestId)
-    if (!request) {
-        throw new Error(`elevation request ${input.requestId} not found on session ${session.id}`)
+    const result = await queue.decideElevationRequest(session.id, {
+        requestId: input.requestId,
+        decision: 'decline',
+        decidedBy: input.decider,
+        reason: input.reason,
+    })
+    if (!result.applied) {
+        if (result.reason === 'not_found') {
+            throw new Error(`elevation request ${input.requestId} not found on session ${session.id}`)
+        }
+        throw new Error(`elevation request ${input.requestId} is ${result.request?.state}, not pending`)
     }
-    if (request.state !== 'pending') {
-        throw new Error(`elevation request ${input.requestId} is ${request.state}, not pending`)
-    }
-    const now = new Date().toISOString()
-    const nextRequests = requests.map((r) =>
-        r.id === input.requestId
-            ? { ...r, state: 'declined' as const, decision_at: now, decision_by: input.decider }
-            : r
-    )
-    await queue.update(session.id, { pending_elevation_requests: nextRequests })
-    return nextRequests.find((r) => r.id === input.requestId)!
+    return result.request
 }

--- a/products/agent_platform/services/agent-ingress/src/triggers/slack-signature.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack-signature.test.ts
@@ -1,0 +1,42 @@
+import { createHmac } from 'crypto'
+import type { Request } from 'express'
+import { describe, expect, it } from 'vitest'
+
+import { verifySlackSignature } from './slack-signature'
+
+const SECRET = 'signing-secret'
+
+function signedReq(opts: { ts: string; body?: string }): Request {
+    const body = opts.body ?? '{}'
+    const base = `v0:${opts.ts}:${body}`
+    const mac = createHmac('sha256', SECRET).update(base).digest('hex')
+    return {
+        headers: { 'x-slack-request-timestamp': opts.ts, 'x-slack-signature': `v0=${mac}` },
+        body: JSON.parse(body),
+        rawBody: body,
+    } as unknown as Request
+}
+
+describe('verifySlackSignature', () => {
+    it('accepts a fresh, correctly-signed request', () => {
+        const ts = String(Math.floor(Date.now() / 1000))
+        expect(verifySlackSignature(signedReq({ ts }), SECRET)).toBe(true)
+    })
+
+    it('rejects a stale timestamp', () => {
+        const ts = String(Math.floor(Date.now() / 1000) - 600)
+        expect(verifySlackSignature(signedReq({ ts }), SECRET)).toBe(false)
+    })
+
+    it('rejects a non-numeric timestamp (NaN must not skip the staleness check)', () => {
+        // A correctly-signed request whose timestamp is non-numeric: parseInt
+        // yields NaN, and `Math.abs(now - NaN) > 300` is false, which previously
+        // skipped the staleness window entirely.
+        expect(verifySlackSignature(signedReq({ ts: 'not-a-number' }), SECRET)).toBe(false)
+        expect(verifySlackSignature(signedReq({ ts: '' }), SECRET)).toBe(false)
+    })
+
+    it('rejects when headers are missing', () => {
+        expect(verifySlackSignature({ headers: {}, body: {} } as unknown as Request, SECRET)).toBe(false)
+    })
+})

--- a/products/agent_platform/services/agent-ingress/src/triggers/slack-signature.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack-signature.ts
@@ -15,7 +15,11 @@ export function verifySlackSignature(req: Request, signingSecret: string): boole
         return false
     }
     const now = Math.floor(Date.now() / 1000)
-    if (Math.abs(now - parseInt(ts, 10)) > 60 * 5) {
+    const tsNum = parseInt(ts, 10)
+    // A non-numeric timestamp parses to NaN, and `Math.abs(now - NaN) > 300`
+    // is false — which would silently SKIP the staleness window. Reject
+    // non-finite timestamps explicitly before the freshness check.
+    if (!Number.isFinite(tsNum) || Math.abs(now - tsNum) > 60 * 5) {
         return false
     }
     const raw = ((req as Request & { rawBody?: string }).rawBody ?? JSON.stringify(req.body)) as string

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-queue.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-queue.ts
@@ -18,7 +18,14 @@ import {
     SessionAclEntry,
     SessionUsageTotal,
 } from '../spec/spec'
-import { AggregateStats, LIVE_SESSION_STATES, ListSessionsOpts, SessionQueue } from './queue'
+import {
+    AggregateStats,
+    DecideElevationInput,
+    DecideElevationResult,
+    LIVE_SESSION_STATES,
+    ListSessionsOpts,
+    SessionQueue,
+} from './queue'
 
 const SELECT_COLS = `id, application_id, revision_id, team_id, external_key,
                      idempotency_key, trigger_metadata, state,
@@ -217,6 +224,94 @@ export class PgSessionQueue implements SessionQueue {
              WHERE id = $1`,
             [sessionId, JSON.stringify([req])]
         )
+    }
+
+    async decideElevationRequest(sessionId: string, input: DecideElevationInput): Promise<DecideElevationResult> {
+        // Lock the row and re-read the request state inside the transaction so a
+        // concurrent or replayed decision can't double-apply (e.g. append the
+        // proposed message into pending_inputs twice). Whichever caller wins the
+        // FOR UPDATE lock and finds the request still `pending` performs the
+        // transition; the rest see it already decided and no-op.
+        const client: PoolClient = await this.pool.connect()
+        try {
+            await client.query('BEGIN')
+            const sel = await client.query<{ acl: unknown; pending_elevation_requests: unknown }>(
+                `SELECT acl, pending_elevation_requests FROM agent_session WHERE id = $1 FOR UPDATE`,
+                [sessionId]
+            )
+            if (sel.rowCount === 0) {
+                await client.query('ROLLBACK')
+                return { applied: false, reason: 'not_found', request: null }
+            }
+            const acl: SessionAclEntry[] = Array.isArray(sel.rows[0].acl) ? (sel.rows[0].acl as SessionAclEntry[]) : []
+            const requests: PendingElevationRequest[] = Array.isArray(sel.rows[0].pending_elevation_requests)
+                ? (sel.rows[0].pending_elevation_requests as PendingElevationRequest[])
+                : []
+            const request = requests.find((r) => r.id === input.requestId) ?? null
+            if (!request) {
+                await client.query('ROLLBACK')
+                return { applied: false, reason: 'not_found', request: null }
+            }
+            if (request.state !== 'pending') {
+                await client.query('ROLLBACK')
+                return { applied: false, reason: 'not_pending', request }
+            }
+
+            const now = new Date().toISOString()
+            const decisionState = input.decision === 'grant' ? ('granted' as const) : ('declined' as const)
+            const updated: PendingElevationRequest = {
+                ...request,
+                state: decisionState,
+                decision_at: now,
+                decision_by: input.decidedBy,
+            }
+            const nextRequests = requests.map((r) => (r.id === input.requestId ? updated : r))
+
+            if (input.decision === 'decline') {
+                await client.query(
+                    `UPDATE agent_session SET pending_elevation_requests = $2::jsonb, updated_at = NOW() WHERE id = $1`,
+                    [sessionId, JSON.stringify(nextRequests)]
+                )
+                await client.query('COMMIT')
+                return { applied: true, decision: 'decline', request: updated }
+            }
+
+            const aclEntry: SessionAclEntry = {
+                principal: request.requester,
+                granted_by: input.decidedBy,
+                granted_at: now,
+                expires_at:
+                    input.expiresInMs != null && input.expiresInMs > 0
+                        ? new Date(Date.now() + input.expiresInMs).toISOString()
+                        : null,
+                reason: input.reason ?? null,
+                state: 'active',
+            }
+            // Single statement: land the ACL entry, mark the request granted,
+            // replay the proposed message, and re-queue — all under the lock.
+            await client.query(
+                `UPDATE agent_session
+                 SET acl = $2::jsonb,
+                     pending_elevation_requests = $3::jsonb,
+                     pending_inputs = pending_inputs || $4::jsonb,
+                     state = 'queued',
+                     updated_at = NOW()
+                 WHERE id = $1`,
+                [
+                    sessionId,
+                    JSON.stringify([...acl, aclEntry]),
+                    JSON.stringify(nextRequests),
+                    JSON.stringify([request.proposed_message]),
+                ]
+            )
+            await client.query('COMMIT')
+            return { applied: true, decision: 'grant', request: updated, aclEntry }
+        } catch (err) {
+            await client.query('ROLLBACK')
+            throw err
+        } finally {
+            client.release()
+        }
     }
 
     async get(sessionId: string): Promise<AgentSession | null> {

--- a/products/agent_platform/services/agent-shared/src/persistence/queue.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/queue.ts
@@ -5,7 +5,34 @@
  * the real test DB so claim semantics, indexes, and constraints are exercised.
  */
 
-import { AgentSession, ConversationMessage, PendingElevationRequest } from '../spec/spec'
+import {
+    AgentSession,
+    ConversationMessage,
+    PendingElevationRequest,
+    SessionAclEntry,
+    SessionPrincipal,
+} from '../spec/spec'
+
+/** Input to the atomic elevation-decision transition (`decideElevationRequest`). */
+export interface DecideElevationInput {
+    requestId: string
+    decision: 'grant' | 'decline'
+    /** The principal making the decision (the session owner clicking grant/decline). */
+    decidedBy: SessionPrincipal
+    /** grant only: expiry on the new ACL entry (ms from now). null/omitted = no expiry. */
+    expiresInMs?: number | null
+    reason?: string | null
+}
+
+/**
+ * Result of `decideElevationRequest`. `applied: true` means THIS call performed
+ * the transition; `applied: false` means it was a no-op (the request was already
+ * decided by a concurrent/replayed call, or doesn't exist) — the caller must not
+ * treat a no-op as a fresh decision.
+ */
+export type DecideElevationResult =
+    | { applied: true; decision: 'grant' | 'decline'; request: PendingElevationRequest; aclEntry?: SessionAclEntry }
+    | { applied: false; reason: 'not_found' | 'not_pending'; request: PendingElevationRequest | null }
 
 /** Shape returned by both `aggregateForApplication` and `aggregateForTeam`. */
 export interface AggregateStats {
@@ -67,6 +94,15 @@ export interface SessionQueue extends SessionInputsStore {
      * is preserved so a future grant can replay it.
      */
     appendPendingElevationRequest(sessionId: string, req: PendingElevationRequest): Promise<void>
+    /**
+     * Atomically decide a pending elevation request under a row lock. Re-reads
+     * the request state inside the transaction (NOT from a caller snapshot) so
+     * a concurrent or replayed decision can't apply twice — only the first
+     * caller transitions the request and (for a grant) replays the proposed
+     * message into `pending_inputs` + re-queues. Returns `applied: false` when
+     * the request was already decided or is missing.
+     */
+    decideElevationRequest(sessionId: string, input: DecideElevationInput): Promise<DecideElevationResult>
     get(sessionId: string): Promise<AgentSession | null>
     /** Find an existing session matching (application_id, external_key). */
     findByExternalKey(applicationId: string, externalKey: string): Promise<AgentSession | null>


### PR DESCRIPTION
## Problem

Threat model finding **F8** (TB-1, MEDIUM), the replay/idempotency remainder (the related "interactivity resolves sessionId without binding to the resolved agent" gap was already closed in #63903).

1. **NaN timestamp bypass.** A non-numeric `x-slack-request-timestamp` parses to `NaN`; `Math.abs(now - NaN) > 300` is `false`, so the 5-minute staleness window was silently skipped. (The timestamp is in the HMAC base, so this wasn't directly forgeable, but it's a missing-input-validation gap.)
2. **Interactivity double-apply.** The grant/decline handler read the session once and applied the decision from that in-memory snapshot. Two concurrent or replayed interactivity payloads could both pass the `pending` check before either committed, and both proceed — appending the requester's proposed message into `pending_inputs` twice (the runner then processes it twice). The sequential double-click was already safe; the gap was the concurrent race.

## Changes

- `verifySlackSignature` rejects non-finite timestamps via `Number.isFinite` before the freshness check.
- New `SessionQueue.decideElevationRequest(sessionId, input)`: atomically transitions a pending elevation request under a `SELECT … FOR UPDATE` row lock, re-reading the request state **inside** the transaction. For a grant it lands the ACL entry, marks the request granted, replays the proposed message, and re-queues — all in one statement under the lock. Returns `applied: false` when the request was already decided/missing, so a concurrent or replayed decision is a no-op (the `requestId` is the idempotency key).
- `applyElevationGrant` / `applyElevationDecline` now delegate to it (behaviour and throw-contract preserved).

## Scope note

This makes the **state-changing** interactivity path idempotent — the doc's "idempotency key on the interactivity `requestId`" option. A general short-TTL signature replay-nonce cache for non-state-changing Slack *events* (re-delivering a captured message event within the window) is **not** included: it needs a Redis client wired into the ingress trigger deps, and the harmful state-changing path is already neutralised here. Worth a small follow-up if event-replay is a concern.

## How did you test this code?

I'm an agent. Automated tests:

- `vitest run src/triggers/slack-signature.test.ts` — 4 passed, including the new non-numeric/empty-timestamp cases. New file.
- `tsc --noEmit` on agent-shared, agent-ingress, agent-runner, agent-janitor — all clean (the new `SessionQueue` method is additive; no consumer breaks).
- `oxlint` — clean.
- The DB-backed `acl.test.ts` (real Postgres) gained a case asserting a second grant on the same request is rejected from committed DB state, not the stale snapshot. **I could not run the Postgres-backed suite in this environment (no local DB)** — it needs `agent_runtime_queue_test`; flagging for CI to exercise.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.

Chose a transactional DB primitive over a Redis nonce so the fix is self-contained to persistence + ingress and fully correct under concurrency, rather than depending on new infra wiring.
