### PR TITLE
feat(flags): expose evaluation_runtime and bucketing_identifier in MCP flag tools

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -656,7 +656,7 @@ class FeatureFlagCreateRequestSchemaSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         help_text="Identifier used to bucket users into rollout percentages and variants: 'distinct_id' "
-        "(user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.",
+        "(user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.",
     )
 
 
@@ -702,7 +702,7 @@ class FeatureFlagPartialUpdateRequestSchemaSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         help_text="Identifier used to bucket users into rollout percentages and variants: 'distinct_id' "
-        "(user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.",
+        "(user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.",
     )
 
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -644,6 +644,20 @@ class FeatureFlagCreateRequestSchemaSerializer(serializers.Serializer):
         help_text="Whether to persist a user's flag value across the anonymous-to-identified transition "
         "(the 'persist across authentication steps' option). Incompatible with device_id bucketing.",
     )
+    evaluation_runtime = serializers.ChoiceField(
+        choices=FeatureFlag.EVALUATION_RUNTIME_CHOICES,
+        required=False,
+        allow_null=True,
+        help_text="Where this flag is allowed to evaluate: 'server' (server-side SDKs only), "
+        "'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.",
+    )
+    bucketing_identifier = serializers.ChoiceField(
+        choices=FeatureFlag.BUCKETING_IDENTIFIER_CHOICES,
+        required=False,
+        allow_null=True,
+        help_text="Identifier used to bucket users into rollout percentages and variants: 'distinct_id' "
+        "(user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.",
+    )
 
 
 class FeatureFlagPartialUpdateRequestSchemaSerializer(serializers.Serializer):
@@ -675,6 +689,20 @@ class FeatureFlagPartialUpdateRequestSchemaSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Whether to persist a user's flag value across the anonymous-to-identified transition "
         "(the 'persist across authentication steps' option). Incompatible with device_id bucketing.",
+    )
+    evaluation_runtime = serializers.ChoiceField(
+        choices=FeatureFlag.EVALUATION_RUNTIME_CHOICES,
+        required=False,
+        allow_null=True,
+        help_text="Where this flag is allowed to evaluate: 'server' (server-side SDKs only), "
+        "'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.",
+    )
+    bucketing_identifier = serializers.ChoiceField(
+        choices=FeatureFlag.BUCKETING_IDENTIFIER_CHOICES,
+        required=False,
+        allow_null=True,
+        help_text="Identifier used to bucket users into rollout percentages and variants: 'distinct_id' "
+        "(user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.",
     )
 
 

