### PR TITLE
chore(flags): simplify get_filters to return filters directly

### DIFF
--- a/products/feature_flags/backend/models/feature_flag.py
+++ b/products/feature_flags/backend/models/feature_flag.py
@@ -280,10 +280,6 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
             return None
 
     def get_filters(self) -> dict:
-        if not self.filters:
-            return {"groups": []}
-        if "groups" not in self.filters:
-            return {**self.filters, "groups": []}
         return self.filters
 
     def transform_cohort_filters_for_easy_evaluation(


### PR DESCRIPTION
## Problem

`FeatureFlag.get_filters()` carried a read-time fallback that normalized rows whose `filters` was empty or missing a `groups` key. Migration 1016 (#48458) backfilled every legacy flag row so `filters` always contains `groups`, and it shipped to production in February. The fallback no longer does anything.

## Changes

`get_filters()` now returns `self.filters` directly.

This is safe because every path that writes `filters` already guarantees `groups`: the model field defaults to `{"groups": []}`, the serializer's `validate_filters` does `setdefault("groups", [])`, and no write path sets `filters` to null or an empty dict. Migration 1016's docstring calls out this simplification as its intended follow-up.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format` on the changed file, and ran `products/feature_flags/backend/test/test_feature_flag_manager.py` (2 passed). The behavior is covered by existing feature-flag model and cache tests, which all construct `filters` with a `groups` key.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?