### PR TITLE
fix(llma): optimize messaging cohort backfill clickhouse queries

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
@@ -235,6 +235,11 @@ async def backfill_precalculated_events_activity(
             logger.warning("Invalid BACKFILL_EVENTS_KAFKA_FLUSH_BATCH_SIZE, using default 1000")
             KAFKA_FLUSH_BATCH_SIZE = 1000
 
+        # No ORDER BY: each event is evaluated independently and there is no cursor, so ordering is
+        # not needed. Events within a day are not physically timestamp-ordered (the events sort key
+        # is (team_id, toDate(timestamp), event, ...)), so ORDER BY timestamp would force a full sort
+        # of every matched event and block streaming. Without it, ClickHouse streams rows as it reads
+        # them in primary-key order — lower memory and faster time-to-first-row.
         events_query = """
             SELECT
                 uuid,
@@ -249,7 +254,6 @@ async def backfill_precalculated_events_activity(
               AND timestamp >= %(start_time)s
               AND timestamp < %(end_time)s
               AND person_id IS NOT NULL
-            ORDER BY timestamp
             FORMAT JSONEachRow
         """
 

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -80,9 +80,20 @@ async def get_person_id_ranges_page_activity(inputs: PersonIdRangesPageInputs) -
             )
         )
 
+    # Enumerate person IDs straight off the raw ``person`` table with DISTINCT, not the ``persons``
+    # lazy table. We only need ID range *boundaries* here, not deduplicated / is_deleted-filtered
+    # rows -- the child workflow re-queries each range through ``persons`` with full argMax dedup and
+    # is_deleted filtering, so a deleted/duplicate ID slipping into a boundary just yields no child
+    # rows. The ``persons`` table, by contrast, would rewrite our ``id > cursor`` filter into
+    # ``id IN (SELECT id FROM person WHERE id > cursor)`` with no inner LIMIT, forcing a full
+    # ``GROUP BY id ... HAVING argMax(is_deleted)`` over the entire ID tail on every page before the
+    # outer LIMIT applies -- O(pages x tail). ``SELECT DISTINCT id FROM person WHERE id > cursor
+    # ORDER BY id ASC LIMIT N`` reads the ``(team_id, id)`` primary key in order and stops after N
+    # distinct IDs.
     ranges_query_ast = ast.SelectQuery(
         select=[ast.Alias(alias="person_id", expr=ast.Field(chain=["id"]))],
-        select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
+        distinct=True,
+        select_from=ast.JoinExpr(table=ast.Field(chain=["raw_persons"])),
         where=_combine_where(where_exprs),
         order_by=[ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")],
         limit=ast.Constant(value=query_limit),

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -14,6 +14,8 @@ import temporalio.exceptions
 from structlog.contextvars import bind_contextvars
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLQuerySettings
+from posthog.hogql.database.argmax import argmax_select
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.kafka_client.client import _KafkaProducer
@@ -36,30 +38,25 @@ LOGGER = get_logger(__name__)
 MAX_OPTIMIZED_PROPERTIES = 100  # Safety limit to avoid query complexity issues
 
 
-def build_person_properties_select_exprs(
+def build_person_properties_select_fields(
     person_properties: list[str],
-) -> tuple[list[ast.Alias], dict[str, str]]:
-    """Build HogQL SELECT expressions for the requested person properties.
+) -> tuple[dict[str, list[str | int]], dict[str, str]]:
+    """Map each requested person property to an ``argmax_select`` field chain and its ``prop_N`` alias.
 
-    Property names come from cohort filters, so they must never be substring-concatenated
-    into SQL. Using ``ast.Field(chain=["properties", key])`` keeps the key out of the printed
-    SQL: HogQL either rewrites to a materialized column or routes the key through context
-    parameters when emitting ``JSONExtract``.
+    Property names come from cohort filters, so they must never be substring-concatenated into SQL.
+    Returning ``["properties", key]`` field chains keeps each key inside an ``ast.Field`` chain when
+    ``argmax_select`` wraps it in the per-person ``argMax`` aggregation: HogQL either rewrites to a
+    materialized column or routes the key through context parameters when emitting ``JSONExtract``.
     """
-    selects: list[ast.Alias] = []
+    select_fields: dict[str, list[str | int]] = {}
     alias_mapping: dict[str, str] = {}
 
     for i, prop in enumerate(person_properties):
         alias = f"prop_{i}"
-        selects.append(
-            ast.Alias(
-                alias=alias,
-                expr=ast.Field(chain=["properties", prop]),
-            )
-        )
+        select_fields[alias] = ["properties", prop]
         alias_mapping[alias] = prop
 
-    return selects, alias_mapping
+    return select_fields, alias_mapping
 
 
 def format_cohort_ids_for_logging(cohort_ids: list[int]) -> str:
@@ -485,10 +482,10 @@ async def backfill_precalculated_person_properties_activity(
             # Not in activity context (e.g., during tests), skip metrics
             pass
 
-        # Build the HogQL SELECT list — either targeted property accessors (so HogQL can use
-        # materialized columns when present) or the full ``properties`` JSON as a fallback.
+        # Build the per-property argmax_select fields — either targeted property accessors (so HogQL
+        # can use materialized columns when present) or the full ``properties`` JSON as a fallback.
         property_alias_mapping: dict[str, str] = {}
-        select_exprs: list[ast.Expr] = [ast.Alias(alias="person_id", expr=ast.Field(chain=["id"]))]
+        select_fields: dict[str, list[str | int]] = {}
 
         # A '%' in a property key makes the HogQL printer raise (it can resolve the accessor to a
         # column identifier, and '%' is banned there). Such keys are rare but valid person-property
@@ -497,12 +494,11 @@ async def backfill_precalculated_person_properties_activity(
         has_identifier_unsafe_key = any("%" in prop for prop in person_properties)
 
         if person_properties and len(person_properties) <= MAX_OPTIMIZED_PROPERTIES and not has_identifier_unsafe_key:
-            property_exprs, property_alias_mapping = build_person_properties_select_exprs(person_properties)
-            select_exprs.extend(property_exprs)
+            select_fields, property_alias_mapping = build_person_properties_select_fields(person_properties)
 
             logger.info(f"Optimized query: fetching {len(person_properties)} specific properties via HogQL")
         else:
-            select_exprs.append(ast.Field(chain=["properties"]))
+            select_fields["properties"] = ["properties"]
             if person_properties and len(person_properties) > MAX_OPTIMIZED_PROPERTIES:
                 logger.warning(
                     f"Too many properties ({len(person_properties)} > {MAX_OPTIMIZED_PROPERTIES}) - falling back to fetching all properties for performance"
@@ -537,19 +533,31 @@ async def backfill_precalculated_person_properties_activity(
                 )
             )
 
-        persons_query_ast = ast.SelectQuery(
-            select=select_exprs,
-            # The HogQL ``persons`` table handles ``team_id`` scoping, argMax/FINAL dedup, and
-            # ``is_deleted = 0`` filtering automatically. Note it also adds an implicit
-            # ``argMax(created_at) < now() + 1 day`` clamp, so future-dated persons (clock skew /
-            # backdated imports) are excluded — unlike the old raw-SQL ``person FINAL`` query.
-            select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
-            where=ast.And(exprs=where_exprs),
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")],
-            # No explicit limit: compile_hogql_for_streaming uses LimitContext.COHORT_CALCULATION,
-            # which injects LIMIT 1_000_000_000. ID ranges are bounded by batch_size (default
-            # 1000 persons), so this cap is never reached in practice.
+        # Deduplicate straight off the raw ``person`` table with ``argmax_select`` instead of the
+        # ``persons`` lazy table. ``argmax_select`` is the exact helper the ``persons`` table uses
+        # internally, so the semantics are identical: ``team_id`` scoping (added by the printer),
+        # latest-version-per-id dedup, ``is_deleted = 0`` filtering, and the
+        # ``argMax(created_at) < now() + 1 day`` clamp that drops future-dated persons. The win is in
+        # how the ID-range filter is applied: querying ``persons`` rewrites our ``id BETWEEN start AND
+        # end`` predicate into ``id IN (SELECT id FROM person WHERE id BETWEEN start AND end)``, which
+        # scans the range twice (build the IN set, then re-read for the GROUP BY). Setting the range as
+        # a direct ``WHERE`` on the argMax aggregation reads the ``(team_id, id)`` primary key once.
+        # Output column for the person UUID is ``id`` (argmax_select aliases the group field by name).
+        persons_query_ast = argmax_select(
+            table_name="raw_persons",
+            select_fields=select_fields,
+            group_fields=["id"],
+            argmax_field="version",
+            deleted_field="is_deleted",
+            timestamp_field_to_clamp="created_at",
         )
+        persons_query_ast.where = ast.And(exprs=where_exprs)
+        persons_query_ast.order_by = [ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")]
+        # optimize_aggregation_in_order lets ClickHouse aggregate as it streams the primary key in
+        # order, so the GROUP BY + ORDER BY id never buffers the whole range. No explicit limit:
+        # compile_hogql_for_streaming uses LimitContext.COHORT_CALCULATION (LIMIT 1_000_000_000), and
+        # ID ranges are bounded by batch_size (default 1000 persons), so the cap is never reached.
+        persons_query_ast.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
 
         persons_query, query_params = await compile_hogql_for_streaming(persons_query_ast, team_id=inputs.team_id)
 
@@ -583,11 +591,11 @@ async def backfill_precalculated_person_properties_activity(
                             "First row received from ClickHouse query",
                             team_id=inputs.team_id,
                             time_to_first_row_seconds=round(query_first_row_time - query_start_time, 2),
-                            first_person_id=str(row["person_id"]),
+                            first_person_id=str(row["id"]),
                         )
                         first_row = False
                     batch_count += 1
-                    person_id = str(row["person_id"])
+                    person_id = str(row["id"])
                     last_person_id = person_id  # Track the last person ID for next cursor
 
                     # Handle both optimized (individual property columns) and fallback (full properties JSON) formats

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
@@ -244,6 +244,13 @@ class TestGetPersonIdRangesPageActivity:
         node = captured["node"]
         assert isinstance(node, ast.SelectQuery)
         assert node.where is None
+        # Pagination must enumerate IDs off the raw ``person`` table with DISTINCT, not the
+        # ``persons`` lazy table -- otherwise ``id > cursor`` is wrapped in an unbounded
+        # ``id IN (...)`` subquery that GROUP BYs the whole ID tail on every page.
+        assert node.distinct is True
+        assert isinstance(node.select_from, ast.JoinExpr)
+        assert isinstance(node.select_from.table, ast.Field)
+        assert node.select_from.table.chain == ["raw_persons"]
 
     @pytest.mark.asyncio
     async def test_where_is_single_expr_with_only_after_person_id(self):

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -7,11 +7,12 @@ import temporalio.exceptions
 from parameterized import parameterized
 
 from posthog.hogql import ast
+from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
     backfill_precalculated_person_properties_activity,
-    build_person_properties_select_exprs,
+    build_person_properties_select_fields,
     evaluate_combined_filters_sync,
     flush_kafka_batch_async,
 )
@@ -20,6 +21,22 @@ from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import execute_bytecode
 from common.hogvm.python.operation import Operation
+
+
+class _FieldChainCollector(TraversingVisitor):
+    """Collect every ``ast.Field`` chain reachable from a node (e.g. inside argMax wrappers)."""
+
+    def __init__(self) -> None:
+        self.chains: list[list[str | int]] = []
+
+    def visit_field(self, node: ast.Field) -> None:
+        self.chains.append(list(node.chain))
+
+
+def _collect_field_chains(node: ast.Expr) -> list[list[str | int]]:
+    collector = _FieldChainCollector()
+    collector.visit(node)
+    return collector.chains
 
 
 class _NoopHeartbeater:
@@ -225,22 +242,16 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         # Basic verification that the filter was stored correctly
         assert inputs.filter_storage_key == storage_key
 
-    def test_build_person_properties_select_exprs_keeps_keys_in_field_chain(self):
+    def test_build_person_properties_select_fields_keeps_keys_in_field_chain(self):
         malicious_property = "email') FROM person WHERE team_id != %(team_id)s UNION ALL SELECT sleep(3) --"
 
-        property_exprs, property_alias_mapping = build_person_properties_select_exprs([malicious_property])
+        select_fields, property_alias_mapping = build_person_properties_select_fields([malicious_property])
 
         assert property_alias_mapping == {"prop_0": malicious_property}
-        assert len(property_exprs) == 1
 
-        alias_expr = property_exprs[0]
-        assert isinstance(alias_expr, ast.Alias)
-        assert alias_expr.alias == "prop_0"
-
-        # The malicious key must live inside an ast.Field chain — never inline as a SQL fragment.
-        field_expr = alias_expr.expr
-        assert isinstance(field_expr, ast.Field)
-        assert field_expr.chain == ["properties", malicious_property]
+        # The malicious key must live inside an argmax_select field chain — never inline as a SQL
+        # fragment. argmax_select wraps the chain in an ``ast.Field``, keeping the key parameterized.
+        assert select_fields == {"prop_0": ["properties", malicious_property]}
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -330,10 +341,10 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
             expr for expr in node.select if isinstance(expr, ast.Alias) and expr.alias.startswith("prop_")
         ]
         assert len(property_aliases) == 1
-        # The key lives inside an ast.Field chain — never concatenated into the SQL as a fragment.
-        prop_field = property_aliases[0].expr
-        assert isinstance(prop_field, ast.Field)
-        assert prop_field.chain == ["properties", malicious_property]
+        # The key lives inside an ast.Field chain (wrapped in argMax by argmax_select) — never
+        # concatenated into the SQL as a fragment.
+        prop_chains = _collect_field_chains(property_aliases[0])
+        assert any(chain[-2:] == ["properties", malicious_property] for chain in prop_chains)
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -419,11 +430,14 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         ]
         assert property_aliases == []
 
-        # The full ``properties`` JSON is selected instead, and the '%' key never appears as a field.
-        properties_fields = [
-            expr for expr in node.select if isinstance(expr, ast.Field) and expr.chain == ["properties"]
+        # The full ``properties`` JSON is selected instead (argmax_select aliases it as "properties"),
+        # and the '%' key never appears as a field chain element anywhere in the query.
+        properties_aliases = [
+            expr for expr in node.select if isinstance(expr, ast.Alias) and expr.alias == "properties"
         ]
-        assert len(properties_fields) == 1
+        assert len(properties_aliases) == 1
+        assert any(chain[-1:] == ["properties"] for chain in _collect_field_chains(properties_aliases[0]))
+        assert all(percent_property not in chain for chain in _collect_field_chains(node))
 
 
 class TestCombineFilterBytecodes:


### PR DESCRIPTION
## Problem

This optimizes the ClickHouse queries behind the messaging cohort backfill workflows (`posthog/temporal/messaging/backfill_precalculated_*`), applying the `optimizing-clickhouse-and-hogql-queries` skill across the person-properties and events backfills.

### Person properties backfill (`backfill_precalculated_person_properties_*`)

Both the coordinator and child queried person data through the HogQL `persons` lazy table, whose "where optimization" rewrites any `id` filter into `id IN (SELECT id FROM person AS where_optimization WHERE …)` before a full `GROUP BY id … HAVING argMax(is_deleted, version) = 0 …` dedup (shape confirmed in `ee/clickhouse/models/test/__snapshots__/test_cohort.ambr`). That is right for a cohort join over a big `id IN (list)`, but pure overhead here:

1. **Coordinator pagination** — `WHERE id > {cursor}` became `id IN (SELECT id FROM person WHERE id > cursor)` **with no inner LIMIT**, so every page deduplicated the *entire remaining ID tail* before the outer `LIMIT` kept only the next page. O(pages × tail).
2. **Child range fetch** — `WHERE id BETWEEN start AND end` became `id IN (SELECT id FROM person WHERE id BETWEEN start AND end)`, scanning the bounded range **twice**.

### Events backfill (`backfill_precalculated_events_*`)

The child scans a day of events with raw ClickHouse SQL and an `ORDER BY timestamp`. Each event is evaluated independently and there is no cursor, so ordering is not needed — and since events within a day are not physically timestamp-ordered (sort key `(team_id, toDate(timestamp), event, …)`), the `ORDER BY` forces a full sort of every matched event and blocks streaming.

## Changes

**Coordinator pagination** only needs ID range *boundaries*, so it now reads straight off raw `person` with `DISTINCT` — primary-key ordered, stops after N distinct IDs:

```sql
SELECT DISTINCT id AS person_id FROM person WHERE team_id = X AND id > cursor ORDER BY id ASC LIMIT N
```

**Child range fetch** still needs dedup + `is_deleted` semantics, so it builds the query with `argmax_select` (the same helper the `persons` table uses internally) directly against `raw_persons`, applying the range as a direct `WHERE` instead of an `id IN (…)` subquery — identical semantics, the `(team_id, id)` primary key read once, `optimize_aggregation_in_order` keeping GROUP BY + ORDER BY id streaming. The deduped UUID column is now `id`; row reads and the property-key safety tests were updated. The cohort-filter property key still only reaches the printer inside an `ast.Field` chain (now wrapped in `argMax`), never as a SQL fragment.

**Events backfill** drops the unnecessary `ORDER BY timestamp` so ClickHouse streams rows as it reads them in primary-key order — lower memory, faster time-to-first-row, no sort.

### Deliberately left as follow-ups

- The events scan is raw single-team SQL that selects the full `properties` blob per event. The skill prefers HogQL here (materialized-column substitution, team-id guard). Narrowing to only the properties the filters reference is the bigger I/O win, but the filters are precompiled bytecode and the available `event_filters` metadata may not capture every referenced key — narrowing without a live dataset to validate against risks changing evaluation results, so it's flagged rather than done. Converting to HogQL also risks changing `person_id` semantics (raw PoE column vs person join), so it's deferred too.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run any of this against a live ClickHouse — the sandbox had no reachable Postgres or ClickHouse, so there are no measured before/after timings. The analysis is grounded in the `persons`-table transformation source (`posthog/hogql/database/schema/persons.py`), the committed `.ambr` snapshot of that rewrite, the shared `argmax_select` helper, and the events table sort key.

Automated checks I actually ran (all green):

- `test_backfill_precalculated_person_properties_coordinator_workflow.py` — 9 passed; asserts the pagination AST uses `distinct=True` + `raw_persons`.
- `test_backfill_precalculated_person_properties_workflow.py` — 32 passed, 2 deselected (the `django_db` printer tests need a DB; I validated their assertions against the real AST `argmax_select` emits).
- `test_backfill_precalculated_events_workflow.py` + coordinator — 28 passed.
- `ruff check` / `ruff format --check` on all changed files — clean.

Suggested reviewer verification on the Test Cluster (team 2): EXPLAIN/time the old `id IN (subquery) … GROUP BY` person forms vs the new direct-filter forms, and the events scan with vs without `ORDER BY timestamp`; compare `read_bytes` / `memory_usage` / `Granules`. The pagination win is largest for cursors near the start of a large team.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code using the `optimizing-clickhouse-and-hogql-queries` skill, applied across the messaging cohort backfill workflows (person properties coordinator + child, events child).

- Traced each activity to its ClickHouse query and confirmed which compile through the HogQL printer (person backfills) vs raw SQL (events).
- Person backfills: confirmed the `persons` lazy table's `id IN (where_optimization subquery)` rewrite from `persons.py` and the `test_cohort.ambr` snapshot. Coordinator → `raw_persons` + `DISTINCT` (boundaries only); child → `argmax_select` with a direct range `WHERE` (zero semantic divergence). Rejected pushing the LIMIT into `persons.py` — higher blast radius, and that push-down is deliberately disabled when an outer WHERE exists.
- Events backfill: removed the load-bearing-looking but functionally unnecessary `ORDER BY timestamp`. Held back on property narrowing and the HogQL move because both carry correctness risk that can't be validated without live data.
