### PR TITLE
chore(insights): remove scene subscribe label experiment

### DIFF
--- a/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
@@ -1,11 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import posthog from 'posthog-js'
 
 import { IconBell } from '@posthog/icons'
-import { useFeatureFlagVariantKey } from '@posthog/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userLogic } from 'scenes/userLogic'
@@ -15,13 +12,6 @@ import { AvailableFeature, InsightShortId, QueryBasedInsightModel } from '~/type
 import { subscriptionsLogic } from '../Subscriptions/subscriptionsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../Subscriptions/utils'
 import { SceneDataAttrKeyProps } from './utils'
-
-const SUBSCRIBE_LABEL_BY_VARIANT: Record<string, string> = {
-    control: 'Subscribe',
-    'recurring-updates': 'Get recurring updates',
-    'scheduled-notifications': 'Schedule notifications',
-    'scheduled-reports': 'Get scheduled reports',
-}
 
 interface SceneSubscribeButtonProps extends SubscriptionBaseProps, SceneDataAttrKeyProps {
     insight?: Partial<QueryBasedInsightModel>
@@ -52,19 +42,11 @@ export function SceneSubscribeButton({
     const { push } = useActions(router)
     const { hasAvailableFeature } = useValues(userLogic)
     const hasSubscriptionsFeature = hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)
-    const labelVariant = useFeatureFlagVariantKey(FEATURE_FLAGS.SCENE_SUBSCRIBE_LABEL_EXPERIMENT)
-    const subscribeLabel =
-        typeof labelVariant === 'string' ? (SUBSCRIBE_LABEL_BY_VARIANT[labelVariant] ?? 'Subscribe') : 'Subscribe'
 
     return (
         <ButtonPrimitive
             menuItem
             onClick={() => {
-                posthog.capture('scene subscribe menu item clicked', {
-                    resource_type: dataAttrKey,
-                    label_variant: typeof labelVariant === 'string' ? labelVariant : 'control',
-                    label_text: subscribeLabel,
-                })
                 push(urlForSubscriptions({ insightShortId: insight?.short_id, dashboardId }))
             }}
             data-attr={`${dataAttrKey}-subscribe-dropdown-menu-item`}
@@ -75,7 +57,7 @@ export function SceneSubscribeButton({
             ) : (
                 <IconBell />
             )}
-            {subscribeLabel}
+            Subscribe
         </ButtonPrimitive>
     )
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -460,7 +460,6 @@ export const FEATURE_FLAGS = {
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     SCENE_ALERTS_LABEL_EXPERIMENT: 'scene-alerts-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,get-notified,monitor-changes,set-up-alert
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection
-    SCENE_SUBSCRIBE_LABEL_EXPERIMENT: 'scene-subscribe-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,recurring-updates,scheduled-notifications,scheduled-reports
     SCHEMA_ENFORCEMENT_REJECT: 'schema-enforcement-reject', // owner: @aspicer, gates the ability to set schema enforcement mode to "reject"
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer
     SEARCH_DEBOUNCE_ALL: 'search-debounce-all', // owner: @adamleithp #team-platform-ux


### PR DESCRIPTION
## Problem

The "Scene subscribe menu label clarity" experiment ([375117](https://us.posthog.com/project/2/experiments/375117)) tested clearer copy for the buried "Subscribe" side-panel action against the generic baseline. It ended with no improvement (conclusion: lost), so the control wins and the experiment scaffolding is now dead code.

## Changes

- Keep the control "Subscribe" label on the scene subscribe button.
- Remove the variant label map, the `useFeatureFlagVariantKey` lookup, and the per-click exposure capture (`scene subscribe menu item clicked`) that only existed to power the experiment metric.
- Drop the `SCENE_SUBSCRIBE_LABEL_EXPERIMENT` feature-flag constant and now-unused imports.

The `insight-subscribe-prominent-button` experiment is a separate test and was left untouched. The remote feature flag `scene-subscribe-label-experiment` is now orphaned (serving 100% control) and can be deleted separately.

## How did you test this code?

I'm an agent. I verified there are no remaining references to the flag key, the variant map, or the metric event across the frontend. I could not run `format`/`typescript:check` because `node_modules` is not installed in this environment; the change is a straightforward dead-code removal with all remaining imports still used.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed this cleanup after ending the experiment with no improvement. Used Claude Code with the PostHog MCP `experiment-get` tool to confirm the experiment's ended/lost status and that the control was retained at 100%, then removed the corresponding frontend experiment code while preserving the control behavior.
