### PR TITLE
chore(skills): add ownership resolver to code-ownership skill

### DIFF
--- a/.agents/skills/establishing-code-ownership/SKILL.md
+++ b/.agents/skills/establishing-code-ownership/SKILL.md
@@ -10,6 +10,23 @@ Two sources, checked in order:
 1. **`products/*/product.yaml`: source of truth under `products/`.** Lists owning team(s) under `owners:` as bare slugs (the CODEOWNERS handle minus `@PostHog/`: `conversations`, `logs`, `team-signals`, …) and owns **all** of `products/<name>/**`. Lives in the dir it owns, so never stale.
 2. **`.github/CODEOWNERS` + [`CODEOWNERS-soft`](../../../.github/CODEOWNERS-soft): backup for paths outside `products/`.** [`CODEOWNERS`](../../../.github/CODEOWNERS) is hard/blocking (mostly infra); `CODEOWNERS-soft` carries most product mappings for shared code (backend, frontend scenes, generated artifacts, overrides).
 
+## Fast path: `ownership.js`
+
+[`ownership.js`](ownership.js) automates the deterministic repo-file resolution for both lookups. It finds the repo root from its own location (cwd- and worktree-independent) and enumerates tracked files via `git ls-files`. Run it first, then fall back to the manual reasoning below for what it can't resolve.
+
+```bash
+S=.agents/skills/establishing-code-ownership/ownership.js
+node $S file posthog/hogql/printer.py   # who owns this file (pass --all to see every matching CODEOWNERS rule)
+node $S team team-surveys               # every tracked file the team owns (slug or @PostHog/ handle both work)
+node $S unowned                          # every tracked file with no owner (append path prefixes to scope, e.g. `unowned products/ frontend/`)
+```
+
+For glob matching it reuses `fileMatchesPattern` from [`.github/scripts/assign-reviewers.js`](../../../.github/scripts/assign-reviewers.js), the same matcher the reviewer auto-assigner runs in CI, so answers track what CI assigns rather than a separate reimplementation. That matcher is stricter than GitHub's docs: patterns are anchored, a slash-free pattern matches only at the repo root, and a directory needs a trailing slash (or `/**`) to match its contents. A side effect is that the script exposes dead `CODEOWNERS-soft` entries (a missing trailing slash, or escaped `\*\*` wildcards) as unowned, the same way CI silently skips them.
+
+Precedence: `product.yaml` for `products/<name>/**`; else a blocking `CODEOWNERS` owner; else the last-matching `CODEOWNERS-soft` rule. A blocking `CODEOWNERS` glob with **no owner** (a reset, e.g. `posthog/hogql/database/schema/**`) only clears the blocking owner, it does not erase a soft mapping. `file` prints the source line behind each answer.
+
+It does **not** trace generated files to their source's owner, consult the handbook, or search Slack. When it returns no owner (or the path is a generated file), keep going with the steps below.
+
 ## path → team (who owns this file?)
 
 1. **Under `products/<name>/`?** Read that `product.yaml` `owners:`; prefix each slug with `@PostHog/` (`team-replay` → `@PostHog/team-replay`). This beats any matching CODEOWNERS entry. No CODEOWNERS entry for a product path is fine, not a gap.

