### PR TITLE
refactor(experiments): compute running-time estimates via backend

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
@@ -27,7 +27,7 @@ export const RunningTime = ({
         isComplete,
         isManualMode,
         primaryMetricsResultsLoading,
-    } = useValues(runningTimeLogic({ experimentId: experiment.id }))
+    } = useValues(runningTimeLogic({ experimentId: experiment.id, experiment }))
 
     const showProgress = currentExposures !== null && targetSampleSize !== null
 
@@ -80,7 +80,7 @@ export const RunningTime = ({
                     />
                 </div>
             </div>
-            <RunningTimeConfigModal experimentId={experiment.id} />
+            <RunningTimeConfigModal experimentId={experiment.id} experiment={experiment} />
         </>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/RunningTime.tsx
@@ -27,7 +27,7 @@ export const RunningTime = ({
         isComplete,
         isManualMode,
         primaryMetricsResultsLoading,
-    } = useValues(runningTimeLogic({ experimentId: experiment.id, experiment }))
+    } = useValues(runningTimeLogic({ experiment }))
 
     const showProgress = currentExposures !== null && targetSampleSize !== null
 
@@ -80,7 +80,7 @@ export const RunningTime = ({
                     />
                 </div>
             </div>
-            <RunningTimeConfigModal experimentId={experiment.id} experiment={experiment} />
+            <RunningTimeConfigModal experiment={experiment} />
         </>
     )
 }

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
@@ -13,7 +13,6 @@ import { ManualCalculatorMetricType } from './calculations'
 import { runningTimeLogic } from './runningTimeLogic'
 
 export interface RunningTimeConfigModalProps {
-    experimentId: Experiment['id']
     experiment: Experiment
 }
 
@@ -45,10 +44,7 @@ function getBaselineHelp(metricType: ManualCalculatorMetricType): string {
     }
 }
 
-export function RunningTimeConfigModal({
-    experimentId,
-    experiment: experimentProp,
-}: RunningTimeConfigModalProps): JSX.Element {
+export function RunningTimeConfigModal({ experiment: experimentProp }: RunningTimeConfigModalProps): JSX.Element {
     const {
         config,
         manualFormPreview,
@@ -59,8 +55,8 @@ export function RunningTimeConfigModal({
         isRunningTimeConfigModalOpen,
         experiment,
         isSaving,
-    } = useValues(runningTimeLogic({ experimentId, experiment: experimentProp }))
-    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId, experiment: experimentProp }))
+    } = useValues(runningTimeLogic({ experiment: experimentProp }))
+    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experiment: experimentProp }))
 
     const hasAutomaticData = remainingDays !== null
     const isPreLaunch = !isLaunched(experiment)

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeConfigModal.tsx
@@ -14,6 +14,7 @@ import { runningTimeLogic } from './runningTimeLogic'
 
 export interface RunningTimeConfigModalProps {
     experimentId: Experiment['id']
+    experiment: Experiment
 }
 
 const METRIC_TYPE_OPTIONS: { value: ManualCalculatorMetricType; label: string }[] = [
@@ -44,7 +45,10 @@ function getBaselineHelp(metricType: ManualCalculatorMetricType): string {
     }
 }
 
-export function RunningTimeConfigModal({ experimentId }: RunningTimeConfigModalProps): JSX.Element {
+export function RunningTimeConfigModal({
+    experimentId,
+    experiment: experimentProp,
+}: RunningTimeConfigModalProps): JSX.Element {
     const {
         config,
         manualFormPreview,
@@ -54,8 +58,9 @@ export function RunningTimeConfigModal({ experimentId }: RunningTimeConfigModalP
         remainingDays,
         isRunningTimeConfigModalOpen,
         experiment,
-    } = useValues(runningTimeLogic({ experimentId }))
-    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId }))
+        isSaving,
+    } = useValues(runningTimeLogic({ experimentId, experiment: experimentProp }))
+    const { setConfig, save, cancel } = useActions(runningTimeLogic({ experimentId, experiment: experimentProp }))
 
     const hasAutomaticData = remainingDays !== null
     const isPreLaunch = !isLaunched(experiment)
@@ -267,10 +272,10 @@ export function RunningTimeConfigModal({ experimentId }: RunningTimeConfigModalP
                     </div>
                 )}
                 <div className="flex items-center gap-2 justify-end w-full">
-                    <LemonButton type="secondary" onClick={cancel}>
+                    <LemonButton type="secondary" onClick={cancel} disabledReason={isSaving ? 'Saving…' : undefined}>
                         Cancel
                     </LemonButton>
-                    <LemonButton type="primary" onClick={save}>
+                    <LemonButton type="primary" onClick={save} loading={isSaving}>
                         Save
                     </LemonButton>
                 </div>

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/calculations.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/calculations.test.ts
@@ -6,601 +6,130 @@ import {
     ExperimentMetricType,
     NodeKind,
 } from '~/queries/schema/schema-general'
-import { Experiment, ExperimentMetricMathType, FeatureFlagBasicType } from '~/types'
+import { ExperimentMetricMathType } from '~/types'
 
-import { calculateBaselineValue, calculateRecommendedSampleSize, calculateVarianceFromResults } from './calculations'
+import {
+    baselineStatsFromResults,
+    calculateCurrentExposures,
+    calculateDaysElapsed,
+    calculateExposureRate,
+    getCalculatorMetricType,
+} from './calculations'
 
