### PR TITLE
Fix AppsFlyer daily report slug

### DIFF
--- a/posthog/temporal/data_imports/sources/appsflyer/appsflyer.py
+++ b/posthog/temporal/data_imports/sources/appsflyer/appsflyer.py
@@ -105,8 +105,9 @@ def validate_credentials(api_token: str, app_id: str) -> bool:
             "(e.g. 'id123456789' for iOS or the package name for Android)."
         ) from None
     today = datetime.now(UTC).strftime("%Y-%m-%d")
+    daily_report = APPSFLYER_ENDPOINTS["daily_report"].report
     response = _get_session(api_token).get(
-        f"{APPSFLYER_BASE_URL}/api/agg-data/export/app/{quote(app)}/daily_report/v5"
+        f"{APPSFLYER_BASE_URL}/api/agg-data/export/app/{quote(app)}/{daily_report}/v5"
         f"?{urlencode({'from': today, 'to': today})}",
         timeout=30,
     )

--- a/posthog/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
+++ b/posthog/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
@@ -126,6 +126,15 @@ class TestValidateCredentials:
             validate_credentials("token", "id123")
         assert str(status_code) in str(exc.value)
 
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_validate_credentials_uses_daily_report_endpoint(self, mock_session):
+        mock_session.return_value.get.return_value = _response("")
+
+        assert validate_credentials("token", "id123") is True
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert urlparse(url).path == "/api/agg-data/export/app/id123/daily_report/v5"
+
     @pytest.mark.parametrize("status_code", [429, 500, 503])
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_validate_raises_on_transient_status(self, mock_session, status_code):


### PR DESCRIPTION
## Problem

The AppsFlyer data warehouse source validates credentials by probing the aggregate Pull API with the `dailyreport` report slug. AppsFlyer returns `400 Invalid query: Unknown report type: dailyreport` for that slug, so valid credentials can be rejected as `Invalid AppsFlyer API token or app id`.

Fixes #64004

## Changes

- Use the documented `daily_report` slug for AppsFlyer daily reports.
- Reuse the configured daily report slug during credential validation instead of hardcoding it.
- Update AppsFlyer source tests to assert the corrected path.

## Verification

- `python3.13 -m py_compile posthog/temporal/data_imports/sources/appsflyer/appsflyer.py posthog/temporal/data_imports/sources/appsflyer/settings.py posthog/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py posthog/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py`
- `git diff --check`

I could not run the targeted pytest files in this sparse checkout because the local `uv` version cannot resolve PostHog's pinned Python `3.13.13` on macOS arm64, and isolated pytest runs hit the repository's full Django/Celery bootstrap.