### PR TITLE
feat(signals): enable scout emission-reports MCP tool

### DIFF
--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -263,7 +263,24 @@ tools:
             scout's inferred learnings.
     signals-scout-runs-emission-reports:
         operation: signals_scout_runs_emission_reports
-        enabled: false
+        enabled: true
+        scopes:
+            - signal_scout:read
+            - task:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List the inbox reports a scout run's findings linked to
+        description: >
+            For a `SignalScoutRun`, return each emitted finding paired with the inbox report its signal grouped into —
+            the reverse lookup from a scout's emission to the `SignalReport` it actually produced. One row per emission
+            with its `finding_id`, the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`), and the linked
+            `report` (`id`, `title`, `status`) or `null` when the finding never matched a report (or the report was
+            deleted/suppressed). Use this to see *which* findings turned into actionable reports, not just what a run
+            surfaced (`signals-scout-runs-emissions-list`). Requires `task:read` on top of `signal_scout:read` because it
+            exposes report titles. Strictly team-scoped — a run UUID belonging to another team returns 404.
     signals-scout-runs-emissions-list:
         operation: signals_scout_runs_emissions
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -279,8 +279,8 @@ tools:
             with its `finding_id`, the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`), and the linked
             `report` (`id`, `title`, `status`) or `null` when the finding never matched a report (or the report was
             deleted/suppressed). Use this to see *which* findings turned into actionable reports, not just what a run
-            surfaced (`signals-scout-runs-emissions-list`). Requires `task:read` on top of `signal_scout:read` because it
-            exposes report titles. Strictly team-scoped — a run UUID belonging to another team returns 404.
+            surfaced (`signals-scout-runs-emissions-list`). Requires `task:read` on top of `signal_scout:read` because
+            it exposes report titles. Strictly team-scoped — a run UUID belonging to another team returns 404.
     signals-scout-runs-emissions-list:
         operation: signals_scout_runs_emissions
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5770,6 +5770,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-runs-emission-reports": {
+        "description": "For a `SignalScoutRun`, return each emitted finding paired with the inbox report its signal grouped into — the reverse lookup from a scout's emission to the `SignalReport` it actually produced. One row per emission with its `finding_id`, the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`), and the linked `report` (`id`, `title`, `status`) or `null` when the finding never matched a report (or the report was deleted/suppressed). Use this to see *which* findings turned into actionable reports, not just what a run surfaced (`signals-scout-runs-emissions-list`). Requires `task:read` on top of `signal_scout:read` because it exposes report titles. Strictly team-scoped — a run UUID belonging to another team returns 404.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "List the inbox reports a scout run's findings linked to",
+        "title": "List the inbox reports a scout run's findings linked to",
+        "required_scopes": ["signal_scout:read", "task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "signals-scout-runs-emissions-list": {
         "description": "Return the findings a `SignalScoutRun` emitted to the inbox, newest first — one row per emit with its `description` (the finding text as surfaced), `weight`, `confidence`, `severity`, `tags`, and the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`) that joins back to the underlying signal. Use this to see *what* a run actually surfaced, not just how many (`emitted_count`) or which ids (`emitted_finding_ids`). Strictly team-scoped — a run UUID belonging to another team returns 404.",
         "category": "Signals",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6251,6 +6251,20 @@
             "readOnlyHint": true
         }
     },
+    "signals-scout-runs-emission-reports": {
+        "description": "For a `SignalScoutRun`, return each emitted finding paired with the inbox report its signal grouped into — the reverse lookup from a scout's emission to the `SignalReport` it actually produced. One row per emission with its `finding_id`, the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`), and the linked `report` (`id`, `title`, `status`) or `null` when the finding never matched a report (or the report was deleted/suppressed). Use this to see *which* findings turned into actionable reports, not just what a run surfaced (`signals-scout-runs-emissions-list`). Requires `task:read` on top of `signal_scout:read` because it exposes report titles. Strictly team-scoped — a run UUID belonging to another team returns 404.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "List the inbox reports a scout run's findings linked to",
+        "title": "List the inbox reports a scout run's findings linked to",
+        "required_scopes": ["signal_scout:read", "task:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "signals-scout-runs-emissions-list": {
         "description": "Return the findings a `SignalScoutRun` emitted to the inbox, newest first — one row per emit with its `description` (the finding text as surfaced), `weight`, `confidence`, `severity`, `tags`, and the deterministic `source_id` (`run:<run_id>:finding:<finding_id>`) that joins back to the underlying signal. Use this to see *what* a run actually surfaced, not just how many (`emitted_count`) or which ids (`emitted_finding_ids`). Strictly team-scoped — a run UUID belonging to another team returns 404.",
         "category": "Signals",

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 19 enabled ops
+ * PostHog API - MCP 20 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -312,6 +312,19 @@ export const SignalsScoutRunsRetrieveParams = /* @__PURE__ */ zod.object({
  * @summary List a run's emitted findings
  */
 export const SignalsScoutRunsEmissionsParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    run_id: zod.string().describe('UUID of the `SignalScoutRun` bridge row.'),
+})
+
+/**
+ * Best-effort reverse of the report -> signals link. For each finding the run emitted, resolve the inbox `SignalReport` (if any) its underlying signal grouped into by walking the deterministic `source_id` back through the signal store. `report` is null when the finding hasn't grouped into a report yet, was de-duplicated away, or its signal was deleted. Lets the scout UI surface which inbox report a finding contributed to — the reverse of the report's evidence list. Strictly team-scoped — a run UUID belonging to another team returns 404.
+ * @summary List the inbox reports a run's findings linked to
+ */
+export const SignalsScoutRunsEmissionReportsParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -13,6 +13,7 @@ import {
     SignalsScoutEmitSignalBody,
     SignalsScoutEmitSignalParams,
     SignalsScoutProjectProfileGetQueryParams,
+    SignalsScoutRunsEmissionReportsParams,
     SignalsScoutRunsEmissionsParams,
     SignalsScoutRunsListQueryParams,
     SignalsScoutRunsRetrieveParams,
@@ -431,6 +432,24 @@ const signalsScoutProjectProfileGet = (): ToolBase<
     },
 })
 
