### PR TITLE
chore(integrations): remove unused Stripe sandbox install support

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -696,12 +696,11 @@ class IntegrationViewSet(
     def authorize(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         kind = request.GET.get("kind")
         next = request.GET.get("next", "")
-        is_sandbox = request.GET.get("is_sandbox", "").lower() in ("true", "1", "yes")
         token = os.urandom(33).hex()
 
         if kind in OauthIntegration.supported_kinds:
             try:
-                auth_url = OauthIntegration.authorize_url(kind, next=next, token=token, is_sandbox=is_sandbox)
+                auth_url = OauthIntegration.authorize_url(kind, next=next, token=token)
                 response = redirect(auth_url)
                 # nosemgrep: python.django.security.audit.secure-cookies.django-secure-set-cookie (OAuth state, short-lived, needed for cross-site redirect)
                 response.set_cookie("ph_oauth_state", token, max_age=60 * 5)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -2200,25 +2200,21 @@ class TestStripeIntegrationOAuthTokens:
 
     @parameterized.expand(
         [
-            ("write_uses_sandbox_when_flag_set", "write_posthog_secrets", {"is_sandbox": True}, "sk_test_sandbox"),
-            ("clear_uses_sandbox_when_flag_set", "clear_posthog_secrets", {"is_sandbox": True}, "sk_test_sandbox"),
-            ("write_uses_live_when_flag_missing", "write_posthog_secrets", {}, "sk_live"),
+            ("write", "write_posthog_secrets"),
+            ("clear", "clear_posthog_secrets"),
         ]
     )
     @patch("stripe.StripeClient")
     @patch("posthog.models.integration.settings")
-    def test_stripe_client_secret_selection(
-        self, _name, method_name, config, expected_key, mock_settings, MockStripeClient
-    ):
+    def test_stripe_client_uses_live_secret(self, _name, method_name, mock_settings, MockStripeClient):
         mock_settings.STRIPE_POSTHOG_OAUTH_CLIENT_ID = self.oauth_app.client_id
         mock_settings.STRIPE_APP_SECRET_KEY = "sk_live"
-        mock_settings.STRIPE_APP_SANDBOX_SECRET_KEY = "sk_test_sandbox"
         MockStripeClient.return_value = MagicMock()
 
         integration = Integration.objects.create(
             team=self.team,
             kind="stripe",
-            config=config,
+            config={},
             sensitive_config={},
             integration_id=f"acct_{_name}",
             created_by=self.user,
@@ -2229,25 +2225,23 @@ class TestStripeIntegrationOAuthTokens:
         else:
             stripe_int.clear_posthog_secrets()
 
-        MockStripeClient.assert_called_once_with(expected_key)
+        MockStripeClient.assert_called_once_with("sk_live")
 
     @patch("posthog.models.integration.capture_exception")
     @patch("stripe.StripeClient")
     @patch("posthog.models.integration.settings")
-    def test_write_posthog_secrets_skips_when_sandbox_keys_missing(self, mock_settings, MockStripeClient, mock_capture):
+    def test_write_posthog_secrets_skips_when_keys_missing(self, mock_settings, MockStripeClient, mock_capture):
         mock_settings.STRIPE_POSTHOG_OAUTH_CLIENT_ID = self.oauth_app.client_id
-        mock_settings.STRIPE_APP_CLIENT_ID = "ca_live"
-        mock_settings.STRIPE_APP_SECRET_KEY = "sk_live"
-        mock_settings.STRIPE_APP_SANDBOX_CLIENT_ID = None
-        mock_settings.STRIPE_APP_SANDBOX_SECRET_KEY = None
+        mock_settings.STRIPE_APP_CLIENT_ID = None
+        mock_settings.STRIPE_APP_SECRET_KEY = None
         MockStripeClient.return_value = MagicMock()
 
         integration = Integration.objects.create(
             team=self.team,
             kind="stripe",
-            config={"is_sandbox": True},
+            config={},
             sensitive_config={},
-            integration_id="acct_sandbox_missing_write",
+            integration_id="acct_missing_write",
             created_by=self.user,
         )
         stripe_int = StripeIntegration(integration)
@@ -2261,19 +2255,15 @@ class TestStripeIntegrationOAuthTokens:
     @patch("posthog.models.integration.capture_exception")
     @patch("stripe.StripeClient")
     @patch("posthog.models.integration.settings")
-    def test_clear_posthog_secrets_skips_and_revokes_tokens_when_sandbox_keys_missing(
+    def test_clear_posthog_secrets_skips_and_revokes_tokens_when_keys_missing(
         self, mock_settings, MockStripeClient, mock_capture
     ):
         mock_settings.STRIPE_POSTHOG_OAUTH_CLIENT_ID = self.oauth_app.client_id
-        mock_settings.STRIPE_APP_CLIENT_ID = "ca_live"
-        mock_settings.STRIPE_APP_SECRET_KEY = "sk_live"
-        mock_settings.STRIPE_APP_SANDBOX_CLIENT_ID = None
-        mock_settings.STRIPE_APP_SANDBOX_SECRET_KEY = None
+        mock_settings.STRIPE_APP_CLIENT_ID = None
+        mock_settings.STRIPE_APP_SECRET_KEY = None
         MockStripeClient.return_value = MagicMock()
 
         integration, access_token, refresh_token = self._create_integration_with_tokens()
-        integration.config = {"is_sandbox": True}
-        integration.save()
 
         stripe_int = StripeIntegration(integration)
         stripe_int.clear_posthog_secrets()

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -324,7 +324,7 @@ class OauthIntegration:
 
     @classmethod
     @cache_for(timedelta(minutes=5))
-    def oauth_config_for_kind(cls, kind: str, is_sandbox: bool = False) -> OauthConfig:
+    def oauth_config_for_kind(cls, kind: str) -> OauthConfig:
         if kind == "slack":
             from_settings = get_instance_settings(
                 [
@@ -630,17 +630,8 @@ class OauthIntegration:
             if not settings.STRIPE_APP_CLIENT_ID or not settings.STRIPE_APP_SECRET_KEY:
                 raise NotImplementedError("Stripe app not configured")
 
-            # Stripe issues separate client_id and secret for live vs sandbox installs of the
-            # same app. Sandbox-issued OAuth codes can only be redeemed with the sandbox secret;
-            # using the live secret returns "Authorization code provided does not belong to you".
-            if is_sandbox:
-                if not settings.STRIPE_APP_SANDBOX_CLIENT_ID or not settings.STRIPE_APP_SANDBOX_SECRET_KEY:
-                    raise NotImplementedError("Stripe sandbox not configured")
-                client_id = settings.STRIPE_APP_SANDBOX_CLIENT_ID
-                client_secret = settings.STRIPE_APP_SANDBOX_SECRET_KEY
-            else:
-                client_id = settings.STRIPE_APP_CLIENT_ID
-                client_secret = settings.STRIPE_APP_SECRET_KEY
+            client_id = settings.STRIPE_APP_CLIENT_ID
+            client_secret = settings.STRIPE_APP_SECRET_KEY
 
             authorize_url = (
                 settings.STRIPE_APP_OVERRIDE_AUTHORIZE_URL or "https://marketplace.stripe.com/oauth/v2/authorize"
@@ -665,8 +656,8 @@ class OauthIntegration:
         return f"{settings.SITE_URL.replace('http://', 'https://')}/integrations/{kind}/callback"
 
     @classmethod
-    def authorize_url(cls, kind: str, token: str, next: str = "", is_sandbox: bool = False) -> str:
-        oauth_config = cls.oauth_config_for_kind(kind, is_sandbox=is_sandbox)
+    def authorize_url(cls, kind: str, token: str, next: str = "") -> str:
+        oauth_config = cls.oauth_config_for_kind(kind)
 
         state_payload: dict[str, str] = {"next": next, "token": token}
 
@@ -741,37 +732,6 @@ class OauthIntegration:
                     "grant_type": "authorization_code",
                 },
             )
-            # Marketplace-initiated installs land on /integrations/stripe/confirm-install
-            # without any signal indicating live vs sandbox. If the live secret rejected
-            # the code as "does not belong to you", it was minted by the sandbox app -
-            # retry with the sandbox secret. Both sandbox client_id and secret must be
-            # configured: oauth_config_for_kind requires both, so guard on both here to
-            # avoid raising NotImplementedError over the original OAuth error.
-            if (
-                res.status_code == 400
-                and settings.STRIPE_APP_SANDBOX_CLIENT_ID
-                and settings.STRIPE_APP_SANDBOX_SECRET_KEY
-                and "does not belong to you" in (res.text or "")
-            ):
-                sandbox_oauth_config = cls.oauth_config_for_kind("stripe", is_sandbox=True)
-                res = requests.post(
-                    sandbox_oauth_config.token_url,
-                    auth=HTTPBasicAuth(sandbox_oauth_config.client_secret, ""),
-                    data={
-                        "code": params["code"],
-                        "grant_type": "authorization_code",
-                    },
-                )
-                if res.status_code == 200:
-                    # Use the sandbox config for downstream API calls (account name lookup)
-                    # and persist the flag so refresh / write_posthog_secrets / clear_posthog_secrets
-                    # pick the sandbox secret without retrying.
-                    oauth_config = sandbox_oauth_config
-                    stripe_is_sandbox = True
-                else:
-                    stripe_is_sandbox = False
-            else:
-                stripe_is_sandbox = False
         else:
             redirect_uri = OauthIntegration.redirect_uri(kind)
             res = requests.post(
@@ -984,12 +944,6 @@ class OauthIntegration:
         if not config.get("expires_in") and kind == "stripe":
             config["expires_in"] = 3600
 
-        if kind == "stripe":
-            # Persisted so downstream Stripe API calls (refresh_access_token,
-            # StripeIntegration.write_posthog_secrets / clear_posthog_secrets)
-            # pick the right developer secret without error-driven retries.
-            config["is_sandbox"] = stripe_is_sandbox
-
         config["refreshed_at"] = int(time.time())
 
         integration, created = Integration.objects.update_or_create(
@@ -1038,8 +992,7 @@ class OauthIntegration:
         """
         Refresh the access token for the integration if necessary
         """
-        is_sandbox = _stripe_integration_is_sandbox(self.integration)
-        oauth_config = self.oauth_config_for_kind(self.integration.kind, is_sandbox=is_sandbox)
+        oauth_config = self.oauth_config_for_kind(self.integration.kind)
 
         # Clear out previous token refreshing errors, as they'll be re-set below if another error occurs
         self.integration.errors = ""
@@ -3324,16 +3277,6 @@ class AzureBlobIntegration:
         return None
 
 
-def _stripe_integration_is_sandbox(integration: Integration) -> bool:
-    """True when this is a Stripe integration provisioned via the sandbox channel.
-
-    Strict identity check on the config flag - a malformed string write (e.g. "false")
-    fails closed to live rather than escalating to sandbox-secret usage. Returns
-    False for non-stripe integrations so non-Stripe call sites can pass through.
-    """
-    return integration.kind == "stripe" and integration.config.get("is_sandbox") is True
-
-
 class StripeIntegration:
     integration: Integration
 
@@ -3364,25 +3307,18 @@ class StripeIntegration:
             raise ValueError(f"Expected stripe integration, got {integration.kind}")
         self.integration = integration
 
-    @property
-    def is_sandbox(self) -> bool:
-        return _stripe_integration_is_sandbox(self.integration)
-
     def _stripe_client(self) -> "StripeClient | None":
-        # Sandbox accounts are issued by a separate Stripe app (live vs sandbox), so the
-        # Apps Secret Store and account-scoped API calls must authenticate with the matching
-        # developer secret. Returns None when the required env vars are missing so callers
-        # can skip Stripe API calls without raising past their per-secret error handling.
+        # Returns None when the required env vars are missing so callers can skip Stripe
+        # API calls without raising past their per-secret error handling.
         from stripe import StripeClient  # noqa: PLC0415
 
         try:
-            oauth_config = OauthIntegration.oauth_config_for_kind("stripe", is_sandbox=self.is_sandbox)
+            oauth_config = OauthIntegration.oauth_config_for_kind("stripe")
         except NotImplementedError as e:
             capture_exception(
                 e,
                 {
                     "stripe_user_id": self.integration.integration_id,
-                    "is_sandbox": self.is_sandbox,
                 },
             )
             return None
@@ -3449,7 +3385,6 @@ class StripeIntegration:
                     {
                         "secret_name": name,
                         "stripe_user_id": stripe_user_id,
-                        "is_sandbox": self.is_sandbox,
                     },
                 )
 
@@ -3485,7 +3420,6 @@ class StripeIntegration:
                     {
                         "secret_name": name,
                         "stripe_user_id": stripe_user_id,
-                        "is_sandbox": self.is_sandbox,
                     },
                 )
 

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -643,152 +643,11 @@ class TestOauthIntegrationModel(BaseTest):
     def test_stripe_authorize_url_uses_live_client_id_by_default(self):
         with self.settings(
             STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
             STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
             STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
         ):
             url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test")
             assert "client_id=ca_live_clientid" in url
-            assert "client_id=ca_sandbox_clientid" not in url
-
-    def test_stripe_authorize_url_uses_sandbox_client_id_when_is_sandbox(self):
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-            STRIPE_APP_OVERRIDE_AUTHORIZE_URL="",
-        ):
-            url = OauthIntegration.authorize_url("stripe", token="state_token", next="/projects/test", is_sandbox=True)
-            assert "client_id=ca_sandbox_clientid" in url
-            assert "client_id=ca_live_clientid" not in url
-
-    def test_stripe_oauth_config_uses_sandbox_secret_when_is_sandbox(self):
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-        ):
-            live_cfg = OauthIntegration.oauth_config_for_kind("stripe")
-            sandbox_cfg = OauthIntegration.oauth_config_for_kind("stripe", is_sandbox=True)
-            assert live_cfg.client_secret == "sk_live_secret"
-            assert sandbox_cfg.client_secret == "sk_test_sandbox_secret"
-
-    def test_stripe_authorize_url_raises_when_sandbox_requested_but_not_configured(self):
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="",
-            STRIPE_APP_SANDBOX_SECRET_KEY="",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-        ):
-            with pytest.raises(NotImplementedError, match="sandbox"):
-                OauthIntegration.authorize_url("stripe", token="state_token", is_sandbox=True)
-
-    def test_stripe_authorize_url_raises_when_sandbox_secret_missing(self):
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SANDBOX_SECRET_KEY="",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-        ):
-            with pytest.raises(NotImplementedError, match="sandbox"):
-                OauthIntegration.authorize_url("stripe", token="state_token", is_sandbox=True)
-
-    @patch("posthog.models.integration.requests.post")
-    def test_stripe_token_exchange_falls_back_to_sandbox_on_does_not_belong_error(self, mock_post):
-        # First call (live secret) returns 400 with the marker error - second call should
-        # retry with sandbox config and succeed.
-        first_response = MagicMock(
-            status_code=400,
-            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
-        )
-        first_response.json.return_value = {
-            "error": "invalid_grant",
-            "error_description": "Authorization code provided does not belong to you",
-        }
-        second_response = MagicMock(status_code=200)
-        second_response.json.return_value = {
-            "access_token": "FAKE_SANDBOX_ACCESS",
-            "refresh_token": "FAKE_SANDBOX_REFRESH",
-            "stripe_user_id": "acct_sandbox_123",
-            "account_name": "Sandbox Account",
-            "expires_in": 3600,
-        }
-        mock_post.side_effect = [first_response, second_response]
-
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-        ):
-            OauthIntegration.integration_from_oauth_response(
-                "stripe",
-                self.team.id,
-                self.user,
-                {"code": "ac_sandbox_code"},
-            )
-
-        assert mock_post.call_count == 2
-        first_call_secret = mock_post.call_args_list[0].kwargs["auth"].username
-        second_call_secret = mock_post.call_args_list[1].kwargs["auth"].username
-        assert first_call_secret == "sk_live_secret"
-        assert second_call_secret == "sk_test_sandbox_secret"
-
-    @patch("posthog.models.integration.requests.post")
-    def test_stripe_token_exchange_does_not_retry_when_sandbox_secret_unset(self, mock_post):
-        first_response = MagicMock(
-            status_code=400,
-            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
-        )
-        first_response.json.return_value = {"error": "invalid_grant"}
-        mock_post.return_value = first_response
-
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="",
-        ):
-            with pytest.raises(ValidationError, match="OAuth failed"):
-                OauthIntegration.integration_from_oauth_response(
-                    "stripe",
-                    self.team.id,
-                    self.user,
-                    {"code": "ac_some_code"},
-                )
-
-        assert mock_post.call_count == 1
-
-    @patch("posthog.models.integration.requests.post")
-    def test_stripe_token_exchange_does_not_retry_when_only_sandbox_secret_set(self, mock_post):
-        # If the sandbox secret is set but the sandbox client_id is not, the retry guard
-        # must fail closed - oauth_config_for_kind would otherwise raise NotImplementedError
-        # and mask the original Stripe error.
-        first_response = MagicMock(
-            status_code=400,
-            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
-        )
-        first_response.json.return_value = {"error": "invalid_grant"}
-        mock_post.return_value = first_response
-
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-        ):
-            with pytest.raises(ValidationError, match="OAuth failed"):
-                OauthIntegration.integration_from_oauth_response(
-                    "stripe",
-                    self.team.id,
-                    self.user,
-                    {"code": "ac_some_code"},
-                )
-
-        assert mock_post.call_count == 1
 
     @patch("posthog.models.integration.reload_integrations_on_workers")
     @patch("posthog.models.integration.requests.post")
