### PR TITLE
feat(replay-vision): vision action scheduling + processing workflows

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -88,6 +88,7 @@ from products.replay_vision.backend.temporal.gemini_cleanup_sweep import (
     create_replay_vision_gemini_cleanup_sweep_schedule,
 )
 from products.replay_vision.backend.temporal.reconciler import create_replay_vision_reconciler_schedule
+from products.replay_vision.backend.temporal.vision_actions import create_replay_vision_actions_schedule
 from products.signals.backend.temporal.agentic.schedule import create_signals_scout_coordinator_schedule
 from products.tasks.backend.temporal.code_workstreams.schedule import create_evaluate_code_workstreams_schedule
 from products.web_analytics.backend.temporal.digest_notification.types import WADigestNotificationInput
@@ -693,6 +694,7 @@ schedules = [
     create_signals_scout_coordinator_schedule,
     create_replay_vision_reconciler_schedule,
     create_replay_vision_estimates_schedule,
+    create_replay_vision_actions_schedule,
     create_evaluate_code_workstreams_schedule,
 ]
 

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -88,7 +88,6 @@ from products.replay_vision.backend.temporal.gemini_cleanup_sweep import (
     create_replay_vision_gemini_cleanup_sweep_schedule,
 )
 from products.replay_vision.backend.temporal.reconciler import create_replay_vision_reconciler_schedule
-from products.replay_vision.backend.temporal.vision_actions import create_replay_vision_actions_schedule
 from products.signals.backend.temporal.agentic.schedule import create_signals_scout_coordinator_schedule
 from products.tasks.backend.temporal.code_workstreams.schedule import create_evaluate_code_workstreams_schedule
 from products.web_analytics.backend.temporal.digest_notification.types import WADigestNotificationInput
@@ -694,7 +693,6 @@ schedules = [
     create_signals_scout_coordinator_schedule,
     create_replay_vision_reconciler_schedule,
     create_replay_vision_estimates_schedule,
-    create_replay_vision_actions_schedule,
     create_evaluate_code_workstreams_schedule,
 ]
 

--- a/products/replay_vision/backend/temporal/__init__.py
+++ b/products/replay_vision/backend/temporal/__init__.py
@@ -39,7 +39,7 @@ from products.replay_vision.backend.temporal.vision_actions import (
     create_vision_action_run_activity,
     emit_action_ready_activity,
     evaluate_due_vision_actions_activity,
-    synthesize_action_activity,
+    synthesize_group_summary_activity,
     update_vision_action_run_activity,
     validate_vision_action_activity,
 )
@@ -82,7 +82,7 @@ ACTIVITIES: list[Callable[..., Any]] = [
     evaluate_due_vision_actions_activity,
     create_vision_action_run_activity,
     validate_vision_action_activity,
-    synthesize_action_activity,
+    synthesize_group_summary_activity,
     emit_action_ready_activity,
     update_vision_action_run_activity,
 ]
