### PR TITLE
fix(clickhouse): treat missing source table as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -181,6 +181,14 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # an existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
             "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            # Raised from `_get_table` when `system.columns` returns no columns for the
+            # configured table — the table no longer exists in the source database at sync
+            # time. It was dropped or renamed, or (commonly) the schema points at a
+            # materialized view's auto-generated `.inner_id.<uuid>` inner table whose UUID
+            # changed when the view was recreated. Either way the table is gone and retrying
+            # replays the identical failure, so stop and tell the customer to fix the schema.
+            # We match the stable suffix, not the volatile `<database>.<table>` prefix.
+            "not found or has no columns": "We couldn't find this table in your ClickHouse database — it may have been dropped or renamed. If you were syncing a materialized view, sync it by its own name rather than its internal `.inner_id.<uuid>` table (those names change whenever the view is recreated). Remove or re-point this table in your source, then resync.",
         }
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -531,6 +531,10 @@ class TestClickHouseSourceNonRetryableErrors:
             # MEMORY_LIMIT_EXCEEDED (code 241) — per-query `max_memory_usage` budget
             "Code: 241. DB::Exception: Query memory limit exceeded: would use 3.73 GiB "
             "(attempt to allocate chunk of 4.60 MiB), maximum: 3.73 GiB. (MEMORY_LIMIT_EXCEEDED)",
+            # Source table no longer exists at sync time — dropped/renamed, or a materialized
+            # view's `.inner_id.<uuid>` inner table whose UUID changed when the view was recreated.
+            "Table soax_stage..inner_id.8c612ff0-b72c-4b20-8ea5-405ed002c2f6 not found or has no columns",
+            "Table default.some_dropped_table not found or has no columns",
         ],
     )
     def test_permanent_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `ValueError` from the ClickHouse data-warehouse import source:

> `Table <database>..inner_id.<uuid> not found or has no columns`

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed149-4c80-7fd0-a66e-e3a1c9e8ad08)

The stack confirms it originates in this source's code: `import_data_sync` → `ClickHouseSource.source_for_pipeline` → `clickhouse_source` → `_get_table` (`clickhouse.py:621`), which raises when `system.columns` returns no columns for the configured table.

This happens when the source table no longer exists at sync time — it was dropped or renamed, or (as in the reported case) the schema points at a materialized view's auto-generated `.inner_id.<uuid>` inner table whose UUID changes whenever the view is recreated. Schema discovery (`get_schemas`) already filters these inner tables out, so a schema pointed at one is stale. Either way the table is gone, so retrying replays the identical failure on every scheduled run.

## Changes

Add `not found or has no columns` to `ClickHouseSource.get_non_retryable_errors`, mirroring the existing entries. The matched substring is stable — the volatile `<database>.<table>` prefix is excluded — and unique to this source's `_get_table`. On match, the pipeline stops auto-syncing the schema and surfaces a message telling the customer the table is gone and, if it's a materialized view, to sync it by its own name rather than its `.inner_id.<uuid>` table.

This is scoped to this one error string on the ClickHouse source — no change to global retry policy. Transient ClickHouse errors (timeouts, socket errors, 5xx gateway codes) remain retryable, as covered by the existing retryable-error test.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Extended `TestClickHouseSourceNonRetryableErrors::test_permanent_errors_are_non_retryable` with the observed message and a plain dropped-table variant.
- Ran the full `test_clickhouse.py` suite: 151 passed.
- `ruff check` / `ruff format`: clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the ClickHouse import source with Claude Code, using the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the trace, frequency, and a representative event, then read the source implementation to find the raise site and call path.

Decision: user/upstream condition, not a code bug. The table genuinely no longer exists in the customer's ClickHouse, so there is nothing to retry or gracefully skip at the single-table sync layer — the correct behavior is to stop retrying and surface an actionable message. Matched a stable, low-false-positive substring rather than the volatile `<database>.<table>` prefix, consistent with the existing entries and the Stripe reference pattern.
