### PR TITLE
fix(redshift): bound stalled discovery connections with TCP keepalives

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -67,9 +67,25 @@ __all__ = [
 # cert paths are intentionally pointed at non-existent files so psycopg
 # uses the system default verification without picking up an unintended
 # client cert.
+#
+# TCP keepalives bound a *post-connect* socket stall. `connect_timeout` only
+# covers establishing the connection — once connected, a query blocks in
+# psycopg's `wait_c` for as long as the socket stays open with no response.
+# If the Redshift peer goes away mid-query (cluster pause/resize, network
+# drop), that wait would otherwise hang until the Temporal activity hits its
+# `start_to_close_timeout` and cancels the worker thread, surfacing a
+# misleading `CancelledError` and burning the whole activity budget. With
+# keepalives a dead peer is detected in ~30-60s and raised as a fast,
+# retryable `OperationalError` instead. These only fire when the peer stops
+# responding, so they never interrupt a healthy long-running streaming sync.
 _REDSHIFT_CONNECT_OPTS: dict[str, Any] = {
     "sslmode": "require",
     "connect_timeout": 15,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+    "tcp_user_timeout": 60000,  # 60s: force-close if sent data stays unacked
     "sslrootcert": "/tmp/no.txt",
     "sslcert": "/tmp/no.txt",
     "sslkey": "/tmp/no.txt",

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -843,3 +843,37 @@ class TestBuildPipeline:
 
         # Migrated row keeps its original subdir rather than moving to `analytics_users`.
         assert response.name == "users"
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    def test_connect_forwards_tcp_keepalive_opts(self, mocker):
+        # Regression: a discovery query (`get_columns`) hung in psycopg's `wait_c` on a dead
+        # connection until the Temporal activity's `start_to_close_timeout` cancelled the worker
+        # thread, surfacing a misleading `CancelledError`. `connect_timeout` only bounds
+        # establishing the connection, so the connection must enable TCP keepalives to detect a
+        # dead peer mid-query and fail fast with a retryable error instead.
+        mocker.patch(
+            "posthog.temporal.data_imports.sources.redshift.redshift.open_ssh_tunnel",
+        ).return_value.__enter__.return_value = ("localhost", 5439)
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mock_connect = mocker.patch(
+            "posthog.temporal.data_imports.sources.redshift.redshift.psycopg.connect",
+            return_value=mock_conn,
+        )
+
+        impl = RedshiftImplementation()
+        with impl.connect(_make_config()):
+            pass
+
+        kwargs = mock_connect.call_args.kwargs
+        assert kwargs["keepalives"] == 1
+        assert kwargs["keepalives_idle"] > 0
+        assert kwargs["keepalives_interval"] > 0
+        assert kwargs["keepalives_count"] > 0
+        assert kwargs["tcp_user_timeout"] > 0

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -873,7 +873,7 @@ class TestConnect:
 
         kwargs = mock_connect.call_args.kwargs
         assert kwargs["keepalives"] == 1
-        assert kwargs["keepalives_idle"] > 0
-        assert kwargs["keepalives_interval"] > 0
-        assert kwargs["keepalives_count"] > 0
-        assert kwargs["tcp_user_timeout"] > 0
+        assert kwargs["keepalives_idle"] == 30
+        assert kwargs["keepalives_interval"] == 10
+        assert kwargs["keepalives_count"] == 3
+        assert kwargs["tcp_user_timeout"] == 60000


### PR DESCRIPTION
## Problem

Error tracking surfaced a `CancelledError` (message `Cancelled`) originating from the Redshift data-warehouse import source: [issue 019ed290-c3b6-7be2-9fe2-6dd222f0ad87](https://us.posthog.com/project/2/error_tracking/019ed290-c3b6-7be2-9fe2-6dd222f0ad87).

The exception is `temporalio.exceptions.CancelledError`, raised when Temporal cancels the threaded `sync_new_schemas_activity` (which has a 10-minute `start_to_close_timeout`). The captured stack shows the discovery query `get_columns` (`posthog/temporal/data_imports/sources/redshift/redshift.py`) blocked in psycopg's `wait_c` on a `[BAD]` connection.

Root cause: `_REDSHIFT_CONNECT_OPTS` sets `connect_timeout`, which only bounds *establishing* the connection. Once connected, a query waits on the socket for as long as it stays open with no response. When the Redshift peer goes away mid-query (cluster pause/resize, network drop), nothing bounds that wait — so it hangs until Temporal's activity timeout fires and cancels the worker thread. That:

- wastes the full 10-minute activity budget (×3 retries),
- pollutes error tracking with a misleading `CancelledError` that gives no hint about the real failure.

This is the same class of fragility the `google_sheets` source already documented and fixed (an unbounded socket stall in a threaded activity that Temporal then cancels).

## Changes

Enable TCP keepalives (and `tcp_user_timeout`) on the shared Redshift psycopg connection (`_REDSHIFT_CONNECT_OPTS`). A dead/stalled peer is now detected at the socket layer in ~30–60s and raised as a fast, retryable `OperationalError` instead of hanging until the activity is cancelled.

These settings only fire when the peer stops responding, so they do **not** interrupt a healthy long-running streaming sync (the streaming path in `build_pipeline` deliberately runs without a statement timeout).

Deliberately **not** done: adding `CancelledError`/`"Cancelled"` to the source's `NonRetryableErrors`. A cancellation is a control-flow signal, not a user/upstream credential/config error, and must remain retryable — and `"Cancelled"` is far too generic a substring to match safely. The right fix is to make the underlying stall fail fast and cleanly, which keeps it retryable.

## How did you test this code?

I'm an agent (Claude Code). I added a regression test and ran it; I did not perform manual testing against a live Redshift cluster.

- New `TestConnect::test_connect_forwards_tcp_keepalive_opts` asserts `RedshiftImplementation.connect()` forwards the keepalive options to `psycopg.connect`.
- Ran the full file: `pytest posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py` → 83 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the Redshift import source. Used the PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, then read the source under `posthog/temporal/data_imports/sources/redshift/` and the discovery activity/workflow.

Decision path: confirmed the failure is in the live call stack (`get_columns` → psycopg `wait_c`), not just serialized variables. Classified it as a fixable fragility rather than a user/upstream error — so the `NonRetryableErrors` route was rejected (cancellation must stay retryable; `"Cancelled"` is an unsafe substring). Chose TCP keepalives over a session-wide `statement_timeout` because the connection was network-dead (`[BAD]`), where a server-side statement timeout can't reach the client, and because keepalives are safe for the unbounded streaming-sync path. Mirrors the existing `google_sheets` precedent of turning an indefinite socket stall into a fast, retryable error.