### PR TITLE
fix(llm-gateway): exact integer micro-USD cost throttle accounting

### DIFF
--- a/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
+++ b/services/llm-gateway/src/llm_gateway/cli/reset_posthog_code_usage.py
@@ -24,11 +24,11 @@ _REDIS_GLOB_METACHARS = re.compile(r"([\\*?\[\]])")
 
 
 # Mirrors the cache key built by _UserCostThrottleBase._get_cache_key in
-# rate_limiting/cost_throttles.py (with the outer "ratelimit:" added by
-# redis_limiter). Update both ends if the key shape changes.
+# rate_limiting/cost_throttles.py (with the outer "costlimit:" added by
+# CostRateLimiter). Update both ends if the key shape changes.
 def _patterns_for(user_id: str | None) -> tuple[str, ...]:
     if user_id is None:
-        return tuple(f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:*" for scope in SCOPES)
+        return tuple(f"costlimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:*" for scope in SCOPES)
     # Escape glob metachars so a user_id like "10*" cannot expand the SCAN
     # match and delete unrelated users' counters.
     safe_id = _REDIS_GLOB_METACHARS.sub(r"\\\1", user_id)
@@ -36,7 +36,7 @@ def _patterns_for(user_id: str | None) -> tuple[str, ...]:
     # variants. The trailing ':' prevents user "100" from matching user "1000".
     patterns: list[str] = []
     for scope in SCOPES:
-        base = f"ratelimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:{safe_id}"
+        base = f"costlimit:cost:user:{scope}:{POSTHOG_CODE_PRODUCT}:{safe_id}"
         patterns.append(base)
         patterns.append(f"{base}:*")
     return tuple(patterns)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -92,7 +92,7 @@ class CostThrottle(Throttle):
             ttl_seconds=ttl,
             remaining=limit - current,
         )
-        if current >= limit:
+        if limiter.at_or_over_limit(current):
             retry_after = await limiter.get_ttl(key)
             logger.error(
                 "cost_throttle_exceeded",
@@ -154,7 +154,7 @@ class CostThrottle(Throttle):
             limit_usd=limit,
             remaining_usd=remaining,
             resets_in_seconds=ttl,
-            exceeded=current >= limit,
+            exceeded=limiter.at_or_over_limit(current),
         )
 
 
@@ -214,7 +214,7 @@ class ProductCostThrottle(CostThrottle):
             limit_usd=limit,
             remaining_usd=max(0.0, limit - current),
             resets_in_seconds=ttl,
-            exceeded=current >= limit,
+            exceeded=limiter.at_or_over_limit(current),
         )
 
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/redis_limiter.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/redis_limiter.py
@@ -12,6 +12,25 @@ logger = structlog.get_logger(__name__)
 
 IN_MEMORY_LIMIT_DIVIDER = 10  # When Redis unavailable, use limit / 10
 
