### PR TITLE
chore(experiments): read feature-flag variants from the flag, not parameters

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -523,16 +523,12 @@ class ExperimentService:
     def _resolved_variant_keys(cls, experiment: Experiment, update_data: dict) -> list[str]:
         """Variant keys the experiment will have after this update.
 
-        Prefer the variants the PATCH sets; otherwise fall back to the experiment's
-        current variants (its parameters first, then the linked flag's multivariate set).
+        Prefer the variants the PATCH sets; otherwise resolve from the linked flag,
+        which is the source of truth for variants.
         """
         update_variants = (update_data.get("parameters") or {}).get("feature_flag_variants")
         if update_variants is None:
-            update_variants = (experiment.parameters or {}).get("feature_flag_variants") or (
-                experiment.feature_flag.filters.get("multivariate", {}).get("variants", [])
-                if experiment.feature_flag
-                else []
-            )
+            update_variants = experiment.feature_flag.variants if experiment.feature_flag else []
         return cls._variant_keys(update_variants)
 
     @staticmethod
@@ -2185,14 +2181,20 @@ class ExperimentService:
 
         parameters = deepcopy(source_experiment.parameters) or {}
 
-        # Reuse variants from an existing flag in the target project.
+        # Variants come from the source experiment's feature flag (the source of truth),
+        # not the stale copy denormalized into parameters.
+        source_variants = source_experiment.feature_flag.variants
+        if source_variants:
+            parameters["feature_flag_variants"] = deepcopy(source_variants)
+
+        # An existing flag in the target project wins — reuse its variants instead.
         # For cross-project clones we always check the target; for same-project
         # clones we only check when the key differs from the source flag.
         should_check_existing = is_cross_project or feature_flag_key != source_experiment.feature_flag.key
         if should_check_existing:
             existing_flag = FeatureFlag.objects.filter(key=feature_flag_key, team_id=target.id).first()
-            if existing_flag and existing_flag.filters.get("multivariate", {}).get("variants"):
-                parameters["feature_flag_variants"] = deepcopy(existing_flag.filters["multivariate"]["variants"])
+            if existing_flag and existing_flag.variants:
+                parameters["feature_flag_variants"] = deepcopy(existing_flag.variants)
 
         self.validate_experiment_parameters(parameters)
         self.validate_experiment_exposure_criteria(source_experiment.exposure_criteria)

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -149,9 +149,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
         return self.feature_flag.key_without_tombstone()
 
     def get_analytics_metadata(self) -> dict[str, Any]:
-        variants = (self.parameters or {}).get("feature_flag_variants")
-        if not variants:
-            variants = self.feature_flag.filters.get("multivariate", {}).get("variants", [])
+        variants = self.feature_flag.variants
 
         return {
             "experiment_id": self.id,

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1857,13 +1857,16 @@ class TestExperimentService(APIBaseTest):
         flag_variants = dup.feature_flag.filters["multivariate"]["variants"]
         assert len(flag_variants) == 3
 
-    def test_duplicate_experiment_revalidates_source_parameters(self):
-        self._create_flag(key="dup-invalid-source")
+    def test_duplicate_experiment_uses_flag_variants_over_stale_parameters(self):
+        self._create_flag(key="dup-stale-source")
         service = self._service()
         source = service.create_experiment(
-            name="Invalid Source",
-            feature_flag_key="dup-invalid-source",
+            name="Stale Source",
+            feature_flag_key="dup-stale-source",
         )
+        # Drift the stored parameters to an invalid single-variant set. The linked flag
+        # stays the source of truth (control + test), so duplication must ignore the stale
+        # copy and build the new flag from the flag's variants rather than revalidate them.
         Experiment.objects.filter(id=source.id).update(
             parameters={
                 "feature_flag_variants": [
@@ -1873,10 +1876,10 @@ class TestExperimentService(APIBaseTest):
         )
         source.refresh_from_db()
 
-        with self.assertRaises(ValidationError) as ctx:
-            service.duplicate_experiment(source)
+        dup = service.duplicate_experiment(source, feature_flag_key="dup-stale-target")
 
-        assert "at least 2 variants" in str(ctx.exception)
+        assert dup.feature_flag.key == "dup-stale-target"
+        assert [v["key"] for v in dup.feature_flag.variants] == ["control", "test"]
 
     def test_duplicate_experiment_copies_saved_metrics(self):
         self._create_flag(key="dup-saved")


### PR DESCRIPTION
## Problem

`Experiment.parameters` carries a denormalized `feature_flag_variants` copy of data that already lives on the linked `FeatureFlag`. The two can silently drift, and the flag is the real source of truth — the analysis/query layer already reads variants from the flag, leaving `parameters.feature_flag_variants` an effectively stale shadow.

This is the feature-flag-variants slice of PR 4 in the `parameters` deprecation plan: switch the remaining backend **reads** of variant data off `parameters` so everything resolves from the flag. It is additive and backwards-compatible — no API or write-path change.

## Changes

Switched the three remaining backend stored-state reads to resolve variants from the `FeatureFlag` via its canonical, null-safe `variants` property:

| Site | Before | After |
|---|---|---|
| `models/experiment.py` `get_analytics_metadata` | preferred `parameters.feature_flag_variants`, fell back to the flag | reads `self.feature_flag.variants` |
| `experiment_service.py` `_resolved_variant_keys` | fell back to `experiment.parameters.feature_flag_variants` before the flag | resolves from `experiment.feature_flag.variants` |
| `experiment_service.py` `clone_experiment` | carried variants via the source's stale `parameters` deepcopy | sources them from `source_experiment.feature_flag.variants` (existing-target-flag override preserved) |

Deliberately **out of scope**: every other touch of `parameters.feature_flag_variants` reads the *incoming request body*, not stored state — the create path (`_ensure_feature_flag`), the update flag-sync, payload validation, and the serializer's API surface. Those are the input/write channels the not-yet-migrated frontend still depends on; they are removed at the hard API cutover (a later PR), not here.

Side effect (a fix): cross-project copy previously fell back to *default* variants when `parameters` was empty — it now carries the source flag's real variants.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I actually ran, all green:

- `products/experiments/backend/test/test_experiment_service.py` — 339 passed
- `products/experiments/backend/test/test_max_tools.py` — 26 passed
- `products/experiments/backend/test/test_presentation_api.py` (analytics / duplicate / copy / variant slice) — 24 passed
- `ruff check`, `ruff format`, and `ty` type-check pass

One test changed: `test_duplicate_experiment_revalidates_source_parameters` → `test_duplicate_experiment_uses_flag_variants_over_stale_parameters`. The old test asserted the parameters-trusting behavior (drift stored `parameters` to an invalid single-variant set, expect duplication to fail). Under the new source-of-truth model the clone correctly ignores the stale copy and builds from the valid flag, so the test now asserts that behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing or API change — internal read-source refactor only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) under direction to remove backend reads of feature-flag-variant data from `Experiment.parameters` and resolve them from the flag instead, per the `deprecate-experiment-parameters` plan.

Key decisions:
- Scoped to **backend reads only** (the FF-variants part of plan PR 4), kept independently shippable off `master`. The frontend migration is a separate plan PR and depends on a `variants_config` write channel that isn't built yet, so it was intentionally excluded.
- Carefully separated genuine stale reads of stored variant state (switched) from reads of the incoming request payload (left intact until the hard cutover) — a grep confirmed no stored-state reads of any FF-derived key remain.
- Used the existing `FeatureFlag.variants` property everywhere rather than re-deriving `filters["multivariate"]["variants"]`, for null-safety and consistency with the query runners.
