### PR TITLE
feat(web-analytics): add multiMatch-backed bot detection UDFs

### DIFF
--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -2,7 +2,7 @@ from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
 
-# Bot-detection UDFs (isLikelyBot / getBotName / …). SQL UDFs are macro-expanded
+# Bot-detection UDFs (webAnalyticsIsLikelyBot / webAnalyticsGetBotName / …). SQL UDFs are macro-expanded
 # at query-analysis time, so they need to exist wherever bot queries are analyzed — the same two
 # routes the dict serves (see 0275): DATA (events-table queries) and AUX (web-analytics
 # preaggregated tables). Bodies are multiMatch-based (Hyperscan), not dictGet — see

--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -2,9 +2,6 @@ from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
 
-# Bot-detection UDFs (webAnalyticsIsLikelyBot / webAnalyticsGetBotName / …). SQL UDFs are macro-expanded
-# at query-analysis time, so they need to exist wherever bot queries are analyzed — the same two
-# routes the dict serves (see 0275): DATA (events-table queries) and AUX (web-analytics
-# preaggregated tables). Bodies are multiMatch-based (Hyperscan), not dictGet — see
-# posthog/models/bot_definition/sql.py for the rationale.
+# Created on DATA + AUX (same routes the dict serves, see 0275) since SQL UDFs are resolved where
+# the query is analyzed.
 operations = [run_sql_with_exceptions(sql, node_roles=[NodeRole.DATA, NodeRole.AUX]) for sql in BOT_DEFINITION_UDFS_SQL]

--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -2,7 +2,7 @@ from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
 
-# Bot-detection UDFs (isBot / getBotName / …). SQL UDFs are macro-expanded
+# Bot-detection UDFs (isLikelyBot / getBotName / …). SQL UDFs are macro-expanded
 # at query-analysis time, so they need to exist wherever bot queries are analyzed — the same two
 # routes the dict serves (see 0275): DATA (events-table queries) and AUX (web-analytics
 # preaggregated tables). Bodies are multiMatch-based (Hyperscan), not dictGet — see

--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -2,6 +2,4 @@ from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
 
-# Created on DATA + AUX (same routes the dict serves, see 0275) since SQL UDFs are resolved where
-# the query is analyzed.
 operations = [run_sql_with_exceptions(sql, node_roles=[NodeRole.DATA, NodeRole.AUX]) for sql in BOT_DEFINITION_UDFS_SQL]

--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -2,7 +2,7 @@ from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
 
-# Bot-detection UDFs (webAnalyticsIsBot / webAnalyticsBotName / …). SQL UDFs are macro-expanded
+# Bot-detection UDFs (isBot / getBotName / …). SQL UDFs are macro-expanded
 # at query-analysis time, so they need to exist wherever bot queries are analyzed — the same two
 # routes the dict serves (see 0275): DATA (events-table queries) and AUX (web-analytics
 # preaggregated tables). Bodies are multiMatch-based (Hyperscan), not dictGet — see

--- a/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
+++ b/posthog/clickhouse/migrations/0276_add_web_bot_definition_udfs.py
@@ -1,0 +1,10 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.bot_definition.sql import BOT_DEFINITION_UDFS_SQL
+
+# Bot-detection UDFs (webAnalyticsIsBot / webAnalyticsBotName / …). SQL UDFs are macro-expanded
+# at query-analysis time, so they need to exist wherever bot queries are analyzed — the same two
+# routes the dict serves (see 0275): DATA (events-table queries) and AUX (web-analytics
+# preaggregated tables). Bodies are multiMatch-based (Hyperscan), not dictGet — see
+# posthog/models/bot_definition/sql.py for the rationale.
+operations = [run_sql_with_exceptions(sql, node_roles=[NodeRole.DATA, NodeRole.AUX]) for sql in BOT_DEFINITION_UDFS_SQL]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0275_add_web_bot_definition_dict
+0276_add_web_bot_definition_udfs

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -132,7 +132,7 @@ LAYOUT(REGEXP_TREE())
 
 
 # Namespaced (`webAnalytics*`) to avoid clashes in ClickHouse's global function catalog; the HogQL
