### PR TITLE
chore(ci): validate test quarantine enforcement end-to-end

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -1,4 +1,23 @@
 {
     "version": 1,
-    "entries": []
+    "entries": [
+        {
+            "id": "posthog/test/test_quarantine_smoke.py::test_quarantine_run_mode_should_xfail",
+            "runner": "pytest",
+            "reason": "throwaway: validate quarantine run-mode xfail in CI (#62737)",
+            "owner": "@raul",
+            "added": "2026-06-16",
+            "expires": "2026-06-23",
+            "mode": "run"
+        },
+        {
+            "id": "posthog/test/test_quarantine_smoke.py::test_quarantine_skip_mode_should_not_run",
+            "runner": "pytest",
+            "reason": "throwaway: validate quarantine skip-mode in CI (#62737)",
+            "owner": "@raul",
+            "added": "2026-06-16",
+            "expires": "2026-06-23",
+            "mode": "skip"
+        }
+    ]
 }

--- a/posthog/test/test_quarantine_smoke.py
+++ b/posthog/test/test_quarantine_smoke.py
@@ -1,0 +1,16 @@
+# Throwaway end-to-end validation of the checked-in test quarantine (#62737).
+# Both tests fail on purpose: the quarantine file neutralizes them, so CI is
+# green only if enforcement works — `run` mode reports xfailed, `skip` mode
+# never executes. Delete this file (and its quarantine entries) before merge;
+# this PR is not meant to land.
+
+
+def test_quarantine_run_mode_should_xfail() -> None:
+    # Quarantined mode=run -> still executes, marked xfail(strict=False),
+    # so this failure is reported as xfailed and cannot fail the shard.
+    raise AssertionError("intentional failure neutralized by quarantine mode=run")
+
+
+def test_quarantine_skip_mode_should_not_run() -> None:
+    # Quarantined mode=skip -> never executed. If it ever runs, this fails CI.
+    raise AssertionError("intentional failure that quarantine mode=skip must prevent")


### PR DESCRIPTION
## Problem

Throwaway PR — **do not merge**. End-to-end validation that the checked-in test quarantine shipped in the test-quarantine feature PR (#62737) actually neutralizes failing tests in real CI, not just in unit tests.

## Changes

- `posthog/test/test_quarantine_smoke.py`: two tests that fail on purpose (`raise AssertionError`).
- `.test_quarantine.json`: quarantines both via `hogli test:quarantine add` —
  - `...::test_quarantine_run_mode_should_xfail` → `mode: run` (should report **xfailed**, still executes)
  - `...::test_quarantine_skip_mode_should_not_run` → `mode: skip` (should **not execute**)

CI is green **only if** enforcement works: both deliberately-failing tests must be neutralized. A red backend shard means quarantine failed to catch one.

## How did you test this code?

I'm an agent (Claude Code); these were actually run:

- `hogli test:quarantine add|list|remove|check` round-trips against a temp file, plus failure paths: invalid selector rejected (exit 1), expired-past-grace entry fails `check` (exit 1).
- Local pytest on the two smoke tests → `1 skipped, 1 xfailed` (exit 0): the `conftest.py` hook applies `xfail` to `mode: run` and skips `mode: skip`.
- This PR carries the `run-ci-backend` label to force the full backend matrices on a draft, and touches `.test_quarantine.json` (in the ci-backend paths-filter) so the `test-quarantine.yml` `check` job also runs.

Expected in CI: backend shards green with the run-mode test reported `xfailed`, the skip-mode test absent, and `Test quarantine / check-quarantine` passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl asked to exercise the quarantine commands and stand up a throwaway draft PR (labeled so CI runs) to validate the feature end-to-end. Built with Claude Code. Design: two intentionally-failing tests so a single green/red CI outcome is an unambiguous pass/fail for both enforcement modes. `assert False` was rejected by ruff `B011`, switched to `raise AssertionError`. Not meant to land — delete the test file and its quarantine entries after the run is observed.
