### PR TITLE
perf(web-analytics): raise precompute today-bucket TTL to 2h

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
@@ -65,7 +65,9 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_SUCCESS = Counter(
 # to UTC before filtering on `time_window_start`. Half-hour-offset timezones
 # (IST, Newfoundland, Nepal, etc.) are explicitly gated out below.
 LAZY_TTL_SECONDS: dict[str, int] = {
-    "0d": 15 * 60,
+    # today: 2h — kept in sync with web_lazy_precompute_common.LAZY_TTL_SECONDS;
+    # see there for the rationale (the ~6h result cache fronts these reads).
+    "0d": 2 * 60 * 60,
     "1d": 60 * 60,
     "7d": 24 * 60 * 60,
     "default": 7 * 24 * 60 * 60,

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -47,10 +47,13 @@ _FILTERS_ELIGIBILITY_HASH_IGNORED_QUERY_FIELDS: frozenset[str] = frozenset(
     }
 )
 
-# Hourly UTC bucketing TTL schedule. Today gets 15 min so dashboards stay
-# fresh; older buckets get longer TTLs so we don't keep recomputing them.
+# Hourly UTC bucketing TTL schedule. Today gets 2h: recomputing it more often
+# buys nothing, since the ~6h HogQL result cache already fronts these queries (a
+# cache hit never reads the precompute), and a tighter TTL just makes the warmer
+# re-scan the whole current day every tick — which is what kept a full warm pass
+# from finishing inside the hourly window. Older buckets get longer TTLs.
 LAZY_TTL_SECONDS: dict[str, int] = {
-    "0d": 15 * 60,
+    "0d": 2 * 60 * 60,
     "1d": 60 * 60,
     "7d": 24 * 60 * 60,
     "default": 7 * 24 * 60 * 60,


### PR DESCRIPTION
## Problem

The lazy precompute "today" bucket (`LAZY_TTL_SECONDS["0d"]`) has a 15-min TTL, so the eager warmer re-scans the entire current day on (almost) every hourly tick. At the current cohort size a full warm pass already exceeds the hour, so the concurrent-run guard skips every other trigger — effective ~2h cadence — while still doing the heaviest possible recompute.

That 15-min freshness buys nothing in practice: these queries are fronted by the **~6h HogQL result cache**, and a cache hit never reads the precompute at all. So there's no point keeping the precompute fresher than the cache that sits in front of it.

## Changes

Raise the today-bucket TTL from **15 min → 2h** (in both copies of `LAZY_TTL_SECONDS` — `web_lazy_precompute_common.py` and `web_analytics_lazy_precompute.py`; kept in sync, with a cross-reference comment). Other tiers unchanged.

Effect:
- Warmer recompute of today drops ~**8×**, so a full pass comfortably finishes inside the hourly window — no more skipped ticks.
- Worst-case staleness of "today" goes to 2h, which is still well inside the ~6h the result cache already allows, so no user-visible regression.
- Headroom to enroll more teams (pairs with the cohort-broadening enrollment in PostHog/charts#12190).

2h is the conservative choice; 6h (matching the cache ceiling) is available if we want to push warmer load even lower. Follow-up worth noting: the two `LAZY_TTL_SECONDS` copies should be consolidated into one constant.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Constant change only — no behavior to unit-test beyond the existing TTL-schedule tests. Validated the rationale against prod query-log data: today's bucket is the dominant warmer recompute load, and lazy reads are already fronted by the result cache.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. From the precompute performance evaluation: the warmer was running ~2h effective cadence because a full pass exceeds the hourly tick, dominated by re-scanning the 15-min-TTL "today" bucket. Since the ~6h result cache fronts these queries, a sub-cache TTL is wasted work — raising it to 2h cuts the recompute ~8× with staleness still inside the cache window.
