### PR TITLE
fix(linkedin_ads): treat invalid accounts URN 400 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -47,6 +47,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # key value (volatile) followed by this stable type-coercion phrase. The account id is a
             # fixed config value, so retrying can't help — fail fast and tell the user to fix it.
             "must be of type 'java.lang.Long'": "LinkedIn rejected the configured Account ID. It must be the numeric LinkedIn ad account ID (digits only). Please correct the Account ID in your source settings and re-sync.",
+            # Same root cause as above (a non-numeric Account ID) but surfaced by the analytics
+            # endpoint, which sends the account as a `urn:li:sponsoredAccount:<id>` array element. A
+            # non-numeric id makes the URN undeserializable, so LinkedIn returns a 400 naming the
+            # offending value (volatile) after this stable prefix. Retrying can't fix a config value.
+            "Array parameter 'accounts' value": "LinkedIn rejected the configured Account ID. It must be the numeric LinkedIn ad account ID (digits only). Please correct the Account ID in your source settings and re-sync.",
             # LinkedIn returns 404 RESOURCE_NOT_FOUND / "No virtual resource found" when the
             # account-scoped resource can't be resolved — the configured ad account doesn't exist
             # or PostHog no longer has access to it. Retrying can't fix a missing resource, so we

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -68,6 +68,9 @@ class TestLinkedInAdsSource:
             # type-coercion phrase is the stable part we match on.
             'LinkedIn API error (400): {"message":"Key value \'Reed%20Lnkedin\' must be of type \'java.lang.Long\'","status":400}',
             'LinkedIn API error (400): {"message":"Key value \'LI\' must be of type \'java.lang.Long\'","status":400}',
+            # Same root cause via the analytics endpoint, which sends the account as a
+            # `urn:li:sponsoredAccount:<id>` URN — a non-numeric id makes the URN undeserializable.
+            "LinkedIn API error (400): {\"message\":\"Array parameter 'accounts' value 'urn:li:sponsoredAccount:Futuros' is invalid. Reason: Deserializing output 'urn:li:sponsoredAccount:Futuros' failed\",\"status\":400}",
         ],
     )
     def test_non_retryable_errors_match_invalid_account_id(self, observed_error):


### PR DESCRIPTION
## Problem

The LinkedIn Ads data-warehouse source repeatedly fails (and burns Temporal retries on every schedule) when a customer has configured a non-numeric Account ID.

Observed in error tracking: [issue 019ed07e-1676-7a50-b832-e44ed76e86a8](https://us.posthog.com/project/2/error_tracking/019ed07e-1676-7a50-b832-e44ed76e86a8)

```
Exception: LinkedIn API error (400): {"message":"Array parameter 'accounts' value 'urn:li:sponsoredAccount:<id>' is invalid. Reason: Deserializing output 'urn:li:sponsoredAccount:<id>' failed","status":400}
```

The stack trace originates in this source's code: `linkedin_ads.py:get_rows` → `client.py:get_data_by_resource` → `get_analytics` → `_make_request` → `_call_finder` (`client.py:309`), which raises the bare `Exception` on a non-2xx response.

## Changes

The analytics endpoint sends the configured Account ID as a `urn:li:sponsoredAccount:<id>` array element. When the Account ID is non-numeric, the URN's id portion can't be deserialized into a Long, so LinkedIn returns a 400. This is the **same root cause** the source already treats as non-retryable via the `must be of type 'java.lang.Long'` rule (which the entity endpoints surface when they put the Account ID directly in the path) — the analytics endpoint just reports it with a different message shape.

Since retrying cannot fix a misconfigured config value, this adds a non-retryable rule matching the stable prefix `Array parameter 'accounts' value` (the offending URN value that follows is volatile and deliberately excluded). The friendly message reuses the existing one, directing the user to correct the Account ID to the numeric ad account ID.

Scope is deliberately narrow: one new entry in `LinkedInAdsSource.get_non_retryable_errors`. No global retry policy or transient-error handling was touched.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing.

- Extended the existing parametrized `test_non_retryable_errors_match_invalid_account_id` with the real 400 payload from the error-tracking issue.
- Existing tests assert the new match doesn't fire on transient/5xx/connection errors, keeping those retryable.
- Ran `pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py` — 14 passed. `ruff check` / `ruff format` clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Triaged from a PostHog error-tracking webhook for the `linkedin_ads` import source. Used the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, pull the full stack trace, and verify the failure originates in this source's code rather than only appearing in serialized log context.
- Decision: classified as a user/config error (non-numeric Account ID), not a code bug. The URN is always well-formed for a numeric ID, so a deserialization failure on the `accounts` param can only stem from a bad config value — making it safe and correct to stop retrying. Chose to match a stable, low-false-positive prefix over the volatile URN value, mirroring the existing `java.lang.Long` rule and the Stripe `get_non_retryable_errors` pattern.
