### PR TITLE
feat(hogql): rust edge coverage signal for parser-parity PBT

### DIFF
--- a/posthog/hogql/test/test_parser_pbt.py
+++ b/posthog/hogql/test/test_parser_pbt.py
@@ -12,10 +12,13 @@ are compared.
 
 import os
 import math
+import importlib
+from types import ModuleType
 from typing import Any
 
 import pytest
 
+import numpy as np
 from hypothesis import (
     HealthCheck,
     assume,
@@ -38,6 +41,22 @@ pytestmark = pytest.mark.skipif(
     not os.environ.get("RUN_PBT"),
     reason="PBT tests are slow (~8 min); set RUN_PBT=1 to run",
 )
+
+# Optional `rust_edges` steering signal: only available when the loaded
+# `hogql_parser_rs` wheel was built with `--features coverage` (see
+# `rust/hogql/parser/README.md` → "Coverage-instrumented build"). Production
+# wheels do NOT expose `cov_snapshot` / `cov_reset`, so this gracefully
+# degrades to just the `ast_depth` target on a normal install. Detected at
+# import time so each test invocation is a single `hasattr` short-circuit
+# rather than a try/except.
+_hogql_parser_rs_module: ModuleType | None
+try:
+    _hogql_parser_rs_module = importlib.import_module("hogql_parser_rs")
+except ImportError:
+    _hogql_parser_rs_module = None
+_RUST_COV: bool = _hogql_parser_rs_module is not None and hasattr(_hogql_parser_rs_module, "cov_snapshot")
+# Must match `cov::BITMAP_SIZE` in rust/hogql/parser/src/cov.rs.
+_RUST_COV_BITMAP_BYTES: int = 1 << 16
 
 # ---------------------------------------------------------------------------
 # AST generation strategies
@@ -365,6 +384,28 @@ _BASE = settings(
 )
 
 
+# Cumulative edge bitmap for the `rust_edges` Pareto target — accumulates
+# across every example in this test session. Per-rule keying isn't needed
+# here (only one test method exercises the rust backend). Allocated lazily
+# to zero bytes when the rust wheel is the production (non-coverage) build,
+# so the import cost is paid only when the instrumented wheel is loaded.
+_seen_edges: np.ndarray = np.zeros(_RUST_COV_BITMAP_BYTES, dtype=np.uint8) if _RUST_COV else np.zeros(0, dtype=np.uint8)
+
+
+def _emit_rust_edges_target() -> None:
+    """Snapshot the rust edge bitmap, count edges this parse hit for the first
+    time, OR them into the cumulative `_seen_edges`, and feed the count to
+    Hypothesis `target("rust_edges", ...)`. No-op when the loaded `hogql_parser_rs`
+    wheel isn't the coverage-instrumented build (production wheels never expose
+    `cov_snapshot`). Call after each rust parse, never twice per test case."""
+    if not _RUST_COV or _hogql_parser_rs_module is None:
+        return
+    bitmap = np.frombuffer(_hogql_parser_rs_module.cov_snapshot(), dtype=np.uint8)
+    novel = int(np.count_nonzero(bitmap & ~_seen_edges))
+    np.bitwise_or(_seen_edges, bitmap, out=_seen_edges)
+    target(float(novel), label="rust_edges")
+
+
 class TestExprRoundTrip:
     """Print → parse → print yields the same HogQL string."""
 
@@ -392,7 +433,16 @@ class TestParserBackendEquivalence:
             assume(False)
             return  # type: ignore[unreachable]
 
+        # Clear the rust edge bitmap before the rust parse so the post-parse
+        # snapshot captures only edges hit by THIS example. The cpp parse
+        # doesn't touch the bitmap (cpp is a separate wheel without sancov),
+        # so it doesn't matter that it runs in the same `_parse_both_backends`
+        # call. No-op when the loaded wheel isn't the coverage build.
+        if _RUST_COV and _hogql_parser_rs_module is not None:
+            _hogql_parser_rs_module.cov_reset()
+
         rust_ast, cpp_ast = _parse_both_backends(hogql_string)
+        _emit_rust_edges_target()
 
         if rust_ast is None and cpp_ast is None:
             event("outcome", "both_reject")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.69",
-    "hogql-parser-rs==1.3.84",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.88",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.84"
+version = "1.3.88"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.84); each ships as its own PyPI wheel.
-version = "1.3.84"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.88); each ships as its own PyPI wheel.
+version = "1.3.88"
 edition = "2021"
 publish = false
 
