### PR TITLE
fix(github): treat deleted installation token refresh as non-retryable

### DIFF
--- a/posthog/temporal/tests/data_imports/github/test_github_source.py
+++ b/posthog/temporal/tests/data_imports/github/test_github_source.py
@@ -889,6 +889,7 @@ class TestGithubSourceNonRetryableErrors:
             ("bad_credentials",),
             ("client_id_not_configured",),
             ("private_key_not_configured",),
+            ("installation_token_not_found",),
         ]
     )
     def test_non_retryable_errors_contains_key(self, _name: str) -> None:
@@ -899,6 +900,7 @@ class TestGithubSourceNonRetryableErrors:
             "bad_credentials": "Bad credentials",
             "client_id_not_configured": "GITHUB_APP_CLIENT_ID is not configured",
             "private_key_not_configured": "GITHUB_APP_PRIVATE_KEY is not configured",
+            "installation_token_not_found": 'Failed to refresh installation token: {"message":"Not Found"',
         }
         assert expected_keys[_name] in self.source.get_non_retryable_errors()
 


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `GitHubIntegrationError` from the GitHub data-warehouse import source:

> Failed to refresh installation token: `{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app","status":"404"}`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ed03e-f932-7352-ae5a-aac9c854ce08

The stack trace originates in this source's code path:
`GithubSource.source_for_pipeline` → `GithubSource._get_access_token` (`posthog/temporal/data_imports/sources/github/source.py`) → `GitHubIntegration.refresh_access_token` (`posthog/models/github_integration_base.py`).

For OAuth (GitHub App) connections, `_get_access_token` refreshes the installation access token via `POST /app/installations/{id}/access_tokens`. GitHub returns **404 Not Found** when the App installation no longer exists — the user uninstalled the PostHog GitHub App, or the installation was deleted. In that state the token can never be refreshed, so every retry fails identically until the activity exhausts its attempts. The import keeps retrying a permanently-broken connection.

## Changes

This is a user/upstream condition, not a bug in our code: the customer must reconnect their GitHub account. The fix extends `GithubSource.get_non_retryable_errors` so this failure stops retrying and surfaces an actionable message.

The match is scoped to the **404 "Not Found" body** (`Failed to refresh installation token: {"message":"Not Found"`) rather than the bare `Failed to refresh installation token` prefix. `client_request` does not call `raise_for_status()`, so a transient 5xx with a JSON body would also reach the same raise site — matching only the 404 body keeps those transient failures retryable, per the retry guardrails.

## How did you test this code?

I'm an agent. I added automated tests in `posthog/temporal/data_imports/sources/github/tests/test_github_source.py` and ran them (8 passed):

- the new 404 key is present in `get_non_retryable_errors`
- the exact observed error message is recognised as non-retryable (mirroring the substring check in `_handle_import_error`)
- a 5xx token-refresh message is **not** matched, so it stays retryable

`ruff check` / `ruff format` pass on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the `github` import source. Confirmed via the PostHog error-tracking MCP tools that the failure genuinely originates in `sources/github/source.py` (full stack trace includes `source_for_pipeline` and `_get_access_token` frames), then traced into the shared `GitHubIntegrationBase.refresh_access_token` helper.

Decision: classified the 404 installation-not-found as a user/upstream error (installation removed; reconnect required) → extended `NonRetryableErrors`, following the Stripe source pattern. Deliberately did **not** match the broader `Failed to refresh installation token` prefix after confirming `client_request` doesn't raise on non-201, which would let a 5xx body hit the same raise site and must remain retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
