### PR TITLE
fix(postgres): retry transient connection drop when advancing CDC slot

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -141,12 +141,20 @@ class PgCDCStreamReader:
             lsn=sql.Literal(position),
         )
 
-        advance_conn = _connect_to_postgres(
-            host=self._effective_host,
-            port=self._effective_port,
-            database=self._params.database,
-            user=self._params.user,
-            password=self._params.password,
+        # This short-lived connection reaches the source through the same SSH tunnel /
+        # connection pooler as the initial connect, either of which can drop it with a
+        # transient "server closed the connection unexpectedly". Mirror connect() and
+        # absorb those drops in-process rather than failing the whole extraction
+        # activity; permanent errors (auth, SSL-required) are re-raised immediately.
+        advance_conn = _connect_with_dropped_retry(
+            lambda: _connect_to_postgres(
+                host=self._effective_host,
+                port=self._effective_port,
+                database=self._params.database,
+                user=self._params.user,
+                password=self._params.password,
+            ),
+            logger,
         )
         try:
             with advance_conn.cursor() as cur:

--- a/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/posthog/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -64,3 +64,51 @@ class TestPgCDCStreamReaderConnect:
                 reader.connect()
 
         assert connect.call_count == 1
+
+
+class TestPgCDCStreamReaderConfirmPosition:
+    def test_confirm_position_retries_transient_dropped_connection(self, params):
+        good_conn = mock.MagicMock()
+        connect = mock.MagicMock(
+            side_effect=[
+                # The short-lived slot-advance connection reaches the source through the
+                # same tunnel / pooler as the initial connect, so it can hit the same
+                # transient drop while advancing the replication slot after a run.
+                psycopg.OperationalError("server closed the connection unexpectedly"),
+                good_conn,
+            ]
+        )
+
+        reader = PgCDCStreamReader(params)
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"),
+        ):
+            reader.confirm_position("0/1234ABCD")
+
+        assert connect.call_count == 2
+        good_conn.commit.assert_called_once()
+        good_conn.close.assert_called_once()
+
+    def test_confirm_position_does_not_retry_permanent_error(self, params):
+        connect = mock.MagicMock(
+            side_effect=psycopg.OperationalError(
+                'connection to server at "10.0.0.1" failed: FATAL: password authentication failed'
+            )
+        )
+
+        reader = PgCDCStreamReader(params)
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+                connect,
+            ),
+            patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"),
+        ):
+            with pytest.raises(psycopg.OperationalError):
+                reader.confirm_position("0/1234ABCD")
+
+        assert connect.call_count == 1


### PR DESCRIPTION
## Problem

The PostgreSQL CDC data-warehouse import surfaced an `OperationalError` in error tracking:

```
connection failed: connection to server at "127.0.0.1", port 33005 failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ed205-6c1a-7051-b766-aef4d0cf45e6

The stack trace originates in this source's CDC code:

```
cdc_extract_activity → CDCExtractActivity.run → _advance_slot_after_run
  → stream_reader.PgCDCStreamReader.confirm_position (stream_reader.py:144)
  → postgres._connect_to_postgres → postgres._connect_with_options_fallback (raises)
```

`confirm_position()` runs `pg_replication_slot_advance(...)` after a successful
CDC read. It opens a short-lived connection that reaches the source through the
same SSH tunnel / connection pooler as the initial connect — either of which
can drop the connection with a transient *"server closed the connection
unexpectedly"*. The initial connect in `connect()` already absorbs that drop via
`_connect_with_dropped_retry`, but `confirm_position()` called the raw
`_connect_to_postgres()` directly, so a transient drop there crashed the whole
extraction activity instead of being retried.

## Changes

This is a transient infrastructure error, not a user/upstream error — so it
should stay retryable rather than be added to `NonRetryableErrors`. The fix
wraps `confirm_position()`'s short-lived connect in the existing
`_connect_with_dropped_retry` helper, mirroring `connect()`:

- Transient connection-drop errors (already enumerated in
  `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, which includes *"server closed the
  connection unexpectedly"*) are retried in-process with bounded backoff.
- Permanent errors (auth failure, SSL-required) still re-raise immediately,
  because `_is_connection_dropped_error` only matches transient drops.

Scoped strictly to the slot-advance connection — no global retry-policy change.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests below; I did not perform
manual testing.

- Added two regression tests to `test_stream_reader.py` mirroring the existing
  `connect()` tests:
  - `test_confirm_position_retries_transient_dropped_connection` — asserts a
    *"server closed the connection unexpectedly"* drop is retried and the
    slot-advance then commits and closes.
  - `test_confirm_position_does_not_retry_permanent_error` — asserts an auth
    failure is re-raised without retry.
- `pytest posthog/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py` — 4 passed.
- `ruff check` / `ruff format` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the full stack trace via the
PostHog error-tracking tools, confirmed the failure originates in
`posthog/temporal/data_imports/sources/postgres/cdc/stream_reader.py`, and
traced it to a short-lived connection that skipped the retry helper the rest of
the CDC path uses. Chose a code fix over `NonRetryableErrors` because the error
is a transient connection drop that the existing infrastructure is already
designed to retry — the only gap was that `confirm_position()` didn't apply it.
Authored with Claude Code.