### PR TITLE
fix(devex): unescape wildcards in CODEOWNERS-soft so soft owners match

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -9,7 +9,7 @@
 frontend/src/scenes/settings/environment/SurveySettings.tsx @PostHog/team-surveys
 frontend/src/scenes/surveys/ @PostHog/team-surveys
 frontend/src/scenes/onboarding/sdks/surveys @PostHog/team-surveys
-ee/surveys @PostHog/team-surveys
+ee/surveys/ @PostHog/team-surveys
 posthog/tasks/stop_surveys_reached_target.py @PostHog/team-surveys
 posthog/tasks/update_survey_adaptive_sampling.py @PostHog/team-surveys
 posthog/tasks/update_survey_iteration.py @PostHog/team-surveys
@@ -86,7 +86,7 @@ frontend/src/scenes/subscriptions/ @PostHog/team-analytics-platform
 frontend/src/scenes/sessions/ @PostHog/team-analytics-platform
 
 # Revenue Analytics - owned by @rafaeelaudibert and @PostHog/team-web-analytics
-products/revenue_analytics/\*\* @rafaeelaudibert @PostHog/team-web-analytics
+products/revenue_analytics/** @rafaeelaudibert @PostHog/team-web-analytics
 
 # Feature Flags (Rust evaluator + remaining monolith tests) - owned by @PostHog/team-feature-flags
 # Note: the Django models and API moved to products/feature_flags/ (covered by products/feature_flags/product.yaml).
@@ -109,7 +109,7 @@ posthog/tasks/early_access_feature.py @PostHog/team-feature-flags
 posthog/temporal/data_imports/** @PostHog/team-warehouse-sources
 posthog/warehouse/** @PostHog/team-data-stack
 products/data_warehouse/** @PostHog/team-data-stack
-frontend/src/scenes/data-warehouse/\*\* @PostHog/team-data-stack
+frontend/src/scenes/data-warehouse/** @PostHog/team-data-stack
 posthog/management/commands/generate_source_configs.py @PostHog/team-warehouse-sources
 frontend/src/scenes/data-management/ @PostHog/team-warehouse-sources
 posthog/settings/data_warehouse.py @PostHog/team-data-stack
@@ -118,7 +118,7 @@ posthog/temporal/data_modeling/** @PostHog/team-data-modeling
 
 # HogQL - owned by @PostHog/team-data-tools
 # and also hard owned by the @PostHog/hogql on `CODEOWNERS` file
-posthog/hogql/\*\* @PostHog/team-data-tools
+posthog/hogql/** @PostHog/team-data-tools
 posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
 
 # Tracing/Metrics — owned by @PostHog/logs (logs itself comes from products/logs/product.yaml)
@@ -158,8 +158,8 @@ posthog/models/resource_transfer/ @PostHog/team-platform-features
 posthog/rbac/ @PostHog/team-platform-features
 
 # Session Replay python files - owned by @PostHog/team-replay
-posthog/session_recordings/**/\*.py @PostHog/team-replay
-ee/session_recordings/**/\*.py @PostHog/team-replay
+posthog/session_recordings/**/*.py @PostHog/team-replay
+ee/session_recordings/**/*.py @PostHog/team-replay
 
 # Session Replay frontend - owned by @PostHog/team-replay
 frontend/src/scenes/session-recordings/ @PostHog/team-replay
@@ -229,7 +229,7 @@ services/llm-gateway/ @PostHog/team-ai-gateway
 .github/dependabot.yml @PostHog/team-devex
 .github/pull_request_template.md @PostHog/team-devex
 Dockerfile @PostHog/team-devex
-docker-compose\*.yml @PostHog/team-devex
+docker-compose*.yml @PostHog/team-devex
 .prettierrc @PostHog/team-devex
 mypy.ini @PostHog/team-devex
 .test_quarantine.json @PostHog/team-devex
@@ -315,7 +315,7 @@ posthog/temporal/quota_limiting/ @PostHog/team-billing
 # Query performance - owned by @PostHog/team-query-performance
 posthog/queries/ @PostHog/team-query-performance
 posthog/caching/ @PostHog/team-query-performance
