### PR TITLE
fix(google_sheets): bound Sheets API request timeout

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -18,6 +18,15 @@ from posthog.temporal.data_imports.sources.generated_configs import GoogleSheets
 
 from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
 
+# (connect, read) timeout for every Sheets API request, in seconds. gspread defaults to no
+# timeout, so a stalled connection blocks the worker thread indefinitely. Because the sync
+# activities are threaded, a blocked thread can't be interrupted cleanly — Temporal eventually
+# hits the activity's `start_to_close_timeout` and raises a `CancelledError` into the thread mid
+# socket-read, which surfaces as a noisy "Cancelled" error. A bounded timeout turns a stall into a
+# fast, retryable `requests.Timeout` instead. The read timeout is the max gap between received
+# bytes (not total download time), so it stays safe for large sheets that stream in steadily.
+_REQUEST_TIMEOUT_SECONDS: tuple[float, float] = (30.0, 120.0)
+
 
 def google_sheets_client() -> gspread.Client:
     credentials = service_account.Credentials.from_service_account_info(
@@ -36,7 +45,9 @@ def google_sheets_client() -> gspread.Client:
     adapter = make_tracked_adapter()
     session.mount("https://", adapter)
     session.mount("http://", adapter)
-    return gspread.authorize(credentials, session=session)
+    client = gspread.authorize(credentials, session=session)
+    client.set_timeout(_REQUEST_TIMEOUT_SECONDS)
+    return client
 
 
 cache: Cache[Any, Any] = TTLCache(maxsize=500, ttl=120)  # 120 seconds

--- a/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -9,10 +9,12 @@ import gspread
 from posthog.temporal.data_imports.sources.generated_configs import GoogleSheetsSourceConfig
 from posthog.temporal.data_imports.sources.google_sheets.google_sheets import (
     _PERMISSION_DENIED_MESSAGE,
+    _REQUEST_TIMEOUT_SECONDS,
     _get_worksheet,
     _retry_on_transient_api_error,
     get_schema_incremental_fields,
     get_schemas,
+    google_sheets_client,
     google_sheets_source,
 )
 from posthog.temporal.data_imports.sources.google_sheets.source import GoogleSheetsSource
@@ -379,3 +381,19 @@ def test_get_schema_incremental_fields_reraises_other_api_errors():
         get_schema_incremental_fields(config, "sheet1")
 
     assert mock_worksheet.get_all_values.call_count == 10
+
+
+def test_google_sheets_client_sets_request_timeout():
+    """Every gspread client must be built with a bounded (connect, read) timeout. gspread defaults
+    to no timeout, so a stalled Sheets API read blocks the threaded sync activity until Temporal's
+    start_to_close_timeout cancels the thread mid-read — which surfaces as a noisy CancelledError
+    rather than a fast, retryable timeout."""
+    with (
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.service_account"),
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.AuthorizedSession"),
+        mock.patch("posthog.temporal.data_imports.sources.google_sheets.google_sheets.make_tracked_adapter"),
+    ):
+        client = google_sheets_client()
+
+    assert client.http_client.timeout == _REQUEST_TIMEOUT_SECONDS
+    assert client.http_client.timeout is not None


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `CancelledError` (`"Cancelled"`) originating in the Google Sheets data-warehouse source. The stack trace runs through `posthog/temporal/data_imports/sources/google_sheets/source.py` → `google_sheets.py` → gspread → `requests` and bottoms out in a blocking SSL socket read, where the exception is raised.

This is not a customer credential/config error and not a logic bug in the source — it's a **Temporal activity cancellation**. Schema discovery (`sync_new_schemas_activity`) and import run as *threaded* (sync) Temporal activities. The gspread client was constructed with **no request timeout**, so a stalled Sheets API connection blocks the worker thread indefinitely. A blocked thread can't be interrupted cleanly, so Temporal eventually hits the activity's `start_to_close_timeout`, raises `temporalio.exceptions.CancelledError` directly into the thread mid socket-read (via `PyThreadState_SetAsyncExc`), and the global activity interceptor captures it as an exception — producing the noisy "Cancelled" error.

Because `temporalio.exceptions.CancelledError` subclasses `Exception`, it is caught and reported like any application error.

## Changes

Set a bounded `(connect, read)` timeout on the gspread client in `google_sheets_client()` (the single chokepoint all code paths build their client through). A stall now fails fast as a retryable `requests.Timeout` instead of hanging until the activity is cancelled. The `read` value is the max gap between received bytes (not total download time), so it remains safe for large sheets that stream in steadily, and stays comfortably under the discovery activity's 10-minute `start_to_close_timeout`.

Deliberately **not** added to `NonRetryableErrors`: a Temporal cancellation is not a user/upstream failure, and matching on `"Cancelled"` there would disable a customer's sync (and show a misleading error) any time a worker redeploy or workflow cancellation interrupts an in-flight run.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I ran:

- Added a regression test (`test_google_sheets_client_sets_request_timeout`) asserting the built client carries a bounded timeout rather than `None`.
- Ran the full source test suite: `pytest posthog/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py` — 29 passed.
- `ruff check` / `ruff format` clean on the changed files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the GoogleSheets source. Pulled the issue's exception events via the PostHog MCP (the dedicated error-tracking query endpoints 404'd, so I read the sampled `$exception` events through `execute-sql`), confirmed the failing frame is genuinely in this source's call path, then traced the Temporal SDK's threaded-activity cancellation mechanism to establish that the `CancelledError` is a cancellation signal rather than a source bug. Rejected extending `NonRetryableErrors` (would be harmful on benign cancellations) in favor of the underlying fragility — the missing HTTP timeout that lets a stalled read run until the activity times out. Scope kept to the one client-construction helper plus a regression test.