-# layer exposes them unprefixed. multiMatch-based, not the dict's dictGet.
+# layer exposes them unprefixed.
 _BOT_UDF_PATTERNS = _format_array([*BOT_DEFINITIONS.keys(), "^$"])
 
 

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -151,7 +151,7 @@ def _bot_udf_label_lookup(attr: str, default: str, empty_ua_value: str) -> str:
 
 
 BOT_DEFINITION_UDF_NAMES = [
-    "isBot",
+    "isLikelyBot",
     "getBotName",
     "getBotCategory",
     "getBotTrafficType",
@@ -161,7 +161,7 @@ BOT_DEFINITION_UDF_NAMES = [
 # CREATE OR REPLACE so a later BOT_DEFINITIONS change re-creates the functions idempotently via a
 # follow-up migration. Defaults mirror the inline HogQL builder (traffic_type.py).
 BOT_DEFINITION_UDFS_SQL = [
-    f"CREATE OR REPLACE FUNCTION isBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
+    f"CREATE OR REPLACE FUNCTION isLikelyBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
     f"CREATE OR REPLACE FUNCTION getBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
     f"CREATE OR REPLACE FUNCTION getBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
     f"CREATE OR REPLACE FUNCTION getBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -131,22 +131,14 @@ LAYOUT(REGEXP_TREE())
 """
 
 
-# Bot-detection UDFs. Names are prefixed with `webAnalytics` because ClickHouse functions share one
-# global catalog, so generic names risk clashing with built-ins or other products. The HogQL layer
-# exposes them without the prefix (`getBotName`/`isLikelyBot`), so query authors still get clean
-# names while the installed ClickHouse functions stay namespaced. Bodies use multiMatchAnyIndex
-# (Hyperscan), NOT the REGEXP_TREE dict's dictGet: benchmarks on real traffic showed dictGet costs
-# 7-46x more CPU and grows with row count, while multiMatch stays flat (~200 ms at any window). SQL
-# UDFs are macro-expanded at query-analysis time, so call sites stay tiny yet execute at full
-# multiMatch speed. BOT_DEFINITIONS remains the single source of truth — the same patterns/labels
-# the dict is seeded from and the inline HogQL path emits.
+# Namespaced (`webAnalytics*`) to avoid clashes in ClickHouse's global function catalog; the HogQL
+# layer exposes them unprefixed. multiMatch-based, not the dict's dictGet.
 _BOT_UDF_PATTERNS = _format_array([*BOT_DEFINITIONS.keys(), "^$"])
 
 
 def _bot_udf_label_lookup(attr: str, default: str, empty_ua_value: str) -> str:
-    # Label array aligns with the patterns array: [default, <per-bot attr>…, empty_ua_value].
-    # multiMatchAnyIndex returns 0 (no match) or 1..N+1 ("^$" is N+1); arrayElement(arr, idx + 1)
-    # then maps 0 -> default, k -> attr of bot k, N+1 -> empty_ua_value.
+    # multiMatchAnyIndex returns 0 (no match) or 1..N+1; arrayElement(arr, idx + 1) maps it onto
+    # [default, <per-bot attr>…, empty_ua_value].
     labels = [default, *(getattr(bot, attr) for bot in BOT_DEFINITIONS.values()), empty_ua_value]
     return f"arrayElement({_format_array(labels)}, multiMatchAnyIndex(ifNull(ua, ''), {_BOT_UDF_PATTERNS}) + 1)"
 
@@ -159,8 +151,7 @@ BOT_DEFINITION_UDF_NAMES = [
     "webAnalyticsGetBotOperator",
 ]
 
-# CREATE OR REPLACE so a later BOT_DEFINITIONS change re-creates the functions idempotently via a
-# follow-up migration. Defaults mirror the inline HogQL builder (traffic_type.py).
+# CREATE OR REPLACE so a follow-up migration can re-create them when BOT_DEFINITIONS changes.
 BOT_DEFINITION_UDFS_SQL = [
     f"CREATE OR REPLACE FUNCTION webAnalyticsIsLikelyBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
     f"CREATE OR REPLACE FUNCTION webAnalyticsGetBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -131,14 +131,15 @@ LAYOUT(REGEXP_TREE())
 """
 
 
-# Bot-detection UDFs. Names mirror the HogQL `__preview_*` functions and every one carries "Bot"
-# so they stay clash-safe in ClickHouse's single global function catalog (no generic single-word
-# name like `name`). Bodies use multiMatchAnyIndex (Hyperscan), NOT the REGEXP_TREE dict's dictGet:
-# benchmarks on real traffic showed dictGet costs 7-46x more CPU and grows with row count, while
-# multiMatch stays flat (~200 ms at any window). SQL UDFs are macro-expanded at query-analysis
-# time, so call sites stay tiny (`getBotName(ua)`) yet execute at full multiMatch speed.
-# BOT_DEFINITIONS remains the single source of truth — the same patterns/labels the dict is
-# seeded from and the inline HogQL path emits.
+# Bot-detection UDFs. Names are prefixed with `webAnalytics` because ClickHouse functions share one
+# global catalog, so generic names risk clashing with built-ins or other products. The HogQL layer
+# exposes them without the prefix (`getBotName`/`isLikelyBot`), so query authors still get clean
+# names while the installed ClickHouse functions stay namespaced. Bodies use multiMatchAnyIndex
+# (Hyperscan), NOT the REGEXP_TREE dict's dictGet: benchmarks on real traffic showed dictGet costs
+# 7-46x more CPU and grows with row count, while multiMatch stays flat (~200 ms at any window). SQL
+# UDFs are macro-expanded at query-analysis time, so call sites stay tiny yet execute at full
+# multiMatch speed. BOT_DEFINITIONS remains the single source of truth — the same patterns/labels
+# the dict is seeded from and the inline HogQL path emits.
 _BOT_UDF_PATTERNS = _format_array([*BOT_DEFINITIONS.keys(), "^$"])
 
 
@@ -151,21 +152,21 @@ def _bot_udf_label_lookup(attr: str, default: str, empty_ua_value: str) -> str:
 
 
 BOT_DEFINITION_UDF_NAMES = [
-    "isLikelyBot",
-    "getBotName",
-    "getBotCategory",
-    "getBotTrafficType",
-    "getBotOperator",
+    "webAnalyticsIsLikelyBot",
+    "webAnalyticsGetBotName",
+    "webAnalyticsGetBotCategory",
+    "webAnalyticsGetBotTrafficType",
+    "webAnalyticsGetBotOperator",
 ]
 
 # CREATE OR REPLACE so a later BOT_DEFINITIONS change re-creates the functions idempotently via a
 # follow-up migration. Defaults mirror the inline HogQL builder (traffic_type.py).
 BOT_DEFINITION_UDFS_SQL = [
-    f"CREATE OR REPLACE FUNCTION isLikelyBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
-    f"CREATE OR REPLACE FUNCTION getBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
-    f"CREATE OR REPLACE FUNCTION getBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
-    f"CREATE OR REPLACE FUNCTION getBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",
-    f"CREATE OR REPLACE FUNCTION getBotOperator AS (ua) -> {_bot_udf_label_lookup('operator', '', '')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsIsLikelyBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsGetBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsGetBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsGetBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsGetBotOperator AS (ua) -> {_bot_udf_label_lookup('operator', '', '')}",
 ]
 
 DROP_BOT_DEFINITION_UDFS_SQL = [f"DROP FUNCTION IF EXISTS {name}" for name in BOT_DEFINITION_UDF_NAMES]

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -131,12 +131,12 @@ LAYOUT(REGEXP_TREE())
 """
 
 
-# Bot-detection UDFs. Names are namespaced (`webAnalytics*`) because ClickHouse functions share
-# one global catalog — a generic `isBot`/`botName` would risk clashing with built-ins or other
-# products. Bodies use multiMatchAnyIndex (Hyperscan), NOT the REGEXP_TREE dict's dictGet:
+# Bot-detection UDFs. Names mirror the HogQL `__preview_*` functions and every one carries "Bot"
+# so they stay clash-safe in ClickHouse's single global function catalog (no generic single-word
+# name like `name`). Bodies use multiMatchAnyIndex (Hyperscan), NOT the REGEXP_TREE dict's dictGet:
 # benchmarks on real traffic showed dictGet costs 7-46x more CPU and grows with row count, while
 # multiMatch stays flat (~200 ms at any window). SQL UDFs are macro-expanded at query-analysis
-# time, so call sites stay tiny (`webAnalyticsBotName(ua)`) yet execute at full multiMatch speed.
+# time, so call sites stay tiny (`getBotName(ua)`) yet execute at full multiMatch speed.
 # BOT_DEFINITIONS remains the single source of truth — the same patterns/labels the dict is
 # seeded from and the inline HogQL path emits.
 _BOT_UDF_PATTERNS = _format_array([*BOT_DEFINITIONS.keys(), "^$"])
@@ -151,21 +151,21 @@ def _bot_udf_label_lookup(attr: str, default: str, empty_ua_value: str) -> str:
 
 
 BOT_DEFINITION_UDF_NAMES = [
-    "webAnalyticsIsBot",
-    "webAnalyticsBotName",
-    "webAnalyticsBotCategory",
-    "webAnalyticsBotTrafficType",
-    "webAnalyticsBotOperator",
+    "isBot",
+    "getBotName",
+    "getBotCategory",
+    "getBotTrafficType",
+    "getBotOperator",
 ]
 
 # CREATE OR REPLACE so a later BOT_DEFINITIONS change re-creates the functions idempotently via a
 # follow-up migration. Defaults mirror the inline HogQL builder (traffic_type.py).
 BOT_DEFINITION_UDFS_SQL = [
-    f"CREATE OR REPLACE FUNCTION webAnalyticsIsBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
-    f"CREATE OR REPLACE FUNCTION webAnalyticsBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
-    f"CREATE OR REPLACE FUNCTION webAnalyticsBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
-    f"CREATE OR REPLACE FUNCTION webAnalyticsBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",
-    f"CREATE OR REPLACE FUNCTION webAnalyticsBotOperator AS (ua) -> {_bot_udf_label_lookup('operator', '', '')}",
+    f"CREATE OR REPLACE FUNCTION isBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
+    f"CREATE OR REPLACE FUNCTION getBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
+    f"CREATE OR REPLACE FUNCTION getBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
+    f"CREATE OR REPLACE FUNCTION getBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",
+    f"CREATE OR REPLACE FUNCTION getBotOperator AS (ua) -> {_bot_udf_label_lookup('operator', '', '')}",
 ]
 
 DROP_BOT_DEFINITION_UDFS_SQL = [f"DROP FUNCTION IF EXISTS {name}" for name in BOT_DEFINITION_UDF_NAMES]

--- a/posthog/models/bot_definition/sql.py
+++ b/posthog/models/bot_definition/sql.py
@@ -129,3 +129,43 @@ PRIMARY KEY regexp
 LIFETIME(MIN 3000 MAX 3600)
 LAYOUT(REGEXP_TREE())
 """
+
+
+# Bot-detection UDFs. Names are namespaced (`webAnalytics*`) because ClickHouse functions share
+# one global catalog — a generic `isBot`/`botName` would risk clashing with built-ins or other
+# products. Bodies use multiMatchAnyIndex (Hyperscan), NOT the REGEXP_TREE dict's dictGet:
+# benchmarks on real traffic showed dictGet costs 7-46x more CPU and grows with row count, while
+# multiMatch stays flat (~200 ms at any window). SQL UDFs are macro-expanded at query-analysis
+# time, so call sites stay tiny (`webAnalyticsBotName(ua)`) yet execute at full multiMatch speed.
+# BOT_DEFINITIONS remains the single source of truth — the same patterns/labels the dict is
+# seeded from and the inline HogQL path emits.
+_BOT_UDF_PATTERNS = _format_array([*BOT_DEFINITIONS.keys(), "^$"])
+
+
+def _bot_udf_label_lookup(attr: str, default: str, empty_ua_value: str) -> str:
+    # Label array aligns with the patterns array: [default, <per-bot attr>…, empty_ua_value].
+    # multiMatchAnyIndex returns 0 (no match) or 1..N+1 ("^$" is N+1); arrayElement(arr, idx + 1)
+    # then maps 0 -> default, k -> attr of bot k, N+1 -> empty_ua_value.
+    labels = [default, *(getattr(bot, attr) for bot in BOT_DEFINITIONS.values()), empty_ua_value]
+    return f"arrayElement({_format_array(labels)}, multiMatchAnyIndex(ifNull(ua, ''), {_BOT_UDF_PATTERNS}) + 1)"
+
+
+BOT_DEFINITION_UDF_NAMES = [
+    "webAnalyticsIsBot",
+    "webAnalyticsBotName",
+    "webAnalyticsBotCategory",
+    "webAnalyticsBotTrafficType",
+    "webAnalyticsBotOperator",
+]
+
+# CREATE OR REPLACE so a later BOT_DEFINITIONS change re-creates the functions idempotently via a
+# follow-up migration. Defaults mirror the inline HogQL builder (traffic_type.py).
+BOT_DEFINITION_UDFS_SQL = [
+    f"CREATE OR REPLACE FUNCTION webAnalyticsIsBot AS (ua) -> multiMatchAny(ifNull(ua, ''), {_BOT_UDF_PATTERNS})",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsBotName AS (ua) -> {_bot_udf_label_lookup('name', '', '')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsBotCategory AS (ua) -> {_bot_udf_label_lookup('category', 'regular', 'no_user_agent')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsBotTrafficType AS (ua) -> {_bot_udf_label_lookup('traffic_type', 'Regular', 'Automation')}",
+    f"CREATE OR REPLACE FUNCTION webAnalyticsBotOperator AS (ua) -> {_bot_udf_label_lookup('operator', '', '')}",
+]
+
+DROP_BOT_DEFINITION_UDFS_SQL = [f"DROP FUNCTION IF EXISTS {name}" for name in BOT_DEFINITION_UDF_NAMES]

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -5,6 +5,7 @@ from posthog.models.bot_definition.sql import (
     BOT_DEFINITION_UDFS_SQL,
     DROP_BOT_DEFINITION_UDFS_SQL,
     _bot_definition_rows,
+    _format_array,
 )
 
 from products.web_analytics.backend.hogql_queries.bot_definitions import BOT_DEFINITIONS
@@ -150,27 +151,30 @@ class TestBotDefinitionUDFs:
             assert name.startswith("webAnalytics"), f"UDF {name} is not namespaced"
             assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
 
-    def test_udfs_use_multimatch_not_dictget(self):
+    def test_no_udf_uses_dictget(self):
         # The whole point: multiMatch (Hyperscan) is 7-46x cheaper than the REGEXP_TREE dictGet.
         for sql in BOT_DEFINITION_UDFS_SQL:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
-        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
-        assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index
-        for name in ("webAnalyticsBotName", "webAnalyticsBotCategory", "webAnalyticsBotTrafficType"):
-            sql = next(s for s in BOT_DEFINITION_UDFS_SQL if name in s)
-            assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
-            assert "arrayElement(" in sql
 
-    def test_label_arrays_align_with_patterns(self):
-        # arrayElement(arr, multiMatchAnyIndex(...) + 1): arr must be [default, <N bots>, empty_ua],
-        # i.e. len(BOT_DEFINITIONS) + 2, so index 0 -> default and index N+1 (^$) -> empty_ua_value.
+    def test_isbot_uses_cheapest_multimatchany(self):
+        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
+        assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index lookup
+
+    # Derive the attribute UDFs from the canonical name list so a newly added UDF can't be
+    # silently skipped (it gets parametrized automatically).
+    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "webAnalyticsIsBot"])
+    def test_attribute_udf_uses_multimatchanyindex(self, udf_name):
+        sql = next(s for s in BOT_DEFINITION_UDFS_SQL if udf_name in s)
+        assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
+        assert "arrayElement(" in sql
+
+    def test_label_array_aligns_with_patterns(self):
+        # arrayElement(arr, multiMatchAnyIndex(...) + 1): arr must be [default, <N bots>, empty_ua].
+        # Reconstruct the expected array literal with the same escaping rather than counting quotes
+        # (apostrophe-safe: a label like "it's bot" escapes to '' and would break a naive count).
+        expected = _format_array(["", *(bot.name for bot in BOT_DEFINITIONS.values()), ""])
         bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsBotName" in s)
-        # count quoted elements in the first array literal of the lookup
-        array_literal = bot_name_sql[
-            bot_name_sql.index("arrayElement([") + len("arrayElement(") : bot_name_sql.index("], multiMatch") + 1
-        ]
-        n_elements = array_literal.count("'") // 2
-        assert n_elements == len(BOT_DEFINITIONS) + 2
+        assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
 
     def test_isbot_equivalent_to_traffic_type_not_regular(self):
         # webAnalyticsIsBot is multiMatchAny (any pattern matches). That equals the dict's

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -142,13 +142,13 @@ class TestBotDefinitionsDataStructure:
 
 
 class TestBotDefinitionUDFs:
-    def test_all_five_udfs_generated_with_namespaced_names(self):
-        # Namespaced (webAnalytics*) to avoid clashing with built-ins / other products in
-        # ClickHouse's single global function catalog.
+    def test_all_five_udfs_generated_with_clash_safe_names(self):
+        # Every UDF name carries "Bot" so it stays clash-safe in ClickHouse's single global
+        # function catalog (no generic single-word name).
         assert len(BOT_DEFINITION_UDFS_SQL) == 5
         joined = "\n".join(BOT_DEFINITION_UDFS_SQL)
         for name in BOT_DEFINITION_UDF_NAMES:
-            assert name.startswith("webAnalytics"), f"UDF {name} is not namespaced"
+            assert "Bot" in name, f"UDF {name} is not bot-specific (clash risk)"
             assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
 
     def test_no_udf_uses_dictget(self):
@@ -157,12 +157,12 @@ class TestBotDefinitionUDFs:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
 
     def test_isbot_uses_cheapest_multimatchany(self):
-        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
+        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "isBot" in s)
         assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index lookup
 
     # Derive the attribute UDFs from the canonical name list so a newly added UDF can't be
     # silently skipped (it gets parametrized automatically).
-    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "webAnalyticsIsBot"])
+    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "isBot"])
     def test_attribute_udf_uses_multimatchanyindex(self, udf_name):
         sql = next(s for s in BOT_DEFINITION_UDFS_SQL if udf_name in s)
         assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
