### PR TITLE
fix(sentry): skip tag values fetch on persistent server error

### DIFF
--- a/posthog/temporal/data_imports/sources/sentry/sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/sentry.py
@@ -8,7 +8,7 @@ from urllib.parse import quote, urljoin
 import structlog
 from dateutil import parser as dateutil_parser
 from requests import Request, Response
-from requests.exceptions import RequestException
+from requests.exceptions import HTTPError, RequestException
 from tenacity import RetryCallState, retry, retry_if_exception_type, retry_if_result, stop_after_attempt
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -400,7 +400,25 @@ def _iter_issue_tag_values_rows(
                     break
 
                 response = _request_with_retry(url=values_url, headers=headers, params=values_params)
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except HTTPError:
+                    # Sentry intermittently returns a persistent 5xx for a single
+                    # (issue, tag) values endpoint — seen on tags with unusual
+                    # keys/values. Retries are already exhausted by
+                    # _request_with_retry, so skip this tag's remaining values
+                    # rather than failing the whole sync. Non-server errors
+                    # (auth, etc.) still propagate to the job-level handler.
+                    if response.status_code >= 500:
+                        logger.warning(
+                            "sentry_source.issue_tag_values_server_error_skipped",
+                            organization_slug=organization_slug,
+                            issue_id=issue_id,
+                            tag_key=tag_key,
+                            status_code=response.status_code,
+                        )
+                        break
+                    raise
                 rows = response.json()
 
                 should_stop = False

--- a/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from parameterized import parameterized
+from requests.exceptions import HTTPError
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import SentrySourceConfig
@@ -31,7 +32,7 @@ def _response(payload, status_code: int = 200, link_header: str = "") -> Mock:
 
     def _raise_for_status() -> None:
         if status_code >= 400:
-            raise Exception(f"{status_code} client error")
+            raise HTTPError(f"{status_code} Server Error", response=response)
 
     response.raise_for_status = _raise_for_status
     return response
@@ -441,6 +442,64 @@ class TestSentrySourceValidation:
         assert rows == [
             {"value": "Chrome", "lastSeen": "2026-03-05T12:00:00Z", "issue_id": "100", "tag_key": "browser"}
         ]
+
+    # Patch _request_with_retry directly so the test exercises the iterator's
+    # skip logic without incurring the real (post-exhaustion) retry sleeps.
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_issue_tag_values_skips_tag_on_persistent_server_error(self, mock_request) -> None:
+        def side_effect(url, headers=None, params=None, timeout=None):
+            if url.endswith("/organizations/acme/issues/"):
+                return _response([{"id": "100"}])
+            if url.endswith("/organizations/acme/issues/100/tags/"):
+                return _response([{"key": "bad tag"}, {"key": "browser"}])
+            if "tags/bad%20tag/values/" in url:
+                # Sentry persistently 500s for this tag's values endpoint.
+                return _response(None, status_code=500)
+            if url.endswith("/organizations/acme/issues/100/tags/browser/values/"):
+                return _response([{"value": "Chrome"}])
+            return _response([])
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        # The 500 on the "bad tag" values endpoint is skipped; the healthy
+        # "browser" tag still yields its values instead of the whole sync crashing.
+        rows = list(cast(Any, resp.items()))
+        assert rows == [{"value": "Chrome", "issue_id": "100", "tag_key": "browser"}]
+
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_issue_tag_values_propagates_client_error(self, mock_request) -> None:
+        def side_effect(url, headers=None, params=None, timeout=None):
+            if url.endswith("/organizations/acme/issues/"):
+                return _response([{"id": "100"}])
+            if url.endswith("/organizations/acme/issues/100/tags/"):
+                return _response([{"key": "browser"}])
+            if url.endswith("/organizations/acme/issues/100/tags/browser/values/"):
+                # A 4xx is not a transient upstream blip — it must still propagate.
+                return _response(None, status_code=403)
+            return _response([])
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        with pytest.raises(HTTPError):
+            list(cast(Any, resp.items()))
 
 
 class TestSentrySourceResumable:


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HTTPError` from the Sentry data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed086-0de7-7321-a6f2-d56bce4bb337)):

```
500 Server Error: Internal Server Error for url:
https://.../organizations/<org>/issues/<id>/tags/mac%20catalyst%20app.name/values/?limit=100&sort=-date
```

The top in-app frame is `_iter_issue_tag_values_rows` at `sentry.py:403` (`response.raise_for_status()`).

The `issue_tag_values` schema is a hand-rolled three-level fan-out: issues → tags-per-issue → values-per-tag. Sentry returned a **persistent** HTTP 500 for one single `(issue, tag)` values endpoint (an oddly-named tag whose top value is an empty string, pointing at bad data on Sentry's side). `_request_with_retry` already exhausts its retries (500 is retryable), then `raise_for_status()` raises and **crashes the entire `issue_tag_values` sync**. Since the failure is deterministic for that tag, every Temporal job retry hits it again and the endpoint never makes progress — one bad tag blocks the whole dataset.

## Changes

Gracefully skip an individual `(issue, tag)` values fetch when its endpoint returns a server error (HTTP ≥ 500) after retries are exhausted: log a warning and continue with the remaining tags and issues, rather than failing the whole sync.

Why a graceful-skip and **not** an addition to `NonRetryableErrors`: a 500 is normally a transient upstream blip and must stay retryable at the job level (e.g. a transient 500 on the issues list should still retry). Marking any `500 Server Error` non-retryable for the whole job would swallow those real transient failures. Scoping the skip to the single failing tag's values fetch keeps the rest of the import working while leaving all other error handling — transient retries and the existing auth/scope `NonRetryableErrors` — untouched. Non-server (4xx) errors still propagate so they retain their current handling.

## How did you test this code?

I'm an agent (triage assistant). I ran the existing Sentry source test suite plus two new regression tests at the same layer as the fix:

- `test_issue_tag_values_skips_tag_on_persistent_server_error` — a tag whose values endpoint persistently 500s is skipped; a healthy tag on the same issue still yields its values.
- `test_issue_tag_values_propagates_client_error` — a 4xx still propagates instead of being swallowed.

`uv run pytest posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py` → 55 passed. `ruff check` and `ruff format --check` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `sentry` import source. Used the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, pull the full stack trace, and verify the failure originates in `_iter_issue_tag_values_rows`. Read the source and decided this is a fixable fragility (missing graceful-skip) rather than a `NonRetryableErrors` case, because 500s are generally transient and should remain retryable job-wide — only the single bad tag should be skipped. Tooling: Claude Code with the PostHog MCP server.