### PR TITLE
fix(data-imports): treat Reddit Ads 403 Forbidden as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -38,6 +38,10 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "401 Client Error": None,
+            # Reddit returns 403 when the connected account lacks permission to read the
+            # configured ad account's reports (access revoked or insufficient scope). The
+            # request can never succeed without the user reconnecting, so stop retrying.
+            "403 Client Error": None,
             "404 Client Error": None,
             # Raised by OAuthMixin.get_oauth_integration when the connected Reddit Ads
             # account has been deleted or disconnected. The integration row is gone, so

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -114,6 +114,7 @@ class TestRedditAdsSource:
         "observed_error",
         [
             "401 Client Error: Unauthorized for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
+            "403 Client Error: Forbidden for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/reports?page.size=100",
             "404 Client Error: Not Found for url: https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns",
             "ValueError: Integration not found: 154683",
         ],


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HTTPError: 403 Client Error: Forbidden` coming out of the data-warehouse import pipeline ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed03f-c262-7883-a955-f6bef2906c7d)).

The stack trace originates in the shared REST source client (`posthog/temporal/data_imports/sources/common/rest_source/rest_client.py:183`, `_send_request` → `raise_for_status`), and the exception value consistently points at the Reddit Ads reports endpoint:

```
403 Client Error: Forbidden for url: https://ads-api.reddit.com/api/v3/ad_accounts/<id>/reports?page.size=100
```

A `403 Forbidden` here means the connected Reddit Ads account no longer has permission to read the configured ad account's reports (access revoked, or the granted scope is insufficient). This is a user/upstream condition — retrying cannot recover it, so the import keeps retrying and re-raising until the run gives up, generating noise.

`RedditAdsSource.get_non_retryable_errors` already treats `401 Client Error` and `404 Client Error` as non-retryable, but `403` was missing, so a forbidden response was still being retried.

## Changes

- Add `"403 Client Error"` to `RedditAdsSource.get_non_retryable_errors`, mirroring the existing `401`/`404` handling on this source (and matching how the Stripe source treats `403 Forbidden`). The match is on the stable status-text substring, not the per-request URL/account id.
- Extend the existing parameterized non-retryable test to assert a representative Reddit Ads `403 Forbidden` message is recognised as non-retryable.

The change is scoped strictly to the Reddit Ads source — no global retry-policy changes.

## How did you test this code?

I'm an agent. I ran the automated tests only:

- `pytest posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py` — 20 passed (including the new 403 case in `test_non_retryable_errors_match_known_failures`; transient errors like `500`/`ConnectionError` still correctly stay retryable via `test_non_retryable_errors_does_not_match_transient`).
- `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue via the PostHog error-tracking MCP tools (full stack trace, exception type, frequency, and the consistent Reddit Ads `reports` endpoint as the source). Classified it as a user/upstream permission error rather than a code bug: a `403` from the ads API is non-recoverable without the user reconnecting, and it mirrors the source's existing `401`/`404` non-retryable entries and Stripe's `403 Forbidden` handling. Chose to extend `NonRetryableErrors` with the stable `"403 Client Error"` substring (avoiding volatile URL/account-id matching) and added regression coverage to the existing parameterized test.
