### PR TITLE
feat(oauth): @default union scope ceilings

### DIFF
--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -288,8 +288,10 @@ def resolve_ceiling(app_scopes: Iterable[str]) -> frozenset[str] | None:
     """An app's explicit scope ceiling, or `None` when it has none (empty `scopes`,
     which falls back to the `UNPRIVILEGED_SCOPES` default). A `@default` sentinel
     expands to `UNPRIVILEGED_SCOPES` unioned with the other listed scopes; without it,
-    a non-empty ceiling stays an exhaustive allow-list."""
-    app = set(app_scopes or [])
+    a non-empty ceiling stays an exhaustive allow-list. Entries are stripped so a
+    fat-fingered `" @default"` still resolves (real scopes never have whitespace)."""
+    app = {s.strip() for s in (app_scopes or [])}
+    app.discard("")
     if not app:
         return None
     if DEFAULT_CEILING_SENTINEL in app:

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -274,11 +274,34 @@ def filter_to_unprivileged_scopes(scopes: Iterable[object]) -> list[str]:
     return result
 
 
+# Sentinel element in `OAuthApplication.scopes` meaning "the `UNPRIVILEGED_SCOPES`
+# default *plus* the other listed scopes" — lets an app ride the broad default and add
+# a few explicit (e.g. privileged) extras without enumerating the whole set, and keeps
+# auto-tracking unprivileged scopes added later. Starts with `@` so it can never collide
+# with a real `obj:action` scope. Not grantable itself: it's stripped from the resolved
+# ceiling, and `filter_to_unprivileged_scopes` drops it so a self-registering app can't
+# inject it to widen its own ceiling.
+DEFAULT_CEILING_SENTINEL = "@default"
+
+
+def resolve_ceiling(app_scopes: Iterable[str]) -> frozenset[str] | None:
+    """An app's explicit scope ceiling, or `None` when it has none (empty `scopes`,
+    which falls back to the `UNPRIVILEGED_SCOPES` default). A `@default` sentinel
+    expands to `UNPRIVILEGED_SCOPES` unioned with the other listed scopes; without it,
+    a non-empty ceiling stays an exhaustive allow-list."""
+    app = set(app_scopes or [])
+    if not app:
+        return None
+    if DEFAULT_CEILING_SENTINEL in app:
+        return frozenset(UNPRIVILEGED_SCOPES | (app - {DEFAULT_CEILING_SENTINEL}))
+    return frozenset(app)
+
+
 def effective_ceiling(app_scopes: Iterable[str]) -> frozenset[str]:
     """The scope set a request resolves against: the explicit `app_scopes` ceiling,
     or the broad `UNPRIVILEGED_SCOPES` default when the app has none."""
-    app = frozenset(app_scopes or [])
-    return app if app else UNPRIVILEGED_SCOPES
+    ceiling = resolve_ceiling(app_scopes)
+    return ceiling if ceiling is not None else UNPRIVILEGED_SCOPES
 
 
 def scopes_within_ceiling(
@@ -296,6 +319,8 @@ def scopes_within_ceiling(
     - OIDC + introspection (`ALWAYS_ALLOWED_SCOPES`) are always granted.
     - An explicit `app_scopes` ceiling is an exhaustive allow-list: anything
       outside it is rejected, including `*`.
+    - A `@default` sentinel in `app_scopes` resolves to `UNPRIVILEGED_SCOPES` plus
+      the other listed scopes (see `resolve_ceiling`).
     - An empty `app_scopes` falls back to the broad `UNPRIVILEGED_SCOPES` default.
 
     `allow_wildcard_under_empty_ceiling` is the only resolution difference between
@@ -304,12 +329,12 @@ def scopes_within_ceiling(
     (the default) since it never granted wildcard, so an unseeded ceiling must not
     silently become one.
     """
-    app = frozenset(app_scopes or [])
+    ceiling = resolve_ceiling(app_scopes)
     to_check = set(requested) - ALWAYS_ALLOWED_SCOPES
     if not to_check:
         return True
-    if app:
-        return "*" not in to_check and to_check.issubset(app)
+    if ceiling is not None:
+        return "*" not in to_check and to_check.issubset(ceiling)
     allowed = UNPRIVILEGED_SCOPES | {"*"} if allow_wildcard_under_empty_ceiling else UNPRIVILEGED_SCOPES
     return to_check.issubset(allowed)
 
