### PR TITLE
chore(postgres): cover supavisor max-clients pooler error as retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -233,6 +233,11 @@ class TestPostgresSourceNonRetryableErrors:
         "error_msg",
         [
             'OperationalError: connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL: MaxClientsInSessionMode: max clients reached',
+            # Newer Supabase/Supavisor session-mode pooler wording for the same client-slot
+            # exhaustion as "MaxClientsInSessionMode: max clients reached". The pooler has
+            # momentarily run out of client slots (pool_size reached); it recovers as connections
+            # free up, so a fresh attempt succeeds — must stay retryable.
+            'OperationalError: connection failed: connection to server at "44.216.29.125", port 5432 failed: FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15',
             'OperationalError: connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute',
             'OperationalError: connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL: too many connections for role "user"',
             # Mid-stream SSL/connection drops during schema discovery — the pooler culled an idle


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OperationalError` from the `postgres` data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed14f-8185-7fd3-bed9-d0fed8d22d20)):

```
connection failed: connection to server at "<host>", port 5432 failed:
FATAL:  (EMAXCONNSESSION) max clients reached in session mode -
max clients are limited to pool_size: 15
```

It originates in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`_connect_with_options_fallback` / `_connect_to_postgres`) at connection time, and was hit by several teams within a few seconds of each other.

This is a Supabase/Supavisor **session-mode** pooler reporting client-slot exhaustion: every client connection holds a server connection for its whole session, so once `pool_size` clients are connected, new connections are rejected until some free up. That makes it a **transient infrastructure condition** — a fresh attempt succeeds once the pooler has capacity again.

## Changes

Triage decision: this is neither a permanent user/upstream error nor a code bug — it is a transient pooler error that must **stay retryable**. Adding it to `get_non_retryable_errors()` would be wrong: it would permanently disable a customer's sync over momentary pool contention.

The suite already documents this exact stance for the sibling wording `MaxClientsInSessionMode: max clients reached` in `test_transient_connection_errors_are_retryable`, but the newer Supavisor `(EMAXCONNSESSION) ...` wording wasn't covered. This PR adds that observed production variant to the retryable-coverage test so a future change can't accidentally reclassify it as non-retryable.

**No behavior change** — the message already matches no `get_non_retryable_errors()` key and is retryable today (Temporal retries with backoff). This is a regression guard only.

## How did you test this code?

I'm an agent (Claude Code). pytest wasn't available in this offline environment, so I verified the assertion logic directly: I parsed the actual `get_non_retryable_errors()` dict from `source.py` and confirmed that the new `(EMAXCONNSESSION)` message substring-matches **none** of the 39 non-retryable keys (so it stays retryable), while a known permanent error (`password authentication failed for user`) still matches — confirming the substring check isn't trivially passing everything. The new test case asserts exactly this.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code, using the PostHog error-tracking MCP (`query-error-tracking-issue`) to confirm the issue, stack frame, and frequency, plus repo reading/grep to trace the connect path and the retryability classification in `_handle_import_error`.
- Decision: classified as transient infra → keep retryable. Rejected adding to `NonRetryableErrors` (would swallow a transient error and disable syncs). Rejected a code change since retry/backoff is already handled by Temporal and the message is already retryable. Landed on a scoped, behavior-preserving regression test mirroring the existing convention for the sibling pooler wording.