### PR TITLE
fix(google_sheets): retry transient 5xx errors with non-int API codes

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -60,6 +60,28 @@ _PERMISSION_DENIED_MESSAGE = "Spreadsheet access denied. Please share the spread
 T = TypeVar("T")
 
 
+def _is_retryable_api_error(e: gspread.exceptions.APIError) -> bool:
+    """Decide whether a gspread APIError is a transient error worth retrying.
+
+    We deliberately key off the HTTP status on the response rather than `e.code`.
+    gspread derives `e.code` from the JSON error body (`error.code`), which is not a
+    reliable signal for transient failures: when Google (or a gateway/proxy in front of
+    it) returns a 5xx/429 with a non-JSON body, gspread falls back to `code = -1`, and
+    some error envelopes carry the code as a string. In those cases the underlying request
+    is still a transient 5xx/429 that should be retried, but a `code`-based check misses it
+    and fails the sync on the first attempt. `response.status_code` is always the real HTTP
+    status, so prefer it and fall back to `e.code` only when it is unavailable."""
+
+    status_code = getattr(getattr(e, "response", None), "status_code", None)
+    if isinstance(status_code, int):
+        return status_code in _RETRYABLE_API_ERROR_CODES
+
+    try:
+        return int(e.code) in _RETRYABLE_API_ERROR_CODES
+    except (TypeError, ValueError):
+        return False
+
+
 def _retry_on_transient_api_error(execute: Callable[[], T]) -> T:
     """Run `execute` with linear backoff, retrying transient Google Sheets API
     errors. Google Sheets has a 300 request quota per minute, and also returns
@@ -77,7 +99,7 @@ def _retry_on_transient_api_error(execute: Callable[[], T]) -> T:
         try:
             return execute()
         except gspread.exceptions.APIError as e:
-            if e.code not in _RETRYABLE_API_ERROR_CODES or attempts >= max_attempts:
+            if not _is_retryable_api_error(e) or attempts >= max_attempts:
                 raise
 
             jitter = random.uniform(-jitter_in_seconds, jitter_in_seconds)

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -235,6 +235,68 @@ def test_retry_on_transient_api_error_retries_then_exhausts(status_code):
         assert fn.call_count == 10
 
 
+def _api_error_with_status(
+    status_code: int, body: dict[str, Any] | None, text: str = ""
+) -> gspread.exceptions.APIError:
+    """Build an APIError whose HTTP status and body can differ. When `body` is None the
+    JSON body is unparseable, mirroring a transient 5xx returned by a gateway/proxy with a
+    non-JSON payload — gspread then falls back to `code == -1`."""
+    mock_response = mock.MagicMock()
+    mock_response.status_code = status_code
+    if body is None:
+        mock_response.json.side_effect = ValueError("no json")
+        mock_response.text = text
+    else:
+        mock_response.json.return_value = body
+    return gspread.exceptions.APIError(mock_response)
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+def test_retry_on_transient_api_error_retries_5xx_with_non_json_body(status_code):
+    """A transient 5xx/429 can arrive with a non-JSON body (e.g. a gateway/proxy error
+    page), in which case gspread sets `code` to -1. The retry decision must fall back to
+    the HTTP status so the genuinely transient error is still retried rather than failing
+    the sync on the first attempt."""
+    with mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"):
+        error = _api_error_with_status(status_code, body=None, text="upstream connect error")
+        assert error.code == -1  # gspread couldn't parse a code out of the body
+        fn = mock.MagicMock(side_effect=error)
+
+        with pytest.raises(gspread.exceptions.APIError):
+            _retry_on_transient_api_error(fn)
+
+        assert fn.call_count == 10
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 503])
+def test_retry_on_transient_api_error_retries_when_code_is_string(status_code):
+    """Some error envelopes carry the code as a string, so `e.code` is e.g. "500" and a
+    direct membership test against the integer set misses it. The retry decision must still
+    recognise the transient status via the HTTP status code."""
+    with mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"):
+        body = {"error": {"code": str(status_code), "message": "Internal error encountered.", "status": "INTERNAL"}}
+        error = _api_error_with_status(status_code, body=body)
+        fn = mock.MagicMock(side_effect=error)
+
+        with pytest.raises(gspread.exceptions.APIError):
+            _retry_on_transient_api_error(fn)
+
+        assert fn.call_count == 10
+
+
+def test_retry_on_transient_api_error_does_not_retry_4xx_with_non_json_body():
+    """A non-transient 4xx with an unparseable body must still be raised immediately — the
+    HTTP-status fallback should only retry the transient codes, not everything."""
+    with mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"):
+        error = _api_error_with_status(400, body=None, text="Bad Request")
+        fn = mock.MagicMock(side_effect=error)
+
+        with pytest.raises(gspread.exceptions.APIError):
+            _retry_on_transient_api_error(fn)
+
+        assert fn.call_count == 1
+
+
 def test_retry_on_transient_api_error_does_not_retry_non_transient():
     with mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.time"):
         fn = mock.MagicMock(side_effect=_api_error(400, status="INVALID_ARGUMENT"))


### PR DESCRIPTION
## Problem

The Google Sheets data-warehouse source surfaces an unhandled `APIError: [500]: Internal error encountered.` to error tracking, originating in `posthog/temporal/data_imports/sources/google_sheets/google_sheets.py` ([error-tracking issue](https://us.posthog.com/project/2/error_tracking/019ed116-9819-76d2-944e-bae8ee765b80)).

A `500 Internal error` from Google is a **transient** server-side error — Google's own guidance is to retry it with backoff, and the source already lists `500` in its retryable set. So this should never have escaped on the first try. The captured stack confirms it did: the `_retry_on_transient_api_error` frame shows `attempts: 1`, meaning the retry loop took its `raise` branch immediately rather than retrying.

The root cause is how retryability was decided. The loop tested `e.code not in _RETRYABLE_API_ERROR_CODES`, and gspread derives `APIError.code` from the **JSON error body** (`error.code`), not the HTTP status. That body-derived code is unreliable for exactly the transient failures we want to retry:

- A transient `5xx`/`429` returned with a **non-JSON body** (e.g. a gateway/proxy error page) makes gspread fall back to `code = -1` → `-1 not in {429, 500, 502, 503, 504}` → not retried.
- Some error envelopes carry the code as a **string** (`"500"`), which misses an integer-set membership test → not retried.

In both cases a genuinely transient error fails the sync on the first attempt instead of being retried.

## Changes

- Added `_is_retryable_api_error`, which bases the retry decision on the reliable HTTP status (`response.status_code`) and falls back to `e.code` only when the status is unavailable.
- The retry loop now calls this helper. The retryable code set is unchanged, so `500` and the other transient codes remain retryable — this is **not** a `NonRetryableErrors` change; a Google `500` is transient infrastructure, not a user/upstream-permanent error.

The deterministic `400 "Unable to parse range"` swallow in `get_schema_incremental_fields` still keys off `e.code`; it additionally requires a specific message substring, so the non-JSON concern does not apply and it was left untouched to keep the change scoped.

## How did you test this code?

I'm an agent (Claude Code). I added regression tests at the same layer as the fix and ran them — no manual testing was performed.

- `test_retry_on_transient_api_error_retries_5xx_with_non_json_body` (parametrized over `429/500/502/503/504`) — transient status with an unparseable body (`code == -1`) is now retried to exhaustion.
- `test_retry_on_transient_api_error_retries_when_code_is_string` (parametrized over `429/500/503`) — transient status with a string `code` is now retried.
- `test_retry_on_transient_api_error_does_not_retry_4xx_with_non_json_body` — a non-transient `400` with an unparseable body is still raised immediately (no over-broad retrying).

Verified the new tests fail against the pre-fix logic (raised on attempt 1, `call_count == 1`) and pass after the fix. Full source test suite: `37 passed`. `ruff check`/`ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged via PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in the Google Sheets source.
- Decision: the `500` is transient (keep retryable), but the retry classifier was buggy — it trusted the JSON-body-derived `APIError.code` instead of the HTTP status. The `attempts: 1` in the captured trace was the key signal that a "retryable" code wasn't being retried.
- Rejected adding `500` to `NonRetryableErrors` (it's transient infra) and rejected widening the retry to all errors (the `4xx` test guards against that).