@@ -327,13 +352,13 @@ def scopes_outside_ceiling(
 
     Returns a sorted list, empty when every requested scope is grantable.
     """
-    app = frozenset(app_scopes or [])
+    ceiling = resolve_ceiling(app_scopes)
     to_check = set(requested) - ALWAYS_ALLOWED_SCOPES
     if not to_check:
         return []
-    if app:
+    if ceiling is not None:
         # `*` is never grantable under an explicit ceiling, even if listed.
-        return sorted(s for s in to_check if s == "*" or s not in app)
+        return sorted(s for s in to_check if s == "*" or s not in ceiling)
     allowed = UNPRIVILEGED_SCOPES | {"*"} if allow_wildcard_under_empty_ceiling else UNPRIVILEGED_SCOPES
     return sorted(to_check - allowed)
 
@@ -353,15 +378,15 @@ def narrow_scopes_to_ceiling(original: Iterable[str], app_scopes: Iterable[str])
       caller should reject with `invalid_grant` and force re-authorization).
     """
     original_list = list(original)
-    app = set(app_scopes or [])
-    if not app:
+    ceiling = resolve_ceiling(app_scopes)
+    if ceiling is None:
         return original_list
 
     original_set = set(original_list)
     if "*" in original_set:
         return original_list
 
-    narrowed = (original_set & app) | (original_set & ALWAYS_ALLOWED_SCOPES)
+    narrowed = (original_set & ceiling) | (original_set & ALWAYS_ALLOWED_SCOPES)
     if not narrowed:
         return None
     return sorted(narrowed)

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -360,10 +360,10 @@ class TestNarrowScopesToCeiling(SimpleTestCase):
                 ["openid"],
             ),
             # `@default` ceiling narrows to the unprivileged default plus listed extras,
-            # dropping a hidden scope (`metrics:read`) the default doesn't cover.
+            # dropping a hidden scope (`wizard_session:read`) the default doesn't cover.
             (
                 "default_sentinel_keeps_unprivileged_and_extras",
-                ["query:read", "llm_gateway:read", "metrics:read"],
+                ["query:read", "llm_gateway:read", "wizard_session:read"],
                 ["@default", "llm_gateway:read"],
                 ["llm_gateway:read", "query:read"],
             ),

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -284,10 +284,19 @@ class TestScopesWithinCeiling(SimpleTestCase):
         assert scopes_within_ceiling(["*"], [], allow_wildcard_under_empty_ceiling=True) is True
         assert scopes_within_ceiling(["*"], [], allow_wildcard_under_empty_ceiling=False) is False
 
-    def test_effective_ceiling(self) -> None:
-        assert effective_ceiling([]) == UNPRIVILEGED_SCOPES
-        assert effective_ceiling(["query:read", "insight:read"]) == frozenset({"query:read", "insight:read"})
-        assert effective_ceiling(["@default", "llm_gateway:read"]) == UNPRIVILEGED_SCOPES | {"llm_gateway:read"}
+    @parameterized.expand(
+        [
+            ("empty_falls_back_to_unprivileged", [], UNPRIVILEGED_SCOPES),
+            ("explicit_list_is_exhaustive", ["query:read", "insight:read"], frozenset({"query:read", "insight:read"})),
+            (
+                "default_sentinel_expands_to_unprivileged_plus_extras",
+                ["@default", "llm_gateway:read"],
+                UNPRIVILEGED_SCOPES | {"llm_gateway:read"},
+            ),
+        ]
+    )
+    def test_effective_ceiling(self, _name: str, app_scopes: list[str], expected: frozenset[str]) -> None:
+        assert effective_ceiling(app_scopes) == expected
 
 
 class TestScopesOutsideCeiling(SimpleTestCase):

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -246,6 +246,22 @@ class TestScopesWithinCeiling(SimpleTestCase):
             # Provisioning never grandfathered `*`; an unseeded ceiling must not grant it.
             ("wildcard_rejected_under_empty_ceiling", ["*"], [], False),
             ("unprivileged_allowed_under_empty_ceiling", ["query:read", "insight:write"], [], True),