@@ -173,11 +173,11 @@ class TestBotDefinitionUDFs:
         # Reconstruct the expected array literal with the same escaping rather than counting quotes
         # (apostrophe-safe: a label like "it's bot" escapes to '' and would break a naive count).
         expected = _format_array(["", *(bot.name for bot in BOT_DEFINITIONS.values()), ""])
-        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsBotName" in s)
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "getBotName" in s)
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
 
     def test_isbot_equivalent_to_traffic_type_not_regular(self):
-        # webAnalyticsIsBot is multiMatchAny (any pattern matches). That equals the dict's
+        # isBot is multiMatchAny (any pattern matches). That equals the dict's
         # "traffic_type != 'Regular'" only if every defined bot is non-Regular — assert it holds.
         for pattern, bot in BOT_DEFINITIONS.items():
             assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type; isBot would diverge"
@@ -189,7 +189,7 @@ class TestBotDefinitionUDFs:
 
     def test_patterns_match_inline_hogql_path(self):
         # The UDF patterns must be exactly the inline HogQL path's patterns (parity): bot keys + ^$.
-        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "isBot" in s)
         for pattern in BOT_DEFINITIONS:
             assert pattern.replace("\\", "\\\\").replace("'", "''") in bot_name_sql
         assert "'^$'" in bot_name_sql

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -142,13 +142,13 @@ class TestBotDefinitionsDataStructure:
 
 
 class TestBotDefinitionUDFs:
