### PR TITLE
fix(postgres): retry transient connection drops while opening setup connection

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1870,7 +1870,12 @@ def postgres_source(
         # letting Temporal re-run setup straight back into the same wall.
         setup_recovery_conflicts = 0
         while True:
-            connection = _open_setup_connection()
+            # Opening the setup connection can itself hit a transient drop ("server closed the
+            # connection unexpectedly", idle cull, failover) — the same class of error the read
+            # path already recovers from. Retry the connect in-process with bounded backoff,
+            # mirroring `offset_chunking`, so a momentary blip during setup doesn't fail the whole
+            # activity. Permanent errors (auth failures, SSL-required) re-raise immediately.
+            connection = _connect_with_dropped_retry(_open_setup_connection, logger)
             try:
                 with connection:
                     with connection.cursor() as cursor:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -314,6 +314,44 @@ class TestPostgresSourceSetupRecoveryConflictRetry:
 
         assert connect_mock.call_count == 1
 
+    def test_connection_dropped_while_opening_setup_connection_is_retried(self):
+        # A transient drop while opening the setup connection ("server closed the connection
+        # unexpectedly") is the same class of error the read path already recovers from. The setup
+        # connect must retry in-process with bounded backoff instead of failing on the first drop.
+        err = psycopg.OperationalError(
+            'connection failed: connection to server at "3.151.121.165", port 5432 failed: '
+            "server closed the connection unexpectedly"
+        )
+
+        with patch(
+            "posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            side_effect=err,
+        ) as connect_mock:
+            with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+                with pytest.raises(psycopg.OperationalError):
+                    self._call_postgres_source()
+
+        # `_connect_with_dropped_retry` defaults to 5 attempts; before the fix the drop escaped on
+        # the first connect (call_count == 1).
+        assert connect_mock.call_count == 5
+
+    def test_permanent_error_while_opening_setup_connection_is_not_retried(self):
+        # A permanent connect failure (bad password) must not be retried by the dropped-connection
+        # handler — it should propagate on the first attempt.
+        err = psycopg.OperationalError(
+            'connection to server at "10.0.0.1" failed: FATAL: password authentication failed for user "u"'
+        )
+
+        with patch(
+            "posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            side_effect=err,
+        ) as connect_mock:
+            with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+                with pytest.raises(psycopg.OperationalError):
+                    self._call_postgres_source()
+
+        assert connect_mock.call_count == 1
+
 
 class TestIsConnectionDroppedError:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: connection failed: ... server closed the connection unexpectedly` originating in the Postgres data-warehouse import source — see the [error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed03e-19e5-7743-a72f-89a4917c7df1).

The real stack (once the serialized variable noise from other concurrent activities is stripped) is:

```
sources/postgres/source.py        source_for_pipeline
sources/postgres/postgres.py      postgres_source
sources/postgres/postgres.py:1834 _open_setup_connection
psycopg/connection.py             connect  → OperationalError: server closed the connection unexpectedly
```

`"server closed the connection unexpectedly"` is a **transient connection drop**, not a user/upstream error — it's already listed in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, and the row-streaming read path (`offset_chunking`) already recovers from it in-process via `_connect_with_dropped_retry`. The gap: the **setup** connection — `_open_setup_connection`, the exact frame that raised here — was opened bare, with no dropped-connection retry. So a momentary drop while establishing the initial setup connection escaped the source and failed the whole import activity, landing in error tracking.

## Changes

Wrap the `_open_setup_connection()` call in `postgres_source` with the existing `_connect_with_dropped_retry` helper, mirroring the read path. Transient drops during setup now recover in-process with bounded backoff instead of failing the activity. Permanent errors (auth failures, SSL-required) still re-raise immediately, since `_is_connection_dropped_error` only matches transient drops.

This deliberately keeps the error **retryable** rather than adding it to `NonRetryableErrors`: a connection reset is an infrastructure blip that retrying resolves, not a permanent config/credential problem.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (the DB-backed `*RealDb`/`TestGetTable` classes can't run in this sandbox — no local Postgres — and are unaffected by this change):

- `test_connection_dropped_while_opening_setup_connection_is_retried` — a dropped-connection `OperationalError` during the setup connect is retried up to the bounded limit (5 attempts) instead of escaping on the first drop. This is the regression test for the observed error.
- `test_permanent_error_while_opening_setup_connection_is_not_retried` — a permanent connect failure (bad password) still propagates on the first attempt.
- Existing `TestPostgresSourceSetupRecoveryConflictRetry` tests continue to pass, confirming the recovery-conflict path is unaffected.

`253 passed` for the file's non-DB unit tests; `ruff check` and `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue and pulled a representative event via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), verified the failure genuinely originates in `_open_setup_connection`, then read the source to understand the retry topology.

Decision: classified as a transient infrastructure error (connection reset), so **not** a `NonRetryableErrors` candidate. The codebase already has a clear convention (`_connect_with_dropped_retry`, `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`) for recovering exactly this error class in-process on the read path; the setup path simply didn't apply it. Fix reuses that helper rather than introducing any new abstraction.