### PR TITLE
fix(workflows): allow behavioral static cohorts as batch/schedule audiences

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -206,7 +206,9 @@ class HogFlowActionSerializer(serializers.Serializer):
     def _reject_behavioral_cohorts_in_audience(self, properties) -> None:
         # Batch/schedule audiences resolve offline by precalculated membership and can't evaluate event
         # behavior the way it's intended; the UI hides behavioral cohorts from the audience picker. Mirror
-        # that for API/MCP callers. Mirrors the feature-flag guard in posthog/api/cohort.py.
+        # that for API/MCP callers. Static cohorts are exempt regardless of how they were built — their
+        # membership is frozen and precalculated — matching the audience-picker exemption in
+        # _build_cohort_dependency_graph in posthog/api/cohort.py.
         if not isinstance(properties, list):
             return
         cohort_ids = [
@@ -222,7 +224,11 @@ class HogFlowActionSerializer(serializers.Serializer):
                 cohort = Cohort.objects.get(pk=cohort_id, team__project_id=project_id, deleted=False)
             except (Cohort.DoesNotExist, ValueError, TypeError):
                 continue  # missing/invalid cohort surfaces during audience resolution, not here
+            if cohort.is_static:
+                continue
             for dep in [cohort, *get_all_cohort_dependencies(cohort)]:
+                if dep.is_static:
+                    continue
                 if any(p.type == "behavioral" for p in dep.properties.flat):
                     raise serializers.ValidationError(
                         {

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1270,7 +1270,12 @@ class TestHogFlowAPI(APIBaseTest):
                     }
                 ],
             }
-        filters = {} if static else {"properties": properties}
+        # A static cohort keeps its original filter definition (behavioral/property/nested) even though
+        # membership is frozen — only a plain static cohort with no source criteria has empty filters.
+        if static and not (behavioral or nested_cohort_id is not None):
+            filters = {}
+        else:
+            filters = {"properties": properties}
         return Cohort.objects.create(team=self.team, name="c", filters=filters, is_static=static)
 
     def _post_batch_with_cohort(self, cohort_id: int, *, status: str = "active", trigger_type: str = "batch", **extra):
@@ -1304,6 +1309,20 @@ class TestHogFlowAPI(APIBaseTest):
     def test_hog_flow_batch_trigger_allows_non_behavioral_cohort(self, _name, cohort_kwargs):
         cohort = self._make_cohort(**cohort_kwargs)
         response = self._post_batch_with_cohort(cohort.pk)
+        assert response.status_code == 201, response.json()
+
+    @parameterized.expand(["batch", "schedule"])
+    def test_hog_flow_audience_allows_behavioral_static_cohort(self, trigger_type: str):
+        # A static cohort built from behavioral criteria keeps its behavioral filter definition, but its
+        # membership is frozen and precalculated, so it's a valid audience — the error even recommends it.
+        cohort = self._make_cohort(behavioral=True, static=True)
+        response = self._post_batch_with_cohort(cohort.pk, trigger_type=trigger_type)
+        assert response.status_code == 201, response.json()
+
+    def test_hog_flow_batch_trigger_allows_wrapper_of_static_behavioral_cohort(self):
+        behavioral_static = self._make_cohort(behavioral=True, static=True)
+        wrapper = self._make_cohort(nested_cohort_id=behavioral_static.pk)
+        response = self._post_batch_with_cohort(wrapper.pk)
         assert response.status_code == 201, response.json()
 
     def test_hog_flow_batch_trigger_behavioral_cohort_rejected_for_mcp_draft(self):


### PR DESCRIPTION
## Problem

A customer building a batch-trigger workflow hit `Save workflow failed: Cohort '…' targets event behavior, which batch/schedule audiences can't evaluate. Use a static or property-based cohort, or an event trigger for behavioral targeting.` They followed the advice — switched from a dynamic behavioral cohort to a **static** one — and the save still failed.

This is a bug, not a missing feature, caused by a three-way inconsistency:

- A static cohort keeps its original behavioral filter definition (`Cohort.properties` deserializes `filters` with no `is_static` guard), so `properties.flat` still contains `behavioral` entries even after the cohort is converted to static and its membership frozen.
- The **UI audience picker** (`_build_cohort_dependency_graph` in `posthog/api/cohort.py`) already exempts static cohorts (`if cohort.is_static: continue`), so it offers behavioral-derived static cohorts as valid choices.
- The **workflow save validator** (`_reject_behavioral_cohorts_in_audience` in `products/workflows/backend/api/hog_flow.py`) did **not** check `is_static`, so it rejected the very cohort the picker offered — and contradicted its own error message.

## Changes

- `_reject_behavioral_cohorts_in_audience`: skip a static referenced cohort outright, and skip nested static cohorts in the dependency loop. A static cohort's membership is frozen and precalculated, so it's a valid offline audience regardless of how it was built. Dynamic behavioral cohorts remain rejected (their membership would require live event evaluation — those need an event trigger).
- Fixed the `_make_cohort` test helper, whose `static=True` path always wiped filters — which is exactly why the regression was never caught. A static behavioral/nested cohort now keeps its filter definition; a plain static cohort still gets empty filters.

## How did you test this code?

I'm an agent. I added/updated automated tests in `products/workflows/backend/api/test/test_hog_flow.py`:

- `test_hog_flow_audience_allows_behavioral_static_cohort` (parameterized over batch + schedule) — the direct regression test for the customer's case.
- `test_hog_flow_batch_trigger_allows_wrapper_of_static_behavioral_cohort` — the nested-static path.
- Existing rejection tests (dynamic behavioral, nested dynamic behavioral) are unchanged and still assert 400.

I could **not** run the Django test suite locally — this environment has no Postgres/ClickHouse. The tests will run in CI. `ruff check` and `ruff format --check` pass on both files.

**Manually verified end-to-end on a local instance:**

- Saving a **batch** and a **schedule** workflow with a static behavioral cohort as the audience now returns **201** (400 on master); a dynamic cohort that wraps it also saves, while a genuinely dynamic behavioral cohort is still rejected (400) and a plain static cohort still saves.
- **Triggered a real batch run** to confirm it targets the right people: the static cohort had a broad behavioral definition (~72 people if evaluated live) but a frozen membership of **8 known persons**. The audience resolved to exactly those **8** (not 72), and the run created **8 invocations for precisely those 8 persons** — confirming the batch reads the cohort's frozen static membership, not the behavioral rule.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Diagnosed from a customer report + error-screenshot: traced the error string to `_reject_behavioral_cohorts_in_audience`, then compared it against the UI's audience-picker guard in `posthog/api/cohort.py` and confirmed the static-cohort exemption was missing on the workflow side. Chose to mirror the picker's `is_static` exemption rather than change how static cohorts store filters, keeping the fix narrow and leaving dynamic-behavioral rejection intact. Also corrected the test helper, which masked the bug by discarding filters for all static cohorts.