### PR TITLE
chore: remove `@types/uuid` stub dependency

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -164,7 +164,6 @@
         "@types/redlock": "^4.0.1",
         "@types/snowflake-sdk": "^1.5.1",
         "@types/supertest": "^6.0.2",
-        "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "chance": "^1.1.13",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
         "@parcel/transformer-typescript-types": "catalog:",
         "@playwright/test": "catalog:",
         "@tailwindcss/postcss": "4.3.0",
-        "@types/uuid": "^11.0.0",
         "@typescript/native-preview": "7.0.0-dev.20260421.2",
         "autoprefixer": "^10.4.13",
         "cssnano": "^7.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
-      '@types/uuid':
-        specifier: ^11.0.0
-        version: 11.0.0
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260421.2
         version: 7.0.0-dev.20260421.2
@@ -1745,9 +1742,6 @@ importers:
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
-      '@types/uuid':
-        specifier: ^11.0.0
-        version: 11.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.58.2
         version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@8.57.0)(typescript@6.0.3))(eslint@8.57.0)(typescript@6.0.3)
@@ -12515,10 +12509,6 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
-  '@types/uuid@11.0.0':
-    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
-    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -33268,10 +33258,6 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@10.0.0': {}
-
-  '@types/uuid@11.0.0':
-    dependencies:
-      uuid: 11.1.1
 
   '@types/uuid@9.0.8': {}
 


### PR DESCRIPTION
Removes the `@types/uuid` dev dependency from both the root and `nodejs` packages, as it is a deprecated stub — `uuid` provides its own type definitions. Also upgrades `enhanced-resolve` from `5.20.0` to `5.22.1`.