### PR TITLE
fix(hubspot): back off and retry token refresh on rate limit

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 import requests
 import structlog
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 
@@ -22,6 +23,16 @@ def _error_message_from_response(res: requests.Response) -> str:
         return res.text
 
 
+@retry(
+    # A 429/5xx from HubSpot's OAuth token endpoint is transient. The data-fetch paths already
+    # back off and retry on HubspotRetryableError; this refresh is also reached at source-setup
+    # time (and from helpers.fetch_data), where no surrounding retry exists — so back off here too
+    # instead of failing the whole sync on a momentary rate limit.
+    retry=retry_if_exception_type((HubspotRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
 def hubspot_refresh_access_token(refresh_token: str, source_id: str | None = None) -> str:
     res = make_tracked_session().post(
         "https://api.hubapi.com/oauth/v1/token",

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
@@ -22,6 +22,13 @@ def _patch_post(response: MagicMock) -> Any:
     )
 
 
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep() -> Any:
+    # hubspot_refresh_access_token backs off on transient errors; skip the real waits in tests.
+    with patch("time.sleep"):
+        yield
+
+
 @pytest.mark.parametrize(
     "status,message",
     [
@@ -76,3 +83,32 @@ def test_transient_status_with_message_less_body_still_retryable() -> None:
 def test_success_returns_access_token() -> None:
     with _patch_post(_make_response(200, {"access_token": "new-token"})):
         assert hubspot_refresh_access_token("refresh-token") == "new-token"
+
+
+def test_transient_status_is_retried_then_succeeds() -> None:
+    # A momentary rate limit on the token endpoint should back off and retry rather than
+    # fail the whole sync; once HubSpot stops returning 429 the refresh succeeds.
+    session = MagicMock()
+    session.post.side_effect = [
+        _make_response(429, {"message": "You have reached your rate limit."}),
+        _make_response(429, {"message": "You have reached your rate limit."}),
+        _make_response(200, {"access_token": "new-token"}),
+    ]
+    with patch(
+        "posthog.temporal.data_imports.sources.hubspot.auth.make_tracked_session",
+        return_value=session,
+    ):
+        assert hubspot_refresh_access_token("refresh-token") == "new-token"
+    assert session.post.call_count == 3
+
+
+def test_transient_status_reraises_after_exhausting_retries() -> None:
+    session = MagicMock()
+    session.post.return_value = _make_response(429, {"message": "You have reached your rate limit."})
+    with patch(
+        "posthog.temporal.data_imports.sources.hubspot.auth.make_tracked_session",
+        return_value=session,
+    ):
+        with pytest.raises(HubspotRetryableError, match="You have reached your rate limit."):
+            hubspot_refresh_access_token("refresh-token")
+    assert session.post.call_count == 5


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HubspotRetryableError: You have reached your rate limit.` from the HubSpot data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ed32e-a11a-7700-8a4f-7093dfe763ca)).

The clean call path at the bottom of the stack is:

```
sources/hubspot/source.py  source_for_pipeline   (legacy config path)
  → sources/hubspot/auth.py:42  hubspot_refresh_access_token  → raises HubspotRetryableError on HTTP 429
```

HubSpot's OAuth token endpoint returned a transient `429`. `hubspot_refresh_access_token` correctly classifies `429`/`5xx` as the retryable `HubspotRetryableError`, but the function itself never retried. The data-fetch paths (`get_rows` / `get_rows_via_search`) wrap their HTTP calls in tenacity retries on exactly this error, but the token refresh is *also* reached at source-setup time (`source_for_pipeline`) and from `helpers.fetch_data` — neither of which has a surrounding retry. So a momentary rate limit on the token endpoint failed sync setup outright.

This is a transient/upstream rate limit, **not** a credential or config problem, so it is correctly *not* added to `NonRetryableErrors`. The fix is to make the refresh back off and retry like the rest of the source already does.

## Changes

- Add a tenacity `@retry` to `hubspot_refresh_access_token` with exponential backoff + jitter, retrying on `HubspotRetryableError` and transient `requests` timeouts/connection errors — mirroring the existing pattern in `hubspot.py`'s fetch helpers. `reraise=True` preserves the original exception (and its message) after retries are exhausted, so error classification and reporting are unchanged.
- This hardens every caller that lacked a surrounding retry: the reported `source_for_pipeline` setup path and `helpers.fetch_data`.

## How did you test this code?

I'm an agent. I ran the existing and new automated tests (no manual testing):

- `posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py` — 12 passed
- `posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py` — 39 passed
- `ruff check` / `ruff format` clean on the changed files

New regression tests assert a `429`-then-`200` sequence is retried and ultimately succeeds, and that a persistent `429` reraises `HubspotRetryableError` after exhausting attempts. Existing transient-error tests patch out the backoff sleep to stay fast.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue. Confirmed the issue in PostHog error tracking (full stack trace, exception type, two recent occurrences) and verified the failure genuinely originates in the HubSpot source code. Decided this is a transient upstream rate limit rather than a user/credential error — so it stays retryable — and that the real defect is the missing backoff on the token-refresh path. Scoped the fix to `hubspot_refresh_access_token` only; no global retry-policy changes.

Tools: Claude Code with the PostHog error-tracking MCP tools.
