### PR TITLE
feat(signals): add has_implementation_pr filter to reports list

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -659,6 +659,24 @@ class TestSignalReportListAPI(APIBaseTest):
         assert body["count"] == 3
         assert len(body["results"]) == 1
 
+    def test_filter_has_implementation_pr_empty_value_is_noop(self):
+        report_with_pr = self._create_report(title="Report with PR")
+        report_without_pr = self._create_report(title="Report without PR")
+        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(self._list_url(has_implementation_pr=""))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert {str(report_with_pr.id), str(report_without_pr.id)} <= ids
+
+    @parameterized.expand([("garbage", "maybe"), ("number", "2")])
+    def test_filter_has_implementation_pr_invalid_value_returns_400(self, _name, raw):
+        response = self.client.get(self._list_url(has_implementation_pr=raw))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["attr"] == "has_implementation_pr"
+        assert body["code"] == "invalid_input"
+
     # --- source_products ---
 
     def test_source_products_defaults_to_empty_list(self):

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -604,29 +604,24 @@ class TestSignalReportListAPI(APIBaseTest):
 
     # --- has_implementation_pr filter ---
 
-    def test_filter_has_implementation_pr_true_keeps_only_pr_reports(self):
+    @parameterized.expand(
+        [
+            ("true_keeps_pr_reports", "true", "with_pr"),
+            ("false_keeps_non_pr_reports", "false", "without_pr"),
+        ]
+    )
+    def test_filter_has_implementation_pr(self, _name, query_value, expected):
         report_with_pr = self._create_report(title="Report with PR")
         report_without_pr = self._create_report(title="Report without PR")
         self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+        expected_id = str(report_with_pr.id if expected == "with_pr" else report_without_pr.id)
 
-        response = self.client.get(self._list_url(has_implementation_pr="true"))
+        response = self.client.get(self._list_url(has_implementation_pr=query_value))
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
-        ids = {r["id"] for r in body["results"]}
-        assert ids == {str(report_with_pr.id)}
+        assert {r["id"] for r in body["results"]} == {expected_id}
         # `count` is the true total (matches what a limit=1 count query returns).
         assert body["count"] == 1
-        assert str(report_without_pr.id) not in ids
-
-    def test_filter_has_implementation_pr_false_keeps_only_non_pr_reports(self):
-        report_with_pr = self._create_report(title="Report with PR")
-        report_without_pr = self._create_report(title="Report without PR")
-        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
-
-        response = self.client.get(self._list_url(has_implementation_pr="false"))
-        assert response.status_code == status.HTTP_200_OK
-        ids = {r["id"] for r in response.json()["results"]}
-        assert ids == {str(report_without_pr.id)}
 
     def test_filter_has_implementation_pr_ignores_empty_pr_url(self):
         report_empty_pr = self._create_report(title="Report with empty PR url")

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -602,6 +602,63 @@ class TestSignalReportListAPI(APIBaseTest):
             str(report_with_pr.id): "https://github.com/org/repo/pull/42",
         }
 
