### PR TITLE
fix(trends): render total-value bar chart when data has negative/zero sum

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -90,7 +90,11 @@ export function ActionsHorizontalBar({
         getTrendsHidden,
     ])
 
-    return data && total > 0 ? (
+    // Render whenever the series carry data points, even if their aggregated
+    // values are negative or sum to <= 0 (e.g. "Property value sum"). Guarding
+    // on `total > 0` wrongly showed the empty state for valid results. `total`
+    // is still computed above for the share-of-total tooltip. See #60163.
+    return data && data[0]?.data?.some((value) => value != null) ? (
         <LineGraph
             data-attr="trend-bar-value-graph"
             type={GraphType.HorizontalBar}


### PR DESCRIPTION
## Problem

Fixes #60163.

The "Total value" horizontal bar chart guarded rendering on `data && total > 0`. A query whose aggregated values are negative or sum to `<= 0` (e.g. "Property value sum") fell through to `<InsightEmptyState />` even though it had real data points. The sibling pie chart (`ActionsPie.tsx`) renders on `data` alone, which is the inconsistency this fixes.

## Fix

Switch the guard to a data-presence check:

```tsx
return data && data[0]?.data?.some((value) => value != null) ? (
```

`total` is still computed for the share-of-total tooltip (`formatAggregationAxisValueWithShareOfTotal`); only the render condition changed. Genuinely empty queries (no data points) still show the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)