@@ -813,7 +672,7 @@ class TestOauthIntegrationModel(BaseTest):
         mock_reload.assert_called_once_with(self.team.id, [integration.id])
 
     @patch("posthog.models.integration.requests.post")
-    def test_stripe_oauth_persists_is_sandbox_false_for_live_install(self, mock_post):
+    def test_stripe_oauth_does_not_persist_is_sandbox(self, mock_post):
         mock_post.return_value.status_code = 200
         mock_post.return_value.json.return_value = {
             "access_token": "FAKE_ACCESS",
@@ -834,57 +693,7 @@ class TestOauthIntegrationModel(BaseTest):
                 {"code": "ac_live_code"},
             )
 
-        assert integration.config.get("is_sandbox") is False
-
-    @patch("posthog.models.integration.requests.post")
-    def test_stripe_oauth_persists_is_sandbox_true_after_sandbox_fallback(self, mock_post):
-        first_response = MagicMock(
-            status_code=400,
-            text='{"error":"invalid_grant","error_description":"Authorization code provided does not belong to you"}',
-        )
-        first_response.json.return_value = {"error": "invalid_grant"}
-        second_response = MagicMock(status_code=200)
-        second_response.json.return_value = {
-            "access_token": "FAKE_SANDBOX_ACCESS",
-            "refresh_token": "FAKE_SANDBOX_REFRESH",
-            "stripe_user_id": "acct_sandbox_1",
-            "account_name": "Sandbox Account",
-            "expires_in": 3600,
-        }
-        mock_post.side_effect = [first_response, second_response]
-
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-        ):
-            integration = OauthIntegration.integration_from_oauth_response(
-                "stripe",
-                self.team.id,
-                self.user,
-                {"code": "ac_sandbox_code"},
-            )
-
-        assert integration.config.get("is_sandbox") is True
-
-    @patch("posthog.models.integration.reload_integrations_on_workers")
-    @patch("posthog.models.integration.requests.post")
-    def test_stripe_refresh_access_token_uses_sandbox_secret_when_flag_set(self, mock_post, mock_reload):
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {"access_token": "REFRESHED", "expires_in": 1000}
-
-        integration = self.create_integration(kind="stripe", config={"expires_in": 1000, "is_sandbox": True})
-
-        with self.settings(
-            STRIPE_APP_CLIENT_ID="ca_live_clientid",
-            STRIPE_APP_SANDBOX_CLIENT_ID="ca_sandbox_clientid",
-            STRIPE_APP_SECRET_KEY="sk_live_secret",
-            STRIPE_APP_SANDBOX_SECRET_KEY="sk_test_sandbox_secret",
-        ):
-            OauthIntegration(integration).refresh_access_token()
-
-        assert mock_post.call_args.kwargs["auth"].username == "sk_test_sandbox_secret"
+        assert "is_sandbox" not in integration.config
 
 
 class TestGoogleCloudIntegrationModel(BaseTest):

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -69,17 +69,13 @@ ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
 # with our internal OAuth system to allow the Stripe app to make API calls to users' PostHog instances.
 # We also support their agentic provisioning protocol which requires us to check even more stuff
 # - STRIPE_APP_CLIENT_ID: The app's public client ID, used in the OAuth authorize redirect URL