@@ -20,3 +20,18 @@ serde_json.workspace = true
 # `abi3-py312` lets one wheel work on every Python 3.12+ via the stable
 # CPython ABI — avoids shipping a separate wheel per minor Python.
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py312"] }
+
+[features]
+default = []
+# Compile the SanitizerCoverage `__sanitizer_cov_trace_pc_*` callbacks in
+# `src/cov.rs` and expose `cov_snapshot()` / `cov_reset()` to Python. The
+# actual edge-coverage instrumentation pass is requested via RUSTFLAGS in
+# the same build:
+#   RUSTFLAGS="-C passes=sancov-module \
+#              -C llvm-args=-sanitizer-coverage-level=3 \
+#              -C llvm-args=-sanitizer-coverage-trace-pc-guard" \
+#   maturin develop --release --features coverage
+# Production wheels never set this; the resulting wheel is the parser-parity
+# grind's coverage-instrumented variant. See the "Coverage-instrumented build"
+# section of `rust/hogql/parser/README.md`.
+coverage = []

--- a/rust/hogql/parser/README.md
+++ b/rust/hogql/parser/README.md
@@ -70,6 +70,64 @@ python -c "import hogql_parser_rs; print(hogql_parser_rs.parse_expr_json('1 + 2'
 musllinux 1_2) and macOS arm64/x86_64; see
 [`.github/workflows/build-hogql-parser-rs.yml`](../../../.github/workflows/build-hogql-parser-rs.yml).
 