+            # `@default` sentinel: the unprivileged default plus the other listed scopes.
+            ("default_sentinel_grants_unprivileged", ["query:read", "insight:write"], ["@default"], True),
+            (
+                "default_sentinel_grants_listed_privileged_extra",
+                ["llm_gateway:read", "query:read"],
+                ["@default", "llm_gateway:read"],
+                True,
+            ),
+            (
+                "default_sentinel_rejects_unlisted_privileged",
+                ["llm_gateway:write"],
+                ["@default", "llm_gateway:read"],
+                False,
+            ),
+            ("wildcard_rejected_under_default_sentinel", ["*"], ["@default"], False),
+            ("sentinel_itself_not_grantable", ["@default"], ["@default"], False),
         ]
     )
     def test_resolution(self, _name: str, requested: list[str], app_scopes: list[str], expected: bool) -> None:
@@ -271,6 +287,7 @@ class TestScopesWithinCeiling(SimpleTestCase):
     def test_effective_ceiling(self) -> None:
         assert effective_ceiling([]) == UNPRIVILEGED_SCOPES
         assert effective_ceiling(["query:read", "insight:read"]) == frozenset({"query:read", "insight:read"})
+        assert effective_ceiling(["@default", "llm_gateway:read"]) == UNPRIVILEGED_SCOPES | {"llm_gateway:read"}
 
 
 class TestScopesOutsideCeiling(SimpleTestCase):
@@ -281,6 +298,12 @@ class TestScopesOutsideCeiling(SimpleTestCase):
             ("privileged_rejected_without_ceiling", ["llm_gateway:read"], [], ["llm_gateway:read"]),
             ("wildcard_rejected_under_explicit_ceiling", ["query:read", "*"], ["query:read"], ["*"]),
             ("oidc_never_rejected", ["openid", "insight:write"], ["query:read"], ["insight:write"]),
+            (
+                "default_sentinel_isolates_unlisted_privileged",
+                ["llm_gateway:write", "query:read"],
+                ["@default", "llm_gateway:read"],
+                ["llm_gateway:write"],
+            ),
         ]
     )
     def test_resolution(self, _name: str, requested: list[str], app_scopes: list[str], expected: list[str]) -> None:
@@ -288,7 +311,12 @@ class TestScopesOutsideCeiling(SimpleTestCase):
 
     def test_inverse_of_within_ceiling(self) -> None:
         # The two helpers must never disagree: empty offender list iff within ceiling.
-        cases = [(["query:read", "insight:write"], ["query:read"]), (["query:read"], []), (["*"], [])]
+        cases = [
+            (["query:read", "insight:write"], ["query:read"]),
+            (["query:read"], []),
+            (["*"], []),
+            (["llm_gateway:write", "query:read"], ["@default", "llm_gateway:read"]),
+        ]
         for requested, app_scopes in cases:
             within = scopes_within_ceiling(requested, app_scopes, allow_wildcard_under_empty_ceiling=True)
             outside = scopes_outside_ceiling(requested, app_scopes, allow_wildcard_under_empty_ceiling=True)
@@ -316,6 +344,14 @@ class TestNarrowScopesToCeiling(SimpleTestCase):
                 ["query:read"],
                 ["openid"],
             ),
+            # `@default` ceiling narrows to the unprivileged default plus listed extras,
+            # dropping a hidden scope (`metrics:read`) the default doesn't cover.
+            (
+                "default_sentinel_keeps_unprivileged_and_extras",
+                ["query:read", "llm_gateway:read", "metrics:read"],
+                ["@default", "llm_gateway:read"],
+                ["llm_gateway:read", "query:read"],
+            ),
         ]
     )
     def test_resolution(
@@ -337,6 +373,8 @@ class TestFilterToUnprivilegedScopes(SimpleTestCase):
             ),
             ("empty_in_empty_out", [], []),
             ("all_dropped_yields_empty", ["llm_gateway:read", "garbage"], []),
+            # A self-registering app can't inject the ceiling sentinel to widen itself.
+            ("drops_default_sentinel", ["@default", "insight:read"], ["insight:read"]),
         ]
     )
     def test_resolution(self, _name: str, given: list[str], expected: list[str]) -> None:

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -262,6 +262,7 @@ class TestScopesWithinCeiling(SimpleTestCase):
             ),
             ("wildcard_rejected_under_default_sentinel", ["*"], ["@default"], False),
             ("sentinel_itself_not_grantable", ["@default"], ["@default"], False),
