### PR TITLE
fix(mysql): treat unknown-column (1054) errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -146,6 +146,15 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
             "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            # MySQL/MariaDB error 1054 (ER_BAD_FIELD_ERROR): a column the sync query references no
+            # longer exists in the source table — almost always the configured incremental field
+            # after the column was renamed or dropped (schema drift). The streaming query reissues
+            # the same WHERE/ORDER BY on every attempt, so it fails identically forever; the COUNT(*)
+            # probe already swallows this same error expecting it to be classified here. Match on the
+            # locale-independent error code (the column name and clause are volatile, and the message
+            # text is translated on non-English servers) so it catches both the raw pymysql string and
+            # the Temporal-wrapped `OperationalError: (1054, ...)` form.
+            '(1054, "Unknown column': "A column referenced during sync no longer exists in your source table (MySQL error 1054). This usually means a column was renamed or dropped — if it's the table's incremental field, update it to a column that exists (or switch to a full re-sync), then resync.",
         }
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -857,6 +857,22 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form (classified in `_handle_import_error`).
+            str(pymysql.err.OperationalError(1054, "Unknown column 'favoritor_id' in 'where clause'")),
+            # Temporal-wrapped str(e.cause) form (classified in external_data_job).
+            "OperationalError: (1054, \"Unknown column 'favoritor_id' in 'where clause'\")",
+            # Other clause variants share the same 1054 code and "Unknown column" prefix.
+            "OperationalError: (1054, \"Unknown column 'deleted_at' in 'order clause'\")",
+        ],
+    )
+    def test_unknown_column_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Unknown-column error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

A MySQL data-warehouse import surfaced this error in error tracking:

> `OperationalError: (1054, "Unknown column 'favoritor_id' in 'where clause'")`

The configured incremental field references a column that no longer exists in the source table (the table's actual columns had drifted — the column was renamed or dropped). The streaming sync query builds its `WHERE`/`ORDER BY` from that incremental field:

```sql
SELECT * FROM `production`.`gn_item_favorites` WHERE `favoritor_id` > %(incremental_value)s ORDER BY `favoritor_id` ASC
```

MySQL rejects this with error 1054 (`ER_BAD_FIELD_ERROR`) deterministically — the column won't reappear — so every retry fails identically while the activity keeps retrying.

Notably, the codebase already *anticipates* this: the best-effort `COUNT(*)` probe (`get_rows_to_sync`) deliberately swallows this exact 1054 error with a comment that "genuine problems resurface in the real streaming query and are classified there." But the streaming path had no non-retryable classification for it, so it was treated as retryable.

## Changes

Add a non-retryable entry to `MySQLSource.get_non_retryable_errors()` keyed on `(1054, "Unknown column`.

- Anchored on the locale-independent MySQL error code rather than the volatile column name/clause (the message text is translated on non-English servers).
- Covers all clause variants (`'where clause'`, `'order clause'`, `'field list'`, …) since it stops at `Unknown column`.
- Matches both classification points: the raw `str(error)` form in `_handle_import_error` (stops within-run retries) and the Temporal-wrapped `OperationalError: (1054, ...)` form in `external_data_job` (stops future scheduled syncs).
- Surfaces a clear user-facing message pointing at the renamed/dropped column and suggesting they fix the incremental field or do a full re-sync.

This is a user/upstream (schema-drift / misconfiguration) error, not a bug in our code — there is nothing for us to do but stop retrying and tell the user, which is why it belongs in `NonRetryableErrors`.

## How did you test this code?

I'm an agent (Claude Code). I added a regression test and ran the automated suite — no manual testing was performed.

- Added `test_unknown_column_is_non_retryable` covering the raw pymysql form, the Temporal-wrapped form, and another clause variant.
- The existing `test_transient_lost_connection_stays_retryable` / `test_cant_create_new_thread_stays_retryable` guards confirm transient errors remain retryable.
- `pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — 104 passed.
- `ruff check` / `ruff format --check` — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue. Investigation: confirmed the issue in PostHog error tracking (full stack trace originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` at `_stream_with_optional_force_index`/`get_rows`), read the import pipeline and the two non-retryable classification paths, and confirmed the probe already swallows the same error in expectation of streaming-path classification.

Decision: classify as user/upstream (schema drift), so extend `NonRetryableErrors` rather than change code behavior. Match string chosen as the error code (`(1054, "Unknown column`) rather than the column name or English-only text, and verified it matches both the raw and Temporal-wrapped error strings (the existing `(1356`/`(1146` entries only matched the wrapped form). Kept it scoped to error 1054 to avoid swallowing unrelated failures.

Tools used: Claude Code with the PostHog error-tracking MCP tools.
