### PR TITLE
fix(bing_ads): dedupe "Invalid client data" error_map key (F601)

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -70,37 +70,30 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             "AuthenticationFailed": auth_friendly,
             "InvalidCredentials": auth_friendly,
             "OAuthTokenExpired": auth_friendly,
-            # Bing rejects the SOAP request as invalid *after* auth succeeds — the configured Account ID
-            # is wrong or the connected Microsoft Advertising user can't access it. The SDK raises this as
-            # `suds.WebFault("Server raised fault: 'Invalid client data. Check the SOAP fault details for
-            # more information. TrackingId: <uuid>.'")`. The fault is deterministic (the same bad request
-            # always reproduces it), so retrying can't recover — the customer has to fix the Account ID or
-            # grant the connected account access. Match the stable phrase only; the TrackingId is volatile.
-            # This does not catch transient Bing faults like "Server raised fault: 'Internal Error'".
+            # Bing returns the generic SOAP fault "Invalid client data. Check the SOAP fault details for
+            # more information. TrackingId: <uuid>." for two distinct deterministic conditions, neither of
+            # which retrying can recover:
+            #   - the request is rejected as invalid *after* auth succeeds — the configured Account ID is
+            #     wrong, or the connected Microsoft Advertising user can't access it — raised by the SDK as
+            #     `suds.WebFault("Server raised fault: 'Invalid client data...'")`;
+            #   - CustomerManagementService.GetUser can't use the connected account (revoked/expired
+            #     credentials, a work/school identity instead of a personal Microsoft account —
+            #     WorkIdentityNotAvailable — or no access). GetUser takes no request parameters, so this is
+            #     never a malformed-request bug on our side.
+            # Match the stable phrase only; the TrackingId is volatile. This does not catch transient Bing
+            # faults like "Server raised fault: 'Internal Error'".
             "Invalid client data": (
-                "Bing Ads rejected the request as invalid. This usually means the configured Account ID is "
-                "incorrect, or the connected Bing Ads account does not have access to it. Please check the "
-                "Account ID in your source settings and that the connected account can access it, then "
-                "reconfigure your Bing Ads source."
+                "PostHog could not use the connected Bing Ads account (Microsoft returned 'Invalid client data'). "
+                "This usually means the configured Account ID is incorrect, the connected account's credentials are "
+                "no longer valid, or it does not have access to the Microsoft Advertising account. Please check the "
+                "Account ID in your source settings and reconnect your Bing Ads integration, making sure the "
+                "signed-in account can access the account in Microsoft Advertising."
             ),
             # Integration row was deleted/disconnected while a scheduled job still references it.
             # Raised by OAuthMixin.get_oauth_integration as `ValueError("Integration not found: <id>")`;
             # the id is volatile, so match only the stable prefix. Retrying can't recreate the row —
             # the customer has to reconnect.
             "Integration not found": "The linked Bing Ads integration no longer exists. Please reconnect your Bing Ads integration.",
-            # CustomerManagementService.GetUser returns the generic SOAP fault "Invalid client data.
-            # Check the SOAP fault details for more information." when the connected account can't be
-            # used — revoked/expired credentials, a work/school identity instead of a personal Microsoft
-            # account (WorkIdentityNotAvailable), or no access to the Microsoft Advertising account.
-            # GetUser takes no request parameters, so this is never a malformed-request bug on our side;
-            # retrying can't recover it. When the specific code above is present in the fault detail it
-            # matches first; this catches the generic umbrella message otherwise.
-            "Invalid client data": (
-                "PostHog could not use the connected Bing Ads account (Microsoft returned 'Invalid client data'). "
-                "This usually means the account's credentials are no longer valid, or the Microsoft account does not "
-                "have access to the Microsoft Advertising account. Please reconnect your Bing Ads integration and make "
-                "sure the signed-in account can access the account in Microsoft Advertising."
-            ),
             # Deterministic credential/config errors raised in source_for_pipeline.
             "Bing Ads access token not found": "Bing Ads OAuth access token is missing. Please reconnect your Bing Ads integration.",
             "Bing Ads refresh token not found": "Bing Ads OAuth refresh token is missing. Please reconnect your Bing Ads integration.",


### PR DESCRIPTION
## Problem

`master` is currently red on the **Python code quality** (ruff) check, blocking every open PR. Two independently-merged PRs each added an `"Invalid client data"` key to the same `error_map` dict in `bing_ads/source.py`:

- #63794 — `fix(bing_ads): stop retrying invalid-client-data auth faults` (`928cfabb5a1`)
- #63965 — `fix(bing_ads): treat "Invalid client data" SOAP fault as non-retryable` (`3d082cfecf3`)

They didn't textually conflict (different line ranges), so git merged both, producing a duplicate dictionary key. `ruff` rejects it with `F601 Dictionary key literal "Invalid client data" repeated` and exits non-zero. At runtime the second entry silently shadowed the first, so one PR's message and intent was already dead code.

## Changes

Merged the two duplicate `"Invalid client data"` entries into a single entry. The combined comment documents both deterministic, non-retryable conditions the same SOAP fault represents (wrong/inaccessible Account ID after auth succeeds; `GetUser` can't use the connected account — revoked/expired credentials, work/school identity, or no access). The combined user-facing message points the customer at both the Account ID and reconnecting the integration, so neither original author's guidance is lost.

No behavior change for retry classification — `"Invalid client data"` remains a single non-retryable pattern.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran locally:

- `ruff check posthog/temporal/data_imports/sources/bing_ads/source.py` → All checks passed (F601 gone)
- `ruff format --check` → already formatted
- `pytest posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py` → 31 passed, including `test_invalid_client_data_maps_to_account_guidance` (asserts the message mentions "Account ID") and `test_transient_bing_internal_error_fault_stays_retryable`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy Maguire directed the work.

Spotted while investigating why an approved PR (#63983) had a failing ruff check. Traced the failure to a semantic merge collision on `master` between #63794 and #63965 — both added the same dict key, which ruff's F601 rejects. The duplicate is live on `master` right now (not fixed by either PR), so updating any branch from master inherits the breakage; a dedicated fix is the unblock. Chose to merge both entries rather than delete one so both authors' user-facing guidance survives.

Tool: Claude Code (Opus 4.8).
