### PR TITLE
fix(batch-exports): drop stale config fields from destination PATCH

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -108,6 +108,24 @@ const BIGQUERY_BATCH_EXPORT = fixture('test-bq-id', 'BigQuery Export', {
     },
 })
 
+// A BigQuery export whose stored config still carries pre-Integration leftovers: the frontend-only
+// `json_config_file` and credentials that now live on the integration. These must be stripped on
+// save — the backend rejects any config key not on the destination's allowlist.
+const BIGQUERY_STALE_BATCH_EXPORT = fixture('test-bq-stale-id', 'BigQuery Stale Export', {
+    type: 'BigQuery',
+    integration: 7,
+    config: {
+        dataset_id: 'test_dataset',
+        table_id: 'events',
+        use_json_type: false,
+        exclude_events: [],
+        include_events: [],
+        json_config_file: [{}],
+        private_key: 'stale-private-key',
+        project_id: 'stale-project',
+    } as any,
+})
+
 const POSTGRES_BATCH_EXPORT = fixture('fixture-postgres', 'Postgres Export', {
     type: 'Postgres',
     config: {
@@ -287,6 +305,7 @@ const ALL_BATCH_EXPORTS: BatchExportConfiguration[] = [
     AWS_S3_BATCH_EXPORT,
     S3_COMPATIBLE_BATCH_EXPORT,
     BIGQUERY_BATCH_EXPORT,
+    BIGQUERY_STALE_BATCH_EXPORT,
     POSTGRES_BATCH_EXPORT,
     SNOWFLAKE_PASSWORD_BATCH_EXPORT,
     SNOWFLAKE_KEYPAIR_BATCH_EXPORT,
@@ -991,6 +1010,31 @@ describe('batchExportConfigFormLogic', () => {
             const body = patchBodiesById[fixture.id]
             expect(body).not.toBeUndefined()
             expect(body.destination).toEqual(fixture.destination)
+        })
+    })
+
+    describe('strips stale/legacy config fields not in the destination allowlist', () => {
+        // Pre-Integration BigQuery configs can still hold json_config_file + credential fields.
+        // Editing such an export must not re-send them, or the backend rejects the PATCH with
+        // "Configuration has unknown field/s".
+        it('drops pre-Integration BigQuery fields from the PATCH payload', async () => {
+            await initLogic({ service: null, id: BIGQUERY_STALE_BATCH_EXPORT.id })
+
+            await expectLogic(logic, () => {
+                logic.actions.submitConfiguration()
+            })
+                .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+                .toFinishAllListeners()
+
+            const body = patchBodiesById[BIGQUERY_STALE_BATCH_EXPORT.id]
+            expect(body).not.toBeUndefined()
+            expect(body.destination.config).toEqual({
+                dataset_id: 'test_dataset',
+                table_id: 'events',
+                use_json_type: false,
+                exclude_events: [],
+                include_events: [],
+            })
         })
     })
 })

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -46,6 +46,8 @@ const TOP_LEVEL_FORM_FIELDS = new Set([
     'integration_id',
 ])
 