+## Coverage-instrumented build (for the parser-parity PBT)
+
+A second build path exists for fuzz-driven parser-parity work: build the crate
+with `--features coverage` and SanitizerCoverage's `trace-pc-guard` pass, and
+the resulting wheel exposes two PyO3 functions (`cov_snapshot()`, `cov_reset()`)
+that the pytest PBT
+([`posthog/hogql/test/test_parser_pbt.py`](../../../posthog/hogql/test/test_parser_pbt.py))
+uses to feed a per-example `rust_edges` novelty count into Hypothesis `target()`
+on top of the existing `ast_depth` / `novel_kpaths` signals. See
+[`src/cov.rs`](src/cov.rs) for the callback + bitmap implementation. The
+production wheel is unchanged: without the feature, neither `cov.rs` nor the
+sancov pass are compiled, and the PBT detects the absence via
+`hasattr(hogql_parser_rs, "cov_snapshot")` and silently skips the third
+steering label.
+
+Cargo applies `RUSTFLAGS` globally to every crate it compiles, including
+dependency proc macros and build scripts, and those don't have our
+`__sanitizer_cov_trace_pc_guard*` callbacks linked in, so a naive
+`RUSTFLAGS=… maturin build --features coverage` segfaults the host build
+scripts on macOS (and fails to link on Linux). The fix is a small per-crate
+rustc wrapper that strips the sancov flags from every invocation except the
+one for `hogql_parser_rs`. That wrapper lives at
+[`scripts/cov-rustc-wrapper.py`](scripts/cov-rustc-wrapper.py):
+
+```bash
+WRAPPER=$PWD/rust/hogql/parser/scripts/cov-rustc-wrapper.py
+
+# Build the instrumented wheel into a temp dir.
+RUSTC_WRAPPER="$WRAPPER" \
+RUSTFLAGS="-C passes=sancov-module \
+           -C llvm-args=-sanitizer-coverage-level=3 \
+           -C llvm-args=-sanitizer-coverage-trace-pc-guard" \
+maturin build --release --manifest-path rust/hogql/parser/Cargo.toml \
+              --features coverage --out /tmp/cov-wheel
+
+# Install it into the active venv (in the same shell session — the shared
+# flox venv prunes manually-installed wheels otherwise).
+VIRTUAL_ENV=$PWD/.flox/cache/venv uv pip install --reinstall --no-deps \
+    /tmp/cov-wheel/hogql_parser_rs-*.whl
+
+# Verify the instrumented wheel is loaded.
+python -c "import hogql_parser_rs; print(hasattr(hogql_parser_rs, 'cov_snapshot'))"
+
+# Run the parity PBT; the rust_edges target appears in --hypothesis-show-statistics.
+RUN_PBT=1 hogli test posthog/hogql/test/test_parser_pbt.py::TestParserBackendEquivalence \
+    --hypothesis-show-statistics
+```
+
+`rust_edges` will show up in Hypothesis's per-test target stats alongside
+`ast_depth`. The wrapper has been verified to work locally on macOS aarch64. On
+a normal install (no coverage build) the PBT just doesn't emit the third label;
+nothing else changes.
+
+If you want a production CI job to produce this wheel as a sidecar, mirror the
+above invocation in a separate workflow file and publish it under a separate
+package name (e.g. `hogql_parser_rs_cov`) so production deploys can't
+accidentally pull the instrumented wheel.
+
 ## Publishing
 
 The crate is pinned via the `hogql-parser-rs==X.Y.Z` line in the

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.84).
-version = "1.3.84"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.88).
+version = "1.3.88"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/scripts/cov-rustc-wrapper.py
+++ b/rust/hogql/parser/scripts/cov-rustc-wrapper.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Per-crate SanitizerCoverage flag scoping for the parser-parity grind.
+
+Cargo applies `RUSTFLAGS` (and `CARGO_ENCODED_RUSTFLAGS`) to every rustc
+invocation it makes, including dependency proc macros and build scripts.
+`-C passes=sancov-module` ends up instrumenting those crates too. Their
+binaries call `__sanitizer_cov_trace_pc_guard*`, which is only defined in
+`hogql_parser_rs::cov` and isn't linked into anything else, so they SIGSEGV
+on macOS (or fail to link on Linux).
+
+Used as `RUSTC_WRAPPER`, cargo invokes this script as
+`cov-rustc-wrapper.py rustc <args>`. We inspect the args for the
+`--crate-name` cargo always passes, and if it's anything other than our
+parser crate, we strip the sancov-related `-C` flags before re-execing rustc.
+For our crate, everything passes through unchanged so the sancov pass runs
+and our `cov.rs` callbacks get linked.
+
+See "Coverage-instrumented build" in `rust/hogql/parser/README.md`.
+"""
+
+import os
+import sys
+
+# The single crate we actually want instrumented. Everything else (deps, proc
+# macros, build scripts) gets the sancov flags stripped.
+TARGET_CRATE = "hogql_parser_rs"
+
+# `-C` flag VALUES that introduce or configure the SanitizerCoverage pass.
+# These have to be stripped as `(-C, VALUE)` pairs; matched on the VALUE half.
+SANCOV_PREFIXES = (
+    "passes=sancov-module",
+    "llvm-args=-sanitizer-coverage",
+)
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    crate_name: str | None = None
+    for i, a in enumerate(args):
+        if a == "--crate-name" and i + 1 < len(args):
+            crate_name = args[i + 1]
+            break
+
+    if crate_name == TARGET_CRATE:
+        os.execvp(args[0], args)
+
+    filtered: list[str] = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "-C" and i + 1 < len(args) and any(args[i + 1].startswith(p) for p in SANCOV_PREFIXES):
+            i += 2
+            continue
+        filtered.append(a)
+        i += 1
+    os.execvp(filtered[0], filtered)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/hogql/parser/src/cov.rs
+++ b/rust/hogql/parser/src/cov.rs
@@ -1,0 +1,94 @@
+//! SanitizerCoverage edge bitmap for the parser-parity grind.
+//!
+//! Only compiled when the crate is built with `--features coverage`. Implements
+//! the two `__sanitizer_cov_trace_pc_*` callbacks LLVM's
+//! `-sanitizer-coverage-trace-pc-guard` instrumentation pass emits, maintains a
+//! fixed-size atomic bitmap of hit edges, and exposes snapshot / reset to
+//! Python via PyO3. The Python-side PBT
+//! (`posthog/hogql/test/test_parser_pbt.py`) calls `cov_reset()` before each
+//! parse, takes a `cov_snapshot()` afterwards, and feeds
+//! `popcount(snapshot & ~seen)` to Hypothesis `target("rust_edges", ...)` for
+//! coverage-guided steering of the example generator. See the corresponding
+//! README section in `rust/hogql/parser/README.md` for the build dance.
+//!
+//! Bitmap sizing: parser binaries have at most a few thousand basic blocks, so
+//! a 64KiB bitmap with mask-wrap on guard IDs leaves comfortable headroom
+//! without paying for a large per-snapshot copy.
+
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
+
+/// Power of two so `(id) & (BITMAP_SIZE - 1)` is the index. 64KiB.
+pub const BITMAP_SIZE: usize = 1 << 16;
+
+/// One byte per edge; 0 = not hit since last reset, 1 = hit. `AtomicU8` because
+/// the trace callbacks may run from any thread that ends up parsing; `Relaxed`
+/// is sufficient because we only need eventual per-parse visibility, not strict
+/// cross-thread ordering.
+static COVERAGE: [AtomicU8; BITMAP_SIZE] = [const { AtomicU8::new(0) }; BITMAP_SIZE];
+
+/// Monotonic counter handed out at init time so each LLVM guard slot gets a
+/// unique non-zero ID. Wraps via modulo so an oversize binary aliases edges
+/// rather than overflowing; aliased edges still produce a useful steering
+/// signal, just with slightly diluted novelty.
+static NEXT_GUARD: AtomicU32 = AtomicU32::new(1);
+
+/// Called by the runtime once per loaded image with the guard region for this
+/// image's instrumented basic blocks. We assign each guard a unique non-zero ID
+/// so `__sanitizer_cov_trace_pc_guard` can mask it directly to a bitmap index.
+/// LLVM treats a zero guard as "edge disabled"; we never emit one.
+///
+/// # Safety
+/// LLVM guarantees that `start <= stop` and that both pointers refer to a
+/// valid contiguous `u32` array owned by the loaded image; we only write
+/// within that range and don't keep the pointers past this call.
+#[no_mangle]
+pub unsafe extern "C" fn __sanitizer_cov_trace_pc_guard_init(start: *mut u32, stop: *mut u32) {
+    let mut p = start;
+    while p < stop {
+        let next = NEXT_GUARD.fetch_add(1, Ordering::Relaxed);
+        // 1..=BITMAP_SIZE-1 so the value is always non-zero (zero = disabled).
+        let nonzero = (next % (BITMAP_SIZE as u32 - 1)) + 1;
+        *p = nonzero;
+        p = p.add(1);
+    }
+}
+
+/// Hot-path callback fired on every instrumented basic block entry. Pull the
+/// edge ID out of the guard slot, mask into the bitmap, OR-in the hit bit.
+///
+/// # Safety
+/// LLVM passes a pointer to a `u32` slot in the guard region initialized by
+/// `__sanitizer_cov_trace_pc_guard_init`. A single read.
+#[no_mangle]
+pub unsafe extern "C" fn __sanitizer_cov_trace_pc_guard(guard: *mut u32) {
+    let g = *guard;
+    if g == 0 {
+        return;
+    }
+    let idx = (g as usize) & (BITMAP_SIZE - 1);
+    COVERAGE[idx].fetch_or(1, Ordering::Relaxed);
+}
+
+/// Return the current bitmap as a fresh Python `bytes`. The Python diagnostic
+/// reads this with `numpy.frombuffer` and computes the novelty count for the
+/// `target()` call. A 64KiB copy per example is well inside the per-example
+/// budget (microseconds vs the millisecond per-parse cost).
+#[pyfunction]
+pub fn cov_snapshot(py: Python<'_>) -> PyObject {
+    let mut buf = [0u8; BITMAP_SIZE];
+    for (i, cell) in COVERAGE.iter().enumerate() {
+        buf[i] = cell.load(Ordering::Relaxed);
+    }
+    PyBytes::new_bound(py, &buf).into()
+}
+
+/// Zero the bitmap. The diagnostic calls this before each example so the
+/// subsequent `cov_snapshot()` reflects only that example's edges.
+#[pyfunction]
+pub fn cov_reset() {
+    for cell in COVERAGE.iter() {
+        cell.store(0, Ordering::Relaxed);
+    }
+}

--- a/rust/hogql/parser/src/lib.rs
+++ b/rust/hogql/parser/src/lib.rs
@@ -32,6 +32,9 @@ mod lex;
 mod parse;
 mod pyobject;
 
+#[cfg(feature = "coverage")]
+mod cov;
+
 fn run<F>(f: F) -> String
 where
     F: FnOnce() -> Result<serde_json::Value, error::ParseError>,
@@ -173,6 +176,17 @@ fn hogql_parser_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_select_py, m)?)?;
     m.add_function(wrap_pyfunction!(parse_program_py, m)?)?;
     m.add_function(wrap_pyfunction!(parse_full_template_string_py, m)?)?;
+
+    #[cfg(feature = "coverage")]
+    {
+        // Edge-coverage bitmap for the parser-parity grind. Only present in
+        // wheels built with `--features coverage`; the PBT detects via
+        // `hasattr(hogql_parser_rs, "cov_snapshot")` and gracefully skips the
+        // rust_edges steering signal on a production wheel. See `src/cov.rs`.
+        m.add_function(wrap_pyfunction!(cov::cov_snapshot, m)?)?;
+        m.add_function(wrap_pyfunction!(cov::cov_reset, m)?)?;
+    }
+
     Ok(())
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.84"
+version = "1.3.88"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/8c/03d5335d3d98bff386f0497a4624e761a6ea283e802bc01a77ac8cc8d221/hogql_parser_rs-1.3.84.tar.gz", hash = "sha256:7db5389fcb36e52624d5c6c8733f3d50477a06439a82ad3e027a3ed19e5514c7", size = 282589, upload-time = "2026-06-08T18:03:21.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/66/027b3cd67a113b813c53374fd3e960d341b1cf1ad9b19985cc2ed25ba781/hogql_parser_rs-1.3.88.tar.gz", hash = "sha256:d51d23450b11fee08e2ad35f7df71eae0731d02e8568dcd315e5f5f6a90caa8b", size = 289394, upload-time = "2026-06-16T15:16:23.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/8e/ad99eff56a05ca6b2f1bd592efde1aa81a7a52b3fc7fcd4c7519c9ce5515/hogql_parser_rs-1.3.84-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fc32c43413bd2692798faedc65e2687ba52630d9f232b167fc745f9113e0621c", size = 727303, upload-time = "2026-06-08T18:03:12.447Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/89/c94866d0ab46d8bbd2a45c741a2ff5c1dd7b977083ba3f3b6e2f01690f6e/hogql_parser_rs-1.3.84-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:44aaae7a57a29762d3598284183443e16098a5a65d5cba430f11ea5727fee16b", size = 685009, upload-time = "2026-06-08T18:03:13.943Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a7/68e64caf41f9e8606cf21c126371b75d401259655ce88f4fd35501d32825/hogql_parser_rs-1.3.84-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ef3dfb8a520e17a9315c18be59dda9e81c37be2b30d3f8a0fca14c118ade452f", size = 2474527, upload-time = "2026-06-08T18:03:15.475Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/5d/d2894e3ae4e2c4197cfc36c6735af0ed48b2ad6cbe97f5b267b6c0d6c5a6/hogql_parser_rs-1.3.84-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:097551f2733d2dabe7b419f08199d30f6e2970f442dc8a87fa3228fa7be82b15", size = 2733806, upload-time = "2026-06-08T18:03:17.2Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f1/56857dea8c90b4f5b5731327bf3977c90737bd32c21ef3a6fb487b62a769/hogql_parser_rs-1.3.84-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bf77c7067610833aae1292ed995619445d44f7cbf2cb7790a9d3ec26653b335b", size = 2647471, upload-time = "2026-06-08T18:03:18.568Z" },
-    { url = "https://files.pythonhosted.org/packages/78/34/411d1e5c8c08474d0c49c9e03b734895867a2b3eaff8730da2c8550445bc/hogql_parser_rs-1.3.84-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:497c7d435f6bcbc839372f12026176fbccf6b419714673edda61a4fd2d05913d", size = 2696957, upload-time = "2026-06-08T18:03:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/49/26/f170891fc0c66a725c1bb78a45a788ab09f08d9b94d9df1c1d5320a71518/hogql_parser_rs-1.3.88-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a71a91174e841581b7579d868dc2f00ec0da64ad68823445b8f56140b9bba546", size = 728865, upload-time = "2026-06-16T15:16:14.172Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ae/a54a9a96b021b9a9fbea7b3a34f1c135c1e4d05071e14d160096e8a28039/hogql_parser_rs-1.3.88-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:306df747402d902d096321529d1bc1043e25f021efbba5a568fd0eb72724759a", size = 686870, upload-time = "2026-06-16T15:16:15.779Z" },
+    { url = "https://files.pythonhosted.org/packages/78/25/31cff3e3ffa17036a130b810d1f68ea304252f0cce3cf7291144e53fd65f/hogql_parser_rs-1.3.88-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ed90abd0818306fed28bf7666da26e4aca6702ab23f695736848ed3e9771ad9b", size = 2477042, upload-time = "2026-06-16T15:16:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fc/67bdd23adf5b6cc777775a9bff96f91c9bdc44f7aa5f080bc100a7e3acd5/hogql_parser_rs-1.3.88-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:eafdc5d68a8ba36a5789f39c0fb37dcdc871c92082321a20ee0533d9ee23d682", size = 2736240, upload-time = "2026-06-16T15:16:18.719Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/25/0acda0ac9c6cf5d46a816bb81469dcc0491ba3db2c5bfa2cc4d8fc86a2bb/hogql_parser_rs-1.3.88-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d0cbb8ad5689b45ee2226cf95fcb7ab262072809c6375c3b37dcf5047c0061d3", size = 2648922, upload-time = "2026-06-16T15:16:20.318Z" },
+    { url = "https://files.pythonhosted.org/packages/83/55/ee96470a9d239e35a043c0280fa9cc6dd733fd5f43ec1f0155f5702fd154/hogql_parser_rs-1.3.88-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d80a92568058f31e5e459a84a71054e2b401e0cf4fbc21563bd2abc41e327e84", size = 2698769, upload-time = "2026-06-16T15:16:21.969Z" },
 ]
 
 [[package]]
@@ -5864,7 +5864,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.69" },
-    { name = "hogql-parser-rs", specifier = "==1.3.84" },
+    { name = "hogql-parser-rs", specifier = "==1.3.88" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },
@@ -9146,18 +9146,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986, upload-time = "2025-01-14T10:35:00.498Z" },
     { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750, upload-time = "2025-01-14T10:35:03.378Z" },
     { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload-time = "2025-01-14T10:35:44.018Z" },
-]
-
-[[package]]
-name = "wsproto"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!NOTE]
> Stacked on [#64005](https://github.com/PostHog/posthog/pull/64005) → [#63910](https://github.com/PostHog/posthog/pull/63910) → `master`. Merge the parents first; the GitHub UI base will flip automatically.

## Problem

The PBT in [#64005](https://github.com/PostHog/posthog/pull/64005) added two cheap in-process `target()` signals (`ast_depth`, `novel_kpaths`) that the shrinker uses to preserve interesting shapes. Both targets are derived from the *output* AST. They tell Hypothesis nothing about which **internal parser code paths** were exercised by the input string — and a parser-parity PBT cares deeply about that, because divergences between the C++ oracle and the Rust candidate are concentrated in code paths neither has been hammered on yet.

The standard tool for that is edge coverage: instrument the parser binary, count which basic-block edges were hit per parse, and feed the novelty count as a `target()` to Hypothesis so the shrinker preserves novel-edge-hitting examples (and the optional `Phase.target` hill-climbing phase can hunt for them at generation time if turned on). This is the third `target()` label.

## Changes

Adds an opt-in `--features coverage` build path to `hogql_parser_rs` plus PBT wiring. Production wheels are unchanged: without the feature, neither `cov.rs` nor the SanitizerCoverage pass are compiled, and the PBT detects the absence via `hasattr(hogql_parser_rs, "cov_snapshot")` and silently skips the third label.

### Rust side

- **`rust/hogql/parser/src/cov.rs`** (new, 94 lines): the two `__sanitizer_cov_trace_pc_guard*` callbacks LLVM emits when `-sanitizer-coverage-trace-pc-guard` is enabled. Maintains a 64KiB `AtomicU8` bitmap (`Relaxed` ordering — only need eventual per-parse visibility, not strict cross-thread ordering). `cov_snapshot()` returns a fresh Python `bytes` copy; `cov_reset()` zeros the bitmap. Bitmap sized power-of-two so guard IDs mask directly to indices; oversize binaries alias rather than overflow.
- **`rust/hogql/parser/src/lib.rs`**: `#[cfg(feature = "coverage")] mod cov;` at the top + feature-gated PyO3 registration of `cov_snapshot` and `cov_reset` inside the `#[pymodule]` block.
- **`rust/hogql/parser/Cargo.toml`**: new `[features] coverage = []` block with the canonical `RUSTFLAGS` recipe documented in the comment.

### Per-crate sancov flag scoping (macOS gotcha)

Cargo applies `RUSTFLAGS` globally to every rustc invocation it makes, including dependency proc macros and build scripts. Those don't have our `__sanitizer_cov_trace_pc_guard*` callbacks linked in, so a naive `RUSTFLAGS=… maturin build --features coverage` segfaults the host build scripts on macOS (and fails to link on Linux). 

**`rust/hogql/parser/scripts/cov-rustc-wrapper.py`** (new): used as `RUSTC_WRAPPER`. Inspects each rustc invocation's `--crate-name`; for `hogql_parser_rs` it passes everything through unchanged, for everything else it strips the `-C` flag pairs whose value starts with `passes=sancov-module` or `llvm-args=-sanitizer-coverage`. Verified on macOS aarch64.

### Python wiring

- **`posthog/hogql/test/test_parser_pbt.py`**: at import time, attempts to import `hogql_parser_rs` and checks `hasattr(module, "cov_snapshot")`. `TestParserBackendEquivalence.test_rust_py_and_cpp_backends_agree` calls `cov_reset()` before the rust parse and `_emit_rust_edges_target()` after, which snapshots the bitmap, counts edges set in this parse but not in the cumulative `_seen_edges`, ORs them in, and feeds the count to `target(label="rust_edges")`. Module-level `_seen_edges` accumulates across the run (only one test method exercises the rust backend, so per-rule keying isn't needed). 

### Docs

- **`rust/hogql/parser/README.md`**: new "Coverage-instrumented build" section with the full `RUSTC_WRAPPER` + `RUSTFLAGS` + `maturin build --features coverage` + install + verify recipe, plus a note about how to spin a sidecar CI job to publish the instrumented wheel under a separate package name if anyone wants that.

### Parser version bump

Bumps `hogql-parser-rs` from `1.3.84` to `1.3.87`. Master is at `1.3.84`; `1.3.85` and `1.3.86` are already on PyPI from earlier work on the broader [#60227](https://github.com/PostHog/posthog/pull/60227) PR. CI's `build-hogql-parser-rs` workflow publishes the wheel and auto-commits the `uv.lock` update.

## How did you test this code?

I'm an agent (Claude). I ran:

- `ruff check --fix` and `ruff format` on the two touched Python files — pass.
- Compile-check of the Rust crate was blocked by a local TLS issue (cargo couldn't reach `index.crates.io` for `determinator`). The Rust changes are mechanical: drop in `cov.rs`, add 3 feature-gated lines to `lib.rs`, add `[features] coverage = []` to `Cargo.toml`. CI will validate the full build matrix.
- The PBT was smoke-tested at the previous stack level (#64005) — confirmed the import graph and `target()` wiring resolve. The `rust_edges` addition is a pure conditional extension that's a no-op when the production wheel is loaded.
- Local execution of the full instrumented build requires the coverage wheel to be built and installed; the recipe in the README has been verified to work on macOS aarch64 in the larger [#60227](https://github.com/PostHog/posthog/pull/60227) PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — the relevant docs are inline in `rust/hogql/parser/README.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by Robbie.

Third (and final) slice of the larger parser-parity PR ([#60227](https://github.com/PostHog/posthog/pull/60227)), stacked on [#64005](https://github.com/PostHog/posthog/pull/64005). This one is the "aggressive coverage-guidance" piece that needed Rust instrumentation; the previous two slices stayed pure-Python.

Decisions:
- `rust_edges` is wired into `test_parser_pbt.py::TestParserBackendEquivalence` (which actually uses the rust backend), not the grammar PBT (which compares python vs cpp). The grammar PBT keeps its `ast_depth` and `novel_kpaths` targets only.
- The wrapper strips sancov flags **only from non-target crates**. The alternative (per-crate `RUSTFLAGS` via `[target.'cfg(…)']`) doesn't work because cargo's `RUSTFLAGS` is a single global. This is also how `cargo-fuzz` solves the same problem internally.
- Production wheel build path is unchanged. `default = []` in the new `[features]` block means CI's production build won't accidentally enable coverage.
- Sidecar CI job for the coverage wheel is left as a follow-up — the README points at the manual recipe for now. Doing the CI job in this PR would require coordinating a second package name and a separate publish workflow; not worth bundling.