### PR TITLE
fix(postgres): treat RDS Proxy wrong-password as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -198,6 +198,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "could not translate host name": None,
             "timeout expired connection to server at": None,
             "password authentication failed for user": None,
+            # AWS RDS Proxy reports bad credentials with its own wording instead of PostgreSQL's
+            # "password authentication failed for user" — it validates against Secrets Manager and
+            # returns "The password that was provided for the role <role> is wrong." None of the
+            # password keys above substring-match this, so without its own key Temporal keeps
+            # retrying a credential mismatch that can only be fixed on the customer's side. Match the
+            # stable prefix and exclude the volatile role name.
+            "The password that was provided for the role": (
+                "Your database proxy (for example AWS RDS Proxy) rejected the credentials "
+                '("the password that was provided for the role is wrong"). Check that the username '
+                "and password configured for this source match what the proxy expects, then "
+                "re-enable the sync."
+            ),
             "No primary key defined for table": None,
             "failed: timeout expired": None,
             # NOTE: "SSL connection has been closed unexpectedly" is intentionally NOT listed here.

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -272,6 +272,10 @@ class TestPostgresSourceNonRetryableErrors:
             'connection failed: connection to server at "52.45.94.125", port 6543 failed: FATAL:  (ENOTFOUND) tenant/user postgres.hksbxxtlcfeyyalgveif not found',
             "ProtocolViolation: server login has been failing, cached error: connect timeout (server_login_retry)",
             "server login has been failing, cached error: connection refused (server_login_retry)",
+            # AWS RDS Proxy rejects bad credentials with its own wording (validated against Secrets
+            # Manager), not PostgreSQL's "password authentication failed for user". Newlines are
+            # normalized to spaces upstream, so the real message arrives as the doubled single line.
+            'connection failed: connection to server at "127.0.0.1", port 35425 failed: FATAL:  The password that was provided for the role postgres is wrong. connection to server at "127.0.0.1", port 35425 failed: FATAL:  This RDS Proxy requires TLS connections',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):
@@ -325,6 +329,22 @@ class TestPostgresSourceNonRetryableErrors:
         friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
         assert friendly, "Exceeded compute-time quota error should surface an actionable message"
         assert "compute-time quota" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            'connection failed: connection to server at "127.0.0.1", port 35425 failed: FATAL:  The password that was provided for the role postgres is wrong.',
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL:  The password that was provided for the role posthog_readonly is wrong.',
+        ],
+    )
+    def test_rds_proxy_wrong_password_is_non_retryable(self, source, error_msg):
+        # RDS Proxy's wrong-credentials wording isn't covered by the PostgreSQL "password
+        # authentication failed for user" key, so confirm the dedicated role-password key is what
+        # recognises it, independent of the volatile role name.
+        non_retryable = source.get_non_retryable_errors()
+        assert "The password that was provided for the role" in non_retryable
+        assert "password authentication failed for user" not in error_msg
+        assert any(pattern in error_msg for pattern in non_retryable.keys())
 
     def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
         # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports sitting behind **AWS RDS Proxy** were failing to connect and flooding error tracking. The surfaced issue is fingerprinted as `OperationalError: ... RDS Proxy currently doesn't support command-line options`, but that part is already handled: the `_connect_with_options_fallback` helper correctly detects the proxy's "command-line options" rejection, drops the libpq `options` startup param, and retries.

The retry then fails for a *different*, genuine reason — RDS Proxy reports bad credentials with its own wording:

```
FATAL:  The password that was provided for the role <role> is wrong.
```

This propagates as the top-level `OperationalError` (the command-line-options error is just its `__context__`). None of the existing non-retryable password keys (`password authentication failed for user`, SCRAM `Wrong password`, …) substring-match RDS Proxy's phrasing, so Temporal kept retrying a credential mismatch the customer must fix, and the activity interceptor re-captured the failure on every attempt.

## Changes

- Add `"The password that was provided for the role"` to `PostgresSource.get_non_retryable_errors()`, matching the stable prefix and excluding the volatile role name. Maps to an actionable message telling the user to fix the proxy credentials and re-enable the sync.
- This is a credential / upstream-config error (not transient), so it belongs in the non-retryable set alongside the existing PostgreSQL password keys.

## How did you test this code?

I'm an agent. I did not perform manual testing. Automated tests run locally:

- `pytest .../postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors` — 47 passed (includes a new `test_rds_proxy_wrong_password_is_non_retryable` and the real doubled production message added to the permanent-errors parametrization).
- `pytest .../postgres/test_postgres.py::TestConnectOptionsStartupParamFallback` — 8 passed (no regression to the existing options fallback).
- `ruff check` / `ruff format --check` — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue for the Postgres source. Investigation: pulled the issue's sampled events and reconstructed the exception chain — the `command-line options` rejection (cause) is already caught and retried by the existing `_connect_with_options_fallback`; the propagating top-level error is RDS Proxy's wrong-credentials message. Verified via the psycopg 3.2.4 source that `str(error)` (what the non-retryable matcher checks) carries the top exception's message, not the `__context__`, so matching the credential wording is correct. Considered also matching the co-occurring "This RDS Proxy requires TLS connections" line but kept the fix scoped to the unambiguous credential error to avoid touching SSL-mode behavior. Confirmed the new key is not already covered by `Any_Source_Errors` or existing entries, so this is not a no-op.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds AWS RDS Proxy's wrong-password error message (`"The password that was provided for the role"`) to the Postgres source's non-retryable errors dict, so the import pipeline stops retrying a credential mismatch that only the customer can fix, and surfaces an actionable user-facing message.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c7790e4ac0fae3ba513cd2c98af7ec56bb9098a8.</sup>
<!-- /MENDRAL_SUMMARY -->