### PR TITLE
fix(postgres): clamp out-of-range timestamps instead of crashing sync

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -20,6 +20,7 @@ import pyarrow as pa
 import structlog
 from psycopg import sql
 from psycopg.adapt import Loader
+from psycopg.types.datetime import TimestampLoader, TimestamptzLoader
 from structlog.types import FilteringBoundLogger
 
 from posthog.hogql.database.schema.duckdb_table_functions import is_dangerous_table_function
@@ -1014,6 +1015,84 @@ class SafeDateLoader(Loader):
 
         # Fallback: clamp to max for unparseable dates
         return date.max
+
+
+def _timestamp_out_of_python_range(s: str) -> Literal["min", "max"] | None:
+    """Classify a PostgreSQL timestamp text value relative to Python's datetime range.
+
+    Returns "max" for values past datetime.max (year > 9999, 'infinity'), "min" for
+    values before datetime.min (year < 1, BC dates, '-infinity'), and None when the
+    value is in range and should be parsed normally. The year is always the leading
+    run of digits before the first '-', so this works for both `timestamp` and
+    `timestamptz` text (the timezone offset and any ' BC' suffix come later).
+    """
+    if s == "infinity":
+        return "max"
+    if s == "-infinity":
+        return "min"
+    # PostgreSQL emits pre-AD-1 timestamps with a trailing " BC"; all are before datetime.min.
+    if s.lower().endswith(" bc"):
+        return "min"
+    year_str = s.split("-", 1)[0]
+    if year_str.isdigit():
+        year = int(year_str)
+        if year > 9999:
+            return "max"
+        if year < 1:
+            return "min"
+    return None
+
+
+class SafeDateTimeLoader(Loader):
+    """Load PostgreSQL `timestamp` values, clamping those outside Python's datetime range.
+
+    PostgreSQL timestamps span 4713 BC to 294276 AD, far wider than Python's
+    datetime (year 1 to 9999). psycopg's default loader raises
+    `DataError: timestamp too large (after year 10K)` on out-of-range values, which
+    aborts the entire sync over a single bad row. Mirror SafeDateLoader: clamp to
+    datetime.max/min (and handle infinity) instead of crashing. In-range values
+    delegate to psycopg's own loader so precision parsing stays correct.
+    """
+
+    def __init__(self, oid: int, context: Any = None) -> None:
+        super().__init__(oid, context)
+        self._delegate = TimestampLoader(oid, context)
+
+    def load(self, data) -> datetime | None:
+        if data is None:
+            return None
+
+        clamp = _timestamp_out_of_python_range(bytes(data).decode("utf-8"))
+        if clamp == "max":
+            return datetime.max
+        if clamp == "min":
+            return datetime.min
+        return self._delegate.load(data)
+
+
+class SafeDateTimeTzLoader(Loader):
+    """Load PostgreSQL `timestamptz` values, clamping those outside Python's datetime range.
+
+    The timezone-aware counterpart of SafeDateTimeLoader. Clamps out-of-range
+    values to datetime.max/min in UTC (matching the UTC-typed Arrow column the
+    pipeline builds for `timestamptz`) and delegates in-range values to psycopg's
+    own timezone-aware loader.
+    """
+
+    def __init__(self, oid: int, context: Any = None) -> None:
+        super().__init__(oid, context)
+        self._delegate = TimestamptzLoader(oid, context)
+
+    def load(self, data) -> datetime | None:
+        if data is None:
+            return None
+
+        clamp = _timestamp_out_of_python_range(bytes(data).decode("utf-8"))
+        if clamp == "max":
+            return datetime.max.replace(tzinfo=UTC)
+        if clamp == "min":
+            return datetime.min.replace(tzinfo=UTC)
+        return self._delegate.load(data)
 
 
 def _build_query(
@@ -2116,6 +2195,11 @@ def postgres_source(
                 connection.adapters.register_loader("tstzrange", RangeAsStringLoader)
                 connection.adapters.register_loader("daterange", RangeAsStringLoader)
                 connection.adapters.register_loader("date", SafeDateLoader)
+                # Postgres timestamps span years far beyond Python's datetime (max 9999);
+                # without these, a single out-of-range row aborts the whole sync with
+                # "timestamp too large (after year 10K)". Clamp instead of crashing.
+                connection.adapters.register_loader("timestamp", SafeDateTimeLoader)
+                connection.adapters.register_loader("timestamptz", SafeDateTimeTzLoader)
                 # Bump statement_timeout for the streaming connection. A server
                 # cursor FETCH inherits the session statement_timeout, and on
                 # wide/partitioned scans the source's default (often 30-60s)

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -47,6 +47,8 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     PostgreSQLColumn,
     RangeAsStringLoader,
     SafeDateLoader,
+    SafeDateTimeLoader,
+    SafeDateTimeTzLoader,
     _build_count_query,
     _build_query,
     _connect_with_dropped_retry,
@@ -105,6 +107,53 @@ class TestSafeDateLoader:
         ],
     )
     def test_load_dates(self, loader, input_data, expected):
