### PR TITLE
fix(postgres): treat TLS ALPN rejection as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -238,6 +238,23 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "No route to host": None,
             "password authentication failed connection": None,
             "connection timeout expired": None,
+            # TLS ALPN alert (RFC 7301 "no_application_protocol", alert 120) sent by the server
+            # during the TLS handshake. libpq (Postgres 17+) offers the "postgresql" ALPN protocol;
+            # an endpoint that negotiates ALPN but doesn't accept it rejects the handshake outright.
+            # In practice this means the configured host/port isn't a PostgreSQL server speaking TLS
+            # — it's an HTTP/proxy/edge endpoint, or simply the wrong port — so retrying re-runs into
+            # the same rejection. The raw psycopg message ("... SSL error: tlsv1 alert no application
+            # protocol") only matches when require_ssl=False leaves it unwrapped; with require_ssl=True
+            # it's surfaced as SSLRequiredError below instead. Match the stable alert text and exclude
+            # the volatile host/port so the condition is caught on both paths. Placed before the
+            # generic SSL entries so its accurate message wins if both happen to match.
+            "no application protocol": (
+                "PostHog couldn't complete a TLS handshake with the host and port you configured — "
+                'the server rejected the connection during TLS negotiation ("no application '
+                "protocol\"). This usually means the host and port don't point at a PostgreSQL server "
+                "speaking TLS (for example an HTTP, proxy, or edge endpoint, or the wrong port). "
+                "Check your host and port, then re-enable the sync."
+            ),
             "SSLRequiredError": None,
             "SSL/TLS connection is required": None,
             "Could not establish session to SSH gateway": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -271,6 +271,32 @@ class TestPostgresSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Permanent error should be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw psycopg message (what the activity-level check sees via str(e)) when require_ssl=False
+            # leaves the OperationalError unwrapped. The host/port are volatile; the alert text is stable.
+            'connection failed: connection to server at "37.16.27.102", port 6432 failed: SSL error: tlsv1 alert no application protocol',
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: SSL error: tlsv1 alert no application protocol',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'OperationalError: connection failed: connection to server at "37.16.27.102", port 6432 failed: SSL error: tlsv1 alert no application protocol',
+        ],
+    )
+    def test_tls_no_application_protocol_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"TLS ALPN rejection error should be non-retryable: {error_msg}"
+
+    def test_tls_no_application_protocol_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "37.16.27.102", port 6432 failed: '
+            "SSL error: tlsv1 alert no application protocol"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "TLS ALPN rejection error should surface an actionable message"
+        assert "host and port" in friendly[0]
+
     def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
         # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,
         # so confirm it's specifically the new key that recognises this message.


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OperationalError` from the Postgres data-warehouse import source:

> connection failed: connection to server at "…", port 6432 failed: SSL error: tlsv1 alert no application protocol

Issue: https://us.posthog.com/project/2/error_tracking/019ed237-d7ab-7cd0-bb97-4d48a1466c71

`no application protocol` is a TLS ALPN alert (RFC 7301, alert 120) sent by the server **during** the TLS handshake. libpq (Postgres 17+) offers the `postgresql` ALPN protocol; an endpoint that negotiates ALPN but doesn't accept it rejects the handshake outright. In practice this means the configured host/port isn't a PostgreSQL server speaking TLS — it's an HTTP/proxy/edge endpoint, or simply the wrong port. This is a **user/upstream misconfiguration**: retrying always re-runs into the same rejection.

In the observed event the source had `require_ssl=True`, so `_open_setup_connection` wrapped the error into `SSLRequiredError` (matched by the existing `"SSL/TLS connection is required"` key) and it was correctly stopped. **But the raw `OperationalError` substring is not itself in `get_non_retryable_errors()`.** For `require_ssl=False` sources (created before the SSL cutoff, or an SSH tunnel with `require_tls` off) the error is left unwrapped, matches no non-retryable key, and retries on every scheduled sync indefinitely.

## Changes

- Add `"no application protocol"` to `PostgresSource.get_non_retryable_errors()` with an actionable message that points at the host/port rather than (misleadingly) telling the user to enable SSL.
- The key matches the stable alert text and excludes the volatile host/port, so it's caught on both the activity-level (raw `str(e)`) and workflow-level (Temporal-wrapped) checks, and on both the `require_ssl=True` and `require_ssl=False` paths. Placed before the generic SSL entries so its accurate message wins if both happen to match.
- Add regression tests asserting the message is recognised as non-retryable and surfaces the actionable text.

Scope is deliberately narrow: one substring + tests. No change to retry policy, timeouts, or the transient connection-drop handling (those remain retryable).

## How did you test this code?

I'm an agent (Claude Code). I ran the source's non-retryable unit tests:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors
# 48 passed
```

Verified the existing transient-error tests still pass (the new substring doesn't match any transient case), and ran `ruff check` / `ruff format`.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the stack originates in `posthog/temporal/data_imports/sources/postgres/`. Traced the exception chain (`OperationalError` → `SSLRequiredError` → `NonRetryableException`) and the activity-level (`extract.py`) and workflow-level (`external_data_job.py`) classification paths.

Decision: user/upstream error → extend `NonRetryableErrors`. Considered reporting "already handled" since the observed `require_ssl=True` event is caught via `SSLRequiredError`, but confirmed (by checking the raw message against every current key) that the `require_ssl=False` path is a real gap where the identical failure retries forever — so this is not a no-op. Matched on the stable `no application protocol` substring, excluding volatile host/port, consistent with the file's existing low-false-positive matching convention.
