### PR TITLE
fix(visual_review): skip hidden quarantined snapshots when navigating

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -544,7 +544,7 @@ export function VisualReviewRunScene(): JSX.Element {
                                     onClick={toggleQuarantinedThumbnails}
                                 />
                             )}
-                            {navSnapshots.length > 1 && (
+                            {visibleNavSnapshots.length > 1 && (
                                 <div className="flex items-center gap-2">
                                     <LemonButton
                                         size="xsmall"
@@ -558,7 +558,7 @@ export function VisualReviewRunScene(): JSX.Element {
                                     </LemonButton>
                                     {currentIndex >= 0 && (
                                         <span className="text-xs text-muted">
-                                            {currentIndex + 1} of {navSnapshots.length}
+                                            {currentIndex + 1} of {visibleNavSnapshots.length}
                                         </span>
                                     )}
                                     <LemonButton

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -258,21 +258,23 @@ export function VisualReviewRunScene(): JSX.Element {
     const hiddenQuarantinedCount = navSnapshots.length - visibleNavSnapshots.length
     const showQuarantinedToggle = quarantinedNavCount > 0 && (hiddenQuarantinedCount > 0 || showQuarantinedThumbnails)
 
+    // Navigate over what's actually visible — when quarantined items are hidden, next/previous
+    // must skip them rather than selecting a hidden quarantined snapshot.
     const currentIndex = selectedSnapshot
-        ? navSnapshots.findIndex((s: SnapshotApi) => s.id === selectedSnapshot.id)
+        ? visibleNavSnapshots.findIndex((s: SnapshotApi) => s.id === selectedSnapshot.id)
         : -1
     const hasPrevious = currentIndex > 0
-    const hasNext = currentIndex >= 0 && currentIndex < navSnapshots.length - 1
+    const hasNext = currentIndex >= 0 && currentIndex < visibleNavSnapshots.length - 1
 
     const goToPrevious = (): void => {
         if (hasPrevious) {
-            setSelectedSnapshotId(navSnapshots[currentIndex - 1].id)
+            setSelectedSnapshotId(visibleNavSnapshots[currentIndex - 1].id)
         }
     }
 
     const goToNext = (): void => {
         if (hasNext) {
-            setSelectedSnapshotId(navSnapshots[currentIndex + 1].id)
+            setSelectedSnapshotId(visibleNavSnapshots[currentIndex + 1].id)
         }
     }
 
@@ -281,7 +283,7 @@ export function VisualReviewRunScene(): JSX.Element {
             p: { action: goToPrevious, disabled: !hasPrevious },
             n: { action: goToNext, disabled: !hasNext },
         },
-        [currentIndex, navSnapshots.length]
+        [currentIndex, visibleNavSnapshots.length]
     )
 
     // Show skeleton only on initial load — once `run` is populated, keep showing it

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -363,10 +363,18 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
                 ],
             }
 
-            // Find the next pending snapshot in sorted order before the async call
+            // Find the next pending snapshot in sorted order before the async call.
+            // Skip quarantined snapshots when they're hidden, otherwise approving advances
+            // onto an unrelated quarantined item the user can't see in the thumbnail strip.
             const sorted = values.sortedChangedSnapshots
             const currentIdx = sorted.findIndex((s) => s.id === snapshot.id)
-            const nextPending = sorted.slice(currentIdx + 1).find((s) => s.review_state === 'pending')
+            const nextPending = sorted
+                .slice(currentIdx + 1)
+                .find(
+                    (s) =>
+                        s.review_state === 'pending' &&
+                        (values.showQuarantinedThumbnails || !values.quarantinedIdentifierSet.has(s.identifier))
+                )
 
             try {
                 await visualReviewRunsApproveCreate(String(values.currentProjectId), props.runId, approvalPayload)


### PR DESCRIPTION
## Problem

When quarantined items are hidden in the visual review run scene, accepting a change (or pressing next/previous) could land on an unrelated quarantined snapshot — which then becomes the selected snapshot and pops into view. Reported from a Slack thread: "Sometimes when accepting a change on the visual story diff I'll randomly get an unrelated quarantined item popup."

The cause: next/previous navigation and the post-approve auto-advance both walked the *full* snapshot list (`navSnapshots` / `sortedChangedSnapshots`), including quarantined items, even when those items were hidden from the thumbnail strip.

## Changes

- Next/previous navigation now iterates over `visibleNavSnapshots` (the filtered list) instead of the full one, so it skips hidden quarantined snapshots.
- The approve auto-advance now skips quarantined snapshots when `showQuarantinedThumbnails` is false.

When the user has quarantined items shown, behavior is unchanged — they remain reachable.

## How did you test this code?

I'm an agent. I did not run the frontend test suite or manual UI testing in this environment (the lint/format toolchain wasn't installed). The change is a small, self-contained logic adjustment; reviewers should sanity-check the navigation flow with quarantined items hidden.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread where Paul D'Ambra identified the cause. Located the navigation logic in `VisualReviewRunScene.tsx` and the approve auto-advance in `visualReviewRunSceneLogic.ts`, then routed both through the already-existing visible/quarantine filtering rather than introducing new state.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781623772421309?thread_ts=1781623772.421309&cid=C0ACRAMJUAG)*
