### PR TITLE
fix(redshift): skip dup-PK check on system-requested query abort

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -742,6 +742,15 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
         except psycopg.errors.QueryCanceled:
             raise
         except Exception as e:
+            # A Redshift system-requested query abort (error code 1020, "system requested abort")
+            # is the cluster's WLM/QMR cancelling the query — the same transient, non-actionable
+            # class as `QueryCanceled`, which psycopg surfaces here as `InternalError_` rather than
+            # `QueryCanceled`. The duplicate-PK check is best-effort (the caller defaults to no
+            # duplicates), so skip gracefully instead of reporting an expected, non-actionable error
+            # to error tracking. Mirrors the graceful-skip probes elsewhere in this driver.
+            if "system requested abort" in str(e):
+                logger.debug(f"has_duplicate_primary_keys: query aborted by Redshift, skipping check: {e}")
+                return False
             capture_exception(e)
             return False
 

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -401,7 +401,21 @@ class TestHasDuplicatePrimaryKeys:
 
     def test_returns_false_on_exception(self, impl, cursor, logger):
         cursor.execute.side_effect = RuntimeError("boom")
-        assert impl.has_duplicate_primary_keys(cursor, "public", "t", ["id"], logger) is False
+        with patch("posthog.temporal.data_imports.sources.redshift.redshift.capture_exception") as mock_capture:
+            assert impl.has_duplicate_primary_keys(cursor, "public", "t", ["id"], logger) is False
+        mock_capture.assert_called_once()
+
+    def test_system_requested_abort_is_not_reported(self, impl, cursor, logger):
+        # Redshift WLM/QMR aborts (code 1020, "system requested abort") surface as `InternalError_`
+        # and are expected, non-actionable noise — skip gracefully without reporting to error tracking.
+        abort_message = (
+            "abort query\nDETAIL:  \n  error:  abort query\n  code:      1020\n"
+            "  context:   system requested abort\n  location:  queryabort.hpp:103\n"
+        )
+        cursor.execute.side_effect = psycopg.errors.InternalError(abort_message)
+        with patch("posthog.temporal.data_imports.sources.redshift.redshift.capture_exception") as mock_capture:
+            assert impl.has_duplicate_primary_keys(cursor, "public", "t", ["id"], logger) is False
+        mock_capture.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `InternalError_` from the Redshift data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ed291-381f-7a22-b6bb-afba1ac39e6a)):

```
abort query
DETAIL:
  error:  abort query
  code:      1020
  context:   system requested abort
  location:  queryabort.hpp:103
```

The single in-app, **handled** stack frame is `has_duplicate_primary_keys` in `posthog/temporal/data_imports/sources/redshift/redshift.py`, running the best-effort duplicate-primary-key probe (`SELECT <pk> FROM <table> GROUP BY 1 HAVING COUNT(*) > 1 LIMIT 1`).

The method already catches the exception and degrades gracefully (returns `False`; the caller defaults to "no duplicate PKs"), so the pipeline never crashes or retries from it. The only problem is that its generic `except Exception` calls `capture_exception(e)`, reporting an **expected, non-actionable** error to error tracking.

Redshift error code 1020 / "system requested abort" is the cluster's WLM/QMR cancelling the query — a transient, system-initiated cancellation that is the same class as `QueryCanceled`, which psycopg here surfaces as `InternalError_` rather than `QueryCanceled`.

## Changes

In `has_duplicate_primary_keys`, recognize the system-requested abort (stable substring `"system requested abort"`) and skip it gracefully — log at debug and return `False` — instead of reporting it. This mirrors the other graceful-skip probes already in this driver (`_explain_query`, `fetch_table_stats`'s `InsufficientPrivilege`, `fetch_average_row_size`). All other unexpected exceptions are still captured.

Deliberately **not** added to `NonRetryableErrors`: the error is already swallowed inside the probe and never reaches the retry layer, and the same abort occurring in the streaming read path is transient and worth retrying — making it globally non-retryable would suppress legitimate retries.

## How did you test this code?

I'm an agent. I ran the automated tests for this source — `posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py` (83 passed), including a new regression test asserting the system-requested abort is **not** reported via `capture_exception`, and an updated existing test confirming other exceptions still are. `ruff check` and `ruff format --check` pass on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the Redshift import source. Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the failure genuinely originates in this source's `has_duplicate_primary_keys` frame (handled), and read the driver to understand the probe's role.

Decision: classified as a fixable bug (best-effort probe reporting expected, non-actionable noise) rather than a `NonRetryableErrors` extension, because the error is already handled and the same abort is transient/retryable in the streaming path. Scoped the fix to a graceful skip consistent with the file's existing patterns, and added a regression test.