### PR TITLE
fix(data-warehouse): pass group_properties to digest rollout flag

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -674,10 +674,18 @@ def send_external_data_failure_digest(team_id: int, schemas: list[dict[str, Any]
 
     # Rollout gate (absent flag = off). Gated teams are never stamped, so when the
     # flag opens up the catch-up delivers their currently-failing schemas naturally.
+    # group_properties mirror the warehouse-pipelines-v3 gate (create_job_model.py):
+    # without them, release conditions on the project/organization group can't match,
+    # because the analytics group records are keyed by uuid rather than team_id/org_id.
     if not settings.TEST and not posthoganalytics.feature_enabled(
         key="external-data-failure-digest-email",
         distinct_id=str(team.uuid),
         groups={"organization": str(team.organization_id), "project": str(team.id)},
+        group_properties={
+            "organization": {"id": str(team.organization_id)},
+            "project": {"id": str(team.id)},
+        },
+        only_evaluate_locally=False,
     ):
         EXTERNAL_DATA_FAILURE_DIGEST_COUNTER.labels(outcome="flag_disabled").inc()
         return False

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -686,6 +686,10 @@ def send_external_data_failure_digest(team_id: int, schemas: list[dict[str, Any]
             "project": {"id": str(team.id)},
         },
         only_evaluate_locally=False,
+        # This gate fires once per failed-sync digest run; a $feature_flag_called
+        # event each time would be pure volume with no operational value (we monitor
+        # via the EXTERNAL_DATA_FAILURE_DIGEST_* metrics instead). Matches the v3 gate.
+        send_feature_flag_events=False,
     ):
         EXTERNAL_DATA_FAILURE_DIGEST_COUNTER.labels(outcome="flag_disabled").inc()
         return False

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -655,6 +655,9 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         # group_properties must be passed so project/organization release conditions can match.
         assert mock_flag.call_args.kwargs["group_properties"]["project"]["id"] == str(self.team.pk)
         assert mock_flag.call_args.kwargs["group_properties"]["organization"]["id"] == str(self.team.organization_id)
+        # Network fallback stays on, and the high-frequency gate must not emit $feature_flag_called events.
+        assert mock_flag.call_args.kwargs["only_evaluate_locally"] is False
+        assert mock_flag.call_args.kwargs["send_feature_flag_events"] is False
 
     def test_send_external_data_failure_digest_skips_when_already_sent_today(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -652,6 +652,9 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert len(mocked_email_messages) == expected_emails
         assert mock_flag.call_args.kwargs["key"] == "external-data-failure-digest-email"
         assert mock_flag.call_args.kwargs["groups"]["project"] == str(self.team.pk)
+        # group_properties must be passed so project/organization release conditions can match.
+        assert mock_flag.call_args.kwargs["group_properties"]["project"]["id"] == str(self.team.pk)
+        assert mock_flag.call_args.kwargs["group_properties"]["organization"]["id"] == str(self.team.organization_id)
 
     def test_send_external_data_failure_digest_skips_when_already_sent_today(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)


### PR DESCRIPTION
## Problem

The data warehouse sync **failure digest email** (shipped in #62874) is gated behind the `external-data-failure-digest-email` feature flag, evaluated server-side as:

```python
posthoganalytics.feature_enabled(
    key="external-data-failure-digest-email",
    distinct_id=str(team.uuid),
    groups={"organization": str(team.organization_id), "project": str(team.id)},
)
```

This call omits `group_properties`. As a result, **release conditions on the `project` or `organization` group can never match** — so the flag can only be rolled out by percentage on the team UUID or globally, not per-org/project/team. Attempting to scope it to a specific project (`project.id = N`) silently never matches, because the backend uses local flag evaluation and the analytics group records are keyed by UUID rather than `team_id`/`org_id`, so there's nothing for the condition to resolve against.

## Changes

Mirror the established **`warehouse-pipelines-v3`** rollout gate (`posthog/temporal/data_imports/workflow_activities/create_job_model.py`), which passes the org and project ids as `group_properties`:

```python
group_properties={
    "organization": {"id": str(team.organization_id)},
    "project": {"id": str(team.id)},
},
only_evaluate_locally=False,
```

With the properties supplied at eval time, release conditions like `project.id = N` / `organization.id = …` resolve correctly, so the digest can be rolled out per project / organization / team — consistent with how pipeline v3 is gated. No behavior change while the flag is absent/off (still fails closed → no email).

## How did you test this code?

I'm an agent (Claude Code), human-directed. Automated only:

- Updated `posthog/tasks/test/test_email.py::test_send_external_data_failure_digest_respects_rollout_flag` to assert `group_properties` (project + organization `id`) is passed to `feature_enabled`.
- `ruff check` + `ruff format --check` pass on both changed files.
- Did **not** run the Python suite locally (relying on CI). No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #62874. While helping roll the digest out to a specific project, we found per-project/org targeting didn't work: the gate's `feature_enabled` call passed only group *keys*, no group *properties*, so group release conditions never matched (confirmed by inspecting the merged code, the local-eval config in `posthog/apps.py`, and the UUID-keyed `project` group data). Diagnosed against the working `warehouse-pipelines-v3` gate, which passes `group_properties`; this PR brings the digest gate in line with that pattern. Scope deliberately minimal — only the `feature_enabled` call and its test assertion.
