### PR TITLE
feat(retention): highlight clicked interval column in the persons modal

### DIFF
--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -40,6 +40,7 @@ export function RetentionModal(): JSX.Element | null {
         isCohortModalOpen,
         theme,
         retentionFilter,
+        selectedColumnIndex,
     } = useValues(retentionModalLogic(insightProps))
     const { closeModal, saveAsCohort, setIsCohortModalOpen } = useActions(retentionModalLogic(insightProps))
     const { startExport } = useActions(exportsLogic)
@@ -178,7 +179,13 @@ export function RetentionModal(): JSX.Element | null {
                                         <th>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</th>
                                         {row.values?.map((data: any, index: number) => {
                                             return (
-                                                <th key={index}>
+                                                <th
+                                                    key={index}
+                                                    className={clsx('!pl-2', {
+                                                        'RetentionTable__SelectedColumn--header':
+                                                            index === selectedColumnIndex,
+                                                    })}
+                                                >
                                                     <div>{data.label}</div>
                                                     <div>
                                                         {data.count}
@@ -231,7 +238,13 @@ export function RetentionModal(): JSX.Element | null {
                                                     .map((appearance: number, index: number) => {
                                                         const hasAppearance = !!appearance
                                                         return (
-                                                            <td key={index}>
+                                                            <td
+                                                                key={index}
+                                                                className={clsx({
+                                                                    'RetentionTable__SelectedColumn--cell':
+                                                                        index === selectedColumnIndex,
+                                                                })}
+                                                            >
                                                                 <div
                                                                     className={clsx(
                                                                         'RetentionTable__Tab',

--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -198,6 +198,20 @@ export function RetentionTable({
                                             return (
                                                 <td
                                                     key={columnIndex}
+                                                    onClick={(e) => {
+                                                        // Open the modal for this cohort and tell it which
+                                                        // interval column was clicked so it can highlight it.
+                                                        e.stopPropagation()
+                                                        if (!inSharedMode) {
+                                                            openModal(
+                                                                rowIndex,
+                                                                breakdownValue === NO_BREAKDOWN_VALUE
+                                                                    ? null
+                                                                    : breakdownValue,
+                                                                columnIndex
+                                                            )
+                                                        }
+                                                    }}
                                                     className={clsx({
                                                         'RetentionTable__SelectedColumn--cell':
                                                             columnIndex === selectedInterval,

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -43,7 +43,11 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
         actions: [retentionPeopleLogic(props), ['loadPeople']],
     })),
     actions(() => ({
-        openModal: (rowIndex: number, breakdownValue?: string | number | null) => ({ rowIndex, breakdownValue }),
+        openModal: (rowIndex: number, breakdownValue?: string | number | null, columnIndex?: number | null) => ({
+            rowIndex,
+            breakdownValue,
+            columnIndex,
+        }),
         closeModal: true,
         saveAsCohort: (cohortName: string) => ({ cohortName }),
         setIsCohortModalOpen: (isOpen: boolean) => ({ isOpen }),
@@ -61,6 +65,14 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
             {
                 openModal: (_, { breakdownValue }: { rowIndex: number; breakdownValue?: string | number | null }) =>
                     breakdownValue ?? null,
+                closeModal: () => null,
+            },
+        ],
+        // The interval column of the cell the modal was opened from, so the modal can highlight it.
+        selectedColumnIndex: [
+            null as number | null,
+            {
+                openModal: (_, { columnIndex }: { columnIndex?: number | null }) => columnIndex ?? null,
                 closeModal: () => null,
             },
         ],


### PR DESCRIPTION
## Problem

Opening the retention persons modal gives no indication of which interval column the clicked cell belonged to — every column looks the same.

## Changes

https://github.com/user-attachments/assets/6947ac60-11d5-42df-8dd8-eb24e415a128


Clicking a retention cell now opens the modal with that interval column highlighted (header + cells). The clicked cell's column index is threaded through `openModal` into a `selectedColumnIndex` reducer in `retentionModalLogic` and rendered with the existing `RetentionTable__SelectedColumn` styles. Person-column header padding tidied.

## How did you test this code?

I'm an agent (Claude Code). No automated tests added — UI-only change reusing existing styles. The author verified the behavior in the running app.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Column index flows clicked cell → `openModal` → kea reducer → modal highlight. Initially prototyped with local React state but moved into `retentionModalLogic` per the repo's kea convention.