-    def test_all_five_udfs_generated_with_clash_safe_names(self):
-        # Every UDF name carries "Bot" so it stays clash-safe in ClickHouse's single global
-        # function catalog (no generic single-word name).
+    def test_all_five_udfs_generated_with_namespaced_names(self):
+        # Namespaced with a webAnalytics prefix to stay clash-safe in ClickHouse's single global
+        # function catalog (the HogQL layer exposes them without the prefix).
         assert len(BOT_DEFINITION_UDFS_SQL) == 5
         joined = "\n".join(BOT_DEFINITION_UDFS_SQL)
         for name in BOT_DEFINITION_UDF_NAMES:
-            assert "Bot" in name, f"UDF {name} is not bot-specific (clash risk)"
+            assert name.startswith("webAnalytics"), f"UDF {name} is not namespaced (clash risk)"
             assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
 
     def test_no_udf_uses_dictget(self):
@@ -157,12 +157,12 @@ class TestBotDefinitionUDFs:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
 
     def test_isbot_uses_cheapest_multimatchany(self):
-        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "isLikelyBot" in s)
+        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsLikelyBot" in s)
         assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index lookup
 
     # Derive the attribute UDFs from the canonical name list so a newly added UDF can't be
     # silently skipped (it gets parametrized automatically).
