### PR TITLE
fix(mysql): don't capture known connection errors during credential validation

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -994,6 +994,7 @@ class TestMySQLSourceValidateCredentials:
                 2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)"
             ),
             pymysql.err.OperationalError(1045, "Access denied for user 'u'@'1.2.3.4' (using password: YES)"),
+            pymysql.err.OperationalError(1129, "Host '1.2.3.4' is blocked because of many connection errors"),
         ],
     )
     def test_known_connection_errors_are_not_captured(self, source, mocker, raised):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ConnectionRefusedError` (`[Errno 111] Connection refused`) originating in the MySQL data-warehouse source: [issue](https://us.posthog.com/project/2/error_tracking/019ed0ce-39e6-7ee3-aa33-b9fdd9be4234).

The stack shows it raised in `mysql.py:380` (`connect`), propagating through `get_schemas` into `MySQLSource.validate_credentials` (`source.py`). The originating request was the `external_data_sources/database_schema` endpoint — i.e. a user setting up a source, with their MySQL server unreachable. pymysql wraps the refusal as `OperationalError(2003, "Can't connect to MySQL server on '<host>' (...)")`.

`validate_credentials` already handles this gracefully: it catches the exception and returns a friendly "Could not connect... please check all connection details" message to the user. The problem is it *also* calls `capture_exception(e)` for **every** exception, so expected user/upstream connection failures (server down, wrong host/port, firewall, bad password) are reported to error tracking as if they were bugs.

## Changes

This is the credential-validation path, not the Temporal import workflow — `get_non_retryable_errors` (consumed only in `external_data_job.py`) never runs here, and `"Can't connect to MySQL server on"` is already classified non-retryable for the import path. So the fix is not to extend `NonRetryableErrors`; it is to stop capturing the already-recognised, already-handled user error.

- `validate_credentials` now only calls `capture_exception` when the error is **not** already classified as user-recoverable. A new `_is_known_user_error` helper reuses the source's existing `get_non_retryable_errors()` registry, so credential validation and the import pipeline agree on what counts as a user/upstream failure.
- Unrecognised exceptions are still captured, so genuine bugs in our connection code stay visible.

This mirrors an existing convention in this source — the COUNT(*) probe and EXPLAIN helper in `mysql.py` already deliberately avoid flooding error tracking with handled failures.

## How did you test this code?

I'm an agent. Dependencies aren't installed in my environment, so I could not run the full pytest suite here. I:

- Added a regression test class `TestValidateCredentialsCapture` asserting `capture_exception` is **not** called for known user errors (connection refused, access denied, host blocked) and **is** called for an unexpected `RuntimeError`.
- Verified both edited files compile (`py_compile`) and pass `ruff check` + `ruff format --check`.
- Validated the substring-matching logic in isolation against the exact error message from the error-tracking event — `"Can't connect to MySQL server on"` is recognised, while an unexpected message is not.

Please run `pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py::TestValidateCredentialsCapture` in CI to confirm.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MySQL import source. Investigated via the PostHog error-tracking MCP tools: confirmed the issue, pulled the full stack trace and a representative event, and traced the call path to `validate_credentials` reached via the `database_schema` API endpoint (not the import pipeline).

Decision: the underlying `ConnectionRefusedError` is a user/upstream failure, but it is already handled gracefully and already non-retryable for the import path — so extending `NonRetryableErrors` would be a no-op for this event. The real defect is `validate_credentials` capturing an expected, already-recognised user error as an exception. Fixed at that layer, reusing the existing non-retryable registry rather than introducing a new classification.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a test case for MySQL OperationalError 1129 ("Host is blocked") and fixes the Postgres server-cursor test mock by adding the missing `broken` attribute that was causing CI failures.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d45c97575b3f9f31a6fb70f797175956b6960d7c.</sup>
<!-- /MENDRAL_SUMMARY -->