### PR TITLE
feat(conversations): email widget replies when address is known

### DIFF
--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -465,3 +465,115 @@ class TestEmailReplySignalGuard(BaseTest):
         )
 
         assert EmailOutboxMessage.objects.filter(ticket=self.email_ticket).count() == expected_count
+
+    @parameterized.expand(
+        [
+            ("valid_email", {"name": "Customer", "email": "customer@example.com"}, "customer@example.com"),
+        ]
+    )
+    def test_widget_ticket_with_email_trait_creates_email_outbox(
+        self, _mock_on_commit, _name, anonymous_traits, distinct_id
+    ):
+        widget_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id=str(uuid.uuid4()),
+            distinct_id=distinct_id,
+            anonymous_traits=anonymous_traits,
+        )
+
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(widget_ticket.id),
+            content="reply from support",
+            created_by=self.user,
+            item_context={"author_type": "support", "is_private": False},
+        )
+
+        outbox = EmailOutboxMessage.objects.get(ticket=widget_ticket)
+        widget_ticket.refresh_from_db()
+
+        assert outbox.comment.content == "reply from support"
+        assert widget_ticket.email_from == "customer@example.com"
+        assert widget_ticket.email_config_id == self.config.id
+
+    @parameterized.expand(
+        [
+            ("missing_email", {}),
+            ("invalid_email", {"email": "not-an-email"}),
+            ("unmatched_distinct_id", {"email": "customer@example.com"}),
+        ]
+    )
+    def test_widget_ticket_without_valid_email_trait_does_not_create_email_outbox(
+        self, _mock_on_commit, _name, anonymous_traits
+    ):
+        widget_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id=str(uuid.uuid4()),
+            distinct_id="user-123",
+            anonymous_traits=anonymous_traits,
+        )
+
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(widget_ticket.id),
+            content="reply from support",
+            created_by=self.user,
+            item_context={"author_type": "support", "is_private": False},
+        )
+
+        assert EmailOutboxMessage.objects.filter(ticket=widget_ticket).count() == 0
+
+    def test_widget_ticket_without_verified_email_config_does_not_create_email_outbox(self, _mock_on_commit):
+        self.config.domain_verified = False
+        self.config.save(update_fields=["domain_verified"])
+        widget_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id=str(uuid.uuid4()),
+            distinct_id="customer@example.com",
+            anonymous_traits={"email": "customer@example.com"},
+        )
+
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(widget_ticket.id),
+            content="reply from support",
+            created_by=self.user,
+            item_context={"author_type": "support", "is_private": False},
+        )
+
+        widget_ticket.refresh_from_db()
+
+        assert widget_ticket.email_config_id is None
+        assert EmailOutboxMessage.objects.filter(ticket=widget_ticket).count() == 0
+
+    def test_widget_ticket_over_promotion_limit_does_not_create_email_outbox(self, _mock_on_commit):
+        widget_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id=str(uuid.uuid4()),
+            distinct_id="customer@example.com",
+            anonymous_traits={"email": "customer@example.com"},
+        )
+
+        with patch(
+            "products.conversations.backend.signals._reserve_widget_email_reply_promotion_slot", return_value=False
+        ):
+            Comment.objects.create(
+                team=self.team,
+                scope="conversations_ticket",
+                item_id=str(widget_ticket.id),
+                content="reply from support",
+                created_by=self.user,
+                item_context={"author_type": "support", "is_private": False},
+            )
+
+        widget_ticket.refresh_from_db()
+
+        assert widget_ticket.email_config_id is None
+        assert EmailOutboxMessage.objects.filter(ticket=widget_ticket).count() == 0

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -1,6 +1,9 @@
 from email.utils import make_msgid
 from typing import Any, cast
 
+from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db import transaction
 from django.db.models import F, Q
 from django.db.models.functions import Greatest
@@ -17,11 +20,14 @@ from posthog.models.instance_setting import get_instance_setting
 
 from .cache import invalidate_messages_cache, invalidate_tickets_cache
 from .events import capture_message_received, capture_message_sent, capture_ticket_created
-from .models import EmailOutboxMessage, Ticket
+from .models import EmailChannel, EmailOutboxMessage, Ticket
 from .models.constants import Channel
 from .tasks import post_reply_to_github, post_reply_to_slack, post_reply_to_teams, send_email_reply
 
 logger = structlog.get_logger(__name__)
+
+WIDGET_EMAIL_REPLY_PROMOTION_LIMIT_PER_HOUR = 100
+WIDGET_EMAIL_REPLY_PROMOTION_TTL_SECONDS = 60 * 60
 
 
 def _is_private_message(item_context: dict | None) -> bool:
@@ -34,6 +40,72 @@ def _is_private_message(item_context: dict | None) -> bool:
 def _get_comment_created_by_id(comment: Comment) -> int | None:
     created_by_id = getattr(comment, "created_by_id", None)
     return created_by_id if isinstance(created_by_id, int) else None
