### PR TITLE
fix(mysql): stop capturing expected connection errors during validation

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -179,6 +179,20 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
                 or f"Could not connect to {self.get_source_config.name} via the SSH tunnel. Please check all connection details are valid.",
             )
         except Exception as e:
+            # Connection/credential failures we already classify as non-retryable during sync
+            # (an unreachable host, a refused connection, a blocked host, an SSL mismatch, ...)
+            # are expected user/upstream errors, not bugs on our side. Surface the friendly
+            # message without reporting them to error tracking — only genuinely unexpected
+            # failures get captured. Mirrors the Postgres and MSSQL `validate_credentials` handling.
+            error_msg = " ".join(str(arg) for arg in e.args) if e.args else str(e)
+            for pattern, friendly_error in self.get_non_retryable_errors().items():
+                if pattern in error_msg:
+                    return (
+                        False,
+                        friendly_error
+                        or f"Could not connect to {self.get_source_config.name}. Please check all connection details are valid.",
+                    )
+
             capture_exception(e)
             return (
                 False,

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -911,3 +911,46 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Transient thread-exhaustion error should remain retryable: {error_msg}"
+
+
+class TestMySQLSourceValidateCredentials:
+    @pytest.fixture
+    def source(self, mocker):
+        source = MySQLSource()
+        mocker.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None))
+        mocker.patch.object(source, "is_database_host_valid", return_value=(True, None))
+        return source
+
+    @pytest.mark.parametrize(
+        "raised",
+        [
+            # The exact error that fired this triage: an unreachable host surfaces as a
+            # pymysql OperationalError(2003) wrapping an OSError — already non-retryable.
+            pymysql.err.OperationalError(
+                2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 101] Network is unreachable)"
+            ),
+            pymysql.err.OperationalError(
+                2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)"
+            ),
+            pymysql.err.OperationalError(1045, "Access denied for user 'u'@'1.2.3.4' (using password: YES)"),
+        ],
+    )
+    def test_known_connection_errors_are_not_captured(self, source, mocker, raised):
+        capture = mocker.patch("posthog.temporal.data_imports.sources.mysql.source.capture_exception")
+        mocker.patch.object(source, "get_schemas", side_effect=raised)
+
+        valid, error = source.validate_credentials(_make_config(), team_id=1)
+
+        assert valid is False
+        assert error is not None
+        capture.assert_not_called()
+
+    def test_unexpected_errors_are_still_captured(self, source, mocker):
+        capture = mocker.patch("posthog.temporal.data_imports.sources.mysql.source.capture_exception")
+        mocker.patch.object(source, "get_schemas", side_effect=RuntimeError("something genuinely unexpected"))
+
+        valid, error = source.validate_credentials(_make_config(), team_id=1)
+
+        assert valid is False
+        assert error is not None
+        capture.assert_called_once()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OSError: [Errno 101] Network is unreachable` (wrapped in pymysql `OperationalError(2003, "Can't connect to MySQL server on ...")`) originating in the MySQL data-warehouse source. The frame is `posthog/temporal/data_imports/sources/mysql/source.py:validate_credentials`, reached via the `external_data_sources/database_schema` API during source setup.

This is an **expected user/upstream connectivity error** — the customer's MySQL host is unreachable (server down, firewall, host not allowlisted). We already classify `"Can't connect to MySQL server on"` as non-retryable for the sync pipeline, so there is nothing actionable on our side. But `validate_credentials` was sending **every** connection failure straight to `capture_exception`, so each bad-host attempt during setup created error-tracking noise (and fired alert webhooks).

Postgres and MSSQL already avoid this: their `validate_credentials` matches the failure against a known-errors dict and returns the friendly message *without* capturing. MySQL was the odd one out.

## Changes

In `MySQLSource.validate_credentials`, before falling through to `capture_exception`, match the exception message against the source's own `get_non_retryable_errors()` patterns (the same set used by the sync pipeline). On a match, return the friendly message and skip capture. Genuinely unexpected errors are still captured exactly as before.

This is scoped strictly to the validation path — retry policy and the sync pipeline's non-retryable handling are unchanged. No transient errors are newly suppressed (only patterns already deemed non-retryable are matched).

## How did you test this code?

I'm an agent (Claude Code). I added a regression test class `TestMySQLSourceValidateCredentials` and ran only automated tests:

- New: known connection errors (`Network is unreachable`, `Connection refused`, `Access denied for user`) return `(False, message)` and do **not** call `capture_exception`; an unexpected `RuntimeError` still calls it once.
- Full file: `posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — 109 passed.
- `ruff check` / `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue via the PostHog MCP tools. Confirmed the stack genuinely originates in this source (`validate_credentials` → `get_schemas` → `mysql.connect` → pymysql).

Decision: the underlying error is user/upstream and already non-retryable for the sync pipeline, so adding it to `NonRetryableErrors` would be a no-op. The real, fixable bug was that the *validation* path (a separate code path from sync retries) unconditionally captured these expected errors. Fixed by reusing the existing non-retryable patterns to gate `capture_exception`, matching the Postgres/MSSQL pattern rather than introducing a new abstraction.
