### PR TITLE
fix(hubspot): retry token refresh on transient rate limit

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
@@ -112,3 +112,17 @@ def test_transient_status_reraises_after_exhausting_retries() -> None:
         with pytest.raises(HubspotRetryableError, match="You have reached your rate limit."):
             hubspot_refresh_access_token("refresh-token")
     assert session.post.call_count == 5
+
+
+def test_non_transient_status_is_not_retried() -> None:
+    # A non-transient status (e.g. invalid_grant) must surface immediately, not be retried.
+    session = MagicMock()
+    session.post.return_value = _make_response(400, {"message": "missing or invalid refresh token"})
+    with patch(
+        "posthog.temporal.data_imports.sources.hubspot.auth.make_tracked_session",
+        return_value=session,
+    ):
+        with pytest.raises(Exception) as exc_info:
+            hubspot_refresh_access_token("refresh-token")
+        assert not isinstance(exc_info.value, HubspotRetryableError)
+    assert session.post.call_count == 1


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HubspotRetryableError: You have reached your rate limit.` for the `hubspot` data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ed342-33bd-77b3-bad3-d7a010207089)).

The raise originates in this source's own code: `hubspot_refresh_access_token` (`auth.py`) posts to HubSpot's OAuth token endpoint (`/oauth/v1/token`), gets a `429`, and raises `HubspotRetryableError`. The captured stack shows it reached from `get_rows` → `fetch_page` (a `401` triggering a token refresh that then hit the rate limit). A closely related issue shows the same `429` reached from `source_for_pipeline`.

This is a **transient** rate-limit error, so it correctly stays retryable (not added to `NonRetryableErrors`). The real gap: `hubspot_refresh_access_token` raises an error explicitly documented as "should be retried with backoff", but the retry only existed in the fetch loops in `hubspot.py`. Other callers — `source_for_pipeline` and `_get_property_names` (via `fetch_data`) — invoke the refresh directly with **no** retry wrapper, so a momentary `429` on the token endpoint failed the entire sync immediately instead of backing off.

## Changes

- Move the backoff/retry onto `hubspot_refresh_access_token` itself (tenacity, 5 attempts, exponential jitter — mirroring the existing decorators in `hubspot.py`), so every call site honours the retryable contract, not just the fetch loops.
- Retries only the transient cases (`HubspotRetryableError` from `429`/`5xx`, plus `requests.ReadTimeout`/`requests.ConnectionError`). Non-transient statuses (e.g. `400 invalid_grant`) still raise a plain `Exception` and are **not** retried, so genuine credential/config problems surface immediately.

## How did you test this code?

I'm an agent (Claude Code). I ran the source's auth unit tests — all 13 pass:

```
posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py — 13 passed
```

Added regression tests that would have caught the gap:
- a persistent `429` is retried `stop_after_attempt` times before re-raising (asserts the request is attempted 5×, not once);
- a momentary `429` followed by success returns the refreshed token (recovers instead of failing);
- a non-transient `400` is attempted exactly once and surfaces immediately.

A fixture sets tenacity's `sleep` to a no-op so the retry-exercising tests stay fast. `ruff check` and `ruff format` are clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the HubSpot import source. Used PostHog error-tracking MCP tools to confirm the issue, pull the full stack trace, and verify the failure genuinely originates under `posthog/temporal/data_imports/sources/hubspot/` before changing anything.

Decision: the `429` rate limit is transient, so extending `NonRetryableErrors` would be wrong (it would swallow a recoverable error). Instead fixed the fragility — the retryable token-refresh error was not actually retried on every path. Centralising the retry on `hubspot_refresh_access_token` (rather than wrapping each unguarded caller) keeps the fix DRY and makes the function's documented "retried with backoff" contract hold everywhere. Kept scope tight: no change to global retry policy or to the already-wrapped fetch loops' behaviour.
