### PR TITLE
fix(agent-platform): add tenant-scoped reads for approval + revision stores

### DIFF
--- a/products/agent_platform/backend/logic/janitor_client.py
+++ b/products/agent_platform/backend/logic/janitor_client.py
@@ -261,8 +261,11 @@ class JanitorClient:
             params["offset"] = offset
         return self._call("GET", "/fleet/approvals", params=params)
 
-    def get_approval(self, approval_id: str) -> dict:
-        return self._call("GET", f"/approvals/{approval_id}")
+    def get_approval(self, approval_id: str, *, application_id: str | None = None) -> dict:
+        # application_id scopes the janitor's read to this tenant (defence in
+        # depth alongside the app/team gate the view already enforces).
+        params = {"application_id": application_id} if application_id else None
+        return self._call("GET", f"/approvals/{approval_id}", params=params)
 
     def decide_approval(
         self,
@@ -272,13 +275,15 @@ class JanitorClient:
         decided_by: str,
         edited_args: dict[str, Any] | None = None,
         reason: str | None = None,
+        application_id: str | None = None,
     ) -> dict:
         body: dict[str, Any] = {"decision": decision, "decided_by": decided_by}
         if edited_args is not None:
             body["edited_args"] = edited_args
         if reason is not None:
             body["reason"] = reason
-        return self._call("POST", f"/approvals/{approval_id}/decide", json=body)
+        params = {"application_id": application_id} if application_id else None
+        return self._call("POST", f"/approvals/{approval_id}/decide", json=body, params=params)
 
     # ── catalog ────────────────────────────────────────────────────────────
 

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -1436,7 +1436,7 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise NotFound("Application not found")
         self._require_team_admin()
         try:
-            payload = _janitor().get_approval(approval_id)
+            payload = _janitor().get_approval(approval_id, application_id=str(application.id))
         except JanitorClientError as e:
             raise JanitorUpstreamError(e) from e
         # Cross-check ownership: the janitor doesn't know about teams.
@@ -1481,7 +1481,7 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         body.is_valid(raise_exception=True)
         # Cross-check ownership before forwarding.
         try:
-            existing = _janitor().get_approval(approval_id)
+            existing = _janitor().get_approval(approval_id, application_id=str(application.id))
         except JanitorClientError as e:
             raise JanitorUpstreamError(e) from e
         if existing.get("application_id") != str(application.id):
@@ -1502,6 +1502,7 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 decided_by=str(request.user.uuid) if request.user and request.user.is_authenticated else "",
                 edited_args=body.validated_data.get("edited_args"),
                 reason=body.validated_data.get("reason"),
+                application_id=str(application.id),
             )
         except JanitorClientError as e:
             raise JanitorUpstreamError(e) from e

--- a/products/agent_platform/backend/tests/test_approvals_api.py
+++ b/products/agent_platform/backend/tests/test_approvals_api.py
@@ -93,12 +93,17 @@ class TestApprovalEndpointsAuth(APIBaseTest):
             format="json",
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # The pre-flight read is tenant-scoped to the application in the URL.
+        mock_janitor.return_value.get_approval.assert_called_once_with(
+            self.approval_id, application_id=str(self.application.id)
+        )
         mock_janitor.return_value.decide_approval.assert_called_once_with(
             self.approval_id,
             decision="approve",
             decided_by=str(self.user.uuid),
             edited_args=None,
             reason="looks good",
+            application_id=str(self.application.id),
         )
 
     @patch("products.agent_platform.backend.presentation.views._janitor")