@@ -99,7 +99,7 @@ __all__ = [
     "create_vision_action_run_activity",
     "emit_action_ready_activity",
     "evaluate_due_vision_actions_activity",
-    "synthesize_action_activity",
+    "synthesize_group_summary_activity",
     "update_vision_action_run_activity",
     "validate_vision_action_activity",
     "advance_scanner_watermark_activity",

--- a/products/replay_vision/backend/temporal/__init__.py
+++ b/products/replay_vision/backend/temporal/__init__.py
@@ -34,6 +34,17 @@ from products.replay_vision.backend.temporal.gemini_cleanup_sweep import (
 )
 from products.replay_vision.backend.temporal.reconciler import ReconcileScannerSchedulesWorkflow
 from products.replay_vision.backend.temporal.sweep_workflow import SweepScannerWorkflow
+from products.replay_vision.backend.temporal.vision_actions import (
+    ProcessVisionActionWorkflow,
+    ScheduleAllVisionActionsWorkflow,
+    advance_next_run_at_activity,
+    create_vision_action_run_activity,
+    emit_action_ready_activity,
+    fetch_due_vision_actions_activity,
+    synthesize_action_activity,
+    update_vision_action_run_activity,
+    validate_vision_action_activity,
+)
 from products.replay_vision.backend.temporal.workflow import ApplyScannerWorkflow
 
 WORKFLOWS = [
@@ -42,6 +53,8 @@ WORKFLOWS = [
     RefreshScannerEstimatesWorkflow,
     ReplayVisionGeminiCleanupSweepWorkflow,
     SweepScannerWorkflow,
+    ScheduleAllVisionActionsWorkflow,
+    ProcessVisionActionWorkflow,
 ]
 ACTIVITIES: list[Callable[..., Any]] = [
     create_observation_activity,
@@ -69,16 +82,32 @@ ACTIVITIES: list[Callable[..., Any]] = [
     list_stale_scanner_estimates_activity,
     refresh_scanner_estimate_activity,
     sweep_gemini_files_activity,
+    fetch_due_vision_actions_activity,
+    create_vision_action_run_activity,
+    validate_vision_action_activity,
+    synthesize_action_activity,
+    emit_action_ready_activity,
+    update_vision_action_run_activity,
+    advance_next_run_at_activity,
 ]
 
 __all__ = [
     "ACTIVITIES",
     "WORKFLOWS",
     "ApplyScannerWorkflow",
+    "ProcessVisionActionWorkflow",
     "ReconcileScannerSchedulesWorkflow",
     "RefreshScannerEstimatesWorkflow",
     "ReplayVisionGeminiCleanupSweepWorkflow",
+    "ScheduleAllVisionActionsWorkflow",
     "SweepScannerWorkflow",
+    "advance_next_run_at_activity",
+    "create_vision_action_run_activity",
+    "emit_action_ready_activity",
+    "fetch_due_vision_actions_activity",
+    "synthesize_action_activity",
+    "update_vision_action_run_activity",
+    "validate_vision_action_activity",
     "advance_scanner_watermark_activity",
     "call_scanner_provider_activity",
     "cleanup_gemini_file_activity",

--- a/products/replay_vision/backend/temporal/__init__.py
+++ b/products/replay_vision/backend/temporal/__init__.py
@@ -36,11 +36,9 @@ from products.replay_vision.backend.temporal.reconciler import ReconcileScannerS
 from products.replay_vision.backend.temporal.sweep_workflow import SweepScannerWorkflow
 from products.replay_vision.backend.temporal.vision_actions import (
     ProcessVisionActionWorkflow,
-    ScheduleAllVisionActionsWorkflow,
-    advance_next_run_at_activity,
     create_vision_action_run_activity,
     emit_action_ready_activity,
-    fetch_due_vision_actions_activity,
+    evaluate_due_vision_actions_activity,
     synthesize_action_activity,
     update_vision_action_run_activity,
     validate_vision_action_activity,
@@ -53,7 +51,6 @@ WORKFLOWS = [
     RefreshScannerEstimatesWorkflow,
     ReplayVisionGeminiCleanupSweepWorkflow,
     SweepScannerWorkflow,
-    ScheduleAllVisionActionsWorkflow,
     ProcessVisionActionWorkflow,
 ]
 ACTIVITIES: list[Callable[..., Any]] = [
@@ -82,13 +79,12 @@ ACTIVITIES: list[Callable[..., Any]] = [
     list_stale_scanner_estimates_activity,
     refresh_scanner_estimate_activity,
     sweep_gemini_files_activity,
-    fetch_due_vision_actions_activity,
+    evaluate_due_vision_actions_activity,
     create_vision_action_run_activity,
     validate_vision_action_activity,
     synthesize_action_activity,
     emit_action_ready_activity,
     update_vision_action_run_activity,
-    advance_next_run_at_activity,
 ]
 
 __all__ = [
@@ -99,12 +95,10 @@ __all__ = [
     "ReconcileScannerSchedulesWorkflow",
     "RefreshScannerEstimatesWorkflow",
     "ReplayVisionGeminiCleanupSweepWorkflow",
-    "ScheduleAllVisionActionsWorkflow",
     "SweepScannerWorkflow",
-    "advance_next_run_at_activity",
     "create_vision_action_run_activity",
     "emit_action_ready_activity",
-    "fetch_due_vision_actions_activity",
+    "evaluate_due_vision_actions_activity",
     "synthesize_action_activity",
     "update_vision_action_run_activity",
     "validate_vision_action_activity",

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -4,6 +4,17 @@ from uuid import UUID
 APPLY_SCANNER_WORKFLOW_NAME = "replay-vision-apply-scanner"
 SWEEP_SCANNER_WORKFLOW_NAME = "replay-vision-sweep-scanner"
 
+# Per-action vision-action child, fire-and-forgot by the sweep. Name + timeout live here (not in the
+# workflow-def module) so the sweep can start it without cross-importing another @wf.defn module.
+PROCESS_VISION_ACTION_WORKFLOW_NAME = "process-vision-action"
+PROCESS_VISION_ACTION_EXECUTION_TIMEOUT = dt.timedelta(hours=1)
+
+
+def build_process_vision_action_workflow_id(vision_action_id: UUID) -> str:
+    """Deterministic id: a still-running action is skipped (WorkflowAlreadyStartedError), not double-fired."""
+    return f"{PROCESS_VISION_ACTION_WORKFLOW_NAME}-{vision_action_id}"
+
+
 SCANNER_SCHEDULE_INTERVAL = dt.timedelta(minutes=5)
 
 # Children are ABANDONed and don't count against this budget.

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -28,8 +28,11 @@ from products.replay_vision.backend.temporal.constants import (
     APPLY_SCANNER_WORKFLOW_NAME,
     COUNT_IN_FLIGHT_APPLIES_TIMEOUT,
     MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
+    PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
+    PROCESS_VISION_ACTION_WORKFLOW_NAME,
     SWEEP_SCANNER_WORKFLOW_NAME,
     build_apply_scanner_workflow_id,
+    build_process_vision_action_workflow_id,
 )
 from products.replay_vision.backend.temporal.sweep_types import (
     AdvanceScannerWatermarkInputs,
@@ -39,6 +42,15 @@ from products.replay_vision.backend.temporal.sweep_types import (
     SweepScannerInputs,
 )
 from products.replay_vision.backend.temporal.types import ApplyScannerInputs
+from products.replay_vision.backend.temporal.vision_actions.activities import evaluate_due_vision_actions_activity
+from products.replay_vision.backend.temporal.vision_actions.types import (
+    EvaluateDueVisionActionsInputs,
+    ProcessVisionActionInputs,
+)
+
+_VISION_ACTION_EVAL_RETRY = common.RetryPolicy(
+    initial_interval=dt.timedelta(seconds=5), maximum_interval=dt.timedelta(minutes=1), maximum_attempts=3
+)
 
 
 @wf.defn(name=SWEEP_SCANNER_WORKFLOW_NAME)
@@ -47,6 +59,11 @@ class SweepScannerWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: SweepScannerInputs) -> None:
+        # The sweep is also the heartbeat for this scanner's "and then…" vision actions. Run it first
+        # and best-effort: a vision-action problem must never block the scanner's core session scan,
+        # and it's independent of the in-flight throttle below (which is about apply-scanner load).
+        await self._dispatch_due_vision_actions(inputs)
+
         # Hard per-scanner concurrency cap: don't fetch more than the in-flight headroom, and skip entirely
         # when saturated. Keeps one bad config from flooding the shared rasterizer + provider concurrency.
         # The activity fails open (returns 0 on any error), so there's nothing to retry.
@@ -85,6 +102,42 @@ class SweepScannerWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(seconds=30),
             retry_policy=common.RetryPolicy(maximum_attempts=3),
         )
+
+    async def _dispatch_due_vision_actions(self, inputs: SweepScannerInputs) -> None:
+        """Evaluate this scanner's due vision actions and fire-and-forget one child per action.
+
+        The eligibility activity claims each action (advances next_run_at) in its own transaction, so
+        an ABANDONed child that runs slowly or fails can't be re-fired by the next sweep. Wrapped in a
+        broad except: the session scan that follows must proceed even if vision-action dispatch fails.
+        """
+        try:
+            due = await wf.execute_activity(
+                evaluate_due_vision_actions_activity,
+                EvaluateDueVisionActionsInputs(scanner_id=inputs.scanner_id, team_id=inputs.team_id),
+                start_to_close_timeout=dt.timedelta(seconds=30),
+                retry_policy=_VISION_ACTION_EVAL_RETRY,
+            )
+            for d in due:
+                try:
+                    await wf.start_child_workflow(
+                        PROCESS_VISION_ACTION_WORKFLOW_NAME,
+                        ProcessVisionActionInputs(
+                            vision_action_id=d.vision_action_id, team_id=d.team_id, scheduled_at=d.scheduled_at
+                        ),
+                        id=build_process_vision_action_workflow_id(d.vision_action_id),
+                        task_queue=settings.REPLAY_VISION_TASK_QUEUE,
+                        parent_close_policy=wf.ParentClosePolicy.ABANDON,
+                        execution_timeout=PROCESS_VISION_ACTION_EXECUTION_TIMEOUT,
+                    )
+                except WorkflowAlreadyStartedError:
+                    wf.logger.info(
+                        "replay_vision.vision_action_already_running",
+                        extra={"vision_action_id": str(d.vision_action_id)},
+                    )
+        except Exception:
+            wf.logger.exception(
+                "replay_vision.vision_action_dispatch_failed", extra={"scanner_id": str(inputs.scanner_id)}
+            )
 
     async def _start_child(self, inputs: SweepScannerInputs, candidate: CandidateSessionPayload) -> None:
         try:

--- a/products/replay_vision/backend/temporal/sweep_workflow.py
+++ b/products/replay_vision/backend/temporal/sweep_workflow.py
@@ -134,7 +134,16 @@ class SweepScannerWorkflow(PostHogWorkflow):
                         "replay_vision.vision_action_already_running",
                         extra={"vision_action_id": str(d.vision_action_id)},
                     )
+                except Exception:
+                    # The action was already claimed (next_run_at advanced in the eval txn), so a child
+                    # that fails to start drops this occurrence until the next fire. Log it per-action
+                    # so the drop is visible/graphable, and keep dispatching the rest.
+                    wf.logger.exception(
+                        "replay_vision.vision_action_claim_dispatch_failed",
+                        extra={"scanner_id": str(inputs.scanner_id), "vision_action_id": str(d.vision_action_id)},
+                    )
         except Exception:
+            # The eligibility activity itself failed (exhausted retries); no action was claimed.
             wf.logger.exception(
                 "replay_vision.vision_action_dispatch_failed", extra={"scanner_id": str(inputs.scanner_id)}
             )

--- a/products/replay_vision/backend/temporal/vision_actions/__init__.py
+++ b/products/replay_vision/backend/temporal/vision_actions/__init__.py
@@ -1,13 +1,27 @@
+from products.replay_vision.backend.temporal.vision_actions.activities import (
+    create_vision_action_run_activity,
+    emit_action_ready_activity,
+    evaluate_due_vision_actions_activity,
+    update_vision_action_run_activity,
+    validate_vision_action_activity,
+)
 from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_group_summary_activity
 from products.replay_vision.backend.temporal.vision_actions.types import (
     SynthesisStatus,
     SynthesizeGroupSummaryInputs,
     SynthesizeGroupSummaryResult,
 )
+from products.replay_vision.backend.temporal.vision_actions.workflows import ProcessVisionActionWorkflow
 
 __all__ = [
+    "ProcessVisionActionWorkflow",
     "SynthesisStatus",
     "SynthesizeGroupSummaryInputs",
     "SynthesizeGroupSummaryResult",
+    "create_vision_action_run_activity",
+    "emit_action_ready_activity",
+    "evaluate_due_vision_actions_activity",
     "synthesize_group_summary_activity",
+    "update_vision_action_run_activity",
+    "validate_vision_action_activity",
 ]

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -66,9 +66,13 @@ def _evaluate_due(inputs: EvaluateDueVisionActionsInputs) -> list[DueVisionActio
         )
         for action in actions:
             scheduled_at = action.next_run_at
+            # Claim via a direct .update() rather than save(): VisionAction.save() re-derives
+            # next_run_at when the schedule key changed, and we've already advanced it here — going
+            # through .update() bypasses that override so the claim can't double-recompute the cursor.
             action._recompute_next_run_at()
-            action.last_run_at = now
-            action.save(update_fields=["next_run_at", "last_run_at", "updated_at"])
+            VisionAction.objects.for_team(inputs.team_id).filter(pk=action.id).update(
+                next_run_at=action.next_run_at, last_run_at=now, updated_at=now
+            )
             due.append(DueVisionAction(vision_action_id=action.id, team_id=action.team_id, scheduled_at=scheduled_at))
     return due
 

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -9,7 +9,7 @@ from django.db import transaction
 import structlog
 from temporalio import activity
 
-from posthog.api.capture_dispatch import capture_internal_routed
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 from posthog.sync import database_sync_to_async
 
 from products.replay_vision.backend.models.vision_action import (
@@ -32,7 +32,6 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
 logger = structlog.get_logger(__name__)
 
 _EVENT_NAME = "$replay_vision_action_ready"
-_EVENT_SOURCE = "replay_vision"
 
 
 @activity.defn
@@ -142,22 +141,22 @@ def _emit(inputs: EmitActionReadyInputs) -> None:
     team = run.team
 
     action_url = f"{settings.SITE_URL}/project/{team.id}/replay/vision-actions/{action.id}"
-    properties = {
-        "$insert_id": str(run.id),
-        "vision_action_id": str(action.id),
-        "scanner_id": str(action.scanner_id) if action.scanner_id else None,
-        "vision_action_run_id": str(run.id),
-        "slack_text": run.output.get("slack", ""),
-        "action_url": action_url,
-    }
-    result = capture_internal_routed(
-        token=team.api_token,
-        event_name=_EVENT_NAME,
-        event_source=_EVENT_SOURCE,
-        distinct_id=replay_vision_distinct_id(team.id),
-        timestamp=datetime.now(UTC),
-        properties=properties,
-        process_person_profile=False,
-        event_uuid=str(run.id),
+    # Private internal event (cdp_internal_events topic), NOT the public capture pipeline — an
+    # internal_destination HogFunction filtered on vision_action_id delivers it. This is non-forgeable
+    # with the public project token, and (unlike capture) it does NOT land in the analytics events
+    # table — VisionActionRun is the durable history. `uuid=run.id` keeps the emit idempotent on retry.
+    produce_internal_event(
+        team_id=team.id,
+        event=InternalEventEvent(
+            event=_EVENT_NAME,
+            distinct_id=replay_vision_distinct_id(team.id),
+            uuid=str(run.id),
+            properties={
+                "vision_action_id": str(action.id),
+                "scanner_id": str(action.scanner_id) if action.scanner_id else None,
+                "vision_action_run_id": str(run.id),
+                "slack_text": run.output.get("slack", ""),
+                "action_url": action_url,
+            },
+        ),
     )
-    result.raise_for_status()

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -1,0 +1,154 @@
+"""Supporting activities for the vision-action engine: due scan, run lifecycle, advance, and emit."""
+
+import datetime as dt
+from datetime import UTC, datetime
+from uuid import UUID
+
+from django.conf import settings
+
+import structlog
+from temporalio import activity
+
+from posthog.api.capture_dispatch import capture_internal_routed
+from posthog.sync import database_sync_to_async
+
+from products.replay_vision.backend.models.vision_action import (
+    TriggerType,
+    VisionAction,
+    VisionActionRun,
+    VisionActionRunStatus,
+)
+from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
+from products.replay_vision.backend.temporal.decorators import track_activity
+from products.replay_vision.backend.temporal.vision_actions.types import (
+    CreateVisionActionRunInputs,
+    DueVisionAction,
+    EmitActionReadyInputs,
+    ScheduleAllVisionActionsInputs,
+    UpdateVisionActionRunInputs,
+)
+
+logger = structlog.get_logger(__name__)
+
+_EVENT_NAME = "$replay_vision_action_ready"
+_EVENT_SOURCE = "replay_vision"
+
+
+@activity.defn
+@track_activity()
+async def fetch_due_vision_actions_activity(inputs: ScheduleAllVisionActionsInputs) -> list[DueVisionAction]:
+    return await database_sync_to_async(_fetch_due, thread_sensitive=False)(inputs)
+
+
+def _fetch_due(inputs: ScheduleAllVisionActionsInputs) -> list[DueVisionAction]:
+    cutoff = datetime.now(UTC) + dt.timedelta(seconds=inputs.buffer_seconds)
+    # nosemgrep: semgrep.rules.idor-lookup-without-team — internal scheduler scans all teams
+    rows = VisionAction.all_teams.filter(
+        enabled=True,
+        trigger_type=TriggerType.SCHEDULE,
+        next_run_at__isnull=False,
+        next_run_at__lte=cutoff,
+    ).values_list("id", "team_id", "next_run_at")
+    return [DueVisionAction(vision_action_id=row[0], team_id=row[1], scheduled_at=row[2]) for row in rows]
+
+
+@activity.defn
+@track_activity()
+async def create_vision_action_run_activity(inputs: CreateVisionActionRunInputs) -> UUID:
+    return await database_sync_to_async(_create_run, thread_sensitive=False)(inputs)
+
+
+def _create_run(inputs: CreateVisionActionRunInputs) -> UUID:
+    # idempotency_key is unique → get_or_create makes the activity safe to retry.
+    run, _ = VisionActionRun.all_teams.get_or_create(
+        idempotency_key=inputs.idempotency_key,
+        defaults={
+            "vision_action_id": inputs.vision_action_id,
+            "team_id": inputs.team_id,
+            "temporal_workflow_id": inputs.temporal_workflow_id,
+            "scheduled_at": inputs.scheduled_at,
+            "status": VisionActionRunStatus.STARTING,
+        },
+    )
+    return run.id
+
+
+@activity.defn
+@track_activity()
+async def validate_vision_action_activity(vision_action_id: UUID) -> str | None:
+    """Return a skip reason if the action shouldn't deliver, else None."""
+    return await database_sync_to_async(_validate, thread_sensitive=False)(vision_action_id)
+
+
+def _validate(vision_action_id: UUID) -> str | None:
+    action = VisionAction.all_teams.filter(pk=vision_action_id).first()
+    if action is None:
+        return "not_found"
+    if not action.enabled:
+        return "disabled"
+    if action.hog_flow_id is None:
+        return "no_delivery_flow"
+    return None
+
+
+@activity.defn
+@track_activity()
+async def update_vision_action_run_activity(inputs: UpdateVisionActionRunInputs) -> None:
+    await database_sync_to_async(_update_run, thread_sensitive=False)(inputs)
+
+
+def _update_run(inputs: UpdateVisionActionRunInputs) -> None:
+    # .update() bypasses auto_now, so stamp updated_at explicitly.
+    VisionActionRun.all_teams.filter(pk=inputs.run_id).update(
+        status=inputs.status, error=inputs.error, updated_at=datetime.now(UTC)
+    )
+
+
+@activity.defn
+@track_activity()
+async def advance_next_run_at_activity(vision_action_id: UUID) -> None:
+    await database_sync_to_async(_advance_next_run, thread_sensitive=False)(vision_action_id)
+
+
+def _advance_next_run(vision_action_id: UUID) -> None:
+    action = VisionAction.all_teams.filter(pk=vision_action_id).first()
+    if action is None:
+        return
+    # Recompute to the next occurrence after now and stamp the run time. The save() guard won't
+    # re-touch next_run_at (rrule unchanged), so our computed value is what persists.
+    action._recompute_next_run_at()
+    action.last_run_at = datetime.now(UTC)
+    action.save(update_fields=["next_run_at", "last_run_at", "updated_at"])
+
+
+@activity.defn
+@track_activity()
+async def emit_action_ready_activity(inputs: EmitActionReadyInputs) -> None:
+    await database_sync_to_async(_emit, thread_sensitive=False)(inputs)
+
+
+def _emit(inputs: EmitActionReadyInputs) -> None:
+    run = VisionActionRun.all_teams.select_related("vision_action", "team").get(pk=inputs.run_id)
+    action = run.vision_action
+    team = run.team
+
+    action_url = f"{settings.SITE_URL}/project/{team.id}/replay/vision-actions/{action.id}"
+    properties = {
+        "$insert_id": str(run.id),
+        "vision_action_id": str(action.id),
+        "scanner_id": str(action.scanner_id) if action.scanner_id else None,
+        "vision_action_run_id": str(run.id),
+        "slack_text": run.slack_text,
+        "action_url": action_url,
+    }
+    result = capture_internal_routed(
+        token=team.api_token,
+        event_name=_EVENT_NAME,
+        event_source=_EVENT_SOURCE,
+        distinct_id=replay_vision_distinct_id(team.id),
+        timestamp=datetime.now(UTC),
+        properties=properties,
+        process_person_profile=False,
+        event_uuid=str(run.id),
+    )
+    result.raise_for_status()

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -26,6 +26,7 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
     EmitActionReadyInputs,
     EvaluateDueVisionActionsInputs,
     UpdateVisionActionRunInputs,
+    ValidateVisionActionInputs,
 )
 
 logger = structlog.get_logger(__name__)
@@ -79,8 +80,9 @@ async def create_vision_action_run_activity(inputs: CreateVisionActionRunInputs)
 
 
 def _create_run(inputs: CreateVisionActionRunInputs) -> UUID:
-    # idempotency_key is unique → get_or_create makes the activity safe to retry.
-    run, _ = VisionActionRun.all_teams.get_or_create(
+    # idempotency_key is unique → get_or_create makes the activity safe to retry. for_team scopes the
+    # lookup; team_id stays in defaults because the filter doesn't propagate into row creation.
+    run, _ = VisionActionRun.objects.for_team(inputs.team_id).get_or_create(
         idempotency_key=inputs.idempotency_key,
         defaults={
             "vision_action_id": inputs.vision_action_id,
@@ -95,13 +97,13 @@ def _create_run(inputs: CreateVisionActionRunInputs) -> UUID:
 
 @activity.defn
 @track_activity()
-async def validate_vision_action_activity(vision_action_id: UUID) -> str | None:
+async def validate_vision_action_activity(inputs: ValidateVisionActionInputs) -> str | None:
     """Return a skip reason if the action shouldn't deliver, else None."""
-    return await database_sync_to_async(_validate, thread_sensitive=False)(vision_action_id)
+    return await database_sync_to_async(_validate, thread_sensitive=False)(inputs)
 
 
-def _validate(vision_action_id: UUID) -> str | None:
-    action = VisionAction.all_teams.filter(pk=vision_action_id).first()
+def _validate(inputs: ValidateVisionActionInputs) -> str | None:
+    action = VisionAction.objects.for_team(inputs.team_id).filter(pk=inputs.vision_action_id).first()
     if action is None:
         return "not_found"
     if not action.enabled:
@@ -119,7 +121,7 @@ async def update_vision_action_run_activity(inputs: UpdateVisionActionRunInputs)
 
 def _update_run(inputs: UpdateVisionActionRunInputs) -> None:
     # .update() bypasses auto_now, so stamp updated_at explicitly.
-    VisionActionRun.all_teams.filter(pk=inputs.run_id).update(
+    VisionActionRun.objects.for_team(inputs.team_id).filter(pk=inputs.run_id).update(
         status=inputs.status, error=inputs.error, updated_at=datetime.now(UTC)
     )
 
@@ -131,7 +133,7 @@ async def emit_action_ready_activity(inputs: EmitActionReadyInputs) -> None:
 
 
 def _emit(inputs: EmitActionReadyInputs) -> None:
-    run = VisionActionRun.all_teams.select_related("vision_action", "team").get(pk=inputs.run_id)
+    run = VisionActionRun.objects.for_team(inputs.team_id).select_related("vision_action", "team").get(pk=inputs.run_id)
     action = run.vision_action
     team = run.team
 

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -67,7 +67,7 @@ def _create_run(inputs: CreateVisionActionRunInputs) -> UUID:
             "team_id": inputs.team_id,
             "temporal_workflow_id": inputs.temporal_workflow_id,
             "scheduled_at": inputs.scheduled_at,
-            "status": VisionActionRunStatus.STARTING,
+            "status": VisionActionRunStatus.RUNNING,
         },
     )
     return run.id
@@ -138,7 +138,7 @@ def _emit(inputs: EmitActionReadyInputs) -> None:
         "vision_action_id": str(action.id),
         "scanner_id": str(action.scanner_id) if action.scanner_id else None,
         "vision_action_run_id": str(run.id),
-        "slack_text": run.slack_text,
+        "slack_text": run.output.get("slack", ""),
         "action_url": action_url,
     }
     result = capture_internal_routed(

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -1,10 +1,10 @@
-"""Supporting activities for the vision-action engine: due scan, run lifecycle, advance, and emit."""
+"""Supporting activities for the vision-action engine: per-scanner eligibility/claim, run lifecycle, and emit."""
 
-import datetime as dt
 from datetime import UTC, datetime
 from uuid import UUID
 
 from django.conf import settings
+from django.db import transaction
 
 import structlog
 from temporalio import activity
@@ -24,7 +24,7 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
     CreateVisionActionRunInputs,
     DueVisionAction,
     EmitActionReadyInputs,
-    ScheduleAllVisionActionsInputs,
+    EvaluateDueVisionActionsInputs,
     UpdateVisionActionRunInputs,
 )
 
@@ -36,20 +36,40 @@ _EVENT_SOURCE = "replay_vision"
 
 @activity.defn
 @track_activity()
-async def fetch_due_vision_actions_activity(inputs: ScheduleAllVisionActionsInputs) -> list[DueVisionAction]:
-    return await database_sync_to_async(_fetch_due, thread_sensitive=False)(inputs)
+async def evaluate_due_vision_actions_activity(inputs: EvaluateDueVisionActionsInputs) -> list[DueVisionAction]:
+    return await database_sync_to_async(_evaluate_due, thread_sensitive=False)(inputs)
 
 
-def _fetch_due(inputs: ScheduleAllVisionActionsInputs) -> list[DueVisionAction]:
-    cutoff = datetime.now(UTC) + dt.timedelta(seconds=inputs.buffer_seconds)
-    # nosemgrep: semgrep.rules.idor-lookup-without-team — internal scheduler scans all teams
-    rows = VisionAction.all_teams.filter(
-        enabled=True,
-        trigger_type=TriggerType.SCHEDULE,
-        next_run_at__isnull=False,
-        next_run_at__lte=cutoff,
-    ).values_list("id", "team_id", "next_run_at")
-    return [DueVisionAction(vision_action_id=row[0], team_id=row[1], scheduled_at=row[2]) for row in rows]
+def _evaluate_due(inputs: EvaluateDueVisionActionsInputs) -> list[DueVisionAction]:
+    """Return this scanner's due schedule actions, claiming each by advancing next_run_at.
+
+    The claim happens in the same transaction as the read so the next sweep can't re-fire an action
+    while its child is still running — advancing the cursor here (not in the child) is what prevents
+    a slow or failed child from hot-looping.
+    """
+    now = datetime.now(UTC)
+    due: list[DueVisionAction] = []
+    with transaction.atomic():
+        # for_team scopes the read to one team (no all_teams scan); select_for_update guards against
+        # a concurrent claim (belt-and-suspenders — per-scanner sweeps are already serialized).
+        actions = (
+            VisionAction.objects.for_team(inputs.team_id)
+            .select_for_update()
+            .filter(
+                scanner_id=inputs.scanner_id,
+                enabled=True,
+                trigger_type=TriggerType.SCHEDULE,
+                next_run_at__isnull=False,
+                next_run_at__lte=now,
+            )
+        )
+        for action in actions:
+            scheduled_at = action.next_run_at
+            action._recompute_next_run_at()
+            action.last_run_at = now
+            action.save(update_fields=["next_run_at", "last_run_at", "updated_at"])
+            due.append(DueVisionAction(vision_action_id=action.id, team_id=action.team_id, scheduled_at=scheduled_at))
+    return due
 
 
 @activity.defn
@@ -102,23 +122,6 @@ def _update_run(inputs: UpdateVisionActionRunInputs) -> None:
     VisionActionRun.all_teams.filter(pk=inputs.run_id).update(
         status=inputs.status, error=inputs.error, updated_at=datetime.now(UTC)
     )
-
-
-@activity.defn
-@track_activity()
-async def advance_next_run_at_activity(vision_action_id: UUID) -> None:
-    await database_sync_to_async(_advance_next_run, thread_sensitive=False)(vision_action_id)
-
-
-def _advance_next_run(vision_action_id: UUID) -> None:
-    action = VisionAction.all_teams.filter(pk=vision_action_id).first()
-    if action is None:
-        return
-    # Recompute to the next occurrence after now and stamp the run time. The save() guard won't
-    # re-touch next_run_at (rrule unchanged), so our computed value is what persists.
-    action._recompute_next_run_at()
-    action.last_run_at = datetime.now(UTC)
-    action.save(update_fields=["next_run_at", "last_run_at", "updated_at"])
 
 
 @activity.defn

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -64,9 +64,11 @@ async def synthesize_group_summary_activity(inputs: SynthesizeGroupSummaryInputs
 
 
 def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryResult:
-    run = VisionActionRun.all_teams.select_related(
-        "vision_action", "team", "team__organization", "vision_action__created_by"
-    ).get(pk=inputs.run_id)
+    run = (
+        VisionActionRun.objects.for_team(inputs.team_id)
+        .select_related("vision_action", "team", "team__organization", "vision_action__created_by")
+        .get(pk=inputs.run_id)
+    )
     action = run.vision_action
     team = run.team
 

--- a/products/replay_vision/backend/temporal/vision_actions/types.py
+++ b/products/replay_vision/backend/temporal/vision_actions/types.py
@@ -23,17 +23,19 @@ class SynthesizeGroupSummaryResult(BaseModel, frozen=True):
     observation_count: int = 0
 
 
-# --- engine (scheduling + per-action processing) ---
+# --- engine (per-scanner eligibility + per-action processing) ---
 
 
-class ScheduleAllVisionActionsInputs(BaseModel, frozen=True):
-    # Look-ahead so an action whose next_run_at falls within the next tick is picked up now.
-    buffer_seconds: int = 120
+class EvaluateDueVisionActionsInputs(BaseModel, frozen=True):
+    # Scoped to one scanner (the sweep already knows scanner + team) → no cross-team scan.
+    scanner_id: UUID
+    team_id: int
 
 
 class DueVisionAction(BaseModel, frozen=True):
     vision_action_id: UUID
     team_id: int
+    # The next_run_at that fired this action, captured before the claim advanced it.
     scheduled_at: datetime | None = None
 
 

--- a/products/replay_vision/backend/temporal/vision_actions/types.py
+++ b/products/replay_vision/backend/temporal/vision_actions/types.py
@@ -14,8 +14,9 @@ class SynthesisStatus(str, Enum):
 
 
 class SynthesizeGroupSummaryInputs(BaseModel, frozen=True):
-    # The run already references its action (run.vision_action), so run_id is sufficient.
+    # The run already references its action (run.vision_action); team_id scopes the fail-closed read.
     run_id: UUID
+    team_id: int
 
 
 class SynthesizeGroupSummaryResult(BaseModel, frozen=True):
@@ -53,11 +54,18 @@ class CreateVisionActionRunInputs(BaseModel, frozen=True):
     scheduled_at: datetime | None = None
 
 
+class ValidateVisionActionInputs(BaseModel, frozen=True):
+    vision_action_id: UUID
+    team_id: int
+
+
 class UpdateVisionActionRunInputs(BaseModel, frozen=True):
     run_id: UUID
+    team_id: int
     status: str
     error: dict | None = None
 
 
 class EmitActionReadyInputs(BaseModel, frozen=True):
     run_id: UUID
+    team_id: int

--- a/products/replay_vision/backend/temporal/vision_actions/types.py
+++ b/products/replay_vision/backend/temporal/vision_actions/types.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from uuid import UUID
 
@@ -20,3 +21,41 @@ class SynthesizeGroupSummaryInputs(BaseModel, frozen=True):
 class SynthesizeGroupSummaryResult(BaseModel, frozen=True):
     status: SynthesisStatus
     observation_count: int = 0
+
+
+# --- engine (scheduling + per-action processing) ---
+
+
+class ScheduleAllVisionActionsInputs(BaseModel, frozen=True):
+    # Look-ahead so an action whose next_run_at falls within the next tick is picked up now.
+    buffer_seconds: int = 120
+
+
+class DueVisionAction(BaseModel, frozen=True):
+    vision_action_id: UUID
+    team_id: int
+    scheduled_at: datetime | None = None
+
+
+class ProcessVisionActionInputs(BaseModel, frozen=True):
+    vision_action_id: UUID
+    team_id: int
+    scheduled_at: datetime | None = None
+
+
+class CreateVisionActionRunInputs(BaseModel, frozen=True):
+    vision_action_id: UUID
+    team_id: int
+    idempotency_key: str
+    temporal_workflow_id: str
+    scheduled_at: datetime | None = None
+
+
+class UpdateVisionActionRunInputs(BaseModel, frozen=True):
+    run_id: UUID
+    status: str
+    error: dict | None = None
+
+
+class EmitActionReadyInputs(BaseModel, frozen=True):
+    run_id: UUID

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -19,7 +19,7 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
     EmitActionReadyInputs,
     ProcessVisionActionInputs,
     SynthesisStatus,
-    SynthesizeActionInputs,
+    SynthesizeGroupSummaryInputs,
     UpdateVisionActionRunInputs,
 )
 
@@ -32,7 +32,7 @@ with wf.unsafe.imports_passed_through():
         update_vision_action_run_activity,
         validate_vision_action_activity,
     )
-    from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
+    from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_group_summary_activity
 
 _RECORD_RETRY = common.RetryPolicy(initial_interval=dt.timedelta(seconds=5), maximum_attempts=3)
 _SYNTH_RETRY = common.RetryPolicy(
@@ -78,8 +78,8 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                 return  # final_status stays SKIPPED (the initialized default)
 
             synth = await wf.execute_activity(
-                synthesize_action_activity,
-                SynthesizeActionInputs(run_id=run_id),
+                synthesize_group_summary_activity,
+                SynthesizeGroupSummaryInputs(run_id=run_id),
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=_SYNTH_RETRY,
             )

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -1,0 +1,206 @@
+"""Vision-action engine workflows: schedule fan-out and per-action processing."""
+
+import asyncio
+import datetime as dt
+from typing import TYPE_CHECKING
+
+import temporalio.workflow as wf
+from temporalio import common
+from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from products.replay_vision.backend.temporal.vision_actions.types import (
+    CreateVisionActionRunInputs,
+    EmitActionReadyInputs,
+    ProcessVisionActionInputs,
+    ScheduleAllVisionActionsInputs,
+    SynthesisStatus,
+    SynthesizeActionInputs,
+    UpdateVisionActionRunInputs,
+)
+
+# `activities` + the synthesis activity pull in Django/ee, which the workflow sandbox can't re-import.
+with wf.unsafe.imports_passed_through():
+    from products.replay_vision.backend.models.vision_action import VisionActionRunStatus
+    from products.replay_vision.backend.temporal.vision_actions.activities import (
+        advance_next_run_at_activity,
+        create_vision_action_run_activity,
+        emit_action_ready_activity,
+        fetch_due_vision_actions_activity,
+        update_vision_action_run_activity,
+        validate_vision_action_activity,
+    )
+    from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
+
+if TYPE_CHECKING:
+    from temporalio.client import Client
+
+SCHEDULE_ALL_WORKFLOW_NAME = "schedule-all-vision-actions"
+PROCESS_WORKFLOW_NAME = "process-vision-action"
+SCHEDULE_ID = "replay-vision-actions-schedule"
+SCHEDULE_WORKFLOW_ID = "replay-vision-actions"
+SCHEDULE_INTERVAL = dt.timedelta(minutes=5)
+SCHEDULE_EXECUTION_TIMEOUT = dt.timedelta(minutes=30)
+_PROCESS_EXECUTION_TIMEOUT = dt.timedelta(hours=1)
+
+_FETCH_RETRY = common.RetryPolicy(
+    initial_interval=dt.timedelta(seconds=10), maximum_interval=dt.timedelta(minutes=5), maximum_attempts=3
+)
+_RECORD_RETRY = common.RetryPolicy(initial_interval=dt.timedelta(seconds=5), maximum_attempts=3)
+_SYNTH_RETRY = common.RetryPolicy(
+    initial_interval=dt.timedelta(seconds=30), maximum_interval=dt.timedelta(minutes=5), maximum_attempts=3
+)
+_EMIT_RETRY = common.RetryPolicy(initial_interval=dt.timedelta(seconds=10), maximum_attempts=3)
+
+
+@wf.defn(name=SCHEDULE_ALL_WORKFLOW_NAME)
+class ScheduleAllVisionActionsWorkflow(PostHogWorkflow):
+    """Parent fan-out: find due schedule actions and start one child per action."""
+
+    inputs_cls = ScheduleAllVisionActionsInputs
+    inputs_optional = True
+
+    @wf.run
+    async def run(self, inputs: ScheduleAllVisionActionsInputs) -> None:
+        due = await wf.execute_activity(
+            fetch_due_vision_actions_activity,
+            inputs,
+            start_to_close_timeout=dt.timedelta(minutes=5),
+            retry_policy=_FETCH_RETRY,
+        )
+        if not due:
+            return
+
+        tasks = [
+            wf.execute_child_workflow(
+                ProcessVisionActionWorkflow.run,
+                ProcessVisionActionInputs(
+                    vision_action_id=d.vision_action_id, team_id=d.team_id, scheduled_at=d.scheduled_at
+                ),
+                # Deterministic id dedups overlapping ticks: a still-running action is skipped, not double-fired.
+                id=f"process-vision-action-{d.vision_action_id}",
+                parent_close_policy=wf.ParentClosePolicy.ABANDON,
+                execution_timeout=_PROCESS_EXECUTION_TIMEOUT,
+            )
+            for d in due
+        ]
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        failed: list[str] = []
+        for d, result in zip(due, results):
+            if isinstance(result, BaseException):
+                if isinstance(result, WorkflowAlreadyStartedError):
+                    wf.logger.info("vision_action.already_running", vision_action_id=str(d.vision_action_id))
+                else:
+                    failed.append(str(d.vision_action_id))
+        if failed:
+            raise ApplicationError(f"Vision action deliveries failed for: {failed}", non_retryable=True)
+
+
+@wf.defn(name=PROCESS_WORKFLOW_NAME)
+class ProcessVisionActionWorkflow(PostHogWorkflow):
+    """Per-action: create run → validate → synthesize → emit, always updating the run and advancing the schedule."""
+
+    inputs_cls = ProcessVisionActionInputs
+
+    @wf.run
+    async def run(self, inputs: ProcessVisionActionInputs) -> None:
+        run_id = None
+        final_status = VisionActionRunStatus.SKIPPED.value
+        error_info: dict | None = None
+        caught: BaseException | None = None
+
+        try:
+            run_id = await wf.execute_activity(
+                create_vision_action_run_activity,
+                CreateVisionActionRunInputs(
+                    vision_action_id=inputs.vision_action_id,
+                    team_id=inputs.team_id,
+                    idempotency_key=str(wf.uuid4()),
+                    temporal_workflow_id=wf.info().workflow_id,
+                    scheduled_at=inputs.scheduled_at,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=_RECORD_RETRY,
+            )
+
+            skip_reason = await wf.execute_activity(
+                validate_vision_action_activity,
+                inputs.vision_action_id,
+                start_to_close_timeout=dt.timedelta(minutes=1),
+                retry_policy=_RECORD_RETRY,
+            )
+            if skip_reason is not None:
+                final_status = VisionActionRunStatus.SKIPPED.value
+                return
+
+            synth = await wf.execute_activity(
+                synthesize_action_activity,
+                SynthesizeActionInputs(vision_action_id=inputs.vision_action_id, run_id=run_id),
+                start_to_close_timeout=dt.timedelta(minutes=10),
+                retry_policy=_SYNTH_RETRY,
+            )
+            if synth.status in (SynthesisStatus.ABORTED_NO_CONSENT, SynthesisStatus.ABORTED_NO_USER):
+                final_status = VisionActionRunStatus.FAILED.value
+                return
+            if synth.status in (SynthesisStatus.SKIPPED_EMPTY, SynthesisStatus.SKIPPED_OVER_BUDGET):
+                final_status = VisionActionRunStatus.SKIPPED.value
+                return
+
+            await wf.execute_activity(
+                emit_action_ready_activity,
+                EmitActionReadyInputs(run_id=run_id),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=_EMIT_RETRY,
+            )
+            final_status = VisionActionRunStatus.COMPLETED.value
+
+        except Exception as e:
+            caught = e
+            final_status = VisionActionRunStatus.FAILED.value
+            error_info = {"message": str(e)[:500]}
+
+        finally:
+            if run_id is not None:
+                try:
+                    await wf.execute_activity(
+                        update_vision_action_run_activity,
+                        UpdateVisionActionRunInputs(run_id=run_id, status=final_status, error=error_info),
+                        start_to_close_timeout=dt.timedelta(minutes=2),
+                        retry_policy=_RECORD_RETRY,
+                    )
+                except Exception:
+                    wf.logger.exception(
+                        "vision_action.update_run_failed", vision_action_id=str(inputs.vision_action_id)
+                    )
+                    if caught is None:
+                        raise
+            # Always advance — even a failed run must not hot-loop on the same next_run_at.
+            await wf.execute_activity(
+                advance_next_run_at_activity,
+                inputs.vision_action_id,
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=_RECORD_RETRY,
+            )
+
+        # Re-raise after finally — Temporal blocks activity scheduling while an exception propagates.
+        if caught:
+            raise caught
+
+
+async def create_replay_vision_actions_schedule(client: "Client") -> None:
+    """Upsert the global vision-actions fan-out schedule. Called from worker startup."""
+    # Function-local: this module holds `@wf.defn`, and the sandbox can't re-import the schedule
+    # helper's Django/temporalio.client dependencies when validating the workflow.
+    from products.replay_vision.backend.temporal.schedule import upsert_interval_schedule  # noqa: PLC0415
+
+    await upsert_interval_schedule(
+        client,
+        schedule_id=SCHEDULE_ID,
+        workflow_name=SCHEDULE_ALL_WORKFLOW_NAME,
+        workflow_id=SCHEDULE_WORKFLOW_ID,
+        inputs=ScheduleAllVisionActionsInputs(),
+        interval=SCHEDULE_INTERVAL,
+        execution_timeout=SCHEDULE_EXECUTION_TIMEOUT,
+    )

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -132,12 +132,11 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                 retry_policy=_RECORD_RETRY,
             )
             if skip_reason is not None:
-                final_status = VisionActionRunStatus.SKIPPED.value
-                return
+                return  # final_status stays SKIPPED (the initialized default)
 
             synth = await wf.execute_activity(
                 synthesize_action_activity,
-                SynthesizeActionInputs(vision_action_id=inputs.vision_action_id, run_id=run_id),
+                SynthesizeActionInputs(run_id=run_id),
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=_SYNTH_RETRY,
             )
@@ -145,8 +144,7 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                 final_status = VisionActionRunStatus.FAILED.value
                 return
             if synth.status in (SynthesisStatus.SKIPPED_EMPTY, SynthesisStatus.SKIPPED_OVER_BUDGET):
-                final_status = VisionActionRunStatus.SKIPPED.value
-                return
+                return  # final_status stays SKIPPED (the initialized default)
 
             await wf.execute_activity(
                 emit_action_ready_activity,
@@ -177,12 +175,18 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                     if caught is None:
                         raise
             # Always advance — even a failed run must not hot-loop on the same next_run_at.
-            await wf.execute_activity(
-                advance_next_run_at_activity,
-                inputs.vision_action_id,
-                start_to_close_timeout=dt.timedelta(minutes=2),
-                retry_policy=_RECORD_RETRY,
-            )
+            try:
+                await wf.execute_activity(
+                    advance_next_run_at_activity,
+                    inputs.vision_action_id,
+                    start_to_close_timeout=dt.timedelta(minutes=2),
+                    retry_policy=_RECORD_RETRY,
+                )
+            except Exception:
+                # Must not overwrite a caught error from the body — re-raise only if there was none.
+                wf.logger.exception("vision_action.advance_failed", vision_action_id=str(inputs.vision_action_id))
+                if caught is None:
+                    raise
 
         # Re-raise after finally — Temporal blocks activity scheduling while an exception propagates.
         if caught:

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -21,6 +21,7 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
     SynthesisStatus,
     SynthesizeGroupSummaryInputs,
     UpdateVisionActionRunInputs,
+    ValidateVisionActionInputs,
 )
 
 # `activities` + the synthesis activity pull in Django/ee, which the workflow sandbox can't re-import.
@@ -70,7 +71,7 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
 
             skip_reason = await wf.execute_activity(
                 validate_vision_action_activity,
-                inputs.vision_action_id,
+                ValidateVisionActionInputs(vision_action_id=inputs.vision_action_id, team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=1),
                 retry_policy=_RECORD_RETRY,
             )
@@ -79,7 +80,7 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
 
             synth = await wf.execute_activity(
                 synthesize_group_summary_activity,
-                SynthesizeGroupSummaryInputs(run_id=run_id),
+                SynthesizeGroupSummaryInputs(run_id=run_id, team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=_SYNTH_RETRY,
             )
@@ -91,7 +92,7 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
 
             await wf.execute_activity(
                 emit_action_ready_activity,
-                EmitActionReadyInputs(run_id=run_id),
+                EmitActionReadyInputs(run_id=run_id, team_id=inputs.team_id),
                 start_to_close_timeout=dt.timedelta(minutes=2),
                 retry_policy=_EMIT_RETRY,
             )
@@ -107,16 +108,21 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                 try:
                     await wf.execute_activity(
                         update_vision_action_run_activity,
-                        UpdateVisionActionRunInputs(run_id=run_id, status=final_status, error=error_info),
+                        UpdateVisionActionRunInputs(
+                            run_id=run_id, team_id=inputs.team_id, status=final_status, error=error_info
+                        ),
                         start_to_close_timeout=dt.timedelta(minutes=2),
                         retry_policy=_RECORD_RETRY,
                     )
                 except Exception:
+                    # If the body already succeeded, the delivery event was emitted (Slack post happened);
+                    # a failed bookkeeping update must not flip the workflow to FAILED — re-running would
+                    # double-post. Log loudly and let the workflow finish; the run row may stay RUNNING
+                    # (cosmetic, a post-MVP reconciler can resolve it). If the body failed, the original
+                    # error still re-raises below — the update failure must not mask it.
                     wf.logger.exception(
                         "vision_action.update_run_failed", vision_action_id=str(inputs.vision_action_id)
                     )
-                    if caught is None:
-                        raise
 
         # Re-raise after finally — Temporal blocks activity scheduling while an exception propagates.
         if caught:

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -76,7 +76,9 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                 retry_policy=_RECORD_RETRY,
             )
             if skip_reason is not None:
-                return  # final_status stays SKIPPED (the initialized default)
+                # final_status stays SKIPPED; record why so the run isn't an unexplained skip.
+                error_info = {"skip_reason": skip_reason}
+                return
 
             synth = await wf.execute_activity(
                 synthesize_group_summary_activity,
@@ -86,9 +88,12 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
             )
             if synth.status in (SynthesisStatus.ABORTED_NO_CONSENT, SynthesisStatus.ABORTED_NO_USER):
                 final_status = VisionActionRunStatus.FAILED.value
+                error_info = {"aborted": synth.status.value}
                 return
             if synth.status in (SynthesisStatus.SKIPPED_EMPTY, SynthesisStatus.SKIPPED_OVER_BUDGET):
-                return  # final_status stays SKIPPED (the initialized default)
+                # final_status stays SKIPPED; record why so the run isn't an unexplained skip.
+                error_info = {"skip_reason": synth.status.value}
+                return
 
             await wf.execute_activity(
                 emit_action_ready_activity,

--- a/products/replay_vision/backend/temporal/vision_actions/workflows.py
+++ b/products/replay_vision/backend/temporal/vision_actions/workflows.py
@@ -1,20 +1,23 @@
-"""Vision-action engine workflows: schedule fan-out and per-action processing."""
+"""Vision-action engine: the per-action processing workflow.
 
-import asyncio
+The trigger is the per-scanner sweep (`SweepScannerWorkflow`), not a standalone schedule — the
+sweep evaluates due actions and fire-and-forgets one of these children per action. The schedule
+cursor is advanced at claim time in `evaluate_due_vision_actions_activity`, so this workflow never
+touches `next_run_at`.
+"""
+
 import datetime as dt
-from typing import TYPE_CHECKING
 
 import temporalio.workflow as wf
 from temporalio import common
-from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.temporal.common.base import PostHogWorkflow
 
+from products.replay_vision.backend.temporal.constants import PROCESS_VISION_ACTION_WORKFLOW_NAME
 from products.replay_vision.backend.temporal.vision_actions.types import (
     CreateVisionActionRunInputs,
     EmitActionReadyInputs,
     ProcessVisionActionInputs,
-    ScheduleAllVisionActionsInputs,
     SynthesisStatus,
     SynthesizeActionInputs,
     UpdateVisionActionRunInputs,
@@ -24,29 +27,13 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
 with wf.unsafe.imports_passed_through():
     from products.replay_vision.backend.models.vision_action import VisionActionRunStatus
     from products.replay_vision.backend.temporal.vision_actions.activities import (
-        advance_next_run_at_activity,
         create_vision_action_run_activity,
         emit_action_ready_activity,
-        fetch_due_vision_actions_activity,
         update_vision_action_run_activity,
         validate_vision_action_activity,
     )
     from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
 
-if TYPE_CHECKING:
-    from temporalio.client import Client
-
-SCHEDULE_ALL_WORKFLOW_NAME = "schedule-all-vision-actions"
-PROCESS_WORKFLOW_NAME = "process-vision-action"
-SCHEDULE_ID = "replay-vision-actions-schedule"
-SCHEDULE_WORKFLOW_ID = "replay-vision-actions"
-SCHEDULE_INTERVAL = dt.timedelta(minutes=5)
-SCHEDULE_EXECUTION_TIMEOUT = dt.timedelta(minutes=30)
-_PROCESS_EXECUTION_TIMEOUT = dt.timedelta(hours=1)
-
-_FETCH_RETRY = common.RetryPolicy(
-    initial_interval=dt.timedelta(seconds=10), maximum_interval=dt.timedelta(minutes=5), maximum_attempts=3
-)
 _RECORD_RETRY = common.RetryPolicy(initial_interval=dt.timedelta(seconds=5), maximum_attempts=3)
 _SYNTH_RETRY = common.RetryPolicy(
     initial_interval=dt.timedelta(seconds=30), maximum_interval=dt.timedelta(minutes=5), maximum_attempts=3
@@ -54,53 +41,9 @@ _SYNTH_RETRY = common.RetryPolicy(
 _EMIT_RETRY = common.RetryPolicy(initial_interval=dt.timedelta(seconds=10), maximum_attempts=3)
 
 
-@wf.defn(name=SCHEDULE_ALL_WORKFLOW_NAME)
-class ScheduleAllVisionActionsWorkflow(PostHogWorkflow):
-    """Parent fan-out: find due schedule actions and start one child per action."""
-
-    inputs_cls = ScheduleAllVisionActionsInputs
-    inputs_optional = True
-
-    @wf.run
-    async def run(self, inputs: ScheduleAllVisionActionsInputs) -> None:
-        due = await wf.execute_activity(
-            fetch_due_vision_actions_activity,
-            inputs,
-            start_to_close_timeout=dt.timedelta(minutes=5),
-            retry_policy=_FETCH_RETRY,
-        )
-        if not due:
-            return
-
-        tasks = [
-            wf.execute_child_workflow(
-                ProcessVisionActionWorkflow.run,
-                ProcessVisionActionInputs(
-                    vision_action_id=d.vision_action_id, team_id=d.team_id, scheduled_at=d.scheduled_at
-                ),
-                # Deterministic id dedups overlapping ticks: a still-running action is skipped, not double-fired.
-                id=f"process-vision-action-{d.vision_action_id}",
-                parent_close_policy=wf.ParentClosePolicy.ABANDON,
-                execution_timeout=_PROCESS_EXECUTION_TIMEOUT,
-            )
-            for d in due
-        ]
-
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        failed: list[str] = []
-        for d, result in zip(due, results):
-            if isinstance(result, BaseException):
-                if isinstance(result, WorkflowAlreadyStartedError):
-                    wf.logger.info("vision_action.already_running", vision_action_id=str(d.vision_action_id))
-                else:
-                    failed.append(str(d.vision_action_id))
-        if failed:
-            raise ApplicationError(f"Vision action deliveries failed for: {failed}", non_retryable=True)
-
-
-@wf.defn(name=PROCESS_WORKFLOW_NAME)
+@wf.defn(name=PROCESS_VISION_ACTION_WORKFLOW_NAME)
 class ProcessVisionActionWorkflow(PostHogWorkflow):
-    """Per-action: create run → validate → synthesize → emit, always updating the run and advancing the schedule."""
+    """Per-action: create run → validate → synthesize → emit, always updating the run at the end."""
 
     inputs_cls = ProcessVisionActionInputs
 
@@ -174,37 +117,7 @@ class ProcessVisionActionWorkflow(PostHogWorkflow):
                     )
                     if caught is None:
                         raise
-            # Always advance — even a failed run must not hot-loop on the same next_run_at.
-            try:
-                await wf.execute_activity(
-                    advance_next_run_at_activity,
-                    inputs.vision_action_id,
-                    start_to_close_timeout=dt.timedelta(minutes=2),
-                    retry_policy=_RECORD_RETRY,
-                )
-            except Exception:
-                # Must not overwrite a caught error from the body — re-raise only if there was none.
-                wf.logger.exception("vision_action.advance_failed", vision_action_id=str(inputs.vision_action_id))
-                if caught is None:
-                    raise
 
         # Re-raise after finally — Temporal blocks activity scheduling while an exception propagates.
         if caught:
             raise caught
-
-
-async def create_replay_vision_actions_schedule(client: "Client") -> None:
-    """Upsert the global vision-actions fan-out schedule. Called from worker startup."""
-    # Function-local: this module holds `@wf.defn`, and the sandbox can't re-import the schedule
-    # helper's Django/temporalio.client dependencies when validating the workflow.
-    from products.replay_vision.backend.temporal.schedule import upsert_interval_schedule  # noqa: PLC0415
-
-    await upsert_interval_schedule(
-        client,
-        schedule_id=SCHEDULE_ID,
-        workflow_name=SCHEDULE_ALL_WORKFLOW_NAME,
-        workflow_id=SCHEDULE_WORKFLOW_ID,
-        inputs=ScheduleAllVisionActionsInputs(),
-        interval=SCHEDULE_INTERVAL,
-        execution_timeout=SCHEDULE_EXECUTION_TIMEOUT,
-    )

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -442,6 +442,29 @@ async def test_sweep_dispatches_a_child_per_due_vision_action() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sweep_one_failed_vision_child_does_not_drop_the_others() -> None:
+    # Each due action is already claimed independently, so one child failing to start must not abort
+    # dispatch of the rest — the others still get fired this sweep.
+    failing = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=42)
+    ok = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=42)
+    mocks = _SweepMocks(
+        activity_results={
+            evaluate_due_vision_actions_activity: [failing, ok],
+            find_scanner_candidates_activity: FindScannerCandidatesOutput(candidates=[], saturated=False),
+        },
+        child_errors_for_ids={
+            build_process_vision_action_workflow_id(failing.vision_action_id): RuntimeError("temporal blip")
+        },
+    )
+
+    await _run_sweep(mocks)
+
+    started = {call["id"] for call in mocks.child_calls}
+    # Both were attempted; the healthy one's start is recorded despite the other failing.
+    assert build_process_vision_action_workflow_id(ok.vision_action_id) in started
+
+
+@pytest.mark.asyncio
 async def test_sweep_vision_action_failure_does_not_block_session_scan() -> None:
     # A vision-action child that fails to start must not abort the scanner's core duty: the session
     # scan still runs and advances its watermark.

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -17,7 +17,10 @@ from products.replay_vision.backend.temporal.activities.advance_scanner_watermar
 )
 from products.replay_vision.backend.temporal.activities.count_in_flight_applies import count_in_flight_applies_activity
 from products.replay_vision.backend.temporal.activities.find_scanner_candidates import find_scanner_candidates_activity
-from products.replay_vision.backend.temporal.constants import MAX_IN_FLIGHT_APPLIES_PER_SCANNER
+from products.replay_vision.backend.temporal.constants import (
+    MAX_IN_FLIGHT_APPLIES_PER_SCANNER,
+    build_process_vision_action_workflow_id,
+)
 from products.replay_vision.backend.temporal.sweep_types import (
     AdvanceScannerWatermarkInputs,
     CandidateSessionPayload,
@@ -26,6 +29,8 @@ from products.replay_vision.backend.temporal.sweep_types import (
     FindScannerCandidatesOutput,
     SweepScannerInputs,
 )
+from products.replay_vision.backend.temporal.vision_actions.activities import evaluate_due_vision_actions_activity
+from products.replay_vision.backend.temporal.vision_actions.types import DueVisionAction
 
 
 def _make_scanner(**overrides) -> ReplayScanner:
@@ -247,6 +252,9 @@ class _SweepMocks:
         # Default to 0 in-flight (full headroom) unless a test overrides it.
         if activity_fn is count_in_flight_applies_activity and activity_fn not in self.activity_results:
             return 0
+        # Default to no due vision actions unless a test overrides it.
+        if activity_fn is evaluate_due_vision_actions_activity and activity_fn not in self.activity_results:
+            return []
         return self.activity_results.get(activity_fn)
 
     async def start_child_workflow(self, *args: Any, **kwargs: Any) -> Any:
@@ -267,7 +275,11 @@ def _sweep_inputs() -> SweepScannerInputs:
 
 async def _run_sweep(mocks: _SweepMocks, inputs: SweepScannerInputs | None = None) -> None:
     # `workflow.logger` reaches into the workflow runtime, which isn't set up here.
-    fake_logger = type("Logger", (), {"info": staticmethod(lambda *_a, **_kw: None)})()
+    fake_logger = type(
+        "Logger",
+        (),
+        {"info": staticmethod(lambda *_a, **_kw: None), "exception": staticmethod(lambda *_a, **_kw: None)},
+    )()
     with (
         patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
         patch("temporalio.workflow.start_child_workflow", side_effect=mocks.start_child_workflow),
@@ -287,6 +299,7 @@ async def test_empty_batch_skips_dispatch_and_advance() -> None:
     await _run_sweep(mocks)
 
     assert [fn for fn, _ in mocks.activity_calls] == [
+        evaluate_due_vision_actions_activity,
         count_in_flight_applies_activity,
         find_scanner_candidates_activity,
     ]
@@ -397,11 +410,74 @@ async def test_inflight_cap_gates_the_sweep(in_flight: int, expected_candidate_l
 
     find_calls = [inp for fn, inp in mocks.activity_calls if fn == find_scanner_candidates_activity]
     if expected_candidate_limit is None:
-        # Throttled: only the in-flight count ran — no find, no dispatch.
-        assert [fn for fn, _ in mocks.activity_calls] == [count_in_flight_applies_activity]
+        # Throttled: vision-action eval still runs (it rides every sweep), but no find, no apply dispatch.
+        assert [fn for fn, _ in mocks.activity_calls] == [
+            evaluate_due_vision_actions_activity,
+            count_in_flight_applies_activity,
+        ]
         assert mocks.child_calls == []
     else:
         assert find_calls[0].candidate_limit == expected_candidate_limit
+
+
+# SweepScannerWorkflow vision-action dispatch (the "and then…" trigger riding the sweep)
+
+
+@pytest.mark.asyncio
+async def test_sweep_dispatches_a_child_per_due_vision_action() -> None:
+    due = [DueVisionAction(vision_action_id=uuid.uuid4(), team_id=42) for _ in range(2)]
+    mocks = _SweepMocks(
+        activity_results={
+            evaluate_due_vision_actions_activity: due,
+            find_scanner_candidates_activity: FindScannerCandidatesOutput(candidates=[], saturated=False),
+        }
+    )
+
+    await _run_sweep(mocks)
+
+    started = {call["id"] for call in mocks.child_calls}
+    assert started == {build_process_vision_action_workflow_id(d.vision_action_id) for d in due}
+    # Dispatch happens before the session scan, so the children start even with no candidates.
+    assert evaluate_due_vision_actions_activity == mocks.activity_calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_sweep_vision_action_failure_does_not_block_session_scan() -> None:
+    # A vision-action child that fails to start must not abort the scanner's core duty: the session
+    # scan still runs and advances its watermark.
+    d = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=42)
+    candidate = _build_payload("sess-a", dt.datetime(2026, 5, 1, 10, 0, 0, tzinfo=dt.UTC))
+    mocks = _SweepMocks(
+        activity_results={
+            evaluate_due_vision_actions_activity: [d],
+            find_scanner_candidates_activity: FindScannerCandidatesOutput(candidates=[candidate], saturated=False),
+        },
+        child_errors_for_ids={
+            build_process_vision_action_workflow_id(d.vision_action_id): RuntimeError("temporal down")
+        },
+    )
+
+    await _run_sweep(mocks)
+
+    assert [call for fn, call in mocks.activity_calls if fn == advance_scanner_watermark_activity]
+
+
+@pytest.mark.asyncio
+async def test_sweep_swallows_already_running_vision_action() -> None:
+    d = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=42)
+    vision_child_id = build_process_vision_action_workflow_id(d.vision_action_id)
+    mocks = _SweepMocks(
+        activity_results={
+            evaluate_due_vision_actions_activity: [d],
+            find_scanner_candidates_activity: FindScannerCandidatesOutput(candidates=[], saturated=False),
+        },
+        child_errors_for_ids={
+            vision_child_id: WorkflowAlreadyStartedError(workflow_id=vision_child_id, workflow_type="x")
+        },
+    )
+
+    # An already-running action is skipped, not a failure.
+    await _run_sweep(mocks)
 
 
 # count_in_flight_applies_activity

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -22,6 +22,7 @@ from products.replay_vision.backend.temporal.vision_actions.types import (
     SynthesisStatus,
     SynthesizeGroupSummaryResult,
     UpdateVisionActionRunInputs,
+    ValidateVisionActionInputs,
 )
 from products.replay_vision.backend.temporal.vision_actions.workflows import ProcessVisionActionWorkflow
 
@@ -140,7 +141,9 @@ class TestEngineActivities(BaseTest):
             action_id = _action(self.team, name="off", enabled=False).id
         else:
             action_id = _action(self.team, name="noflow").id
-        self.assertEqual(act._validate(action_id), case)
+        self.assertEqual(
+            act._validate(ValidateVisionActionInputs(vision_action_id=action_id, team_id=self.team.id)), case
+        )
 
     def test_update_run(self) -> None:
         action = _action(self.team)
@@ -148,7 +151,7 @@ class TestEngineActivities(BaseTest):
         run.save()
         act._update_run(
             UpdateVisionActionRunInputs(
-                run_id=run.id, status=VisionActionRunStatus.FAILED.value, error={"message": "x"}
+                run_id=run.id, team_id=self.team.id, status=VisionActionRunStatus.FAILED.value, error={"message": "x"}
             )
         )
         run.refresh_from_db()
@@ -165,7 +168,7 @@ class TestEngineActivities(BaseTest):
         captured = MagicMock()
         captured.raise_for_status = MagicMock()
         with patch.object(act, "capture_internal_routed", return_value=captured) as mock_capture:
-            act._emit(EmitActionReadyInputs(run_id=run.id))
+            act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
 
         mock_capture.assert_called_once()
         kwargs = mock_capture.call_args.kwargs
@@ -278,6 +281,24 @@ async def test_process_synthesis_failure_records_failed_and_reraises() -> None:
 
     # Even on failure the run is still updated to FAILED (the schedule was already advanced at claim).
     assert _final_status(mocks) == VisionActionRunStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_update_run_failure_after_success_is_swallowed() -> None:
+    # Body succeeded (emit happened → Slack delivered); a failed bookkeeping update must NOT flip the
+    # workflow to FAILED — re-running would double-post. The workflow finishes without raising.
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: None,
+            synthesize_group_summary_activity: SynthesizeGroupSummaryResult(status=SynthesisStatus.SYNTHESIZED),
+        },
+        errors={act.update_vision_action_run_activity: RuntimeError("update boom")},
+    )
+    await _run_process(_process_inputs(), mocks)
+
+    assert act.emit_action_ready_activity in mocks.calls()
+    assert _final_status(mocks) == VisionActionRunStatus.COMPLETED.value
 
 
 @pytest.mark.asyncio

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -13,14 +13,14 @@ from products.replay_vision.backend.models import ReplayScanner, VisionAction, V
 from products.replay_vision.backend.models.replay_scanner import ScannerModel, ScannerType
 from products.replay_vision.backend.models.vision_action import TriggerType, VisionActionRunStatus
 from products.replay_vision.backend.temporal.vision_actions import activities as act
-from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
+from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_group_summary_activity
 from products.replay_vision.backend.temporal.vision_actions.types import (
     CreateVisionActionRunInputs,
     EmitActionReadyInputs,
     EvaluateDueVisionActionsInputs,
     ProcessVisionActionInputs,
     SynthesisStatus,
-    SynthesizeActionResult,
+    SynthesizeGroupSummaryResult,
     UpdateVisionActionRunInputs,
 )
 from products.replay_vision.backend.temporal.vision_actions.workflows import ProcessVisionActionWorkflow
@@ -237,13 +237,13 @@ async def test_process_maps_synthesis_status(
         results={
             act.create_vision_action_run_activity: uuid.uuid4(),
             act.validate_vision_action_activity: None,
-            synthesize_action_activity: SynthesizeActionResult(status=synth_status),
+            synthesize_group_summary_activity: SynthesizeGroupSummaryResult(status=synth_status),
         }
     )
     await _run_process(_process_inputs(), mocks)
 
     call_fns = mocks.calls()
-    assert synthesize_action_activity in call_fns
+    assert synthesize_group_summary_activity in call_fns
     assert (act.emit_action_ready_activity in call_fns) is expect_emit
     assert _final_status(mocks) == expected_final
     # The schedule cursor is advanced by the eligibility claim, never by this workflow.
@@ -271,7 +271,7 @@ async def test_process_synthesis_failure_records_failed_and_reraises() -> None:
             act.create_vision_action_run_activity: uuid.uuid4(),
             act.validate_vision_action_activity: None,
         },
-        errors={synthesize_action_activity: RuntimeError("llm exploded")},
+        errors={synthesize_group_summary_activity: RuntimeError("llm exploded")},
     )
     with pytest.raises(RuntimeError, match="llm exploded"):
         await _run_process(_process_inputs(), mocks)
@@ -286,7 +286,7 @@ async def test_update_run_failure_does_not_mask_body_error() -> None:
     # the update failure must not clobber it.
     mocks = _Mocks(
         errors={
-            synthesize_action_activity: RuntimeError("llm exploded"),
+            synthesize_group_summary_activity: RuntimeError("llm exploded"),
             act.update_vision_action_run_activity: RuntimeError("update boom"),
         },
         results={

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -17,16 +17,13 @@ from products.replay_vision.backend.temporal.vision_actions.synthesis import syn
 from products.replay_vision.backend.temporal.vision_actions.types import (
     CreateVisionActionRunInputs,
     EmitActionReadyInputs,
+    EvaluateDueVisionActionsInputs,
     ProcessVisionActionInputs,
-    ScheduleAllVisionActionsInputs,
     SynthesisStatus,
     SynthesizeActionResult,
     UpdateVisionActionRunInputs,
 )
-from products.replay_vision.backend.temporal.vision_actions.workflows import (
-    ProcessVisionActionWorkflow,
-    ScheduleAllVisionActionsWorkflow,
-)
+from products.replay_vision.backend.temporal.vision_actions.workflows import ProcessVisionActionWorkflow
 
 DAILY = "FREQ=DAILY;BYHOUR=9"
 
@@ -47,23 +44,78 @@ def _action(team, **overrides) -> VisionAction:
     return a
 
 
-class TestEngineActivities(BaseTest):
-    def test_fetch_due_selects_only_due_enabled_schedule(self) -> None:
-        due = _action(self.team, name="due")
-        VisionAction.all_teams.filter(pk=due.pk).update(next_run_at=timezone.now() - timedelta(hours=1))
+def _scanner(team) -> ReplayScanner:
+    return ReplayScanner.objects.create(
+        team=team,
+        name=f"scanner-{uuid.uuid4().hex[:8]}",
+        scanner_type=ScannerType.SUMMARIZER,
+        scanner_config={"prompt": "x"},
+        model=ScannerModel.GEMINI_3_FLASH,
+    )
 
-        future = _action(self.team, name="future")
+
+def _make_due(action) -> None:
+    VisionAction.all_teams.filter(pk=action.pk).update(next_run_at=timezone.now() - timedelta(hours=1))
+
+
+class TestEvaluateDue(BaseTest):
+    def _inputs(self, scanner) -> EvaluateDueVisionActionsInputs:
+        return EvaluateDueVisionActionsInputs(scanner_id=scanner.id, team_id=self.team.id)
+
+    def test_selects_only_this_scanners_due_enabled_schedule(self) -> None:
+        scanner = _scanner(self.team)
+        due = _action(self.team, name="due", scanner=scanner)
+        _make_due(due)
+
+        future = _action(self.team, name="future", scanner=scanner)
         VisionAction.all_teams.filter(pk=future.pk).update(next_run_at=timezone.now() + timedelta(days=1))
 
-        _action(self.team, name="disabled", enabled=False)
-        VisionAction.all_teams.filter(name="disabled").update(next_run_at=timezone.now() - timedelta(hours=1))
+        disabled = _action(self.team, name="disabled", scanner=scanner, enabled=False)
+        _make_due(disabled)
 
-        _action(self.team, name="threshold", trigger_type=TriggerType.THRESHOLD, trigger_config={})
+        threshold = _action(self.team, name="threshold", scanner=scanner, trigger_type=TriggerType.THRESHOLD)
+        _make_due(threshold)
 
-        result = act._fetch_due(ScheduleAllVisionActionsInputs())
+        # Due action on a *different* scanner must not be picked up by this scanner's sweep.
+        other_scanner_action = _action(self.team, name="other-scanner")
+        _make_due(other_scanner_action)
+
+        result = act._evaluate_due(self._inputs(scanner))
         self.assertEqual([d.vision_action_id for d in result], [due.id])
         self.assertEqual(result[0].team_id, self.team.id)
 
+    def test_claims_by_advancing_next_run_at(self) -> None:
+        scanner = _scanner(self.team)
+        action = _action(self.team, scanner=scanner)
+        _make_due(action)
+        action.refresh_from_db()
+        fired_at = action.next_run_at
+
+        result = act._evaluate_due(self._inputs(scanner))
+
+        # The fired time is reported as scheduled_at, and the cursor is advanced past now so the next
+        # sweep won't re-fire while the child runs.
+        self.assertEqual(result[0].scheduled_at, fired_at)
+        action.refresh_from_db()
+        assert action.next_run_at is not None
+        self.assertGreater(action.next_run_at, timezone.now())
+        self.assertIsNotNone(action.last_run_at)
+
+        # A second eval finds nothing — the claim already moved the cursor.
+        self.assertEqual(act._evaluate_due(self._inputs(scanner)), [])
+
+    def test_scoped_to_team(self) -> None:
+        scanner = _scanner(self.team)
+        action = _action(self.team, scanner=scanner)
+        _make_due(action)
+        # Querying the same scanner id but a different (real) team returns nothing (for_team scoping).
+        other_team = self.organization.teams.create(name="other")
+        self.assertEqual(
+            act._evaluate_due(EvaluateDueVisionActionsInputs(scanner_id=scanner.id, team_id=other_team.id)), []
+        )
+
+
+class TestEngineActivities(BaseTest):
     def test_create_run_is_idempotent(self) -> None:
         action = _action(self.team)
         inputs = CreateVisionActionRunInputs(
@@ -103,16 +155,6 @@ class TestEngineActivities(BaseTest):
         self.assertEqual(run.status, VisionActionRunStatus.FAILED)
         self.assertEqual(run.error, {"message": "x"})
 
-    def test_advance_next_run(self) -> None:
-        action = _action(self.team)
-        VisionAction.all_teams.filter(pk=action.pk).update(next_run_at=timezone.now() - timedelta(days=2))
-        act._advance_next_run(action.id)
-        action.refresh_from_db()
-        self.assertIsNotNone(action.next_run_at)
-        assert action.next_run_at is not None
-        self.assertGreater(action.next_run_at, timezone.now())
-        self.assertIsNotNone(action.last_run_at)
-
     def test_emit_captures_event(self) -> None:
         action = _action(self.team)
         run = VisionActionRun(
@@ -139,25 +181,16 @@ class TestEngineActivities(BaseTest):
 
 
 class _Mocks:
-    def __init__(self, *, results=None, errors=None, child_errors=None):
+    def __init__(self, *, results=None, errors=None):
         self.results = results or {}
         self.errors = errors or {}
-        self.child_errors = child_errors or {}
         self.activity_calls: list = []
-        self.child_calls: list = []
 
     async def execute_activity(self, fn, arg=None, **_kwargs):
         self.activity_calls.append((fn, arg))
         if fn in self.errors:
             raise self.errors[fn]
         return self.results.get(fn)
-
-    async def execute_child_workflow(self, _run, arg=None, **kwargs):
-        cid = kwargs.get("id")
-        self.child_calls.append((cid, arg))
-        if cid in self.child_errors:
-            raise self.child_errors[cid]
-        return None
 
     def calls(self) -> list:
         return [fn for fn, _ in self.activity_calls]
@@ -213,8 +246,8 @@ async def test_process_maps_synthesis_status(
     assert synthesize_action_activity in call_fns
     assert (act.emit_action_ready_activity in call_fns) is expect_emit
     assert _final_status(mocks) == expected_final
-    # The schedule is always advanced, whatever the outcome — a stuck run must not hot-loop.
-    assert act.advance_next_run_at_activity in call_fns
+    # The schedule cursor is advanced by the eligibility claim, never by this workflow.
+    assert act.evaluate_due_vision_actions_activity not in call_fns
 
 
 @pytest.mark.asyncio
@@ -229,7 +262,6 @@ async def test_process_skips_when_validate_returns_reason() -> None:
 
     assert act.emit_action_ready_activity not in mocks.calls()
     assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
-    assert act.advance_next_run_at_activity in mocks.calls()
 
 
 @pytest.mark.asyncio
@@ -244,19 +276,18 @@ async def test_process_synthesis_failure_records_failed_and_reraises() -> None:
     with pytest.raises(RuntimeError, match="llm exploded"):
         await _run_process(_process_inputs(), mocks)
 
-    # Even on failure: run is updated to FAILED and the schedule is advanced (no hot-loop).
+    # Even on failure the run is still updated to FAILED (the schedule was already advanced at claim).
     assert _final_status(mocks) == VisionActionRunStatus.FAILED.value
-    assert act.advance_next_run_at_activity in mocks.calls()
 
 
 @pytest.mark.asyncio
-async def test_advance_failure_does_not_mask_body_error() -> None:
-    # If both the body and the finally's advance raise, the original body error must win —
-    # the advance failure must not clobber it.
+async def test_update_run_failure_does_not_mask_body_error() -> None:
+    # If both the body and the finally's run-update raise, the original body error must win —
+    # the update failure must not clobber it.
     mocks = _Mocks(
         errors={
             synthesize_action_activity: RuntimeError("llm exploded"),
-            act.advance_next_run_at_activity: RuntimeError("advance boom"),
+            act.update_vision_action_run_activity: RuntimeError("update boom"),
         },
         results={
             act.create_vision_action_run_activity: uuid.uuid4(),
@@ -265,47 +296,3 @@ async def test_advance_failure_does_not_mask_body_error() -> None:
     )
     with pytest.raises(RuntimeError, match="llm exploded"):
         await _run_process(_process_inputs(), mocks)
-
-
-async def _run_schedule_all(due_list, mocks: _Mocks) -> None:
-    with (
-        patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
-        patch("temporalio.workflow.execute_child_workflow", side_effect=mocks.execute_child_workflow),
-        patch("temporalio.workflow.logger", MagicMock()),
-    ):
-        mocks.results[act.fetch_due_vision_actions_activity] = due_list
-        await ScheduleAllVisionActionsWorkflow().run(ScheduleAllVisionActionsInputs())
-
-
-@pytest.mark.asyncio
-async def test_schedule_all_fans_out_one_child_per_due_action() -> None:
-    from products.replay_vision.backend.temporal.vision_actions.types import DueVisionAction
-
-    due = [DueVisionAction(vision_action_id=uuid.uuid4(), team_id=1) for _ in range(3)]
-    mocks = _Mocks()
-    await _run_schedule_all(due, mocks)
-
-    child_ids = {cid for cid, _ in mocks.child_calls}
-    assert child_ids == {f"process-vision-action-{d.vision_action_id}" for d in due}
-
-
-@pytest.mark.asyncio
-async def test_schedule_all_swallows_already_started() -> None:
-    from temporalio.exceptions import WorkflowAlreadyStartedError
-
-    from products.replay_vision.backend.temporal.vision_actions.types import DueVisionAction
-
-    d = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=1)
-    cid = f"process-vision-action-{d.vision_action_id}"
-    mocks = _Mocks(
-        child_errors={cid: WorkflowAlreadyStartedError(workflow_id=cid, workflow_type="process-vision-action")}
-    )
-    # Should not raise — an already-running action is skipped, not a failure.
-    await _run_schedule_all([d], mocks)
-
-
-@pytest.mark.asyncio
-async def test_schedule_all_noop_when_nothing_due() -> None:
-    mocks = _Mocks()
-    await _run_schedule_all([], mocks)
-    assert mocks.child_calls == []

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -158,26 +158,26 @@ class TestEngineActivities(BaseTest):
         self.assertEqual(run.status, VisionActionRunStatus.FAILED)
         self.assertEqual(run.error, {"message": "x"})
 
-    def test_emit_captures_event(self) -> None:
+    def test_emit_produces_internal_event(self) -> None:
         action = _action(self.team)
         run = VisionActionRun(
             vision_action=action, team=self.team, idempotency_key="k", output={"slack": "hello *world*"}
         )
         run.save()
 
-        captured = MagicMock()
-        captured.raise_for_status = MagicMock()
-        with patch.object(act, "capture_internal_routed", return_value=captured) as mock_capture:
+        # Delivery rides the private internal-events channel (not the public capture pipeline), so it
+        # can't be forged with the project token.
+        with patch.object(act, "produce_internal_event") as mock_emit:
             act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
 
-        mock_capture.assert_called_once()
-        kwargs = mock_capture.call_args.kwargs
-        self.assertEqual(kwargs["event_name"], "$replay_vision_action_ready")
-        self.assertEqual(kwargs["event_uuid"], str(run.id))
-        self.assertEqual(kwargs["properties"]["vision_action_id"], str(action.id))
-        self.assertEqual(kwargs["properties"]["slack_text"], "hello *world*")
-        self.assertFalse(kwargs["process_person_profile"])
-        captured.raise_for_status.assert_called_once()
+        mock_emit.assert_called_once()
+        kwargs = mock_emit.call_args.kwargs
+        self.assertEqual(kwargs["team_id"], self.team.id)
+        event = kwargs["event"]
+        self.assertEqual(event.event, "$replay_vision_action_ready")
+        self.assertEqual(event.uuid, str(run.id))
+        self.assertEqual(event.properties["vision_action_id"], str(action.id))
+        self.assertEqual(event.properties["slack_text"], "hello *world*")
 
 
 # --- workflow orchestration (activities mocked at the temporalio.workflow boundary) ---

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from products.replay_vision.backend.models import VisionAction, VisionActionRun
 from products.replay_vision.backend.models.vision_action import TriggerType, VisionActionRunStatus
 from products.replay_vision.backend.temporal.vision_actions import activities as act
@@ -63,14 +65,21 @@ class TestEngineActivities(BaseTest):
         self.assertEqual(first, second)
         self.assertEqual(VisionActionRun.all_teams.filter(idempotency_key="key-x").count(), 1)
 
-    def test_validate_reasons(self) -> None:
-        self.assertEqual(act._validate(uuid.uuid4()), "not_found")
-
-        disabled = _action(self.team, name="off", enabled=False)
-        self.assertEqual(act._validate(disabled.id), "disabled")
-
-        no_flow = _action(self.team, name="noflow")
-        self.assertEqual(act._validate(no_flow.id), "no_delivery_flow")
+    @parameterized.expand(
+        [
+            ("not_found",),
+            ("disabled",),
+            ("no_delivery_flow",),
+        ]
+    )
+    def test_validate_reasons(self, case: str) -> None:
+        if case == "not_found":
+            action_id = uuid.uuid4()
+        elif case == "disabled":
+            action_id = _action(self.team, name="off", enabled=False).id
+        else:
+            action_id = _action(self.team, name="noflow").id
+        self.assertEqual(act._validate(action_id), case)
 
     def test_update_run(self) -> None:
         action = _action(self.team)
@@ -167,22 +176,33 @@ def _final_status(mocks: _Mocks) -> str:
 
 
 @pytest.mark.asyncio
-async def test_process_happy_path_emits_and_completes() -> None:
-    run_id = uuid.uuid4()
+@pytest.mark.parametrize(
+    "synth_status, expected_final, expect_emit",
+    [
+        (SynthesisStatus.SYNTHESIZED, VisionActionRunStatus.COMPLETED.value, True),
+        (SynthesisStatus.SKIPPED_EMPTY, VisionActionRunStatus.SKIPPED.value, False),
+        (SynthesisStatus.SKIPPED_OVER_BUDGET, VisionActionRunStatus.SKIPPED.value, False),
+        (SynthesisStatus.ABORTED_NO_CONSENT, VisionActionRunStatus.FAILED.value, False),
+        (SynthesisStatus.ABORTED_NO_USER, VisionActionRunStatus.FAILED.value, False),
+    ],
+)
+async def test_process_maps_synthesis_status(
+    synth_status: SynthesisStatus, expected_final: str, expect_emit: bool
+) -> None:
     mocks = _Mocks(
         results={
-            act.create_vision_action_run_activity: run_id,
+            act.create_vision_action_run_activity: uuid.uuid4(),
             act.validate_vision_action_activity: None,
-            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.SYNTHESIZED, observation_count=3),
+            synthesize_action_activity: SynthesizeActionResult(status=synth_status),
         }
     )
     await _run_process(_process_inputs(), mocks)
 
     call_fns = mocks.calls()
-    assert act.emit_action_ready_activity in call_fns
     assert synthesize_action_activity in call_fns
-    assert _final_status(mocks) == VisionActionRunStatus.COMPLETED.value
-    # always advances
+    assert (act.emit_action_ready_activity in call_fns) is expect_emit
+    assert _final_status(mocks) == expected_final
+    # The schedule is always advanced, whatever the outcome — a stuck run must not hot-loop.
     assert act.advance_next_run_at_activity in call_fns
 
 
@@ -199,36 +219,6 @@ async def test_process_skips_when_validate_returns_reason() -> None:
     assert act.emit_action_ready_activity not in mocks.calls()
     assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
     assert act.advance_next_run_at_activity in mocks.calls()
-
-
-@pytest.mark.asyncio
-async def test_process_empty_synthesis_skips_without_emit() -> None:
-    mocks = _Mocks(
-        results={
-            act.create_vision_action_run_activity: uuid.uuid4(),
-            act.validate_vision_action_activity: None,
-            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.SKIPPED_EMPTY),
-        }
-    )
-    await _run_process(_process_inputs(), mocks)
-
-    assert act.emit_action_ready_activity not in mocks.calls()
-    assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
-
-
-@pytest.mark.asyncio
-async def test_process_no_consent_marks_failed_without_emit() -> None:
-    mocks = _Mocks(
-        results={
-            act.create_vision_action_run_activity: uuid.uuid4(),
-            act.validate_vision_action_activity: None,
-            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.ABORTED_NO_CONSENT),
-        }
-    )
-    await _run_process(_process_inputs(), mocks)
-
-    assert act.emit_action_ready_activity not in mocks.calls()
-    assert _final_status(mocks) == VisionActionRunStatus.FAILED.value
 
 
 @pytest.mark.asyncio

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -238,6 +238,24 @@ async def test_process_synthesis_failure_records_failed_and_reraises() -> None:
     assert act.advance_next_run_at_activity in mocks.calls()
 
 
+@pytest.mark.asyncio
+async def test_advance_failure_does_not_mask_body_error() -> None:
+    # If both the body and the finally's advance raise, the original body error must win —
+    # the advance failure must not clobber it.
+    mocks = _Mocks(
+        errors={
+            synthesize_action_activity: RuntimeError("llm exploded"),
+            act.advance_next_run_at_activity: RuntimeError("advance boom"),
+        },
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: None,
+        },
+    )
+    with pytest.raises(RuntimeError, match="llm exploded"):
+        await _run_process(_process_inputs(), mocks)
+
+
 async def _run_schedule_all(due_list, mocks: _Mocks) -> None:
     with (
         patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -1,0 +1,292 @@
+import uuid
+from datetime import timedelta
+
+import pytest
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from products.replay_vision.backend.models import VisionAction, VisionActionRun
+from products.replay_vision.backend.models.vision_action import TriggerType, VisionActionRunStatus
+from products.replay_vision.backend.temporal.vision_actions import activities as act
+from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
+from products.replay_vision.backend.temporal.vision_actions.types import (
+    CreateVisionActionRunInputs,
+    EmitActionReadyInputs,
+    ProcessVisionActionInputs,
+    ScheduleAllVisionActionsInputs,
+    SynthesisStatus,
+    SynthesizeActionResult,
+    UpdateVisionActionRunInputs,
+)
+from products.replay_vision.backend.temporal.vision_actions.workflows import (
+    ProcessVisionActionWorkflow,
+    ScheduleAllVisionActionsWorkflow,
+)
+
+DAILY = "FREQ=DAILY;BYHOUR=9"
+
+
+def _action(team, **overrides) -> VisionAction:
+    defaults: dict = {"team": team, "name": "a", "trigger_config": {"rrule": DAILY, "timezone": "UTC"}}
+    defaults.update(overrides)
+    a = VisionAction(**defaults)
+    a.save()
+    return a
+
+
+class TestEngineActivities(BaseTest):
+    def test_fetch_due_selects_only_due_enabled_schedule(self) -> None:
+        due = _action(self.team, name="due")
+        VisionAction.all_teams.filter(pk=due.pk).update(next_run_at=timezone.now() - timedelta(hours=1))
+
+        future = _action(self.team, name="future")
+        VisionAction.all_teams.filter(pk=future.pk).update(next_run_at=timezone.now() + timedelta(days=1))
+
+        _action(self.team, name="disabled", enabled=False)
+        VisionAction.all_teams.filter(name="disabled").update(next_run_at=timezone.now() - timedelta(hours=1))
+
+        _action(self.team, name="threshold", trigger_type=TriggerType.THRESHOLD, trigger_config={})
+
+        result = act._fetch_due(ScheduleAllVisionActionsInputs())
+        self.assertEqual([d.vision_action_id for d in result], [due.id])
+        self.assertEqual(result[0].team_id, self.team.id)
+
+    def test_create_run_is_idempotent(self) -> None:
+        action = _action(self.team)
+        inputs = CreateVisionActionRunInputs(
+            vision_action_id=action.id, team_id=self.team.id, idempotency_key="key-x", temporal_workflow_id="wf-1"
+        )
+        first = act._create_run(inputs)
+        second = act._create_run(inputs)
+        self.assertEqual(first, second)
+        self.assertEqual(VisionActionRun.all_teams.filter(idempotency_key="key-x").count(), 1)
+
+    def test_validate_reasons(self) -> None:
+        self.assertEqual(act._validate(uuid.uuid4()), "not_found")
+
+        disabled = _action(self.team, name="off", enabled=False)
+        self.assertEqual(act._validate(disabled.id), "disabled")
+
+        no_flow = _action(self.team, name="noflow")
+        self.assertEqual(act._validate(no_flow.id), "no_delivery_flow")
+
+    def test_update_run(self) -> None:
+        action = _action(self.team)
+        run = VisionActionRun(vision_action=action, team=self.team, idempotency_key="k")
+        run.save()
+        act._update_run(
+            UpdateVisionActionRunInputs(
+                run_id=run.id, status=VisionActionRunStatus.FAILED.value, error={"message": "x"}
+            )
+        )
+        run.refresh_from_db()
+        self.assertEqual(run.status, VisionActionRunStatus.FAILED)
+        self.assertEqual(run.error, {"message": "x"})
+
+    def test_advance_next_run(self) -> None:
+        action = _action(self.team)
+        VisionAction.all_teams.filter(pk=action.pk).update(next_run_at=timezone.now() - timedelta(days=2))
+        act._advance_next_run(action.id)
+        action.refresh_from_db()
+        self.assertIsNotNone(action.next_run_at)
+        assert action.next_run_at is not None
+        self.assertGreater(action.next_run_at, timezone.now())
+        self.assertIsNotNone(action.last_run_at)
+
+    def test_emit_captures_event(self) -> None:
+        action = _action(self.team)
+        run = VisionActionRun(vision_action=action, team=self.team, idempotency_key="k", slack_text="hello *world*")
+        run.save()
+
+        captured = MagicMock()
+        captured.raise_for_status = MagicMock()
+        with patch.object(act, "capture_internal_routed", return_value=captured) as mock_capture:
+            act._emit(EmitActionReadyInputs(run_id=run.id))
+
+        mock_capture.assert_called_once()
+        kwargs = mock_capture.call_args.kwargs
+        self.assertEqual(kwargs["event_name"], "$replay_vision_action_ready")
+        self.assertEqual(kwargs["event_uuid"], str(run.id))
+        self.assertEqual(kwargs["properties"]["vision_action_id"], str(action.id))
+        self.assertEqual(kwargs["properties"]["slack_text"], "hello *world*")
+        self.assertFalse(kwargs["process_person_profile"])
+        captured.raise_for_status.assert_called_once()
+
+
+# --- workflow orchestration (activities mocked at the temporalio.workflow boundary) ---
+
+
+class _Mocks:
+    def __init__(self, *, results=None, errors=None, child_errors=None):
+        self.results = results or {}
+        self.errors = errors or {}
+        self.child_errors = child_errors or {}
+        self.activity_calls: list = []
+        self.child_calls: list = []
+
+    async def execute_activity(self, fn, arg=None, **_kwargs):
+        self.activity_calls.append((fn, arg))
+        if fn in self.errors:
+            raise self.errors[fn]
+        return self.results.get(fn)
+
+    async def execute_child_workflow(self, _run, arg=None, **kwargs):
+        cid = kwargs.get("id")
+        self.child_calls.append((cid, arg))
+        if cid in self.child_errors:
+            raise self.child_errors[cid]
+        return None
+
+    def calls(self) -> list:
+        return [fn for fn, _ in self.activity_calls]
+
+    def arg_for(self, fn):
+        return next(arg for f, arg in self.activity_calls if f is fn)
+
+
+async def _run_process(inputs: ProcessVisionActionInputs, mocks: _Mocks) -> None:
+    info = MagicMock()
+    info.workflow_id = "wf-test"
+    with (
+        patch("temporalio.workflow.info", return_value=info),
+        patch("temporalio.workflow.uuid4", return_value=uuid.UUID("00000000-0000-0000-0000-0000000000aa")),
+        patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
+        patch("temporalio.workflow.logger", MagicMock()),
+    ):
+        await ProcessVisionActionWorkflow().run(inputs)
+
+
+def _process_inputs() -> ProcessVisionActionInputs:
+    return ProcessVisionActionInputs(vision_action_id=uuid.uuid4(), team_id=1)
+
+
+def _final_status(mocks: _Mocks) -> str:
+    return mocks.arg_for(act.update_vision_action_run_activity).status
+
+
+@pytest.mark.asyncio
+async def test_process_happy_path_emits_and_completes() -> None:
+    run_id = uuid.uuid4()
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: run_id,
+            act.validate_vision_action_activity: None,
+            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.SYNTHESIZED, observation_count=3),
+        }
+    )
+    await _run_process(_process_inputs(), mocks)
+
+    call_fns = mocks.calls()
+    assert act.emit_action_ready_activity in call_fns
+    assert synthesize_action_activity in call_fns
+    assert _final_status(mocks) == VisionActionRunStatus.COMPLETED.value
+    # always advances
+    assert act.advance_next_run_at_activity in call_fns
+
+
+@pytest.mark.asyncio
+async def test_process_skips_when_validate_returns_reason() -> None:
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: "no_delivery_flow",
+        }
+    )
+    await _run_process(_process_inputs(), mocks)
+
+    assert act.emit_action_ready_activity not in mocks.calls()
+    assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
+    assert act.advance_next_run_at_activity in mocks.calls()
+
+
+@pytest.mark.asyncio
+async def test_process_empty_synthesis_skips_without_emit() -> None:
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: None,
+            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.SKIPPED_EMPTY),
+        }
+    )
+    await _run_process(_process_inputs(), mocks)
+
+    assert act.emit_action_ready_activity not in mocks.calls()
+    assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
+
+
+@pytest.mark.asyncio
+async def test_process_no_consent_marks_failed_without_emit() -> None:
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: None,
+            synthesize_action_activity: SynthesizeActionResult(status=SynthesisStatus.ABORTED_NO_CONSENT),
+        }
+    )
+    await _run_process(_process_inputs(), mocks)
+
+    assert act.emit_action_ready_activity not in mocks.calls()
+    assert _final_status(mocks) == VisionActionRunStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_process_synthesis_failure_records_failed_and_reraises() -> None:
+    mocks = _Mocks(
+        results={
+            act.create_vision_action_run_activity: uuid.uuid4(),
+            act.validate_vision_action_activity: None,
+        },
+        errors={synthesize_action_activity: RuntimeError("llm exploded")},
+    )
+    with pytest.raises(RuntimeError, match="llm exploded"):
+        await _run_process(_process_inputs(), mocks)
+
+    # Even on failure: run is updated to FAILED and the schedule is advanced (no hot-loop).
+    assert _final_status(mocks) == VisionActionRunStatus.FAILED.value
+    assert act.advance_next_run_at_activity in mocks.calls()
+
+
+async def _run_schedule_all(due_list, mocks: _Mocks) -> None:
+    with (
+        patch("temporalio.workflow.execute_activity", side_effect=mocks.execute_activity),
+        patch("temporalio.workflow.execute_child_workflow", side_effect=mocks.execute_child_workflow),
+        patch("temporalio.workflow.logger", MagicMock()),
+    ):
+        mocks.results[act.fetch_due_vision_actions_activity] = due_list
+        await ScheduleAllVisionActionsWorkflow().run(ScheduleAllVisionActionsInputs())
+
+
+@pytest.mark.asyncio
+async def test_schedule_all_fans_out_one_child_per_due_action() -> None:
+    from products.replay_vision.backend.temporal.vision_actions.types import DueVisionAction
+
+    due = [DueVisionAction(vision_action_id=uuid.uuid4(), team_id=1) for _ in range(3)]
+    mocks = _Mocks()
+    await _run_schedule_all(due, mocks)
+
+    child_ids = {cid for cid, _ in mocks.child_calls}
+    assert child_ids == {f"process-vision-action-{d.vision_action_id}" for d in due}
+
+
+@pytest.mark.asyncio
+async def test_schedule_all_swallows_already_started() -> None:
+    from temporalio.exceptions import WorkflowAlreadyStartedError
+
+    from products.replay_vision.backend.temporal.vision_actions.types import DueVisionAction
+
+    d = DueVisionAction(vision_action_id=uuid.uuid4(), team_id=1)
+    cid = f"process-vision-action-{d.vision_action_id}"
+    mocks = _Mocks(
+        child_errors={cid: WorkflowAlreadyStartedError(workflow_id=cid, workflow_type="process-vision-action")}
+    )
+    # Should not raise — an already-running action is skipped, not a failure.
+    await _run_schedule_all([d], mocks)
+
+
+@pytest.mark.asyncio
+async def test_schedule_all_noop_when_nothing_due() -> None:
+    mocks = _Mocks()
+    await _run_schedule_all([], mocks)
+    assert mocks.child_calls == []

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -222,19 +222,33 @@ def _final_status(mocks: _Mocks) -> str:
     return mocks.arg_for(act.update_vision_action_run_activity).status
 
 
