### PR TITLE
fix(logs): show value-match indicator in rebuilt taxonomic filter menu

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -56,6 +56,7 @@ import {
 } from '../utils/collapsedContainsRow'
 import { promoteMatchingBy } from '../utils/promoteProperties'
 import { MenuFilterHeader } from './Header'
+import { MatchedValueBadge } from './MatchedValueBadge'
 import { PreviewPane } from './PreviewPane'
 import { CommitFn, CommitSelectionContext, DrillCategory, MenuFilterEntry, TAXONOMIC_FILTER_SURFACE } from './types'
 import { VerificationBadge } from './VerificationBadge'
@@ -1271,6 +1272,7 @@ function Row({ entry, showCategory, recency, opensSubmenu, selectedRowId, onSele
                 )}
                 {showCategory && <MenuLabel className="text-tertiary/50 text-xxs p-0 mt-1">{category}</MenuLabel>}
             </div>
+            <MatchedValueBadge entry={entry} />
             {recency && (
                 <Badge variant="default" className="gap-1 shrink-0">
                     {recency === 'recent' ? <IconClock className="size-3" /> : <IconPinFilled className="size-3" />}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/MatchedValueBadge.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/MatchedValueBadge.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { getMatchedValue, MatchedValueBadge } from './MatchedValueBadge'
+import { MenuFilterEntry } from './types'
+
+function makeEntry(item: Record<string, any>): MenuFilterEntry {
+    return {
+        item,
+        group: { type: 'log_attributes', name: 'Log attributes' },
+        name: item.name ?? 'attr',
+    } as unknown as MenuFilterEntry
+}
+
+describe('MatchedValueBadge', () => {
+    afterEach(cleanup)
+
+    it('renders the matched value when the item matched on value', () => {
+        render(<MatchedValueBadge entry={makeEntry({ name: 'level', matchedOn: 'value', matchedValue: 'error' })} />)
+        expect(screen.getByLabelText('Matched on value')).toHaveTextContent('error')
+    })
+
+    it('truncates long matched values', () => {
+        const long = 'a'.repeat(40)
+        render(<MatchedValueBadge entry={makeEntry({ name: 'level', matchedOn: 'value', matchedValue: long })} />)
+        expect(screen.getByLabelText('Matched on value')).toHaveTextContent('…')
+    })
+
+    it.each([
+        ['matched on name', { name: 'level', matchedOn: 'name', matchedValue: 'error' }],
+        ['no matchedValue', { name: 'level', matchedOn: 'value' }],
+        ['empty matchedValue', { name: 'level', matchedOn: 'value', matchedValue: '' }],
+        ['plain attribute', { name: 'level' }],
+    ])('renders nothing for %s', (_label, item) => {
+        const { container } = render(<MatchedValueBadge entry={makeEntry(item)} />)
+        expect(container).toBeEmptyDOMElement()
+        expect(getMatchedValue(makeEntry(item))).toBeNull()
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/menu/MatchedValueBadge.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/MatchedValueBadge.tsx
@@ -1,0 +1,61 @@
+/**
+ * "Matched on value" badge for taxonomic filter rows + preview pane.
+ *
+ * Some groups (log / resource attributes) search attribute *values* as well
+ * as names via `search_values=true`. When a row surfaces because the query
+ * matched one of its values — not the attribute name — the endpoint tags the
+ * item with `matchedOn: 'value'` and the `matchedValue`. Surfacing it tells
+ * the user why an attribute appears for a query that isn't in its name.
+ */
+import { Badge, cn, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
+
+import { MenuFilterEntry } from './types'
+
+const VALUE_MATCH_MAX_LENGTH = 30
+
+export function getMatchedValue(entry: MenuFilterEntry): string | null {
+    const item = entry.item as { matchedOn?: string; matchedValue?: string } | null
+    if (item && item.matchedOn === 'value' && typeof item.matchedValue === 'string' && item.matchedValue.length > 0) {
+        return item.matchedValue
+    }
+    return null
+}
+
+export function MatchedValueBadge({
+    entry,
+    className,
+}: {
+    entry: MenuFilterEntry
+    className?: string
+}): JSX.Element | null {
+    const matchedValue = getMatchedValue(entry)
+    if (!matchedValue) {
+        return null
+    }
+    const truncated =
+        matchedValue.length > VALUE_MATCH_MAX_LENGTH
+            ? matchedValue.slice(0, VALUE_MATCH_MAX_LENGTH) + '…'
+            : matchedValue
+    return (
+        <Tooltip>
+            {/* Trigger must render a host element so base-ui's hover ref attaches —
+                `Badge` is a plain component (not forwardRef). See VerificationBadge. */}
+            <TooltipTrigger
+                delay={300}
+                render={(triggerProps) => (
+                    <span {...triggerProps} className={cn('inline-flex min-w-0', className)}>
+                        <Badge
+                            variant="default"
+                            aria-label="Matched on value"
+                            data-attr="taxonomic-value-match-indicator"
+                            className="max-w-48 shrink-0 truncate font-mono"
+                        >
+                            {truncated}
+                        </Badge>
+                    </span>
+                )}
+            />
+            <TooltipContent className="max-w-64">Matched on value: "{matchedValue}"</TooltipContent>
+        </Tooltip>
+    )
+}

--- a/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/PreviewPane.tsx
@@ -21,6 +21,7 @@ import { ActionType, CohortType, EventDefinition, PropertyDefinition } from '~/t
 
 import { useTaxonomicAutocompleteItemDetails } from '../headless'
 import { TaxonomicFilterGroupType } from '../types'
+import { getMatchedValue } from './MatchedValueBadge'
 import { ActionMatchGroups } from './preview/ActionMatchGroups'
 import { MenuFilterEntry } from './types'
 import { VerificationBadge } from './VerificationBadge'
@@ -58,6 +59,7 @@ function PreviewBody({ entry }: { entry: MenuFilterEntry }): JSX.Element | null 
     // for event first/last seen (handled later if needed).
     const isAction = entry.group.type === TaxonomicFilterGroupType.Actions
     const viewUrl = resolveViewUrl(entry)
+    const matchedValue = getMatchedValue(entry)
 
     return (
         <ScrollArea className="flex-1 min-h-0">
@@ -76,6 +78,13 @@ function PreviewBody({ entry }: { entry: MenuFilterEntry }): JSX.Element | null 
                     <div className="flex flex-col gap-0.5 border-t pt-2">
                         <div className="text-xxs uppercase tracking-wide text-secondary">Property type</div>
                         <div className="text-xs">{details.propertyType}</div>
+                    </div>
+                )}
+
+                {matchedValue && (
+                    <div className="flex flex-col gap-0.5 border-t pt-2">
+                        <div className="text-xxs uppercase tracking-wide text-secondary">Matched on value</div>
+                        <code className="break-all font-mono text-xs text-tertiary">{matchedValue}</code>
                     </div>
                 )}
 


### PR DESCRIPTION
## Problem

In the rebuilt taxonomic filter menu (behind `taxonomic-filter-menu-rebuild`), searching log / resource attributes by **value** gave no feedback. Logs are the surface that searches attributes by value: the `logs/attributes` endpoint is queried with `search_values=true`, so a query can match an attribute's values rather than its name. The endpoint tags those rows with `matchedOn: 'value'` + `matchedValue`, and the legacy `InfiniteList` renders a "Matched on value" tag for them — but the rebuilt menu's `Row` and preview pane never read those fields. Users saw the matched attribute with no indication of, or the value it matched on.

## Changes

Port the legacy indicator into the rebuilt menu:

- **`MatchedValueBadge.tsx`** — new component mirroring the existing `VerificationBadge` convention (quill `Badge` + `Tooltip`); exports a shared `getMatchedValue` guard (`matchedOn === 'value'` + non-empty value), with truncation at 30 chars for the badge.
- **`Combobox.tsx`** — render the badge on each row, next to `VerificationBadge`.
- **`PreviewPane.tsx`** — add a "Matched on value" section showing the full, untruncated value (the pane has room).

No backend or data-flow changes — the search term was already forwarded to the remote endpoint and raw results passed through untouched; only the rendering was missing.

To test locally: enable the `taxonomic-filter-menu-rebuild` flag (the rebuilt menu is then the default), open a logs filter, pick Log/Resource attributes, and type a query that matches a value rather than an attribute name.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual UI testing. Automated:

- Added `MatchedValueBadge.test.tsx` (6 cases: renders value, truncates long values, and renders nothing for name-match / missing / empty / plain attribute) — all passing via `hogli test`.
- Traced the data path to confirm `matchedOn`/`matchedValue` survive from the endpoint onto the committed `entry.item` (`fetchTaxonomicListPage` passes raw results through; `Combobox` builds entries with `item` intact).

Note: `@posthog/quill` had to be built in the worktree (`pnpm --filter='@posthog/quill*' build`) for jest to resolve it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). The user reported that in the new property filter UI they saw the matched log attribute but not the value it matched on. Investigation narrowed the cause to the rebuilt menu being a key-picker that delegates value handling to the host row, while the legacy-only "matched on value" indicator (`InfiniteList.valueMatchIndicator`) was never ported. Chosen fix mirrors the established `VerificationBadge` pattern and reuses one `getMatchedValue` helper across the row badge and preview pane. Considered and rejected reimplementing value search inside the menu — out of scope; the indicator was the actual gap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