-    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "isLikelyBot"])
+    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "webAnalyticsIsLikelyBot"])
     def test_attribute_udf_uses_multimatchanyindex(self, udf_name):
         sql = next(s for s in BOT_DEFINITION_UDFS_SQL if udf_name in s)
         assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
@@ -173,14 +173,16 @@ class TestBotDefinitionUDFs:
         # Reconstruct the expected array literal with the same escaping rather than counting quotes
         # (apostrophe-safe: a label like "it's bot" escapes to '' and would break a naive count).
         expected = _format_array(["", *(bot.name for bot in BOT_DEFINITIONS.values()), ""])
-        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "getBotName" in s)
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsGetBotName" in s)
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
 
     def test_isbot_equivalent_to_traffic_type_not_regular(self):
-        # isLikelyBot is multiMatchAny (any pattern matches). That equals the dict's
+        # webAnalyticsIsLikelyBot is multiMatchAny (any pattern matches). That equals the dict's
         # "traffic_type != 'Regular'" only if every defined bot is non-Regular — assert it holds.
         for pattern, bot in BOT_DEFINITIONS.items():
-            assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type; isLikelyBot would diverge"
+            assert bot.traffic_type != "Regular", (
+                f"{pattern} has Regular traffic_type; webAnalyticsIsLikelyBot would diverge"
+            )
 
     def test_drop_statements_cover_every_udf(self):
         assert len(DROP_BOT_DEFINITION_UDFS_SQL) == len(BOT_DEFINITION_UDF_NAMES)