-# - STRIPE_APP_SANDBOX_CLIENT_ID: Separate client ID Stripe issues for sandbox installs of the same app
 # - STRIPE_APP_OVERRIDE_AUTHORIZE_URL: Optional override for testing (e.g., with a channel link URL)
 # - STRIPE_APP_SECRET_KEY: API secret key used for HTTP Basic auth during live token exchange/refresh
-# - STRIPE_APP_SANDBOX_SECRET_KEY: API secret key used to redeem sandbox-issued OAuth codes (sk_test_*)
 # - STRIPE_POSTHOG_OAUTH_CLIENT_ID: Client ID of the PostHog OAuthApplication for Stripe to authenticate with PostHog APIs
 # - STRIPE_SIGNING_SECRET: Used to verify the authenticity of incoming webhook/agentic provisioning requests from Stripe
 STRIPE_APP_CLIENT_ID = get_from_env("STRIPE_APP_CLIENT_ID", "")
-STRIPE_APP_SANDBOX_CLIENT_ID = get_from_env("STRIPE_APP_SANDBOX_CLIENT_ID", "")
 STRIPE_APP_OVERRIDE_AUTHORIZE_URL = get_from_env("STRIPE_APP_OVERRIDE_AUTHORIZE_URL", "")
 STRIPE_APP_SECRET_KEY = get_from_env("STRIPE_APP_SECRET_KEY", "")
