### PR TITLE
fix(mssql): treat invalid object name (error 208) as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -55,6 +55,15 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # same login can never succeed. Match the stable message text, not the object/database
             # names that follow it.
             "The SELECT permission was denied on the object": "Your SQL Server login doesn't have permission to read one of the tables or views being synced. Grant it SELECT access (for example via the db_datareader role or an explicit GRANT SELECT) on the objects you want to import, then re-enable the sync.",
+            # SQL Server error 208 — the SELECT we run during the sync references an object the
+            # server can't resolve. Either the table/view we're syncing was dropped or renamed
+            # after schema discovery, or (as seen in practice) the view we select from has a body
+            # that references another object the login can't reach (a cross-database table, or one
+            # the login lost permission to). Our query is built from validated identifiers
+            # discovered via information_schema, so this is the customer's schema/permissions, not
+            # a momentary blip — retrying replays the identical 208. Match the stable error text,
+            # not the volatile object name / procedure / line number in the rest of the message.
+            "Invalid object name": "One of the tables or views you're syncing references a database object that no longer exists or that this login can't access (SQL Server error 208). Check that the object still exists and that the connection user has permission to read it (including any tables a view depends on), then re-sync.",
             "Cannot find the CREDENTIAL": "Cannot find the credential - check that it exists and you have permission to access it",
             # Raised by the `sshtunnel` library (via the shared `open_ssh_tunnel` helper) when the
             # SSH tunnel can't be brought up — the bastion host is unreachable, the host/port is

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -498,3 +498,19 @@ class TestMSSQLSourceNonRetryableErrors:
     def test_permission_denied_errors_are_non_retryable(self, error_msg):
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Real pymssql MSSQLDatabaseException for SQL Server error 208 raised mid-sync when the
+            # view being selected references an object the login can't resolve.
+            "SQL Server message 208, severity 16, state 1, procedure b'VentasAsesorMes', line 8: "
+            "b\"Invalid object name 'Imagiq.dbo.inv_cuedoc'.DB-Lib error message 20018, severity 16:\\n"
+            'General SQL Server error: Check messages from the SQL Server\\n"',
+            # The table being synced was dropped/renamed after schema discovery.
+            "Invalid object name 'dbo.orders'.",
+        ],
+    )
+    def test_invalid_object_name_is_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `MSSQLDatabaseException` from the MSSQL data-warehouse import source:

```
SQL Server message 208, severity 16, state 1, procedure b'VentasAsesorMes', line 8:
Invalid object name 'Imagiq.dbo.inv_cuedoc'.
DB-Lib error message 20018, severity 16:
General SQL Server error: Check messages from the SQL Server
```

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ed0cf-b40f-77b1-bc7f-cbcbcc0ba510

The failure originates in `posthog/temporal/data_imports/sources/mssql/mssql.py`, in the `cursor.execute(...)` that runs our `SELECT … FROM [schema].[table]` during the sync. SQL Server **error 208 ("Invalid object name")** means the server could not resolve an object referenced by the query — here, the view being synced has a body that references a cross-database object (`Imagiq.dbo.inv_cuedoc`) that no longer exists or that the connection's login cannot reach.

Because we don't recognise this error, the job keeps retrying and re-failing, then surfaces a generic failure instead of an actionable message.

## Changes

This is a user/upstream condition, not a fixable bug or a transient blip:

- Our query is constructed from validated identifiers discovered via `information_schema`, so the SQL we send is well-formed.
- Error 208 is deterministic for a given source state — a dropped/renamed object, a view referencing a missing/inaccessible object, or revoked cross-database permission. Retrying replays the identical failure.

So we add `"Invalid object name"` to `MSSQLSource.get_non_retryable_errors()` with an actionable message telling the customer to check that the referenced object still exists and that the connection user can read it (including any tables a view depends on). The match uses the stable error text only — the volatile object name, procedure name, and line number are intentionally excluded to avoid false positives.

## How did you test this code?

I'm an agent. I ran the source's automated tests; I did not perform manual testing.

- Added a parametrized `test_invalid_object_name_is_non_retryable` to the MSSQL source tests, using the real error-208 message from the issue plus a dropped-table variant.
- `pytest posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py` — 53 passed.
- `ruff check` / `ruff format` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the MSSQL import source. Read the stack frame and the MSSQL implementation to confirm the failure originates in our `SELECT` execution (`mssql.py`), then classified SQL Server error 208 as a persistent customer-side schema/permissions condition rather than a bug in our code or a transient infra error. Mirrored the existing `get_non_retryable_errors` pattern (matching a stable, low-false-positive substring) used by the Stripe source and the existing MSSQL entries. Verified the string was not already covered by `Any_Source_Errors` or the existing MSSQL non-retryable set before adding it.