--- a/products/feature_flags/backend/api/test/feature_flag_openapi_test_helpers.py
+++ b/products/feature_flags/backend/api/test/feature_flag_openapi_test_helpers.py
@@ -14,11 +14,9 @@ FEATURE_FLAG_REQUEST_SCHEMA_EXCLUDED_RUNTIME_FIELDS: frozenset[str] = frozenset(
         "_create_in_folder",  # create-only write_only helper for folder placement
         "_should_create_usage_dashboard",  # create-only write_only internal toggle
         "analytics_dashboards",  # relational link managed via dashboards, not the flag create/update surface
-        "bucketing_identifier",  # runtime-writable but not yet on the agent-facing MCP contract; candidate for future exposure (#63823)
         "created_at",  # server-managed timestamp, not agent-facing
         "creation_context",  # write_only origin-product marker set by internal callers
         "deleted",  # soft-delete handled via the DELETE endpoint, not the create/update body
-        "evaluation_runtime",  # runtime-writable but not yet on the agent-facing MCP contract; candidate for future exposure (#63823)
         "has_encrypted_payloads",  # server-managed, derived from payload encryption
         "has_enriched_analytics",  # internal analytics flag, not agent-facing
         "last_called_at",  # server-managed usage timestamp, not agent-facing

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -706,6 +706,17 @@ export interface FeatureFlagCreateRequestSchemaApi {
      * @nullable
      */
     ensure_experience_continuity?: boolean | null
+    /** Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
+    evaluation_runtime?: EvaluationRuntimeEnumApi | null
+    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
+    bucketing_identifier?: BucketingIdentifierEnumApi | null
 }
 
 export interface PatchedFeatureFlagPartialUpdateRequestSchemaApi {
@@ -731,6 +742,17 @@ export interface PatchedFeatureFlagPartialUpdateRequestSchemaApi {
      * @nullable
      */
     ensure_experience_continuity?: boolean | null
+    /** Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
+    evaluation_runtime?: EvaluationRuntimeEnumApi | null
+    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
+    bucketing_identifier?: BucketingIdentifierEnumApi | null
 }
 
 export interface ChangeApi {

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -712,7 +712,7 @@ export interface FeatureFlagCreateRequestSchemaApi {
      * * `client` - Client
      * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | null
-    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.
      *
      * * `distinct_id` - User ID (default)
      * * `device_id` - Device ID */
@@ -748,7 +748,7 @@ export interface PatchedFeatureFlagPartialUpdateRequestSchemaApi {
      * * `client` - Client
      * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | null
-    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+    /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.
      *
      * * `distinct_id` - User ID (default)
      * * `device_id` - Device ID */

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -378,6 +378,28 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             "Whether to persist a user's flag value across the anonymous-to-identified transition (the 'persist across authentication steps' option). Incompatible with device_id bucketing."
         ),
+    evaluation_runtime: zod
+        .union([
+            zod
+                .enum(['server', 'client', 'all'])
+                .describe('\* `server` - Server\n\* `client` - Client\n\* `all` - All'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.\n\n\* `server` - Server\n\* `client` - Client\n\* `all` - All"
+        ),
+    bucketing_identifier: zod
+        .union([
+            zod
+                .enum(['distinct_id', 'device_id'])
+                .describe('\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
+        ),
 })
 
 /**
@@ -770,6 +792,28 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .nullish()
         .describe(
             "Whether to persist a user's flag value across the anonymous-to-identified transition (the 'persist across authentication steps' option). Incompatible with device_id bucketing."
+        ),
+    evaluation_runtime: zod
+        .union([
+            zod
+                .enum(['server', 'client', 'all'])
+                .describe('\* `server` - Server\n\* `client` - Client\n\* `all` - All'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.\n\n\* `server` - Server\n\* `client` - Client\n\* `all` - All"
+        ),
+    bucketing_identifier: zod
+        .union([
+            zod
+                .enum(['distinct_id', 'device_id'])
+                .describe('\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
         ),
 })
 

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -398,7 +398,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
         ),
 })
 
@@ -813,7 +813,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.\n\n\* `distinct_id` - User ID (default)\n\* `device_id` - Device ID"
         ),
 })
 

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -63,7 +63,7 @@ tools:
             bucketing_identifier:
                 description:
                     Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the
-                    default) or `device_id`. Incompatible with `ensure_experience_continuity`.
+                    default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`.
     delete-feature-flag:
         operation: feature_flags_destroy
         enabled: true
@@ -465,4 +465,4 @@ tools:
             bucketing_identifier:
                 description:
                     Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the
-                    default) or `device_id`. Incompatible with `ensure_experience_continuity`.
+                    default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`.

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -43,6 +43,8 @@ tools:
             - evaluation_contexts
             - is_remote_configuration
             - ensure_experience_continuity
+            - evaluation_runtime
+            - bucketing_identifier
         param_overrides:
             is_remote_configuration:
                 description:
@@ -54,6 +56,14 @@ tools:
                     Whether to persist the flag's value for a user across the anonymous-to-identified transition (the "persist
                     across authentication steps" option in the UI). Keeps a user's evaluated value stable once they log
                     in. Incompatible with `device_id` bucketing.
+            evaluation_runtime:
+                description:
+                    Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs
+                    only), or `all` (both). Defaults to `all`.
+            bucketing_identifier:
+                description:
+                    Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the
+                    default) or `device_id`. Incompatible with `ensure_experience_continuity`.
     delete-feature-flag:
         operation: feature_flags_destroy
         enabled: true
@@ -433,6 +443,8 @@ tools:
             - evaluation_contexts
             - is_remote_configuration
             - ensure_experience_continuity
+            - evaluation_runtime
+            - bucketing_identifier
         param_overrides:
             id:
                 cast: string-int
@@ -446,3 +458,11 @@ tools:
                     Whether to persist the flag's value for a user across the anonymous-to-identified transition (the "persist
                     across authentication steps" option in the UI). Keeps a user's evaluated value stable once they log
                     in. Incompatible with `device_id` bucketing.
+            evaluation_runtime:
+                description:
+                    Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs
+                    only), or `all` (both). Defaults to `all`.
+            bucketing_identifier:
+                description:
+                    Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the
+                    default) or `device_id`. Incompatible with `ensure_experience_continuity`.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21778,6 +21778,17 @@ export namespace Schemas {
          * @nullable
          */
       ensure_experience_continuity?: boolean | null;
+      /** Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
+      evaluation_runtime?: EvaluationRuntimeEnum | null;
+      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
+      bucketing_identifier?: BucketingIdentifierEnum | null;
     }
 
     export interface FeatureFlagStatusResponse {
@@ -34238,6 +34249,17 @@ export namespace Schemas {
          * @nullable
          */
       ensure_experience_continuity?: boolean | null;
+      /** Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
+      evaluation_runtime?: EvaluationRuntimeEnum | null;
+      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
+      bucketing_identifier?: BucketingIdentifierEnum | null;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21784,7 +21784,7 @@ export namespace Schemas {
        * * `client` - Client
        * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | null;
-      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.
        *
        * * `distinct_id` - User ID (default)
        * * `device_id` - Device ID */
@@ -34255,7 +34255,7 @@ export namespace Schemas {
        * * `client` - Client
        * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | null;
-      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.
+      /** Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.
        *
        * * `distinct_id` - User ID (default)
        * * `device_id` - Device ID */

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -396,6 +396,26 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             "Whether to persist a user's flag value across the anonymous-to-identified transition (the 'persist across authentication steps' option). Incompatible with device_id bucketing."
         ),
+    evaluation_runtime: zod
+        .union([
+            zod.enum(['server', 'client', 'all']).describe('* `server` - Server\n* `client` - Client\n* `all` - All'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.\n\n* `server` - Server\n* `client` - Client\n* `all` - All"
+        ),
+    bucketing_identifier: zod
+        .union([
+            zod
+                .enum(['distinct_id', 'device_id'])
+                .describe('* `distinct_id` - User ID (default)\n* `device_id` - Device ID'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
+        ),
 })
 
 /**
@@ -731,6 +751,26 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .nullish()
         .describe(
             "Whether to persist a user's flag value across the anonymous-to-identified transition (the 'persist across authentication steps' option). Incompatible with device_id bucketing."
+        ),
+    evaluation_runtime: zod
+        .union([
+            zod.enum(['server', 'client', 'all']).describe('* `server` - Server\n* `client` - Client\n* `all` - All'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Where this flag is allowed to evaluate: 'server' (server-side SDKs only), 'client' (client-side SDKs only), or 'all' (both). Defaults to 'all'.\n\n* `server` - Server\n* `client` - Client\n* `all` - All"
+        ),
+    bucketing_identifier: zod
+        .union([
+            zod
+                .enum(['distinct_id', 'device_id'])
+                .describe('* `distinct_id` - User ID (default)\n* `device_id` - Device ID'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
         ),
 })
 

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -414,7 +414,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
         ),
 })
 
@@ -770,7 +770,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Incompatible with ensure_experience_continuity.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
+            "Identifier used to bucket users into rollout percentages and variants: 'distinct_id' (user ID, the default) or 'device_id'. Using 'device_id' is incompatible with ensure_experience_continuity=True.\n\n* `distinct_id` - User ID (default)\n* `device_id` - Device ID"
         ),
 })
 

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -42,6 +42,12 @@ const CreateFeatureFlagSchema = FeatureFlagsCreateBody.extend({
     ensure_experience_continuity: FeatureFlagsCreateBody.shape['ensure_experience_continuity'].describe(
         'Whether to persist the flag\'s value for a user across the anonymous-to-identified transition (the "persist across authentication steps" option in the UI). Keeps a user\'s evaluated value stable once they log in. Incompatible with `device_id` bucketing.'
     ),
+    evaluation_runtime: FeatureFlagsCreateBody.shape['evaluation_runtime'].describe(
+        'Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`.'
+    ),
+    bucketing_identifier: FeatureFlagsCreateBody.shape['bucketing_identifier'].describe(
+        'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`.'
+    ),
 })
 
 const createFeatureFlag = (): ToolBase<typeof CreateFeatureFlagSchema, WithPostHogUrl<Schemas.FeatureFlag>> => ({
@@ -73,6 +79,12 @@ const createFeatureFlag = (): ToolBase<typeof CreateFeatureFlagSchema, WithPostH
         }
         if (params.ensure_experience_continuity !== undefined) {
             body['ensure_experience_continuity'] = params.ensure_experience_continuity
+        }
+        if (params.evaluation_runtime !== undefined) {
+            body['evaluation_runtime'] = params.evaluation_runtime
+        }
+        if (params.bucketing_identifier !== undefined) {
+            body['bucketing_identifier'] = params.bucketing_identifier
         }
         const result = await context.api.request<Schemas.FeatureFlag>({
             method: 'POST',
@@ -609,6 +621,12 @@ const UpdateFeatureFlagSchema = FeatureFlagsPartialUpdateParams.omit({ project_i
         ensure_experience_continuity: FeatureFlagsPartialUpdateBody.shape['ensure_experience_continuity'].describe(
             'Whether to persist the flag\'s value for a user across the anonymous-to-identified transition (the "persist across authentication steps" option in the UI). Keeps a user\'s evaluated value stable once they log in. Incompatible with `device_id` bucketing.'
         ),
+        evaluation_runtime: FeatureFlagsPartialUpdateBody.shape['evaluation_runtime'].describe(
+            'Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`.'
+        ),
+        bucketing_identifier: FeatureFlagsPartialUpdateBody.shape['bucketing_identifier'].describe(
+            'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`.'
+        ),
     })
 
 const updateFeatureFlag = (): ToolBase<typeof UpdateFeatureFlagSchema, WithPostHogUrl<Schemas.FeatureFlag>> => ({
@@ -640,6 +658,12 @@ const updateFeatureFlag = (): ToolBase<typeof UpdateFeatureFlagSchema, WithPostH
         }
         if (params.ensure_experience_continuity !== undefined) {
             body['ensure_experience_continuity'] = params.ensure_experience_continuity
+        }
+        if (params.evaluation_runtime !== undefined) {
+            body['evaluation_runtime'] = params.evaluation_runtime
+        }
+        if (params.bucketing_identifier !== undefined) {
+            body['bucketing_identifier'] = params.bucketing_identifier
         }
         const result = await context.api.request<Schemas.FeatureFlag>({
             method: 'PATCH',

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -46,7 +46,7 @@ const CreateFeatureFlagSchema = FeatureFlagsCreateBody.extend({
         'Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`.'
     ),
     bucketing_identifier: FeatureFlagsCreateBody.shape['bucketing_identifier'].describe(
-        'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`.'
+        'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`.'
     ),
 })
 
@@ -625,7 +625,7 @@ const UpdateFeatureFlagSchema = FeatureFlagsPartialUpdateParams.omit({ project_i
             'Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`.'
         ),
         bucketing_identifier: FeatureFlagsPartialUpdateBody.shape['bucketing_identifier'].describe(
-            'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`.'
+            'Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`.'
         ),
     })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
@@ -16,7 +16,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`."
+            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`."
         },
         "ensure_experience_continuity": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
@@ -5,6 +5,19 @@
             "description": "Whether the feature flag is active.",
             "type": "boolean"
         },
+        "bucketing_identifier": {
+            "anyOf": [
+                {
+                    "description": "* `distinct_id` - User ID (default)\n* `device_id` - Device ID",
+                    "enum": ["distinct_id", "device_id"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`."
+        },
         "ensure_experience_continuity": {
             "anyOf": [
                 {
@@ -22,6 +35,19 @@
                 "type": "string"
             },
             "type": "array"
+        },
+        "evaluation_runtime": {
+            "anyOf": [
+                {
+                    "description": "* `server` - Server\n* `client` - Client\n* `all` - All",
+                    "enum": ["server", "client", "all"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`."
         },
         "filters": {
             "description": "Feature flag targeting configuration.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
@@ -16,7 +16,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`."
+            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Using `device_id` is incompatible with `ensure_experience_continuity=true`."
         },
         "ensure_experience_continuity": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
@@ -5,6 +5,19 @@
             "description": "Whether the feature flag is active.",
             "type": "boolean"
         },
+        "bucketing_identifier": {
+            "anyOf": [
+                {
+                    "description": "* `distinct_id` - User ID (default)\n* `device_id` - Device ID",
+                    "enum": ["distinct_id", "device_id"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Identifier used to bucket users into rollout percentages and variants — `distinct_id` (user ID, the default) or `device_id`. Incompatible with `ensure_experience_continuity`."
+        },
         "ensure_experience_continuity": {
             "anyOf": [
                 {
@@ -22,6 +35,19 @@
                 "type": "string"
             },
             "type": "array"
+        },
+        "evaluation_runtime": {
+            "anyOf": [
+                {
+                    "description": "* `server` - Server\n* `client` - Client\n* `all` - All",
+                    "enum": ["server", "client", "all"],
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Where this flag is allowed to evaluate — `server` (server-side SDKs only), `client` (client-side SDKs only), or `all` (both). Defaults to `all`."
         },
         "filters": {
             "description": "Feature flag targeting configuration.",


### PR DESCRIPTION
## Problem

PR #63880 exposed `ensure_experience_continuity` to the MCP create/update flag tools and added a drift-guard test to prevent future gaps. That test shipped with two fields on its exclusion list explicitly marked as candidates for follow-up exposure: `evaluation_runtime` and `bucketing_identifier`.

<!-- Closes #ISSUE_ID -->

## Changes

Both fields are writable on the runtime `FeatureFlagSerializer` and accepted by the REST API, but were absent from the `@extend_schema(request=...)` doc serializers that drive the OpenAPI spec, generated types, and MCP tool schemas.

- Added `evaluation_runtime` and `bucketing_identifier` as `ChoiceField`s (with model choices and `help_text`) to `FeatureFlagCreateRequestSchemaSerializer` and `FeatureFlagPartialUpdateRequestSchemaSerializer`.
- Added both to `include_params` and `param_overrides` for the `create-feature-flag` and `update-feature-flag` tools in `products/feature_flags/mcp/tools.yaml`.
- Removed both from `FEATURE_FLAG_REQUEST_SCHEMA_EXCLUDED_RUNTIME_FIELDS` in the drift-guard test helper.
- Regenerated the OpenAPI spec, frontend types, and MCP tools via `hogli build:openapi`.

`evaluation_runtime` controls where a flag evaluates (`server`, `client`, or `all`). `bucketing_identifier` sets the bucketing key (`distinct_id` or `device_id`) and interacts with `ensure_experience_continuity`: the runtime serializer rejects `device_id` + `ensure_experience_continuity=true`, so exposing the bucketing field lets agents avoid that validation error.

## How did you test this code?

- `pnpm --filter=@posthog/mcp exec vitest run -u`: 1826 passed, 2 snapshots updated (`create-feature-flag.json`, `update-feature-flag.json`). The 1 failure is `manifest.test.ts`, which fetches from GitHub over TLS and fails in the sandbox environment; it is unrelated to this change.
- `hogli test products/feature_flags/backend/api/test/test_feature_flag_openapi.py`: 2 passed. The drift-guard now requires both fields to be present in the doc serializers.
- `ruff check` and `ruff format --check`: clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Identified the two fields as the follow-up candidates from the drift-guard exclusion list in #63880. Added them to both doc serializers as `ChoiceField`s referencing the model's own choice constants, mirrored the `ensure_experience_continuity` pattern for the YAML wiring, removed the stale exclusion entries, then regenerated via `hogli build:openapi` and updated vitest snapshots.