@@ -189,7 +191,7 @@ class TestBotDefinitionUDFs:
 
     def test_patterns_match_inline_hogql_path(self):
         # The UDF patterns must be exactly the inline HogQL path's patterns (parity): bot keys + ^$.
-        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "isLikelyBot" in s)
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsLikelyBot" in s)
         for pattern in BOT_DEFINITIONS:
             assert pattern.replace("\\", "\\\\").replace("'", "''") in bot_name_sql
         assert "'^$'" in bot_name_sql

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -152,7 +152,6 @@ class TestBotDefinitionUDFs:
             assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
 
     def test_no_udf_uses_dictget(self):
-        # multiMatch, not the dict's dictGet (much cheaper per row).
         for sql in BOT_DEFINITION_UDFS_SQL:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
 
@@ -174,13 +173,10 @@ class TestBotDefinitionUDFs:
         bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsGetBotName" in s)
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
 
-    def test_isbot_equivalent_to_traffic_type_not_regular(self):
-        # webAnalyticsIsLikelyBot is multiMatchAny (any pattern matches). That equals the dict's
-        # "traffic_type != 'Regular'" only if every defined bot is non-Regular — assert it holds.
+    def test_every_bot_is_non_regular(self):
+        # isLikelyBot is multiMatchAny (any pattern matches), correct only if no bot is "Regular".
         for pattern, bot in BOT_DEFINITIONS.items():
-            assert bot.traffic_type != "Regular", (
-                f"{pattern} has Regular traffic_type; webAnalyticsIsLikelyBot would diverge"
-            )
+            assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type"
 
     def test_drop_statements_cover_every_udf(self):
         assert len(DROP_BOT_DEFINITION_UDFS_SQL) == len(BOT_DEFINITION_UDF_NAMES)

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -157,12 +157,12 @@ class TestBotDefinitionUDFs:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
 
     def test_isbot_uses_cheapest_multimatchany(self):
-        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "isBot" in s)
+        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "isLikelyBot" in s)
         assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index lookup
 
     # Derive the attribute UDFs from the canonical name list so a newly added UDF can't be
     # silently skipped (it gets parametrized automatically).
-    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "isBot"])
+    @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "isLikelyBot"])
     def test_attribute_udf_uses_multimatchanyindex(self, udf_name):
         sql = next(s for s in BOT_DEFINITION_UDFS_SQL if udf_name in s)
         assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
@@ -177,10 +177,10 @@ class TestBotDefinitionUDFs:
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
 
     def test_isbot_equivalent_to_traffic_type_not_regular(self):
-        # isBot is multiMatchAny (any pattern matches). That equals the dict's
+        # isLikelyBot is multiMatchAny (any pattern matches). That equals the dict's
         # "traffic_type != 'Regular'" only if every defined bot is non-Regular — assert it holds.
         for pattern, bot in BOT_DEFINITIONS.items():
-            assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type; isBot would diverge"
+            assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type; isLikelyBot would diverge"
 
     def test_drop_statements_cover_every_udf(self):
         assert len(DROP_BOT_DEFINITION_UDFS_SQL) == len(BOT_DEFINITION_UDF_NAMES)
@@ -189,7 +189,7 @@ class TestBotDefinitionUDFs:
 
     def test_patterns_match_inline_hogql_path(self):
         # The UDF patterns must be exactly the inline HogQL path's patterns (parity): bot keys + ^$.
-        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "isBot" in s)
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "isLikelyBot" in s)
         for pattern in BOT_DEFINITIONS:
             assert pattern.replace("\\", "\\\\").replace("'", "''") in bot_name_sql
         assert "'^$'" in bot_name_sql

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -143,8 +143,6 @@ class TestBotDefinitionsDataStructure:
 
 class TestBotDefinitionUDFs:
     def test_all_five_udfs_generated_with_namespaced_names(self):
-        # Namespaced with a webAnalytics prefix to stay clash-safe in ClickHouse's single global
-        # function catalog (the HogQL layer exposes them without the prefix).
         assert len(BOT_DEFINITION_UDFS_SQL) == 5
         joined = "\n".join(BOT_DEFINITION_UDFS_SQL)
         for name in BOT_DEFINITION_UDF_NAMES:
@@ -157,10 +155,8 @@ class TestBotDefinitionUDFs:
 
     def test_isbot_uses_cheapest_multimatchany(self):
         is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsLikelyBot" in s)
-        assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index lookup
+        assert "multiMatchAny(ifNull(ua, '')," in is_bot
 
-    # Derive the attribute UDFs from the canonical name list so a newly added UDF can't be
-    # silently skipped (it gets parametrized automatically).
     @pytest.mark.parametrize("udf_name", [n for n in BOT_DEFINITION_UDF_NAMES if n != "webAnalyticsIsLikelyBot"])
     def test_attribute_udf_uses_multimatchanyindex(self, udf_name):
         sql = next(s for s in BOT_DEFINITION_UDFS_SQL if udf_name in s)
