### PR TITLE
feat(llma): add cache_name label to hypercache signal-update counter

### DIFF
--- a/posthog/storage/gateway_credential_signal_handlers.py
+++ b/posthog/storage/gateway_credential_signal_handlers.py
@@ -42,7 +42,7 @@ from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
 
 logger = structlog.get_logger(__name__)
 
-_NAMESPACE = "gateway_credential"
+_CACHE_NAME = "gateway_credential"
 
 _LOADED_HASH_ATTR = "_fp_loaded_hash"
 _LOADED_ELIGIBLE_ATTR = "_fp_loaded_eligible"
@@ -162,7 +162,9 @@ def _on_credential_save(
                 # Scope was removed: clear promptly rather than waiting for a task.
                 clear_gateway_credential(new_hash)
         except Exception as e:
-            HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace=_NAMESPACE, operation="enqueue", result="failure").inc()
+            HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+                namespace="team_metadata", cache_name=_CACHE_NAME, operation="enqueue", result="failure"
+            ).inc()
             logger.exception("Failed to enqueue gateway credential cache update", kind=kind, error=str(e))
             # A sync clear/enqueue failed (e.g. transient Redis) — queue the task so a
             # revoke self-heals in queue-time instead of waiting out the blob TTL. The

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -57,7 +57,7 @@ CACHE_SIZE_SAMPLE_LIMIT = 1000
 HYPERCACHE_SIGNAL_UPDATE_COUNTER = Counter(
     "posthog_hypercache_signal_updates",
     "Cache updates triggered by Django signals",
-    labelnames=["namespace", "operation", "result"],
+    labelnames=["namespace", "cache_name", "operation", "result"],
 )
 
 

--- a/posthog/storage/team_llm_gateway_policy_signal_handlers.py
+++ b/posthog/storage/team_llm_gateway_policy_signal_handlers.py
@@ -144,7 +144,10 @@ def _update_cache_on_save(sender: type[Team], instance: Team, created: bool, **k
                 clear_team_llm_gateway_policy_cache(instance, kinds=kinds)
         except Exception as e:
             HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-                namespace="team_llm_gateway_policy", operation="enqueue", result="failure"
+                namespace="team_metadata",
+                cache_name="llm_gateway_policy",
+                operation="enqueue",
+                result="failure",
             ).inc()
             logger.exception(
                 "Failed to enqueue llm-gateway policy cache update",

--- a/posthog/storage/test/test_team_llm_gateway_policy_cache.py
+++ b/posthog/storage/test/test_team_llm_gateway_policy_cache.py
@@ -147,7 +147,10 @@ class TestLLMGatewayPolicySignals(BaseTest):
         mock_delay.side_effect = Exception("broker down")
 
         self.team.llm_gateway_revoked_at = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
-        self.team.save()
+        try:
+            self.team.save()
+        except Exception:
+            self.fail("enqueue failure should not propagate to the caller")
 
         mock_counter.labels.assert_called_once_with(
             namespace="team_metadata", cache_name="llm_gateway_policy", operation="enqueue", result="failure"

--- a/posthog/storage/test/test_team_llm_gateway_policy_cache.py
+++ b/posthog/storage/test/test_team_llm_gateway_policy_cache.py
@@ -137,7 +137,7 @@ class TestLLMGatewayPolicySignals(BaseTest):
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.transaction")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.HYPERCACHE_SIGNAL_UPDATE_COUNTER")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
-    @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.update_team_llm_gateway_policy_cache_task.delay")
+    @patch("posthog.tasks.team_llm_gateway_policy.update_team_llm_gateway_policy_cache_task.delay")
     def test_enqueue_failure_records_counter_and_does_not_propagate(
         self, mock_delay, mock_settings, mock_counter, mock_transaction
     ):

--- a/posthog/storage/test/test_team_llm_gateway_policy_cache.py
+++ b/posthog/storage/test/test_team_llm_gateway_policy_cache.py
@@ -134,6 +134,26 @@ class TestLLMGatewayPolicySignals(BaseTest):
 
         mock_delay.assert_not_called()
 
+    @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.transaction")
+    @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.HYPERCACHE_SIGNAL_UPDATE_COUNTER")
+    @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
+    @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.update_team_llm_gateway_policy_cache_task.delay")
+    def test_enqueue_failure_records_counter_and_does_not_propagate(
+        self, mock_delay, mock_settings, mock_counter, mock_transaction
+    ):
+        mock_settings.AI_GATEWAY_REDIS_URL = "redis://localhost"
+        mock_settings.TEST = True
+        mock_transaction.on_commit.side_effect = lambda fn: fn()
+        mock_delay.side_effect = Exception("broker down")
+
+        self.team.llm_gateway_revoked_at = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        self.team.save()
+
+        mock_counter.labels.assert_called_once_with(
+            namespace="team_metadata", cache_name="llm_gateway_policy", operation="enqueue", result="failure"
+        )
+        mock_counter.labels.return_value.inc.assert_called_once_with()
+
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.settings")
     @patch("posthog.storage.team_llm_gateway_policy_signal_handlers.clear_team_llm_gateway_policy_cache")
     def test_team_delete_clears_cache(self, mock_clear, mock_settings):

--- a/posthog/tasks/gateway_credential.py
+++ b/posthog/tasks/gateway_credential.py
@@ -29,7 +29,7 @@ from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
 
 logger = structlog.get_logger(__name__)
 
-_NAMESPACE = "gateway_credential"
+_CACHE_NAME = "gateway_credential"
 _SECRET_KEY_KIND = "project_secret_api_key"
 _OAUTH_KIND = "oauth_access_token"
 
@@ -51,7 +51,9 @@ def update_gateway_credential_cache_task(credential_kind: str, credential_id: st
         return
 
     project_gateway_credential(credential)
-    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace=_NAMESPACE, operation="update", result="success").inc()
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+        namespace="team_metadata", cache_name=_CACHE_NAME, operation="update", result="success"
+    ).inc()
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)

