### PR TITLE
chore: add utils.tsx extraction to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,4 @@ c63bcb7a5763ec8ef05a0b59c922469b57e649a0 # bumped prettier and kea-typegen
 90175d065868ca42aa6471bc2b4356ac415c986e # added prettier-plugin-sort-imports (sort frontend imports)
 1e3813a2f8d762893687946400f90fe96c555742 # added isort (sort backend imports)
 9944d1837e02649864e2602907095691cb6cd3ca # moved from prettier to oxfmt
+1cb11ef76ef158e11f8a6d977341b0544e5f455e # extracted utils.tsx into many different utils files


### PR DESCRIPTION
Adds the recent utils.tsx extraction refactor commit to the git blame ignore revs list, preventing it from cluttering `git blame` output since it was a non-functional reorganization of code.