### PR TITLE
fix(bing_ads): treat "Invalid client data" SOAP fault as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -69,6 +69,19 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             "AuthenticationFailed": auth_friendly,
             "InvalidCredentials": auth_friendly,
             "OAuthTokenExpired": auth_friendly,
+            # Bing rejects the SOAP request as invalid *after* auth succeeds — the configured Account ID
+            # is wrong or the connected Microsoft Advertising user can't access it. The SDK raises this as
+            # `suds.WebFault("Server raised fault: 'Invalid client data. Check the SOAP fault details for
+            # more information. TrackingId: <uuid>.'")`. The fault is deterministic (the same bad request
+            # always reproduces it), so retrying can't recover — the customer has to fix the Account ID or
+            # grant the connected account access. Match the stable phrase only; the TrackingId is volatile.
+            # This does not catch transient Bing faults like "Server raised fault: 'Internal Error'".
+            "Invalid client data": (
+                "Bing Ads rejected the request as invalid. This usually means the configured Account ID is "
+                "incorrect, or the connected Bing Ads account does not have access to it. Please check the "
+                "Account ID in your source settings and that the connected account can access it, then "
+                "reconfigure your Bing Ads source."
+            ),
             # Integration row was deleted/disconnected while a scheduled job still references it.
             # Raised by OAuthMixin.get_oauth_integration as `ValueError("Integration not found: <id>")`;
             # the id is volatile, so match only the stable prefix. Retrying can't recreate the row —

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -259,6 +259,13 @@ class TestBingAdsSource:
                 "Failed to fetch customer ID: OAuthTokenRequestException: invalid_client AADSTS650052: "
                 "The app is trying to access a service that your organization lacks a service principal for.",
             ),
+            # Bing rejects the request as invalid after auth succeeds (e.g. wrong/inaccessible Account ID).
+            # The SDK raises suds.WebFault whose str() embeds a volatile TrackingId — match the stable phrase.
+            (
+                "Invalid client data",
+                "Server raised fault: 'Invalid client data. Check the SOAP fault details for more "
+                "information. TrackingId: 9471598f-2992-4c98-9d96-cbe84a0ddb47.'",
+            ),
             # Integration deleted/disconnected — OAuthMixin.get_oauth_integration raises
             # `ValueError("Integration not found: <id>")`; match only the volatile-id-free prefix.
             ("Integration not found", "Integration not found: 160672"),
@@ -311,6 +318,27 @@ class TestBingAdsSource:
         assert friendly_errors[0] is not None
         assert "AADSTS650052" in friendly_errors[0]
         assert "service principal" in friendly_errors[0]
+
+    def test_invalid_client_data_maps_to_account_guidance(self):
+        # The dominant cause is a wrong/inaccessible Account ID (auth has already succeeded by this point),
+        # so the toast must point at the Account ID rather than telling the user to reconnect OAuth.
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        error_message = (
+            "Server raised fault: 'Invalid client data. Check the SOAP fault details for more "
+            "information. TrackingId: 9471598f-2992-4c98-9d96-cbe84a0ddb47.'"
+        )
+        friendly_errors = [msg for pattern, msg in non_retryable_errors.items() if pattern in error_message]
+
+        assert friendly_errors[0] is not None
+        assert "Account ID" in friendly_errors[0]
+
+    def test_transient_bing_internal_error_fault_stays_retryable(self):
+        # A generic Bing-side fault ("Internal Error") is transient and must keep retrying — it must not
+        # be caught by the "Invalid client data" pattern.
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        transient_message = "Server raised fault: 'Internal Error. TrackingId: abc-123.'"
+
+        assert not any(pattern in transient_message for pattern in non_retryable_errors)
 
     def test_get_resumable_source_manager(self):
         """Test that get_resumable_source_manager returns a manager that round-trips BingAdsResumeConfig."""


### PR DESCRIPTION
## Problem

PostHog error tracking is showing a high-volume, currently-firing data-warehouse import failure for the Bing Ads source: `WebFault: Server raised fault: 'Invalid client data. Check the SOAP fault details for more information. TrackingId: <uuid>.'`. It is grouped across two active issues ([client.py](https://us.posthog.com/project/2/error_tracking/019dd31d-d2aa-78e1-81a6-9d865aa7a965), [bing_ads.py](https://us.posthog.com/project/2/error_tracking/019e4b52-9e7b-7dd2-b503-a0e4057f6b71)) totalling thousands of occurrences, with the most recent today.

The exception genuinely originates in our code: `bing_ads/client.py` `get_campaigns` calls `GetCampaignsByAccountId`, and the Bing SDK's suds layer raises `WebFault` from `process_reply`. In the sampled events, `get_customer_id` had **already succeeded** (a customer id was returned), so authentication is fine — the failing call uses an Account ID that Bing won't accept, and it returns the generic "Invalid client data" SOAP fault.

## Changes

This is an upstream/customer-configuration error, not a code bug: the most common cause is a wrong Account ID in the source settings, or the connected Microsoft Advertising account lacking access to that Account ID. The fault is deterministic — retrying the identical request always reproduces it — so it should stop retrying rather than churn.

- Add `"Invalid client data"` to `BingAdsSource.get_non_retryable_errors()` with an account-focused friendly message (check the Account ID and that the connected account can access it).
- Match only the stable phrase; the per-request `TrackingId` is volatile and excluded.
- Deliberately narrow: transient Bing faults such as `Server raised fault: 'Internal Error'` do **not** contain this phrase and remain retryable.

## How did you test this code?

I'm an agent. I added/extended automated unit tests and ran them; I did not perform manual testing.

- Extended the parameterized non-retryable recognition test with the real "Invalid client data" message (including a TrackingId).
- Added `test_invalid_client_data_maps_to_account_guidance` (asserts the friendly toast points at the Account ID).
- Added `test_transient_bing_internal_error_fault_stays_retryable` (asserts an "Internal Error" Bing fault is not swallowed).
- `pytest posthog/temporal/data_imports/sources/bing_ads/tests/` → all pass (30 + 4). `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the BingAds import source. Pulled the full stack trace and sampled events via the PostHog MCP error-tracking tools, confirmed the frame chain runs through `sources/bing_ads/client.py` (not just serialized log context), and that auth had already succeeded — pointing at an invalid/inaccessible Account ID rather than credentials. Chose to extend `NonRetryableErrors` (mirroring the Stripe source pattern) over a code fix, since the fault is deterministic and not recoverable by retry. Kept the match phrase narrow to avoid masking transient Bing faults or genuine request-building bugs.
