### PR TITLE
ci(cli): refresh master before release commit

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -162,6 +162,9 @@ jobs:
                   filter: blob:none
                   token: ${{ steps.app-token.outputs.token }}
 
+            - name: Update to latest master before preparing release
+              run: git pull --ff-only origin master
+
             - name: Install Rust
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
@@ -228,6 +231,14 @@ jobs:
                   fi
 
                   echo "committed=true" >> "$GITHUB_OUTPUT"
+
+            - name: Ensure master did not advance during release prep
+              run: |
+                  git fetch origin master
+                  if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+                      echo "::error::master advanced while preparing the CLI release. Re-run the workflow so the release includes the latest changesets."
+                      exit 1
+                  fi
 
             - name: Commit release changes
               id: commit-release

--- a/cli/.sampo/changesets/release-master-freshness.md
+++ b/cli/.sampo/changesets/release-master-freshness.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Refresh master before preparing CLI releases


### PR DESCRIPTION
## Problem

CLI releases can fail after approval when master advances before the release commit step. The release job prepares the version bump successfully, but the commit action refuses to write because the branch no longer points at the workflow trigger SHA.

## Changes

- Fast-forward the release checkout to the latest master before preparing release files.
- Check that master has not advanced again before committing generated release changes.
- Add a CLI patch changeset so merging this PR matches the Release CLI workflow path filter and starts a new release attempt.

## How did you test this code?

As an agent, I ran:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml"); YAML.load_file("cli/.sampo/changesets/release-master-freshness.md"); puts "yaml parses"'`
- `git diff --check`
- pre-commit hook via `git commit --amend --no-edit`, including `bin/hogli format:markdown`
- `$autoreview` on the workflow patch and on the changeset patch; no accepted/actionable findings

Merging this PR should trigger Release CLI because it adds `cli/.sampo/changesets/release-master-freshness.md`, matching the workflow path filter.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated the failed Release CLI run, compared the pattern with the posthog-js release workflow, and applied the same freshness guard style here. The chosen fix keeps the release job deterministic: it starts from latest master after approval, then fails with a clear message if master advances again during release prep.