-posthog/hogql/database/schema/sessions*\*.py @PostHog/team-query-performance
+posthog/hogql/database/schema/sessions*.py @PostHog/team-query-performance
 posthog/models/raw_sessions/** @PostHog/team-query-performance
 posthog/models/sessions/** @PostHog/team-query-performance
 


### PR DESCRIPTION
## Problem

Several entries in `.github/CODEOWNERS-soft` never match any file under PostHog's own ownership matcher (`globToRegex` / `fileMatchesPattern` in [`.github/scripts/assign-reviewers.js`](https://github.com/PostHog/posthog/blob/master/.github/scripts/assign-reviewers.js), which the reviewer auto-assigner runs in CI). As a result the listed soft owners were silently never requested as reviewers for those paths.

Two root causes:

1. **Backslash-escaped wildcards** (`\*` / `\**`). The matcher escapes the backslash first, so these patterns only match paths containing a literal backslash, i.e. nothing.
2. **A directory pattern missing its trailing slash.** `ee/surveys` matched only the exact path `ee/surveys` (a directory, never a changed file), not its contents (e.g. `ee/surveys/summaries/*.py`).

`CODEOWNERS-soft` is non-blocking, so this never broke merges, only soft reviewer assignment.

## Changes

Fixed 8 patterns:

| Before | After | Soft owner affected |
| --- | --- | --- |
| `products/revenue_analytics/\*\*` | `products/revenue_analytics/**` | extra `@rafaeelaudibert` reviewer (team already covered via `product.yaml`) |
| `frontend/src/scenes/data-warehouse/\*\*` | `frontend/src/scenes/data-warehouse/**` | `@PostHog/team-data-stack` (biggest gap — not under `products/`, so the whole scene was unowned in CI) |
| `posthog/hogql/\*\*` | `posthog/hogql/**` | `@PostHog/team-data-tools` (hogql still hard-owned via `CODEOWNERS`) |
| `posthog/session_recordings/**/\*.py` | `posthog/session_recordings/**/*.py` | `@PostHog/team-replay` |
| `ee/session_recordings/**/\*.py` | `ee/session_recordings/**/*.py` | `@PostHog/team-replay` |
| `docker-compose\*.yml` | `docker-compose*.yml` | `@PostHog/team-devex` |
| `posthog/hogql/database/schema/sessions*\*.py` | `posthog/hogql/database/schema/sessions*.py` | `@PostHog/team-query-performance` |
| `ee/surveys` | `ee/surveys/` | `@PostHog/team-surveys` |

Each owner was sanity-checked against its section comment, sibling entries, and (for `revenue_analytics`) `product.yaml` — all still the intended team. `ee/session_recordings/` currently has no tracked `.py` files (only an excluded `.ambr` snapshot), but the escaping fix is still correct and will assign `team-replay` if Python is re-added there.

## How did you test this code?

I'm an agent (Claude Code). I verified before/after using the exact CI matcher (`fileMatchesPattern` exported from `.github/scripts/assign-reviewers.js`), plus the `product.yaml` rule-loading the auto-assigner layers on top:

- **Before:** all 8 patterns returned `NOMATCH` against real file paths.
- **After:** resolving the full rule set (CODEOWNERS-soft + `product.yaml`) for representative paths yields the expected owners — e.g. `frontend/src/scenes/data-warehouse/DataWarehouseScene.tsx` → `@PostHog/team-data-stack`, `ee/surveys/summaries/summarize_surveys.py` → `@PostHog/team-surveys`, `docker-compose.dev.yml` → `@PostHog/team-devex`.
- Confirmed no backslash-escaped wildcards remain in the file.

No automated test suite covers this file's contents; the matcher itself is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by Robbie.

Authored with Claude Code (Opus 4.8). The fix is mechanical (unescape wildcards, add a trailing slash), but each line was validated two ways before changing: (1) the listed owners were checked against the section comment, neighbouring entries, and `product.yaml` to catch ownership drift, and (2) the resulting glob was run through the real CI matcher to confirm it now matches actual on-disk files. `.github/CODEOWNERS-soft` is itself soft-owned by `@PostHog/team-devex`.
