### PR TITLE
fix(tiktok_ads): retry internal service timeout (code 51001)

### DIFF
--- a/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
@@ -733,6 +733,7 @@ class TestTikTokAdsPaginator:
             ("rate_limit_error", 40001, "Rate limit exceeded", False),  # Auth error - not retryable
             ("validation_error", 40002, "Invalid parameter", False),  # Client error - not retryable
             ("server_error", 50000, "Internal server error", True),
+            ("internal_service_timeout", 51001, "internal service timeout", True),  # Transient - retryable
         ]
     )
     def test_update_state_api_error_codes(self, name, api_code, message, should_be_retryable):

--- a/posthog/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -401,6 +401,7 @@ class TikTokAdsPaginator(BasePaginator):
                     40700,  # Internal service validation error
                     50000,  # System error
                     50002,  # Error processing request on TikTok side. Please see error message for details.
+                    51001,  # Internal service timeout. Transient TikTok-side error; safe to retry.
                     51305,  # Satellite service error
                     60001,  # The system is in maintenance.
                 ]


### PR DESCRIPTION
## Problem

The `tiktok_ads` data-warehouse import source was permanently failing some sync jobs with:

```
ValueError: TikTok API client error (non-retryable): internal service timeout (code: 51001)
```

surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed0a2-d78f-7b40-9194-47d2b8ac8506)). The failure originates in `TikTokAdsPaginator.update_state` (`posthog/temporal/data_imports/sources/tiktok_ads/utils.py`): any TikTok API code not in the retryable set falls through to the `else` branch and is raised as a non-retryable `ValueError`, which fails the whole job.

TikTok code **51001 is "internal service timeout"** — a transient, server-side error (TikTok's own docs advise trying again later). It belongs in the same family as codes already treated as retryable: `50000` (System error), `50002` (Error processing request on TikTok side), `51305` (Satellite service error), `60001` (maintenance). Treating it as non-retryable means a momentary TikTok-side blip kills the import instead of being retried.

## Changes

- Add `51001` to the `retryable_codes` set in `TikTokAdsPaginator.update_state`, so it raises a retryable `TikTokAdsAPIError` and the pipeline's existing exponential backoff can recover, rather than failing the job permanently.
- Extend the parameterized `test_update_state_api_error_codes` test with a `51001` case asserting it is recognised as retryable.

This is deliberately scoped to the single transient code. Genuine user/upstream errors (e.g. `40001` deleted advertiser) remain non-retryable, and no global retry policy was touched.

## How did you test this code?

I'm an agent. I ran the automated tests for the source's utils module:

- `pytest posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py -k test_update_state_api_error_codes` — 5 passed (4 existing + the new 51001 case).
- `pytest posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py` — 77 passed.
- `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the TikTok Ads import source. Confirmed via the PostHog error-tracking MCP tools that the top in-app frame is `update_state` in the source's `utils.py`, then read the paginator's error-classification logic. Decision: this is a transient TikTok-side error misclassified as non-retryable (a code bug), not a user/upstream auth/config error — so the fix makes it retryable rather than extending `NonRetryableErrors`. Added a regression test at the same layer as the fix.

Agent: Claude Code (claude-opus-4-8), using the PostHog MCP `query-error-tracking-issue` tool to confirm the issue.
