### PR TITLE
fix(batch-exports): Cap insert block size writing to internal stage

### DIFF
--- a/posthog/settings/batch_exports.py
+++ b/posthog/settings/batch_exports.py
@@ -77,6 +77,10 @@ OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(
 )
 
 CLICKHOUSE_OFFLINE_5MIN_CLUSTER_HOST: str | None = os.getenv("CLICKHOUSE_OFFLINE_5MIN_CLUSTER_HOST", None)
+# Used in internal stage to cap Arrow record batch size
+BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES: int = get_from_env(
+    "BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES", 64 * 1024 * 1024, type_cast=int
+)
 
 BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT: str = os.getenv(
     "BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT", "http://objectstorage:19000"

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -567,7 +567,16 @@ async def _write_batch_export_record_batches_to_internal_stage(
     await wait_for_delta_past_data_interval_end(end_at, delta)
 
     done_ranges: list[tuple[dt.datetime, dt.datetime]] = []
-    async with get_client(team_id=team_id, clickhouse_url=clickhouse_url) as client:
+    async with get_client(
+        team_id=team_id,
+        clickhouse_url=clickhouse_url,
+        use_strict_insert_block_limits=1,
+        max_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
+        # Disable all of these so only the bytes limit counts.
+        max_insert_block_size_rows=0,
+        min_insert_block_size_bytes=0,
+        min_insert_block_size_rows=0,
+    ) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -570,11 +570,14 @@ async def _write_batch_export_record_batches_to_internal_stage(
     async with get_client(
         team_id=team_id,
         clickhouse_url=clickhouse_url,
-        use_strict_insert_block_limits=1,
-        max_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
-        # Disable all of these so only the bytes limit counts.
-        max_insert_block_size_rows=0,
-        min_insert_block_size_bytes=0,
+        # TODO: Strict limits are available in ClickHouse 26.4
+        # We should uncomment all of these here to let max_insert_block_size_bytes dictate the size
+        # once clickhouse is upgraded.
+        # use_strict_insert_block_limits=1,
+        # max_insert_block_size_rows=0,
+        # max_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
+        min_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
+        # Disable all of these so only the bytes limits counts.
         min_insert_block_size_rows=0,
     ) as client:
         if not await client.is_alive():


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

ClickHouse may sometimes write record batches with wildly different number
of rows and bytes. To try to cap this, the initial plan was to set the 
following variables:
* `min_insert_block_size_bytes=0`: To remove the lower bound.
* `min_insert_block_size_rows=0`: Also, to remove the lower bound.
* `max_insert_block_size_bytes=64*1024*1024`: To cap the record batches to
  64MiB.
* `max_insert_block_size_rows=0`: So that only the bytes limit counts.
* `use_strict_insert_block_limits=1`: So that clickhouse actually respects
  the limits.


HOWEVER, our current clickhouse version does not support strict limits, only
minimums. So, instead for now, we set only:
* `min_insert_block_size_rows=0`: Still, to disable the limit
* `min_insert_block_size_bytes=64MiB`: To provide a soft cap to record batch
  size.

During testing, just the minimum values do not dictate the entire picture:
ClickHouse could produce even smaller record batches and, unfortunately,
I couldn't figure out what other setting is playing a part.

Regardless, the minimum value does provide a cap to the record batch size:
I tested this by manually generating data with very large properties
(15KiB) and lots of rows (1 million) and trying different values of the
`min_insert_block_size_bytes`. The results follow:
* With the default of 64MiB, batches of around 7MiB-10MiB were written to
internal stage. This shows some other setting is playing a part here.

* With an overridden value of 1MiB, batches of roughly 1MiB were written to
internal stage. This shows that the minimum setting does limit record batch
size (although not perfect, with some variance).

So, all in all, I consider this an improvement that gets us at least
somewhat more consistent record batches until our ClickHouse version is
upgraded.

This should cap record batches to 64MiB, which seems a sensible default
given most destinations split batches into 50MiB/60MiB. Maybe we should
line these amounts up so we don't have to split anything anymore, but
leaving that as a follow-up.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually, additionally to the above I ran some other normal tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I used the robot to scour through logs and provide potential explanations for this issue. Eventually, I also got the robot the write a script to analyze a sample arrow file and land at this problem. The code is all mine.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