--- a/.agents/skills/establishing-code-ownership/ownership.js
+++ b/.agents/skills/establishing-code-ownership/ownership.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+// Resolve PostHog code ownership from products/*/product.yaml + CODEOWNERS.
+//
+// Resolution order (mirrors the establishing-code-ownership skill):
+//   1. A file under products/<name>/ is owned by that product.yaml's `owners:`
+//      (beats any CODEOWNERS entry). Products without a product.yaml fall through.
+//   2. Otherwise the CODEOWNERS files decide. Within each file the last matching
+//      glob wins. Across the two files a blocking CODEOWNERS owner wins when
+//      present, else the CODEOWNERS-soft owner applies. A blocking glob with no
+//      owner (a reset, used so product teams can edit infra-owned trees) clears
+//      only the blocking owner; it does not erase a soft mapping.
+//   3. No owner from either file means unowned.
+//
+// Glob matching is NOT reimplemented here: it reuses fileMatchesPattern from
+// .github/scripts/assign-reviewers.js, the same matcher PostHog's reviewer
+// auto-assigner runs in CI, so answers stay in lockstep with what CI assigns.
+// That matcher is intentionally stricter than GitHub's docs: patterns are
+// anchored, a slash-free pattern matches only at the root, and a directory must
+// carry a trailing slash (or /**) to match its contents.
+//
+// Usage:
+//   ownership.js file <path>... [--all]        who owns these files
+//   ownership.js team <slug-or-handle> [prefix...] every tracked file a team owns
+//   ownership.js unowned [prefix...]              every tracked file with no owner
+//
+// Data goes to stdout; counts and notes go to stderr (so you can pipe stdout).
+
+const fs = require('fs')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+function findRepoRoot(start) {
+    let dir = start
+    for (;;) {
+        if (fs.existsSync(path.join(dir, '.github', 'CODEOWNERS'))) {
+            return dir
+        }
+        const parent = path.dirname(dir)
+        if (parent === dir) {
+            throw new Error('could not locate repo root (no .github/CODEOWNERS found above this script)')
+        }
+        dir = parent
+    }
+}
+
+const REPO_ROOT = findRepoRoot(__dirname)
+const { fileMatchesPattern } = require(path.join(REPO_ROOT, '.github', 'scripts', 'assign-reviewers.js'))
+if (typeof fileMatchesPattern !== 'function') {
+    throw new Error('.github/scripts/assign-reviewers.js no longer exports fileMatchesPattern; ownership resolver is out of sync with CI')
+}
+
+// Bare product.yaml slug -> @PostHog/<slug>; an explicit @handle is left as-is.
+function toHandle(owner) {
+    return owner.startsWith('@') ? owner : `@PostHog/${owner}`
+}
+
+// @PostHog/team-x or @team-x or team-x -> team-x (for comparison).
+function toSlug(owner) {
+    if (owner.startsWith('@PostHog/')) return owner.slice('@PostHog/'.length)
+    if (owner.startsWith('@')) return owner.slice(1)
+    return owner
+}
+
+// Literal prefix before the first glob wildcard. The matcher anchors `^`, so a
+// file can only match a rule if it starts with this; checking it first skips the
+// regex build for non-candidates and keeps a full-repo sweep fast.
+function literalPrefix(pattern) {
+    const i = pattern.search(/[*?]/)
+    if (i === -1) return pattern
+    // The matcher leaves `?` as a regex quantifier (it makes the preceding char
+    // optional), so the guaranteed literal prefix ends one char earlier there.
+    return pattern[i] === '?' ? pattern.slice(0, Math.max(0, i - 1)) : pattern.slice(0, i)
+}
+
+function parseCodeowners(file, label) {
+    if (!fs.existsSync(file)) return []
+    const rules = []
+    fs.readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((raw, idx) => {
+            const line = raw.trim()
+            if (!line || line.startsWith('#')) return
+            const tokens = line.split(/\s+/)
+            rules.push({
+                pattern: tokens[0],
+                owners: tokens.slice(1),
+                source: label,
+                lineno: idx + 1,
+                prefix: literalPrefix(tokens[0]),
+            })
+        })
+    return rules
+}
+
+// Pull the `owners:` value out of a product.yaml without a YAML dependency.
+// Handles all three forms: block list, inline list, and a bare scalar.
+function parseProductOwners(content) {
+    const owners = []
+    let inOwners = false
+    for (const raw of content.split('\n')) {
+        const line = raw.replace(/\s+#.*$/, '').trimEnd()
+        if (!line.trim() || /^\s*#/.test(raw)) continue
+        const ownersMatch = line.match(/^owners\s*:\s*(.*)$/)
+        if (ownersMatch) {
+            const rest = ownersMatch[1].trim()
+            if (rest.startsWith('[')) {
+                const close = rest.lastIndexOf(']')
+                const inner = rest.slice(1, close === -1 ? rest.length : close)
+                for (const item of inner.split(',')) {
+                    const value = item.trim().replace(/^["']|["']$/g, '')
+                    if (value) owners.push(value)
+                }
+            } else if (rest) {
+                owners.push(rest.replace(/^["']|["']$/g, ''))
+            } else {
+                inOwners = true // block list follows on the next lines
+            }
+            continue
+        }
+        if (!inOwners) continue
+        const m = line.match(/^\s+-\s+(.+?)$/)
+        if (m) {
+            owners.push(m[1].replace(/^["']|["']$/g, '').trim())
+            continue
+        }
+        if (/^\S/.test(raw)) inOwners = false
+    }
+    return owners
+}
+
+function loadProductOwners(root) {
+    const map = new Map()
+    const productsDir = path.join(root, 'products')
+    if (!fs.existsSync(productsDir)) return map
+    for (const entry of fs.readdirSync(productsDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue
+        const yaml = path.join(productsDir, entry.name, 'product.yaml')
+        if (!fs.existsSync(yaml)) continue
+        const owners = parseProductOwners(fs.readFileSync(yaml, 'utf8'))
+            .filter((slug) => slug && slug !== 'team-CHANGEME') // a bootstrap placeholder, not a real team
+            .map(toHandle)
+        if (owners.length) map.set(entry.name, owners)
+    }
+    return map
+}
+
+function src(rule) {
+    return `${rule.source}:${rule.lineno} (${rule.pattern})`
+}
+
+class Resolver {
+    constructor(root) {
+        this.root = root
+        this.productOwners = loadProductOwners(root)
+        this.softRules = parseCodeowners(path.join(root, '.github', 'CODEOWNERS-soft'), 'CODEOWNERS-soft')
+        this.hardRules = parseCodeowners(path.join(root, '.github', 'CODEOWNERS'), 'CODEOWNERS')
+        this.rules = this.softRules.concat(this.hardRules)
+    }
+
+    lastMatch(rules, file) {
+        for (let i = rules.length - 1; i >= 0; i--) {
+            const rule = rules[i]
+            if (!file.startsWith(rule.prefix)) continue
+            if (fileMatchesPattern(file, rule.pattern)) return rule
+        }
+        return null
+    }
+
+    resolve(file) {
+        if (file.startsWith('products/')) {
+            const name = file.split('/')[1]
+            if (name && this.productOwners.has(name)) {
+                return { owners: this.productOwners.get(name), source: `products/${name}/product.yaml`, reset: false }
+            }
+        }
+        const hard = this.lastMatch(this.hardRules, file)
+        if (hard && hard.owners.length) return { owners: hard.owners, source: src(hard), reset: false }
+        const soft = this.lastMatch(this.softRules, file)
+        if (soft && soft.owners.length) return { owners: soft.owners, source: src(soft), reset: false }
+        const reset = hard || soft
+        if (reset) return { owners: [], source: src(reset), reset: true }
+        return { owners: [], source: null, reset: false }
+    }
+
+    allMatches(file) {
+        return this.rules.filter((rule) => file.startsWith(rule.prefix) && fileMatchesPattern(file, rule.pattern))
+    }
+}
+
+function listTrackedFiles(root, prefixes) {
+    const args = ['ls-files', '-z']
+    if (prefixes.length) args.push('--', ...prefixes)
+    const out = execFileSync('git', args, { cwd: root, maxBuffer: 1024 * 1024 * 512 }).toString('utf8')
+    return out.split('\0').filter(Boolean)
+}
+
+// Turn a user-supplied path into a normalized repo-relative one. Prefers the
+// repo-relative reading (the documented contract) so the answer doesn't depend
+// on cwd; only falls back to cwd-relative when that is clearly what was meant.
+// A return value starting with "../" means the input points outside the repo.
+function normalizeInputPath(root, raw) {
+    const repoRel = path.posix.normalize(raw.split(path.sep).join('/').replace(/^\/+/, ''))
+    if (!path.isAbsolute(raw)) {
+        const underRoot = fs.existsSync(path.join(root, repoRel))
+        const underCwd = fs.existsSync(path.join(process.cwd(), raw))
+        if (underRoot || !underCwd) return repoRel
+    }
+    const abs = path.isAbsolute(raw) ? raw : path.resolve(process.cwd(), raw)
+    return path.relative(root, abs).split(path.sep).join('/')
+}
+
+function cmdFile(resolver, paths, showAll) {
+    for (const raw of paths) {
+        const rel = normalizeInputPath(resolver.root, raw)
+        if (rel.startsWith('../') || path.isAbsolute(rel)) {
+            console.error(`warning: ${raw} is outside the repo root; ownership only covers tracked repo files`)
+        }
+        const res = resolver.resolve(rel)
+        console.log(rel)
+        if (res.owners.length) {
+            console.log(`  owners: ${res.owners.join(', ')}`)
+            console.log(`  source: ${res.source}`)
+        } else if (res.reset) {
+            console.log('  owners: none (ownership explicitly cleared)')
+            console.log(`  source: ${res.source}`)
+        } else {
+            console.log('  owners: none (no product.yaml or CODEOWNERS match)')
+        }
+        if (showAll) {
+            const matches = resolver.allMatches(rel)
+            if (matches.length) {
+                console.log('  all CODEOWNERS matches (last wins):')
+                for (const rule of matches) {
+                    const owners = rule.owners.length ? rule.owners.join(', ') : '(reset)'
+                    console.log(`    ${rule.source}:${rule.lineno}  ${rule.pattern}  -> ${owners}`)
+                }
+            }
+        }
+    }
+}
+
+function cmdTeam(resolver, team, prefixes) {
+    const target = toSlug(team).toLowerCase()
+    const files = listTrackedFiles(resolver.root, prefixes)
+    const owned = files.filter((f) => resolver.resolve(f).owners.some((o) => toSlug(o).toLowerCase() === target))
+    for (const f of owned) console.log(f)
+    console.error(`${owned.length} file(s) owned by ${team}`)
+}
+
+function cmdUnowned(resolver, prefixes) {
+    const files = listTrackedFiles(resolver.root, prefixes)
+    const unowned = files.filter((f) => resolver.resolve(f).owners.length === 0)
+    for (const f of unowned) console.log(f)
+    console.error(`${unowned.length} unowned of ${files.length} tracked file(s)`)
+}
+
+function usage(message) {
+    if (message) console.error(`error: ${message}`)
+    console.error('usage:')
+    console.error('  ownership.js file <path>... [--all]               who owns these files')
+    console.error('  ownership.js team <slug-or-handle> [prefix...]    every tracked file a team owns')
+    console.error('  ownership.js unowned [prefix...]                  every tracked file with no owner')
+    process.exit(message ? 2 : 0)
+}
+
+function main(argv) {
+    const [command, ...rest] = argv
+    if (!command || command === '-h' || command === '--help') usage()
+    const resolver = new Resolver(REPO_ROOT)
+    if (command === 'file') {
+        const paths = rest.filter((a) => a !== '--all')
+        if (!paths.length) usage('file needs at least one path')
+        cmdFile(resolver, paths, rest.includes('--all'))
+    } else if (command === 'team') {
+        if (!rest.length) usage('team needs a slug or handle')
+        cmdTeam(resolver, rest[0], rest.slice(1))
+    } else if (command === 'unowned') {
+        cmdUnowned(resolver, rest)
+    } else {
+        usage(`unknown command: ${command}`)
+    }
+}
+
+try {
+    main(process.argv.slice(2))
+} catch (err) {
+    console.error(`error: ${err.message}`)
+    process.exit(1)
+}


### PR DESCRIPTION
## Problem

The `establishing-code-ownership` skill described how to resolve ownership by hand: read `products/*/product.yaml`, then grep both CODEOWNERS files with last-match-wins precedence. That is fiddly to get right and does not scale to questions like "list every file with no owner".

## Changes

Add `ownership.js` to the skill: a Node CLI with three subcommands.

- `file <path>...`: print the owning team(s) for each file (`--all` shows every matching CODEOWNERS rule)
- `team <slug-or-handle>`: print every tracked file a team owns (slug or `@PostHog/` handle)
- `unowned [prefixes...]`: print every tracked file with no owner, optionally scoped to path prefixes

For glob matching it reuses `fileMatchesPattern` from `.github/scripts/assign-reviewers.js`, the same matcher the reviewer auto-assigner runs in CI, rather than reimplementing CODEOWNERS semantics. So the script's answers track what CI actually assigns. On top of that primitive it applies the skill's precedence: `product.yaml` wins under `products/<name>/**`, then a blocking `CODEOWNERS` owner, then the last-matching `CODEOWNERS-soft` rule, with a blocking reset (a glob with no owner) clearing only the blocking owner.

Because that matcher is intentionally stricter than GitHub's docs (anchored patterns, slash-free patterns match only at the repo root, directories need a trailing slash or `/**`), the script also exposes dead `CODEOWNERS-soft` entries as unowned, the same way CI silently skips them. `SKILL.md` points at the script as the fast path and keeps the manual steps as the fallback for generated-file tracing, the handbook, and Slack.

## How did you test this code?

I am an agent (Claude Code, Opus 4.8); this lists only automated checks I actually ran, no manual QA.

- `node --check` passes; the script runs a full-repo sweep (~26k tracked files) in ~0.1s.
- Spot-checked known cases: product.yaml ownership, individual `@user` owners, blocking-owner-wins (`posthog/hogql/printer.py` resolves to `@PostHog/hogql`), hard-only paths (clickhouse migrations), and soft frontend mappings.
- Confirmed the matcher reuse agrees with CI semantics, including that it correctly reports dead `CODEOWNERS-soft` entries (`ee/surveys` without a trailing slash, the escaped `\*\*` lines) as unowned.
- Checked an invariant: zero files under a product that has a `product.yaml` are ever reported unowned.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs change. The only documentation touched is the internal skill `SKILL.md`, updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), driven by Robbie.

Authored with Claude Code (Opus 4.8). The ask was a script to resolve code ownership (who owns a file, what a team owns, what is unowned) and to reference it from the skill.

Key decisions:

- Started with a self-contained Python port of GitHub's CODEOWNERS matcher, then switched to importing PostHog's own `fileMatchesPattern` (already exported from `assign-reviewers.js`, the CI auto-assigner) so there is a single matcher instead of a parallel reimplementation. That required the script to be Node so it can `require` the function.
- The reuse changes a few results versus a GitHub-docs-faithful matcher, on purpose: PostHog's matcher is stricter, so the script now agrees with what CI assigns and surfaces dead `CODEOWNERS-soft` entries rather than papering over them.
- Kept the script's own thin parsing and resolution policy (product.yaml precedence, hard-over-soft, reset handling) on top of the shared matcher; only the glob path-matching is delegated.
