### PR TITLE
fix(data-imports): normalize zendesk subdomain to avoid doubled host

### DIFF
--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -20,7 +20,11 @@ from posthog.temporal.data_imports.sources.zendesk.settings import (
     PARTITION_FIELDS,
     SUPPORT_ENDPOINTS,
 )
-from posthog.temporal.data_imports.sources.zendesk.zendesk import validate_credentials, zendesk_source
+from posthog.temporal.data_imports.sources.zendesk.zendesk import (
+    normalize_subdomain,
+    validate_credentials,
+    zendesk_source,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -64,11 +68,12 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
     def validate_credentials(
         self, config: ZendeskSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
+        subdomain = normalize_subdomain(config.subdomain)
         subdomain_regex = re.compile("^[a-zA-Z0-9-]+$")
-        if not subdomain_regex.match(config.subdomain):
+        if not subdomain_regex.match(subdomain):
             return False, "Zendesk subdomain is incorrect"
 
-        if validate_credentials(config.subdomain, config.api_key, config.email_address):
+        if validate_credentials(subdomain, config.api_key, config.email_address):
             return True, None
 
         return False, "Invalid credentials"

--- a/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -5,7 +5,10 @@ import pytest
 
 from requests import Request, Response
 
-from posthog.temporal.data_imports.sources.zendesk.zendesk import ZendeskTicketsCursorIncrementalPaginator
+from posthog.temporal.data_imports.sources.zendesk.zendesk import (
+    ZendeskTicketsCursorIncrementalPaginator,
+    normalize_subdomain,
+)
 
 
 def _make_response(json_body: dict[str, Any] | None = None) -> Response:
@@ -14,6 +17,29 @@ def _make_response(json_body: dict[str, Any] | None = None) -> Response:
     resp.headers["Content-Type"] = "application/json"
     resp._content = json.dumps(json_body or {}).encode()
     return resp
+
+
+class TestNormalizeSubdomain:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            pytest.param("nibbles", "nibbles", id="bare_subdomain"),
+            pytest.param("nibbles.zendesk.com", "nibbles", id="full_host"),
+            pytest.param("https://nibbles.zendesk.com", "nibbles", id="https_url"),
+            pytest.param("https://nibbles.zendesk.com/", "nibbles", id="https_url_trailing_slash"),
+            pytest.param("http://nibbles.zendesk.com/api/v2", "nibbles", id="url_with_path"),
+            pytest.param("  nibbles.zendesk.com  ", "nibbles", id="whitespace"),
+            pytest.param("nibbles.ZENDESK.com", "nibbles", id="mixed_case_host"),
+            pytest.param("multi-word-team", "multi-word-team", id="hyphenated_subdomain"),
+        ],
+    )
+    def test_collapses_to_subdomain_label(self, raw: str, expected: str) -> None:
+        assert normalize_subdomain(raw) == expected
+
+    def test_full_host_does_not_double_when_building_base_url(self) -> None:
+        # Regression: a pasted full host previously produced "nibbles.zendesk.com.zendesk.com",
+        # whose TLS handshake the Zendesk edge rejects.
+        assert f"https://{normalize_subdomain('nibbles.zendesk.com')}.zendesk.com/" == "https://nibbles.zendesk.com/"
 
 
 class TestZendeskTicketsCursorIncrementalPaginator:

--- a/posthog/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/posthog/temporal/data_imports/sources/zendesk/zendesk.py
@@ -1,3 +1,4 @@
+import re
 import base64
 from typing import Any, Optional
 
@@ -304,6 +305,23 @@ class ZendeskIncrementalEndpointPaginator(BasePaginator):
         request.params = {}
 
 