+def _final_error(mocks: _Mocks) -> dict | None:
+    return mocks.arg_for(act.update_vision_action_run_activity).error
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "synth_status, expected_final, expect_emit",
+    "synth_status, expected_final, expect_emit, expected_error",
     [
-        (SynthesisStatus.SYNTHESIZED, VisionActionRunStatus.COMPLETED.value, True),
-        (SynthesisStatus.SKIPPED_EMPTY, VisionActionRunStatus.SKIPPED.value, False),
-        (SynthesisStatus.SKIPPED_OVER_BUDGET, VisionActionRunStatus.SKIPPED.value, False),
-        (SynthesisStatus.ABORTED_NO_CONSENT, VisionActionRunStatus.FAILED.value, False),
-        (SynthesisStatus.ABORTED_NO_USER, VisionActionRunStatus.FAILED.value, False),
+        (SynthesisStatus.SYNTHESIZED, VisionActionRunStatus.COMPLETED.value, True, None),
+        (SynthesisStatus.SKIPPED_EMPTY, VisionActionRunStatus.SKIPPED.value, False, {"skip_reason": "skipped_empty"}),
+        (
+            SynthesisStatus.SKIPPED_OVER_BUDGET,
+            VisionActionRunStatus.SKIPPED.value,
+            False,
+            {"skip_reason": "skipped_over_budget"},
+        ),
+        (
+            SynthesisStatus.ABORTED_NO_CONSENT,
+            VisionActionRunStatus.FAILED.value,
+            False,
+            {"aborted": "aborted_no_consent"},
+        ),
+        (SynthesisStatus.ABORTED_NO_USER, VisionActionRunStatus.FAILED.value, False, {"aborted": "aborted_no_user"}),
     ],
 )
 async def test_process_maps_synthesis_status(
-    synth_status: SynthesisStatus, expected_final: str, expect_emit: bool
+    synth_status: SynthesisStatus, expected_final: str, expect_emit: bool, expected_error: dict | None
 ) -> None:
     mocks = _Mocks(
         results={
@@ -249,6 +263,8 @@ async def test_process_maps_synthesis_status(
     assert synthesize_group_summary_activity in call_fns
     assert (act.emit_action_ready_activity in call_fns) is expect_emit
     assert _final_status(mocks) == expected_final
+    # Skip/abort runs carry the reason so they aren't unexplained; a completed run records no error.
+    assert _final_error(mocks) == expected_error
     # The schedule cursor is advanced by the eligibility claim, never by this workflow.
     assert act.evaluate_due_vision_actions_activity not in call_fns
 
@@ -265,6 +281,7 @@ async def test_process_skips_when_validate_returns_reason() -> None:
 
     assert act.emit_action_ready_activity not in mocks.calls()
     assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
+    assert _final_error(mocks) == {"skip_reason": "no_delivery_flow"}
 
 
 @pytest.mark.asyncio

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -9,7 +9,8 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
-from products.replay_vision.backend.models import VisionAction, VisionActionRun
+from products.replay_vision.backend.models import ReplayScanner, VisionAction, VisionActionRun
+from products.replay_vision.backend.models.replay_scanner import ScannerModel, ScannerType
 from products.replay_vision.backend.models.vision_action import TriggerType, VisionActionRunStatus
 from products.replay_vision.backend.temporal.vision_actions import activities as act
 from products.replay_vision.backend.temporal.vision_actions.synthesis import synthesize_action_activity
@@ -31,6 +32,14 @@ DAILY = "FREQ=DAILY;BYHOUR=9"
 
 
 def _action(team, **overrides) -> VisionAction:
+    if "scanner" not in overrides:
+        overrides["scanner"] = ReplayScanner.objects.create(
+            team=team,
+            name=f"scanner-{uuid.uuid4().hex[:8]}",
+            scanner_type=ScannerType.SUMMARIZER,
+            scanner_config={"prompt": "x"},
+            model=ScannerModel.GEMINI_3_FLASH,
+        )
     defaults: dict = {"team": team, "name": "a", "trigger_config": {"rrule": DAILY, "timezone": "UTC"}}
     defaults.update(overrides)
     a = VisionAction(**defaults)
@@ -106,7 +115,9 @@ class TestEngineActivities(BaseTest):
 
     def test_emit_captures_event(self) -> None:
         action = _action(self.team)
-        run = VisionActionRun(vision_action=action, team=self.team, idempotency_key="k", slack_text="hello *world*")
+        run = VisionActionRun(
+            vision_action=action, team=self.team, idempotency_key="k", output={"slack": "hello *world*"}
+        )
         run.save()
 
         captured = MagicMock()

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -76,7 +76,7 @@ class TestVisionActionSynthesis(BaseTest):
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
             patch(f"{_SYNTH_PATH}.genai", _mock_genai(llm_content)),
         ):
-            return _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id))
+            return _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
     def test_happy_path_persists_markdown_and_slack(self) -> None:
         self._observation("Users churned at checkout", title="Checkout")