+# Cost accumulates as integer micro-USD (1e-6 USD): a cluster-wide INCRBY is
+# exact where repeated float addition drifts. Six decimals match the ai-gateway
+# ledger's numeric(20, 6) scale; the public surface stays float USD.
+MICRO_USD = 1_000_000
+
+
+def _usd_to_micro(usd: float) -> int:
+    """Scale a USD amount to integer micro-USD, rounding to the nearest
+    micro-USD. A positive charge below half a micro-USD rounds up to 1 so a
+    stream of sub-micro charges accumulates instead of vanishing to zero."""
+    micro = round(usd * MICRO_USD)
+    if micro == 0 and usd > 0:
+        return 1
+    return micro
+
+
+def _micro_to_usd(micro: int) -> float:
+    return micro / MICRO_USD
+
 
 class RateLimiter:
     """
@@ -184,40 +203,54 @@ class TokenRateLimiter:
 
 
 class CostAccumulator:
-    """In-memory cost accumulator with TTL-based expiration for fallback rate limiting."""
+    """In-memory cost accumulator with TTL-based expiration for fallback rate
+    limiting. Cost is held as integer micro-USD to match the Redis path; the
+    public surface still accepts and returns float USD."""
 
     def __init__(self, limit: float, window_seconds: int):
-        self._buckets: dict[str, tuple[float, float]] = {}  # key -> (cost, start_time)
-        self._limit = limit
+        self._buckets: dict[str, tuple[int, float]] = {}  # key -> (micro_usd, start_time)
+        self._limit_micro = round(limit * MICRO_USD)
         self._window = window_seconds
 
-    def _get_bucket(self, key: str) -> tuple[float, float]:
+    def _get_bucket(self, key: str) -> tuple[int, float]:
         """Get or create bucket, expiring old ones."""
         now = time.monotonic()
         if key in self._buckets:
-            cost, start_time = self._buckets[key]
+            micro, start_time = self._buckets[key]
             if now - start_time < self._window:
-                return cost, start_time
-        self._buckets[key] = (0.0, now)
-        return 0.0, now
+                return micro, start_time
+        self._buckets[key] = (0, now)
+        return 0, now
 
     def get_current(self, key: str) -> float:
-        cost, _ = self._get_bucket(key)
-        return cost
+        micro, _ = self._get_bucket(key)
+        return _micro_to_usd(micro)
 
     def incr(self, key: str, cost: float) -> bool:
         current, start_time = self._get_bucket(key)
-        new_val = current + cost
+        new_val = current + _usd_to_micro(cost)
         self._buckets[key] = (new_val, start_time)
-        return new_val <= self._limit
+        return new_val <= self._limit_micro
 
 
 class CostRateLimiter:
     """
     Redis-backed cost rate limiter with local fallback.
 
