### PR TITLE
fix(postgres): treat exceeded compute-time quota as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -274,6 +274,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "the pooler's credentials for the database are wrong. Check that the database is "
                 "running and reachable from your pooler, then re-enable the sync."
             ),
+            # Serverless Postgres providers (e.g. Neon) suspend a project's compute once it exhausts
+            # the plan's compute-time quota, and the connection attempt fails at handshake with
+            # "Your account or project has exceeded the compute time quota. Upgrade your plan to
+            # increase limits." The compute stays suspended until the customer upgrades their plan or
+            # the quota resets at the next billing period, so retrying the activity just re-hits the
+            # same wall. Match the stable provider message and exclude the volatile host/IP/port.
+            "exceeded the compute time quota": (
+                "Your database provider has suspended the database because the account or project "
+                'exceeded its compute-time quota ("exceeded the compute time quota"). PostHog can\'t '
+                "connect until the database is available again. Upgrade your provider's plan or wait "
+                "for the quota to reset, then re-enable the sync."
+            ),
             # `offset_chunking` retries a Postgres standby recovery conflict ("canceling statement
             # due to conflict with recovery") 30 times in-process with backoff + chunk-size
             # reduction before raising this. The conflict comes from the customer's read replica

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -302,6 +302,27 @@ class TestPostgresSourceNonRetryableErrors:
         assert friendly, "TLS ALPN rejection error should surface an actionable message"
         assert "host and port" in friendly[0]
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Neon suspends compute when the plan's compute-time quota is exhausted; the handshake
+            # fails with this provider message. The host/IP and port are volatile and excluded.
+            'connection failed: connection to server at "44.198.216.75", port 5432 failed: ERROR:  Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits.',
+            "OperationalError: Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits.",
+        ],
+    )
+    def test_exceeded_compute_time_quota_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Exceeded compute-time quota error should be non-retryable: {error_msg}"
+
+    def test_exceeded_compute_time_quota_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = "Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits."
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Exceeded compute-time quota error should surface an actionable message"
+        assert "compute-time quota" in friendly[0]
+
     def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
         # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,
         # so confirm it's specifically the new key that recognises this message.


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError` from the Postgres data-warehouse import source:

> connection failed: connection to server at "…", port 5432 failed: ERROR:  Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ed124-2331-7650-bdf2-717ab2768ae7

The stack originates in the source's own connection path (`source_for_pipeline` → `postgres_source` → `_connect_with_dropped_retry` → `_open_setup_connection` → `_connect_with_options_fallback`). It fires against a serverless Postgres provider (Neon) whose project compute has been **suspended** because the account exhausted its plan's compute-time quota.

This is an upstream/customer condition: the database is unavailable until the customer upgrades their provider plan or the quota resets at the next billing period. Retrying the import activity just re-hits the same handshake failure and produces captured-error noise.

## Changes

- Add the stable provider message `"exceeded the compute time quota"` to `PostgresSource.get_non_retryable_errors`, with an actionable user-facing message. The match deliberately excludes the volatile host/IP/port so it is low-false-positive.
- Add regression tests asserting the message (raw and wrapped) is recognised as non-retryable and that a friendly message is surfaced.

This is scoped strictly to this one error string — no change to global retry policy, and transient connection drops remain retryable (covered by existing tests).

## How did you test this code?

I'm an agent (Claude Code). I ran the source's non-retryable unit tests:

```
uv run pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors
# 47 passed
```

Also ran `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in PostHog error tracking (full stack trace, exception type, representative event) and verified the failure genuinely originates inside the postgres source's connection code rather than only appearing in serialized log context.

Decision: this is a user/upstream error (provider suspended the database for quota), not a fixable bug in our code and not a transient infra blip — retrying cannot recover it within a sync window. Mirrored the existing `get_non_retryable_errors` pattern (matching a stable substring, excluding volatile host/IP) rather than touching retry policy.

Tool used: Claude Code with the PostHog error-tracking MCP tools.