### PR TITLE
fix(postgres): drop unsupported `options` startup param for poolers

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -276,6 +276,41 @@ def _get_sslmode(require_ssl: bool) -> str:
     return "require" if require_ssl else "prefer"
 
 
+# Transaction-mode connection poolers reject the libpq `options` startup parameter outright:
+# Supabase's Supavisor (port 6543) and PgBouncer in transaction mode report "unsupported startup
+# parameter: options", and AWS RDS Proxy reports "RDS Proxy currently doesn't support command-line
+# options". We only send `options` to pin client_encoding=UTF8 for Redshift's legacy UNICODE alias
+# (see FORCE_UTF8_CLIENT_ENCODING), and Redshift never sits behind these poolers — so when a server
+# rejects `options`, dropping it and retrying is safe (UTF8 is the default client encoding for real
+# Postgres). The RDS Proxy text uses a typographic apostrophe, so match the apostrophe-free tail.
+_OPTIONS_STARTUP_PARAM_UNSUPPORTED_SUBSTRINGS = (
+    "unsupported startup parameter: options",
+    "support command-line options",
+)
+
+
+def _is_options_startup_param_unsupported(error: BaseException) -> bool:
+    if not isinstance(error, psycopg.OperationalError):
+        return False
+    message = " ".join(str(arg) for arg in error.args).lower()
+    return any(substring in message for substring in _OPTIONS_STARTUP_PARAM_UNSUPPORTED_SUBSTRINGS)
+
+
+def _connect_with_options_fallback(**connect_kwargs: Any) -> psycopg.Connection:
+    """`psycopg.connect` that retries without the libpq `options` startup parameter when the
+    server rejects it.
+
+    See `_OPTIONS_STARTUP_PARAM_UNSUPPORTED_SUBSTRINGS` for why transaction-mode poolers reject
+    `options` and why dropping it is safe.
+    """
+    try:
+        return psycopg.connect(**connect_kwargs)
+    except psycopg.OperationalError as e:
+        if connect_kwargs.get("options") and _is_options_startup_param_unsupported(e):
+            return psycopg.connect(**{k: v for k, v in connect_kwargs.items() if k != "options"})
+        raise
+
+
 def _connect_to_postgres(
     *,
     host: str,
@@ -296,7 +331,7 @@ def _connect_to_postgres(
     caller_options = kwargs.pop("options", None)
     options = f"{FORCE_UTF8_CLIENT_ENCODING} {caller_options}" if caller_options else FORCE_UTF8_CLIENT_ENCODING
     try:
-        return psycopg.connect(
+        return _connect_with_options_fallback(
             host=host,
             port=port,
             dbname=database,
@@ -1934,7 +1969,7 @@ def postgres_source(
 
         def _open_setup_connection() -> psycopg.Connection:
             try:
-                conn = psycopg.connect(
+                conn = _connect_with_options_fallback(
                     host=host,
                     port=port,
                     dbname=database,
@@ -2192,7 +2227,7 @@ def postgres_source(
 
             def get_connection():
                 try:
-                    connection = psycopg.connect(
+                    connection = _connect_with_options_fallback(
                         host=host,
                         port=port,
                         dbname=database,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -54,6 +54,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _build_query,
     _connect_to_postgres,
     _connect_with_dropped_retry,
+    _connect_with_options_fallback,
     _get_estimated_row_count_for_partitioned_table,
     _get_partition_settings,
     _get_partition_settings_for_partitioned_table,
@@ -64,6 +65,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _get_table_chunk_size,
     _has_duplicate_primary_keys,
     _is_connection_dropped_error,
+    _is_options_startup_param_unsupported,
     _is_partitioned_table,
     _is_read_replica,
     _is_recovery_conflict_error,
@@ -581,6 +583,71 @@ class TestConnectForcesUtf8ClientEncoding:
             )
 
         assert connect_mock.call_args.kwargs["options"] == f"{FORCE_UTF8_CLIENT_ENCODING} -c statement_timeout=5000"
+
+
+# Transaction-mode poolers (Supabase Supavisor on :6543, PgBouncer transaction mode, AWS RDS Proxy)
+# reject the libpq `options` startup parameter we send to pin client_encoding=UTF8. When they do, we
+# drop `options` and retry rather than failing the connection.
+class TestConnectOptionsStartupParamFallback:
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            (
+                'connection to server at "1.2.3.4", port 6543 failed: FATAL:  unsupported startup parameter: options',
+                True,
+            ),
+            (
+                "connection failed: FATAL:  Feature not supported: RDS Proxy currently "
+                "doesn’t support command-line options.",
+                True,
+            ),
+            ("password authentication failed for user", False),
+            ("server closed the connection unexpectedly", False),
+        ],
+    )
+    def test_detects_options_unsupported_message(self, message, expected):
+        assert _is_options_startup_param_unsupported(psycopg.OperationalError(message)) is expected
+
+    def test_non_operational_error_is_not_matched(self):
+        assert _is_options_startup_param_unsupported(ValueError("unsupported startup parameter: options")) is False
+
+    def test_retries_without_options_when_pooler_rejects_it(self):
+        good_conn = mock.MagicMock()
+        connect_mock = mock.MagicMock(
+            side_effect=[
+                psycopg.OperationalError("FATAL:  unsupported startup parameter: options"),
+                good_conn,
+            ]
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect", connect_mock):
+            result = _connect_with_options_fallback(host="db", options=FORCE_UTF8_CLIENT_ENCODING)
+
+        assert result is good_conn
+        assert connect_mock.call_count == 2
+        # First attempt carries options, retry drops it entirely.
+        assert connect_mock.call_args_list[0].kwargs["options"] == FORCE_UTF8_CLIENT_ENCODING
+        assert "options" not in connect_mock.call_args_list[1].kwargs
+
+    def test_does_not_retry_when_no_options_were_sent(self):
+        connect_mock = mock.MagicMock(
+            side_effect=psycopg.OperationalError("FATAL:  unsupported startup parameter: options")
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect", connect_mock):
+            with pytest.raises(psycopg.OperationalError):
+                _connect_with_options_fallback(host="db")
+
+        assert connect_mock.call_count == 1
+
+    def test_unrelated_operational_error_is_not_retried(self):
+        connect_mock = mock.MagicMock(side_effect=psycopg.OperationalError("password authentication failed for user"))
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.psycopg.connect", connect_mock):
+            with pytest.raises(psycopg.OperationalError):
+                _connect_with_options_fallback(host="db", options=FORCE_UTF8_CLIENT_ENCODING)
+
+        assert connect_mock.call_count == 1
 
 
 class TestStatementTimeoutAsNonRetryable:


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports were failing at connection time for sources that sit behind a transaction-mode connection pooler. The error surfaced in error tracking as:

```
OperationalError: connection failed: connection to server at "…", port 6543 failed:
FATAL:  unsupported startup parameter: options
```

…and the AWS variant of the same root cause:

```
FATAL:  Feature not supported: RDS Proxy currently doesn’t support command-line options.
```

We unconditionally pass the libpq `options` startup parameter on every connection (to pin `client_encoding=UTF8` — a workaround for Redshift reporting its encoding as the legacy `UNICODE` alias, which psycopg3 can't decode). Transaction-mode poolers — Supabase's Supavisor (the `:6543` pooler port), PgBouncer in transaction mode, and AWS RDS Proxy — reject the `options` startup parameter outright, so the connection never establishes and the sync fails every attempt.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ed0b6-cd2a-7b12-a220-907f8f2ba953

## Changes

This is a fixable bug on our side (we send a startup parameter these poolers don't accept), not a user/upstream error — so rather than mark it non-retryable, we make the connection degrade gracefully.

- Added `_connect_with_options_fallback`, a thin `psycopg.connect` wrapper that retries the connection **without** the `options` startup parameter when the server rejects it (matching the stable, apostrophe-free message fragments `unsupported startup parameter: options` and `support command-line options`).
- Routed all three psycopg connect sites through the helper (metadata/`_connect_to_postgres`, the per-sync setup connection, and the row-streaming connection), since the same connection would otherwise fail again at the next stage.

Dropping `options` is safe: the only reason we send it is the Redshift UTF8 workaround, and Redshift never sits behind these poolers; UTF8 is the default client encoding for real Postgres anyway. The retry only triggers on the specific pooler-rejection message, so unrelated failures (auth, SSL-required, transient drops) keep their existing behavior.

## How did you test this code?

I'm an agent. I added unit tests and ran them locally — no manual end-to-end testing.

Automated tests in `test_postgres.py` (`TestConnectOptionsStartupParamFallback`):
- detector recognizes both the Supavisor/PgBouncer and RDS Proxy messages, and rejects unrelated / non-`OperationalError` errors
- connect retries without `options` on the pooler rejection and succeeds
- connect does not retry when no `options` were sent, nor on unrelated `OperationalError`s

All new tests plus the existing `TestConnectForcesUtf8ClientEncoding` and connect/retry suites pass locally (one unrelated pre-existing test errors in setup because it needs a live dev DB to resolve a hostname).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to confirm the issue, pull the full stack trace (failure originates in `postgres.py:_open_setup_connection`), and inspect a representative event — which revealed the two message variants (Supavisor and RDS Proxy) grouped under one issue, both pointing at the `options` startup parameter.

Decision: classified as a fixable bug (unsupported request param) rather than a non-retryable user/upstream error, because we can drop the offending parameter and still connect. Chose a shared connect-wrapper over editing each call site inline to keep the three connect paths consistent and avoid drift. Matched on apostrophe-free message fragments to avoid the typographic apostrophe in the RDS Proxy text.