-    Uses Redis for cluster-wide cost limits with float values.
-    Falls back to in-memory with limit / IN_MEMORY_LIMIT_DIVIDER.
+    Cost accumulates in Redis as integer micro-USD via incrby, so the
+    cluster-wide counter is exact instead of drifting through repeated float
+    addition. The public surface is float USD; scaling to and from micro-USD
+    happens only at the Redis boundary. Falls back to in-memory with
+    limit / IN_MEMORY_LIMIT_DIVIDER.
+
+    Cost keys live under the ``costlimit:`` prefix, separate from the
+    ``ratelimit:`` token/request counters, so the integer INCRBY never lands
+    on a key still holding a float string from the previous format.
+
+    DEPLOY NOTE: the ``costlimit:`` prefix is a one-time cutover from the old
+    ``ratelimit:cost:*`` float keys (which integer INCRBY can't read). In-flight
+    windows reset to zero once on the deploy that introduces it. Rollback is safe:
+    old code reads the old prefix, so it resumes from a clean window.
     """
 
     def __init__(
@@ -228,21 +261,29 @@ class CostRateLimiter:
     ):
         self.redis = redis
         self.limit = limit
+        self._limit_micro = round(limit * MICRO_USD)
         self.window = window_seconds
         self._fallback_limit = limit / IN_MEMORY_LIMIT_DIVIDER
         self._fallback = CostAccumulator(self._fallback_limit, window_seconds)
 
+    def at_or_over_limit(self, current_usd: float) -> bool:
+        """Decide the threshold in integer micro-USD so it matches the stored
+        counter exactly; a descaled-float compare can disagree by one micro at
+        the edge for a non-exact-micro limit."""
+        return _usd_to_micro(current_usd) >= self._limit_micro
+
     async def get_current(self, key: str) -> float:
-        """Get current accumulated cost for a key."""
+        """Get current accumulated cost for a key, in USD."""
         if self.redis is None:
             return self._fallback.get_current(key)
 
         try:
-            redis_key = f"ratelimit:{key}"
+            redis_key = f"costlimit:{key}"
             current = await self.redis.get(redis_key)
-            return float(current or 0)
+            return _micro_to_usd(int(current or 0))
         except Exception:
             logger.exception("redis_get_current_failed", key=key)
+            REDIS_FALLBACK.inc()
             return self._fallback.get_current(key)
 
     async def incr(self, key: str, cost: float) -> bool:
@@ -250,21 +291,20 @@ class CostRateLimiter:
         if self.redis is None:
             return self._fallback.incr(key, cost)
 
+        charge = _usd_to_micro(cost)
         try:
-            redis_key = f"ratelimit:{key}"
-            script = """
-            local current = redis.call('GET', KEYS[1])
-            local new_val = tonumber(current or 0) + tonumber(ARGV[1])
-            local ttl = redis.call('TTL', KEYS[1])
-            if ttl < 0 then
-                redis.call('SET', KEYS[1], new_val, 'EX', ARGV[2])
-            else
-                redis.call('SET', KEYS[1], new_val, 'KEEPTTL')
-            end
-            return new_val
-            """
-            new_val = await self.redis.eval(script, 1, redis_key, str(cost), self.window)
-            return float(new_val) <= self.limit
+            redis_key = f"costlimit:{key}"
+            # Seed the TTL and increment atomically: SET NX EX stamps the window
+            # expiry only on the first charge (fixed window, never extended), and
+            # pairing it with INCRBY means a charge can't strand a key with no
+            # TTL. The short-window token limiters above tolerate that gap; a
+            # 30-day cost window does not.
+            async with self.redis.pipeline(transaction=True) as pipe:
+                pipe.set(redis_key, 0, ex=self.window, nx=True)
+                pipe.incrby(redis_key, charge)
+                results = await pipe.execute()
+            new_val = int(results[-1])
+            return new_val <= self._limit_micro
         except Exception:
             logger.exception("redis_cost_incr_failed", key=key)
             REDIS_FALLBACK.inc()
@@ -276,10 +316,12 @@ class CostRateLimiter:
             return self.window
 
         try:
-            redis_key = f"ratelimit:{key}"
+            redis_key = f"costlimit:{key}"
             ttl = await self.redis.ttl(redis_key)
             if ttl < 0:
                 return self.window
             return ttl
         except Exception:
+            logger.exception("redis_get_ttl_failed", key=key)
+            REDIS_FALLBACK.inc()
             return self.window

--- a/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
+++ b/services/llm-gateway/tests/cli/test_reset_posthog_code_usage.py
@@ -16,12 +16,12 @@ class TestResetUsage:
     async def test_resets_every_user_regardless_of_plan(self, redis: fakeredis.FakeRedis) -> None:
         # Free, pro, and unknown-plan users — all should be reset.
         keys = [
-            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:200",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:200:period:0",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:300:tm2",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:300:tm2:period:1",
+            "costlimit:cost:user:user_cost_burst:posthog_code:100",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:200",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:200:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:300:tm2",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:300:tm2:period:1",
         ]
         for k in keys:
             await redis.set(k, "10.0")
@@ -34,30 +34,33 @@ class TestResetUsage:
 
     @pytest.mark.parametrize("user_id", [None, "100"])
     async def test_dry_run_counts_without_deleting(self, redis: fakeredis.FakeRedis, user_id: str | None) -> None:
-        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
-        await redis.set("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
+        await redis.set("costlimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
+        await redis.set("costlimit:cost:user:user_cost_sustained:posthog_code:100:period:0", "1.0")
 
         deleted = await reset_usage(redis, dry_run=True, user_id=user_id)
 
         assert deleted == 2
-        assert await redis.get("ratelimit:cost:user:user_cost_burst:posthog_code:100") is not None
-        assert await redis.get("ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0") is not None
+        assert await redis.get("costlimit:cost:user:user_cost_burst:posthog_code:100") is not None
+        assert await redis.get("costlimit:cost:user:user_cost_sustained:posthog_code:100:period:0") is not None
 
     async def test_returns_zero_when_no_keys(self, redis: fakeredis.FakeRedis) -> None:
         assert await reset_usage(redis, dry_run=False) == 0
 
     async def test_leaves_unrelated_keys_untouched(self, redis: fakeredis.FakeRedis) -> None:
         # Other products, plan cache, and unrelated rate-limit scopes must survive.
+        # The old-prefix cost key proves the reset matches costlimit:, not the
+        # pre-migration ratelimit:cost: prefix.
         survivors = [
-            "ratelimit:cost:user:user_cost_burst:other_product:100",
-            "ratelimit:cost:user:user_cost_sustained:other_product:100:period:0",
+            "costlimit:cost:user:user_cost_burst:other_product:100",
+            "costlimit:cost:user:user_cost_sustained:other_product:100:period:0",
+            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
             "plan:posthog_code:100",
             "ratelimit:burst:user:100",
             "some:other:key",
         ]
         for k in survivors:
             await redis.set(k, "x")
-        await redis.set("ratelimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
+        await redis.set("costlimit:cost:user:user_cost_burst:posthog_code:100", "1.0")
 
         deleted = await reset_usage(redis, dry_run=False)
 
@@ -67,19 +70,19 @@ class TestResetUsage:
 
     async def test_user_id_resets_only_that_user(self, redis: fakeredis.FakeRedis) -> None:
         target_keys = [
-            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:100:tm2",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:tm2:period:1",
+            "costlimit:cost:user:user_cost_burst:posthog_code:100",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:100:tm2",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:100:tm2:period:1",
         ]
         # Other users, including one whose id is a prefix of the target's id (1 vs 100)
         # and one whose id starts with the target's id (1000 vs 100).
         other_keys = [
-            "ratelimit:cost:user:user_cost_burst:posthog_code:1",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:1:period:0",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:1000",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:1000:period:0",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:200",
+            "costlimit:cost:user:user_cost_burst:posthog_code:1",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:1:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:1000",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:1000:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:200",
         ]
         for k in target_keys + other_keys:
             await redis.set(k, "1.0")
@@ -96,10 +99,10 @@ class TestResetUsage:
         # A user_id like "10*" must be treated as a literal id, not a glob that
         # would match every user starting with "10".
         survivors = [
-            "ratelimit:cost:user:user_cost_burst:posthog_code:100",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:1000",
-            "ratelimit:cost:user:user_cost_burst:posthog_code:10abc",
-            "ratelimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
+            "costlimit:cost:user:user_cost_burst:posthog_code:100",
+            "costlimit:cost:user:user_cost_burst:posthog_code:1000",
+            "costlimit:cost:user:user_cost_burst:posthog_code:10abc",
+            "costlimit:cost:user:user_cost_sustained:posthog_code:100:period:0",
         ]
         for k in survivors:
             await redis.set(k, "1.0")

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -587,7 +587,9 @@ class TestRetryAfterHeader:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         mock_redis = MagicMock()
-        mock_redis.get = AsyncMock(return_value=b"1000.0")
+        # $1000 of accumulated cost, stored as integer micro-USD, exceeds the
+        # burst limit so the request is denied and surfaces the TTL.
+        mock_redis.get = AsyncMock(return_value=b"1000000000")
         mock_redis.ttl = AsyncMock(return_value=600)
 
         throttle = UserCostBurstThrottle(redis=mock_redis)
@@ -637,23 +639,22 @@ class TestCostAccumulation:
 
 class TestCostRateLimiterRedisIntegration:
     @pytest.mark.asyncio
-    async def test_redis_incr_called_with_correct_args(self) -> None:
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_record_cost_stores_integer_micro_under_costlimit_key(self) -> None:
+        from fakeredis import aioredis as fakeredis
 
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
-        mock_redis = MagicMock()
-        mock_redis.eval = AsyncMock(return_value=0.5)
-        mock_redis.get = AsyncMock(return_value=b"0.0")
-
-        throttle = UserCostBurstThrottle(redis=mock_redis)
+        fake = fakeredis.FakeRedis()
+        throttle = UserCostBurstThrottle(redis=fake)
         context = make_context(product="posthog_code")
 
         await throttle.record_cost(context, 0.5)
 
-        mock_redis.eval.assert_called_once()
-        call_args = mock_redis.eval.call_args
-        assert "ratelimit:cost:user:user_cost_burst:posthog_code:1" in call_args[0]
+        # $0.50 -> 500000 micro-USD, stored as an exact integer under the
+        # costlimit: prefix, with the window TTL stamped on the first charge.
+        key = "costlimit:cost:user:user_cost_burst:posthog_code:1"
+        assert await fake.get(key) == b"500000"
+        assert await fake.ttl(key) > 0
 
     @pytest.mark.asyncio
     async def test_redis_get_current_returns_accumulated_cost(self) -> None:
@@ -662,7 +663,8 @@ class TestCostRateLimiterRedisIntegration:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         mock_redis = MagicMock()
-        mock_redis.get = AsyncMock(return_value=b"1.5")
+        # Redis holds integer micro-USD; get_current descales back to USD.
+        mock_redis.get = AsyncMock(return_value=b"1500000")
 
         throttle = UserCostBurstThrottle(redis=mock_redis)
         context = make_context(product="posthog_code")
@@ -681,7 +683,9 @@ class TestCostRateLimiterRedisIntegration:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         mock_redis = MagicMock()
-        mock_redis.get = AsyncMock(return_value=b"1000.0")
+        # $1000 of accumulated cost, stored as integer micro-USD, exceeds the
+        # burst limit so the request is denied.
+        mock_redis.get = AsyncMock(return_value=b"1000000000")
         mock_redis.ttl = AsyncMock(return_value=1800)
 
         throttle = UserCostBurstThrottle(redis=mock_redis)
@@ -695,21 +699,196 @@ class TestCostRateLimiterRedisIntegration:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_local_on_redis_error(self) -> None:
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock, MagicMock, patch
 
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         mock_redis = MagicMock()
-        mock_redis.eval = AsyncMock(side_effect=Exception("Redis error"))
+        # incr accumulates through a transaction pipeline; a Redis outage makes
+        # pipeline()/get raise, and both must degrade to the in-memory fallback.
+        mock_redis.pipeline = MagicMock(side_effect=Exception("Redis error"))
         mock_redis.get = AsyncMock(side_effect=Exception("Redis error"))
 
         throttle = UserCostBurstThrottle(redis=mock_redis)
         context = make_context(product="posthog_code")
 
-        await throttle.record_cost(context, 0.1)
+        with patch("llm_gateway.rate_limiting.redis_limiter.REDIS_FALLBACK") as metric:
+            await throttle.record_cost(context, 0.1)
+        # The charge must actually land in the in-memory fallback, not silently
+        # vanish: the fallback path ran (metric fired) and the accumulator holds it.
+        metric.inc.assert_called()
+        limiter = throttle._get_limiter(context)
+        assert limiter._fallback.get_current(throttle._get_cache_key(context)) == 0.1
 
         result = await throttle.allow_request(context)
         assert result.allowed is True
+
+
+class TestCostRateLimiterRedisExecution:
+    """Exercises the real Redis cost path against fakeredis so the integer
+    storage contract and the limit boundary are pinned, not just call args."""
+
+    @pytest.fixture
+    def fake_redis(self):
+        from fakeredis import aioredis as fakeredis
+
+        return fakeredis.FakeRedis()
+
+    @pytest.mark.asyncio
+    async def test_incr_stores_exact_integer_micro_usd(self, fake_redis) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
+
+        limiter = CostRateLimiter(redis=fake_redis, limit=10.0, window_seconds=60)
+
+        # 0.1 summed ten times is 0.9999999999999999 in float; the stored
+        # counter must be an exact integer micro-USD total.
+        for _ in range(10):
+            await limiter.incr("k", 0.1)
+
+        assert await fake_redis.get("costlimit:k") == b"1000000"
+        assert await limiter.get_current("k") == 1.0
+        # First charge set the window TTL; later charges don't extend it.
+        assert 0 < await fake_redis.ttl("costlimit:k") <= 60
+
+    @pytest.mark.asyncio
+    async def test_incr_allow_then_deny_at_limit_boundary(self, fake_redis) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
+
+        # limit = 3 micro-USD; charge 1 micro-USD each time so the boundary is
+        # exercised exactly on the Redis path (not the in-memory fallback).
+        limiter = CostRateLimiter(redis=fake_redis, limit=0.000003, window_seconds=60)
+
+        assert await limiter.incr("k", 0.000001) is True  # 1 <= 3
+        assert await limiter.incr("k", 0.000001) is True  # 2 <= 3
+        assert await limiter.incr("k", 0.000001) is True  # 3 <= 3
+        assert await limiter.incr("k", 0.000001) is False  # 4 > 3
+
+    @pytest.mark.asyncio
+    async def test_incr_on_legacy_float_value_falls_back(self, fake_redis) -> None:
+        from unittest.mock import patch
+
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
+
+        # The costlimit: prefix is meant to keep the integer incrby off old float
+        # strings, but if one ever existed under the key the incrby raises; we
+        # must degrade to the in-memory accumulator, never 500.
+        await fake_redis.set("costlimit:k", "1.5")
+        limiter = CostRateLimiter(redis=fake_redis, limit=10.0, window_seconds=60)
+
+        with patch("llm_gateway.rate_limiting.redis_limiter.REDIS_FALLBACK") as metric:
+            result = await limiter.incr("k", 0.5)  # incrby on "1.5" raises
+
+        assert isinstance(result, bool)
+        metric.inc.assert_called_once()  # the fallback path was actually taken
+
+    @pytest.mark.asyncio
+    async def test_window_ttl_not_extended_by_later_charges(self, fake_redis) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
+
+        limiter = CostRateLimiter(redis=fake_redis, limit=10.0, window_seconds=60)
+
+        await limiter.incr("k", 0.1)
+        # Simulate the window partway elapsed, then charge again: a fixed window
+        # must run from the first charge, so a later charge must not push the TTL
+        # back toward the full 60s.
+        await fake_redis.expire("costlimit:k", 5)
+        await limiter.incr("k", 0.1)
+
+        assert await fake_redis.ttl("costlimit:k") <= 5
+
+    @pytest.mark.asyncio
+    async def test_read_failure_increments_fallback_metric(self, fake_redis) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
+
+        limiter = CostRateLimiter(redis=fake_redis, limit=10.0, window_seconds=60)
+
+        with patch.object(fake_redis, "get", AsyncMock(side_effect=Exception("boom"))):
+            with patch("llm_gateway.rate_limiting.redis_limiter.REDIS_FALLBACK") as metric:
+                await limiter.get_current("k")
+            metric.inc.assert_called_once()
+
+        with patch.object(fake_redis, "ttl", AsyncMock(side_effect=Exception("boom"))):
+            with patch("llm_gateway.rate_limiting.redis_limiter.REDIS_FALLBACK") as metric:
+                await limiter.get_ttl("k")
+            metric.inc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_allow_request_denies_at_micro_boundary_through_throttle(self) -> None:
+        from fakeredis import aioredis as fakeredis
+
+        from llm_gateway.rate_limiting.cost_throttles import CostThrottle
+
+        class _BoundaryThrottle(CostThrottle):
+            scope = "test_boundary"
+
+            def _get_cache_key(self, context):
+                return "boundary"
+
+            def _get_limit_and_window(self, context):
+                return 100 / 3, 60  # 33.333... USD, not an exact micro-USD multiple
+
+            def _get_limit_exceeded_detail(self):
+                return "over"
+
+        fake = fakeredis.FakeRedis()
+        throttle = _BoundaryThrottle(redis=fake)
+        context = make_context(product="posthog_code")
+        limiter = throttle._get_limiter(context)
+
+        # Seed the counter to exactly the integer-micro boundary. Its descaled
+        # float (33.333333) is < 100/3, so a float `current >= limit` gate would
+        # ADMIT here; the integer at_or_over_limit gate must DENY. This pins the
+        # wiring in allow_request, not just the method in isolation.
+        await fake.set("costlimit:boundary", str(limiter._limit_micro))
+
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
+        # get_status decides exceeded with the same integer gate; pin that site
+        # too (it reverts to the float compare independently of allow_request).
+        status = await throttle.get_status(context)
+        assert status.exceeded is True
+
+    @pytest.mark.asyncio
+    async def test_get_status_for_product_exceeded_at_micro_boundary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fakeredis import aioredis as fakeredis
+
+        from llm_gateway.rate_limiting.cost_throttles import ProductCostThrottle
+        from llm_gateway.rate_limiting.redis_limiter import _usd_to_micro
+
+        # A fractional product limit (100/3 USD) so the integer gate and the old
+        # float `current >= limit` diverge at the boundary.
+        monkeypatch.setenv(
+            "LLM_GATEWAY_PRODUCT_COST_LIMITS",
+            '{"boundaryprod": {"limit_usd": 33.333333333333336, "window_seconds": 60}}',
+        )
+        get_settings.cache_clear()
+
+        fake = fakeredis.FakeRedis()
+        throttle = ProductCostThrottle(redis=fake)
+        # Seed the product counter to exactly the integer-micro boundary. Its
+        # descaled float is < the fractional limit, so a float `current >= limit`
+        # gate would report exceeded=False; the integer gate must report True.
+        await fake.set("costlimit:cost:product:boundaryprod", str(_usd_to_micro(33.333333333333336)))
+
+        status = await throttle.get_status_for_product("boundaryprod")
+
+        assert status is not None
+        assert status.exceeded is True  # fails if the site reverts to current >= limit
+        get_settings.cache_clear()
+
+    def test_at_or_over_limit_decides_in_micro_not_float(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter, _micro_to_usd
+
+        # A limit that isn't an exact micro-USD multiple: 100/3 USD.
+        limiter = CostRateLimiter(redis=None, limit=100 / 3, window_seconds=60)
+        at_boundary = _micro_to_usd(limiter._limit_micro)
+
+        # The integer-space decision treats the stored boundary as at-limit,
+        # where the old descaled-float comparison would have admitted it.
+        assert limiter.at_or_over_limit(at_boundary) is True
+        assert (at_boundary >= 100 / 3) is False
 
 
 class TestRateLimitMultiplier:
@@ -1334,3 +1513,42 @@ class TestCostAccumulatorTTL:
 
         assert accumulator.get_current("user1") == 5.0
         assert accumulator.get_current("user2") == 3.0
+
+    def test_many_small_costs_accumulate_without_float_drift(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostAccumulator
+
+        accumulator = CostAccumulator(limit=10.0, window_seconds=60)
+
+        # 0.1 summed ten times is 0.9999999999999999 in float; integer
+        # micro-USD accumulation keeps the running total exactly 1.0.
+        for _ in range(10):
+            accumulator.incr("user1", 0.1)
+        assert accumulator.get_current("user1") == 1.0
+
+    def test_sub_micro_cost_still_counts(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import CostAccumulator
+
+        accumulator = CostAccumulator(limit=10.0, window_seconds=60)
+
+        # A positive charge below half a micro-USD rounds up to one micro-USD
+        # so a stream of tiny charges accumulates instead of vanishing.
+        accumulator.incr("user1", 0.0000001)
+        assert accumulator.get_current("user1") == pytest.approx(0.000001)
+
+
+class TestMicroUsdScaling:
+    def test_round_trips_usd_to_micro_and_back(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import _micro_to_usd, _usd_to_micro
+
+        assert _usd_to_micro(1.5) == 1_500_000
+        assert _micro_to_usd(1_500_000) == 1.5
+
+    def test_positive_sub_micro_bumps_to_one(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import _usd_to_micro
+
+        assert _usd_to_micro(0.0000001) == 1
+
+    def test_zero_stays_zero(self) -> None:
+        from llm_gateway.rate_limiting.redis_limiter import _usd_to_micro
+
+        assert _usd_to_micro(0.0) == 0


### PR DESCRIPTION
## Problem

The LLM-gateway cost throttle accumulated spend as a Python float in Redis, so the cluster-wide counter drifts under repeated addition. A spend counter should use exact integer arithmetic.

## Changes

- Accumulate cost as integer micro-USD (1e-6 USD) via an atomic `SET NX EX` + `INCRBY` pipeline, and decide the limit in micro-USD too.
- Move cost keys to a `costlimit:` prefix, since integer `INCRBY` can't read the old float values.

## Rollout

One-time cutover: in-flight cost windows reset to zero once on deploy. Rollback is safe (old code reads the old prefix).

## How did you test this code?

Full llm-gateway suite green; new `fakeredis` tests pin integer storage, the allow/deny boundary, and the fixed-window TTL.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Brandon directed the work. Agent-authored with Claude Code; requires human review.
