### PR TITLE
fix(ducklake): remove unused cross-account catalog fields

### DIFF
--- a/posthog/admin/admins/ducklake_catalog_admin.py
+++ b/posthog/admin/admins/ducklake_catalog_admin.py
@@ -13,12 +13,11 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
         "db_database",
         "bucket",
         "bucket_region",
-        "cross_account_role_arn",
         "created_at",
         "updated_at",
     )
     list_filter = ("bucket_region",)
-    search_fields = ("=team__id", "=organization__id", "db_host", "bucket", "cross_account_role_arn")
+    search_fields = ("=team__id", "=organization__id", "db_host", "bucket")
     readonly_fields = ("id", "created_at", "updated_at")
     raw_id_fields = ("team", "organization")
 
@@ -39,13 +38,6 @@ class DuckLakeCatalogAdmin(admin.ModelAdmin):
             "S3 bucket",
             {
                 "fields": ("bucket", "bucket_region"),
-            },
-        ),
-        (
-            "Cross-account S3 access",
-            {
-                "fields": ("cross_account_role_arn", "cross_account_external_id"),
-                "description": "Required settings for writing to customer-owned S3 buckets via IAM role assumption",
             },
         ),
         (

--- a/posthog/dags/README_DUCKLINGS.md
+++ b/posthog/dags/README_DUCKLINGS.md
@@ -114,8 +114,8 @@ class DucklingBackfillConfig:
    - `bucket_region`: AWS region
    - `db_host`: RDS endpoint
    - `db_name`: Database name
-   - `cross_account_role_arn`: IAM role for Dagster to assume
-   - `cross_account_external_id`: External ID for role assumption
+
+   Ensure the runtime IAM role can read from and write to the configured S3 bucket.
 
 2. The discovery sensor will automatically pick up the new team on its next run
 

--- a/posthog/ducklake/models.py
+++ b/posthog/ducklake/models.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from django.db import models
 
 from posthog.helpers.encrypted_fields import EncryptedTextField
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
-
-if TYPE_CHECKING:
-    from posthog.ducklake.storage import CrossAccountDestination
 
 
 class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
@@ -46,16 +41,6 @@ class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     bucket = models.CharField(max_length=255)
     bucket_region = models.CharField(max_length=50, default="us-east-1")
 
-    # Cross-account S3 access settings (required - for writing to customer-owned buckets)
-    cross_account_role_arn = models.CharField(
-        max_length=255,
-        help_text="ARN of the IAM role to assume for cross-account S3 access",
-    )
-    cross_account_external_id = EncryptedTextField(
-        max_length=500,
-        help_text="External ID for cross-account role assumption (encrypted)",
-    )
-
     class Meta:
         db_table = "posthog_ducklakecatalog"
         verbose_name = "DuckLake catalog"
@@ -73,17 +58,6 @@ class DuckLakeCatalog(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
             "DUCKLAKE_S3_ACCESS_KEY": "",
             "DUCKLAKE_S3_SECRET_KEY": "",
         }
-
-    def to_cross_account_destination(self) -> CrossAccountDestination:
-        """Convert to a CrossAccountDestination for cross-account S3 access."""
-        from posthog.ducklake.storage import CrossAccountDestination
-
-        return CrossAccountDestination(
-            role_arn=self.cross_account_role_arn,
-            bucket_name=self.bucket,
-            external_id=self.cross_account_external_id,
-            region=self.bucket_region or None,
-        )
 
 
 class DuckgresServer(CreatedMetaFields, UpdatedMetaFields, UUIDModel):

--- a/posthog/ducklake/storage.py
+++ b/posthog/ducklake/storage.py
@@ -583,8 +583,6 @@ def _collect_delta_log_keys(
 def stage_delta_table(
     source_uri: str,
     catalog_bucket: str,
-    role_arn: str,
-    external_id: str | None = None,
     *,
     storage_config: DuckLakeStorageConfig | None = None,
     team_id: int | None = None,
@@ -615,14 +613,7 @@ def stage_delta_table(
         organization_id=organization_id,
     )
 
-    access_key, secret_key, session_token = _get_cross_account_credentials(role_arn, external_id)
-
-    s3 = boto3.client(
-        "s3",
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        aws_session_token=session_token,
-    )
+    s3 = boto3.client("s3")
 
     log_keys = _collect_delta_log_keys(s3, source_bucket, source_prefix, version)
 
@@ -644,8 +635,6 @@ def stage_delta_table(
 
 def cleanup_staged_files(
     staging_uri: str,
-    role_arn: str,
-    external_id: str | None = None,
 ) -> None:
     """Delete staged Delta files from the staging bucket."""
     import boto3
@@ -656,14 +645,7 @@ def cleanup_staged_files(
     if not prefix.endswith("/"):
         prefix += "/"
 
-    access_key, secret_key, session_token = _get_cross_account_credentials(role_arn, external_id)
-
-    s3 = boto3.client(
-        "s3",
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        aws_session_token=session_token,
-    )
+    s3 = boto3.client("s3")
 
     paginator = s3.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):

--- a/posthog/ducklake/test_storage.py
+++ b/posthog/ducklake/test_storage.py
@@ -314,43 +314,6 @@ class TestCrossAccountDestination:
         assert dest.region is None
 
 
-class TestDuckLakeCatalogToCrossAccountDestination:
-    def test_converts_to_cross_account_destination(self):
-        from unittest.mock import MagicMock
-
-        from posthog.ducklake.models import DuckLakeCatalog
-
-        # Create a mock catalog with the required attributes
-        catalog = MagicMock(spec=DuckLakeCatalog)
-        catalog.cross_account_role_arn = "arn:aws:iam::222222222222:role/CustomerRole"
-        catalog.cross_account_external_id = "external-id-456"
-        catalog.bucket = "customer-bucket"
-        catalog.bucket_region = "eu-west-1"
-
-        # Call the real method on the mock
-        dest = DuckLakeCatalog.to_cross_account_destination(catalog)
-
-        assert dest.role_arn == "arn:aws:iam::222222222222:role/CustomerRole"
-        assert dest.external_id == "external-id-456"
-        assert dest.bucket_name == "customer-bucket"
-        assert dest.region == "eu-west-1"
-
-    def test_none_region_handled(self):
-        from unittest.mock import MagicMock
-
-        from posthog.ducklake.models import DuckLakeCatalog
-
-        catalog = MagicMock(spec=DuckLakeCatalog)
-        catalog.cross_account_role_arn = "arn:aws:iam::111:role/Role"
-        catalog.cross_account_external_id = "ext-id"
-        catalog.bucket = "bucket"
-        catalog.bucket_region = ""  # Empty string should become None
-
-        dest = DuckLakeCatalog.to_cross_account_destination(catalog)
-
-        assert dest.region is None
-
-
 def _make_s3_page(keys: list[str]) -> list[dict]:
     return [{"Contents": [{"Key": k} for k in keys]}]
 
@@ -508,10 +471,6 @@ class TestStageDeltaTable:
             )
         )
         monkeypatch.setattr("posthog.ducklake.storage._get_delta_snapshot_files", mock_get_snapshot_files)
-        monkeypatch.setattr(
-            "posthog.ducklake.storage._get_cross_account_credentials",
-            lambda role_arn, external_id=None: ("ak", "sk", "tok"),
-        )
 
         mock_s3 = MagicMock()
         mock_s3.get_paginator.return_value = _mock_paginator(
@@ -532,7 +491,6 @@ class TestStageDeltaTable:
         result = stage_delta_table(
             source_uri="s3://customer-bucket/data/table",
             catalog_bucket="catalog-bucket",
-            role_arn="arn:aws:iam::123:role/Role",
             organization_id="org-123",
         )
 

--- a/posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py
+++ b/posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py
@@ -18,6 +18,15 @@ class Migration(migrations.Migration):
                     name="cross_account_role_arn",
                 ),
             ],
-            database_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE posthog_ducklakecatalog
+                        ALTER COLUMN cross_account_external_id DROP NOT NULL,
+                        ALTER COLUMN cross_account_role_arn DROP NOT NULL;
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
         ),
     ]