+        assert loader.load(input_data) == expected
+
+
+class TestSafeDateTimeLoader:
+    @pytest.fixture
+    def loader(self):
+        return SafeDateTimeLoader(oid=1114)
+
+    @pytest.mark.parametrize(
+        "input_data,expected",
+        [
+            (b"2024-01-15 10:30:00", datetime(2024, 1, 15, 10, 30, 0)),
+            (b"2026-06-16 10:46:45.554162", datetime(2026, 6, 16, 10, 46, 45, 554162)),
+            (b"0001-01-01 00:00:00", datetime(1, 1, 1, 0, 0, 0)),
+            (b"9999-12-31 23:59:59.999999", datetime(9999, 12, 31, 23, 59, 59, 999999)),
+            # The reported crash: a year-17026 timestamp must clamp, not raise.
+            (b"17026-04-30 22:00:00", datetime.max),
+            (b"99999-12-31 00:00:00", datetime.max),
+            (b"infinity", datetime.max),
+            (b"-infinity", datetime.min),
+            (b"0044-03-15 00:00:00 BC", datetime.min),
+            (None, None),
+        ],
+    )
+    def test_load_timestamps(self, loader, input_data, expected):
+        assert loader.load(input_data) == expected
+
+
+class TestSafeDateTimeTzLoader:
+    @pytest.fixture
+    def loader(self):
+        return SafeDateTimeTzLoader(oid=1184)
+
+    @pytest.mark.parametrize(
+        "input_data,expected",
+        [
+            (b"2026-06-16 10:46:45.554162+00", datetime(2026, 6, 16, 10, 46, 45, 554162, tzinfo=UTC)),
+            (b"9999-12-31 23:59:59.999999+00", datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=UTC)),
+            (b"17026-04-30 22:00:00+00", datetime.max.replace(tzinfo=UTC)),
+            (b"99999-12-31 00:00:00+00", datetime.max.replace(tzinfo=UTC)),
+            (b"infinity", datetime.max.replace(tzinfo=UTC)),
+            (b"-infinity", datetime.min.replace(tzinfo=UTC)),
+            (b"0044-03-15 00:00:00+00 BC", datetime.min.replace(tzinfo=UTC)),
+            (None, None),
+        ],
+    )
+    def test_load_timestamptz(self, loader, input_data, expected):
         assert loader.load(input_data) == expected
 
 


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import was crashing with `DataError: timestamp too large (after year 10K): '17026-04-30 22:00:00'`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed04b-c791-71d2-bb2d-4da96146683b)).

PostgreSQL timestamps span 4713 BC to 294276 AD, far wider than Python's `datetime` (year 1–9999). psycopg's default *text* timestamp loaders (`TimestampLoader` / `TimestamptzLoader`) raise `DataError` the moment they hit a value past year 9999. The deepest in-app frame is `posthog/temporal/data_imports/sources/postgres/postgres.py` → `get_rows` → server-cursor `fetchmany` → `psycopg_binary._psycopg.TimestampLoader.cload`, so a single out-of-range row in a source table aborts the whole sync.

This is the timestamp analog of a case we already handle for `date` columns via `SafeDateLoader` — there was simply no equivalent for `timestamp` / `timestamptz`.

## Changes

- Add `SafeDateTimeLoader` (for `timestamp`) and `SafeDateTimeTzLoader` (for `timestamptz`), mirroring the existing `SafeDateLoader`. They clamp out-of-range values to `datetime.max` / `datetime.min` (handling `infinity` / `-infinity` and BC dates), and delegate in-range values to psycopg's own loader so precision and timezone parsing stay correct. The tz variant clamps to UTC-aware bounds, matching the UTC-typed Arrow column the pipeline builds for `timestamptz`.
- Register both loaders on the row-streaming connection alongside the existing `date` loader, so both the server-cursor and offset-chunking read paths are covered.

This is a fixable-bug fix, not a retry-policy change: the data is valid in PostgreSQL and we should ingest it (clamped) rather than fail. No change to `NonRetryableErrors`.

## How did you test this code?

I'm an agent (Claude Code). I added parameterized regression tests (`TestSafeDateTimeLoader`, `TestSafeDateTimeTzLoader`) covering in-range values, the exact reported year-17026 value, 5-digit years, `infinity`/`-infinity`, BC dates, and `None`. The year-17026 case reproduces the original crash and now clamps instead of raising.

Automated tests run locally:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py \
  -k "SafeDateLoader or SafeDateTimeLoader or SafeDateTimeTzLoader"
# 32 passed
```

`ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used Claude Code with the PostHog error-tracking MCP tools to pull the full stack trace and a representative event, confirming the failure originates in the Postgres source's `get_rows` row-loading path (not just referenced in serialized log context). Reproduced the `DataError` locally against psycopg 3.2.4 to confirm the text loaders raise on year > 9999, and verified the pure-Python loader override is invoked by the transformer (the same mechanism that makes the existing `SafeDateLoader` work). Chose to clamp rather than treat as non-retryable because the value is legitimate Postgres data and retrying would never help — keeping the sync moving is the right behavior.
