### PR TITLE
chore(agent-platform): document why dev OAuth setup is hard DEBUG-gated

### DIFF
--- a/posthog/management/commands/setup_oauth_for_agent_console.py
+++ b/posthog/management/commands/setup_oauth_for_agent_console.py
@@ -52,6 +52,14 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # SECURITY: this command provisions an `is_first_party=True` OAuth app,
+        # which skips the OAuth consent screen for EVERY org/user. That's fine
+        # for a throwaway local-dev app, but it must NEVER be created this way
+        # in a real deployment — prod's first-party app is provisioned by ops
+        # through the admin UI with appropriate scoping. These two guards are
+        # the control that keeps the consent-skip blast radius local-only; do
+        # not relax them. (`DEBUG` is False in every deployed environment;
+        # `CLOUD_DEPLOYMENT` is the belt-and-braces catch for a misconfig.)
         if not settings.DEBUG:
             raise CommandError("This command can only run with DEBUG=True")
         if settings.CLOUD_DEPLOYMENT:


### PR DESCRIPTION
## Problem

Threat model finding **F17** (TB-13, INFO). The `setup_oauth_for_agent_console` management command creates an `is_first_party=True` OAuth app, which skips the OAuth consent screen across all orgs. It is already hard-gated behind `DEBUG=True` **and** `not CLOUD_DEPLOYMENT`, so it cannot run in any deployed environment — this is an accepted risk, not a live exposure.

## Changes

- Verified the gate is sufficient (no code-path change needed): `DEBUG` is `False` in every deployed environment and the command `raise`s before touching any model; `CLOUD_DEPLOYMENT` is a second catch.
- Added a security comment on the guards explaining that the `is_first_party` consent-skip is the reason they're load-bearing, so a future reader doesn't relax them.

No behavioral change.

## How did you test this code?

I'm an agent. `ruff check` on the file passes. The change is a comment only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this as part of the agent-platform threat-model remediation. Closing F17 as accepted risk per the threat-model doc, with the reasoning documented inline.