+def normalize_subdomain(subdomain: str) -> str:
+    """Reduce whatever the user entered to the bare Zendesk subdomain label.
+
+    Users frequently paste the full host ("nibbles.zendesk.com") or a URL
+    ("https://nibbles.zendesk.com/") into the subdomain field. Without normalizing,
+    the base URL becomes "https://nibbles.zendesk.com.zendesk.com/", whose doubled
+    host the TLS handshake rejects (SSLV3_ALERT_HANDSHAKE_FAILURE) and never recovers.
+    """
+    subdomain = subdomain.strip()
+    if "://" in subdomain:
+        subdomain = subdomain.split("://", 1)[1]
+    # Drop any path/query left over from a pasted URL.
+    subdomain = subdomain.split("/", 1)[0]
+    # Strip a trailing ".zendesk.com" so a full host collapses to the subdomain label.
+    return re.sub(r"\.zendesk\.com$", "", subdomain, flags=re.IGNORECASE)
+
+
 def zendesk_source(
     subdomain: str,
     api_key: str,
@@ -316,7 +334,7 @@ def zendesk_source(
 ):
     config: RESTAPIConfig = {
         "client": {
-            "base_url": f"https://{subdomain}.zendesk.com/",
+            "base_url": f"https://{normalize_subdomain(subdomain)}.zendesk.com/",
             "auth": {
                 "type": "http_basic",
                 "username": f"{email_address}/token",
@@ -340,7 +358,7 @@ def zendesk_source(
 def validate_credentials(subdomain: str, api_key: str, email_address: str) -> bool:
     basic_token = base64.b64encode(f"{email_address}/token:{api_key}".encode("ascii")).decode("ascii")
     res = make_tracked_session().get(
-        f"https://{subdomain}.zendesk.com/api/v2/tickets/count",
+        f"https://{normalize_subdomain(subdomain)}.zendesk.com/api/v2/tickets/count",
         headers={"Authorization": f"Basic {basic_token}"},
     )
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring, unrecoverable `SSLError` in the data-warehouse import pipeline:

```
SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:1032)
```

Issue: https://us.posthog.com/project/2/error_tracking/019ed2ec-420b-76e2-9b44-0dae65b10e47

The fingerprint groups by the shared `ssl.py` frames, so it initially looks source-agnostic, but every sampled event is the same Zendesk sync wrapped in a `MaxRetryError`:

```
HTTPSConnectionPool(host='<sub>.zendesk.com.zendesk.com', port=443):
Max retries exceeded with url: /api/v2/incremental/ticket_events ...
(Caused by SSLError(... SSLV3_ALERT_HANDSHAKE_FAILURE ...))
```

The host is doubled. The Zendesk source builds its base URL as `https://{subdomain}.zendesk.com/`, so when a user enters the full host (`<sub>.zendesk.com`) instead of the bare label, the result is `<sub>.zendesk.com.zendesk.com`. Zendesk's TLS edge doesn't recognize that SNI hostname and aborts the handshake, so every request and retry fails the same way — the run never recovers.

## Changes

This is a fixable input-handling bug, not an upstream/credential failure, so the fix normalizes the input rather than suppressing retries:

- Add `normalize_subdomain()` in the Zendesk source helper, which reduces whatever the user entered (bare label, full host, or full URL) to just the subdomain label before building any URL.
- Apply it at both URL-construction sites (`zendesk_source` base URL and `validate_credentials`) and in the source's creation-time validation, so a bare subdomain, a full host, or a URL all resolve to the same correct base URL.

Scoped strictly to the Zendesk source — no change to global retry policy.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- New `TestNormalizeSubdomain` parameterized cases cover bare label, full host, `http`/`https` URLs, trailing slash, path, surrounding whitespace, mixed case, and hyphenated subdomains, plus a regression assertion that a pasted full host no longer produces the doubled `*.zendesk.com.zendesk.com` base URL.
- `python -m pytest posthog/temporal/data_imports/sources/zendesk/tests/test_zendesk.py` — 17 passed.
- `ruff check` / `ruff format` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's sampled `$exception` events via the PostHog MCP, read the stack trace end-to-end (Zendesk REST client → shared HTTP transport → urllib3 → `ssl.do_handshake`), and traced the doubled host back to un-normalized subdomain input in `zendesk_source`.

Considered adding the SSL handshake message to the source's `NonRetryableErrors`, but rejected it: that would only stop retrying a still-broken source and risks masking genuinely transient TLS errors. Normalizing the subdomain actually fixes the root cause and lets affected sources sync. Kept the change scoped to the Zendesk source.
