### PR TITLE
fix(data-imports): skip Sentry service hooks endpoint on 403

### DIFF
--- a/posthog/temporal/data_imports/sources/sentry/sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/sentry.py
@@ -548,6 +548,33 @@ def get_resource(
 # ---------------------------------------------------------------------------
 
 
+def _skip_endpoint_on_forbidden(resource: Iterable[Any], endpoint: str) -> Iterator[Any]:
+    """Yield pages from a fan-out resource, treating a 403 as "endpoint not
+    available for this organization" and stopping gracefully.
+
+    Sentry's project service hooks API is gated at the organization level, so it
+    returns 403 Forbidden even for tokens that already hold full project/admin
+    scopes. Letting that 403 propagate marks the whole schema as a non-retryable
+    failure (see ``SentrySource.get_non_retryable_errors``), permanently erroring
+    a source whose credentials are otherwise valid. Skipping the endpoint instead
+    lets the sync complete with an empty table — the same graceful-skip approach
+    used for persistent server errors in ``_iter_issue_tag_values_rows``. Genuine
+    scope problems still surface on the other (non-skipped) endpoints.
+    """
+    try:
+        yield from resource
+    except HTTPError as exc:
+        response = exc.response
+        if response is not None and response.status_code == 403:
+            logger.warning(
+                "sentry_source.endpoint_forbidden_skipped",
+                endpoint=endpoint,
+                status_code=response.status_code,
+            )
+            return
+        raise
+
+
 def _make_source_response(endpoint_config: SentryEndpointConfig, items_fn) -> SourceResponse:
     return SourceResponse(
         name=endpoint_config.name,
@@ -620,6 +647,13 @@ def sentry_source(
                 incremental_config_factory=_sentry_incremental_window,
             ),
         )
+        # Sentry gates the service hooks API at the org level, so it 403s even
+        # for fully-scoped tokens. Skip it gracefully rather than permanently
+        # erroring the schema (which the non-retryable 403 handling would do).
+        if endpoint == "project_service_hooks":
+            return _make_source_response(
+                endpoint_config, lambda: _skip_endpoint_on_forbidden(dependent_resource, endpoint)
+            )
         return _make_source_response(endpoint_config, lambda: dependent_resource)
 
     # --- Flat org-level endpoints (via rest_api_resources) ---

--- a/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -67,6 +67,18 @@ class _FakeDltResource:
         return iter(self._rows)
 
 
+class _RaisingResource:
+    """Fan-out resource stand-in that raises an HTTPError when iterated."""
+
+    def __init__(self, status_code: int) -> None:
+        self._status_code = status_code
+
+    def __iter__(self):
+        response = Mock()
+        response.status_code = self._status_code
+        raise HTTPError(f"{self._status_code} Client Error", response=response)
+
+
 class TestSentryTransport:
     def test_normalize_api_base_url(self) -> None:
         assert _normalize_api_base_url(None) == "https://sentry.io"
@@ -335,6 +347,60 @@ class TestSentrySourceValidation:
         assert row["project_slug"] == "web"
         assert "_projects_id" not in row
         assert "_projects_slug" not in row
+
+    # ----- Project service hooks: graceful skip on org-gated 403 -----
+
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry.build_dependent_resource")
+    def test_project_service_hooks_skips_on_forbidden(self, mock_build) -> None:
+        # Sentry 403s the service hooks endpoint for orgs without the feature,
+        # even with full scopes. The schema should complete empty, not error.
+        mock_build.return_value = _RaisingResource(403)
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="project_service_hooks",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        assert list(cast(Any, resp.items())) == []
+
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry.build_dependent_resource")
+    def test_project_service_hooks_propagates_non_forbidden(self, mock_build) -> None:
+        # A server error is not the org-gate signal — it must still propagate.
+        mock_build.return_value = _RaisingResource(500)
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="project_service_hooks",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        with pytest.raises(HTTPError):
+            list(cast(Any, resp.items()))
+
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry.build_dependent_resource")
+    def test_other_fanout_endpoint_propagates_forbidden(self, mock_build) -> None:
+        # A 403 on a non-servicehooks fan-out endpoint is a genuine scope error
+        # and must still reach the non-retryable handler.
+        mock_build.return_value = _RaisingResource(403)
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="project_users",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        with pytest.raises(HTTPError):
+            list(cast(Any, resp.items()))
 
     # ----- Issue fan-out: dependent resources (issue_events, issue_hashes) -----
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` from the data-warehouse import pipeline:

> `403 Client Error: Forbidden for url: https://sentry.io/api/0/projects/<org>/<project>/hooks/?limit=100`

([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed367-e0a1-7801-ad96-1a4736309cb5))

The failing request is the Sentry source's `project_service_hooks` fan-out endpoint (`/projects/{org}/{project}/hooks/`). The captured event shows the customer's Sentry token already holds **full scopes** (`project:admin`, `org:integrations`, `project:read`, …) — yet the request still 403s. That's because Sentry gates the **service hooks API at the organization level**: it returns 403 Forbidden for orgs without the feature, regardless of token scopes.

The Sentry source already classifies `"403 Client Error"` as non-retryable. That rule is correct for genuine scope problems on other endpoints, but for service hooks it is misleading and harmful: a perfectly-credentialed source has its entire `project_service_hooks` schema permanently marked as a non-retryable failure for an endpoint that simply isn't available for the org.

## Changes

Gracefully skip the `project_service_hooks` fan-out endpoint when it returns a 403: the wrapper swallows the 403, logs a warning, and ends iteration so the sync completes with an empty table — instead of failing the schema. This mirrors the graceful-skip already used for persistent server errors in `_iter_issue_tag_values_rows`.

Scoped deliberately:
- Only `project_service_hooks` is wrapped; other fan-out endpoints are untouched.
- Only **403** is skipped. 401/404/5xx and any other status still propagate, so genuine credential/scope errors on other endpoints still reach the non-retryable handler.

## How did you test this code?

I'm an agent. The full pytest harness couldn't run in this environment (Django/pytest core not installed in the provisioned venv), so I could not execute the suite here. I did:

- Add three regression tests in `test_sentry.py` (`TestSentrySourceValidation`): 403 on service hooks yields an empty table; a 500 on service hooks still propagates; a 403 on a non-servicehooks fan-out endpoint still propagates.
- Verify the helper's control flow in isolation (403 → skip; 401/404/500 → raise; happy-path pages pass through unchanged).
- `ruff check` and `ruff format --check` pass on both changed files.

CI will run the full test suite.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue end-to-end with Claude Code (PostHog error-tracking MCP tools to pull the stack trace, representative event, and affected scopes; codebase exploration of the Sentry source and the import pipeline's non-retryable handling).

Decision: this is a fixable bug (missing graceful-skip), not a credentials/upstream error. The 403 was already non-retryable, so simply extending `NonRetryableErrors` would have been a no-op — and the underlying classification is wrong for this endpoint, since the token has full scopes and the 403 is an org-level feature gate. Chose to scope the skip strictly to `project_service_hooks` + status 403 to avoid masking real scope errors elsewhere.