### PR TITLE
fix(mongodb): treat unescaped connection-string credentials as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -34,6 +34,12 @@ _MONGO_UNREACHABLE_MESSAGE = (
     "IP addresses are allowlisted in your database's network access settings."
 )
 
+_MONGO_UNESCAPED_CREDENTIALS_MESSAGE = (
+    "Your MongoDB connection string is invalid: the username and password must be percent-encoded "
+    "per RFC 3986. Escape any reserved characters (e.g. : / ? # [ ] @ %) in your credentials — for "
+    "example with urllib.parse.quote_plus — and update the connection string."
+)
+
 _MONGO_ATLAS_SQL_MESSAGE = (
     "This connection string points at a MongoDB Atlas SQL / Data Federation endpoint "
     "(its host ends in .query.mongodb.net), which PostHog can't import from — those endpoints "
@@ -52,6 +58,15 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
         return {
             "The DNS query name does not exist": None,
+            # pymongo raises InvalidURI("Username and password must be escaped according to RFC 3986,
+            # use urllib.parse.quote_plus") before any network call when the credentials in the
+            # connection string contain unescaped reserved characters (e.g. ':', '/', '@', '%' in the
+            # password). The same RFC-3986 hint also appears on the "Port contains non-digit characters"
+            # variant, which is the same unescaped-credential mistake. This is a malformed connection
+            # string the user must fix — we can't safely percent-encode it ourselves because the
+            # reserved characters are ambiguous with the URI's own delimiters — so retrying never
+            # recovers. Match the stable RFC-3986 fragment, not the volatile surrounding text.
+            "must be escaped according to RFC 3986": _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
             # pymongo raises OperationFailure with codeName 'AuthenticationFailed' (code 18) and
             # errmsg 'Authentication failed.' when the credentials are wrong. Non-retryable error
             # matching is case-sensitive, so the previous lowercase "authentication failed" never

--- a/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -345,6 +345,19 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
+            # pymongo InvalidURI raised before any network call when credentials in the connection
+            # string contain unescaped reserved characters — a malformed string the user must fix.
+            (
+                "unescaped_credentials",
+                "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus",
+            ),
+            # Same unescaped-credential mistake surfacing via the "Port contains non-digit characters"
+            # variant, which carries the identical RFC-3986 hint.
+            (
+                "unescaped_credentials_port_variant",
+                "Port contains non-digit characters. Hint: username and password must be escaped "
+                "according to RFC 3986, use urllib.parse.quote_plus",
+            ),
             # ServerSelectionTimeoutError variants — cluster unreachable for the whole selection
             # timeout. All carry the "Topology Description:" suffix regardless of the per-reason text.
             ("no_servers", "No servers found yet, Timeout: 5.0s, Topology Description: ..."),
@@ -411,6 +424,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ("atlas_bad_auth", "bad auth", "password"),
             ("unreachable_topology", "Topology Description:", "allowlist"),
             ("atlas_sql_endpoint", "query.mongodb.net", "connection string"),
+            ("unescaped_credentials", "must be escaped according to RFC 3986", "connection string"),
         ]
     )
     def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):


### PR DESCRIPTION
## Problem

The MongoDB data-warehouse import source surfaced a recurring error in error tracking:

- **Exception:** `InvalidURI`
- **Message:** `Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus`
- **Origin:** `posthog/temporal/data_imports/sources/mongodb/mongo.py` → `mongo_client` → `MongoClient(connection_string, ...)`
- Issue: https://us.posthog.com/project/2/error_tracking/019ed0b2-6352-79e3-b78c-414f2ef86040

pymongo raises this `InvalidURI` while parsing the connection string, **before any network call**, when the username or password contains reserved characters (`: / ? # [ ] @ %`) that haven't been percent-encoded. The same RFC-3986 hint also appears on pymongo's "Port contains non-digit characters" variant, which is the same underlying mistake.

This is a user/config error: the connection string is malformed and only the user can fix it. Retrying never recovers, so the job was burning its full retry budget on every attempt. We can't safely percent-encode the credentials ourselves — the reserved characters are ambiguous with the URI's own delimiters, which is exactly why pymongo refuses to guess.

## Changes

- Add a non-retryable entry to `MongoDBSource.get_non_retryable_errors`, matching the stable substring `must be escaped according to RFC 3986` (not the volatile surrounding text), with an actionable user-facing message telling them to percent-encode their credentials.
- Mirrors the existing pattern used for the other MongoDB non-retryable classifications (auth failure, DNS failure, unreachable topology, Atlas SQL endpoint).
- Extend the unit tests: the unescaped-credentials message (and its port-variant) are asserted non-retryable, and the new pattern is covered by the friendly-message assertion.

## How did you test this code?

I'm an agent. I ran the automated tests only — no manual testing:

- `pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py::TestMongoDBNonRetryableErrors` — 19 passed
- `pytest posthog/temporal/data_imports/sources/mongodb/test_mongo.py` — 57 passed
- `ruff check` on the changed files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MongoDB import source. Confirmed via the PostHog error-tracking MCP tools that the failure originates in `mongodb/mongo.py` (`mongo_client`) and is raised by pymongo's URI parser before any connection is made. Decided this is a user/upstream config error rather than a code bug — auto-escaping the credentials was considered and rejected as unsafe (reserved characters are ambiguous with URI delimiters), so the correct action is to stop retrying and surface a clear message. Scoped strictly to this error class; global retry policy untouched.