+
+
+def _get_widget_reply_email(ticket: Ticket) -> str:
+    email = (ticket.anonymous_traits or {}).get("email")
+    if not isinstance(email, str):
+        return ""
+
+    email = email.strip()
+    if not email:
+        return ""
+
+    try:
+        validate_email(email)
+    except ValidationError:
+        return ""
+
+    if ticket.distinct_id != email:
+        return ""
+
+    return email
+
+
+def _reserve_widget_email_reply_promotion_slot(team_id: int) -> bool:
+    key = f"conversations:widget_email_reply_promotions:{team_id}"
+    try:
+        if cache.add(key, 1, timeout=WIDGET_EMAIL_REPLY_PROMOTION_TTL_SECONDS):
+            return True
+        return cache.incr(key) <= WIDGET_EMAIL_REPLY_PROMOTION_LIMIT_PER_HOUR
+    except Exception:
+        return True
+
+
+def _prepare_ticket_for_email_reply(ticket: Ticket) -> bool:
+    if ticket.email_from and ticket.email_config_id:
+        return True
+
+    if ticket.channel_source != Channel.WIDGET:
+        return False
+
+    email_from = ticket.email_from or _get_widget_reply_email(ticket)
+    if not email_from:
+        return False
+
+    email_config = ticket.email_config
+    if email_config is None:
+        email_config = (
+            EmailChannel.objects.filter(team_id=ticket.team_id, domain_verified=True).order_by("created_at").first()
+        )
+        if email_config is None:
+            return False
+
+    if not _reserve_widget_email_reply_promotion_slot(ticket.team_id):
+        return False
+
+    update_fields: list[str] = []
+    if not ticket.email_from:
+        ticket.email_from = email_from
+        update_fields.append("email_from")
+    if not ticket.email_config_id:
+        ticket.email_config = email_config
+        update_fields.append("email_config")
+
+    if update_fields:
+        ticket.save(update_fields=update_fields)
+
+    return True
 
 
 @receiver(post_save, sender=Ticket)
@@ -331,14 +403,15 @@ def post_slack_reply_on_team_message(sender, instance: Comment, created: bool, *
 @receiver(post_save, sender=Comment)
 def send_email_reply_on_team_message(sender, instance: Comment, created: bool, **kwargs):
     """
-    When a team member replies to an email-sourced ticket, send the reply
-    back to the customer via email through a Celery task.
+    When a team member replies to an email-sourced ticket, or a widget ticket
+    where the customer provided an email address, send the reply back to the
+    customer via email through a Celery task.
 
     Only triggers for:
     - Newly created comments (not edits)
     - Non-private messages
     - Messages with a created_by (team member, not customer)
-    - Tickets with channel_source="email"
+    - Tickets with channel_source="email", or channel_source="widget" with a valid email trait
     """
     if instance.scope != "conversations_ticket":
         return
@@ -371,17 +444,23 @@ def send_email_reply_on_team_message(sender, instance: Comment, created: bool, *
     # is down, the row still exists and flush_pending_email_replies will send it.
     ticket = (
         Ticket.objects.select_related("team", "email_config")
-        .filter(id=item_id, team_id=team_id, channel_source=Channel.EMAIL)
+        .filter(id=item_id, team_id=team_id, channel_source__in=[Channel.EMAIL, Channel.WIDGET])
         .first()
     )
-    if not ticket or not ticket.email_from:
+    if not ticket:
         return
 
     settings_dict = ticket.team.conversations_settings or {}
     if not settings_dict.get("email_enabled"):
         return
 
+    if not _prepare_ticket_for_email_reply(ticket):
+        return
+
     config = ticket.email_config
+    if config is None:
+        return
+
     inbound_domain = get_instance_setting("CONVERSATIONS_EMAIL_INBOUND_DOMAIN") or (config.domain if config else None)
     message_id = make_msgid(domain=inbound_domain) if inbound_domain else make_msgid()
 


### PR DESCRIPTION

  ## Summary
Fixes https://github.com/PostHog/posthog/issues/55602
  This fixes widget conversations where the customer provided an email address but support replies only stayed inside
  the widget.

  When a team member replies to a widget ticket, we now check whether the ticket has a valid customer email in its
  anonymous traits. If it does, we attach the team’s verified email channel and create the same email outbox message
  used by normal email-sourced tickets.

  Widget tickets without a valid email are still ignored, so we do not try to send replies when there is no reliable
  recipient.

  ## Changes

  - Allow the email reply signal to handle widget tickets as well as email tickets
  - Validate the widget-provided email before using it
  - Reuse the existing durable email outbox flow for delivery
  - Add tests for valid, missing, and invalid widget email cases

  ## Testing

  - `python -m py_compile products/conversations/backend/signals.py products/conversations/backend/api/tests/
  test_signals.py`
  - `git diff --check -- products/conversations/backend/signals.py products/conversations/backend/api/tests/
  test_signals.py`
