### PR TITLE
fix(mssql): treat SELECT permission denied as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -49,6 +49,12 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # hostname is wrong), not a momentary blip, so retrying the job won't recover it.
             "Adaptive Server is unavailable or does not exist": "Could not reach your SQL Server. Check that the server is running and reachable, and that PostHog's IP addresses are allowed through its firewall / security group.",
             "Login failed for user": None,
+            # SQL Server error 229 — the login PostHog connects with was authenticated but lacks
+            # SELECT permission on a table/view being synced. This is a server-side GRANT the
+            # customer has to make (db_datareader or an explicit GRANT SELECT); retrying with the
+            # same login can never succeed. Match the stable message text, not the object/database
+            # names that follow it.
+            "The SELECT permission was denied on the object": "Your SQL Server login doesn't have permission to read one of the tables or views being synced. Grant it SELECT access (for example via the db_datareader role or an explicit GRANT SELECT) on the objects you want to import, then re-enable the sync.",
             "Cannot find the CREDENTIAL": "Cannot find the credential - check that it exists and you have permission to access it",
             # Raised by the `sshtunnel` library (via the shared `open_ssh_tunnel` helper) when the
             # SSH tunnel can't be brought up — the bastion host is unreachable, the host/port is

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -456,3 +456,19 @@ class TestMSSQLSourceNonRetryableErrors:
     def test_connection_errors_are_non_retryable(self, error_msg):
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Real pymssql MSSQLDatabaseException for SQL Server error 229 on a table.
+            "SQL Server message 229, severity 14, state 5, procedure b'', line 1:\n"
+            "b\"The SELECT permission was denied on the object 'ExistenciasProductoMagiQ', "
+            "database 'VirtualMedios', schema 'dbo'.DB-Lib error message 20018, severity 14:\n"
+            'General SQL Server error: Check messages from the SQL Server\n"',
+            # Different object/database names must still match the stable substring.
+            "The SELECT permission was denied on the object 'zzz_segtieint', database 'VirtualMedios', schema 'dbo'.",
+        ],
+    )
+    def test_permission_denied_errors_are_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `MSSQLDatabaseException` from the Microsoft SQL Server data-warehouse import source ([issue 019ed0cf-cd5f-7b93-888d-94512c839d43](https://us.posthog.com/project/2/error_tracking/019ed0cf-cd5f-7b93-888d-94512c839d43)).

The failure originates in `posthog/temporal/data_imports/sources/mssql/mssql.py` (`get_rows` → `cursor.execute`) and surfaces as SQL Server error 229:

```
The SELECT permission was denied on the object '<table>', database '<db>', schema 'dbo'.
```

The login PostHog connects with is authenticated successfully but does not have `SELECT` permission on a table/view being synced. This is a server-side `GRANT` the customer must make — retrying the import with the same login can never succeed, yet today it keeps retrying and re-firing the exception.

## Changes

- Add `"The SELECT permission was denied on the object"` to `MSSQLSource.get_non_retryable_errors()` with a friendly, actionable reason telling the customer to grant the login read access (db_datareader / `GRANT SELECT`) and re-enable the sync.
- The match key is the stable SQL Server 229 message text, deliberately excluding the volatile object / database / schema names that follow it, so it won't false-positive or miss on different objects.
- Add a parametrized regression test asserting the new pattern is recognized as non-retryable across different object/database names.

This mirrors the existing pattern in the Stripe source's `get_non_retryable_errors`. It does not touch global retry policy or any other source.

## How did you test this code?

I'm an agent (Claude Code). I added and ran the automated regression test:

```
.venv/bin/python -m pytest \
  posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py::TestMSSQLSourceNonRetryableErrors
# 9 passed
```

Also ran `ruff check` / `ruff format` on the changed files. No manual end-to-end testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MSSQL import source using Claude Code with the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, pull the full stack trace, and verify the failure genuinely originates in this source's `get_rows` path rather than only appearing in serialized log context.

Decision: this is a customer/upstream configuration error (a missing database-side `GRANT`), not a bug in our code and not a transient infra error, so the correct fix is to stop retrying via `NonRetryableErrors` rather than changing the query logic. Matched on the stable error-229 message substring to keep false positives low.
