### PR TITLE
fix(agent-platform): redact token query params from ingress access logs

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/routing/http-utils.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/http-utils.test.ts
@@ -13,7 +13,7 @@ import { z } from 'zod'
 import { createLogger } from '@posthog/agent-shared'
 import type { Logger } from '@posthog/agent-shared'
 
-import { asyncHandler, errorHandler, requestLogger } from './http-utils'
+import { asyncHandler, errorHandler, redactUrl, requestLogger } from './http-utils'
 import { AmbiguousRevisionError } from './resolver'
 
 function buildHarness(routes: (r: Router) => void): express.Express {
@@ -190,5 +190,41 @@ describe('requestLogger', () => {
         await request(appWith(log)).get('/healthz')
         await tick()
         expect(lastRequestLine(records)!.level).toBe('debug')
+    })
+
+    it('redacts token / preview_token query params from the logged url', async () => {
+        const { records, log } = fakeLogger()
+        await request(appWith(log)).get('/ok?session_id=s1&token=phx_secret&preview_token=jwt.secret.val')
+        await tick()
+        const line = lastRequestLine(records)!
+        const url = line.obj.url as string
+        expect(url).not.toContain('phx_secret')
+        expect(url).not.toContain('jwt.secret.val')
+        expect(url).toContain('token=REDACTED')
+        expect(url).toContain('preview_token=REDACTED')
+        // Non-sensitive params are preserved.
+        expect(url).toContain('session_id=s1')
+        // request_start (debug) is redacted too.
+        const startLine = records.find((r) => r.msg === 'request_start')!
+        expect(startLine.obj.url as string).not.toContain('phx_secret')
+    })
+})
+
+describe('redactUrl', () => {
+    it('returns the url unchanged when there is no query string', () => {
+        expect(redactUrl('/listen')).toBe('/listen')
+    })
+
+    it('returns the url unchanged when no sensitive params are present', () => {
+        expect(redactUrl('/listen?session_id=s1')).toBe('/listen?session_id=s1')
+    })
+
+    it('masks token and preview_token values, preserving other params', () => {
+        const out = redactUrl('/listen?token=abc&session_id=s1&preview_token=xyz')
+        expect(out).toContain('token=REDACTED')
+        expect(out).toContain('preview_token=REDACTED')
+        expect(out).toContain('session_id=s1')
+        expect(out).not.toContain('abc')
+        expect(out).not.toContain('xyz')
     })
 })

--- a/products/agent_platform/services/agent-ingress/src/routing/http-utils.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/http-utils.ts
@@ -23,6 +23,36 @@ import type { Logger } from '@posthog/agent-shared'
 import { AmbiguousRevisionError } from './resolver'
 
 /**
+ * Query params that carry a secret and must never reach the access log.
+ * PATs ride in `?token=` and preview JWTs in `?preview_token=` for browser
+ * `EventSource` callers (the EventSource API can't set request headers), so
+ * the value lands in `originalUrl` — redact it before logging.
+ */
+const REDACT_QUERY_PARAMS = ['token', 'preview_token']
+
+/**
+ * Return `rawUrl` with the values of any sensitive query params masked. Keeps
+ * the param present (so the shape of the request is still visible) but replaces
+ * the secret with `REDACTED`. Handles the path+query `originalUrl` shape.
+ */
+export function redactUrl(rawUrl: string): string {
+    const qIndex = rawUrl.indexOf('?')
+    if (qIndex === -1) {
+        return rawUrl
+    }
+    const path = rawUrl.slice(0, qIndex)
+    const params = new URLSearchParams(rawUrl.slice(qIndex + 1))
+    let changed = false
+    for (const key of REDACT_QUERY_PARAMS) {
+        if (params.has(key)) {
+            params.set(key, 'REDACTED')
+            changed = true
+        }
+    }
+    return changed ? `${path}?${params.toString()}` : rawUrl
+}
+
+/**
  * One structured log line per request, emitted when the response completes so
  * it carries the final status + total duration — the trail you need when an
  * ingress call misbehaves and there's otherwise nothing to grep for.
@@ -39,7 +69,7 @@ import { AmbiguousRevisionError } from './resolver'
 export function requestLogger(log: Logger): RequestHandler {
     return (req, res, next) => {
         const start = process.hrtime.bigint()
-        log.debug({ method: req.method, url: req.originalUrl }, 'request_start')
+        log.debug({ method: req.method, url: redactUrl(req.originalUrl) }, 'request_start')
         let logged = false
         const emit = (): void => {
             if (logged) {
@@ -48,7 +78,7 @@ export function requestLogger(log: Logger): RequestHandler {
             logged = true
             const fields = {
                 method: req.method,
-                url: req.originalUrl,
+                url: redactUrl(req.originalUrl),
                 status: res.statusCode,
                 duration_ms: Math.round((Number(process.hrtime.bigint() - start) / 1e6) * 10) / 10,
                 ip: req.ip,


### PR DESCRIPTION
## Problem

Threat model finding **F9** (TB-1, MEDIUM). PATs are accepted from `?token=` and preview JWTs from `?preview_token=` — needed for browser `EventSource` (`GET /listen` SSE), which can't set request headers. The ingress request logger wrote the full `req.originalUrl` (at `request_start` debug and on response completion), so those secrets landed in access logs.

## Changes

- New `redactUrl()` helper masks the values of `token` / `preview_token` query params to `REDACTED`, keeping the param key (so the request shape stays legible) and all non-sensitive params intact.
- Applied at both `requestLogger` log sites.

Header-based auth remains the primary path; the query fallback exists only because `EventSource` can't set headers. (A stretch goal in the finding — replacing `?token=` with a signed single-use SSE ticket — is out of scope here; this stops the log leak.)

## How did you test this code?

I'm an agent. Automated tests I ran:

- `vitest run src/routing/http-utils.test.ts` — 14 passed, including a new requestLogger case (asserts the secret values are absent and the params show `REDACTED`, non-sensitive params preserved, and `request_start` is redacted too) and direct `redactUrl` unit cases.
- `oxlint` (no errors) + `tsc --noEmit` on agent-ingress — clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.