@@ -121,7 +121,7 @@ class TestVisionActionSynthesis(BaseTest):
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
             patch(f"{_SYNTH_PATH}.genai", _NO_LLM),
         ):
-            result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id))
+            result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
         self.assertEqual(result.status, SynthesisStatus.SYNTHESIZED)
         self.assertEqual(result.observation_count, 5)
@@ -154,7 +154,7 @@ class TestVisionActionSynthesis(BaseTest):
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=(gate == "over_budget")),
             patch(f"{_SYNTH_PATH}.genai", _NO_LLM),
         ):
-            result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id))
+            result = _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
         self.assertEqual(result.status, expected)
         run.refresh_from_db()
@@ -220,7 +220,7 @@ class TestVisionActionSynthesis(BaseTest):
             patch(f"{_SYNTH_PATH}.is_team_over_ai_credit_budget", return_value=False),
             patch(f"{_SYNTH_PATH}.genai", SimpleNamespace(Client=_capturing_client)),
         ):
-            _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id))
+            _synthesize(SynthesizeGroupSummaryInputs(run_id=run.id, team_id=self.team.id))
 
         human = captured["human"]
         self.assertIn("focus on rage clicks", human)


### PR DESCRIPTION
## Problem

PR 3 of the Replay Vision "and then…" stack (scheduled Slack digests). With the model (#64168) and synthesis activity (#64176) in place, this adds the Temporal engine that actually runs scheduled actions on a cadence.

## Changes

The vision-action engine under `products/replay_vision/backend/temporal/vision_actions/`:

- **`ScheduleAllVisionActionsWorkflow`** — parent fan-out. `fetch_due_vision_actions_activity` scans enabled + `schedule` actions whose `next_run_at` is due (cross-team internal scan), then starts one child per action with a **deterministic id** and `ParentClosePolicy.ABANDON`. `WorkflowAlreadyStartedError` is swallowed so overlapping ticks dedup rather than double-fire.
- **`ProcessVisionActionWorkflow`** — per-action: create run → validate (skip if disabled / no delivery flow) → synthesize → emit `$replay_vision_action_ready`. The run record is **always** updated and `next_run_at` **always** advanced in `finally` (a failed run must not hot-loop), with the re-raise-after-finally pattern Temporal requires.
- **Supporting activities** — `create_run` (idempotent on `idempotency_key`), `validate`, `update_run`, `advance_next_run_at`, and `emit` (via `capture_internal_routed`, dedup-keyed by run id, `process_person_profile=False`).
- **Wiring** — registered in the worker (`WORKFLOWS` / `ACTIVITIES`) and as an interval schedule (`create_replay_vision_actions_schedule`, every 5 min, `SKIP` overlap) in `posthog/temporal/schedule.py`.

No `products.workflows` dependency yet — the delivery-flow provisioning that consumes the emitted event lands with the API PR. `tach check --dependencies --interfaces` passes.

## How did you test this code?

I'm an agent (PostHog Code). Added and ran `products/replay_vision/backend/tests/test_vision_action_engine.py` — **14 tests passing** locally via `hogli test`. Activity tests (real DB) cover: due-scan selectivity (only due + enabled + `schedule`), `create_run` idempotency, validate skip reasons, `update_run`, `advance_next_run_at`, and `emit` event properties. Workflow-orchestration tests (activities mocked at the `temporalio.workflow` boundary) cover: happy path → emit + COMPLETED + advance, validate-skip, empty/over-budget → SKIPPED without emit, no-consent → FAILED without emit, synthesis failure → FAILED + advance + re-raise, fan-out one-child-per-due-action, `WorkflowAlreadyStartedError` swallowed, and no-op when nothing is due.

Also verified `tach` boundaries are clean and the worker import graph resolves via the test run. No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus), stacked on #64176. Modeled on the exports subscriptions engine (deterministic child ids, advance-in-finally, hoist-and-reraise). Per the design discussion, this RV-owned scheduler is the piece most likely to be replaced if the Workflows team ships a "scheduled run kicks an async job" primitive — everything downstream (synthesis, event hand-off, delivery) is durable regardless.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*