### PR TITLE
test(insights): DEMO — exercise flake-test targeting (do not merge)

### DIFF
--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -57,55 +57,119 @@ if [ -z "$changed_test_files" ]; then
     echo "No changed Playwright test files found — skipping flake verification"
     exit 0
 fi
-declare -a tests_to_run=()
+# Top-level test declaration (test / test.skip / .only / .fixme / .fail). Used both to
+# locate test boundaries and as a heuristic test count — it doesn't expand parameterized
+# loops or test.describe fan-out, but it's good enough to target and budget the re-run.
+TEST_DECL_RE='^[[:space:]]*test(\.(skip|fixme|only|fail))?\('
+
+# Convert a repo-relative spec path to one relative to playwright/ (the CI step's cwd:
+# `pnpm --filter=@posthog/playwright exec playwright test`). Files outside that dir need `../`.
+playwright_path() {
+    local f="$1"
+    if [[ "$f" == playwright/* ]]; then
+        printf '%s' "${f#playwright/}"
+    else
+        printf '%s' "../$f"
+    fi
+}
+
+# Re-run only the tests that actually changed. We map the diff's changed line ranges onto
+# the test() declarations in each file and target those tests by `file:line`. A change that
+# lands outside any test body — imports, helpers, fixtures, before/after hooks, describe-level
+# setup — can affect every test in the file, so we conservatively fall back to the whole file.
+declare -a targets=()
+num_targeted_tests=0
 while IFS= read -r test_file; do
+    [ -z "$test_file" ] && continue
     if [ ! -f "$test_file" ]; then
         echo "Warning: $test_file no longer exists (deleted in PR) — skipping"
         continue
     fi
 
-    # Convert repo-relative paths to playwright-cwd-relative paths. The CI step runs
-    # `pnpm --filter=@posthog/playwright exec playwright test`, which sets cwd to
-    # playwright/, so files outside that directory need a `../` prefix.
-    if [[ "$test_file" == playwright/* ]]; then
-        tests_to_run+=("${test_file#playwright/}")
-    else
-        tests_to_run+=("../${test_file}")
+    pw_file="$(playwright_path "$test_file")"
+
+    # Test declaration line numbers in the new file (ascending — grep emits in file order).
+    mapfile -t test_lines < <(grep -nE "$TEST_DECL_RE" "$test_file" | cut -d: -f1)
+    total_file_tests=${#test_lines[@]}
+
+    # Changed line numbers in the new file. -U0 keeps each hunk to just its changed lines;
+    # parse the `@@ -a,b +c,d @@` headers for the new-side range c..c+d-1 (d defaults to 1;
+    # d=0 is a pure deletion, mapped to the line it sat on so the enclosing test still re-runs).
+    mapfile -t changed_lines < <(
+        git diff -U0 "$merge_base..HEAD" -- "$test_file" \
+            | sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p' \
+            | while read -r start count; do
+                count=${count:-1}
+                ((count == 0)) && count=1
+                for ((i = 0; i < count; i++)); do echo $((start + i)); done
+            done
+    )
+
+    # Can't analyze (no detectable tests, or no changed lines) → re-run the whole file.
+    if ((total_file_tests == 0)) || ((${#changed_lines[@]} == 0)); then
+        targets+=("$pw_file")
+        num_targeted_tests=$((num_targeted_tests + (total_file_tests > 0 ? total_file_tests : 1)))
+        continue
     fi
+
+    first_test_line=${test_lines[0]}
+    declare -A hit_test_lines=()
+    shared_change=0
+    for cl in "${changed_lines[@]}"; do
+        # Above the first test → shared scope (imports / module helpers / top-of-describe hooks).
+        if ((cl < first_test_line)); then
+            shared_change=1
+            break
+        fi
+        enclosing=$first_test_line
+        for tl in "${test_lines[@]}"; do
+            ((tl <= cl)) && enclosing=$tl || break
+        done
+        hit_test_lines[$enclosing]=1
+    done
+
+    # Shared-scope change, or every test touched → whole file (correctness over cleverness).
+    if ((shared_change)) || ((${#hit_test_lines[@]} >= total_file_tests)); then
+        ((shared_change)) && echo "  $test_file: change touches shared scope — re-running all $total_file_tests test(s)"
+        targets+=("$pw_file")
+        num_targeted_tests=$((num_targeted_tests + total_file_tests))
+        continue
+    fi
+
+    for tl in "${!hit_test_lines[@]}"; do
+        targets+=("$pw_file:$tl")
+    done
+    num_targeted_tests=$((num_targeted_tests + ${#hit_test_lines[@]}))
+    echo "  $test_file: re-running ${#hit_test_lines[@]} changed test(s) of $total_file_tests"
 done <<< "$changed_test_files"
 
-if [ ${#tests_to_run[@]} -eq 0 ]; then
-    echo "No runnable Playwright test files to verify"
+if [ ${#targets[@]} -eq 0 ]; then
+    echo "No runnable Playwright tests to verify"
     exit 0
 fi
 
-# Verification runs serially (--workers=1), so total work is files × repeat. Wide
-# mechanical refactors can touch dozens of spec files; repeating each 10x would blow
-# past the job's 45-minute timeout. Scale the repeat count down to fit a file-run
-# budget, and below MIN_REPEAT repetitions there's no flake signal left — skip.
-MAX_TOTAL_FILE_RUNS=60
-MIN_REPEAT=2
-
-num_files=${#tests_to_run[@]}
-if ((num_files * REPEAT_COUNT > MAX_TOTAL_FILE_RUNS)); then
-    scaled_repeat=$((MAX_TOTAL_FILE_RUNS / num_files))
-    if ((scaled_repeat < MIN_REPEAT)); then
-        echo "Skipping flake verification: $num_files changed spec files exceed the time budget even at --repeat-each=$MIN_REPEAT (likely a broad mechanical refactor)"
-        exit 0
-    fi
-    echo "Scaling --repeat-each from $REPEAT_COUNT to $scaled_repeat: $num_files changed spec files exceed the $MAX_TOTAL_FILE_RUNS file-run budget"
-    REPEAT_COUNT=$scaled_repeat
+# Verification runs serially (--workers=1) at the full --repeat-each, so total work is
+# targeted_tests × repeat. Because we re-run only the changed tests, this stays small for a
+# normal PR and keeps the full repeat. A genuinely broad change — dozens of edited tests, or
+# a shared-scope edit in a large spec that forces a whole-file fallback — can still blow the
+# job's 45-minute timeout. Rather than water down the repeat count (which destroys the flake
+# signal), skip verification entirely. ~40 serial test-runs (~5 min) fits the slack left after
+# the main suite.
+MAX_TOTAL_TEST_RUNS=40
+if ((num_targeted_tests * REPEAT_COUNT > MAX_TOTAL_TEST_RUNS)); then
+    echo "Skipping flake verification: $num_targeted_tests targeted test(s) × --repeat-each=$REPEAT_COUNT exceeds the ~${MAX_TOTAL_TEST_RUNS}-run time budget (broad change or a shared-scope edit in a large spec)"
+    exit 0
 fi
 
-echo "Verifying ${#tests_to_run[@]} file(s) with --repeat-each=$REPEAT_COUNT:"
-printf "  %s\n" "${tests_to_run[@]}"
+echo "Verifying $num_targeted_tests test(s) with --repeat-each=$REPEAT_COUNT:"
+printf "  %s\n" "${targets[@]}"
 
 # Write a JSON results file for the PR comment step to pick up.
 write_results() {
     local status="$1"
     local message="$2"
     local files_json
-    files_json=$(printf '%s\n' "${tests_to_run[@]}" | jq -R . | jq -s .)
+    files_json=$(printf '%s\n' "${targets[@]}" | jq -R . | jq -s .)
     jq -n \
         --arg status "$status" \
         --arg message "$message" \
@@ -121,7 +185,7 @@ set +e
 # the verification report is the one that matters (the main tests passed).
 # Fail fast once instability is detected so the job doesn't burn the full timeout
 # on the remaining repeated runs.
-pnpm --filter=@posthog/playwright exec playwright test "${tests_to_run[@]}" \
+pnpm --filter=@posthog/playwright exec playwright test "${targets[@]}" \
     --workers=1 --repeat-each="$REPEAT_COUNT" --retries=0 --max-failures=1
 test_exit=$?
 set -e

--- a/playwright/e2e/product-analytics/insights/funnels.spec.ts
+++ b/playwright/e2e/product-analytics/insights/funnels.spec.ts
@@ -236,8 +236,6 @@ test.describe('Funnel insights', () => {
         await test.step('switch back to Sequential', async () => {
             await insight.funnels.selectStepOrder('Sequential')
             await insight.funnels.waitForChart()
-            // Without this check a silently failed switch gets saved below, and any
-            // test reading this insight afterwards runs against the wrong step order.
             await expect(insight.funnels.stepOrderFilter).toContainText('Sequential')
         })
 

--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -337,7 +337,6 @@ test.describe('Trends insights', () => {
             await expect(insight.trends.dateRangeButton).toContainText('Last 30 days')
             await expect(insight.saveButton).toBeEnabled()
             await insight.discard()
-            // Wait for mode transition to complete first (Edit → View)
             await expect(insight.editButton).toBeVisible()
             await insight.trends.waitForChart()
             // Handle race where DateFilter state is lost during mode transition remount


### PR DESCRIPTION
**Disposable demo — not for merge.**

Validates the changed-test targeting from #64056 in real CI. It carries that PR's script change plus a one-comment removal inside one test in each of two different insight specs (`trends.spec.ts`, `funnels.spec.ts`).

Watch the **"Verify changed Playwright tests are stable"** step in the E2E Playwright job: it should target exactly two tests — `funnels.spec.ts:211` and `trends.spec.ts:316` — at `--repeat-each=10`, and ignore the other 18 tests across those two files.

Close + delete branch after observing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
