### PR TITLE
fix(temporalio): treat gRPC Unauthenticated as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -46,6 +46,10 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
             # come straight from the source config, so this is a malformed-credential problem — retrying
             # can never recover.
             "CertificateParseError": "PostHog could not parse the TLS certificate or key configured for this source. Check that the client certificate, client private key, and server client root CA are valid PEM and were pasted in full, including the BEGIN and END lines.",
+            # tonic surfaces a gRPC UNAUTHENTICATED status when the server requires API key (JWT/Bearer)
+            # authentication, which this source does not provide — it authenticates with mTLS client
+            # certificates. This is a credential/host configuration problem, so retrying can never recover.
+            "code: Unauthenticated": "Temporal rejected the connection because it requires API key (JWT) authentication, which this source does not provide. This usually means the configured host points at a Temporal Cloud API endpoint that uses API key authentication rather than your namespace's mTLS gRPC endpoint (typically <namespace>.<account>.tmprl.cloud:7233). Update the source's host to the namespace's gRPC endpoint that accepts client-certificate (mTLS) authentication.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -64,6 +64,19 @@ class TestTemporalIONonRetryableErrors:
     @pytest.mark.parametrize(
         "error_message",
         [
+            'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unauthenticated, message: "Jwt is missing", metadata: MetadataMap { headers: {"www-authenticate": "Bearer realm=\\"https://us-east4.gcp.api.temporal.io/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo\\"", "content-type": "application/grpc", "server": "temporal"} }, source: None }',
+        ],
+    )
+    def test_authentication_failures_are_non_retryable(self, error_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert any(pattern in error_message for pattern in non_retryable_errors), (
+            f"Expected '{error_message}' to match a non-retryable pattern"
+        )
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
             "activity Heartbeat timeout",
             'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Os { code: 60, kind: TimedOut, message: "Operation timed out" }))) }',
         ],


### PR DESCRIPTION
## Problem

The Temporal.io data-warehouse import source surfaced a recurring `RuntimeError` in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed058-9288-7963-bd4b-23d55beb5c90)):

```
Failed client connect: `get_system_info` call error after connection:
Status { code: Unauthenticated, message: "Jwt is missing", metadata: ... "www-authenticate": "Bearer realm=..." }
```

The source authenticates with mTLS client certificates. When the configured host points at a Temporal endpoint that requires API key (JWT/Bearer) authentication instead of the namespace's mTLS gRPC endpoint, the server rejects the connection with a gRPC `UNAUTHENTICATED` status. The failure originates in this source's code (`_get_temporal_client` → `connect`), and the import job was retrying an error that can never recover without a configuration change.

## Changes

Extend `TemporalIOSource.get_non_retryable_errors` to treat the gRPC `code: Unauthenticated` status as non-retryable, with an actionable message explaining that the host likely points at an API-key endpoint rather than the namespace's client-certificate (mTLS) gRPC endpoint.

Matching is on the stable tonic status text `code: Unauthenticated` (the gRPC equivalent of a 401), not on the volatile `www-authenticate` realm URL. `UNAUTHENTICATED` always indicates a credentials problem, so it is safe to classify as non-retryable, while transient transport errors (`code: Unknown` / `TimedOut`) remain retryable.

## How did you test this code?

I'm an agent. I added a parametrized regression test asserting the production error message is recognised as non-retryable, and verified the existing TLS-failure and transient-failure cases still behave correctly. `pytest` is not installed in this environment, so I validated the substring-matching logic directly against the real error messages from error tracking and confirmed the transient cases (`Heartbeat timeout`, `TimedOut`) still stay retryable. `ruff check` and `ruff format --check` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the TemporalIO source. Confirmed via the PostHog error-tracking tools that the stack trace originates in `posthog/temporal/data_imports/sources/temporalio/temporalio.py` (`_get_temporal_client` → `posthog/temporal/common/client.py:connect`), and that the configured host was a Temporal Cloud API endpoint rather than the namespace's mTLS gRPC endpoint. Decided this is a user/upstream credential/config error (gRPC `UNAUTHENTICATED`), not a code bug, so extended `NonRetryableErrors` mirroring the Stripe and existing TLS patterns rather than changing the connection logic. Matched the stable status text instead of the per-request realm URL to keep false positives low.