--- a/posthog/tasks/team_llm_gateway_policy.py
+++ b/posthog/tasks/team_llm_gateway_policy.py
@@ -35,13 +35,14 @@ def update_team_llm_gateway_policy_cache_task(team_id: int) -> None:
     except Team.DoesNotExist:
         logger.debug("Team does not exist for llm-gateway policy cache update", team_id=team_id)
         HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-            namespace="team_llm_gateway_policy", operation="update", result="failure"
+            namespace="team_metadata", cache_name="llm_gateway_policy", operation="update", result="failure"
         ).inc()
         return
 
     success = update_team_llm_gateway_policy_cache(team)
     HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-        namespace="team_llm_gateway_policy",
+        namespace="team_metadata",
+        cache_name="llm_gateway_policy",
         operation="update",
         result="success" if success else "failure",
     ).inc()

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -47,12 +47,17 @@ def update_team_metadata_cache_task(team_id: int) -> None:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
         logger.debug("Team does not exist for metadata cache update", team_id=team_id)
-        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", operation="update", result="failure").inc()
+        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+            namespace="team_metadata", cache_name="team_metadata", operation="update", result="failure"
+        ).inc()
         return
 
     success = update_team_metadata_cache(team)
     HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-        namespace="team_metadata", operation="update", result="success" if success else "failure"
+        namespace="team_metadata",
+        cache_name="team_metadata",
+        operation="update",
+        result="success" if success else "failure",
     ).inc()
 
 
@@ -165,7 +170,9 @@ def clear_team_metadata_cache_on_delete(sender: type[Team], instance: Team, **kw
 
 
 def _record_enqueue_failure() -> None:
-    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", operation="enqueue", result="failure").inc()
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+        namespace="team_metadata", cache_name="team_metadata", operation="enqueue", result="failure"
+    ).inc()
 
 
 def _name_may_have_changed(update_fields: frozenset[str] | None) -> bool:

--- a/posthog/tasks/test/test_team_metadata_signals.py
+++ b/posthog/tasks/test/test_team_metadata_signals.py
@@ -67,9 +67,12 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
         with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
             mock_task.delay.side_effect = Exception("broker down")
             with patch("posthog.tasks.team_metadata.HYPERCACHE_SIGNAL_UPDATE_COUNTER") as mock_counter:
-                with self.captureOnCommitCallbacks(execute=True):
-                    self.organization.name = "Renamed org"
-                    self.organization.save(update_fields=["name"])
+                try:
+                    with self.captureOnCommitCallbacks(execute=True):
+                        self.organization.name = "Renamed org"
+                        self.organization.save(update_fields=["name"])
+                except Exception:
+                    self.fail("enqueue failure should not propagate to the caller")
 
         mock_counter.labels.assert_called_once_with(
             namespace="team_metadata", cache_name="team_metadata", operation="enqueue", result="failure"

--- a/posthog/tasks/test/test_team_metadata_signals.py
+++ b/posthog/tasks/test/test_team_metadata_signals.py
@@ -63,6 +63,19 @@ class TestTeamMetadataInvalidationSignals(BaseTest):
 
         mock_task.delay.assert_not_called()
 
+    def test_enqueue_failure_records_counter_and_does_not_propagate(self) -> None:
+        with patch("posthog.tasks.team_metadata.update_related_teams_metadata_cache_task") as mock_task:
+            mock_task.delay.side_effect = Exception("broker down")
+            with patch("posthog.tasks.team_metadata.HYPERCACHE_SIGNAL_UPDATE_COUNTER") as mock_counter:
+                with self.captureOnCommitCallbacks(execute=True):
+                    self.organization.name = "Renamed org"
+                    self.organization.save(update_fields=["name"])
+
+        mock_counter.labels.assert_called_once_with(
+            namespace="team_metadata", cache_name="team_metadata", operation="enqueue", result="failure"
+        )
+        mock_counter.labels.return_value.inc.assert_called_once_with()
+
 
 @override_settings(FLAGS_REDIS_URL="redis://localhost:6379")
 class TestRelatedTeamsMetadataFanoutTask(BaseTest):

--- a/products/feature_flags/backend/tasks.py
+++ b/products/feature_flags/backend/tasks.py
@@ -60,12 +60,14 @@ def update_team_service_flags_cache(team_id: int) -> None:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
         logger.debug("Team does not exist for service flags cache update", team_id=team_id)
-        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", operation="update", result="failure").inc()
+        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+            namespace="feature_flags", cache_name="flags", operation="update", result="failure"
+        ).inc()
         return
 
     success = update_flags_cache(team)
     HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
-        namespace="feature_flags", operation="update", result="success" if success else "failure"
+        namespace="feature_flags", cache_name="flags", operation="update", result="success" if success else "failure"
     ).inc()
 
 


### PR DESCRIPTION
## Problem

`posthog_hypercache_signal_updates_total` was labeled only by `namespace`, `operation`, and `result`. Two caches share `namespace=team_metadata` (the llm_gateway_policy cache and the team_metadata cache), so there was no way to attribute signal-triggered updates to a specific cache in metrics.

The `llm_gateway_policy` call sites were also using `namespace="team_llm_gateway_policy"`, which doesn't match the cache's actual HyperCache namespace (`team_metadata`), so those increments weren't landing in the right namespace bucket.

Closes #61288

Builds on top of [#61535
](https://github.com/PostHog/posthog/pull/61535) (thanks @igennova!)
## Changes

- Add `cache_name` label to `HYPERCACHE_SIGNAL_UPDATE_COUNTER` and thread it through all six call sites.
- Fix `llm_gateway_policy` call sites to use `namespace="team_metadata"` (the correct HyperCache namespace) and `cache_name="llm_gateway_policy"`.
- Add tests for the enqueue-failure counter path in both `team_metadata` and `llm_gateway_policy` signal handlers, which were previously untested.

## How did you test this code?

Added automated tests that verify the counter is incremented with the correct labels on the enqueue-failure path.

The only Grafana dashboard panel that queries this metric (`feature-flags-cache.json`, "Signal-Triggered Cache Updates") uses `sum by(operation, result, namespace)`, which aggregates over `cache_name`, so the existing visualization is unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.