--- a/posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py
+++ b/posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1222_alter_integration_kind_google_analytics"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="ducklakecatalog",
+                    name="cross_account_external_id",
+                ),
+                migrations.RemoveField(
+                    model_name="ducklakecatalog",
+                    name="cross_account_role_arn",
+                ),
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1222_alter_integration_kind_google_analytics
+1223_remove_ducklakecatalog_cross_account_fields

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -971,7 +971,7 @@ def background_delete_model_task(
     import structlog
 
     logger = structlog.get_logger(__name__)
-    logger.setLevel(logging.INFO)
+    logging.getLogger(__name__).setLevel(logging.INFO)
 
     try:
         # Parse model name

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -62,7 +62,7 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
 logger = structlog.get_logger(__name__)
-logger.setLevel(logging.INFO)
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 # AI events dynamically generated from AIEventType TS enum
 # Changes to the AIEventType enum will impact usage reporting

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -296,8 +296,6 @@ def _copy_data_imports_via_duckgres(inputs: DuckLakeCopyDataImportsActivityInput
     stage_delta_table(
         source_uri=inputs.model.source_table_uri,
         catalog_bucket=catalog.bucket,
-        role_arn=catalog.cross_account_role_arn,
-        external_id=catalog.cross_account_external_id,
         organization_id=org_id,
     )
 
@@ -334,8 +332,6 @@ def cleanup_data_imports_staging_activity(inputs: DuckLakeDataImportsStagingClea
         return
     cleanup_staged_files(
         staging_uri=inputs.staging_uri,
-        role_arn=catalog.cross_account_role_arn,
-        external_id=catalog.cross_account_external_id,
     )
 
 

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -24,7 +24,6 @@ from posthog.ducklake.storage import (
     cleanup_staged_files,
     compute_staging_uri,
     configure_connection,
-    configure_cross_account_connection,
     connect_to_duckgres,
     ensure_ducklake_bucket_exists,
     get_deltalake_storage_options,
@@ -250,7 +249,7 @@ def verify_ducklake_copy_activity(inputs: DuckLakeCopyActivityInputs) -> list[Du
                     )
                 config = catalog.to_public_config()
                 config["DUCKLAKE_RDS_PASSWORD"] = catalog.db_password
-                configure_cross_account_connection(conn, destinations=[catalog.to_cross_account_destination()])
+                configure_connection(conn)
             _attach_ducklake_catalog(conn, config, alias=alias)
 
             ducklake_table = f"{alias}.{inputs.model.schema_name}.{inputs.model.table_name}"
@@ -519,8 +518,6 @@ def _copy_data_modeling_via_duckgres(inputs: DuckLakeCopyActivityInputs, logger)
     stage_delta_table(
         source_uri=inputs.model.source_table_uri,
         catalog_bucket=catalog.bucket,
-        role_arn=catalog.cross_account_role_arn,
-        external_id=catalog.cross_account_external_id,
         organization_id=org_id,
     )
 
@@ -557,8 +554,6 @@ def cleanup_data_modeling_staging_activity(inputs: DuckLakeDataModelingStagingCl
         return
     cleanup_staged_files(
         staging_uri=inputs.staging_uri,
-        role_arn=catalog.cross_account_role_arn,
-        external_id=catalog.cross_account_external_id,
     )
 
 

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
@@ -268,7 +268,7 @@ async def test_prepare_data_imports_ducklake_metadata_activity_empty_schema_ids(
 
 
 def _create_mock_catalog():
-    """Create a mock DuckLakeCatalog with cross-account settings."""
+    """Create a mock DuckLakeCatalog."""
     mock_catalog = MagicMock()
     mock_catalog.to_public_config.return_value = {
         "DUCKLAKE_RDS_HOST": "localhost",
@@ -282,12 +282,6 @@ def _create_mock_catalog():
         "DUCKLAKE_S3_SECRET_KEY": "",
     }
     mock_catalog.bucket = "test-bucket"
-    mock_catalog.cross_account_role_arn = "arn:aws:iam::123456789012:role/test-role"
-    mock_catalog.cross_account_external_id = "external-id-123"
-    mock_cross_account_dest = MagicMock()
-    mock_cross_account_dest.role_arn = "arn:aws:iam::123456789012:role/test-role"
-    mock_cross_account_dest.bucket_name = "test-bucket"
-    mock_catalog.to_cross_account_destination.return_value = mock_cross_account_dest
     return mock_catalog
 
 
@@ -477,8 +471,6 @@ def test_copy_data_imports_to_ducklake_activity_via_duckgres(monkeypatch):
     mock_stage.assert_called_once_with(
         source_uri="s3://bucket/team_1/customers",
         catalog_bucket="test-bucket",
-        role_arn="arn:aws:iam::123456789012:role/test-role",
-        external_id="external-id-123",
         organization_id="org-123",
     )
     execute_calls = mock_conn.execute.call_args_list

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py
@@ -29,7 +29,7 @@ from products.data_modeling.backend.models.datawarehouse_saved_query import Data
 
 
 def _create_mock_catalog():
-    """Create a mock DuckLakeCatalog with cross-account settings."""
+    """Create a mock DuckLakeCatalog."""
     mock_catalog = MagicMock()
     mock_catalog.to_public_config.return_value = {
         "DUCKLAKE_RDS_HOST": "localhost",
@@ -43,12 +43,6 @@ def _create_mock_catalog():
         "DUCKLAKE_S3_SECRET_KEY": "",
     }
     mock_catalog.bucket = "test-bucket"
-    mock_catalog.cross_account_role_arn = "arn:aws:iam::123456789012:role/test-role"
-    mock_catalog.cross_account_external_id = "external-id-123"
-    mock_cross_account_dest = MagicMock()
-    mock_cross_account_dest.role_arn = "arn:aws:iam::123456789012:role/test-role"
-    mock_cross_account_dest.bucket_name = "test-bucket"
-    mock_catalog.to_cross_account_destination.return_value = mock_cross_account_dest
     return mock_catalog
 
 
@@ -248,8 +242,6 @@ def test_copy_data_modeling_model_to_ducklake_activity_via_duckgres(monkeypatch)
     mock_stage.assert_called_once_with(
         source_uri="s3://source/table",
         catalog_bucket="test-bucket",
-        role_arn="arn:aws:iam::123456789012:role/test-role",
-        external_id="external-id-123",
         organization_id="org-123",
     )
     execute_calls = mock_conn.execute.call_args_list
@@ -311,7 +303,7 @@ def test_verify_ducklake_copy_activity_runs_queries(monkeypatch):
         MagicMock(return_value=_create_mock_catalog()),
     )
     monkeypatch.setattr(
-        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_cross_account_connection",
+        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_connection",
         MagicMock(),
     )
 
@@ -460,7 +452,7 @@ def test_verify_ducklake_copy_activity_reports_failures(monkeypatch):
         MagicMock(return_value=_create_mock_catalog()),
     )
     monkeypatch.setattr(
-        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_cross_account_connection",
+        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_connection",
         MagicMock(),
     )
 
@@ -616,7 +608,7 @@ def test_verify_ducklake_copy_activity_respects_tolerance(monkeypatch, observed,
         MagicMock(return_value=_create_mock_catalog()),
     )
     monkeypatch.setattr(
-        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_cross_account_connection",
+        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_connection",
         MagicMock(),
     )
 
@@ -697,7 +689,7 @@ def test_verify_ducklake_copy_activity_includes_additional_checks(monkeypatch):
         MagicMock(return_value=_create_mock_catalog()),
     )
     monkeypatch.setattr(
-        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_cross_account_connection",
+        "posthog.temporal.ducklake.ducklake_copy_data_modeling_workflow.configure_connection",
         MagicMock(),
     )
 


### PR DESCRIPTION
## Problem

DuckLake catalog rows still exposed cross-account S3 role fields in the model and Django admin CRUD page, but the DuckLake/Duckgres jobs no longer use catalog-stored role assumption settings.

## Changes

- Remove `cross_account_role_arn` and `cross_account_external_id` from `DuckLakeCatalog` and the Django admin form/list/search configuration.
- Add a Django migration that removes the fields from Django state without dropping the physical columns, and relaxes the legacy physical columns so new catalog rows can be inserted safely.
- Stop passing catalog-stored role/external ID values through DuckLake staging and cleanup helpers; those now use the standard runtime S3 credentials.
- Fix two task logger level assignments that used `setLevel` on structlog loggers and blocked DB-backed test setup through activity-log signal imports.
- Update focused DuckLake tests, Ducklings setup docs, and migration linearity marker.

## How did you test this code?

As an agent, I ran:

- `env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE bin/hogli test posthog/ducklake/test_storage.py`
- `env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE .venv/bin/pytest -q posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py -m "not django_db"`
- `env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE PATH="/var/folders/m6/djv2gsfj34b60yq9pb48gpdh0000gn/T/opencode:$PATH" TEST=1 PGHOST=localhost PGPORT=15532 PGUSER=posthog PGPASSWORD=posthog PGDATABASE=posthog CLICKHOUSE_HOST=localhost CLICKHOUSE_SECURE=false CLICKHOUSE_VERIFY=false .venv/bin/pytest -q posthog/ducklake/test_storage.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py` (`77 passed`)
- Docker-backed `sqlmigrate posthog 1223` to confirm the migration only relaxes `NOT NULL` on the legacy physical columns and does not drop columns.
- Docker-backed `makemigrations --check --dry-run` to confirm no model/migration drift.
- `uv run ruff check posthog/tasks/usage_report.py posthog/tasks/tasks.py posthog/admin/admins/ducklake_catalog_admin.py posthog/ducklake/models.py posthog/ducklake/storage.py posthog/ducklake/test_storage.py posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py`
- `uv run ruff format --check posthog/tasks/usage_report.py posthog/tasks/tasks.py posthog/admin/admins/ducklake_catalog_admin.py posthog/ducklake/models.py posthog/ducklake/storage.py posthog/ducklake/test_storage.py posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_modeling_workflow.py posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py posthog/migrations/1223_remove_ducklakecatalog_cross_account_fields.py`
- `git diff --check`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the internal Ducklings setup docs to remove the obsolete cross-account catalog fields and call out runtime IAM access to the configured bucket.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with OpenCode in response to a request to remove unused DuckLake cross-account S3 catalog fields. I chose a migration that removes fields from Django state without dropping physical columns during a rolling deploy, while relaxing the legacy columns so new catalog rows remain insertable. DuckLake staging paths now use normal runtime S3 credentials instead of removed catalog attributes.

The DB-backed Temporal tests required Docker-backed Postgres, ZooKeeper, and ClickHouse with the repo ClickHouse dev config mounted. While running those tests, activity-log setup exposed existing task logger level assignments that were targeting structlog wrappers instead of stdlib loggers; this PR includes the minimal fix so the DB-backed tests can complete.
