### PR TITLE
feat(insights): ship prominent subscribe button on insights

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5143,7 +5143,7 @@ snapshots:
     scenes-app-hogfunctions-destination--runs-with-data--light:
         hash: v1.k794b7964.0096a479368226c8e814746b035ce360a9345b27a081ffc2083cf6e855489432.jMrGy2vE-erlaH_1tAskw0DDuKX-SdTXXjE32rc2uI0
     scenes-app-insights-boldnumber--compare-null-previous--dark:
-        hash: v1.k794b7964.740b2306ae975e77739d9c4ff65993c554b635eeab9bbfbec410f10d4277dace.R7fAb_Em3P8l4hNZsC15VVzEbFobuwzIKb2P9tM6CRM
+        hash: v1.k794b7964.ccab3f6785db86e659c4186e305b97ba81c7bda8c51e7fd5c05e179be4393fde.C-X-Y3nG_88O1MxV0YKV52bqS_DKlvdLVHa5HDj0GRI
     scenes-app-insights-boldnumber--compare-null-previous--light:
         hash: v1.k794b7964.785007f2c0354ca71f02f79eedc11b2fd48d97aab007f2b1e252bc102ddd94ad.uPVYk4rJBkgswqvx1leCKTQvPsRP1ahBR7wdAjOpxxQ
     scenes-app-insights-boldnumber--default--dark:
@@ -5151,29 +5151,29 @@ snapshots:
     scenes-app-insights-boldnumber--default--light:
         hash: v1.k794b7964.81f205b47382c368f40c35aa70de8df86ee70f6a559822c507d78aad82eb3d06.-bwL4_vIt9WdYeFZrSEnNTZZ92RXRmdQ5u_h1JGwyv4
     scenes-app-insights-boldnumber--empty-result--dark:
-        hash: v1.k794b7964.a0da8e049e4cdf517ae48f965205d8ed98b27a4359eb5076aa03463c0d15b4e3.r7Zn_jzdIQy9A6YlCxnobxsJ0As6Kmmih9AbXGyIV1M
+        hash: v1.k794b7964.5cfecce464cf0a7c39180db4e18e872a5cc2bee9b39f7aac6523335d2dfca338.k-PcU5Nz8u1w6A15afd1uRtEXZATYzg9Ac1ZAZYxymI
     scenes-app-insights-boldnumber--empty-result--light:
-        hash: v1.k794b7964.81ffbc71dc8468df520f9db5de3bb5f21aaded4a88a59866bb16e3e7ffffb760.xfP6yH_OnibFLMOSLYFqqSlR7LFwWbBzMVzDDF8mz2g
+        hash: v1.k794b7964.43dd405458463a51299237ee08a8a6d4d800a90e7c8c780b482dc4869221f3d1.wXplXiK-YmHa2PibOdk7Ho2POfSR8zftI8scyBO8v7E
     scenes-app-insights-error-empty-states--empty--dark:
         hash: v1.k794b7964.0368a42b05ce1ff1d84ee0a9452a0b8b3d28877b8ffcc408a0647cba07889ae1.foa5cNmmNsSXL-P_pWyfu6N4vdAwiQCgCmLq0-TCV1Y
     scenes-app-insights-error-empty-states--empty--light:
         hash: v1.k794b7964.92c8fb304c0601de4d84a18678870a40c35c564e46b77acd5d67f43106ed7c40.B5nsQBFrl5RQa5KF1Wu8Hf7u_3-WE0gU616WAFM6prw
     scenes-app-insights-error-empty-states--estimated-query-execution-time-too-long--dark:
-        hash: v1.k794b7964.01874e0e94b964228fbdcd2cadd802045e06b4853da1934d6596d032cbcbc609.WznWT7gJsofBoxnaeuckvidzthZmKRCVu6V7MaCwQ_Q
+        hash: v1.k794b7964.b9422f5449cc4322a2711ea01cbe37125ef573d616a60847393d82b0e32c35ce.1ztGhvMfdYM7xrcsqPGPzZIeMlEsI3awB6hZsuwDWN8
     scenes-app-insights-error-empty-states--estimated-query-execution-time-too-long--light:
-        hash: v1.k794b7964.932521074da69dfb0d11423e2facd3326a6a9d8ae47534429e0affd7b4c1bdc5.rDxdA3YxAsnROCyAn1vtVee7B7e0g7CK52EGnRnPv7Q
+        hash: v1.k794b7964.8810832fe97457e77bbc37bb929f7031cf62a9212d1b945fef172a891ca79bd6.skbXB6_-gEt23wRqKZLI_y3rfIO_rmTAblpKL00oCXU
     scenes-app-insights-error-empty-states--funnel-single-step--dark:
-        hash: v1.k794b7964.9856b7890d81a12062b00b1e8121b749088570b605ca712661eb07365cbecb2a.d3IProXtLoBWkSExgpaw7emuz8UkyN2gjHDsgb21rXw
+        hash: v1.k794b7964.500698fc3cfec746784e86268d0d3186f8fe68bcd4ef5fd7b5c857910d331a93.E8yqBTALuUUhRx6fRrQLKzr2f-BWZ0vr9kcKACMMJFs
     scenes-app-insights-error-empty-states--funnel-single-step--light:
-        hash: v1.k794b7964.1fcaf1beeb8a7cbefa50c9e597fc38217b426f42d7829158557bbfa80efbf446.FgqXbViDk6HF_so8iaWZRUGDj731xiZdPMqK4tJxSyI
+        hash: v1.k794b7964.9c5df35b0f9a37a777f699a31ac22e00fb92e70df42ba53b7e9bf8cc4f46b26b.WaPac1RajKdQQdH_8InxPTcyUumG2G9jLUjImYxa3NI
     scenes-app-insights-error-empty-states--long-loading--dark:
-        hash: v1.k794b7964.d68b30f3a141f2bb40ad86b5686397645c5bfdccedd4ecd294d87af01b9db891.go6-VGCMExeZRyrNrxfqiDiBzGKoQciMEUh1LjQ0k98
+        hash: v1.k794b7964.14e42bd6366be9a25f39949ee99d702a1c0c080f649245f2aadde1160de4de07.zLR54ZqGTQ_PSCYRduAQBXdJbqYZVkhJCkOIdKYnS08
     scenes-app-insights-error-empty-states--long-loading--light:
-        hash: v1.k794b7964.7836f5a8f0d620d698b0441c20211c916fcdb4b5b3b9e618aa147e065ea2b431.y8AJcEw-DLi60NvoiKL_UfCgdZHkHH2vGUfszJs3q3I
+        hash: v1.k794b7964.bc38196e0f4667d4ffcea70574dc5800a0b485c05f8a10c4b256ebfd190c503c.yxj4ggN_Gb_emZvBr-d6kM7HexA1pBrqHUQspTs6aLM
     scenes-app-insights-error-empty-states--query-server-error--dark:
-        hash: v1.k794b7964.694e4e345cfc341bcad0f45a5dba9c294633f793ef987426484a0e8f2fdc2e21.oi2SereFxkWDIz6ht4o7lbKUvxy4qwjHgtHl1vxf-GM
+        hash: v1.k794b7964.57499c5a390ee60c42fce51c65836c956a7835030de67d2be8c3da7d6e015b80.4yDwEGWym0PgXsrkjIAlkVb0bRJnmRQkiXueOZBiAq0
     scenes-app-insights-error-empty-states--query-server-error--light:
-        hash: v1.k794b7964.2fcc77e884e48188122f920ac175c45beba66bddf5535b65d40adf65c8165149.OijghXAUjslhadKI5fnaVyYZvKafuE-pLN0RG83RVjY
+        hash: v1.k794b7964.00b63f71c46b269e4a0b02f60b7bba736136f63c1fb9c0980d4d05e3e936a433.x-Twbcyn3EAi2ZDIbhE0kVRvbLE_dqjxJ8q2tWeU9Sg
     scenes-app-insights-error-empty-states--server-error--dark:
         hash: v1.k794b7964.0368a42b05ce1ff1d84ee0a9452a0b8b3d28877b8ffcc408a0647cba07889ae1.nlvBufFIcinhNJezNIG_ja_X2TB1MX_kjIV4kFYybHc
     scenes-app-insights-error-empty-states--server-error--light:
@@ -5215,7 +5215,7 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
         hash: v1.k794b7964.6c391cbc05b64230fbd8defdbb960b131fd433409817497873fb9ffc705cd360.EIwByuofuT77yP259A9ffqfjSFwW9MrUDOvsZNA_aZM
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
-        hash: v1.k794b7964.d64808d2bfc36017f89b57feeaa373e20188738a622801207fa1beb59d02fdd9.cFuKF_Ow887Z3X3BoNhtTvkUWY2vips9HDBe-B02eQE
+        hash: v1.k794b7964.cd8e1c296deca557090cea1d5b4ae8b35f73aec0ecd9230f12e7e8a0447c68d0.6AK3HUdKJb0vDaN8oC7UZrIv2U3Lm1EKu5XpDKMcoaw
     scenes-app-insights-funnels--funnel-time-to-convert--light:
         hash: v1.k794b7964.68da8b42ca1d02295cb56a9444ff9a7002b0626c620e0ec065d42844815c6e83.tnZvKyg0BKUhLY0Cnh_j3zlxUCFY72xBGl6Ek8gbYbQ
     scenes-app-insights-funnels--funnel-time-to-convert-edit--dark:
@@ -5223,13 +5223,13 @@ snapshots:
     scenes-app-insights-funnels--funnel-time-to-convert-edit--light:
         hash: v1.k794b7964.61e950dfdb6f72f937c311d32292dc439a9290fc1ea1f219f08edaf87222e815.BsrF9SvDR3za4p4oN8yGY4nA2pS5YJV6IqB6N-2IbD0
     scenes-app-insights-funnels--funnel-top-to-bottom--dark:
-        hash: v1.k794b7964.047437f29fee75e8d38fd37eed1fdf3f6cba642ccc3c58e0c5ee70e4dcf2b1d6.oE4ra-CvS2sbEClZjCws4NvqpAiKUC_SQPjqjw1BueQ
+        hash: v1.k794b7964.a4f13ee3bf53e1386348a7cb72553c4da3f63d312af992574643ef8a21fd997b.HYi1oWs4QD1y3mTu8M-rYrg7_LY4L1BFMclury2vgZM
     scenes-app-insights-funnels--funnel-top-to-bottom--light:
-        hash: v1.k794b7964.04fc0cef0d9c1bcf2dc6019c2f9a90166229be9d4e7174de3c174765ae987644.aFOMQDW-KiqlB2SWZ-aSoIGbBRjiQVRLHYZg8L9CJp4
+        hash: v1.k794b7964.99302b9a079da8ffcf0d4e2e0a7c49059f973cf20746db2c36683e54022977ac.lkqpaaItMCexbfaGbzndDNtpZp2L0q4kV9ggQWI4MV4
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown--dark:
-        hash: v1.k794b7964.7dc365ad3f78390e2af4ea0e344b7f84d87398e11364f85e329ac7d1a322e4d7.GCTwusbl-LzbPEPhYv9XX_vKF1DLW6lfJeFbHGxyOZo
+        hash: v1.k794b7964.e706026d9eb968fb9448b0375923c3440614c754bcc9aa60b3c6801e381f66de.owQ0LZjycsvgSzI4VKYl3_ZPO03teUnL8agyZCrNn70
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown--light:
-        hash: v1.k794b7964.934c7d10996aef9b739598a069d4585d0909c26d98e6b4fdc3b40b4177ce550f.3JqYv7dzCnVl6tdJ67YlIZktxGKs3uHnryubVGwEppY
+        hash: v1.k794b7964.9e04d65bb1b8b6df0cbbfe194ae2f11647ac07109ec4fff4490790398f56ee72.o9PP3ui3HnBeKwbuNd6ZMzwRtqbxOdlIg4LIQyW3F3Y
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown-edit--dark:
         hash: v1.k794b7964.cfb0f8cc130e2dc59decdec61afe6821dd4152a3a2fdba63dbee94e5ea74a7f1.KMnTbXNd1fiD0k61yX8Q5JJATI6NssqLXOs7wKNlLf4
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown-edit--light:
@@ -5323,7 +5323,7 @@ snapshots:
     scenes-app-insights-trendsvalue--trends-table--light:
         hash: v1.k794b7964.3fe9e04283703a914a561cdfe9f61bb98da4fe8c44dede07f028d329463b5fa0.uBdrmDvcfwgkL-bxDVhl5t0lB17H__fs4tnReJN6dvc
     scenes-app-insights-trendsvalue--trends-table-breakdown--dark:
-        hash: v1.k794b7964.c60e8b715f9cf20e2a5ecca04f5e26bf1a9f82e48de010170a94165ff83d987e.SFWvhWjJnGvJiAe1nPkSUSe9ErxM9SYd9qUaZJL50Oo
+        hash: v1.k794b7964.6fc3a57221ef65dd56c092fa16a78467ada20fc36e2dd9feadc80c9ce8188c17.-ni-J3yVe4RYt0jvEU2D19wbUVgXDCOOmHLsgCnM4gQ
     scenes-app-insights-trendsvalue--trends-table-breakdown--light:
         hash: v1.k794b7964.abb6eb77363c56063abf959a0b6494fb7dae80701957ce9f6a244dc4ef84d292.X31gO4UC3kRkxTXBvj7Vq3MapKGzreq21oFp36n6m_c
     scenes-app-insights-trendsvalue--trends-table-breakdown-edit--dark:

--- a/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
+++ b/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
@@ -3,9 +3,7 @@ import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { IconBell } from '@posthog/icons'
-import { useFeatureFlagVariantKey } from '@posthog/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { userLogic } from 'scenes/userLogic'
@@ -24,7 +22,7 @@ function SubscribeIcon({ insightShortId }: { insightShortId: InsightShortId }): 
     const { subscriptions } = useValues(subscriptionsLogic({ insightShortId }))
 
     // Mirror the side-panel SceneSubscribeButton: show the active-subscription count badge so
-    // the test arm carries the same "you're already subscribed" signal as the control arm.
+    // the header button carries the same "you're already subscribed" signal.
     if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
         return <IconBell />
     }
@@ -37,20 +35,12 @@ function SubscribeIcon({ insightShortId }: { insightShortId: InsightShortId }): 
 }
 
 /**
- * Experiment (insight-subscribe-prominent-button): promotes "Subscribe" from the buried
- * side-panel action to a visible header button. Reading the flag variant here is the
- * experiment exposure, so this is mounted only for subscribe-eligible insights to keep the
- * exposed population aligned with the control arm.
+ * Promotes "Subscribe" from the buried side-panel action to a visible header button.
  */
 export function InsightSubscribeProminentButton({
     insightShortId,
-}: InsightSubscribeProminentButtonProps): JSX.Element | null {
+}: InsightSubscribeProminentButtonProps): JSX.Element {
     const { push } = useActions(router)
-    const variant = useFeatureFlagVariantKey(FEATURE_FLAGS.INSIGHT_SUBSCRIBE_PROMINENT_BUTTON)
-
-    if (variant !== 'test') {
-        return null
-    }
 
     return (
         <LemonButton

--- a/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
+++ b/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
@@ -37,9 +37,7 @@ function SubscribeIcon({ insightShortId }: { insightShortId: InsightShortId }): 
 /**
  * Promotes "Subscribe" from the buried side-panel action to a visible header button.
  */
-export function InsightSubscribeProminentButton({
-    insightShortId,
-}: InsightSubscribeProminentButtonProps): JSX.Element {
+export function InsightSubscribeProminentButton({ insightShortId }: InsightSubscribeProminentButtonProps): JSX.Element {
     const { push } = useActions(router)
 
     return (

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -309,7 +309,6 @@ export const FEATURE_FLAGS = {
     HACKATHONS_SUBSCRIPTIONS: 'hackathons_subscriptions', // owner: #team-analytics-platform, gates listing subscription delivery history and AI change summaries
     HEALTH_ALERTS: 'health-alerts', // owner: #team-growth, gates the central /health/alerts scene and per-page Alerts buttons
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
-    INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     JS_SNIPPET_VERSIONING: 'js-snippet-versioning', // owner: #team-client-libraries
     LEGAL_DOCUMENTS: 'legal-documents', // owner: @rafaeelaudibert #team-growth


### PR DESCRIPTION
## Problem

The experiment **"Prominent Subscribe button on insights"** (`insight-subscribe-prominent-button`) tested whether surfacing Subscribe as a visible button in the insight header — instead of buried in the side-panel Actions menu — increases the rate at which users create insight subscriptions. The experiment has concluded with the **test variant winning**, so the prominent button is now the permanent behavior and the experiment scaffolding can be removed.

## Changes

- Removed the feature-flag read and `variant !== 'test'` gate in `InsightSubscribeProminentButton`, so the header Subscribe button always renders for subscribe-eligible saved insights.
- Dropped the now-unused `useFeatureFlagVariantKey` / `FEATURE_FLAGS` imports and tightened the return type to `JSX.Element`.
- Removed the `INSIGHT_SUBSCRIBE_PROMINENT_BUTTON` flag constant from `constants.tsx`.

Left intact: the header render guard (`insightMode !== Edit && isSavedInsight && short_id`) is legitimate product logic; the side-panel `SceneSubscribeButton` was never flag-gated and stays; the click analytics event is plain product instrumentation, not flag-dependent.

The feature flag itself still exists in PostHog (pinned to 100% `test` when the experiment ended) and can be deleted now that no code references it.

## How did you test this code?

I'm an agent. I did **not** run the frontend toolchain — this environment has no `node_modules`, so `format` and `typescript:check` could not run. The changes are limited to removing dead flag-gating code and an unused constant; a grep confirms no remaining references to the flag key or constant. CI will run lint/typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt directed this cleanup after the experiment rolled out. I looked up experiment 376024 via the PostHog MCP `experiment-get` tool to confirm the winning variant (`test`, conclusion "won"), then used a search agent to locate every reference to the flag before removing the gating and making the button permanent. The flag and experiment records in PostHog were intentionally left in place for the human to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