-STRIPE_APP_SANDBOX_SECRET_KEY = get_from_env("STRIPE_APP_SANDBOX_SECRET_KEY", "")
 STRIPE_POSTHOG_OAUTH_CLIENT_ID = get_from_env("STRIPE_POSTHOG_OAUTH_CLIENT_ID", "")
 STRIPE_SIGNING_SECRET = get_from_env("STRIPE_SIGNING_SECRET", "")
 STRIPE_ORCHESTRATOR_CALLBACK_URL = get_from_env("STRIPE_ORCHESTRATOR_CALLBACK_URL", "")


### PR DESCRIPTION
## Problem

The Stripe App OAuth flow carried a separate "sandbox install" path: a sandbox client ID and secret, a token-exchange fallback that retried with the sandbox credentials when the live secret rejected a code, and a persisted `is_sandbox` flag that downstream calls read to pick which credential to use. That path is unused, and it adds avoidable branching and extra credential surface to the integration's auth handling. This removes it so Stripe integrations have a single, live credential path.

## Changes

- Drop the `is_sandbox` parameter from `OauthIntegration.oauth_config_for_kind` and `authorize_url`; the Stripe branch always uses the live client ID / secret.
- Remove the token-exchange sandbox-retry fallback in `integration_from_oauth_response` and the persisted `config["is_sandbox"]` flag.
- Remove the `_stripe_integration_is_sandbox` helper and the `StripeIntegration.is_sandbox` property; `_stripe_client` and token refresh now use the live config directly.
- Remove the `STRIPE_APP_SANDBOX_CLIENT_ID` / `STRIPE_APP_SANDBOX_SECRET_KEY` settings.
- Drop the `is_sandbox` query-param handling from the `authorize` endpoint (the backend now ignores it).
- Tests: remove sandbox-only cases, keep live-path coverage.

Existing integrations may still carry a stale `is_sandbox` value in their stored config; nothing reads it anymore, so no migration is needed.

Follow-ups (separate PRs, not here):
- Remove the now-ignored `is_sandbox` param from the frontend (`frontend/src/lib/api.ts`, `frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx`).
- Remove the `STRIPE_APP_SANDBOX_*` env mappings in the charts repo and the matching secret entries.

## How did you test this code?

I'm an agent (Claude Code); automated tests only, no manual testing:

- `posthog/models/test/test_integration_model.py` (Stripe cases) — pass
- `posthog/api/test/test_integration.py` (Stripe / `posthog_secrets` cases) — pass
- Pre-commit ran `ruff` and `ty check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact (`skip-inkeep-docs`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Matt directed this.

Authored with Claude Code. The call to remove the sandbox path rather than re-key it followed from confirming the sandbox install flow is unused, so keeping the live credential path as the only path is the simpler end state. Scoped deliberately to the backend: the frontend still sends an `is_sandbox` query param that the `authorize` endpoint now ignores (harmless), and that cleanup plus the charts/secret removal are tracked as follow-ups above. The diff was reviewed before opening and tests were updated to drop sandbox-only cases while preserving live-path coverage.
