### PR TITLE
fix(agent-platform): recompute bundle sha256 from bytes at freeze

### DIFF
--- a/products/agent_platform/services/agent-shared/src/storage/s3-bundle-store.test.ts
+++ b/products/agent_platform/services/agent-shared/src/storage/s3-bundle-store.test.ts
@@ -6,7 +6,7 @@
  * Each test gets its own random prefix so concurrent suites don't collide.
  */
 
-import { DeleteObjectsCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { DeleteObjectsCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { randomBytes } from 'node:crypto'
 
 import { S3BundleStore } from './s3-bundle-store'
@@ -124,5 +124,27 @@ describe('S3BundleStore (real S3 / SeaweedFS)', () => {
         const shaB = await store.freeze('b')
 
         expect(shaA).toBe(shaB)
+    })
+
+    it('freeze hash reflects actual bytes, not writer-supplied metadata sha256', async () => {
+        // Honest freeze of known content.
+        await store.write('clean', 'agent.md', 'hello')
+        const cleanSha = await store.freeze('clean')
+
+        // Same bytes, but the object metadata sha256 is tampered to a bogus
+        // value (simulating an in-cluster writer setting metadata independently).
+        await store.write('tampered', 'agent.md', 'hello')
+        await client.send(
+            new PutObjectCommand({
+                Bucket: TEST_S3_BUCKET,
+                Key: `${prefix}/tampered/agent.md`,
+                Body: Buffer.from('hello'),
+                Metadata: { sha256: 'deadbeef'.repeat(8) },
+            })
+        )
+        // list trusts the (now bogus) metadata...
+        expect((await store.list('tampered'))[0].sha256).toBe('deadbeef'.repeat(8))
+        // ...but freeze recomputes from bytes, so it matches the honest hash.
+        expect(await store.freeze('tampered')).toBe(cleanSha)
     })
 })

--- a/products/agent_platform/services/agent-shared/src/storage/s3-bundle-store.ts
+++ b/products/agent_platform/services/agent-shared/src/storage/s3-bundle-store.ts
@@ -132,9 +132,18 @@ export class S3BundleStore implements BundleStore {
     }
 
     async freeze(rev: string, precomputedEntries?: BundleEntry[]): Promise<string> {
-        const entries = precomputedEntries ?? (await this.list(rev))
+        const listed = precomputedEntries ?? (await this.list(rev))
+        // Recompute each file's sha256 from its actual bytes rather than trusting
+        // the writer-supplied object metadata `list` reads. The freeze hash is the
+        // bundle's integrity anchor, so it must reflect content, not a metadata
+        // field an in-cluster writer could set independently. For honestly-written
+        // objects this equals the metadata hash, so the frozen hash is unchanged.
+        const verified = await Promise.all(
+            listed.map(async (e): Promise<BundleEntry> => ({ ...e, sha256: await this.sha256OfObject(rev, e.path) }))
+        )
+        verified.sort((a, b) => a.path.localeCompare(b.path))
         const hash = createHash('sha256')
-        for (const e of entries) {
+        for (const e of verified) {
             hash.update(e.path).update('\0').update(e.sha256).update('\0')
         }
         const sha = hash.digest('hex')
@@ -160,6 +169,12 @@ export class S3BundleStore implements BundleStore {
                 MetadataDirective: 'COPY',
             })
         )
+    }
+
+    /** sha256 hex of an object's actual bytes — used to verify integrity at freeze. */
+    private async sha256OfObject(rev: string, p: string): Promise<string> {
+        const buf = await this.read(rev, p)
+        return createHash('sha256').update(buf).digest('hex')
     }
 
     private async headObject(key: string): Promise<boolean> {


### PR DESCRIPTION
## Problem

Threat model finding **F13** (TB-6, LOW, defence-in-depth). A revision's freeze hash is the bundle's integrity anchor, but it was computed from the per-file `sha256` stored in S3 object metadata (`HeadObject.Metadata.sha256`) — a field a writer sets independently of the actual bytes. An in-cluster actor with S3 metadata write could make the freeze hash self-consistent while diverging from content.

## Changes

- `freeze()` now recomputes each file's sha256 from its actual object bytes (`GetObject` → hash) instead of trusting the metadata that `list()` reads. The (path, sha256) tuples are then hashed in path order as before.
- For honestly-written objects the recomputed hash equals the metadata hash, so the frozen hash is unchanged (the existing "same freeze hash across equivalent revisions" behaviour holds). `list()` still reports the metadata hash — it's informational — but it no longer feeds the integrity anchor.

Freeze is a rare authoring operation, so the extra byte reads are acceptable; bundles are small.

## How did you test this code?

I'm an agent. Checks I ran:

- `oxlint` + `tsc --noEmit` on agent-shared — clean.
- Added a test asserting the freeze hash reflects actual bytes: write known content, tamper the object's metadata sha256 to a bogus value, and confirm `list` reports the bogus value while `freeze` still produces the honest-content hash. **The S3/SeaweedFS-backed bundle suite isn't runnable in this environment — flagging for CI** (`AGENT_BUNDLE_TEST_S3_ENDPOINT`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.

Chose to anchor integrity at freeze (the doc's "or at freeze" option) rather than verifying on every read, which would add hashing to session start without a clear expected-hash source at that layer.
