### PR TITLE
fix(agent-platform): require explicit console team allowlist in prod

### DIFF
--- a/products/agent_platform/services/agent-console/src/lib/auth/allowlist.ts
+++ b/products/agent_platform/services/agent-console/src/lib/auth/allowlist.ts
@@ -2,9 +2,12 @@
  * Team allowlist check for the agent console.
  *
  * Driven by `AGENT_CONSOLE_ALLOWED_TEAM_IDS` on `AgentConsoleConfig`.
- * When the list is empty (the default) the gate is disabled — anyone
- * with a working PostHog login can use the console. Set the env var to
- * restrict access to a curated set of teams (projects).
+ * When the list is empty the gate is disabled — anyone with a working
+ * PostHog login can use the console. In production this only happens when
+ * the operator sets the env var to an explicit empty value (the config
+ * loader requires it to be set in prod, so there's no silent default);
+ * dev defaults to `1,2`. Set the env var to restrict access to a curated
+ * set of teams (projects).
  *
  * Checked at two points:
  *   1. The OAuth callback — denial means the session cookie is never

--- a/products/agent_platform/services/agent-console/src/lib/config.ts
+++ b/products/agent_platform/services/agent-console/src/lib/config.ts
@@ -89,7 +89,13 @@ export const AgentConsoleConfigSchema = z.object({
         .describe('Node env. Controls cookie `secure` flag and the dev-default gating above.'),
     allowedTeamIds: z
         .string()
-        .default('1,2')
+        // Dev convenience default only — `1,2` covers the first two projects in
+        // a local install. In prod there is NO default: the operator must set
+        // `AGENT_CONSOLE_ALLOWED_TEAM_IDS` explicitly (see the prod check in
+        // `loadAgentConsoleConfig`) so a deployment can't silently ship the
+        // `1,2` door, and so "run without a team gate" is a deliberate choice
+        // (an explicit empty value) rather than an accident.
+        .default(() => (isDev() ? '1,2' : ''))
         .transform((v) =>
             v
                 .split(',')
@@ -99,7 +105,7 @@ export const AgentConsoleConfigSchema = z.object({
                 .filter((n) => Number.isInteger(n) && n > 0)
         )
         .describe(
-            'Comma-separated PostHog team (project) IDs that may use this console deployment. Defaults to `1,2` — the first two projects in any PostHog install, which cover a typical local dev or small single-tenant setup. Override to lock down a multi-team install, or set to an empty string (`AGENT_CONSOLE_ALLOWED_TEAM_IDS=`) to disable the gate entirely. Checked at OAuth callback (cookie never gets set on denial) AND on every `/api/auth/me` refresh (an admin removing the team mid-session signs the user out on next refresh).'
+            'Comma-separated PostHog team (project) IDs that may use this console deployment. Dev defaults to `1,2`; in prod it must be set explicitly. Set an empty string (`AGENT_CONSOLE_ALLOWED_TEAM_IDS=`) to deliberately run without a team gate. Checked at OAuth callback (cookie never gets set on denial) AND on every `/api/auth/me` refresh (an admin removing the team mid-session signs the user out on next refresh).'
         ),
 })
 
@@ -159,6 +165,16 @@ export function loadAgentConsoleConfig(env: NodeJS.ProcessEnv = process.env): Ag
         if (missing.length > 0) {
             const names = missing.map((k) => PROD_ENV_NAMES[k]).join(', ')
             throw new Error(`Missing required env vars in production: ${names}`)
+        }
+        // The team gate must be an explicit decision in prod: require the env
+        // var to be present (even if empty) so we never silently ship the dev
+        // `1,2` default or fall open by accident. An explicit empty value is a
+        // deliberate opt-out of the gate.
+        if (env.AGENT_CONSOLE_ALLOWED_TEAM_IDS === undefined) {
+            throw new Error(
+                'AGENT_CONSOLE_ALLOWED_TEAM_IDS must be set in production ' +
+                    '(use an explicit empty value to run without a team gate)'
+            )
         }
     }
 


### PR DESCRIPTION
## Problem

Threat model finding **F14** (TB-1, LOW). `allowedTeamIds` defaulted to `1,2` in *every* environment, so a production console deployment that forgot to set `AGENT_CONSOLE_ALLOWED_TEAM_IDS` silently granted access to the first two projects.

Note on semantics: an *empty* allowlist disables the gate entirely (anyone with a PostHog login gets in) — so the finding's literal "(empty)" would be fail-*open*. The real intent is "don't silently grant access in prod"; the fix forces an explicit operator decision rather than flipping a default.

## Changes

- `1,2` is now a **dev-only** default (`isDev() ? '1,2' : ''`).
- In production the loader throws at boot if `AGENT_CONSOLE_ALLOWED_TEAM_IDS` is not set at all — no silent `1,2`, no accidental open gate.
- An explicit empty value (`AGENT_CONSOLE_ALLOWED_TEAM_IDS=`) still opts into "no team gate", so the documented single-tenant escape hatch remains — but it's now a deliberate choice.
- Corrected the stale `allowlist.ts` comment that claimed empty was "the default".

## How did you test this code?

I'm an agent. Checks I ran:

- `oxlint` on the two changed files — clean.
- `tsc --noEmit` on agent-console reports only pre-existing `@posthog/quill` module-resolution errors in unrelated components (that workspace dep isn't built in my local install); `config.ts`/`allowlist.ts` have no errors.
- agent-console has no test runner configured, so there are no unit tests to extend here. The new prod-boot guard is a straightforward presence check.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.

Chose "require explicit value in prod" over literally defaulting prod to empty, because empty means *gate disabled* in the existing consumer (`allowedTeamIds.length > 0`), so an empty prod default would be fail-open — the opposite of the finding's intent.