@@ -168,7 +164,6 @@ class TestBotDefinitionUDFs:
         assert "arrayElement(" in sql
 
     def test_label_array_aligns_with_patterns(self):
-        # Reconstruct the expected [default, <N bots>, empty_ua] array (apostrophe-safe vs counting quotes).
         expected = _format_array(["", *(bot.name for bot in BOT_DEFINITIONS.values()), ""])
         bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsGetBotName" in s)
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql
@@ -184,7 +179,6 @@ class TestBotDefinitionUDFs:
             assert f"DROP FUNCTION IF EXISTS {name}" in DROP_BOT_DEFINITION_UDFS_SQL
 
     def test_patterns_match_inline_hogql_path(self):
-        # The UDF patterns must be exactly the inline HogQL path's patterns (parity): bot keys + ^$.
         bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsLikelyBot" in s)
         for pattern in BOT_DEFINITIONS:
             assert pattern.replace("\\", "\\\\").replace("'", "''") in bot_name_sql

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -152,7 +152,7 @@ class TestBotDefinitionUDFs:
             assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
 
     def test_no_udf_uses_dictget(self):
-        # The whole point: multiMatch (Hyperscan) is 7-46x cheaper than the REGEXP_TREE dictGet.
+        # multiMatch, not the dict's dictGet (much cheaper per row).
         for sql in BOT_DEFINITION_UDFS_SQL:
             assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
 
@@ -169,9 +169,7 @@ class TestBotDefinitionUDFs:
         assert "arrayElement(" in sql
 
     def test_label_array_aligns_with_patterns(self):
-        # arrayElement(arr, multiMatchAnyIndex(...) + 1): arr must be [default, <N bots>, empty_ua].
-        # Reconstruct the expected array literal with the same escaping rather than counting quotes
-        # (apostrophe-safe: a label like "it's bot" escapes to '' and would break a naive count).
+        # Reconstruct the expected [default, <N bots>, empty_ua] array (apostrophe-safe vs counting quotes).
         expected = _format_array(["", *(bot.name for bot in BOT_DEFINITIONS.values()), ""])
         bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsGetBotName" in s)
         assert f"arrayElement({expected}, multiMatchAnyIndex(" in bot_name_sql

--- a/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_bot_definitions.py
@@ -1,6 +1,11 @@
 import pytest
 
-from posthog.models.bot_definition.sql import _bot_definition_rows
+from posthog.models.bot_definition.sql import (
+    BOT_DEFINITION_UDF_NAMES,
+    BOT_DEFINITION_UDFS_SQL,
+    DROP_BOT_DEFINITION_UDFS_SQL,
+    _bot_definition_rows,
+)
 
 from products.web_analytics.backend.hogql_queries.bot_definitions import BOT_DEFINITIONS
 
@@ -133,3 +138,54 @@ class TestBotDefinitionsDataStructure:
                     assert patterns.index(p2) < patterns.index(p1), (
                         f"{p2} must come before {p1} to avoid ambiguity in REGEXP_TREE matching"
                     )
+
+
+class TestBotDefinitionUDFs:
+    def test_all_five_udfs_generated_with_namespaced_names(self):
+        # Namespaced (webAnalytics*) to avoid clashing with built-ins / other products in
+        # ClickHouse's single global function catalog.
+        assert len(BOT_DEFINITION_UDFS_SQL) == 5
+        joined = "\n".join(BOT_DEFINITION_UDFS_SQL)
+        for name in BOT_DEFINITION_UDF_NAMES:
+            assert name.startswith("webAnalytics"), f"UDF {name} is not namespaced"
+            assert f"CREATE OR REPLACE FUNCTION {name} AS (ua)" in joined
+
+    def test_udfs_use_multimatch_not_dictget(self):
+        # The whole point: multiMatch (Hyperscan) is 7-46x cheaper than the REGEXP_TREE dictGet.
+        for sql in BOT_DEFINITION_UDFS_SQL:
+            assert "dictGet" not in sql, f"UDF must not use dictGet: {sql[:80]}"
+        is_bot = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
+        assert "multiMatchAny(ifNull(ua, '')," in is_bot  # boolean: cheapest form, no index
+        for name in ("webAnalyticsBotName", "webAnalyticsBotCategory", "webAnalyticsBotTrafficType"):
+            sql = next(s for s in BOT_DEFINITION_UDFS_SQL if name in s)
+            assert "multiMatchAnyIndex(ifNull(ua, '')," in sql
+            assert "arrayElement(" in sql
+
+    def test_label_arrays_align_with_patterns(self):
+        # arrayElement(arr, multiMatchAnyIndex(...) + 1): arr must be [default, <N bots>, empty_ua],
+        # i.e. len(BOT_DEFINITIONS) + 2, so index 0 -> default and index N+1 (^$) -> empty_ua_value.
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsBotName" in s)
+        # count quoted elements in the first array literal of the lookup
+        array_literal = bot_name_sql[
+            bot_name_sql.index("arrayElement([") + len("arrayElement(") : bot_name_sql.index("], multiMatch") + 1
+        ]
+        n_elements = array_literal.count("'") // 2
+        assert n_elements == len(BOT_DEFINITIONS) + 2
+
+    def test_isbot_equivalent_to_traffic_type_not_regular(self):
+        # webAnalyticsIsBot is multiMatchAny (any pattern matches). That equals the dict's
+        # "traffic_type != 'Regular'" only if every defined bot is non-Regular — assert it holds.
+        for pattern, bot in BOT_DEFINITIONS.items():
+            assert bot.traffic_type != "Regular", f"{pattern} has Regular traffic_type; isBot would diverge"
+
+    def test_drop_statements_cover_every_udf(self):
+        assert len(DROP_BOT_DEFINITION_UDFS_SQL) == len(BOT_DEFINITION_UDF_NAMES)
+        for name in BOT_DEFINITION_UDF_NAMES:
+            assert f"DROP FUNCTION IF EXISTS {name}" in DROP_BOT_DEFINITION_UDFS_SQL
+
+    def test_patterns_match_inline_hogql_path(self):
+        # The UDF patterns must be exactly the inline HogQL path's patterns (parity): bot keys + ^$.
+        bot_name_sql = next(s for s in BOT_DEFINITION_UDFS_SQL if "webAnalyticsIsBot" in s)
+        for pattern in BOT_DEFINITIONS:
+            assert pattern.replace("\\", "\\\\").replace("'", "''") in bot_name_sql
+        assert "'^$'" in bot_name_sql


