### PR TITLE
chore(skills): add Slack MCP fallback to code-ownership skill

### DIFF
--- a/.agents/skills/establishing-code-ownership/SKILL.md
+++ b/.agents/skills/establishing-code-ownership/SKILL.md
@@ -40,7 +40,7 @@ If neither `product.yaml` nor CODEOWNERS resolves it, consult the [feature-owner
 
 ## Even-last-er resort: ask Slack
 
-If even the handbook fails and the Slack MCP is available, search Slack or ask in a channel. It's the least authoritative source (opinions, stale threads), so verify against the repo files and flag the answer as Slack-sourced.
+If even the handbook fails and the Slack MCP is available, search Slack. It's the least authoritative source (opinions, stale threads), so verify against the repo files and flag the answer as Slack-sourced.
 
 ## Slug vs handle
 

--- a/.agents/skills/establishing-code-ownership/SKILL.md
+++ b/.agents/skills/establishing-code-ownership/SKILL.md
@@ -40,7 +40,7 @@ If neither `product.yaml` nor CODEOWNERS resolves it, consult the [feature-owner
 
 ## Even-last-er resort: ask Slack
 
-If even the handbook comes up empty and you have the Slack MCP available, search Slack — or ask in a relevant channel — to track down who owns it. This is the final fallback and the least authoritative source: ad-hoc opinions and stale threads, not a maintained mapping. Verify anything it surfaces against the repo files, and flag the answer as Slack-sourced.
+If even the handbook fails and the Slack MCP is available, search Slack or ask in a channel. It's the least authoritative source (opinions, stale threads), so verify against the repo files and flag the answer as Slack-sourced.
 
 ## Slug vs handle
 

--- a/.agents/skills/establishing-code-ownership/SKILL.md
+++ b/.agents/skills/establishing-code-ownership/SKILL.md
@@ -38,6 +38,10 @@ Check both sources or you'll miss code:
 
 If neither `product.yaml` nor CODEOWNERS resolves it, consult the [feature-ownership handbook](https://posthog.com/handbook/engineering/feature-ownership) (teams to product areas). It's a genuine last resort: coarse-grained (broad areas, not files) and hand-maintained (lags repo moves and reorgs). Prefer the repo files, and flag any handbook-sourced answer as possibly stale.
 
+## Even-last-er resort: ask Slack
+
+If even the handbook comes up empty and you have the Slack MCP available, search Slack — or ask in a relevant channel — to track down who owns it. This is the final fallback and the least authoritative source: ad-hoc opinions and stale threads, not a maintained mapping. Verify anything it surfaces against the repo files, and flag the answer as Slack-sourced.
+
 ## Slug vs handle
 
 - **Handle** (CODEOWNERS): `@PostHog/<slug>`, e.g. `@PostHog/team-replay`.


### PR DESCRIPTION
## Problem

The `establishing-code-ownership` skill stops at the feature-ownership handbook as its last resort. When even the handbook doesn't resolve who owns a path, there's no further guidance — but in practice a quick Slack search often surfaces the owner.

**Why:** Suggested by Julian in a Slack thread — let the agent fall back to the Slack MCP as a final resort when the repo files and handbook all come up empty.

## Changes

Adds an "Even-last-er resort: ask Slack" section after the handbook fallback. It tells the agent to search Slack (or ask in a relevant channel) via the Slack MCP when nothing else resolves ownership, with caveats that it's the least authoritative source (ad-hoc opinions, stale threads) and answers must be verified against the repo files and flagged as Slack-sourced.

## How did you test this code?

I'm an agent (PostHog Slack app). This is a docs-only change to a skill markdown file; no automated tests were run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with the PostHog Slack app at Robbie's request, adding Julian's Slack-thread suggestion as an extra fallback in the skill.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1781611350405129?thread_ts=1781611350.405129&cid=C0113360FFV)*
