### PR TITLE
chore(ci): set llm gateway bedrock test region

### DIFF
--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -82,6 +82,7 @@ jobs:
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
                   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
                   FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+                  AWS_DEFAULT_REGION: us-east-1
               run: uv run pytest tests/ -v --tb=short --junitxml=junit.xml
 
             - name: Upload test results

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -398,6 +398,7 @@ class TestBedrockCountTokensViaProvider:
         call_args = mock_count_tokens.call_args
         assert call_args[0][1] == expected_model_id  # second positional arg is model
 
+    @patch.dict("os.environ", {"AWS_REGION": "", "AWS_DEFAULT_REGION": ""}, clear=False)
     @patch("llm_gateway.api.anthropic.get_settings")
     def test_requires_bedrock_region(
         self,


### PR DESCRIPTION
## Problem

Bedrock integration tests in the LLM Gateway suite only run when a Bedrock/AWS region is configured. Without a region in CI, the Bedrock parametrized cases can skip even when provider credentials are present.

## Changes

Set `AWS_DEFAULT_REGION` to `us-east-1` in the LLM Gateway CI test step so the existing Bedrock integration test fixture enables the Bedrock cases in CI.

Also isolate the unit test that verifies the missing-region error path by clearing ambient AWS region env vars for that test. This keeps the test valid now that CI provides `AWS_DEFAULT_REGION` globally.

## How did you test this code?

As an agent, I ran:

```bash
AWS_DEFAULT_REGION=us-east-1 uv run pytest tests/test_bedrock.py::TestBedrockCountTokensViaProvider::test_requires_bedrock_region -v --tb=short
AWS_DEFAULT_REGION=us-east-1 uv run pytest tests/test_bedrock.py -v --tb=short
```

I also verified the diff with `git diff --check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed for this CI-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this workflow update after checking the existing LLM Gateway Bedrock integration fixture. The selected approach keeps the gateway/test-facing environment variable as `AWS_DEFAULT_REGION` and supplies a fixed AWS region from CI so Bedrock cases are selected consistently.

After CI exposed that the new ambient region changed a missing-region unit test, Codex updated that test to explicitly clear AWS region env vars so it still covers the intended error path.
