### PR TITLE
fix(temporalio): treat empty host config as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -50,6 +50,10 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
             # authentication, which this source does not provide — it authenticates with mTLS client
             # certificates. This is a credential/host configuration problem, so retrying can never recover.
             "code: Unauthenticated": "Temporal rejected the connection because it requires API key (JWT) authentication, which this source does not provide. This usually means the configured host points at a Temporal Cloud API endpoint that uses API key authentication rather than your namespace's mTLS gRPC endpoint (typically <namespace>.<account>.tmprl.cloud:7233). Update the source's host to the namespace's gRPC endpoint that accepts client-certificate (mTLS) authentication.",
+            # The Temporal SDK's Rust bridge raises this when the connection target has no host, i.e. the
+            # source was saved with an empty Host field. This is a config problem — retrying can never
+            # recover until the host is set.
+            "invalid target URL: empty host": "This source has no host configured. Update the source with the host of your Temporal namespace's gRPC endpoint (typically <namespace>.<account>.tmprl.cloud).",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -77,6 +77,20 @@ class TestTemporalIONonRetryableErrors:
     @pytest.mark.parametrize(
         "error_message",
         [
+            "ValueError: invalid target URL: empty host",
+            "RuntimeError: Failed client connect: Invalid client config: invalid target URL: empty host",
+        ],
+    )
+    def test_empty_host_config_is_non_retryable(self, error_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert any(pattern in error_message for pattern in non_retryable_errors), (
+            f"Expected '{error_message}' to match a non-retryable pattern"
+        )
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
             "activity Heartbeat timeout",
             'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Os { code: 60, kind: TimedOut, message: "Operation timed out" }))) }',
         ],


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `ValueError: invalid target URL: empty host` from the TemporalIO data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed092-49ab-7a80-98c5-97082e64cba4)).

The stack originates in this source's code:

```
posthog/temporal/data_imports/sources/temporalio/temporalio.py  (_get_workflow_histories → _get_temporal_client)
posthog/temporal/common/client.py:45                            (connect → Client.connect)
temporalio SDK / Rust bridge                                    → ValueError: invalid target URL: empty host
```

When a source is saved with an empty **Host** field, `connect()` builds the connection target as `f"{host}:{port}"` and the Temporal SDK's Rust bridge rejects the resulting target URL because it has no host. This is a configuration problem: retrying can never recover until the host is set, so each sync burns retries and re-fires the same error.

## Changes

Add `"invalid target URL: empty host"` to `TemporalIOSource.get_non_retryable_errors`, mirroring the existing TLS/credential entries. The match is on the stable SDK message substring (no volatile URLs, ids, or timestamps), and the user-facing message points them at the Host field. Extended the source's unit tests to assert the new string is recognised as non-retryable.

## How did you test this code?

I'm an agent. I ran the source's unit tests:

```
pytest posthog/temporal/data_imports/sources/temporalio/test_temporalio.py::TestTemporalIONonRetryableErrors
# 12 passed
```

The suite includes the new `test_empty_host_config_is_non_retryable` cases plus the existing `test_transient_failures_stay_retryable` guard, confirming the new pattern doesn't broaden into transient (retryable) failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the TemporalIO import source. Pulled the full stack trace and a representative event via the PostHog error-tracking tools, confirmed the failure originates in `posthog/temporal/data_imports/sources/temporalio/` (not just serialized log context), and that the configured `host`/`port` were empty.

Decision: user/upstream config error rather than a code bug — an empty Host can only be fixed by the customer updating the source, so retrying is pointless. Followed the Stripe `get_non_retryable_errors` pattern and matched on the stable SDK substring. Considered adding a pre-flight host validation in code instead, but extending `NonRetryableErrors` is the scoped, convention-aligned fix and avoids duplicating validation the UI already declares.
