### PR TITLE
fix(stripe): treat account-access rejection as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -255,6 +255,14 @@ If automatic creation failed due to a permissions error and you're using a restr
             # A non-Connect key was sent with a `stripe_account` header (the source's "Account id"),
             # so Stripe rejects the whole request for the account rather than a specific scope.
             "Only Stripe Connect platforms can work with other accounts": "Stripe rejected the request because your API key isn't authorized for the configured Stripe account. The 'Account id' in your source settings only applies to Stripe Connect platform accounts — remove or correct it if your key belongs directly to the account, then reconnect.",
+            # Stripe's `account_invalid` rejection: the key can't reach the configured account (a
+            # `stripe_account` header it isn't authorized for) or the connected application's access
+            # was revoked. Surfaced mid-sync as `stripe.PermissionError` straight out of `get_rows`,
+            # so it never matches the URL-based 403 key. Retrying can't fix a key/account mismatch or
+            # a revoked grant — match Stripe's stable message (the account id and key are redacted out
+            # of the substring). `_is_stripe_account_access_error` classifies the same phrase for the
+            # webhook-creation path.
+            "does not have access to account": "Stripe rejected the request because your API key isn't authorized for the configured Stripe account. Remove or correct the 'Account id' in your source settings if your key belongs directly to the account. If you connected via OAuth, the application access may have been revoked — reconnect your Stripe account.",
             # Deterministic credential/config errors from _get_api_key and OAuthMixin
             "Missing Stripe API key": "Stripe API key is not configured. Please update the source configuration.",
             "Missing Stripe integration ID": "Stripe integration ID is not configured. Please reconnect your Stripe account.",

--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -20,6 +20,9 @@ class TestStripeSource:
             # IP allowlist rejection — matched on the stable phrase, ignoring the appended IP address.
             "The API key provided does not allow requests from your IP address.",
             "The API key provided does not allow requests from your IP address (1.2.3.4).",
+            # account_invalid: key not authorized for the configured account, or revoked app access.
+            # Raised mid-sync as stripe.PermissionError, matched on the stable phrase (key/account redacted).
+            "The provided key 'sk_test_***qPsl' does not have access to account 'stripe_s***less' (or that account does not exist). Application access may have been revoked.",
         ],
     )
     def test_non_retryable_errors_match_permission_failures(self, observed_error):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `PermissionError` for the Stripe data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ed3b0-ce30-78b0-8f83-ba2018535fef), 87 occurrences):

> The provided key 'sk_test_***qPsl' does not have access to account 'stripe_s***less' (or that account does not exist). Application access may have been revoked.

This is Stripe's `account_invalid` rejection. It happens when an API key is configured with an "Account id" (`stripe_account` header) it isn't authorized for, or when a connected application's access has been revoked. The stack originates in this source's code — `get_rows` → `_call_stripe` (`posthog/temporal/data_imports/sources/stripe/stripe.py`) — where the Stripe SDK raises `stripe.PermissionError`.

The failure is a **user/upstream credential/config error**: retrying can never satisfy a key/account mismatch or a revoked grant. But during a sync, `external_data_job` matches `str(exc)` against the source's `get_non_retryable_errors()` substrings, and none of them matched this message (the URL-based `403` key only matches `requests`-style HTTPErrors, not the SDK's `PermissionError`). So the import kept retrying.

## Changes

Added a `get_non_retryable_errors` entry matching Stripe's stable `does not have access to account` phrase (the redacted key and account id are outside the matched substring, keeping false-positives low), with an actionable message pointing the user at the "Account id" setting / OAuth reconnection. This mirrors the existing `_is_stripe_account_access_error` classification already used on the webhook-creation path.

## How did you test this code?

I'm an agent (Claude Code). I added a regression case with the exact observed error message to the parameterized non-retryable test and ran the suite:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py -q
# 10 passed
```

The existing "transient errors stay retryable" cases (read timeouts, 5xx, connection reset) still pass, confirming the new substring doesn't over-match. `ruff check` / `ruff format` clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, frequency, and that the genuine stack frames are in the Stripe source (`get_rows` → `_call_stripe`), discounting unrelated grouped-sample variables in the event payload. Decided this is user/upstream (not a fixable code bug or a transient infra error), so the right scope is extending the source's `NonRetryableErrors` rather than changing retry policy. Matched the stable message substring (not the volatile redacted key/account id), consistent with the existing IP-allowlist and Connect-account entries.
