### PR TITLE
fix(mysql): treat SSH gateway connection failure as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -121,6 +121,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             "ProgrammingError: (1146": None,  # Table not found error
             "OperationalError: (1356": None,  # View not found error
             "Bad handshake": None,
+            # Raised by the `sshtunnel` library (via the shared `open_ssh_tunnel` helper) when the
+            # SSH tunnel can't be brought up — the bastion host is unreachable, the host/port is
+            # wrong, the SSH key/credentials are rejected, or a firewall blocks PostHog's IPs. This
+            # is the customer's gateway configuration, not a momentary blip; the import retried it
+            # across attempts and never recovered. `handle_non_retryable_error` still re-tries a few
+            # times across runs before giving up, so a genuinely transient gateway reboot is
+            # absorbed. Postgres and MS SQL already treat this identical error as non-retryable.
+            "Could not establish session to SSH gateway": "Could not connect to your SSH tunnel. Check that the SSH host, port, and credentials are correct, the bastion host is running and reachable, and that PostHog's IP addresses are allowed through its firewall.",
             # MySQL/MariaDB error 1129 (ER_HOST_IS_BLOCKED): the server has blocked our import
             # host because aborted/interrupted connections from it exceeded `max_connect_errors`.
             # The block is server-side state that only a DB admin can clear (FLUSH HOSTS /

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -857,6 +857,20 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raised by the sshtunnel library when the customer's SSH bastion can't be reached
+            # (wrong host/port, rejected key, firewall) — the import goes through `open_ssh_tunnel`.
+            "BaseSSHTunnelForwarderError: Could not establish session to SSH gateway",
+            "Could not establish session to SSH gateway",
+        ],
+    )
+    def test_ssh_gateway_failure_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"SSH gateway failure should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Raw pymysql str(error) form (classified in `_handle_import_error`).
             str(pymysql.err.OperationalError(1054, "Unknown column 'favoritor_id' in 'where clause'")),
             # Temporal-wrapped str(e.cause) form (classified in external_data_job).


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `BaseSSHTunnelForwarderError: Could not establish session to SSH gateway` originating in the MySQL data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed084-b574-7661-9686-ebc9ddd1b916)).

The stack trace confirms the failure originates in this source's code:

- `build_pipeline` (`posthog/temporal/data_imports/sources/mysql/mysql.py:802`) → `self.connect(config)`
- `connect` (`mysql.py:366`) → `open_ssh_tunnel(config)`
- `open_ssh_tunnel` (`sources/common/mixins.py:104`) → `ssh_tunnel.get_tunnel(...)`
- the `sshtunnel` library raises `BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")`

This fires for MySQL sources configured with an SSH tunnel when the customer's SSH bastion can't be brought up — wrong host/port, rejected key/credentials, a stopped bastion, or a firewall blocking PostHog's IPs.

## Changes

This is a **user/upstream configuration error**, not a fixable bug in our code and not a transient blip: the SSH gateway settings live on the customer's side, so retrying replays the identical failure.

The import sync/retry path (`_handle_import_error` in `workflow_activities/import_data_sync.py`) classifies an error as non-retryable using **only** the source's own `get_non_retryable_errors()` — it does not merge the shared `Any_Source_Errors` dict (that merge happens only in the separate `update_external_data_job_model` scheduling path). MySQL's `get_non_retryable_errors()` did not include this string, so the streaming job kept retrying.

The fix adds `"Could not establish session to SSH gateway"` to `MySQLSource.get_non_retryable_errors()` with an actionable user-facing message. This mirrors the existing, identical handling in the Postgres (`sources/postgres/source.py`) and MS SQL (`sources/mssql/source.py`) sources — MySQL had simply been missed. `handle_non_retryable_error` still retries a few times across runs before giving up, so a genuinely transient bastion reboot is still absorbed.

The truly transient MySQL connection drops (`2013` / "Lost connection") deliberately remain retryable — existing tests assert this and continue to pass.

## How did you test this code?

I'm an agent. I ran the source's automated unit tests; no manual testing.

- Added a parameterized regression test (`test_ssh_gateway_failure_is_non_retryable`) covering both the raw message and the class-prefixed `BaseSSHTunnelForwarderError: ...` form, matching the Postgres/MS SQL test pattern.
- `pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — 106 passed (including existing tests asserting transient lost-connection errors stay retryable).
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to pull the full stack trace and confirm the failure originates under `sources/mysql/`, then read the MySQL/Postgres/MS SQL source implementations and the two error-classification paths to decide between extending `NonRetryableErrors` and a code fix.

Decision: user/upstream error → extend `NonRetryableErrors`. Key finding that drove it — the sync/retry path consults only the per-source dict, so the entry already present in the shared `Any_Source_Errors` (and in Postgres/MS SQL) did not cover MySQL's streaming retries. Matched on the stable `sshtunnel` message substring (no volatile host/port/IDs) and used a friendly message mirroring MS SQL.