+const ALLOWED_BASE_CONFIG_KEYS = new Set(['exclude_events', 'include_events'])
+
 function buildDestinationPayload(formValues: Record<string, any>): {
     type: string
     config: Record<string, any>
@@ -56,11 +58,17 @@ function buildDestinationPayload(formValues: Record<string, any>): {
     // Apply destination-specific transform first (e.g. Redshift's COPY copy_inputs assembly).
     // Destinations without a custom serialize get the raw form values passed through.
     const intermediate = definition?.serialize ? definition.serialize(formValues) : formValues
-    // Strip top-level form fields that don't belong in destination.config (always — destinations
-    // shouldn't have to re-implement this).
+    // When a destination declares configKeys, drop any config key outside it (plus the base-export
+    // keys). Mirrors the backend's allowed = destination_fields ∪ base_field_names check, so stale
+    // fields don't survive a deserialize → serialize round-trip and get rejected on save.
+    const allowed = definition?.configKeys ? new Set([...definition.configKeys, ...ALLOWED_BASE_CONFIG_KEYS]) : null
+    // Strip top-level form fields that don't belong in destination.config
     const config: Record<string, any> = {}
     for (const [key, value] of Object.entries(intermediate)) {
         if (TOP_LEVEL_FORM_FIELDS.has(key)) {
+            continue
+        }
+        if (allowed && !allowed.has(key)) {
             continue
         }
         config[key] = value

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
@@ -14,6 +14,7 @@ export const azureBlobDefinition: DestinationDefinition = {
         compression: 'zstd',
     }),
     requiredFields: ({ isNew }) => ['integration_id', 'container_name', ...(isNew ? ['file_format'] : [])],
+    configKeys: ['container_name', 'prefix', 'compression', 'file_format', 'max_file_size_mb'],
     validate: (formValues) => ({
         container_name: validateAzureContainerName(formValues.container_name),
     }),

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
@@ -10,7 +10,7 @@ export const bigqueryDefinition: DestinationDefinition = {
     type: 'BigQuery',
     usesIntegration: true,
     defaults: () => ({}),
-    requiredFields: ({ isNew }) => [...(isNew ? ['integration_id'] : []), 'dataset_id', 'table_id'],
+    requiredFields: () => ['integration_id', 'dataset_id', 'table_id'],
     // Credentials and project_id now live on the integration; json_config_file is a removed legacy field.
     configKeys: ['dataset_id', 'table_id', 'use_json_type'],
     eventTableOverrides: { teamIdHogql: 'team_id' },

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
@@ -11,6 +11,8 @@ export const bigqueryDefinition: DestinationDefinition = {
     usesIntegration: true,
     defaults: () => ({}),
     requiredFields: ({ isNew }) => [...(isNew ? ['integration_id'] : []), 'dataset_id', 'table_id'],
+    // Credentials and project_id now live on the integration; json_config_file is a removed legacy field.
+    configKeys: ['dataset_id', 'table_id', 'use_json_type'],
     eventTableOverrides: { teamIdHogql: 'team_id' },
     eventTableExtraFields: {
         bq_ingested_timestamp: {

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/databricks.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/databricks.tsx
@@ -15,6 +15,7 @@ export const databricksDefinition: DestinationDefinition = {
         http_path: '/sql/1.0/warehouses/',
     }),
     requiredFields: () => ['integration_id', 'http_path', 'catalog', 'schema', 'table_name'],
+    configKeys: ['http_path', 'catalog', 'schema', 'table_name', 'use_variant_type', 'use_automatic_schema_evolution'],
     eventTableExtraFields: {
         team_id: {
             name: 'team_id',

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/types.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/types.ts
@@ -27,6 +27,12 @@ export interface DestinationDefinition {
     validate?: (formValues: Record<string, any>) => Record<string, string | undefined>
     // Form fields → API destination.config payload. Default behaviour: pass remaining fields through unchanged.
     serialize?: (formValues: Record<string, any>) => Record<string, any>
+    // Allowlist of valid destination.config keys (mirrors the backend workflow-inputs dataclass in
+    // products/batch_exports/backend/service.py, destination-specific fields only). When set,
+    // buildDestinationPayload drops any other key — guards against stale/legacy fields being
+    // re-sent and rejected by the backend. Omit to keep pass-through behaviour.
+    // TODO: ideally we could get this from the backend
+    configKeys?: string[]
     // API destination.config → flat form fields. Default: spread.
     deserialize?: (config: Record<string, any>) => Record<string, any>
     // Extra columns added to the events table preview for this destination.


### PR DESCRIPTION
## Problem

The batch exports frontend refactor (#61103) regressed how the destination config payload is built.
The old logic explicitly pulled known fields out of the form state, so legacy/frontend-only keys
(notably `json_config_file`) never reached the API. The refactor replaced that with a fixed
top-level denylist and passes every other form key straight into `destination.config`.

Because the form is seeded by spreading the entire API config into flat form state, any stale key
stored on a destination round-trips back into the PATCH body. The backend rejects unknown config
keys outright (`Configuration has unknown field/s: ...`), so editing an affected export fails.

This affects BigQuery exports created before the Integration model rollout: their stored config can
still carry a `json_config_file` (and old inline credentials) that no longer belong on the config,
and the backend now manages credentials via the integration.

## Changes

- Add an opt-in `configKeys` allowlist to `DestinationDefinition`. When a destination declares it,
  `buildDestinationPayload` drops any config key outside `configKeys ∪ {exclude_events,
  include_events}` — mirroring the backend's `allowed = destination_fields ∪ base_field_names`
  check. Destinations without `configKeys` keep the existing pass-through behaviour, so we never
  silently drop a field we haven't verified.
- Enable `configKeys` for the three integration-backed destinations (BigQuery, Databricks,
  AzureBlob), with each list mirroring its backend workflow-inputs dataclass. We can add
  `configKeys` for other destinations as we migrate them over to the integration model.
- Make `integration_id` unconditionally required for BigQuery (previously only on create). The
  integration model is fully rolled out and the backend already rejects BigQuery saves without an
  integration, so this surfaces the requirement inline instead of via a backend round-trip — and
  matches Databricks/AzureBlob, which already require it always.

## How did you test this code?

Automated tests:

- Added a regression test in `batchExportConfigFormLogic.test.ts` (written test-first, confirmed
  failing before the fix) that loads a BigQuery export whose config carries `json_config_file` +
  stale credentials and asserts those keys are stripped from the PATCH while the real fields
  survive.
- Ran the full `batchExportConfigFormLogic.test.ts` suite: 59/59 pass, including the existing
  per-destination create and round-trip tests (which confirm no legitimate field — including the
  base `exclude_events`/`include_events` — is dropped).

Manual testing via the local stack:
- verified stale fields no longer get sent in the PATCH request
- edited an existing BigQuery batch export successfully
- created a new BigQuery batch export successfully

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Worked this with PostHog Code (Claude). Ross reported the regression and pointed at the old
field-stripping logic. We weighed three approaches — a BigQuery-specific `serialize`, a full
per-destination allowlist, and an opt-in hybrid — and chose the hybrid: it gives a general
mechanism while containing the risk of silently dropping a valid field.
Followed a test-first flow: the regression test was written and confirmed red before any production change.
The BigQuery `requiredFields` cleanup was a related observation Ross raised once the integration
model reached full rollout.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*