### PR TITLE
fix(github): skip empty-repository 409 on commits sync

### DIFF
--- a/posthog/temporal/data_imports/sources/github/github.py
+++ b/posthog/temporal/data_imports/sources/github/github.py
@@ -23,6 +23,14 @@ class GithubRetryableError(Exception):
     pass
 
 
+class GithubEmptyRepositoryError(Exception):
+    """Raised when GitHub's commits endpoint reports an empty repository (no
+    commits yet). A valid empty state, not a failure — the caller treats it as
+    zero rows. See `_is_empty_repository_response` for detection details."""
+
+    pass
+
+
 @dataclasses.dataclass
 class GithubResumeConfig:
     next_url: str
@@ -332,9 +340,9 @@ def get_rows(
             raise GithubRetryableError(f"Github API error (retryable): status={response.status_code}, url={page_url}")
 
         # An empty repository (no commits) is a valid state, not an error — the
-        # loop stops cleanly with zero rows. Return before raise_for_status.
+        # caller stops cleanly with zero rows. Signal it before raise_for_status.
         if _is_empty_repository_response(response):
-            return response
+            raise GithubEmptyRepositoryError(endpoint)
 
         if not response.ok:
             logger.error(f"Github API error: status={response.status_code}, body={response.text}, url={page_url}")
@@ -343,9 +351,9 @@ def get_rows(
         return response
 
     while True:
-        response = fetch_page(url)
-
-        if _is_empty_repository_response(response):
+        try:
+            response = fetch_page(url)
+        except GithubEmptyRepositoryError:
             logger.debug(f"Github: repository is empty, no rows for endpoint {endpoint}")
             break
 

--- a/posthog/temporal/data_imports/sources/github/github.py
+++ b/posthog/temporal/data_imports/sources/github/github.py
@@ -136,6 +136,22 @@ def _parse_next_url(link_header: str) -> str | None:
     return None
 
 
+def _is_empty_repository_response(response: requests.Response) -> bool:
+    """GitHub's commits endpoint returns 409 Conflict with the body message
+    "Git Repository is empty." for a repository that has no commits yet. That's
+    a valid empty state, not a failure (credentials and the repo itself are
+    fine — every other endpoint returns an empty list), so the caller treats it
+    as zero rows instead of raising. Once commits are pushed, the next sync
+    picks them up automatically."""
+    if response.status_code != 409:
+        return False
+    try:
+        message = response.json().get("message", "")
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return isinstance(message, str) and "repository is empty" in message.lower()
+
+
 def _as_utc(dt: datetime) -> datetime:
     """Treat naive datetimes as UTC so tz-aware values (GitHub returns ISO 8601
     with `Z`) can be safely compared against naive cutoffs from the DB."""
@@ -315,6 +331,11 @@ def get_rows(
         if response.status_code == 429 or response.status_code >= 500:
             raise GithubRetryableError(f"Github API error (retryable): status={response.status_code}, url={page_url}")
 
+        # An empty repository (no commits) is a valid state, not an error — the
+        # loop stops cleanly with zero rows. Return before raise_for_status.
+        if _is_empty_repository_response(response):
+            return response
+
         if not response.ok:
             logger.error(f"Github API error: status={response.status_code}, body={response.text}, url={page_url}")
             response.raise_for_status()
@@ -323,6 +344,10 @@ def get_rows(
 
     while True:
         response = fetch_page(url)
+
+        if _is_empty_repository_response(response):
+            logger.debug(f"Github: repository is empty, no rows for endpoint {endpoint}")
+            break
 
         data = response.json()
         # Most GitHub list endpoints return a JSON array at the top level,

--- a/posthog/temporal/tests/data_imports/github/test_github_source.py
+++ b/posthog/temporal/tests/data_imports/github/test_github_source.py
@@ -1,6 +1,7 @@
 from datetime import UTC, date, datetime
 from typing import Any
 
+import pytest
 from unittest import mock
 
 import requests
@@ -13,6 +14,7 @@ from posthog.temporal.data_imports.sources.github.github import (
     _flatten_commit,
     _flatten_stargazer,
     _format_incremental_value,
+    _is_empty_repository_response,
     _is_issue_not_pr,
     _is_older_than_cutoff,
     _parse_next_url,
@@ -372,6 +374,22 @@ class TestIsIssueNotPr:
         assert _is_issue_not_pr(item) == expected
 
 
+class TestIsEmptyRepositoryResponse:
+    @parameterized.expand(
+        [
+            ("empty_repo_409", 409, {"message": "Git Repository is empty."}, True),
+            ("empty_repo_409_lowercase", 409, {"message": "git repository is empty"}, True),
+            ("other_409_message", 409, {"message": "Merge conflict"}, False),
+            ("409_no_message", 409, {}, False),
+            ("409_non_dict_body", 409, [], False),
+            ("404_empty_message", 404, {"message": "Git Repository is empty."}, False),
+            ("200_ok", 200, [{"sha": "abc"}], False),
+        ]
+    )
+    def test_detects_empty_repository(self, _name: str, status: int, body: Any, expected: bool) -> None:
+        assert _is_empty_repository_response(_make_response(status=status, body=body)) is expected
+
+
 class TestValidateCredentials:
     def test_valid_credentials(self) -> None:
         with mock.patch("posthog.temporal.data_imports.sources.github.github.make_tracked_session") as mock_get:
@@ -617,6 +635,61 @@ class TestGetRowsResume:
         assert manager.save_state.call_count == 1
         saved = manager.save_state.call_args.args[0]
         assert saved.next_url == mock_get.return_value.get.call_args_list[0].args[0]
+
+    def test_empty_repository_409_ends_loop_without_raising(self) -> None:
+        """GitHub returns 409 "Git Repository is empty." on the commits endpoint
+        for a repo with no commits. That's a valid empty state — get_rows must
+        yield zero rows and complete instead of raising HTTPError."""
+        manager = _make_manager(can_resume=False)
+        empty_repo_response = _make_response(status=409, body={"message": "Git Repository is empty."})
+
+        with (
+            self._patch_batcher(),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+            ) as mock_get,
+        ):
+            mock_get.return_value.get.side_effect = [empty_repo_response]
+            rows = list(
+                get_rows(
+                    personal_access_token="tok",
+                    repository="owner/repo",
+                    endpoint="commits",
+                    logger=mock.Mock(),
+                    resumable_source_manager=manager,
+                    should_use_incremental_field=False,
+                )
+            )
+
+        assert rows == []
+        manager.save_state.assert_not_called()
+        empty_repo_response.raise_for_status.assert_not_called()
+
+    def test_non_empty_repo_409_still_raises(self) -> None:
+        """A 409 that is not the empty-repository case must still surface as an
+        error rather than being silently swallowed."""
+        manager = _make_manager(can_resume=False)
+        conflict_response = _make_response(status=409, body={"message": "Some other conflict"})
+        conflict_response.raise_for_status.side_effect = requests.HTTPError("409 Client Error: Conflict")
+
+        with (
+            self._patch_batcher(),
+            mock.patch(
+                "posthog.temporal.data_imports.sources.github.github.make_tracked_session",
+            ) as mock_get,
+        ):
+            mock_get.return_value.get.side_effect = lambda *a, **k: conflict_response
+            with pytest.raises(requests.HTTPError):
+                list(
+                    get_rows(
+                        personal_access_token="tok",
+                        repository="owner/repo",
+                        endpoint="commits",
+                        logger=mock.Mock(),
+                        resumable_source_manager=manager,
+                        should_use_incremental_field=False,
+                    )
+                )
 
     def test_workflow_runs_envelope_is_unwrapped(self) -> None:
         manager = _make_manager(can_resume=False)


### PR DESCRIPTION
## Problem

The `github` data-warehouse import source crashes when syncing the `commits` schema of a repository that has **no commits yet**.

GitHub's [List Commits](https://docs.github.com/en/rest/commits/commits#list-commits) endpoint returns `409 Conflict` with the body `{"message": "Git Repository is empty."}` for an empty repository. The commits sync ran `response.raise_for_status()` on that response and the whole import activity died with:

```
HTTPError: 409 Client Error: Conflict for url: https://api.github.com/repos/<owner>/<repo>/commits?per_page=100&state=all&sort=created&direction=asc
```

Surfaced by error tracking ([issue 019ed0b6-0e71-7551-8695-329b6d5ccfe3](https://us.posthog.com/project/2/error_tracking/019ed0b6-0e71-7551-8695-329b6d5ccfe3)) — raised at `posthog/temporal/data_imports/sources/github/github.py` in `fetch_page`, reached through the normal import pipeline (`import_data_sync` → `pipeline` → `github_source` → `get_rows` → `fetch_page`).

This is not a credentials or permissions problem — the repository exists, the token is valid, and every other endpoint (issues, releases, stargazers, …) syncs fine, returning empty lists. The repo simply has no commits.

## Changes

Treat the empty-repository `409` as a valid empty state rather than an error:

- Added `_is_empty_repository_response()`, which matches a `409` whose body message contains `"repository is empty"` (low-false-positive, stable substring — not the volatile URL).
- `fetch_page` returns the response without calling `raise_for_status()` for that case; `get_rows` detects it and stops the pagination loop cleanly, yielding zero rows so the sync completes successfully.
- Any other (non-empty-repo) `409` still raises as before.

This self-heals: once commits are pushed to the repo, the next scheduled sync picks them up with no user intervention. It mirrors how `workflow_runs` already handles an empty envelope.

Decision rationale: this is a fixable bug (missing graceful-skip), not a user/upstream error, so it was **not** added to `NonRetryableErrors` — doing so would permanently mark the commits sync as failed for the perfectly valid "empty repo" state.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `TestIsEmptyRepositoryResponse` — parameterized coverage of the detector (empty-repo 409, case-insensitivity, other 409 messages, non-dict bodies, non-409 statuses).
- `test_empty_repository_409_ends_loop_without_raising` — `get_rows` on the `commits` endpoint yields zero rows and never calls `raise_for_status()` for an empty-repo 409.
- `test_non_empty_repo_409_still_raises` — a different 409 still surfaces as `HTTPError`.

`.venv/bin/python -m pytest posthog/temporal/tests/data_imports/github/test_github_source.py` → 83 passed. `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Confirmed the issue and stack trace via the PostHog MCP error-tracking tools, traced the failure to `fetch_page`/`get_rows`, and identified GitHub's documented empty-repository 409 behavior on the commits endpoint. Chose a graceful-skip fix over extending `NonRetryableErrors` because an empty repo is a valid, self-healing state — failing the sync would be misleading. Scoped strictly to the empty-repo 409; all other error handling and retry behavior is unchanged.
