### PR TITLE
fix(experiments): pin useChart generic in VariantTimeseriesChart

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -18,7 +18,7 @@ export function VariantTimeseriesChart({
     const colors = useChartColors()
     const { getTooltip, showTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
 
-    const { canvasRef } = useChart({
+    const { canvasRef } = useChart<'line'>({
         getConfig: () => {
             if (!data) {
                 return null


### PR DESCRIPTION
## Problem

The frontend typecheck failed on `VariantTimeseriesChart.tsx`:

```
error TS2322: Type '() => { ... } | null' is not assignable to type
'() => ChartConfiguration<"line", (number | Point | null)[], unknown> | null'.
```

The chart's datasets come from `ProcessedChartData`, whose `datasets` field uses a custom `ChartDataset` interface with `data: (number | null)[]`. Because `useChart` infers its `TType` (and the associated data-point type param) from the returned config literal, TS narrowed the data-point param to `(number | null)[]` instead of Chart.js's default `(number | Point | null)[]`. The inferred `ChartConfiguration` then no longer matched what `useChart` expects.

## Changes

Pin the generic explicitly: `useChart<'line'>(...)`. This drops the fragile inference so the returned literal is checked against `ChartConfiguration<'line'>` (with Chart.js's default data-point type) directly. No runtime change.

## How did you test this code?

I'm an agent (PostHog Code). I did not manually test in the browser — this is a type-only fix. I verified `VariantTimeseriesChart.tsx` typechecks cleanly via `tsc --noEmit` scoped to the file after generating kea logic types, and confirmed the change is structurally valid against the custom `ChartDataset` shape with an isolated reproduction.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel asked me to fix a reported frontend CI typecheck error on `VariantTimeseriesChart.tsx`. The error did not reproduce in the local checkout (Chart.js type-def resolution differs locally), so I root-caused it by isolating `useChart`'s generic inference against the custom `ChartDataset` interface. Considered annotating `getConfig`'s return type vs. pinning the hook generic; chose pinning `useChart<'line'>` as the smallest change that removes the inference ambiguity at the call site.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
