### PR TITLE
fix(klaviyo): treat 401/403 credential errors as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -68,6 +68,16 @@ Make sure to grant the following read permissions:
             ),
         )
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # An invalid, revoked, or insufficiently-scoped Klaviyo API key surfaces as a requests
+            # HTTPError when `fetch_page` calls `raise_for_status()`. Retrying can never satisfy a
+            # credential problem, so stop the sync. Match the stable status text and base host, not
+            # the per-request path/query/timestamp.
+            "401 Client Error: Unauthorized for url: https://a.klaviyo.com": "Your Klaviyo API key is invalid or has been revoked. Create a new private API key in your Klaviyo account settings, then reconnect.",
+            "403 Client Error: Forbidden for url: https://a.klaviyo.com": "Your Klaviyo API key is missing the read permissions needed to sync this data. Grant the required read scopes in your Klaviyo account settings, then reconnect.",
+        }
+
     def get_schemas(
         self,
         config: KlaviyoSourceConfig,

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -11,6 +11,7 @@ from posthog.temporal.data_imports.sources.klaviyo.klaviyo import (
     _format_incremental_value,
 )
 from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS, KlaviyoEndpointConfig
+from posthog.temporal.data_imports.sources.klaviyo.source import KlaviyoSource
 
 
 class TestFormatIncrementalValue:
@@ -145,3 +146,38 @@ class TestClampFutureValueToNow:
 
     def test_string_passthrough(self) -> None:
         assert _clamp_future_value_to_now("some-cursor-value") == "some-cursor-value"
+
+
+class TestNonRetryableErrors:
+    @parameterized.expand(
+        [
+            # 401/403 surfaced as a requests HTTPError when `fetch_page` calls `raise_for_status()`.
+            # The per-request path/query/timestamp varies, but the status text and base host are stable.
+            (
+                "unauthorized",
+                "401 Client Error: Unauthorized for url: https://a.klaviyo.com/api/events?filter=greater-than(datetime,2026-06-15T13:03:18.000Z)",
+            ),
+            (
+                "forbidden",
+                "403 Client Error: Forbidden for url: https://a.klaviyo.com/api/metrics",
+            ),
+        ]
+    )
+    def test_credential_errors_are_non_retryable(self, _name: str, observed_error: str) -> None:
+        non_retryable_errors = KlaviyoSource().get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @parameterized.expand(
+        [
+            # Transient/infra errors and server-side failures must stay retryable.
+            ("read_timeout", "HTTPSConnectionPool(host='a.klaviyo.com', port=443): Read timed out."),
+            (
+                "server_error",
+                "500 Server Error: Internal Server Error for url: https://a.klaviyo.com/api/events",
+            ),
+            ("connection_reset", "Connection reset by peer"),
+        ]
+    )
+    def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:
+        non_retryable_errors = KlaviyoSource().get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

The Klaviyo data-warehouse import source surfaces an unhandled `HTTPError` when the customer's API key is invalid, revoked, or missing read scopes:

```
HTTPError: 401 Client Error: Unauthorized for url: https://a.klaviyo.com/api/events?filter=greater-than(datetime,...)
```

The failure originates in `posthog/temporal/data_imports/sources/klaviyo/klaviyo.py` — `fetch_page` calls `response.raise_for_status()` for any non-ok, non-retryable status, which raises a `requests` `HTTPError` for a 401/403. `KlaviyoSource` had no `get_non_retryable_errors`, so the import activity treated this credential failure as retryable and kept retrying to the activity maximum even though retrying can never succeed.

Surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019ed38b-08da-7453-ad3e-23073f53893d

## Changes

Added `get_non_retryable_errors` to `KlaviyoSource`, mirroring the Stripe source. It marks 401 Unauthorized and 403 Forbidden responses from the Klaviyo API as non-retryable, with actionable messages prompting the user to recreate / re-scope their API key.

The match keys use the stable status text and base host (`https://a.klaviyo.com`) rather than the per-request path, query, or timestamp, so transient and server-side failures (read timeouts, connection resets, 5xx) stay retryable.

**Decision (user/upstream vs bug):** This is a user/upstream credentials error — a 401/403 from Klaviyo means the key is invalid, revoked, or under-scoped, which no retry can fix — so the fix is to extend `NonRetryableErrors` rather than change code behavior. Transient/server errors are deliberately left retryable.

## How did you test this code?

I'm an agent. I added parameterized unit tests in `test_klaviyo.py` asserting that representative 401/403 messages are recognized as non-retryable and that transient/5xx messages are not, and ran them:

- `uv run pytest posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py` — 25 passed
- `ruff check` and `ruff format` — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Klaviyo source. Confirmed via the PostHog error-tracking tools that the stack trace genuinely originates in the source's `fetch_page` (`klaviyo.py:196`, `raise_for_status()` on a 401 response), not merely in serialized log context. Verified the 401 was not already handled on master (`KlaviyoSource` inherited the empty base `get_non_retryable_errors`). Chose to extend `NonRetryableErrors` over a code fix because a 401/403 is a non-recoverable credential/permission problem, and scoped the match strings to the stable status text + host to avoid swallowing transient failures.