+    # --- has_implementation_pr filter ---
+
+    def test_filter_has_implementation_pr_true_keeps_only_pr_reports(self):
+        report_with_pr = self._create_report(title="Report with PR")
+        report_without_pr = self._create_report(title="Report without PR")
+        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(self._list_url(has_implementation_pr="true"))
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        ids = {r["id"] for r in body["results"]}
+        assert ids == {str(report_with_pr.id)}
+        # `count` is the true total (matches what a limit=1 count query returns).
+        assert body["count"] == 1
+        assert str(report_without_pr.id) not in ids
+
+    def test_filter_has_implementation_pr_false_keeps_only_non_pr_reports(self):
+        report_with_pr = self._create_report(title="Report with PR")
+        report_without_pr = self._create_report(title="Report without PR")
+        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(self._list_url(has_implementation_pr="false"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert ids == {str(report_without_pr.id)}
+
+    def test_filter_has_implementation_pr_ignores_empty_pr_url(self):
+        report_empty_pr = self._create_report(title="Report with empty PR url")
+        self._create_implementation_task_with_run(report_empty_pr, pr_url="")
+
+        with_pr = self.client.get(self._list_url(has_implementation_pr="true"))
+        assert with_pr.json()["count"] == 0
+        without_pr = self.client.get(self._list_url(has_implementation_pr="false"))
+        assert str(report_empty_pr.id) in {r["id"] for r in without_pr.json()["results"]}
+
+    def test_filter_has_implementation_pr_absent_returns_all(self):
+        report_with_pr = self._create_report(title="Report with PR")
+        report_without_pr = self._create_report(title="Report without PR")
+        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        ids = {r["id"] for r in response.json()["results"]}
+        assert {str(report_with_pr.id), str(report_without_pr.id)} <= ids
+
+    def test_filter_has_implementation_pr_count_via_limit_one(self):
+        for i in range(3):
+            report = self._create_report(title=f"PR report {i}")
+            self._create_implementation_task_with_run(report, pr_url=f"https://github.com/org/repo/pull/{i}")
+        self._create_report(title="No PR report")
+
+        response = self.client.get(self._list_url(has_implementation_pr="true", limit=1))
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["count"] == 3
+        assert len(body["results"]) == 1
+
     # --- source_products ---
 
     def test_source_products_defaults_to_empty_list(self):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -395,6 +395,7 @@ class SignalReportViewSet(
         qs = self._apply_signal_report_status_filter(qs)
         qs = self._apply_signal_report_search_filter(qs)
         qs = self._apply_signal_report_source_product_filter(qs)
+        qs = self._apply_signal_report_implementation_pr_filter(qs)
         qs = self._apply_signal_report_suggested_reviewer_filter(qs)
         qs = self._annotate_latest_actionability_value(qs)
         qs = self._annotate_signal_report_status_rank(qs)
@@ -475,6 +476,32 @@ class SignalReportViewSet(
 
         report_ids_with_source = fetch_report_ids_for_source_products(self.team, source_products)
         return queryset.filter(id__in=report_ids_with_source)
+
+    def _implementation_pr_exists_subquery(self):
+        # EXISTS over the latest implementation TaskRun that carries a non-empty
+        # `pr_url`. Mirrors `_annotate_implementation_pr_url`, but as a boolean
+        # EXISTS so it can be used as a filter (and counted) without the
+        # per-row PR-url annotation, which the list action skips for performance.
+        return Exists(
+            TaskRun.objects.filter(
+                task__signal_report_tasks__report_id=OuterRef("id"),
+                task__signal_report_tasks__relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+                output__pr_url__isnull=False,
+            ).exclude(output__pr_url="")
+        )
+
+    def _apply_signal_report_implementation_pr_filter(self, queryset):
+        # `has_implementation_pr=true|false` filters reports by whether a shipped
+        # implementation PR exists. Lets the inbox count PR reports (the "Pull
+        # requests" tab) with a cheap `limit=1` count query instead of paging the
+        # whole list and filtering client-side. Absent param leaves the list
+        # unchanged.
+        raw = self.request.query_params.get("has_implementation_pr")
+        if raw is None:
+            return queryset
+        wants_pr = raw.strip().lower() in ("1", "true", "yes")
+        pr_exists = self._implementation_pr_exists_subquery()
+        return queryset.filter(pr_exists if wants_pr else ~pr_exists)
 
     def _apply_signal_report_suggested_reviewer_filter(self, queryset):
         suggested_reviewer_filter = self.request.query_params.get("suggested_reviewers")
@@ -796,6 +823,17 @@ class SignalReportViewSet(
                     "Comma-separated ordering clauses. Each clause is a field name optionally prefixed with '-' "
                     "for descending. Allowed fields: status, is_suggested_reviewer, signal_count, total_weight, "
                     "priority, created_at, updated_at, id. Defaults to '-is_suggested_reviewer,status,-updated_at'."
+                ),
+            ),
+            OpenApiParameter(
+                name="has_implementation_pr",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=(
+                    "Filter reports by whether a shipped implementation pull request exists. "
+                    "'true' keeps only reports with a PR; 'false' keeps only those without. "
+                    "Pair with limit=1 to count PR reports cheaply."
                 ),
             ),
         ],

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -494,12 +494,20 @@ class SignalReportViewSet(
         # `has_implementation_pr=true|false` filters reports by whether a shipped
         # implementation PR exists. Lets the inbox count PR reports (the "Pull
         # requests" tab) with a cheap `limit=1` count query instead of paging the
-        # whole list and filtering client-side. Absent param leaves the list
-        # unchanged.
+        # whole list and filtering client-side. Absent or empty param leaves the
+        # list unchanged; an unrecognized value is a 400.
         raw = self.request.query_params.get("has_implementation_pr")
-        if raw is None:
+        if raw is None or not raw.strip():
             return queryset
-        wants_pr = raw.strip().lower() in ("1", "true", "yes")
+        value = raw.strip().lower()
+        if value in ("1", "true", "yes"):
+            wants_pr = True
+        elif value in ("0", "false", "no"):
+            wants_pr = False
+        else:
+            raise serializers.ValidationError(
+                {"has_implementation_pr": f"Invalid value: {raw!r}. Allowed: true, false."}
+            )
         pr_exists = self._implementation_pr_exists_subquery()
         return queryset.filter(pr_exists if wants_pr else ~pr_exists)
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1280,6 +1280,10 @@ export type SignalsProcessingListParams = {
 
 export type SignalsReportsListParams = {
     /**
+     * Filter reports by whether a shipped implementation pull request exists. 'true' keeps only reports with a PR; 'false' keeps only those without. Pair with limit=1 to count PR reports cheaply.
+     */
+    has_implementation_pr?: boolean
+    /**
      * Number of results to return per page.
      */
     limit?: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -59016,6 +59016,10 @@ export namespace Schemas {
 
     export type SignalsReportsListParams = {
     /**
+     * Filter reports by whether a shipped implementation pull request exists. 'true' keeps only reports with a PR; 'false' keeps only those without. Pair with limit=1 to count PR reports cheaply.
+     */
+    has_implementation_pr?: boolean;
+    /**
      * Number of results to return per page.
      */
     limit?: number;

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -17,6 +17,12 @@ export const SignalsReportsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const SignalsReportsListQueryParams = /* @__PURE__ */ zod.object({
+    has_implementation_pr: zod
+        .boolean()
+        .optional()
+        .describe(
+            "Filter reports by whether a shipped implementation pull request exists. 'true' keeps only reports with a PR; 'false' keeps only those without. Pair with limit=1 to count PR reports cheaply."
+        ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     ordering: zod

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -45,6 +45,7 @@ const inboxReportsList = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/reports/`,
             query: {
+                has_implementation_pr: params.has_implementation_pr,
                 limit: params.limit,
                 offset: params.offset,
                 ordering: params.ordering,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/inbox-reports-list.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "has_implementation_pr": {
+            "description": "Filter reports by whether a shipped implementation pull request exists. 'true' keeps only reports with a PR; 'false' keeps only those without. Pair with limit=1 to count PR reports cheaply.",
+            "type": "boolean"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"


### PR DESCRIPTION
## Problem

The PostHog Code inbox derives its per-tab counts (Pull requests / Reports / Runs) from the page of reports it has loaded. With many reports (one project has ~15k), the **Pull requests** count is just however many PR reports happen to fall in the first loaded page — so it's ordering-dependent and capped at the page size. The sidebar "Inbox" badge (which mirrors the Pull-requests count) and the tab itself disagreed: the tab showed `15` (priority-first ordering floats PRs up), the sidebar showed `1` (recency ordering scattered them past the first page).

There was no way to get a true count of PR reports without paging the entire list and filtering client-side on `implementation_pr_url`.

## Change

Add a server-side `has_implementation_pr=true|false` query param to `GET /api/projects/{team_id}/signals/reports/`:

- `true` → only reports that have a shipped implementation PR
- `false` → only reports without one
- absent → unchanged

It's implemented as an `Exists` subquery over the latest implementation `TaskRun` carrying a non-empty `output->pr_url` — mirroring the existing `_annotate_implementation_pr_url`, but as a boolean filter so it works **without** the per-row PR-url annotation (which the list action skips for performance). This lets the client count PR reports with a cheap `limit=1` count query instead of paging the whole list.

## Tests

Added `test_filter_has_implementation_pr_*` covering true/false filtering, empty-`pr_url` handling, the absent-param case, and the `limit=1` count path. All pass; the rest of `TestSignalReportListAPI` is unaffected.

> Note: the pre-existing `TestSignalReportDeleteAPI` failures locally are environment-only (they require Temporal) and are unrelated to this change.

## Deploy ordering

The PostHog Code client change that consumes this param ships separately and must go out **after** this PR is deployed (older clients simply don't send the param).