### PR TITLE
fix(provisioning): require trust proof for all existing-user silent mints

### DIFF
--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -437,7 +437,10 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
         assert kwargs["is_organization_first_user"] is True
         assert kwargs["social_provider"] == self.pkce_partner.name
 
-    def test_pkce_partner_with_skip_consent_existing_user_gets_direct_code(self):
+    def test_pkce_partner_with_skip_consent_existing_user_requires_consent(self):
+        # A public PKCE caller is identified only by a client_id anyone can send, so even with
+        # skip_existing_user_consent it must not silently mint for an existing account — it has
+        # no proof it controls the partner or the account (VERIA-327).
         self.pkce_partner.provisioning_skip_existing_user_consent = True
         self.pkce_partner.save()
         User.objects.create_and_join(
@@ -447,10 +450,8 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
         res = self._post_as_pkce_partner(payload)
         assert res.status_code == 200
         data = res.json()
-        assert data["type"] == "oauth"
-        assert "code" in data["oauth"]
-        # Consent path would return a requires_auth payload with redirect URL; absence proves consent was skipped.
-        assert "requires_auth" not in data
+        assert data["type"] == "requires_auth"
+        assert "oauth" not in data
 
     def test_pkce_partner_missing_code_challenge_returns_400(self):
         User.objects.create_and_join(
@@ -479,11 +480,13 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
 
 
 @override_settings(STRIPE_SIGNING_SECRET=HMAC_SECRET)
-class TestSilentRemintBlockedAfterReview(ProvisioningTestBase):
-    """Once a user has reviewed their credentials, a partner with
-    skip_existing_user_consent=True can only re-mint silently when it already
-    holds live OAuth credentials on that user — otherwise the consent screen
-    is required. Closes the server-side half of the pre-hijacking defense."""
+class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
+    """A partner with skip_existing_user_consent=True can only mint silently for an
+    existing user when the caller proved a prior trust relationship with that user
+    (live partner credential for HMAC, the user's own token for bearer). Otherwise
+    the consent screen is required. This holds whether or not the user has reviewed
+    their credentials: an unreviewed account is still a pre-existing account that a
+    caller must not be able to silently link (VERIA-327)."""
 
     def setUp(self):
         super().setUp()
@@ -635,13 +638,16 @@ class TestSilentRemintBlockedAfterReview(ProvisioningTestBase):
             revoked=timezone.now(),
         )
 
-    def test_unreviewed_user_silent_path_still_works(self):
+    def test_unreviewed_existing_user_pkce_requires_consent(self):
+        # A public PKCE caller never proves control of the partner, so it must not mint
+        # silently for an existing account — even an unreviewed one, whose email may belong
+        # to a direct signup the caller has no relationship with.
         self._make_user(credentials_reviewed=False)
         res = self._post_as_partner(self._account_request_payload())
         assert res.status_code == 200
         data = res.json()
-        assert data["type"] == "oauth"
-        assert "code" in data["oauth"]
+        assert data["type"] == "requires_auth"
+        assert "oauth" not in data
 
     @parameterized.expand(
         [
@@ -672,16 +678,17 @@ class TestSilentRemintBlockedAfterReview(ProvisioningTestBase):
         assert data["type"] == "requires_auth"
         assert "oauth" not in data
 
-    def test_pkce_caller_with_live_credential_unreviewed_silent_still_works(self):
-        # The public-client lockout only applies after review; the legitimate
-        # Connect re-link flow on an unreviewed user must stay silent.
+    def test_pkce_caller_with_live_credential_unreviewed_requires_consent(self):
+        # A live credential on the claimed client_id is not proof the public caller controls
+        # the partner, so it cannot unlock the silent path for an existing user — the
+        # unreviewed state does not relax this.
         user = self._make_user(credentials_reviewed=False)
         self._make_live_access_token(user, self.partner)
         res = self._post_as_partner(self._account_request_payload())
         assert res.status_code == 200
         data = res.json()
-        assert data["type"] == "oauth"
-        assert "code" in data["oauth"]
+        assert data["type"] == "requires_auth"
+        assert "oauth" not in data
 
     @parameterized.expand(
         [
@@ -748,6 +755,61 @@ class TestSilentRemintBlockedAfterReview(ProvisioningTestBase):
         self._mint_bearer_token(user, self.bearer_partner, "owner_bearer_token")
 
         res = self._post_as_bearer_partner(self._account_request_payload(), token="owner_bearer_token")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "oauth"
+        assert "code" in data["oauth"]
+
+    def test_bearer_caller_cannot_remint_for_other_user_unreviewed(self):
+        # VERIA-327: an attacker holding their own bearer token must not silently mint a code
+        # for a victim's pre-existing account just because the victim has never reviewed
+        # credentials. The unreviewed state is not a license to link a stranger's account.
+        self._make_user(credentials_reviewed=False)
+
+        attacker = User.objects.create_and_join(
+            organization=self.organization,
+            email="attacker@example.com",
+            password="testpass",
+            first_name="Attacker",
+        )
+        self._mint_bearer_token(attacker, self.bearer_partner, "attacker_bearer_token")
+
+        res = self._post_as_bearer_partner(self._account_request_payload(), token="attacker_bearer_token")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "requires_auth"
+        assert "oauth" not in data
+
+    def test_bearer_caller_can_remint_for_own_user_unreviewed(self):
+        # The owner re-linking their own unreviewed account is genuine proof, so it stays silent.
+        user = self._make_user(credentials_reviewed=False)
+        self._mint_bearer_token(user, self.bearer_partner, "owner_bearer_token")
+
+        res = self._post_as_bearer_partner(self._account_request_payload(), token="owner_bearer_token")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "oauth"
+        assert "code" in data["oauth"]
+
+    @parameterized.expand([("reviewed", True), ("unreviewed", False)])
+    def test_hmac_first_link_existing_user_requires_consent(self, _name, reviewed):
+        # HMAC proof is "the partner already holds a live credential for this user". On a first
+        # link there is none, so even a trusted HMAC partner must get consent before linking a
+        # pre-existing account, regardless of review state.
+        self._make_user(credentials_reviewed=reviewed)
+        res = self._post_as_hmac_partner(self._account_request_payload())
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "requires_auth"
+        assert "oauth" not in data
+
+    @parameterized.expand([("reviewed", True), ("unreviewed", False)])
+    def test_hmac_relink_existing_user_with_live_credential_silent(self, _name, reviewed):
+        # Genuine HMAC re-link: the partner holds a live credential for the user, so it may
+        # mint silently whether or not the user has reviewed credentials.
+        user = self._make_user(credentials_reviewed=reviewed)
+        self._make_live_access_token(user, self.hmac_partner)
+        res = self._post_as_hmac_partner(self._account_request_payload())
         assert res.status_code == 200
         data = res.json()
         assert data["type"] == "oauth"

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -666,23 +666,12 @@ class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
         assert data["type"] == "oauth"
         assert "code" in data["oauth"]
 
-    def test_pkce_caller_with_live_credential_is_blocked_post_review(self):
-        # A public PKCE caller is unauthenticated, so an existing live credential
-        # for the claimed client_id is not proof the caller controls the partner.
-        # It must not unlock the silent path once the user has reviewed credentials.
-        user = self._make_user(credentials_reviewed=True)
-        self._make_live_access_token(user, self.partner)
-        res = self._post_as_partner(self._account_request_payload())
-        assert res.status_code == 200
-        data = res.json()
-        assert data["type"] == "requires_auth"
-        assert "oauth" not in data
-
-    def test_pkce_caller_with_live_credential_unreviewed_requires_consent(self):
-        # A live credential on the claimed client_id is not proof the public caller controls
-        # the partner, so it cannot unlock the silent path for an existing user — the
-        # unreviewed state does not relax this.
-        user = self._make_user(credentials_reviewed=False)
+    @parameterized.expand([("reviewed", True), ("unreviewed", False)])
+    def test_pkce_caller_with_live_credential_requires_consent(self, _name, reviewed):
+        # A public PKCE caller is unauthenticated, so an existing live credential for the
+        # claimed client_id is not proof the caller controls the partner. It must not unlock
+        # the silent path for an existing user, in either review state.
+        user = self._make_user(credentials_reviewed=reviewed)
         self._make_live_access_token(user, self.partner)
         res = self._post_as_partner(self._account_request_payload())
         assert res.status_code == 200
@@ -726,12 +715,13 @@ class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
             scope="query:read",
         )
 
-    def test_bearer_caller_cannot_remint_for_other_user_post_review(self):
-        # A bearer token only proves the caller holds *some* user's token under the
-        # partner's client, not that they control the partner. An attacker holding their
-        # own token must not ride a reviewed victim's existing credential to mint a code
-        # for the victim's account.
-        victim = self._make_user(credentials_reviewed=True)
+    @parameterized.expand([("reviewed", True), ("unreviewed", False)])
+    def test_bearer_caller_cannot_remint_for_other_user(self, _name, reviewed):
+        # A bearer token only proves the caller holds *some* user's token under the partner's
+        # client, not that they control the partner. An attacker holding their own token must
+        # not ride a victim's account to mint a code for it, whether or not the victim has
+        # reviewed credentials — an unreviewed account is still a pre-existing account.
+        victim = self._make_user(credentials_reviewed=reviewed)
         self._make_live_access_token(victim, self.bearer_partner)
 
         attacker = User.objects.create_and_join(
@@ -748,41 +738,11 @@ class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
         assert data["type"] == "requires_auth"
         assert "oauth" not in data
 
-    def test_bearer_caller_can_remint_for_own_user_post_review(self):
-        # The legitimate bearer re-link path: the caller presents the very user's own
-        # token, which is genuine proof of an existing trust relationship.
-        user = self._make_user(credentials_reviewed=True)
-        self._mint_bearer_token(user, self.bearer_partner, "owner_bearer_token")
-
-        res = self._post_as_bearer_partner(self._account_request_payload(), token="owner_bearer_token")
-        assert res.status_code == 200
-        data = res.json()
-        assert data["type"] == "oauth"
-        assert "code" in data["oauth"]
-
-    def test_bearer_caller_cannot_remint_for_other_user_unreviewed(self):
-        # An attacker holding their own bearer token must not silently mint a code
-        # for a victim's pre-existing account just because the victim has never reviewed
-        # credentials. The unreviewed state is not a license to link a stranger's account.
-        self._make_user(credentials_reviewed=False)
-
-        attacker = User.objects.create_and_join(
-            organization=self.organization,
-            email="attacker@example.com",
-            password="testpass",
-            first_name="Attacker",
-        )
-        self._mint_bearer_token(attacker, self.bearer_partner, "attacker_bearer_token")
-
-        res = self._post_as_bearer_partner(self._account_request_payload(), token="attacker_bearer_token")
-        assert res.status_code == 200
-        data = res.json()
-        assert data["type"] == "requires_auth"
-        assert "oauth" not in data
-
-    def test_bearer_caller_can_remint_for_own_user_unreviewed(self):
-        # The owner re-linking their own unreviewed account is genuine proof, so it stays silent.
-        user = self._make_user(credentials_reviewed=False)
+    @parameterized.expand([("reviewed", True), ("unreviewed", False)])
+    def test_bearer_caller_can_remint_for_own_user(self, _name, reviewed):
+        # The legitimate bearer re-link path: the caller presents the user's own token, which
+        # is genuine proof of an existing trust relationship, so it stays silent in either state.
+        user = self._make_user(credentials_reviewed=reviewed)
         self._mint_bearer_token(user, self.bearer_partner, "owner_bearer_token")
 
         res = self._post_as_bearer_partner(self._account_request_payload(), token="owner_bearer_token")

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -440,7 +440,7 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
     def test_pkce_partner_with_skip_consent_existing_user_requires_consent(self):
         # A public PKCE caller is identified only by a client_id anyone can send, so even with
         # skip_existing_user_consent it must not silently mint for an existing account — it has
-        # no proof it controls the partner or the account (VERIA-327).
+        # no proof it controls the partner or the account.
         self.pkce_partner.provisioning_skip_existing_user_consent = True
         self.pkce_partner.save()
         User.objects.create_and_join(
@@ -486,7 +486,7 @@ class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
     (live partner credential for HMAC, the user's own token for bearer). Otherwise
     the consent screen is required. This holds whether or not the user has reviewed
     their credentials: an unreviewed account is still a pre-existing account that a
-    caller must not be able to silently link (VERIA-327)."""
+    caller must not be able to silently link."""
 
     def setUp(self):
         super().setUp()
@@ -761,7 +761,7 @@ class TestSilentRemintRequiresTrustProof(ProvisioningTestBase):
         assert "code" in data["oauth"]
 
     def test_bearer_caller_cannot_remint_for_other_user_unreviewed(self):
-        # VERIA-327: an attacker holding their own bearer token must not silently mint a code
+        # An attacker holding their own bearer token must not silently mint a code
         # for a victim's pre-existing account just because the victim has never reviewed
         # credentials. The unreviewed state is not a license to link a stranger's account.
         self._make_user(credentials_reviewed=False)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -473,8 +473,8 @@ def _user_has_existing_credentials_from_partner(user: User, partner: OAuthApplic
 def _caller_proved_existing_trust(partner: OAuthApplication, user: User, authenticated_user: User | None) -> bool:
     """True only when the caller proved a prior trust relationship with this user.
 
-    This is what lets a skip-consent partner re-mint silently after the user has reviewed
-    their credentials. The proof differs by auth method:
+    This is what lets a skip-consent partner re-mint silently for an existing user; without
+    it the request falls through to browser consent. The proof differs by auth method:
 
     - HMAC callers authenticate with a partner-level secret, so the partner already holding
       a live OAuth credential for the user is sufficient proof of an existing relationship.
@@ -506,26 +506,28 @@ def _handle_existing_user(
     code_challenge_method: str = "S256",
     authenticated_user: User | None = None,
 ) -> Response:
-    # Pre-hijacking defense: once a user has reviewed their credentials, a partner with
-    # skip_existing_user_consent=True can only mint silently when the caller proved a prior
-    # trust relationship with this user (see _caller_proved_existing_trust). Otherwise we
-    # fall through to consent.
-    silent_blocked_post_review = (
+    # Account-takeover defense: a partner with skip_existing_user_consent=True may only mint
+    # silently for an *existing* account when the caller proved a prior trust relationship with
+    # that user (see _caller_proved_existing_trust). Without proof we fall through to consent,
+    # otherwise any caller could mint a code for an account they don't control. This holds
+    # regardless of whether the user has reviewed their credentials: an unreviewed account is
+    # still a pre-existing account, and the email may belong to a direct signup that never
+    # touched provisioning — silently linking it is the takeover.
+    silent_blocked = (
         partner is not None
         and partner.provisioning_skip_existing_user_consent
-        and user.credentials_reviewed_at is not None
         and not _caller_proved_existing_trust(partner, user, authenticated_user)
     )
 
-    if silent_blocked_post_review:
-        assert partner is not None  # implied by silent_blocked_post_review
+    if silent_blocked:
+        assert partner is not None  # implied by silent_blocked
         _capture_provisioning_event(
             "account_request",
-            "silent_blocked_post_review",
+            "silent_blocked_existing_user",
             partner=partner,
         )
 
-    if partner and (not partner.provisioning_skip_existing_user_consent or silent_blocked_post_review):
+    if partner and (not partner.provisioning_skip_existing_user_consent or silent_blocked):
         if not code_challenge:
             return Response(
                 {


### PR DESCRIPTION
## Problem

Agentic provisioning lets a partner with `provisioning_skip_existing_user_consent=True` link an existing PostHog account by email without showing the browser consent screen, but only when the caller has proven a prior trust relationship with that user (`_caller_proved_existing_trust`). That trust check was only enforced once a user had reviewed their credentials (`credentials_reviewed_at is not None`).

For an account that had never reviewed credentials, the check was skipped and the silent path ran unconditionally. A caller could then obtain an authorization code for an account it does not control:

- **Bearer** caller: a user-scoped token proves a relationship only with its own user, but the gap let any token-holder mint a code for a different user's account.
- **PKCE** caller: a public client identified solely by a `client_id` anyone can send had no proof at all, yet could still mint silently for an existing account.

`credentials_reviewed_at` was the wrong control: an unreviewed account is still a pre-existing account, and the email may belong to a direct signup that never touched provisioning. Silently linking it is account takeover.

## Changes

Drop the `credentials_reviewed_at is not None` clause from the consent gate in `_handle_existing_user`, so `_caller_proved_existing_trust` is required for **every** silent mint to an existing user, reviewed or not. Without proof the request falls through to the browser consent screen.

Behavior after this change:

| Caller | Existing user, no prior relationship | Genuine re-link (proof present) |
| --- | --- | --- |
| Bearer | consent (was: silent if unreviewed) | silent — caller presents the user's own token |
| PKCE (public) | consent (was: silent if unreviewed) | n/a — public clients never qualify |
| HMAC partner | consent on first link (was: silent if unreviewed) | silent — partner already holds a live credential for the user |

The legacy Stripe HMAC path (no partner identified, authenticated by the shared signing secret) is unaffected — that gate is `if partner and ...`, so it still mints silently as before.

## How did you test this code?

I'm an agent (Claude Code); I did not manually exercise the running app. Automated tests only, run locally:

- Reworked `TestSilentRemintRequiresTrustProof` (formerly `…BlockedAfterReview`) to assert the trust-proof requirement applies regardless of review state, including new cases:
  - bearer caller cannot re-mint for another user when the victim is **unreviewed** (the core regression test)
  - bearer owner-token re-link stays silent for an unreviewed account
  - PKCE existing-user (with and without a live credential) falls through to consent
  - HMAC first link → consent; HMAC re-link with a live credential → silent (both review states, parameterized)
- Updated `TestPKCEPartnerExistingUserConsent` and the per-user PKCE cases that previously asserted the silent behavior.
- `test_account_requests.py`, `test_e2e_flow.py`, and `test_authorize.py` pass locally (91 passed). `test_oauth_token.py` hit a local test-DB teardown race unrelated to this change and is not in the changed path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at the request of the human author, who reviews and owns the change.

The reported issue scoped the bypass to bearer provisioning. I traced the gap to the `credentials_reviewed_at` clause added in an earlier hardening pass, which the same gate also applies to PKCE — a public client is an even cleaner cross-user mint — so I closed both rather than ship a partial fix. I kept the auth-method-aware proof model intact (`_caller_proved_existing_trust`) and only removed the review-state precondition.

One behavior change to be aware of: partner-identified HMAC/PKCE **first-time** existing-user linking now requires consent (it was silent for unreviewed accounts). This aligns with the principle that existing-account linking needs PostHog-owned proof rather than partner trust. The legacy Stripe Projects app is **not** affected — verified against prod: its `provisioning_auth_method` is empty (so it is never identified as a `partner` and takes the `partner=None` path the gate skips), and `provisioning_skip_existing_user_consent` is off regardless. The change only affects requests where a provisioning `partner` is identified (CIMD-registered bearer/PKCE clients with consent-skip enabled), which are the cross-user-exploitable cases this closes.

