### PR TITLE
fix(webflow): treat 409 Conflict as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/webflow/source.py
+++ b/posthog/temporal/data_imports/sources/webflow/source.py
@@ -40,6 +40,11 @@ class WebflowSource(ResumableSource[WebflowSourceConfig, WebflowResumeConfig]):
         return {
             "401 Client Error": "Your Webflow API token is invalid or expired. Please generate a new token and reconnect.",
             "403 Client Error": "Your Webflow API token is missing a required scope. Grant the read scopes for the resources you want to sync and reconnect.",
+            # Webflow returns 409 Conflict on the Products/Orders list endpoints when the
+            # connected site does not have ecommerce enabled, and on other resources when
+            # the site has unpublished changes. Both are deterministic state/config issues
+            # that retrying can't resolve, so stop retrying and tell the user how to fix it.
+            "409 Client Error: Conflict": "Webflow returned a 409 Conflict. For the Products and Orders tables this means the connected site does not have ecommerce enabled — enable ecommerce in Webflow or remove those tables from the sync. For other resources it can mean the site has unpublished changes; publish your Webflow site, then try again.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/webflow/tests/test_webflow_source.py
+++ b/posthog/temporal/data_imports/sources/webflow/tests/test_webflow_source.py
@@ -57,6 +57,19 @@ class TestWebflowSource:
         errors = WebflowSource().get_non_retryable_errors()
         assert "401 Client Error" in errors
         assert "403 Client Error" in errors
+        assert "409 Client Error: Conflict" in errors
+
+    def test_409_conflict_message_is_recognised_as_non_retryable(self) -> None:
+        # Webflow returns 409 on /products when the site has no ecommerce; the raised
+        # HTTPError message embeds a volatile site id and URL, so we must match on a
+        # stable substring that excludes them.
+        errors = WebflowSource().get_non_retryable_errors()
+        raised_message = (
+            "409 Client Error: Conflict for url: "
+            "https://api.webflow.com/v2/sites/691afa9e7404e1259a4d0802/products?limit=100&offset=0"
+        )
+        matches = [pattern for pattern in errors if pattern in raised_message]
+        assert matches == ["409 Client Error: Conflict"]
 
     def test_get_schemas_includes_static_and_dynamic_collections(self) -> None:
         with patch(


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HTTPError` from the Webflow data-warehouse import source:

> `409 Client Error: Conflict for url: https://api.webflow.com/v2/sites/<site>/products?limit=100&offset=0`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ed04f-5dbc-77e1-a03f-fa4154a87116

The failure originates in `posthog/temporal/data_imports/sources/webflow/webflow.py` in `fetch_page`, at `response.raise_for_status()`. `fetch_page` only treats `429` and `>= 500` as retryable; a `409` falls straight through to `raise_for_status()`, raising `HTTPError`, which then propagates up and is retried by Temporal until the activity exhausts its attempts.

Per [Webflow's Data API docs](https://developers.webflow.com/data/v2.0.0-beta/reference/ecommerce/products-sk-us/list), a `409 Conflict` on the **List Products & SKUs** endpoint means *"The site does not have ecommerce enabled."* More broadly, [Webflow returns 409](https://discourse.webflow.com/t/documenting-data-api-v2-errors/296289) for state conflicts such as a site with unpublished changes. Both are deterministic config/state conditions — retrying the exact same request can never succeed.

## Changes

Add `"409 Client Error: Conflict"` to the Webflow source's `get_non_retryable_errors` (mirroring the existing `401`/`403` entries and the Stripe source pattern). When matched, the schema stops syncing and the user is shown an actionable message explaining that ecommerce isn't enabled (for Products/Orders) or that the site has unpublished changes (other resources).

The match string deliberately excludes the volatile site id and URL that `requests` embeds in the `HTTPError` message, so it stays low-false-positive and stable across requests.

This is scoped strictly to this error — no change to global retry policy, and transient errors (timeouts, connection resets, 429/5xx) remain retryable as before.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran (all passing):

- `posthog/temporal/data_imports/sources/webflow/tests/` — 45 passed, including:
  - `test_get_non_retryable_errors` — asserts the new `409 Client Error: Conflict` key is present.
  - `test_409_conflict_message_is_recognised_as_non_retryable` — new regression test asserting the real raised message (with site id + URL) is matched by exactly the stable substring.
- `ruff check` and `ruff format` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking webhook for the Webflow import source with Claude Code.

- Confirmed the issue in PostHog error tracking: top in-app frame is `fetch_page` at `webflow.py:185` (`response.raise_for_status()`), `in_app: true`, so the failure genuinely originates in this source.
- Decided this is an upstream/config error, not a code bug: Webflow's own docs define `409` on the products list endpoint as "site does not have ecommerce enabled", a deterministic state that retrying cannot fix. Considered a graceful-skip (return empty) but rejected it — that would silently hide a real misconfiguration and produce an empty table — in favor of `NonRetryableErrors`, which stops the sync and surfaces a clear message.
- Matched on a stable substring (`409 Client Error: Conflict`) rather than the per-request URL/site id, per the source guidance.