--- a/products/agent_platform/services/agent-ingress/src/routing/resolver.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/resolver.ts
@@ -151,7 +151,13 @@ export class RevisionResolver {
         if (!application || application.archived || !application.live_revision_id) {
             return null
         }
-        const revision = await this.opts.revisions.getRevision(application.live_revision_id)
+        // Scope the revision read to the resolved application — the live
+        // revision id always belongs to this app, so this is belt-and-braces
+        // against ever resolving across a tenant boundary.
+        const revision = await this.opts.revisions.getRevisionForApplication(
+            application.live_revision_id,
+            application.id
+        )
         if (!revision) {
             return null
         }

--- a/products/agent_platform/services/agent-janitor/src/server.ts
+++ b/products/agent_platform/services/agent-janitor/src/server.ts
@@ -160,6 +160,18 @@ function defaultSince(): string {
 }
 
 /**
+ * Read an approval by id, tenant-scoped to the `?application_id=` query param
+ * when Django supplies it (it always does for the per-app approval routes).
+ * Scoping here is defence-in-depth — Django also enforces the app/team gate —
+ * but it keeps a leaked approval id from resolving another tenant's row at the
+ * store layer. Falls back to the unscoped read when no application_id is given.
+ */
+async function getApprovalScoped(approvals: ApprovalStore, req: Request): Promise<ApprovalRequest | null> {
+    const applicationId = typeof req.query.application_id === 'string' ? req.query.application_id : undefined
+    return applicationId ? approvals.getForApplication(req.params.id, applicationId) : approvals.get(req.params.id)
+}
+
+/**
  * Compute the freeze-time spec: derive `spec.skills[]` + `spec.tools[]` from
  * the typed resources in the bundle and merge them with the author-written
  * non-custom (native/client) tools already on the spec. Pure — the freeze
@@ -580,7 +592,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
             if (!needApprovalStore(res)) {
                 return
             }
-            const row = await opts.approvals!.get(req.params.id)
+            const row = await getApprovalScoped(opts.approvals!, req)
             if (!row) {
                 res.status(404).json({ error: 'not_found' })
                 return
@@ -596,7 +608,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
                 return
             }
             const body = DecideApprovalBodySchema.parse(req.body)
-            const existing = await opts.approvals!.get(req.params.id)
+            const existing = await getApprovalScoped(opts.approvals!, req)
             if (!existing) {
                 res.status(404).json({ error: 'not_found' })
                 return

--- a/products/agent_platform/services/agent-shared/src/persistence/approval-store.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/approval-store.test.ts
@@ -232,4 +232,15 @@ describe('ApprovalStore (PG)', () => {
             expect(rejected[0].state).toBe('rejected')
         })
     })
+
+    describe('getForApplication (tenant-scoped read)', () => {
+        it('returns the row for the owning application and null for a mismatched one', async () => {
+            const { request } = await store.upsertQueued(buildInput())
+            const owned = await store.getForApplication(request.id, DEFAULT_APP_ID)
+            expect(owned?.id).toBe(request.id)
+            // A different application id must not resolve the row (no cross-tenant read).
+            const otherApp = await store.getForApplication(request.id, '00000000-0000-4000-8000-0000000060ff')
+            expect(otherApp).toBeNull()
+        })
+    })
 })

--- a/products/agent_platform/services/agent-shared/src/persistence/approval-store.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/approval-store.ts
@@ -94,6 +94,13 @@ export interface ApprovalStore {
      */
     upsertQueued(input: UpsertApprovalRequestInput): Promise<UpsertApprovalRequestResult>
     get(id: string): Promise<ApprovalRequest | null>
+    /**
+     * Tenant-scoped variant of `get` for request-path callers: only returns the
+     * row when it belongs to `applicationId`. Use this from HTTP handlers that
+     * receive a caller-supplied id so a leaked id can't resolve another tenant's
+     * request; keep `get` for trusted internal callers (runner, sweep).
+     */
+    getForApplication(id: string, applicationId: string): Promise<ApprovalRequest | null>
     /** Returns the most recently created request for a (session, tool, args). */
     findLatestByArgs(sessionId: string, toolName: string, argsHash: Buffer): Promise<ApprovalRequest | null>
     /** Atomically flip `queued` → `approving` with stamp. Returns null when not in `queued`. */

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-approval-store.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-approval-store.ts
@@ -71,6 +71,18 @@ export class PgApprovalStore implements ApprovalStore {
         return r.rowCount === 0 ? null : rowToRequest(r.rows[0])
     }
 
+    async getForApplication(id: string, applicationId: string): Promise<ApprovalRequest | null> {
+        // Tenant-scoped read for request-path callers: the row must belong to
+        // the application in the request URL, so a leaked approval id can't
+        // resolve another tenant's request. A miss on app mismatch returns null
+        // (same as not-found) so we don't leak existence across tenants.
+        const r = await this.pool.query<DbRow>(
+            `SELECT ${SELECT_COLS} FROM agent_tool_approval_request WHERE id = $1 AND application_id = $2`,
+            [id, applicationId]
+        )
+        return r.rowCount === 0 ? null : rowToRequest(r.rows[0])
+    }
+
     async findLatestByArgs(sessionId: string, toolName: string, argsHash: Buffer): Promise<ApprovalRequest | null> {
         const r = await this.pool.query<DbRow>(
             `SELECT ${SELECT_COLS}

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-impls.test.ts
@@ -92,6 +92,11 @@ maybeDescribe('Postgres impls (real PG)', () => {
         await store.setRevisionState(rev.id, 'live')
         await store.setLiveRevision(app.id, rev.id)
         expect((await store.getApplication(app.id))!.live_revision_id).toBe(rev.id)
+
+        // Tenant-scoped read: resolves for the owning app, null for another.
+        expect((await store.getRevisionForApplication(rev.id, app.id))!.id).toBe(rev.id)
+        const otherApp = await store.createApplication({ team_id: 2, slug: 'echo2', name: 'Echo2', description: '' })
+        expect(await store.getRevisionForApplication(rev.id, otherApp.id)).toBeNull()
     })
 
     it('PgRevisionStore rejects spec updates on non-draft revisions', async () => {

--- a/products/agent_platform/services/agent-shared/src/persistence/pg-revision-store.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/pg-revision-store.ts
@@ -84,6 +84,19 @@ export class PgRevisionStore implements RevisionStore {
         return r.rowCount === 0 ? null : rowToRev(r.rows[0])
     }
 
+    async getRevisionForApplication(revisionId: string, applicationId: string): Promise<AgentRevision | null> {
+        // Tenant-scoped read for request-path callers: the revision must belong
+        // to the resolved application, so a leaked/guessed revision id can't
+        // resolve another tenant's revision. Returns null on app mismatch.
+        const r = await this.pool.query(
+            `SELECT id, application_id, parent_revision_id, created_by_id, created_at, state,
+                    bundle_uri, bundle_sha256, spec
+             FROM agent_revision WHERE id = $1 AND application_id = $2`,
+            [revisionId, applicationId]
+        )
+        return r.rowCount === 0 ? null : rowToRev(r.rows[0])
+    }
+
     async getRevisionRaw(revisionId: string): Promise<AgentRevisionRaw | null> {
         const r = await this.pool.query(
             `SELECT id, application_id, parent_revision_id, created_by_id, created_at, state,

--- a/products/agent_platform/services/agent-shared/src/persistence/revision-store.ts
+++ b/products/agent_platform/services/agent-shared/src/persistence/revision-store.ts
@@ -23,6 +23,14 @@ export interface RevisionStore {
 
     getRevision(revisionId: string): Promise<AgentRevision | null>
     /**
+     * Tenant-scoped variant of `getRevision` for request-path callers: only
+     * returns the revision when it belongs to `applicationId`. Use this when
+     * the revision id came from a caller-influenced source so a leaked id can't
+     * resolve another tenant's revision; keep `getRevision` for trusted internal
+     * callers (runner session-start, janitor sweep).
+     */
+    getRevisionForApplication(revisionId: string, applicationId: string): Promise<AgentRevision | null>
+    /**
      * Same as `getRevision` but skips `AgentSpecSchema.parse`. For callers
      * that only need state / bundle pointers, or that are about to overwrite
      * the spec wholesale (e.g. `put_bundle`'s merge step). Lets a re-seed


### PR DESCRIPTION
## Problem

Threat model finding **F11** (TB-5, LOW). The approval and revision stores exposed only `WHERE id = $1` single-row reads — the structural pattern that made the F2/F5 session-confusion bugs reachable. The session queue half was already addressed in #63903; this closes the remainder for the approval + revision stores.

## Changes

Add tenant-scoped read variants and route the request-path callers through them, keeping the unscoped reads for trusted internal callers (runner session-start, janitor sweep):

- `ApprovalStore.getForApplication(id, applicationId)` — `WHERE id = $1 AND application_id = $2`. The janitor `GET /approvals/:id` and `POST /approvals/:id/decide` handlers now scope by an `?application_id=` query param that Django passes (Django already cross-checks the returned row's `application_id`, so this is defence-in-depth at the store layer). Falls back to the unscoped read when no `application_id` is supplied.
- `RevisionStore.getRevisionForApplication(revisionId, applicationId)` — `WHERE id = $1 AND application_id = $2`. The ingress revision resolver now scopes the live-revision read to the resolved application.

`get` / `getRevision` remain for the trusted internal callers per the finding's guidance.

## How did you test this code?

I'm an agent. Automated checks I ran:

- `tsc --noEmit` on agent-shared, agent-janitor, agent-ingress, agent-runner — all clean (interface additions are additive; no consumer breaks).
- `oxlint` (no errors) and `ruff check` on the touched Python — clean.
- Added DB-backed test cases: `getForApplication` resolves for the owning app and returns null for a mismatched one (approval-store.test.ts); `getRevisionForApplication` likewise (pg-impls.test.ts). **The Postgres-backed suite needs a live `agent_runtime_queue_test` DB I couldn't run in this environment — flagging for CI.**

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.

The Django change only passes `application_id` to the internal janitor client (no change to the DRF request/response contract, so no OpenAPI codegen impact). The janitor revision *authoring* endpoints (manifest/freeze/validate/…) stay on the unscoped read — they're internal-JWT authoring routes where Django validates the revision↔app relationship — and could be tightened in a later pass if desired.
