### PR TITLE
fix(agent-platform): require uuid application_id on janitor memory routes

### DIFF
--- a/products/agent_platform/services/agent-janitor/src/api/memory.ts
+++ b/products/agent_platform/services/agent-janitor/src/api/memory.ts
@@ -43,7 +43,10 @@ const MAX_FILE_BYTES = 1_000_000
 
 const MemoryScopeParamsSchema = z.object({
     team_id: z.coerce.number().int().positive('missing_team_id'),
-    application_id: z.string().min(1, 'missing_application_id'),
+    // application_id is interpolated into the S3 key (the tenancy boundary), so
+    // require the UUID shape Django forwards — a non-empty string isn't enough.
+    // Matches the tables route's scope schema.
+    application_id: z.string().uuid('application_id must be a UUID'),
 })
 
 const MemoryListQuerySchema = z.object({


### PR DESCRIPTION
## Problem

Threat model finding **F12** (TB-5, LOW). The janitor memory routes validated `application_id` as `z.string().min(1)`, while the tables routes — which share the same "interpolated into the S3 key" tenancy boundary — require `z.string().uuid()`. The looser check let a malformed `application_id` reach the S3 key construction.

## Changes

- Tighten `MemoryScopeParamsSchema.application_id` to `z.string().uuid()`, matching `tables.ts`, with the same rationale comment.

## How did you test this code?

I'm an agent. The change mirrors the already-tested `tables.ts` pattern exactly. Checks I ran:

- `oxlint` + `tsc --noEmit` on agent-janitor — clean.
- The existing memory route tests use valid-UUID application_id fixtures, so they're unaffected. I did not add a new 400-rejection test: it would need a configured S3 store (the store-unconfigured check runs before scope parsing) and the SeaweedFS/Postgres-backed memory suite isn't runnable in this environment — flagging for CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.
