### PR TITLE
feat(cohorts): require flag and insight read scopes for used_in

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1722,7 +1722,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         )
 
     @extend_schema(responses=CohortUsedInResponseSerializer)
-    @action(methods=["GET"], detail=True, required_scopes=["cohort:read"])
+    @action(methods=["GET"], detail=True, required_scopes=["cohort:read", "feature_flag:read", "insight:read"])
     def used_in(self, request: request.Request, **kwargs) -> Response:
         cohort: Cohort = self.get_object()
         # Hide references the caller has been denied at the object level, matching the

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -30,8 +30,10 @@ from posthog.models import Person, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.async_deletion.async_deletion import AsyncDeletion
 from posthog.models.file_system.file_system import FileSystem
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.property import BehavioralPropertyType
 from posthog.models.team.team import Team
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.tasks.calculate_cohort import (
     calculate_cohort_ch,
     calculate_cohort_from_list,
@@ -5839,6 +5841,36 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
             "This cohort is used in 1 active feature flag(s): Transitive Flag",
             response.json()["detail"],
         )
+
+    @parameterized.expand(
+        [
+            ("missing_both", ["cohort:read"]),
+            ("missing_insight", ["cohort:read", "feature_flag:read"]),
+            ("missing_flag", ["cohort:read", "insight:read"]),
+        ]
+    )
+    @patch("posthog.api.cohort.report_user_action")
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
+    def test_used_in_requires_flag_and_insight_scopes(self, _name, scopes, patch_calculate_cohort, patch_capture):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={"name": "Scoped Cohort", "groups": [{"properties": {"team_id": 5}}]},
+        )
+        cohort_id = response.json()["id"]
+
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="cohort-only",
+            user=self.user,
+            secure_value=hash_key_value(token),
+            scopes=scopes,
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/cohorts/{cohort_id}/used_in",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.json())
 
 
 class TestCalculateCohortCommand(APIBaseTest):


### PR DESCRIPTION
## Problem

The cohort `used_in` endpoint returns the feature flags and insights that reference a cohort. It required only the `cohort:read` scope, so a personal API key scoped to cohorts could read flag and insight names without being granted `feature_flag:read` or `insight:read`. The required scopes should match the data the endpoint returns.

Split out of #62820 (the `used_in` performance work) because the scope change is an orthogonal access-control hardening that should get its own review and changelog entry. The two PRs are independent; whichever merges second needs a one-line rebase on the `used_in` decorator.

## Changes

`used_in` now requires `cohort:read`, `feature_flag:read`, and `insight:read`. A personal API key missing either new scope gets a `403`.

This is a breaking change for API consumers. Personal API keys scoped to only `cohort:read` will start getting a `403` from `GET /api/projects/:id/cohorts/:id/used_in`, and those integrations need to add `feature_flag:read` and `insight:read`.

Object-level access filtering, where a denied flag or insight is already hidden from the results, is unchanged and stays in the perf PR.

## How did you test this code?

Added `test_used_in_requires_flag_and_insight_scopes`, parameterized over missing-both, missing-insight, and missing-flag. It asserts a `403` when either new scope is absent. All three cases pass locally.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?