### PR TITLE
fix(notebooks): Close button mixing with comment button on markdown-notebooks

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
@@ -370,10 +370,6 @@
     );
 }
 
-.MarkdownNotebook__row:has(.MarkdownNotebook__line-insert-menu-hit-area) .MarkdownNotebook__block-comment-button {
-    transform: translateX(var(--markdown-notebook-inline-control-width));
-}
-
 .MarkdownNotebook__row--dragging {
     opacity: 0.4;
 }


### PR DESCRIPTION
## Problem

On markdown-notebooks, close button overlap w/ comment button when creating a new node

## Changes

Fixed the CSS of the comment button

## How did you test this code?

<img width="2514" height="1056" alt="2026-06-16 13 59 27" src="https://github.com/user-attachments/assets/4cb04695-000b-475e-8d41-9d6d90e09a22" />

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
