### PR TITLE
fix(postgres): treat TLS ALPN handshake alert as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -240,6 +240,23 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "connection timeout expired": None,
             "SSLRequiredError": None,
             "SSL/TLS connection is required": None,
+            # The server's TLS endpoint aborts the handshake with an ALPN alert ("SSL error: tlsv1
+            # alert no application protocol", OpenSSL alert 120). This only surfaces on the
+            # sslmode=prefer path (require_ssl=False) — libpq agreed to SSL and then the handshake
+            # itself failed, so it can't fall back to plaintext and it isn't converted to the
+            # require_ssl SSLRequiredError above. The alert is sent by the server deterministically
+            # because no application protocol was negotiated: the host/port points at a TLS proxy or
+            # service that isn't a plain PostgreSQL server, or the server's TLS is misconfigured.
+            # Every retry replays the identical handshake and gets the identical alert, so stop and
+            # ask the user to fix their connection details. Match the stable alert text; the IP/port
+            # in the surrounding message are volatile and excluded.
+            "tlsv1 alert no application protocol": (
+                "Your database server rejected the TLS/SSL handshake with a "
+                '"no application protocol" alert. This usually means the host and port point at a '
+                "TLS proxy or service that isn't a PostgreSQL server, or the server's TLS is "
+                "misconfigured. Double-check the host and port in your connection settings, then "
+                "re-enable the sync."
+            ),
             "Could not establish session to SSH gateway": None,
             # Surfaced by a connection pooler (e.g. PgBouncer) as a psycopg ProtocolViolation when
             # the pooler has *repeatedly* failed to log in to the backend database within its

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -395,6 +395,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)) — the IP/port vary.
+            'connection failed: connection to server at "37.16.27.102", port 6432 failed: SSL error: tlsv1 alert no application protocol',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'OperationalError: connection failed: connection to server at "10.0.0.1", port 5432 failed: SSL error: tlsv1 alert no application protocol',
+        ],
+    )
+    def test_tls_alpn_handshake_alert_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"TLS ALPN handshake alert should be non-retryable: {error_msg}"
+
+    def test_tls_alpn_handshake_alert_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'connection failed: connection to server at "37.16.27.102", port 6432 failed: SSL error: tlsv1 alert no application protocol'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "TLS ALPN handshake alert should surface an actionable message"
+        assert "host and port" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "cannot call jsonb_each on a non-object",
             "InvalidParameterValue: cannot call jsonb_each on a non-object",
             "cannot call jsonb_each_text on a non-object",


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports are surfacing a connection failure as a **retryable** error when it is, in fact, a permanent upstream/config problem:

```
OperationalError: connection failed: connection to server at "<ip>", port <port> failed: SSL error: tlsv1 alert no application protocol
```

`tlsv1 alert no application protocol` is a TLS-layer ALPN alert (OpenSSL alert 120) sent by the **server** during the TLS handshake. It only surfaces on the `sslmode=prefer` path (`require_ssl=False`): libpq agreed to SSL and the handshake itself then failed, so it cannot fall back to plaintext, and the error is **not** converted into the `require_ssl` `SSLRequiredError` (which is already non-retryable). As a raw `OperationalError` it isn't in the source's non-retryable list, so the sync keeps retrying into an identical, deterministic failure.

In practice this means the configured host/port points at a TLS proxy or service that isn't a plain PostgreSQL server, or the server's TLS is misconfigured. Nothing PostHog can do but stop retrying and tell the user to fix their connection details.

Observed via PostHog error tracking — issue `019ed237-bb5c-7eb0-b0f6-a742b09e009c` (`OperationalError`), originating in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`_open_setup_connection` → `_connect_with_dropped_retry`).

## Changes

- Add the stable substring `tlsv1 alert no application protocol` to `PostgresSource.get_non_retryable_errors()` with an actionable, user-facing message pointing at the host/port and TLS configuration.
- The match deliberately excludes the volatile IP/port in the surrounding message, and is distinct from the intentionally-retryable transient SSL drop (`SSL connection has been closed unexpectedly`), which must stay retryable.

This is the safe, scoped classification (path 4a): a deterministic, server-sent handshake rejection caused by the customer's config — not a transient infra error and not a bug in our code (the `require_ssl=True` variant is already handled).

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing claimed):

- New parametrized test `test_tls_alpn_handshake_alert_is_non_retryable` covering both the raw psycopg message (activity-level `str(e)`) and the Temporal-wrapped `OperationalError: ...` form (workflow-level).
- New `test_tls_alpn_handshake_alert_returns_friendly_message` asserting an actionable message is surfaced.
- Confirmed existing `test_transient_connection_errors_are_retryable` still passes, so the transient mid-stream SSL drop remains retryable.

Ran the non-DB subset of `posthog/temporal/data_imports/sources/postgres/test_postgres.py`: `318 passed`. The only failures in the full file are pre-existing DB-integration tests (`*RealDb`, `TestGetTable`, etc.) that require a live Postgres unavailable in this sandbox — unrelated to this change. `ruff check` and `ruff format --check` are clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a single error-tracking issue for the Postgres warehouse source. The agent pulled the issue's stack trace and a representative event, confirmed the failure originates in the Postgres source's connection setup, and classified it.

Decision trail: the chained exception (`OperationalError` → `SSLRequiredError`) showed the `require_ssl=True` path is already non-retryable, but the issue is named `OperationalError`, so the failure escapes on the `sslmode=prefer` path as a raw retryable error. An ALPN handshake alert is deterministic (not transient like a reset/timeout), so it was classified as user/upstream and added to `NonRetryableErrors` rather than fixed in code. The matched substring was chosen to be stable (excludes IP/port) and to not overlap with the documented transient SSL-drop string that must remain retryable.
