### PR TITLE
feat(signals): serve suppressed reports on detail read paths

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -658,6 +658,66 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["source_products"] == []
 
+    # --- suppressed report reachability ---
+    #
+    # Suppressed (dismissed) reports stay out of the list by default, but the inbox's
+    # Dismissed tab needs to read them by ID (detail + evidence) and reopen them. Read
+    # paths (retrieve, signals, state) are reachable; mutating-by-ID paths (delete,
+    # reingest) deliberately are not, so they keep returning 404.
+
+    def test_retrieve_serves_suppressed_report(self):
+        report = self._create_report(status=SignalReport.Status.SUPPRESSED)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == str(report.id)
+        assert response.json()["status"] == SignalReport.Status.SUPPRESSED
+
+    def test_signals_action_serves_suppressed_report(self):
+        report = self._create_report(status=SignalReport.Status.SUPPRESSED)
+
+        with (
+            patch(
+                "products.signals.backend.views.fetch_source_products_for_reports",
+                return_value={str(report.id): ["zendesk"]},
+            ),
+            patch("products.signals.backend.views.fetch_signals_for_report_sync", return_value=[]),
+        ):
+            response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/signals/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["report"]["id"] == str(report.id)
+
+    def test_list_excludes_suppressed_by_default(self):
+        ready = self._create_report(status=SignalReport.Status.READY)
+        suppressed = self._create_report(status=SignalReport.Status.SUPPRESSED)
+
+        response = self.client.get(self._list_url())
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(ready.id) in ids
+        assert str(suppressed.id) not in ids
+
+    def test_list_includes_suppressed_when_filtered(self):
+        suppressed = self._create_report(status=SignalReport.Status.SUPPRESSED)
+
+        response = self.client.get(self._list_url(status="suppressed"))
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert str(suppressed.id) in ids
+
+    def test_reingest_suppressed_report_returns_404(self):
+        # reingest is a mutating-by-ID action, so a suppressed report stays unreachable
+        # and 404s before any workflow is started (mirrors the delete contract).
+        report = self._create_report(status=SignalReport.Status.SUPPRESSED)
+
+        response = self.client.post(f"/api/projects/{self.team.id}/signals/reports/{report.id}/reingest/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     # --- legacy choice removal ---
 
     def test_actionability_null_for_legacy_choice_artefact(self):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -428,6 +428,14 @@ class SignalReportViewSet(
     # so it is never a valid filter target.
     _FILTERABLE_STATUSES = frozenset(SignalReport.Status.values) - {SignalReport.Status.DELETED}
 
+    # Actions allowed to resolve a suppressed report by ID even without an explicit
+    # `status` filter. These are the read/reopen paths the inbox's Dismissed tab needs:
+    # `state` reopens a dismissed report, `retrieve` loads its detail, and `signals`
+    # loads its evidence. Mutating-by-ID actions (delete, reingest) are deliberately
+    # NOT here, so a suppressed report stays unreachable for those and keeps returning
+    # 404 — matching the existing contract.
+    _SUPPRESSED_VISIBLE_ACTIONS = frozenset({"state", "retrieve", "signals"})
+
     def _apply_signal_report_status_filter(self, queryset):
         status_filter = self.request.query_params.get("status")
         if status_filter:
@@ -441,10 +449,12 @@ class SignalReportViewSet(
                     }
                 )
             return queryset.filter(status__in=statuses)
-        # The `state` action reopens dismissed reports, so it must be able to reach a suppressed
-        # report by ID — otherwise transitioning one back to "potential" would 404. Everywhere
-        # else suppressed reports stay hidden unless an explicit `status` filter asks for them.
-        if self.action == "state":
+        # A few read/reopen actions must be able to reach a suppressed report by ID
+        # (e.g. `state` reopens a dismissed report, `retrieve`/`signals` back the
+        # inbox's Dismissed-tab detail view). Everywhere else — including the list and
+        # mutating-by-ID actions like delete/reingest — suppressed reports stay hidden
+        # unless an explicit `status` filter asks for them.
+        if self.action in self._SUPPRESSED_VISIBLE_ACTIONS:
             return queryset
         return queryset.exclude(status=SignalReport.Status.SUPPRESSED)
 


### PR DESCRIPTION
## Problem

The PostHog Code inbox is gaining a **Dismissed** tab that lists suppressed reports and lets you open one to re-read it before restoring. But the report **detail** (`GET /reports/{id}/`) and **signals/evidence** (`GET /reports/{id}/signals/`) endpoints exclude suppressed reports by default, so opening a dismissed report 404s.

## Change

Extend the existing per-action carve-out in `SignalReportViewSet._apply_signal_report_status_filter`. Previously only the reopen `state` action could resolve a suppressed report by ID; now `retrieve` and `signals` can too:

```python
_SUPPRESSED_VISIBLE_ACTIONS = frozenset({"state", "retrieve", "signals"})
```

This is **purely additive for by-ID reads**. Everything else is unchanged:

| Surface | Before | After |
| --- | --- | --- |
| List (no `status`) | suppressed hidden | **identical** |
| List `?status=suppressed` | returns suppressed | identical |
| Retrieve by ID (suppressed) | 404 | **200** (new) |
| Signals by ID (suppressed) | 404 | **200** (new) |
| Delete / reingest by ID (suppressed) | 404 | **identical — still 404** |
| `state` (restore) | allowed | identical |
| Artefacts / tasks (suppressed parent) | already 200 | identical |

- Team scoping is applied **before** the status filter, so cross-team reports stay 404.
- Deleted reports stay unreachable everywhere (excluded unconditionally, first).
- No new write capability — read-only widening. Mutating-by-ID actions (delete, reingest) deliberately stay out of the allowlist and keep returning 404.

## Tests

New, in `TestSignalReportListAPI`:
- `test_retrieve_serves_suppressed_report` → 200
- `test_signals_action_serves_suppressed_report` → 200
- `test_list_excludes_suppressed_by_default`
- `test_list_includes_suppressed_when_filtered`
- `test_reingest_suppressed_report_returns_404` (locks the contract that reingest is **not** widened)

The pre-existing `test_delete_report_starts_deletion_workflow[from_suppressed] → 404` and `test_can_reopen_suppressed_report` still pass. `TestSignalReportListAPI` + `TestSignalReportSuppressionAPI`: 66 passed, no regressions.

## Coordination

Ship/deploy this before the PostHog Code frontend links the Dismissed tab into a detail route, or clicking-in 404s in the interim. Invisible to users on its own.