### PR TITLE
fix(flags): use 'all' not 'both' for evaluation_runtime filter enum

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2546,7 +2546,7 @@ class FeatureFlagViewSet(
                 OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
                 required=False,
-                enum=["server", "client", "both"],
+                enum=[choice[0] for choice in FeatureFlag.EVALUATION_RUNTIME_CHOICES],
                 description="Filter feature flags by their evaluation runtime.",
             ),
             OpenApiParameter(

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -6253,8 +6253,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         FeatureFlag.objects.create(
             team=self.team,
             created_by=self.user,
-            key="both_flag",
-            evaluation_runtime="both",
+            key="all_flag",
+            evaluation_runtime="all",
         )
 
         # Test filtering by server environment
@@ -6269,11 +6269,11 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert len(response["results"]) == 1
         assert response["results"][0]["key"] == "client_flag"
 
-        # Test filtering by both environment
-        filtered_flags_list = self.client.get(f"/api/projects/@current/feature_flags?evaluation_runtime=both")
+        # Test filtering by all environment
+        filtered_flags_list = self.client.get(f"/api/projects/@current/feature_flags?evaluation_runtime=all")
         response = filtered_flags_list.json()
         assert len(response["results"]) == 1
-        assert response["results"][0]["key"] == "both_flag"
+        assert response["results"][0]["key"] == "all_flag"
 
     @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     def test_flag_is_cached_on_create_and_update(self, mock_on_commit):

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -1412,7 +1412,7 @@ export type FeatureFlagsListEvaluationRuntime =
     (typeof FeatureFlagsListEvaluationRuntime)[keyof typeof FeatureFlagsListEvaluationRuntime]
 
 export const FeatureFlagsListEvaluationRuntime = {
-    Both: 'both',
+    All: 'all',
     Client: 'client',
     Server: 'server',
 } as const

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -55902,7 +55902,7 @@ export namespace Schemas {
 
 
     export const FeatureFlagsListEvaluationRuntime = {
-      Both: 'both',
+      All: 'all',
       Client: 'client',
       Server: 'server',
     } as const;

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -57,7 +57,7 @@ export const FeatureFlagsListQueryParams = /* @__PURE__ */ zod.object({
     active: zod.enum(['STALE', 'false', 'true']).optional(),
     created_by_id: zod.string().optional().describe('The User ID which initially created the feature flag.'),
     evaluation_runtime: zod
-        .enum(['both', 'client', 'server'])
+        .enum(['all', 'client', 'server'])
         .optional()
         .describe('Filter feature flags by their evaluation runtime.'),
     excluded_properties: zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/feature-flag-get-all.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/feature-flag-get-all.json
@@ -11,7 +11,7 @@
         },
         "evaluation_runtime": {
             "description": "Filter feature flags by their evaluation runtime.",
-            "enum": ["both", "client", "server"],
+            "enum": ["all", "client", "server"],
             "type": "string"
         },
         "excluded_properties": {


### PR DESCRIPTION
## Problem

The `evaluation_runtime` filter on the feature flags list API advertised `both` as one of its enum values, but `both` was never a real value. The model has always defined the choices as `server` / `client` / `all` (default `all`), and both backfill migrations set existing rows to `all`. A production check confirms only `all`, `client`, and `server` exist, with zero `both` rows and zero NULLs.

So `both` only ever lived in three drifted artifacts: the hardcoded `@extend_schema` enum, a filter test, and the generated frontend/MCP types. Filtering by `?evaluation_runtime=both` was a silent no-op because the param goes straight to `queryset.filter(...)` without choice validation, so it matched nothing. Writing `both` was never possible either, since the serializer's `ChoiceField` only accepts `server`/`client`/`all`.

## Changes

- Derive the filter param's enum from `FeatureFlag.EVALUATION_RUNTIME_CHOICES` instead of hardcoding it, so it stays in sync with the model.
- Update the filter test to use `all` instead of `both`.
- Regenerate the frontend and MCP types and the tool-schema snapshot.

This is not a breaking change and needs no data migration. There is no `both` data to migrate, and the query param stays unvalidated, so any consumer still passing `both` gets the same empty result it always did.

## How did you test this code?

Updated and ran the affected filter test in `test_feature_flag.py`. Regenerated the OpenAPI-derived types through the codegen pipeline rather than editing the generated files by hand. Confirmed against production Postgres that no `evaluation_runtime = 'both'` rows exist.