### PR DESCRIPTION
## Problem

We shipped a `web_bot_definition` REGEXP_TREE dictionary (#60586) as the storage/source-of-truth but benchmarking the realistic bot-analytics query on real posthog.com traffic (project 371937, materialized-column path) showed the REGEXP_TREE `dictGet` is a **regression** versus the current inline `multiMatchAnyIndex` performance-wise:

| Window | OLD `multiMatchAnyIndex` | `dictGet` (REGEXP_TREE) |
|---|---|---|
| 1d | ~190 ms / 0.4 s CPU | ~950 ms / **~20× CPU** |
| 7d | ~235 ms / 1.5 s CPU | ~4.9 s / **~46× CPU** |

`multiMatchAnyIndex` is a vectorized Hyperscan column scan and stays **flat (~200 ms + I/O at any volume)**; `dictGet` is a per-row dictionary call that doesn't vectorize, so CPU grows with rows. Accuracy is identical (99.9% parity; both validated against an external benchmark).

## Changes

Expose bot detection as **namespaced SQL UDFs whose bodies use `multiMatch`, not `dictGet`** — getting the dict's maintainability win without its query-time cost:

- `webAnalyticsIsBot(ua)` → `multiMatchAny(...)` (cheapest, boolean)
- `webAnalyticsBotName / BotCategory / BotTrafficType / BotOperator(ua)` → `arrayElement([labels], multiMatchAnyIndex(...) + 1)`

Why this shape:
- **UDF, not inline.** ClickHouse SQL UDFs are macro-expanded at query-analysis time, so the call site stays tiny (`webAnalyticsBotName(ua)`) at **both** the HogQL and ClickHouse-SQL layers, while the executed plan is the full `multiMatch` — full Hyperscan speed, no per-row wrapper overhead. The 25 KB pattern array lives once in the function catalog, never in a query or `query_log` row.
- **Namespaced names.** ClickHouse functions share one global catalog, so a generic `isBot`/`botName` risks clashing with built-ins or other products. `webAnalytics*` keeps them collision-free.
- **`multiMatch`, not `dictGet`.** The dict stays as raw-SQL-queryable storage; the hot query path never calls `dictGet`.
- **One source of truth.** Bodies are generated from `BOT_DEFINITIONS` — the same patterns/labels the dict is seeded from and the inline HogQL path emits — so dict, inline, and UDF can't diverge.

Scope is migration-only (migration + the SQL definitions it depends on + tests). Wiring the HogQL bot functions to call these UDFs is the follow-up.

## How did you test this code?

Agent-authored. Automated only:
- 6 new unit tests in `test_bot_definitions.py` asserting: 5 namespaced UDFs generated; **no `dictGet`** anywhere; `isBot` uses `multiMatchAny` and the attr UDFs use `multiMatchAnyIndex`; label arrays align with the patterns array (`len + 2`); patterns match the inline HogQL path; every bot is non-`Regular` (so `isBot = multiMatchAny` ≡ "traffic_type != Regular"); drops cover every UDF. Full bot suite passes (62), `ruff` clean.
- Perf claims come from `system.query_log` benchmarking via Metabase across 6h/1d/3d/7d windows.

**Validation gate before merge:** confirm on a dev/local ClickHouse that `CREATE FUNCTION … -> multiMatch…` **inlines at analysis time** (so `webAnalyticsBotName(ua)` matches raw `multiMatchAnyIndex(...)` on latency/CPU) — documented behavior, but it's the linchpin of the approach. If it ever failed to inline, the fallback is the equivalent table-subquery form.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Skip.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @lricoy. Origin: a perf/maintainability investigation of the bot-detection stack. We benchmarked `multiMatchAnyIndex` vs REGEXP_TREE `dictGet` on real traffic (materialized columns, 6h→7d) and found dictGet 7–46× CPU and scaling badly, so we kept `multiMatch` as the matcher and chose a UDF purely as the maintainability layer (clean call site, single source of truth, tiny queries). Names were deliberately namespaced to avoid global-catalog clashes. This supersedes the earlier dictGet-based UDF approach.
