### PR TITLE
fix(bigquery): lift gRPC inbound message size limit on storage reads

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -67,6 +67,18 @@ __all__ = [
 # tracked gRPC transport's logs/metrics.
 BIGQUERY_STORAGE_HOST = "bigquerystorage.googleapis.com"
 
+# gRPC defaults to a 4 MiB inbound message cap. A single Storage Read API Arrow
+# response can exceed that (it batches many rows), so the read fails client-side
+# with `ResourceExhausted: CLIENT: Received message larger than max`. The gapic
+# transport sets these to -1 (unlimited) when it builds its own channel, but we
+# hand it a pre-built channel (to attach the tracked interceptors), which bypasses
+# that default — so we must replicate it here. Mirrors the options in
+# `BigQueryReadGrpcTransport.__init__`.
+_BIGQUERY_STORAGE_CHANNEL_OPTIONS = [
+    ("grpc.max_send_message_length", -1),
+    ("grpc.max_receive_message_length", -1),
+]
+
 # Stable, source-specific marker for a failed service-account OAuth token refresh.
 # Used both when raising below and when matching in `BigQuerySource.get_non_retryable_errors`,
 # so it must stay free of volatile data (urls, ids, timestamps).
@@ -206,7 +218,9 @@ def bigquery_storage_read_client(
     # via `create_channel(credentials=...)`. This routes the Storage Read API's
     # create_read_session (unary) + read_rows (server-streaming) RPCs through our
     # logging / metrics / sample-capture pipeline.
-    channel = BigQueryReadGrpcTransport.create_channel(host=BIGQUERY_STORAGE_HOST, credentials=credentials)
+    channel = BigQueryReadGrpcTransport.create_channel(
+        host=BIGQUERY_STORAGE_HOST, credentials=credentials, options=_BIGQUERY_STORAGE_CHANNEL_OPTIONS
+    )
     tracked_channel = make_tracked_channel(channel, host=BIGQUERY_STORAGE_HOST)
     transport = BigQueryReadGrpcTransport(channel=tracked_channel)
 

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -7,6 +7,7 @@ from google.api_core.exceptions import BadRequest, Forbidden, NotFound, Permissi
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
+    BIGQUERY_STORAGE_HOST,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryImplementation,
     BigQueryTokenRefreshError,
@@ -18,6 +19,7 @@ from posthog.temporal.data_imports.sources.bigquery.bigquery import (
     _resolve_project_id,
     _resolve_query_project,
     _resolve_region,
+    bigquery_storage_read_client,
     delete_all_temp_destination_tables,
     validate_bigquery_credentials,
 )
@@ -594,3 +596,38 @@ def test_bigquery_dataset_not_found_in_location_is_non_retryable(location):
     non_retryable_errors = BigQuerySource().get_non_retryable_errors()
 
     assert any(pattern in error_msg for pattern in non_retryable_errors)
+
+
+def test_bigquery_storage_read_client_lifts_grpc_message_size_limit():
+    """The Storage Read API can return Arrow messages larger than gRPC's default 4 MiB
+    inbound cap. We build the channel ourselves (to attach tracked interceptors), which
+    bypasses the gapic transport's unlimited-message-size default, so we must pass it
+    explicitly — otherwise reads fail with `ResourceExhausted: Received message larger than max`."""
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.bigquery.service_account.Credentials.from_service_account_info",
+            return_value=mock.MagicMock(),
+        ),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.bigquery.BigQueryReadGrpcTransport"
+        ) as mock_transport,
+        mock.patch(
+            "posthog.temporal.data_imports.sources.bigquery.bigquery.make_tracked_channel",
+            side_effect=lambda channel, host: channel,
+        ),
+        mock.patch("posthog.temporal.data_imports.sources.bigquery.bigquery.bigquery_storage.BigQueryReadClient"),
+    ):
+        with bigquery_storage_read_client(
+            project_id="project-id",
+            private_key="private-key",
+            private_key_id="private-key-id",
+            client_email="client-email",
+            token_uri="token-uri",
+        ):
+            pass
+
+    _, kwargs = mock_transport.create_channel.call_args
+    assert kwargs["host"] == BIGQUERY_STORAGE_HOST
+    options = dict(kwargs["options"])
+    assert options["grpc.max_receive_message_length"] == -1
+    assert options["grpc.max_send_message_length"] == -1


### PR DESCRIPTION
## Problem

The BigQuery data-warehouse import source fails intermittently with:

> `ResourceExhausted: CLIENT: Received message larger than max (4306800 vs. 4194304)`

Observed in error tracking — issue [`019ed066-7e5a-71f0-8f42-44045870b995`](https://us.posthog.com/project/2/error_tracking/019ed066-7e5a-71f0-8f42-44045870b995). The stack originates in our code at `posthog/temporal/data_imports/sources/bigquery/bigquery.py` (`get_rows`), inside the Storage Read API's gRPC `read_rows` call.

The `4194304` cap is gRPC's default 4 MiB inbound message limit, and the message is rejected **client-side** (`CLIENT:`). When we build the Storage Read API channel ourselves — which we do so we can attach the tracked interceptors — and hand it to the gapic transport via `channel=`, the transport's own channel construction is bypassed. That construction is where the gapic library normally sets `grpc.max_send_message_length` / `grpc.max_receive_message_length` to `-1` (unlimited). Our channel kept the gRPC default, so any single Arrow response batch over 4 MiB blows up the read.

This is a bug in our code, not a customer/credentials/config problem: BigQuery is legitimately returning large response messages and the default transport would have accepted them.

## Changes

Pass the unlimited message-size options (`grpc.max_send_message_length` / `grpc.max_receive_message_length` = `-1`) when creating the channel in `bigquery_storage_read_client`, mirroring `BigQueryReadGrpcTransport.__init__`'s defaults. Added a regression test asserting the channel is created with those options.

Scoped strictly to this read path — no change to retry policy or other sources.

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not perform manual testing against live BigQuery.

- New test `test_bigquery_storage_read_client_lifts_grpc_message_size_limit` verifies `create_channel` is called with both message-length options set to `-1`.
- Ran the full `test_source.py` suite: 46 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the BigQuery import source. Confirmed the issue via the PostHog error-tracking MCP tools (full stack trace, exception type, frequency) and that the failure genuinely originates under `sources/bigquery/`. Read the implementation and the shared tracked-gRPC helper, then verified against the installed `google-cloud-bigquery-storage` gapic transport that its default channel sets both message-length options to `-1` — the default we were bypassing by supplying a pre-built channel. Classified as a fixable bug (not a NonRetryableError candidate) because the data and credentials are valid; only our channel configuration was wrong.

Tools: Claude Code; PostHog MCP (`query-error-tracking-issue`, `query-error-tracking-issue-events`).