### PR TITLE
fix(linkedin_ads): treat restricted member 401 as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -51,6 +51,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # resource can't be resolved — typically a deleted account, a wrong Account ID, or lost
             # access. Retrying can't recover it, so stop syncing instead of looping the 404.
             "RESOURCE_NOT_FOUND": "LinkedIn could not find the requested ad account. It may have been deleted, the configured Account ID may be wrong, or PostHog may have lost access. Check the Account ID and re-authorize the LinkedIn Ads integration.",
+            # LinkedIn returns a 401 with this stable error code when the member who authorized the
+            # integration has been restricted on LinkedIn's side (suspended / flagged account). The
+            # token can't be used until LinkedIn lifts the restriction, so retrying never recovers —
+            # stop syncing and tell the user to resolve it with LinkedIn and re-authorize.
+            "RESTRICTED_MEMBER": "LinkedIn has restricted the account that authorized this integration, so PostHog can no longer access your ad data. Resolve the restriction with LinkedIn, then re-authorize the LinkedIn Ads integration.",
             # The Account ID is a free-text field. A malformed value (a profile URL, a name, stray
             # whitespace) makes LinkedIn reject the `urn:li:sponsoredAccount:<id>` accounts param with
             # a deterministic 400 ("...is invalid. Reason: Deserializing output ... failed"). Retrying

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -23,6 +23,7 @@ class TestLinkedInAdsSource:
             'LinkedIn API error (404): {"status":404,"code":"RESOURCE_NOT_FOUND","message":"No virtual resource found"}',
             "REVOKED_ACCESS_TOKEN",
             "The token used in the request has expired",
+            'LinkedIn API error (401): {"status":401,"serviceErrorCode":65608,"code":"RESTRICTED_MEMBER","message":"Member is restricted"}',
         ],
     )
     def test_non_retryable_errors_match_upstream_failures(self, observed_error):


### PR DESCRIPTION
## Problem

The `linkedin_ads` data-warehouse import source surfaced a recurring error in error tracking:

```
LinkedIn API error (401): {"status":401,"serviceErrorCode":65608,"code":"RESTRICTED_MEMBER","message":"Member is restricted"}
```

It is raised in `client.py` (`_call_finder`, the `status_code != 200` branch) while paginating an account's resources, and propagates up through `get_data_by_resource` → `get_rows` in the source. A 401 `RESTRICTED_MEMBER` means LinkedIn has restricted the member account whose token authorized the integration (suspended / flagged account). The token cannot be used until LinkedIn lifts the restriction, so the import retries on every scheduled run with no chance of recovering.

## Changes

Add the stable `RESTRICTED_MEMBER` error code to `LinkedInAdsSource.get_non_retryable_errors`, mirroring the existing `RESOURCE_NOT_FOUND` / `REVOKED_ACCESS_TOKEN` entries. The match is on the stable LinkedIn error code only (not the volatile 401 body or per-request URL), with a user-facing message telling them to resolve the restriction with LinkedIn and re-authorize. This stops the doomed retry loop and fails fast with actionable guidance.

This is a user/upstream condition, not a code bug — there is nothing sensible PostHog can do but stop retrying, which is exactly what `NonRetryableErrors` is for. The change is scoped strictly to this error; global retry policy is untouched.

## How did you test this code?

I'm an agent (Claude Code). I ran the existing source test suite, which now includes a new parametrized case asserting the `RESTRICTED_MEMBER` 401 body is recognised as non-retryable:

```
python -m pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py -q
# 17 passed
```

The existing `test_non_retryable_errors_does_not_match_transient` / `_does_not_match_unrelated` cases continue to pass, confirming transient 5xx/429 errors stay retryable.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the LinkedIn Ads source. Used the PostHog error-tracking MCP tools to pull the issue, a representative event, and the full resolved stack trace, confirming the failure genuinely originates at `linkedin_ads/client.py:309`. Decided this is a user/upstream error (LinkedIn-side member restriction, unrecoverable by retry) rather than a fixable bug, so extended the source's `NonRetryableErrors` per the Stripe-source pattern instead of changing request logic. Matched on the stable `RESTRICTED_MEMBER` code to avoid false positives on volatile body content.
