### PR TITLE
fix(snowflake): treat view column-count mismatch as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -202,6 +202,12 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # lives in the customer's object, not in our SQL. Retrying can't fix it until they repair
             # the object or reconfigure the synced columns.
             "invalid identifier": "A Snowflake table or view you're syncing references a column that no longer exists (for example a stale view definition, or a column that was dropped or renamed). Please fix the table or view in Snowflake, or reconfigure the columns selected for this table, then resync.",
+            # Snowflake error 002057 (42601): selecting from a view recompiles its stored definition,
+            # which fails when the column count no longer matches the underlying query (e.g. a base
+            # table gained a column but the view wasn't recreated). The view is broken in the
+            # customer's account, so retrying recompiles the same invalid definition and fails
+            # identically until they fix it.
+            "but view query produces": "A Snowflake view failed to compile because its stored definition no longer matches its query — the declared column count differs from what the query produces. Recreate the view in Snowflake so its columns match its underlying query, then resync.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. a narrower NUMBER widened
             # to a larger NUMBER/BIGINT) after the destination table was created with the

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -623,6 +623,23 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "View definition for 'RECCE.PUBLIC.INT_AMP_EVENTS_EXCLUDE_DEMO_AND_CI' declared 42 column(s), "
+            "but view query produces 43 column(s).",
+            # The real shape from production: the query id, view name, and column counts vary, but the
+            # message template substring is stable.
+            "002057 (42601): 01c51640-0009-abe9-0001-40ae09621046: SQL compilation error: "
+            "View definition for 'RECCE.PUBLIC.INT_AMP_EVENTS_EXCLUDE_DEMO_AND_CI' declared 42 column(s), "
+            "but view query produces 43 column(s).",
+        ],
+    )
+    def test_view_column_mismatch_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"View column-mismatch error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
             "Operation timed out while waiting for the warehouse to resume",
         ],

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -623,8 +623,7 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
-            "View definition for 'MY_DB.PUBLIC.MY_VIEW' declared 5 column(s), "
-            "but view query produces 6 column(s).",
+            "View definition for 'MY_DB.PUBLIC.MY_VIEW' declared 5 column(s), but view query produces 6 column(s).",
             # The production shape: the query id, view name, and column counts vary, but the
             # message template substring is stable.
             "002057 (42601): 00000000-0000-0000-0000-000000000000: SQL compilation error: "

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -623,13 +623,13 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
-            "View definition for 'RECCE.PUBLIC.INT_AMP_EVENTS_EXCLUDE_DEMO_AND_CI' declared 42 column(s), "
-            "but view query produces 43 column(s).",
-            # The real shape from production: the query id, view name, and column counts vary, but the
+            "View definition for 'MY_DB.PUBLIC.MY_VIEW' declared 5 column(s), "
+            "but view query produces 6 column(s).",
+            # The production shape: the query id, view name, and column counts vary, but the
             # message template substring is stable.
-            "002057 (42601): 01c51640-0009-abe9-0001-40ae09621046: SQL compilation error: "
-            "View definition for 'RECCE.PUBLIC.INT_AMP_EVENTS_EXCLUDE_DEMO_AND_CI' declared 42 column(s), "
-            "but view query produces 43 column(s).",
+            "002057 (42601): 00000000-0000-0000-0000-000000000000: SQL compilation error: "
+            "View definition for 'MY_DB.PUBLIC.MY_VIEW' declared 5 column(s), "
+            "but view query produces 6 column(s).",
         ],
     )
     def test_view_column_mismatch_is_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring failure in the Snowflake data-warehouse import source: [ProgrammingError issue](https://us.posthog.com/project/2/error_tracking/019ed03f-00e2-79a3-992c-4db40626f5a5).

```
ProgrammingError 002057 (42601): SQL compilation error:
View definition for '<view>' declared 42 column(s), but view query produces 43 column(s).
```

The leaf in-app frame is `get_rows` in `posthog/temporal/data_imports/sources/snowflake/snowflake.py`, where the streaming sync runs `SELECT * FROM IDENTIFIER(...)` against a customer **view**. Selecting from a view recompiles its stored definition; when a base table gains a column but the view isn't recreated, Snowflake rejects the query at compile time. The view is broken in the customer's account — every retry recompiles the same invalid definition and fails identically until they recreate the view.

## Changes

This is an upstream/user-config error, not a bug in our code and not transient, so it should stop retrying:

- Add `"but view query produces"` to `SnowflakeSource.get_non_retryable_errors()` with an actionable message telling the user to recreate the view so its columns match its query, then resync. The substring is the stable part of Snowflake's message template — it excludes the volatile query id, view name, and column counts, and does not match other SQL compilation errors (e.g. "object does not exist").
- Add a parametrized regression test covering both the bare message and the full production-shaped message (with error code and query id).

Scoped strictly to this error — no change to the global retry policy.

## How did you test this code?

I'm an agent. I ran the automated tests only:

- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` — 68 passed, including the new `test_view_column_mismatch_is_non_retryable` and the existing `test_transient_errors_are_retryable` guard against over-matching.
- `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed via the PostHog error-tracking MCP tools that the leaf frame originates in the Snowflake source's streaming query path (upper frames contained unrelated serialized variables from other sources — noise). Decided upstream-error over fixable-bug because the failure is a deterministic SQL compilation error on a customer-owned view that no code change on our side can resolve. Followed the Stripe `get_non_retryable_errors` pattern and the existing Snowflake non-retryable test style.