### PR TITLE
fix(agent-platform): add jti + replay guard to internal JWTs

### DIFF
--- a/products/agent_platform/backend/logic/internal_jwt.py
+++ b/products/agent_platform/backend/logic/internal_jwt.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
@@ -28,7 +29,9 @@ def encode_agent_internal_jwt(payload: dict[str, Any], expiry_delta: timedelta, 
     if not key:
         raise RuntimeError("AGENT_INTERNAL_SIGNING_KEY is not configured")
     return jwt.encode(
-        {**payload, "exp": datetime.now(tz=UTC) + expiry_delta, "aud": audience.value},
+        # `jti` is a per-token nonce so the verify side can reject a replayed
+        # token even inside its short exp window (defence-in-depth).
+        {**payload, "exp": datetime.now(tz=UTC) + expiry_delta, "aud": audience.value, "jti": uuid.uuid4().hex},
         key,
         algorithm=JWT_ALGORITHM,
     )

--- a/products/agent_platform/services/agent-ingress/src/routing/resolver.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/resolver.ts
@@ -22,6 +22,7 @@
 import {
     AgentApplication,
     AgentRevision,
+    InMemoryJtiReplayCache,
     INTERNAL_JWT_AUDIENCE,
     InternalJwtVerifyError,
     RevisionStore,
@@ -87,6 +88,10 @@ export interface ResolverOpts {
 }
 
 export class RevisionResolver {
+    // Per-process replay guard for preview tokens — defence-in-depth over the
+    // 60s exp so a captured preview token can't be replayed within the window.
+    private readonly previewReplayCache = new InMemoryJtiReplayCache()
+
     constructor(private readonly opts: ResolverOpts) {}
 
     async resolveFromHostAndPath(
@@ -182,6 +187,7 @@ export class RevisionResolver {
                 token: providedToken,
                 audience: INTERNAL_JWT_AUDIENCE.INGRESS_PREVIEW,
                 signingKey: this.opts.internalSigningKey,
+                replayCache: this.previewReplayCache,
             })
         } catch (e) {
             throw new MissingPreviewSecretError(`token_verify_failed: ${(e as InternalJwtVerifyError).reason}`)

--- a/products/agent_platform/services/agent-janitor/src/server.ts
+++ b/products/agent_platform/services/agent-janitor/src/server.ts
@@ -62,6 +62,7 @@ import {
     EMPTY_USAGE_TOTAL,
     FRAMEWORK_PROMPT_VERSION,
     instrument,
+    InMemoryJtiReplayCache,
     INTERNAL_JWT_AUDIENCE,
     InternalJwtVerifyError,
     lastAssistantTextPreview,
@@ -287,6 +288,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
     app.use(express.json({ limit: '8mb' }))
     if (opts.internalSigningKey) {
         const signingKey = opts.internalSigningKey
+        const replayCache = new InMemoryJtiReplayCache()
         app.use((req: Request, res: Response, next: NextFunction) => {
             if (req.path === '/healthz') {
                 next()
@@ -302,6 +304,7 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
                 token,
                 audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC,
                 signingKey,
+                replayCache,
             })
                 .then(() => next())
                 .catch((e: InternalJwtVerifyError) => {

--- a/products/agent_platform/services/agent-shared/src/runtime/internal-jwt.test.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/internal-jwt.test.ts
@@ -1,4 +1,10 @@
-import { INTERNAL_JWT_AUDIENCE, InternalJwtVerifyError, mintInternalJwt, verifyInternalJwt } from './internal-jwt'
+import {
+    InMemoryJtiReplayCache,
+    INTERNAL_JWT_AUDIENCE,
+    InternalJwtVerifyError,
+    mintInternalJwt,
+    verifyInternalJwt,
+} from './internal-jwt'
 
 describe('internal-jwt', () => {
     const SIGNING_KEY = 'shared-key-shared-key-shared-key'
@@ -59,5 +65,54 @@ describe('internal-jwt', () => {
                 signingKey: SIGNING_KEY,
             })
         ).rejects.toBeInstanceOf(InternalJwtVerifyError)
+    })
+
+    it('mints a unique jti on every token', async () => {
+        const a = await mintInternalJwt({ audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY })
+        const b = await mintInternalJwt({ audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY })
+        const pa = await verifyInternalJwt({
+            token: a,
+            audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC,
+            signingKey: SIGNING_KEY,
+        })
+        const pb = await verifyInternalJwt({
+            token: b,
+            audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC,
+            signingKey: SIGNING_KEY,
+        })
+        expect(pa.jti).toBeTruthy()
+        expect(pa.jti).not.toBe(pb.jti)
+    })
+
+    it('rejects a replayed token when a replay cache is supplied', async () => {
+        const replayCache = new InMemoryJtiReplayCache()
+        const token = await mintInternalJwt({ audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY })
+        const opts = { token, audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY, replayCache }
+        // First use succeeds...
+        await expect(verifyInternalJwt(opts)).resolves.toMatchObject({ aud: 'agent-janitor.rpc' })
+        // ...a replay of the same token is rejected.
+        await expect(verifyInternalJwt(opts)).rejects.toBeInstanceOf(InternalJwtVerifyError)
+    })
+
+    it('does not reject distinct tokens sharing a replay cache', async () => {
+        const replayCache = new InMemoryJtiReplayCache()
+        const t1 = await mintInternalJwt({ audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY })
+        const t2 = await mintInternalJwt({ audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC, signingKey: SIGNING_KEY })
+        await expect(
+            verifyInternalJwt({
+                token: t1,
+                audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC,
+                signingKey: SIGNING_KEY,
+                replayCache,
+            })
+        ).resolves.toBeTruthy()
+        await expect(
+            verifyInternalJwt({
+                token: t2,
+                audience: INTERNAL_JWT_AUDIENCE.JANITOR_RPC,
+                signingKey: SIGNING_KEY,
+                replayCache,
+            })
+        ).resolves.toBeTruthy()
     })
 })

--- a/products/agent_platform/services/agent-shared/src/runtime/internal-jwt.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/internal-jwt.ts
@@ -17,6 +17,7 @@
  */
 
 import { jwtVerify, SignJWT } from 'jose'
+import { randomUUID } from 'node:crypto'
 
 export const INTERNAL_JWT_AUDIENCE = {
     INGRESS_PREVIEW: 'agent-ingress.preview',
@@ -28,7 +29,47 @@ export type InternalJwtAudience = (typeof INTERNAL_JWT_AUDIENCE)[keyof typeof IN
 export interface VerifiedInternalJwt {
     sub?: string
     exp?: number
+    /** Unique token id — basis for replay detection. Present on tokens minted
+     *  after the jti rollout; absent on older tokens (replay check is skipped). */
+    jti?: string
     [claim: string]: unknown
+}
+
+/**
+ * Replay guard for internal JWTs. `aud` + a 60s `exp` already bound the blast
+ * radius; this is defence-in-depth so a captured token can't be replayed even
+ * within that window. `checkAndRecord` returns true when the jti was already
+ * seen (a replay), else records it until it expires.
+ */
+export interface JtiReplayCache {
+    checkAndRecord(jti: string, expEpochSec: number): boolean | Promise<boolean>
+}
+
+/**
+ * In-memory `JtiReplayCache` — a per-process Map pruned lazily by expiry. Good
+ * enough for defence-in-depth at the short (60s) TTL; it does NOT span hosts,
+ * so a token replayed to a *different* pod within its TTL isn't caught. A
+ * shared (Redis) store would close that, but isn't wired here (the janitor has
+ * no Redis) — accepted given the short window.
+ */
+export class InMemoryJtiReplayCache implements JtiReplayCache {
+    private readonly seen = new Map<string, number>()
+
+    checkAndRecord(jti: string, expEpochSec: number): boolean {
+        const now = Math.floor(Date.now() / 1000)
+        // Opportunistically prune expired entries so the map can't grow without bound.
+        for (const [id, exp] of this.seen) {
+            if (exp <= now) {
+                this.seen.delete(id)
+            }
+        }
+        if (this.seen.has(jti)) {
+            return true
+        }
+        // Keep until the token would have expired anyway (min 1s).
+        this.seen.set(jti, Math.max(expEpochSec, now + 1))
+        return false
+    }
 }
 
 export class InternalJwtVerifyError extends Error {
@@ -42,17 +83,29 @@ export async function verifyInternalJwt(opts: {
     token: string
     audience: InternalJwtAudience
     signingKey: string
+    /** When supplied, reject a token whose `jti` was already seen (replay). */
+    replayCache?: JtiReplayCache
 }): Promise<VerifiedInternalJwt> {
     const keyBytes = new TextEncoder().encode(opts.signingKey)
+    let payload: VerifiedInternalJwt
     try {
-        const { payload } = await jwtVerify(opts.token, keyBytes, {
+        const verified = await jwtVerify(opts.token, keyBytes, {
             audience: opts.audience,
             algorithms: ['HS256'],
         })
-        return payload as VerifiedInternalJwt
+        payload = verified.payload as VerifiedInternalJwt
     } catch (e) {
         throw new InternalJwtVerifyError((e as Error).message)
     }
+    if (opts.replayCache && typeof payload.jti === 'string') {
+        // Skip silently when jti is absent (pre-rollout tokens) so deploys
+        // stay compatible; aud + exp still gate those.
+        const replayed = await opts.replayCache.checkAndRecord(payload.jti, payload.exp ?? 0)
+        if (replayed) {
+            throw new InternalJwtVerifyError('replayed token (jti already seen)')
+        }
+    }
+    return payload
 }
 
 export async function mintInternalJwt(opts: {
@@ -68,6 +121,7 @@ export async function mintInternalJwt(opts: {
     return new SignJWT({ ...opts.claims })
         .setProtectedHeader({ alg: 'HS256' })
         .setAudience(opts.audience)
+        .setJti(randomUUID())
         .setExpirationTime(`${ttlSec}s`)
         .sign(keyBytes)
 }


### PR DESCRIPTION
## Problem

Threat model finding **F15** (TB-4, LOW, defence-in-depth). The audience-bound internal JWT (Django ↔ ingress/janitor, signed with `AGENT_INTERNAL_SIGNING_KEY`) used a 60s `exp` as its only replay bound — no `jti`/nonce — so a captured token could be replayed any number of times within that window.

## Changes

- **Mint:** add a `jti` (uuid) to every internal token — Django's `encode_agent_internal_jwt` and the node `mintInternalJwt` helper.
- **Verify:** `verifyInternalJwt` accepts an optional `replayCache` and rejects a token whose `jti` was already seen. A token without a `jti` (pre-rollout) skips the replay check so a partial deploy stays compatible (aud + exp still gate it).
- New `InMemoryJtiReplayCache` (per-process, lazily pruned by expiry) wired into the janitor RPC auth middleware and the ingress preview gate.

## Scope note

The cache is **per-process** — it catches replays to the same pod, not across pods (the janitor has no Redis to back a shared store). Given the 60s TTL this is accepted as defence-in-depth; a shared store would be the next step if cross-pod replay becomes a concern.

## How did you test this code?

I'm an agent. Automated tests:

- `vitest run src/runtime/internal-jwt.test.ts` — 7 passed, including new cases: unique jti per mint, replay rejected when a cache is supplied, distinct tokens sharing a cache both admitted.
- `tsc --noEmit` on agent-shared, agent-janitor, agent-ingress — clean. `oxlint` (no errors) + `oxfmt` applied. `ruff check` on the Python — clean.
- The existing janitor auth test mints a fresh token per request and the ingress resolver preview tests use jti-less tokens, so neither is affected by the replay guard. The DB-backed janitor/ingress suites run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation.