-describe('calculations', () => {
-    // Should match https://docs.google.com/spreadsheets/d/11alyC8n7uqewZFLKfV4UAbW-0zH__EdV_Hrk2OQ4140/edit?gid=777532876#gid=777532876
-    describe('calculations for MEAN total count', () => {
-        const metric: ExperimentMetric = {
-            uuid: uuid(),
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.MEAN,
-            source: {
-                kind: NodeKind.EventsNode,
-                event: 'experiment created',
-                math: ExperimentMetricMathType.TotalCount,
-            },
-        }
+// The sample-size / variance math is verified in the backend
+// (products/experiments/backend/test/test_running_time_calculator.py). These tests
+// cover the client-side helpers that classify metrics and read live experiment state.
+describe('running time calculations', () => {
+    describe('getCalculatorMetricType', () => {
+        const meanMetric = (math: ExperimentMetricMathType): ExperimentMetric =>
+            ({
+                uuid: uuid(),
+                kind: NodeKind.ExperimentMetric,
+                metric_type: ExperimentMetricType.MEAN,
+                source: { kind: NodeKind.EventsNode, event: 'evt', math },
+            }) as ExperimentMetric
 
-        const experiment = {
-            feature_flag: {
-                filters: {
-                    multivariate: {
-                        variants: [
-                            {
-                                key: 'control',
-                                rollout_percentage: 50,
-                            },
-                            {
-                                key: 'test',
-                                rollout_percentage: 50,
-                            },
-                        ],
-                    },
-                },
-            } as unknown as FeatureFlagBasicType,
-        } as Partial<Experiment> as Experiment
+        it('classifies mean count', () => {
+            expect(getCalculatorMetricType(meanMetric(ExperimentMetricMathType.TotalCount))).toBe('mean_count')
+        })
 
-        it('calculates baseline value, variance, and recommended sample size correctly', () => {
-            // Old test input: { uniqueUsers: 14000, averageEventsPerUser: 4 }
-            // New baseline format: sum = uniqueUsers * averageEventsPerUser
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 14000,
-                sum: 56000, // 14000 * 4
-                sum_squares: 0, // Not used
-                step_counts: [],
-            }
+        it('classifies mean sum', () => {
+            expect(getCalculatorMetricType(meanMetric(ExperimentMetricMathType.Sum))).toBe('mean_sum_or_avg')
+        })
 
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBe(4) // averageEventsPerUser
+        it('classifies funnel', () => {
+            const metric = {
+                uuid: uuid(),
+                metric_type: ExperimentMetricType.FUNNEL,
+                series: [{ kind: NodeKind.EventsNode, event: 'step' }],
+            } as ExperimentMetric
+            expect(getCalculatorMetricType(metric)).toBe('funnel')
+        })
 
-            const variance = calculateVarianceFromResults(baselineValue!, metric)
-            expect(variance).toBe(8) // VARIANCE_SCALING_FACTOR_TOTAL_COUNT (2) * 4
+        it('classifies ratio', () => {
+            const metric = {
+                uuid: uuid(),
+                kind: NodeKind.ExperimentMetric,
+                metric_type: ExperimentMetricType.RATIO,
+                numerator: { kind: NodeKind.EventsNode, event: 'purchase' },
+                denominator: { kind: NodeKind.EventsNode, event: 'page_view' },
+            } as ExperimentMetric
+            expect(getCalculatorMetricType(metric)).toBe('ratio')
+        })
 
-            const numberOfVariants = experiment.feature_flag?.filters.multivariate?.variants.length ?? 2
-            const minimumDetectableEffect = 5
-
-            const recommendedSampleSize = calculateRecommendedSampleSize(
-                metric,
-                minimumDetectableEffect,
-                baselineValue!,
-                numberOfVariants
-            )
-
-            expect(recommendedSampleSize).toBeCloseTo(6400, 0)
+        it('classifies retention', () => {
+            const metric = {
+                uuid: uuid(),
+                kind: NodeKind.ExperimentMetric,
+                metric_type: ExperimentMetricType.RETENTION,
+                start_event: { kind: NodeKind.EventsNode, event: 'uploaded' },
+                completion_event: { kind: NodeKind.EventsNode, event: 'downloaded' },
+            } as ExperimentMetric
+            expect(getCalculatorMetricType(metric)).toBe('retention')
         })
     })
 
-    // Should match https://docs.google.com/spreadsheets/d/11alyC8n7uqewZFLKfV4UAbW-0zH__EdV_Hrk2OQ4140/edit?gid=2067479228#gid=2067479228
-    describe('calculations for MEAN sum', () => {
-        const metric: ExperimentMetric = {
-            uuid: uuid(),
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.MEAN,
-            source: {
-                kind: NodeKind.EventsNode,
-                event: 'experiment created',
-                math: ExperimentMetricMathType.Sum,
-            },
-        }
-
-        const experiment = {
-            feature_flag: {
-                filters: {
-                    multivariate: {
-                        variants: [
-                            {
-                                key: 'control',
-                                rollout_percentage: 50,
-                            },
-                            {
-                                key: 'test',
-                                rollout_percentage: 50,
-                            },
-                        ],
-                    },
-                },
-            } as unknown as FeatureFlagBasicType,
-        } as Partial<Experiment> as Experiment
-
-        it('calculates baseline value, variance, and recommended sample size correctly', () => {
-            // Old test input: { uniqueUsers: 14000, averagePropertyValuePerUser: 50 }
-            // New baseline format: sum = uniqueUsers * averagePropertyValuePerUser
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 14000,
-                sum: 700000, // 14000 * 50
-                sum_squares: 0, // Not used
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBe(50) // averagePropertyValuePerUser
-
-            const variance = calculateVarianceFromResults(baselineValue!, metric)
-            expect(variance).toBeCloseTo(625, 0) // VARIANCE_SCALING_FACTOR_SUM (0.25) * 50^2
-
-            const numberOfVariants = experiment.feature_flag?.filters.multivariate?.variants.length ?? 2
-            const minimumDetectableEffect = 5
-
-            const recommendedSampleSize = calculateRecommendedSampleSize(
-                metric,
-                minimumDetectableEffect,
-                baselineValue!,
-                numberOfVariants
-            )
-
-            expect(recommendedSampleSize).toBeCloseTo(3200, 0)
-        })
-    })
-
-    // Should match https://docs.google.com/spreadsheets/d/11alyC8n7uqewZFLKfV4UAbW-0zH__EdV_Hrk2OQ4140/edit?gid=0#gid=0
-    describe('calculations for FUNNEL', () => {
-        const metric: ExperimentMetric = {
-            uuid: uuid(),
-            metric_type: ExperimentMetricType.FUNNEL,
-            series: [
-                {
-                    kind: NodeKind.EventsNode,
-                    event: 'first_step',
-                },
-                {
-                    kind: NodeKind.EventsNode,
-                    event: 'final_step',
-                },
-            ],
-        } as ExperimentMetric
-
-        const experiment = {
-            feature_flag: {
-                filters: {
-                    multivariate: {
-                        variants: [
-                            {
-                                key: 'control',
-                                rollout_percentage: 50,
-                            },
-                            {
-                                key: 'test',
-                                rollout_percentage: 50,
-                            },
-                        ],
-                    },
-                },
-            } as unknown as FeatureFlagBasicType,
-        } as Partial<Experiment> as Experiment
-
-        it('calculates baseline value and recommended sample size correctly', () => {
-            // Old test input: { uniqueUsers: 1000, automaticConversionRateDecimal: 0.1 }
-            // New baseline format: step_counts where last/total = conversion rate
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 100, // number of conversions
-                sum_squares: 0, // Not used
-                step_counts: [1000, 100], // first step count, final step count
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBe(0.1) // conversionRate = 100/1000
-
-            // Funnel metrics don't use separate variance calculation
-            const variance = calculateVarianceFromResults(baselineValue!, metric)
-            expect(variance).toBeNull()
-
-            const numberOfVariants = experiment.feature_flag?.filters.multivariate?.variants.length ?? 2
-            const minimumDetectableEffect = 50
-
-            const recommendedSampleSize = calculateRecommendedSampleSize(
-                metric,
-                minimumDetectableEffect,
-                baselineValue!,
-                numberOfVariants
-            )
-
-            expect(recommendedSampleSize).toBeCloseTo(1152, 0)
-        })
-    })
-
-    // Ratio metric tests
-    describe('calculations for RATIO', () => {
-        const metric: ExperimentMetric = {
-            uuid: uuid(),
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.RATIO,
-            numerator: {
-                kind: NodeKind.EventsNode,
-                event: 'purchase',
-                math: ExperimentMetricMathType.TotalCount,
-            },
-            denominator: {
-                kind: NodeKind.EventsNode,
-                event: 'page_view',
-                math: ExperimentMetricMathType.TotalCount,
-            },
-        } as ExperimentMetric
-
-        it('calculates baseline value, variance, and recommended sample size correctly', () => {
-            /**
-             * Realistic scenario: Revenue per order
-             *
-             * Setup:
-             * - 10,000 users (sample size)
-             * - Total revenue: $500,000 (numerator sum)
-             * - Total orders: 50,000 (denominator sum)
-             * - Baseline ratio: $500,000 / 50,000 = $10 per order
-             *
-             * Variance components (calculated from sums of squares and products):
-             * - meanM = 50, varM = 500 (revenue variance per user)
-             * - meanD = 5, varD = 5 (order count variance per user)
-             * - cov = 10 (positive covariance: more orders → more revenue)
-             *
-             * Delta method variance:
-             * Var(R) = 500/25 + 2500*5/625 - 2*50*10/125
-             *        = 20 + 20 - 8
-             *        = 32
-             *
-             * Sample size for 10% MDE:
-             * d = 0.10 * 10 = 1
-             * N = (16 * 32) / 1² = 512 per variant
-             * Total = 512 * 2 = 1024
-             */
+    describe('baselineStatsFromResults', () => {
+        it('maps the results baseline into the request shape', () => {
             const baseline: CachedNewExperimentQueryResponse['baseline'] = {
                 key: 'control',
                 number_of_samples: 10000,
-                sum: 500000, // Σ revenue ($50 per user)
-                sum_squares: 30000000, // Σ revenue² (includes variance)
-                denominator_sum: 50000, // Σ orders (5 per user)
-                denominator_sum_squares: 300000, // Σ orders² (includes variance)
-                numerator_denominator_sum_product: 2600000, // Σ(revenue × orders) (includes covariance)
-                step_counts: [],
+                sum: 500000,
+                sum_squares: 30000000,
+                denominator_sum: 50000,
+                denominator_sum_squares: 300000,
+                numerator_denominator_sum_product: 2600000,
+                step_counts: [1000, 100],
             }
-
-            // Test baseline value calculation
-            // Backend reference: posthog/products/experiments/stats/shared/statistics.py:119-124
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeCloseTo(10, 4) // $10 per order
-
-            // Test variance calculation using delta method
-            // Backend reference: posthog/products/experiments/stats/shared/statistics.py:135-145
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-            expect(variance).not.toBeNull()
-            expect(variance).toBeCloseTo(32, 1) // Variance = 32
-
-            // Test sample size calculation
-            const numberOfVariants = 2
-            const minimumDetectableEffect = 10 // 10% increase
-
-            const recommendedSampleSize = calculateRecommendedSampleSize(
-                metric,
-                minimumDetectableEffect,
-                baselineValue!,
-                numberOfVariants,
-                baseline
-            )
-
-            expect(recommendedSampleSize).not.toBeNull()
-            expect(recommendedSampleSize).toBeCloseTo(1024, 0) // 512 per variant * 2
-        })
-
-        it('calculates variance correctly with zero covariance', () => {
-            /**
-             * Test case with zero covariance (independent numerator and denominator)
-             *
-             * Setup:
-             * - 1,000 users
-             * - sum = 5,000 (5 per user), sum_squares = 30,000 (variance = 5)
-             * - denominator_sum = 10,000 (10 per user), denominator_sum_squares = 105,000 (variance = 5)
-             * - product = 50,000 (exactly sum * denominator_sum / n, so cov = 0)
-             *
-             * Expected variance with cov = 0:
-             * Var(R) = 5/100 + 25*5/10000 - 0
-             *        = 0.05 + 0.0125
-             *        = 0.0625
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 5000,
-                sum_squares: 30000,
-                denominator_sum: 10000,
-                denominator_sum_squares: 105000,
-                numerator_denominator_sum_product: 50000, // Exactly meanM * meanD * n (zero cov)
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeCloseTo(0.5, 4)
-
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-            expect(variance).toBeCloseTo(0.0625, 5)
-        })
-
-        it('calculates variance correctly with high positive covariance', () => {
-            /**
-             * Test case with high positive covariance
-             * Numerator and denominator move together strongly
-             * This should reduce variance due to the -2M*Cov term
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 5000, // meanM = 5
-                sum_squares: 30000, // varM = 5
-                denominator_sum: 10000, // meanD = 10
-                denominator_sum_squares: 105000, // varD = 5
-                numerator_denominator_sum_product: 52000, // High positive covariance
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-
-            // With positive covariance, variance should be lower than zero-cov case
-            expect(variance).not.toBeNull()
-            expect(variance!).toBeLessThan(0.0625)
-        })
-
-        it('returns null when denominator_sum is zero', () => {
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 100,
-                sum_squares: 500,
-                denominator_sum: 0, // Invalid: division by zero
-                denominator_sum_squares: 0,
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeNull()
-        })
-
-        it('returns null when baseline is missing for variance calculation', () => {
-            const baselineValue = 0.05
-            const variance = calculateVarianceFromResults(baselineValue, metric, undefined)
-            expect(variance).toBeNull()
-        })
-
-        it('returns null when number_of_samples is zero', () => {
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 0,
-                sum: 100,
-                sum_squares: 500,
-                denominator_sum: 1000,
-                denominator_sum_squares: 5000,
-                step_counts: [],
-            }
-
-            const variance = calculateVarianceFromResults(10, metric, baseline)
-            expect(variance).toBeNull()
-        })
-
-        it('handles missing denominator_sum_squares gracefully', () => {
-            /**
-             * Test backward compatibility if denominator_sum_squares is missing
-             * Should default to 0, which means denominator variance = 0
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 5000,
-                sum_squares: 30000,
-                denominator_sum: 10000,
-                // denominator_sum_squares missing
-                numerator_denominator_sum_product: 50000,
-                step_counts: [],
-            }
-
-            const variance = calculateVarianceFromResults(0.5, metric, baseline)
-            expect(variance).not.toBeNull()
-            // Should still calculate, just with varD = 0
-        })
-
-        it('handles missing numerator_denominator_sum_product gracefully', () => {
-            /**
-             * Test backward compatibility if product sum is missing
-             * Should default to 0, which means covariance = -meanM * meanD
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 5000,
-                sum_squares: 30000,
-                denominator_sum: 10000,
-                denominator_sum_squares: 105000,
-                // numerator_denominator_sum_product missing
-                step_counts: [],
-            }
-
-            const variance = calculateVarianceFromResults(0.5, metric, baseline)
-            expect(variance).not.toBeNull()
-            // Should still calculate, covariance will be negative
+            expect(baselineStatsFromResults(baseline)).toEqual({
+                number_of_samples: 10000,
+                sum: 500000,
+                sum_squares: 30000000,
+                denominator_sum: 50000,
+                denominator_sum_squares: 300000,
+                numerator_denominator_sum_product: 2600000,
+                step_counts: [1000, 100],
+            })
         })
     })
 
-    // Retention metric tests
-    describe('calculations for RETENTION', () => {
-        const metric: ExperimentMetric = {
-            uuid: uuid(),
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.RETENTION,
-            start_event: {
-                kind: NodeKind.EventsNode,
-                event: 'uploaded_file',
-            },
-            completion_event: {
-                kind: NodeKind.EventsNode,
-                event: 'downloaded_file',
-            },
-            retention_window_start: 0,
-            retention_window_end: 360,
-            retention_window_unit: 'day',
-            start_handling: 'first_seen',
-        } as ExperimentMetric
-
-        it('calculates baseline value, variance, and recommended sample size correctly', () => {
-            /**
-             * Realistic scenario: File download retention
-             *
-             * Setup:
-             * - 10,000 users uploaded files (number_of_samples)
-             * - 7,000 users downloaded files (sum - completions)
-             * - Retention rate: 7,000 / 10,000 = 70%
-             *
-             * For retention metrics:
-             * - Numerator: binary (0 or 1 per user) - did they complete?
-             * - Denominator: always 1 per user (they all started)
-             * - denominator_sum = number_of_samples = 10,000
-             * - denominator_sum_squares = number_of_samples = 10,000 (since 1² = 1)
-             * - numerator_denominator_sum_product = sum = 7,000 (since value × 1 = value)
-             *
-             * Variance components:
-             * - meanM = 0.7 (70% retention)
-             * - meanD = 1 (everyone who started)
-             * - varM = (sum_squares / n) - meanM² = (7000 / 10000) - 0.49 = 0.7 - 0.49 = 0.21
-             * - varD = 0 (denominator is constant 1)
-             * - cov = (product / n) - meanM × meanD = (7000 / 10000) - 0.7 × 1 = 0
-             *
-             * Delta method variance:
-             * Var(R) = varM / meanD² + meanM² × varD / meanD⁴ - 2 × meanM × cov / meanD³
-             *        = 0.21 / 1 + 0.49 × 0 / 1 - 0
-             *        = 0.21
-             *
-             * Sample size for 10% MDE:
-             * d = 0.10 × 0.7 = 0.07
-             * N = (16 × 0.21) / 0.07² = 3.36 / 0.0049 ≈ 686 per variant
-             * Total = 686 × 2 = 1372
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 10000,
-                sum: 7000, // 7,000 users completed (70% retention)
-                sum_squares: 7000, // Σ(value²) where value is 0 or 1: 7000×1² + 3000×0² = 7000
-                denominator_sum: 10000, // All 10,000 users started
-                denominator_sum_squares: 10000, // Σ(1²) = 10,000
-                numerator_denominator_sum_product: 7000, // Σ(value × 1) = sum
-                step_counts: [],
-            }
-
-            // Test baseline value calculation
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeCloseTo(0.7, 4) // 70% retention
-
-            // Test variance calculation using delta method
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-            expect(variance).not.toBeNull()
-            expect(variance).toBeCloseTo(0.21, 4)
-
-            // Test sample size calculation
-            const numberOfVariants = 2
-            const minimumDetectableEffect = 10 // 10% increase
-
-            const recommendedSampleSize = calculateRecommendedSampleSize(
-                metric,
-                minimumDetectableEffect,
-                baselineValue!,
-                numberOfVariants,
-                baseline
-            )
-
-            expect(recommendedSampleSize).not.toBeNull()
-            expect(recommendedSampleSize).toBeCloseTo(1372, 0)
+    describe('calculateCurrentExposures', () => {
+        it('sums baseline and variant sample counts', () => {
+            const results = {
+                baseline: { number_of_samples: 1000 },
+                variant_results: [{ number_of_samples: 900 }, { number_of_samples: 1100 }],
+            } as CachedNewExperimentQueryResponse
+            expect(calculateCurrentExposures(results)).toBe(3000)
         })
 
-        it('handles zero retention correctly', () => {
-            /**
-             * Edge case: No users completed (0% retention)
-             * - 1,000 users started
-             * - 0 users completed
-             * - Retention rate: 0 / 1,000 = 0%
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 0, // Zero completions
-                sum_squares: 0,
-                denominator_sum: 1000,
-                denominator_sum_squares: 1000,
-                numerator_denominator_sum_product: 0,
-                step_counts: [],
-            }
+        it('returns null without results', () => {
+            expect(calculateCurrentExposures(null)).toBeNull()
+        })
+    })
 
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBe(0) // 0% retention
-
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-            expect(variance).not.toBeNull()
-            // Variance should be 0 since all values are 0
-            expect(variance).toBeCloseTo(0, 4)
+    describe('calculateExposureRate', () => {
+        it('returns exposures per day', () => {
+            expect(calculateExposureRate(1000, 10)).toBe(100)
         })
 
-        it('handles perfect retention correctly', () => {
-            /**
-             * Edge case: All users completed (100% retention)
-             * - 1,000 users started
-             * - 1,000 users completed
-             * - Retention rate: 1,000 / 1,000 = 100%
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 1000, // All completed
-                sum_squares: 1000, // 1000 × 1² = 1000
-                denominator_sum: 1000,
-                denominator_sum_squares: 1000,
-                numerator_denominator_sum_product: 1000,
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBe(1) // 100% retention
-
-            const variance = calculateVarianceFromResults(baselineValue!, metric, baseline)
-            expect(variance).not.toBeNull()
-            // Variance should be 0 since all values are 1 (no variation)
-            expect(variance).toBeCloseTo(0, 4)
+        it('returns null below the minimum elapsed window', () => {
+            expect(calculateExposureRate(1000, 0.05)).toBeNull()
         })
 
-        it('returns null when denominator_sum is zero', () => {
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 100,
-                sum_squares: 100,
-                denominator_sum: 0, // Invalid: no users started
-                denominator_sum_squares: 0,
-                numerator_denominator_sum_product: 0,
-                step_counts: [],
-            }
+        it('returns null without exposures', () => {
+            expect(calculateExposureRate(null, 10)).toBeNull()
+        })
+    })
 
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeNull()
+    describe('calculateDaysElapsed', () => {
+        it('returns null without a start date', () => {
+            expect(calculateDaysElapsed(null)).toBeNull()
         })
 
-        it('handles missing denominator fields gracefully', () => {
-            /**
-             * Test backward compatibility if ratio fields are missing
-             * Should return null for variance
-             */
-            const baseline: CachedNewExperimentQueryResponse['baseline'] = {
-                key: 'control',
-                number_of_samples: 1000,
-                sum: 700,
-                sum_squares: 700,
-                // denominator fields missing
-                step_counts: [],
-            }
-
-            const baselineValue = calculateBaselineValue(baseline, metric)
-            expect(baselineValue).toBeNull() // Can't calculate without denominator_sum
-
-            const variance = calculateVarianceFromResults(0.7, metric, baseline)
-            expect(variance).toBeNull() // Can't calculate variance without baseline
+        it('returns a positive number for a past start date', () => {
+            const elapsed = calculateDaysElapsed('2020-01-01')
+            expect(elapsed).not.toBeNull()
+            expect(elapsed!).toBeGreaterThan(0)
         })
     })
 })

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/calculations.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/calculations.ts
@@ -1,5 +1,4 @@
 import { dayjs } from 'lib/dayjs'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import type { CachedNewExperimentQueryResponse, ExperimentMetric } from '~/queries/schema/schema-general'
 import {
@@ -10,170 +9,21 @@ import {
 } from '~/queries/schema/schema-general'
 import { ExperimentMetricMathType } from '~/types'
 
-const VARIANCE_SCALING_FACTOR_TOTAL_COUNT = 2
-const VARIANCE_SCALING_FACTOR_SUM = 0.25
+import type { RunningTimeBaselineStatsApi } from 'products/experiments/frontend/generated/api.schemas'
 
-// Manual calculator only supports these types (ratio/retention require full baseline data)
+// The sample-size and variance math lives in the backend running-time calculator
+// (products/experiments/backend/running_time_calculator.py), reached via
+// POST /experiments/calculate_running_time. This module keeps only the client-side
+// helpers that classify a metric and read live experiment state to build that request.
+
+// Manual calculator only supports these types (ratio/retention require full baseline data).
 export type ManualCalculatorMetricType = 'funnel' | 'mean_count' | 'mean_sum_or_avg'
 
-// Full calculator supports all metric types
+// Full calculator supports all metric types.
 export type CalculatorMetricType = ManualCalculatorMetricType | 'ratio' | 'retention'
 
 /**
- * Calculate variance for manual calculator metric types.
- * Only supports funnel, mean_count, and mean_sum_or_avg since ratio/retention
- * require full baseline statistics from experiment results.
- */
-export function calculateVariance(metricType: ManualCalculatorMetricType, baselineValue: number): number | null {
-    switch (metricType) {
-        case 'funnel':
-            return null // variance embedded in p(1-p) formula
-        case 'mean_count':
-            return VARIANCE_SCALING_FACTOR_TOTAL_COUNT * baselineValue
-        case 'mean_sum_or_avg':
-            return VARIANCE_SCALING_FACTOR_SUM * baselineValue ** 2
-    }
-}
-
-/**
- * Calculate variance from experiment results based on metric type.
- *
- * - For mean metrics (Count/Sum): Uses scaling factors based on metric type
- * - For funnel metrics: Returns null (variance is implicit in p(1-p))
- * - For ratio and retention metrics: Uses delta method with covariance
- *
- * Delta method for ratio R = M/D:
- * Var(R) ≈ Var(M)/D² + M²Var(D)/D⁴ - 2M*Cov(M,D)/D³
- */
-export function calculateVarianceFromResults(
-    baselineValue: number,
-    metric: ExperimentMetric,
-    baseline?: CachedNewExperimentQueryResponse['baseline']
-): number | null {
-    if (isExperimentMeanMetric(metric)) {
-        if (metric.source.math === ExperimentMetricMathType.Sum) {
-            return VARIANCE_SCALING_FACTOR_SUM * baselineValue ** 2
-        }
-        // Default to TotalCount for mean metrics (when math is undefined or TotalCount)
-        return VARIANCE_SCALING_FACTOR_TOTAL_COUNT * baselineValue
-    }
-
-    if (isExperimentFunnelMetric(metric)) {
-        // Funnel metrics don't need separate variance calculation
-        // The variance is embedded in the formula: p(1-p)
-        return null
-    }
-
-    if (isExperimentRatioMetric(metric) || isExperimentRetentionMetric(metric)) {
-        // Both ratio and retention metrics use delta method variance
-        // Retention: variance of (completions / starters)
-        // Ratio: variance of (numerator / denominator)
-        if (!baseline || !baseline.denominator_sum || baseline.denominator_sum === 0) {
-            lemonToast.error('Ratio/retention metric missing denominator statistics')
-            return null
-        }
-
-        const n = baseline.number_of_samples
-        if (n === 0) {
-            return null
-        }
-
-        // Calculate means for numerator (M) and denominator (D)
-        const meanM = baseline.sum / n
-        const meanD = baseline.denominator_sum / n
-
-        // Calculate variances using the formula: Var(X) = E[X²] - E[X]²
-        const varM = baseline.sum_squares / n - meanM ** 2
-        const varD = (baseline.denominator_sum_squares || 0) / n - meanD ** 2
-
-        // Calculate covariance: Cov(M,D) = E[MD] - E[M]E[D]
-        const cov = (baseline.numerator_denominator_sum_product || 0) / n - meanM * meanD
-
-        // Delta method variance formula for ratio R = M/D
-        // Formula: Var(R) ≈ Var(M)/D² + M²Var(D)/D⁴ - 2M*Cov(M,D)/D³
-        return varM / meanD ** 2 + (meanM ** 2 * varD) / meanD ** 4 - (2 * meanM * cov) / meanD ** 3
-    }
-
-    return null
-}
-
-/**
- * Calculate sample size for manual calculator metric types.
- * For ratio/retention metrics that require pre-calculated variance, use calculateSampleSizeWithVariance.
- */
-export function calculateSampleSize(
-    metricType: ManualCalculatorMetricType,
-    baselineValue: number,
-    mde: number,
-    numberOfVariants: number
-): number | null {
-    if (mde === 0) {
-        return null
-    }
-
-    const mdeDecimal = mde / 100
-    const d = mdeDecimal * baselineValue
-
-    if (d === 0) {
-        return null
-    }
-
-    let sampleSizeFormula: number
-
-    if (metricType === 'funnel') {
-        // Binomial metric: N = (16 * p * (1 - p)) / d²
-        sampleSizeFormula = (16 * baselineValue * (1 - baselineValue)) / d ** 2
-    } else {
-        // Count or Sum metric: N = (16 * variance) / d²
-        const variance = calculateVariance(metricType, baselineValue)
-        if (variance === null) {
-            return null
-        }
-        sampleSizeFormula = (16 * variance) / d ** 2
-    }
-
-    return Math.ceil(sampleSizeFormula * numberOfVariants)
-}
-
-/**
- * Calculate sample size when variance is pre-calculated (for ratio/retention metrics).
- */
-export function calculateSampleSizeWithVariance(
-    metricType: CalculatorMetricType,
-    baselineValue: number,
-    mde: number,
-    numberOfVariants: number,
-    variance: number | null
-): number | null {
-    if (mde === 0) {
-        return null
-    }
-
-    const mdeDecimal = mde / 100
-    const d = mdeDecimal * baselineValue
-
-    if (d === 0) {
-        return null
-    }
-
-    let sampleSizeFormula: number
-
-    if (metricType === 'funnel') {
-        // Binomial metric: N = (16 * p * (1 - p)) / d²
-        sampleSizeFormula = (16 * baselineValue * (1 - baselineValue)) / d ** 2
-    } else {
-        // Count, Sum, Ratio, or Retention: N = (16 * variance) / d²
-        if (variance === null) {
-            return null
-        }
-        sampleSizeFormula = (16 * variance) / d ** 2
-    }
-
-    return Math.ceil(sampleSizeFormula * numberOfVariants)
-}
-
-/**
- * Get the calculator metric type from an ExperimentMetric object.
+ * Map an ExperimentMetric to the calculator metric type expected by the backend endpoint.
  */
 export function getCalculatorMetricType(metric: ExperimentMetric): CalculatorMetricType {
     if (isExperimentFunnelMetric(metric)) {
@@ -191,73 +41,25 @@ export function getCalculatorMetricType(metric: ExperimentMetric): CalculatorMet
     return 'mean_count'
 }
 
-// Returns: avg events/user (count), avg property value/user (sum), conversion rate (funnel), or ratio (ratio/retention)
-export function calculateBaselineValue(
-    baseline: CachedNewExperimentQueryResponse['baseline'],
-    metric: ExperimentMetric
-): number | null {
-    if (baseline.number_of_samples === 0) {
-        return null
-    }
-
-    if (isExperimentMeanMetric(metric)) {
-        return baseline.sum / baseline.number_of_samples
-    }
-
-    if (isExperimentFunnelMetric(metric)) {
-        const stepCounts = baseline.step_counts
-        if (!stepCounts || stepCounts.length === 0) {
-            // Fallback to sum / number_of_samples for funnels when step_counts is not available
-            if (baseline.number_of_samples > 0) {
-                return baseline.sum / baseline.number_of_samples
-            }
-            lemonToast.error('Funnel metric missing step_counts and sample data')
-            return null
-        }
-        // For experiments, conversion rate is: (completed final step) / (total exposed)
-        return baseline.number_of_samples > 0 ? stepCounts[stepCounts.length - 1] / baseline.number_of_samples : null
-    }
-
-    if (isExperimentRatioMetric(metric) || isExperimentRetentionMetric(metric)) {
-        // Both ratio and retention metrics use denominator_sum for the baseline calculation
-        // Retention: completions / starters
-        // Ratio: numerator / denominator
-        if (!baseline.denominator_sum || baseline.denominator_sum === 0) {
-            return null
-        }
-        return baseline.sum / baseline.denominator_sum
-    }
-
-    return null
-}
-
 /**
- * Calculate recommended sample size from experiment metric and results.
- * Handles all metric types including ratio and retention.
+ * Shape the raw baseline stats from experiment results into the backend request body.
+ * The backend derives the baseline value and (for ratio/retention) the delta-method variance from these.
  */
-export function calculateRecommendedSampleSize(
-    metric: ExperimentMetric,
-    minimumDetectableEffect: number,
-    baselineValue: number,
-    numberOfVariants: number,
-    baseline?: CachedNewExperimentQueryResponse['baseline']
-): number | null {
-    const metricType = getCalculatorMetricType(metric)
-
-    // For ratio/retention, we need variance from full baseline data
-    if (metricType === 'ratio' || metricType === 'retention') {
-        const variance = calculateVarianceFromResults(baselineValue, metric, baseline)
-        return calculateSampleSizeWithVariance(
-            metricType,
-            baselineValue,
-            minimumDetectableEffect,
-            numberOfVariants,
-            variance
-        )
+export function baselineStatsFromResults(
+    baseline: CachedNewExperimentQueryResponse['baseline']
+): RunningTimeBaselineStatsApi {
+    // Omit optional stats that are null for this metric type (e.g. step_counts on non-funnel
+    // metrics, denominator_* on non-ratio metrics) — the serializer rejects explicit nulls,
+    // and the backend already treats absent values as unset.
+    return {
+        number_of_samples: baseline.number_of_samples,
+        sum: baseline.sum,
+        sum_squares: baseline.sum_squares,
+        denominator_sum: baseline.denominator_sum ?? undefined,
+        denominator_sum_squares: baseline.denominator_sum_squares ?? undefined,
+        numerator_denominator_sum_product: baseline.numerator_denominator_sum_product ?? undefined,
+        step_counts: baseline.step_counts ?? undefined,
     }
-
-    // For funnel, mean_count, mean_sum_or_avg - use simple calculation
-    return calculateSampleSize(metricType, baselineValue, minimumDetectableEffect, numberOfVariants)
 }
 
 export function calculateCurrentExposures(results: CachedNewExperimentQueryResponse | null): number | null {
@@ -285,22 +87,4 @@ export function calculateExposureRate(currentExposures: number | null, daysElaps
     }
 
     return currentExposures / daysElapsed
-}
-
-export function calculateRemainingDays(
-    recommendedSampleSize: number | null,
-    currentExposures: number | null,
-    exposureRate: number | null
-): number | null {
-    if (!recommendedSampleSize || !currentExposures || !exposureRate) {
-        return null
-    }
-
-    const remainingSample = recommendedSampleSize - currentExposures
-
-    if (remainingSample <= 0) {
-        return 0
-    }
-
-    return remainingSample / exposureRate
 }

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -32,7 +32,6 @@ import {
 import type { runningTimeLogicType } from './runningTimeLogicType'
 
 export interface RunningTimeLogicProps {
-    experimentId: Experiment['id']
     experiment: Experiment
 }
 
@@ -52,32 +51,35 @@ export interface ManualPreview {
 export const runningTimeLogic = kea<runningTimeLogicType>([
     path(['scenes', 'experiments', 'RunningTimeCalculator', 'runningTimeLogic']),
     props({} as RunningTimeLogicProps),
-    key((props) => `${props.experimentId}`),
+    key((props) => `${props.experiment.id}`),
 
-    connect((props: RunningTimeLogicProps) => ({
-        values: [
-            experimentLogic({ experimentId: props.experimentId }),
-            ['experiment', 'orderedPrimaryMetricsWithResults', 'primaryMetricsResultsLoading', 'currentProjectId'],
-            // On the recalculation flow, metric results live in experimentMetricsLogic, not experimentLogic.
-            experimentMetricsLogic({ experiment: props.experiment }),
-            [
-                'primaryMetricsResults as recalcPrimaryMetricsResults',
-                'primaryMetricsResultsErrors as recalcPrimaryMetricsResultsErrors',
+    connect((props: RunningTimeLogicProps) => {
+        const experimentId = props.experiment.id
+        return {
+            values: [
+                experimentLogic({ experimentId }),
+                ['experiment', 'orderedPrimaryMetricsWithResults', 'primaryMetricsResultsLoading', 'currentProjectId'],
+                // On the recalculation flow, metric results live in experimentMetricsLogic, not experimentLogic.
+                experimentMetricsLogic({ experiment: props.experiment }),
+                [
+                    'primaryMetricsResults as recalcPrimaryMetricsResults',
+                    'primaryMetricsResultsErrors as recalcPrimaryMetricsResultsErrors',
+                ],
+                modalsLogic,
+                ['isRunningTimeConfigModalOpen'],
+                experimentsConfigLogic,
+                ['defaultMinimumDetectableEffect'],
+                featureFlagLogic,
+                ['featureFlags'],
             ],
-            modalsLogic,
-            ['isRunningTimeConfigModalOpen'],
-            experimentsConfigLogic,
-            ['defaultMinimumDetectableEffect'],
-            featureFlagLogic,
-            ['featureFlags'],
-        ],
-        actions: [
-            experimentLogic({ experimentId: props.experimentId }),
-            ['setExperiment'],
-            modalsLogic,
-            ['closeRunningTimeConfigModal'],
-        ],
-    })),
+            actions: [
+                experimentLogic({ experimentId }),
+                ['setExperiment'],
+                modalsLogic,
+                ['closeRunningTimeConfigModal'],
+            ],
+        }
+    }),
 
     actions({
         setConfig: (config: Partial<RunningTimeConfig>) => ({ config }),
@@ -346,7 +348,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                 recommended_sample_size: targetSampleSize,
             }
 
-            await api.update(`api/projects/${currentProjectId}/experiments/${props.experimentId}`, {
+            await api.update(`api/projects/${currentProjectId}/experiments/${props.experiment.id}`, {
                 running_time_calculation: updatedRunningTimeCalculation,
             })
 
@@ -412,7 +414,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                 // Await so the experiment reflects the saved config before resetConfig below. Otherwise the
                 // transient (overrides cleared, experiment not yet updated) would re-trigger the automatic
                 // auto-persist with stale values and revert the save.
-                await experimentLogic({ experimentId: props.experimentId }).asyncActions.updateExperiment(update)
+                await experimentLogic({ experimentId: props.experiment.id }).asyncActions.updateExperiment(update)
             } catch {
                 // Keep the modal open (don't close/reset below) so the user can retry.
                 lemonToast.error('Failed to save running time settings. Please try again.')

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -1,27 +1,39 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { experimentsConfigLogic } from '~/scenes/settings/environment/experimentsConfigLogic'
 import { ConversionRateInputType, Experiment } from '~/types'
 
+import { experimentsCalculateRunningTimeCreate } from 'products/experiments/frontend/generated/api'
+import type {
+    RunningTimeCalculationInputApi,
+    RunningTimeCalculationResultApi,
+} from 'products/experiments/frontend/generated/api.schemas'
+
 import { experimentLogic } from '../experimentLogic'
+import { experimentMetricsLogic } from '../experimentMetricsLogic'
 import { isLaunched } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
+import { getOrderedMetricsWithResults } from '../utils'
 import {
     ManualCalculatorMetricType,
-    calculateBaselineValue,
+    baselineStatsFromResults,
     calculateCurrentExposures,
     calculateDaysElapsed,
     calculateExposureRate,
-    calculateRecommendedSampleSize,
-    calculateSampleSize,
+    getCalculatorMetricType,
 } from './calculations'
 import type { runningTimeLogicType } from './runningTimeLogicType'
 
 export interface RunningTimeLogicProps {
     experimentId: Experiment['id']
+    experiment: Experiment
 }
 
 export interface RunningTimeConfig {
@@ -30,6 +42,11 @@ export interface RunningTimeConfig {
     metricType: ManualCalculatorMetricType
     baselineValue: number
     exposureRate: number
+}
+
+export interface ManualPreview {
+    sampleSize: number | null
+    runningTime: number | null
 }
 
 export const runningTimeLogic = kea<runningTimeLogicType>([
@@ -41,14 +58,22 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
         values: [
             experimentLogic({ experimentId: props.experimentId }),
             ['experiment', 'orderedPrimaryMetricsWithResults', 'primaryMetricsResultsLoading', 'currentProjectId'],
+            // On the recalculation flow, metric results live in experimentMetricsLogic, not experimentLogic.
+            experimentMetricsLogic({ experiment: props.experiment }),
+            [
+                'primaryMetricsResults as recalcPrimaryMetricsResults',
+                'primaryMetricsResultsErrors as recalcPrimaryMetricsResultsErrors',
+            ],
             modalsLogic,
             ['isRunningTimeConfigModalOpen'],
             experimentsConfigLogic,
             ['defaultMinimumDetectableEffect'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [
             experimentLogic({ experimentId: props.experimentId }),
-            ['updateExperiment', 'setExperiment'],
+            ['setExperiment'],
             modalsLogic,
             ['closeRunningTimeConfigModal'],
         ],
@@ -60,6 +85,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
         save: true,
         cancel: true,
         persistRunningTimeEstimate: true,
+        setSaving: (saving: boolean) => ({ saving }),
     }),
 
     reducers({
@@ -70,7 +96,40 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                 resetConfig: () => null,
             },
         ],
+        isSaving: [
+            false,
+            {
+                setSaving: (_, { saving }) => saving,
+            },
+        ],
     }),
+
+    loaders(({ values }) => ({
+        // Automatic mode: recommended sample size derived by the backend from live results baseline.
+        automaticCalculation: [
+            null as RunningTimeCalculationResultApi | null,
+            {
+                loadAutomaticCalculation: async (input: RunningTimeCalculationInputApi) => {
+                    return await experimentsCalculateRunningTimeCreate(String(values.currentProjectId), input)
+                },
+            },
+        ],
+        // Manual mode: live preview of sample size / running time for the values being edited in the form.
+        manualPreview: [
+            { sampleSize: null, runningTime: null } as ManualPreview,
+            {
+                loadManualPreview: async (input: RunningTimeCalculationInputApi, breakpoint) => {
+                    // Debounce burst typing in the form so we don't fire a request per keypress.
+                    await breakpoint(300)
+                    const result = await experimentsCalculateRunningTimeCreate(String(values.currentProjectId), input)
+                    return {
+                        sampleSize: result.recommended_sample_size,
+                        runningTime: result.recommended_running_time_days,
+                    }
+                },
+            },
+        ],
+    })),
 
     selectors({
         numberOfVariants: [
@@ -109,57 +168,83 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                 configOverrides ? { ...initialConfig, ...configOverrides } : initialConfig,
         ],
 
+        // Pulled out as a primitive so automaticCalculationInput stays stable when the experiment object
+        // is replaced (e.g. after persisting an estimate) but the mde value itself is unchanged.
+        mde: [(s) => [s.config], (config): number => config.mde],
+
+        // Legacy flow exposes metric results via experimentLogic; the recalculation flow exposes them
+        // via experimentMetricsLogic. Pick whichever is active so automatic mode always has a baseline.
+        metricsWithResults: [
+            (s) => [
+                s.experiment,
+                s.featureFlags,
+                s.orderedPrimaryMetricsWithResults,
+                s.recalcPrimaryMetricsResults,
+                s.recalcPrimaryMetricsResultsErrors,
+            ],
+            (experiment, featureFlags, legacyMetricsWithResults, recalcResults, recalcErrors) => {
+                if (experiment && featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]) {
+                    return getOrderedMetricsWithResults(experiment, recalcResults, recalcErrors, [], [], false)
+                }
+                return legacyMetricsWithResults
+            },
+        ],
+
         currentExposures: [
-            (s) => [s.orderedPrimaryMetricsWithResults],
+            (s) => [s.metricsWithResults],
             (results): number | null => calculateCurrentExposures(results?.[0]?.result ?? null),
         ],
-        targetSampleSize: [
-            (s) => [
-                s.isManualMode,
-                s.experiment,
-                s.orderedPrimaryMetricsWithResults,
-                s.numberOfVariants,
-                s.config,
-                s.defaultMinimumDetectableEffect,
-            ],
-            (
-                isManualMode,
-                experiment,
-                results,
-                numberOfVariants,
-                config,
-                defaultMinimumDetectableEffect
-            ): number | null => {
-                if (isManualMode) {
-                    const saved = experiment?.running_time_calculation?.exposure_estimate_config
-                    const baseline = saved?.manualBaselineValue ?? 0
-                    if (baseline <= 0) {
-                        return null
-                    }
-                    const metricType = (saved?.manualMetricType as ManualCalculatorMetricType) ?? 'funnel'
-                    const adjustedBaseline = metricType === 'funnel' ? baseline / 100 : baseline
-                    const mde =
-                        experiment?.running_time_calculation?.minimum_detectable_effect ??
-                        defaultMinimumDetectableEffect
-                    return calculateSampleSize(metricType, adjustedBaseline, mde, numberOfVariants)
-                }
 
-                // Automatic mode: calculate from live experiment data
+        // Request body for the automatic-mode calculation, or null when not applicable (manual mode / no results yet).
+        automaticCalculationInput: [
+            (s) => [s.isManualMode, s.metricsWithResults, s.numberOfVariants, s.mde],
+            (isManualMode, results, numberOfVariants, mde): RunningTimeCalculationInputApi | null => {
+                if (isManualMode) {
+                    return null
+                }
                 const firstMetric = results?.[0]
                 if (!firstMetric?.metric || !firstMetric?.result?.baseline) {
                     return null
                 }
-                const baselineValue = calculateBaselineValue(firstMetric.result.baseline, firstMetric.metric)
-                if (baselineValue === null) {
+                return {
+                    metric_type: getCalculatorMetricType(firstMetric.metric),
+                    minimum_detectable_effect: mde,
+                    number_of_variants: numberOfVariants,
+                    baseline_stats: baselineStatsFromResults(firstMetric.result.baseline),
+                }
+            },
+        ],
+
+        // Request body for the live manual-mode preview, or null when the form inputs aren't usable yet.
+        manualPreviewInput: [
+            (s) => [s.config, s.numberOfVariants],
+            (config, numberOfVariants): RunningTimeCalculationInputApi | null => {
+                // Use !(x > 0) to catch NaN, 0, negative, and undefined
+                if (config.mode !== 'manual' || !(config.baselineValue > 0) || !(config.mde > 0)) {
                     return null
                 }
-                return calculateRecommendedSampleSize(
-                    firstMetric.metric,
-                    config.mde,
-                    baselineValue,
-                    numberOfVariants,
-                    firstMetric.result.baseline
-                )
+                const baselineValue = config.metricType === 'funnel' ? config.baselineValue / 100 : config.baselineValue
+                return {
+                    metric_type: config.metricType,
+                    minimum_detectable_effect: config.mde,
+                    number_of_variants: numberOfVariants,
+                    baseline_value: baselineValue,
+                    exposure_rate_per_day: config.exposureRate > 0 ? config.exposureRate : undefined,
+                }
+            },
+        ],
+
+        targetSampleSize: [
+            (s) => [s.isManualMode, s.experiment, s.automaticCalculationInput, s.automaticCalculation],
+            (isManualMode, experiment, automaticInput, automaticCalculation): number | null => {
+                if (isManualMode) {
+                    // Persisted by the save listener from the same backend calculation.
+                    return experiment?.running_time_calculation?.recommended_sample_size ?? null
+                }
+                if (!automaticInput) {
+                    return null
+                }
+                return automaticCalculation?.recommended_sample_size ?? null
             },
         ],
 
@@ -207,39 +292,43 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
             (current, target): boolean => current !== null && target !== null && current >= target,
         ],
         manualFormPreview: [
-            (s) => [s.config, s.numberOfVariants],
-            (config, numberOfVariants): { sampleSize: number | null; runningTime: number | null } => {
-                // Use !(x > 0) to catch NaN, 0, negative, and undefined
-                if (config.mode !== 'manual' || !(config.baselineValue > 0)) {
-                    return { sampleSize: null, runningTime: null }
-                }
-
-                const baselineValue = config.metricType === 'funnel' ? config.baselineValue / 100 : config.baselineValue
-                const sampleSize = calculateSampleSize(config.metricType, baselineValue, config.mde, numberOfVariants)
-
-                if (!sampleSize || !(config.exposureRate > 0)) {
-                    return { sampleSize, runningTime: null }
-                }
-
-                const runningTime = Math.ceil(sampleSize / config.exposureRate)
-                return { sampleSize, runningTime }
-            },
+            (s) => [s.manualPreviewInput, s.manualPreview],
+            (input, preview): ManualPreview => (input ? preview : { sampleSize: null, runningTime: null }),
         ],
     }),
 
     subscriptions(({ actions }) => ({
-        primaryMetricsResultsLoading: (loading: boolean) => {
-            if (!loading) {
-                actions.persistRunningTimeEstimate()
+        automaticCalculationInput: (input: RunningTimeCalculationInputApi | null) => {
+            if (input) {
+                actions.loadAutomaticCalculation(input)
+            }
+        },
+        manualPreviewInput: (input: RunningTimeCalculationInputApi | null) => {
+            if (input) {
+                actions.loadManualPreview(input)
             }
         },
     })),
 
     listeners(({ actions, values, props }) => ({
-        persistRunningTimeEstimate: async () => {
-            const { isManualMode, remainingDays, targetSampleSize, experiment, currentProjectId } = values
+        // Persist the automatic estimate once the backend calculation lands and the selectors are fresh.
+        loadAutomaticCalculationSuccess: () => {
+            actions.persistRunningTimeEstimate()
+        },
 
-            if (isManualMode || !isLaunched(experiment) || remainingDays === null || targetSampleSize === null) {
+        persistRunningTimeEstimate: async () => {
+            const { isManualMode, remainingDays, targetSampleSize, experiment, currentProjectId, configOverrides } =
+                values
+
+            // Skip while the user has unsaved edits — `save` owns persistence then. Auto-persisting a
+            // transient value here (e.g. right after `resetConfig`) would race with the save and revert it.
+            if (
+                configOverrides ||
+                isManualMode ||
+                !isLaunched(experiment) ||
+                remainingDays === null ||
+                targetSampleSize === null
+            ) {
                 return
             }
 
@@ -262,45 +351,72 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
             actions.setExperiment({ running_time_calculation: updatedRunningTimeCalculation })
         },
 
-        save: () => {
-            const { config, numberOfVariants, experiment } = values
+        save: async () => {
+            const { config, numberOfVariants, experiment, currentProjectId } = values
 
-            if (config.mode === 'manual') {
-                // Convert NaN (from empty input) to 0
-                const manualBaselineValue = Number.isNaN(config.baselineValue) ? 0 : config.baselineValue
-                const manualExposureRate = Number.isNaN(config.exposureRate) ? 0 : config.exposureRate
+            actions.setSaving(true)
+            try {
+                let update: Partial<Experiment> & { update_feature_flag_params?: boolean }
+                if (config.mode === 'manual') {
+                    // Convert NaN (from empty input) to 0
+                    const manualBaselineValue = Number.isNaN(config.baselineValue) ? 0 : config.baselineValue
+                    const manualExposureRate = Number.isNaN(config.exposureRate) ? 0 : config.exposureRate
 
-                const baselineValue = config.metricType === 'funnel' ? manualBaselineValue / 100 : manualBaselineValue
-                const sampleSize = calculateSampleSize(config.metricType, baselineValue, config.mde, numberOfVariants)
-                const runningTime =
-                    sampleSize && manualExposureRate > 0 ? Math.ceil(sampleSize / manualExposureRate) : null
+                    const baselineValue =
+                        config.metricType === 'funnel' ? manualBaselineValue / 100 : manualBaselineValue
 
-                actions.updateExperiment({
-                    running_time_calculation: {
-                        ...experiment?.running_time_calculation,
-                        minimum_detectable_effect: config.mde,
-                        recommended_sample_size: sampleSize ?? undefined,
-                        recommended_running_time: runningTime ?? undefined,
-                        exposure_estimate_config: {
-                            conversionRateInputType: ConversionRateInputType.MANUAL,
-                            manualMetricType: config.metricType,
-                            manualBaselineValue,
-                            manualExposureRate,
+                    let sampleSize: number | null = null
+                    let runningTime: number | null = null
+                    if (baselineValue > 0) {
+                        const result = await experimentsCalculateRunningTimeCreate(String(currentProjectId), {
+                            metric_type: config.metricType,
+                            minimum_detectable_effect: config.mde,
+                            number_of_variants: numberOfVariants,
+                            baseline_value: baselineValue,
+                            exposure_rate_per_day: manualExposureRate > 0 ? manualExposureRate : undefined,
+                        })
+                        sampleSize = result.recommended_sample_size
+                        runningTime = result.recommended_running_time_days
+                    }
+
+                    update = {
+                        running_time_calculation: {
+                            ...experiment?.running_time_calculation,
+                            minimum_detectable_effect: config.mde,
+                            recommended_sample_size: sampleSize ?? undefined,
+                            recommended_running_time: runningTime ?? undefined,
+                            exposure_estimate_config: {
+                                conversionRateInputType: ConversionRateInputType.MANUAL,
+                                manualMetricType: config.metricType,
+                                manualBaselineValue,
+                                manualExposureRate,
+                            },
                         },
-                    },
-                    update_feature_flag_params: false,
-                })
-            } else {
-                actions.updateExperiment({
-                    running_time_calculation: {
-                        ...experiment?.running_time_calculation,
-                        minimum_detectable_effect: config.mde,
-                        exposure_estimate_config: {
-                            conversionRateInputType: ConversionRateInputType.AUTOMATIC,
+                        update_feature_flag_params: false,
+                    }
+                } else {
+                    update = {
+                        running_time_calculation: {
+                            ...experiment?.running_time_calculation,
+                            minimum_detectable_effect: config.mde,
+                            exposure_estimate_config: {
+                                conversionRateInputType: ConversionRateInputType.AUTOMATIC,
+                            },
                         },
-                    },
-                    update_feature_flag_params: false,
-                })
+                        update_feature_flag_params: false,
+                    }
+                }
+
+                // Await so the experiment reflects the saved config before resetConfig below. Otherwise the
+                // transient (overrides cleared, experiment not yet updated) would re-trigger the automatic
+                // auto-persist with stale values and revert the save.
+                await experimentLogic({ experimentId: props.experimentId }).asyncActions.updateExperiment(update)
+            } catch {
+                // Keep the modal open (don't close/reset below) so the user can retry.
+                lemonToast.error('Failed to save running time settings. Please try again.')
+                return
+            } finally {
+                actions.setSaving(false)
             }
             actions.closeRunningTimeConfigModal()
             actions.resetConfig()

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -109,8 +109,10 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
         automaticCalculation: [
             null as RunningTimeCalculationResultApi | null,
             {
-                loadAutomaticCalculation: async (input: RunningTimeCalculationInputApi) => {
-                    return await experimentsCalculateRunningTimeCreate(String(values.currentProjectId), input)
+                loadAutomaticCalculation: async (input: RunningTimeCalculationInputApi, breakpoint) => {
+                    const result = await experimentsCalculateRunningTimeCreate(String(values.currentProjectId), input)
+                    breakpoint()
+                    return result
                 },
             },
         ],

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -173,9 +173,10 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                 configOverrides ? { ...initialConfig, ...configOverrides } : initialConfig,
         ],
 
-        // Pulled out as a primitive so automaticCalculationInput stays stable when the experiment object
-        // is replaced (e.g. after persisting an estimate) but the mde value itself is unchanged.
+        // Pulled out as primitives so automaticCalculationInput stays stable when the experiment object
+        // is replaced (e.g. after persisting an estimate) but the underlying values are unchanged.
         mde: [(s) => [s.config], (config): number => config.mde],
+        mode: [(s) => [s.config], (config): RunningTimeConfig['mode'] => config.mode],
 
         // Legacy flow exposes metric results via experimentLogic; the recalculation flow exposes them
         // via experimentMetricsLogic. Pick whichever is active so automatic mode always has a baseline.
@@ -202,9 +203,12 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
 
         // Request body for the automatic-mode calculation, or null when not applicable (manual mode / no results yet).
         automaticCalculationInput: [
-            (s) => [s.isManualMode, s.metricsWithResults, s.numberOfVariants, s.mde],
-            (isManualMode, results, numberOfVariants, mde): RunningTimeCalculationInputApi | null => {
-                if (isManualMode) {
+            (s) => [s.mode, s.metricsWithResults, s.numberOfVariants, s.mde],
+            (mode, results, numberOfVariants, mde): RunningTimeCalculationInputApi | null => {
+                // Gate on the in-form mode rather than the persisted mode. While the form is in manual mode
+                // (even if the experiment is still saved as automatic), the automatic estimate is neither
+                // shown nor persisted, so editing the MDE shouldn't fire a wasted automatic calculation.
+                if (mode !== 'automatic') {
                     return null
                 }
                 const firstMetric = results?.[0]

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -126,6 +126,7 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
                     // Debounce burst typing in the form so we don't fire a request per keypress.
                     await breakpoint(300)
                     const result = await experimentsCalculateRunningTimeCreate(String(values.currentProjectId), input)
+                    breakpoint()
                     return {
                         sampleSize: result.recommended_sample_size,
                         runningTime: result.recommended_running_time_days,


### PR DESCRIPTION
## Problem

With the running-time calculator math now available on the backend ( #64032), we can use that in the frontend and remove the calculator logic there.

## Changes

- `calculations.ts` drops the duplicated sample-size, variance, and delta-method formulas. It now keeps only client-side concerns: `getCalculatorMetricType` (classify a metric), `baselineStatsFromResults` (shape live results into the request body), and the live-state helpers `calculateCurrentExposures` / `calculateDaysElapsed` / `calculateExposureRate`.
- `runningTimeLogic.ts` calls the backend via the generated `experimentsCalculateRunningTimeCreate` client using two kea loaders — one for the automatic-mode estimate (from live results) and one for the live manual-form preview. The persisted manual sample size is read back from `experiment.parameters.recommended_sample_size` (written by the save listener from the same backend calculation).
- Saving now performs a network request, so the modal's **Save** button shows a loading state and **Cancel** is disabled while in flight.
- The frontend math tests move to the backend (PR #64032). `calculations.test.ts` now covers the retained client-side helpers.

No user-facing behavior change is intended — the same estimates, computed server-side.

## How did you test this code?

- Tested locally and verified that it works
- CI passes
- New tests added

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of @andehen, second in a 3-PR stack. The reactive selectors that computed sample size synchronously were converted to kea loaders backed by the endpoint. The metric→type classification and the live-state/time helpers were deliberately kept in the frontend — they aren't part of the duplicated math and the time helpers depend on `dayjs`/live results. `automaticCalculationInput` is keyed on a pulled-out `mde` primitive selector so replacing the experiment object after persistence doesn't trigger a redundant recalculation. The existing `api.update` persistence call was left as-is to keep the diff focused on the calculator migration.