+const SignalsScoutRunsEmissionReportsSchema = SignalsScoutRunsEmissionReportsParams.omit({ project_id: true })
+
+const signalsScoutRunsEmissionReports = (): ToolBase<
+    typeof SignalsScoutRunsEmissionReportsSchema,
+    WithPostHogUrl<Schemas.ScoutEmissionReportLink[]>
+> => ({
+    name: 'signals-scout-runs-emission-reports',
+    schema: SignalsScoutRunsEmissionReportsSchema,
+    handler: async (context: Context, params: z.infer<typeof SignalsScoutRunsEmissionReportsSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ScoutEmissionReportLink[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/runs/${encodeURIComponent(String(params.run_id))}/emissions/reports/`,
+        })
+        return await withPostHogUrl(context, result, '/inbox')
+    },
+})
+
 const SignalsScoutRunsEmissionsListSchema = SignalsScoutRunsEmissionsParams.omit({ project_id: true })
 
 const signalsScoutRunsEmissionsList = (): ToolBase<
@@ -581,6 +600,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'signals-scout-config-update': signalsScoutConfigUpdate,
     'signals-scout-emit-signal': signalsScoutEmitSignal,
     'signals-scout-project-profile-get': signalsScoutProjectProfileGet,
+    'signals-scout-runs-emission-reports': signalsScoutRunsEmissionReports,
     'signals-scout-runs-emissions-list': signalsScoutRunsEmissionsList,
     'signals-scout-runs-list': signalsScoutRunsList,
     'signals-scout-runs-retrieve': signalsScoutRunsRetrieve,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-runs-emission-reports.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-runs-emission-reports.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "run_id": {
+            "description": "UUID of the `SignalScoutRun` bridge row.",
+            "type": "string"
+        }
+    },
+    "required": ["run_id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PR #63817 shipped the `signals-scout-runs-emission-reports` REST endpoint — the reverse lookup from a scout run's emitted findings to the inbox reports their signals grouped into. The MCP tool was wired up but left `enabled: false`, so the capability never surfaced to MCP clients. Its sibling `signals-scout-runs-emissions-list` is enabled, so an agent could see *what* a run emitted but not *which* of those findings became actionable reports.

## Changes

- Flip `signals-scout-runs-emission-reports` to `enabled: true` in `products/signals/mcp/tools.yaml` and fill in the config to match its sibling (scopes, read-only annotations, `list`, title, description).
- Declare both `signal_scout:read` and `task:read` scopes — the endpoint exposes report titles, so it gates on `task:read` on top of the scout scope, matching the backend `required_scopes`.
- Regenerate MCP artifacts via `hogli build:openapi` (generated tool definitions, schemas, and handlers).

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. I ran `hogli build:openapi` and confirmed the new tool generated cleanly: it appears in `generated-tool-definitions.json` with both required scopes (`signal_scout:read`, `task:read`) and read-only annotations, and a handler + registry entry were generated in `services/mcp/src/tools/generated/signals.ts`. No new operations were left stale by the sync. The underlying endpoint and its behavior were already tested in #63817.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy noticed the tool added in #63817 shipped with `enabled: false` and asked to enable it. The only hand-edited file is `products/signals/mcp/tools.yaml`; everything else is regenerated by `hogli build:openapi`. Config mirrors the adjacent `signals-scout-runs-emissions-list` tool. Tool/agent: Claude Code (Opus 4.8).
