### PR TITLE
fix(agent-platform): reject PATs on approval-decide when agent approver disallowed

### DIFF
--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -62,6 +62,7 @@ from posthog.schema import ProductKey
 
 from posthog.api.log_entries import LogEntryRequestSerializer, LogEntrySerializer, fetch_log_entries
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.helpers.encrypted_fields import EncryptedTextField
 from posthog.models.organization import OrganizationMembership
@@ -1486,12 +1487,13 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise JanitorUpstreamError(e) from e
         if existing.get("application_id") != str(application.id):
             raise NotFound("Approval not found")
-        if existing.get("approver_scope", {}).get("allow_agent_approver") is False and not getattr(
-            request.user, "is_authenticated", False
+        # When the spec sets `allow_agent_approver: False`, only a human acting
+        # interactively may decide — not a programmatic Personal API key. A PAT
+        # resolves to a real authenticated User, so `is_authenticated` can't tell
+        # them apart; discriminate on the authenticator that actually succeeded.
+        if existing.get("approver_scope", {}).get("allow_agent_approver") is False and isinstance(
+            request.successful_authenticator, PersonalAPIKeyAuthentication
         ):
-            # PATs / service tokens are rejected unless the spec opts in.
-            # Real PAT-vs-user discrimination would go here; for v0 we rely
-            # on Django auth + the admin check above as a coarse filter.
             raise NotFound("Approval not found")
         try:
             payload = _janitor().decide_approval(

--- a/products/agent_platform/backend/tests/test_approvals_api.py
+++ b/products/agent_platform/backend/tests/test_approvals_api.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 from rest_framework import status
 
 from posthog.models.organization import OrganizationMembership
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from ..models import AgentApplication
 
@@ -134,3 +136,46 @@ class TestApprovalEndpointsAuth(APIBaseTest):
         # `decision` is required → 400.
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         mock_janitor.return_value.decide_approval.assert_not_called()
+
+    @patch("products.agent_platform.backend.presentation.views._janitor")
+    def test_personal_api_key_cannot_decide_when_agent_approver_disallowed(self, mock_janitor) -> None:
+        # An admin's Personal API key resolves to an authenticated User, so the
+        # old `is_authenticated` check let it through. When the spec sets
+        # `allow_agent_approver: False`, a programmatic PAT must be rejected.
+        self._set_org_level(OrganizationMembership.Level.ADMIN)
+        mock_janitor.return_value.get_approval.return_value = {
+            "id": self.approval_id,
+            "application_id": str(self.application.id),
+            "approver_scope": {"allow_agent_approver": False},
+        }
+        raw_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="agent", user=self.user, secure_value=hash_key_value(raw_key))
+        resp = self.client.post(
+            self.url_decide,
+            {"decision": "approve"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {raw_key}",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        mock_janitor.return_value.decide_approval.assert_not_called()
+
+    @patch("products.agent_platform.backend.presentation.views._janitor")
+    def test_personal_api_key_can_decide_when_agent_approver_allowed(self, mock_janitor) -> None:
+        # The gate only applies when the spec disallows agent approvers.
+        self._set_org_level(OrganizationMembership.Level.ADMIN)
+        mock_janitor.return_value.get_approval.return_value = {
+            "id": self.approval_id,
+            "application_id": str(self.application.id),
+            "approver_scope": {"allow_agent_approver": True},
+        }
+        mock_janitor.return_value.decide_approval.return_value = {"ok": True, "state": "approving"}
+        raw_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="agent", user=self.user, secure_value=hash_key_value(raw_key))
+        resp = self.client.post(
+            self.url_decide,
+            {"decision": "approve"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {raw_key}",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        mock_janitor.return_value.decide_approval.assert_called_once()


### PR DESCRIPTION
## Problem

Threat model finding **F16** (TB-5, LOW). The approval-decide endpoint enforced the spec's `allow_agent_approver: False` policy with `not getattr(request.user, "is_authenticated", False)`. But `PersonalAPIKeyAuthentication` returns a real `User`, whose `.is_authenticated` is `True` — so a PAT-authenticated call passed the guard exactly like an interactive browser session, bypassing the "no agent approver" policy. (It's already admin-gated via `_require_team_admin`, so this is in-tenant + admin-only — hence LOW.)

## Changes

- Discriminate on `request.successful_authenticator` instead of `is_authenticated`: when the spec disallows agent approvers, reject callers authenticated via `PersonalAPIKeyAuthentication`. Session/OAuth (interactive human) callers still pass. This mirrors the established pattern (`posthog/api/person.py`, `event.py`, `project.py`).
- Replaced the old "real PAT-vs-user discrimination would go here" placeholder comment.

## How did you test this code?

I'm an agent. Checks I ran:

- `ruff check` on the changed view + test — clean.
- Added tests to `test_approvals_api.py`: a PAT-authenticated admin is rejected (404) when `allow_agent_approver: False`, and is allowed when `allow_agent_approver: True`. **Django isn't runnable in this environment (no Django in the local venv), so I could not execute the Python suite — flagging for CI.** The imports (`PersonalAPIKey`, `generate_random_token_personal`, `hash_key_value`, `PersonalAPIKeyAuthentication`) were verified to resolve.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation. Invoked the `improving-drf-endpoints` guidance; the change is in method-body authorization logic and doesn't alter the request/response schema, so there's no OpenAPI codegen impact.