+            ("default_sentinel_tolerates_whitespace", ["query:read", "insight:write"], [" @default "], True),
         ]
     )
     def test_resolution(self, _name: str, requested: list[str], app_scopes: list[str], expected: bool) -> None:
@@ -291,6 +292,11 @@ class TestScopesWithinCeiling(SimpleTestCase):
             (
                 "default_sentinel_expands_to_unprivileged_plus_extras",
                 ["@default", "llm_gateway:read"],
+                UNPRIVILEGED_SCOPES | {"llm_gateway:read"},
+            ),
+            (
+                "sentinel_and_extras_tolerate_whitespace",
+                [" @default ", "llm_gateway:read "],
                 UNPRIVILEGED_SCOPES | {"llm_gateway:read"},
             ),
         ]


### PR DESCRIPTION
## Problem

`OAuthApplication.scopes` (the scope ceiling) is all-or-nothing: an empty value resolves to the broad `UNPRIVILEGED_SCOPES` default (and auto-tracks new scopes), but any non-empty value is an exhaustive allow-list. An app that needs ~the whole unprivileged surface **plus** a privileged scope — e.g. a first-party agent that needs the broad API surface and `llm_gateway:read` — therefore has to seed and hand-maintain a ~180-element ceiling that drifts every time a product adds a scope.

Closes #64086

## Changes

Adds a `@default` sentinel for `OAuthApplication.scopes` meaning "the `UNPRIVILEGED_SCOPES` default plus the other listed scopes." An app's ceiling can then be `["@default", "llm_gateway:read"]` and auto-track unprivileged additions while explicitly granting the privileged extra.

- One new `resolve_ceiling()` helper in `posthog/scopes.py`; the four ceiling functions (`effective_ceiling`, `scopes_within_ceiling`, `scopes_outside_ceiling`, `narrow_scopes_to_ceiling`) all route through it.
- Backward-compatible by construction: empty ceilings and existing explicit-list ceilings (Stripe, CIMD/DCR partners) are unchanged — the sentinel only does anything when literally present. No migration.
- The sentinel starts with `@` so it can't collide with a real `obj:action` scope, it's stripped from the resolved ceiling (not grantable as a scope), and `filter_to_unprivileged_scopes` already drops it so a self-registering app can't inject it to widen itself.

Same shape as Microsoft Graph's `.default`: the grantable set lives server-side and the app references it generically.

## How did you test this code?

- `pytest posthog/test/test_scopes.py` — 88 passed (existing ceiling tests + new `@default` cases across all four helpers): grants unprivileged via the sentinel, grants listed privileged extras, rejects unlisted privileged, rejects `*` under a sentinel ceiling, the sentinel isn't grantable as a scope, the within/outside inverse invariant holds with a sentinel, narrowing keeps default + extras and drops uncovered scopes, and `filter_to_unprivileged_scopes` drops the sentinel.
- `ruff check` / `ruff format` clean; pre-commit `ty` typecheck passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change — internal scope-ceiling resolution only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Backend half of moving the PostHog Code CLI off the `*` wildcard (#60342). A feasibility review against all five ceiling callers (`/authorize`, agentic-provisioning mint + refresh, DCR, CIMD) confirmed the sentinel-in-array design is backward-compatible with no signature or call-site changes. Note for the reviewer: this is ceiling-resolution logic, not the end-user consent/scope-setting UX — the consent screen reads `effective_ceiling`, which now expands `@default` to ~the same unprivileged set it already renders for empty-ceiling apps, so no UX regression, but a visual glance there is worth it.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `@default` sentinel for `OAuthApplication.scopes` that expands to `UNPRIVILEGED_SCOPES` plus any other listed scopes, allowing apps to auto-track the unprivileged default while explicitly adding privileged extras. A new `resolve_ceiling()` helper centralizes ceiling resolution for all four existing ceiling functions.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e38ded66132220269f59fc1e8eaa71fbe36362bd.</sup>
<!-- /MENDRAL_SUMMARY -->