### PR TITLE
feat(capture): publish PreparedEvent batches via serialize_batch

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -107,7 +107,8 @@ pub async fn process_batch(
 
     // serialize_batch consumes the events and hands them back, so we can keep
     // correlating results to them and build the response.
-    let (mut events, serialized) = serialize_batch(events, context).await;
+    let (mut events, serialized) =
+        serialize_batch(events, context, state.capture_v1_scatter_gather_min_batch).await;
 
     let sink_results = sink_router
         .publish_batch(sink_router.default_sink(), context, &serialized.prepared)
@@ -551,7 +552,7 @@ mod tests {
     };
     use crate::v1::analytics::constants::CAPTURE_V1_PATH;
     use crate::v1::analytics::types::{Batch, Event, Options};
-    use crate::v1::sinks::Destination;
+    use crate::v1::sinks::{Destination, DEFAULT_SCATTER_GATHER_MIN_BATCH};
     use crate::v1::test_utils::{
         self, find_by_did, malformed_wrapped_event, raw_obj, valid_event, wrapped_event,
         wrapped_event_at,
@@ -2572,7 +2573,8 @@ mod tests {
             wrapped_event("button_clicked", "user-3"),
         ];
 
-        let (mut events, serialized) = serialize_batch(events, &ctx).await;
+        let (mut events, serialized) =
+            serialize_batch(events, &ctx, DEFAULT_SCATTER_GATHER_MIN_BATCH).await;
 
         let sink_results = router
             .publish_batch(router.default_sink(), &ctx, &serialized.prepared)
@@ -2606,7 +2608,8 @@ mod tests {
                 .with_result(EventResult::Warning, Some("person_processing_disabled")),
         ];
 
-        let (mut events, serialized) = serialize_batch(events, &ctx).await;
+        let (mut events, serialized) =
+            serialize_batch(events, &ctx, DEFAULT_SCATTER_GATHER_MIN_BATCH).await;
 
         assert_eq!(serialized.prepared.len(), 2); // only Ok + Warning are published
 
@@ -2645,7 +2648,8 @@ mod tests {
                 .with_result(EventResult::Drop, Some("billing_limit_exceeded")),
         ];
 
-        let (mut events, serialized) = serialize_batch(events, &ctx).await;
+        let (mut events, serialized) =
+            serialize_batch(events, &ctx, DEFAULT_SCATTER_GATHER_MIN_BATCH).await;
 
         assert!(serialized.prepared.is_empty());
 
@@ -2674,7 +2678,8 @@ mod tests {
         let events =
             vec![wrapped_event("$pageview", "user-1").with_destination(Destination::Overflow)];
 
-        let (mut events, serialized) = serialize_batch(events, &ctx).await;
+        let (mut events, serialized) =
+            serialize_batch(events, &ctx, DEFAULT_SCATTER_GATHER_MIN_BATCH).await;
 
         let sink_results = router
             .publish_batch(router.default_sink(), &ctx, &serialized.prepared)

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -26,7 +26,7 @@ use crate::router;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::event::Event as SinkEvent;
 use crate::v1::sinks::types::SinkResult;
-use crate::v1::sinks::Destination;
+use crate::v1::sinks::{serialize_batch, Destination};
 use crate::v1::Error;
 
 /// Maps event name to its Kafka destination, mirroring legacy DataType assignment.
@@ -98,27 +98,27 @@ pub async fn process_batch(
     )
     .record(processing_start.elapsed().as_secs_f64());
 
-    // Publish to v1 sink, merge results, build response
+    // Serialize (hoisted out of the sink; parallel for large batches), then
+    // publish and merge results before building the response.
     let sink_router = state
         .v1_sink_router
         .as_ref()
         .ok_or_else(|| Error::ServiceUnavailable("v1 sink router not configured".into()))?;
 
-    let event_refs: Vec<&(dyn SinkEvent + Send + Sync)> = events
-        .iter()
-        .filter(|e| SinkEvent::should_publish(*e))
-        .map(|e| {
-            let r: &(dyn SinkEvent + Send + Sync) = e;
-            r
-        })
-        .collect();
+    // serialize_batch consumes the events and hands them back, so we can keep
+    // correlating results to them and build the response.
+    let (mut events, serialized) = serialize_batch(events, context).await;
 
     let sink_results = sink_router
-        .publish_batch(sink_router.default_sink(), context, &event_refs)
+        .publish_batch(sink_router.default_sink(), context, &serialized.prepared)
         .await
         .map_err(|e| Error::InternalError(e.to_string()))?;
 
-    merge_sink_results(&mut events, &sink_results);
+    // Serialize-step failures and sink results are both per-event SinkResults;
+    // merge them together so serialization drops surface in the response.
+    let mut all_results = serialized.failures;
+    all_results.extend(sink_results);
+    merge_sink_results(&mut events, &all_results);
 
     Ok(BatchResponse::build(context, &events))
 }
@@ -2566,27 +2566,22 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.created_at = None;
 
-        let mut events = vec![
+        let events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$identify", "user-2"),
             wrapped_event("button_clicked", "user-3"),
         ];
 
-        let event_refs: Vec<&(dyn crate::v1::sinks::event::Event + Send + Sync)> = events
-            .iter()
-            .filter(|e| SinkEvent::should_publish(*e))
-            .map(|e| {
-                let r: &(dyn crate::v1::sinks::event::Event + Send + Sync) = e;
-                r
-            })
-            .collect();
+        let (mut events, serialized) = serialize_batch(events, &ctx).await;
 
         let sink_results = router
-            .publish_batch(router.default_sink(), &ctx, &event_refs)
+            .publish_batch(router.default_sink(), &ctx, &serialized.prepared)
             .await
             .unwrap();
 
-        merge_sink_results(&mut events, &sink_results);
+        let mut all_results = serialized.failures;
+        all_results.extend(sink_results);
+        merge_sink_results(&mut events, &all_results);
         let resp = BatchResponse::build(&ctx, &events);
 
         assert!(!resp.has_retry);
@@ -2603,7 +2598,7 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.created_at = None;
 
-        let mut events = vec![
+        let events = vec![
             wrapped_event("$pageview", "user-1"),
             wrapped_event("$pageview", "user-2")
                 .with_result(EventResult::Drop, Some("billing_limit_exceeded")),
@@ -2611,23 +2606,18 @@ mod tests {
                 .with_result(EventResult::Warning, Some("person_processing_disabled")),
         ];
 
-        let event_refs: Vec<&(dyn crate::v1::sinks::event::Event + Send + Sync)> = events
-            .iter()
-            .filter(|e| SinkEvent::should_publish(*e))
-            .map(|e| {
-                let r: &(dyn crate::v1::sinks::event::Event + Send + Sync) = e;
-                r
-            })
-            .collect();
+        let (mut events, serialized) = serialize_batch(events, &ctx).await;
 
-        assert_eq!(event_refs.len(), 2); // only Ok + Warning are published
+        assert_eq!(serialized.prepared.len(), 2); // only Ok + Warning are published
 
         let sink_results = router
-            .publish_batch(router.default_sink(), &ctx, &event_refs)
+            .publish_batch(router.default_sink(), &ctx, &serialized.prepared)
             .await
             .unwrap();
 
-        merge_sink_results(&mut events, &sink_results);
+        let mut all_results = serialized.failures;
+        all_results.extend(sink_results);
+        merge_sink_results(&mut events, &all_results);
         let resp = BatchResponse::build(&ctx, &events);
 
         assert!(!resp.has_retry);
@@ -2648,30 +2638,25 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.created_at = None;
 
-        let mut events = vec![
+        let events = vec![
             wrapped_event("$pageview", "user-1")
                 .with_result(EventResult::Drop, Some("billing_limit_exceeded")),
             wrapped_event("$pageview", "user-2")
                 .with_result(EventResult::Drop, Some("billing_limit_exceeded")),
         ];
 
-        let event_refs: Vec<&(dyn crate::v1::sinks::event::Event + Send + Sync)> = events
-            .iter()
-            .filter(|e| SinkEvent::should_publish(*e))
-            .map(|e| {
-                let r: &(dyn crate::v1::sinks::event::Event + Send + Sync) = e;
-                r
-            })
-            .collect();
+        let (mut events, serialized) = serialize_batch(events, &ctx).await;
 
-        assert!(event_refs.is_empty());
+        assert!(serialized.prepared.is_empty());
 
         let sink_results = router
-            .publish_batch(router.default_sink(), &ctx, &event_refs)
+            .publish_batch(router.default_sink(), &ctx, &serialized.prepared)
             .await
             .unwrap();
 
-        merge_sink_results(&mut events, &sink_results);
+        let mut all_results = serialized.failures;
+        all_results.extend(sink_results);
+        merge_sink_results(&mut events, &all_results);
         let resp = BatchResponse::build(&ctx, &events);
 
         assert!(!resp.has_retry);
@@ -2686,24 +2671,19 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.created_at = None;
 
-        let mut events =
+        let events =
             vec![wrapped_event("$pageview", "user-1").with_destination(Destination::Overflow)];
 
-        let event_refs: Vec<&(dyn crate::v1::sinks::event::Event + Send + Sync)> = events
-            .iter()
-            .filter(|e| SinkEvent::should_publish(*e))
-            .map(|e| {
-                let r: &(dyn crate::v1::sinks::event::Event + Send + Sync) = e;
-                r
-            })
-            .collect();
+        let (mut events, serialized) = serialize_batch(events, &ctx).await;
 
         let sink_results = router
-            .publish_batch(router.default_sink(), &ctx, &event_refs)
+            .publish_batch(router.default_sink(), &ctx, &serialized.prepared)
             .await
             .unwrap();
 
-        merge_sink_results(&mut events, &sink_results);
+        let mut all_results = serialized.failures;
+        all_results.extend(sink_results);
+        merge_sink_results(&mut events, &all_results);
         let resp = BatchResponse::build(&ctx, &events);
 
         assert!(!resp.has_retry);

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -260,7 +260,7 @@ analytics-only concern while the sink layer remains capture-mode-agnostic.
 `serialize(ctx)` returns `bytes::Bytes` and `partition_key(ctx)` returns a
 fresh owned `String`. `Bytes` is zero-copy to construct from a `Vec<u8>`
 and cheap (refcounted) to clone, so a `PreparedEvent` can be moved into a
-`spawn_blocking` task and fanned out to multiple sinks without re-encoding.
+tokio task and fanned out to multiple sinks without re-encoding.
 The owned contract needs no shared mutable buffers, which is what makes
 the scatter-gather prep loop safe to parallelize.
 
@@ -364,15 +364,20 @@ back into the request. `Bytes` makes it cheap to clone across a dual-write.
 
   events.len() >= 8
     └── Arc<Vec<E>> + Arc<RequestContext>
-        └── JoinSet of spawn_blocking tasks, one per event index
+        └── JoinSet of tokio tasks (spawn, not spawn_blocking), one per event index
             └── each task: catch_unwind(prepare_one(&events[i], &ctx))
         └── collect by index → preserves input order
 ```
 
-Small batches stay inline because a `JoinSet` of `spawn_blocking` tasks
-costs more than the serialization itself for a handful of events. Large
-batches fan out across the blocking pool to cut tail latency on big
-payloads. Both paths produce identical output (ordering, skips, failures)
+Small batches stay inline because a `JoinSet` of tokio tasks costs more
+than the serialization itself for a handful of events. Large batches fan
+out across the async worker pool to cut tail latency on big payloads. We
+use `spawn` (not `spawn_blocking`) to match v0's `send_batch`: per-event
+serialize is short CPU work, so concurrent execution is naturally bounded
+by `worker_threads` (~num_cpus) and excess events queue cheaply, rather
+than spawning one blocking-pool task per event and risking saturation of
+the shared `spawn_blocking` pool on very large batches. Both paths produce
+identical output (ordering, skips, failures)
 — verified by parity tests in `prepare.rs`.
 
 ### Panic isolation
@@ -385,7 +390,7 @@ returns become `SerializationFailure::from_error`. Both are fatal
 
 ### Ownership (Arc::try_unwrap)
 
-`spawn_blocking` requires `'static`, so the parallel path wraps the events
+`spawn` requires `'static`, so the parallel path wraps the events
 in `Arc<Vec<E>>` and tasks borrow by index. After the `JoinSet` drains,
 every task has dropped its `Arc` clone, so `Arc::try_unwrap` reclaims the
 sole-owner `Vec<E>` and hands it back to the caller. This is why

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -400,14 +400,14 @@ sole-owner `Vec<E>` and hands it back to the caller. This is why
 
 | Metric | Type | Labels | When |
 |---|---|---|---|
-| `capture_v1_serialize_duration_seconds` | histogram | `mode`, `path`, `batch_size` | Per-batch serialize wall-time (sequential or parallel) |
-| `capture_v1_serialize_failed_total` | counter | `mode`, `path` | Per event that failed to serialize |
-| `capture_v1_serialize_panic_total` | counter | `mode`, `path` | Per event whose `serialize` panicked |
+| `capture_v1_serialize_duration_seconds` | histogram | `batch_size` | Per-batch serialize wall-time (sequential or parallel) |
+| `capture_v1_serialize_failed_total` | counter | — | Per event that failed to serialize |
+| `capture_v1_serialize_panic_total` | counter | — | Per event whose `serialize` panicked |
 
 These are sink- and product-agnostic (serialization happens before any
-sink is chosen). Per-mode faceting comes from the deployment
-(`capture-analytics` / `-replay` / `-ai`), so no `cluster`/`destination`
-labels are needed here.
+sink is chosen). Per-mode faceting comes from the Kubernetes deployment
+(`capture-analytics` / `-replay` / `-ai`) via the `namespace` label
+injected by the metrics pipeline.
 
 ---
 

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -327,6 +327,7 @@ modes share one implementation.
 pub async fn serialize_batch<E: Event + Send + Sync + 'static>(
     events: Vec<E>,
     ctx: &RequestContext,
+    scatter_gather_threshold: usize,
 ) -> (Vec<E>, SerializedBatch);
 
 pub struct SerializedBatch {
@@ -358,11 +359,15 @@ back into the request. `Bytes` makes it cheap to clone across a dual-write.
 
 ### Sequential vs parallel
 
+The threshold is configurable via `CAPTURE_V1_SCATTER_GATHER_MIN_BATCH`
+(default 8). Set to 0 to force sequential serialization for all batch
+sizes (useful for modes like replay where batches are always single large events).
+
 ```text
-  events.len() < SCATTER_GATHER_MIN_BATCH (8)
+  scatter_gather_threshold == 0  OR  events.len() < threshold
     └── serialize inline on the request task (no spawn overhead)
 
-  events.len() >= 8
+  events.len() >= threshold  (threshold > 0)
     └── Arc<Vec<E>> + Arc<RequestContext>
         └── JoinSet of tokio tasks (spawn, not spawn_blocking), one per event index
             └── each task: catch_unwind(prepare_one(&events[i], &ctx))

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -29,6 +29,11 @@ they register their own paths under the same scheme.
                            └──────┬───────┘
                                   │  Vec<WrappedEvent>
                                   ▼
+                           ┌──────────────┐
+                           │serialize_batch│─ scatter-gather (prepare.rs)
+                           └──────┬────────┘
+                                  │  Vec<PreparedEvent>
+                                  ▼
                            ┌─────────────┐
                            │   Router     │─── resolves SinkName
                            └──────┬───────┘
@@ -55,8 +60,15 @@ Key properties:
   WarpStream during a migration).
 - **Per-event results** — `publish_batch` returns one `Box<dyn SinkResult>`
   per published event, correlating outcomes back to request events by UUID.
-- **Owned-return API** — `serialize()` and `partition_key()` each return
-  a fresh `String`, keeping the trait simple and parallelism-ready.
+- **Hoisted serialization** — events are serialized into storage-agnostic
+  `PreparedEvent`s by `serialize_batch` (`prepare.rs`) _before_ any sink is
+  touched. Sinks consume `&[PreparedEvent]`, never raw `Event` trait objects.
+  This isolates CPU-bound encoding from sink I/O, lets the same prepared
+  batch fan out to multiple sinks without re-encoding, and enables the
+  scatter-gather parallelism described in [section 2a](#2a-serialize_batch-scatter-gather).
+- **Owned-payload API** — `Event::serialize()` returns `bytes::Bytes` and
+  `partition_key()` returns a fresh `String`, keeping the trait simple and
+  cheap to move into spawned tasks.
 
 ---
 
@@ -68,7 +80,8 @@ graph TD
     constants["constants.rs<br>DEFAULT_PRODUCE_TIMEOUT,<br>SINK_LIVENESS_DEADLINE,<br>SINK_STALL_THRESHOLD"]
     event["event.rs<br>trait Event"]
     sink["sink.rs<br>trait Sink"]
-    types["types.rs<br>Destination, Outcome,<br>trait SinkResult,<br>BatchSummary"]
+    types["types.rs<br>Destination, Outcome,<br>trait SinkResult, BatchSummary,<br>PreparedEvent, SerializationFailure"]
+    prepare["prepare.rs<br>serialize_batch,<br>SerializedBatch"]
     router["router.rs<br>Router,<br>RouterError"]
 
     kmod["kafka/mod.rs<br>KafkaProducerTrait"]
@@ -84,8 +97,12 @@ graph TD
     mod --> event
     mod --> sink
     mod --> types
+    mod --> prepare
     mod --> router
     mod --> kmod
+
+    prepare --> event
+    prepare --> types
 
     kmod --> kconfig
     kmod --> kctx
@@ -113,9 +130,10 @@ Two layers:
 ```rust
 pub use event::Event;
 pub use kafka::KafkaSink;
+pub use prepare::{serialize_batch, SerializedBatch};
 pub use router::{Router, RouterError};
 pub use sink::Sink;
-pub use types::{Destination, Outcome, SinkResult};
+pub use types::{Destination, Outcome, PreparedEvent, SerializationFailure, SinkResult};
 ```
 
 ---
@@ -133,18 +151,20 @@ pub trait Sink: Send + Sync {
 
     async fn publish_batch(
         &self,
-        ctx: &Context,
-        events: &[&(dyn Event + Send + Sync)],
+        ctx: &RequestContext,
+        events: &[PreparedEvent],
     ) -> Vec<Box<dyn SinkResult>>;
 
     async fn flush(&self) -> anyhow::Result<()>;
 }
 ```
 
-Each `Sink` owns its identity (`name`), accepts a batch of trait-object
-events, and returns one `Box<dyn SinkResult>` per _published_ event.
-Skipped events (not publishable, or `Destination::Drop`) produce no
-result entry.
+Each `Sink` owns its identity (`name`), accepts a batch of
+already-serialized `PreparedEvent`s, and returns one `Box<dyn SinkResult>`
+per event it attempts. Events that never reach the sink — filtered by
+`should_publish()` or routed to `Destination::Drop` during
+`serialize_batch` — are simply absent from the input slice. A
+`Destination` with no configured topic still produces no result entry.
 
 `KafkaSink<P: KafkaProducerTrait>` is currently the only implementation.
 It is generic over the producer trait so tests inject `MockProducer`
@@ -209,13 +229,13 @@ pub trait Event: Send + Sync {
     fn uuid(&self) -> Uuid;
     fn should_publish(&self) -> bool;
     fn destination(&self) -> &Destination;
-    fn headers(&self, ctx: &Context) -> CapturedEventHeaders;
-    fn partition_key(&self, ctx: &Context) -> String;
-    fn serialize(&self, ctx: &Context) -> anyhow::Result<String>;
+    fn headers(&self, ctx: &RequestContext) -> CapturedEventHeaders;
+    fn partition_key(&self, ctx: &RequestContext) -> String;
+    fn serialize(&self, ctx: &RequestContext) -> anyhow::Result<bytes::Bytes>;
 }
 ```
 
-`headers` receives the request `Context` so each `Event` implementation
+`headers` receives the request `RequestContext` so each `Event` implementation
 can combine batch-scoped fields (token, now, historical_migration) with
 event-scoped fields into a single `CapturedEventHeaders`
 (`common_types`). The sink converts the returned struct to its
@@ -227,16 +247,26 @@ The analytics capture endpoint's `WrappedEvent` implements this trait
 Other capture endpoints (e.g. session replay, exceptions) provide
 their own `Event` implementations without changing any sink code.
 
+### Context split
+
+Trait methods take `&RequestContext` — the mode-agnostic request context
+(token, IP, timing, raw query string) shared by every future capture mode.
+The analytics endpoint wraps it in `analytics::Context { req, query }`,
+which `Deref`s to `RequestContext`, so the typed `Query` stays an
+analytics-only concern while the sink layer remains capture-mode-agnostic.
+
 ### Owned-return serialization
 
-`partition_key(ctx)` and `serialize(ctx)` each return a fresh owned
-`String`. This trades a small per-event allocation for a simpler trait
-contract that needs no shared mutable buffers — making the prep loop
-trivially parallelizable if needed in the future.
+`serialize(ctx)` returns `bytes::Bytes` and `partition_key(ctx)` returns a
+fresh owned `String`. `Bytes` is zero-copy to construct from a `Vec<u8>`
+and cheap (refcounted) to clone, so a `PreparedEvent` can be moved into a
+`spawn_blocking` task and fanned out to multiple sinks without re-encoding.
+The owned contract needs no shared mutable buffers, which is what makes
+the scatter-gather prep loop safe to parallelize.
 
 `WrappedEvent::serialize` pre-sizes its buffer via
-`String::with_capacity(data.len() + 512)` to minimize reallocations
-for typical payloads.
+`Vec::with_capacity(data.len() + 512)` to minimize reallocations
+for typical payloads, then returns `Bytes::from(buf)`.
 
 ### Skip mechanisms
 
@@ -256,7 +286,7 @@ timestamp, session_id, etc.):
 
 ```text
   ┌──────────────────────────────────────────────┐
-  │ event.headers(ctx: &Context)                 │
+  │ event.headers(ctx: &RequestContext)          │
   │                                              │
   │   CapturedEventHeaders {                     │
   │     token,                     ◄─ from ctx   │
@@ -286,6 +316,96 @@ a single structured type flows from event to transport.
 
 ---
 
+## 2a. serialize_batch (scatter-gather)
+
+`serialize_batch` (`prepare.rs`) is the mode-agnostic step that turns a
+`Vec<E: Event>` into a `SerializedBatch` _before_ the router/sink layer.
+It is generic over the `Event` impl, so analytics, replay, and AI capture
+modes share one implementation.
+
+```rust
+pub async fn serialize_batch<E: Event + Send + Sync + 'static>(
+    events: Vec<E>,
+    ctx: &RequestContext,
+) -> (Vec<E>, SerializedBatch);
+
+pub struct SerializedBatch {
+    pub prepared: Vec<PreparedEvent>,        // publishable, in input order
+    pub failures: Vec<Box<dyn SinkResult>>,  // SerializationFailure per failed event
+}
+```
+
+The caller gets its `Vec<E>` back so it can still build the per-event HTTP
+response after publishing (the prepared events alone don't carry the
+original request event). Recovery uses `Arc::try_unwrap` after the spawned
+tasks finish — see "Ownership" below.
+
+### PreparedEvent
+
+```rust
+pub struct PreparedEvent {
+    pub uuid: Uuid,
+    pub destination: Destination,
+    pub payload: bytes::Bytes,
+    pub headers: CapturedEventHeaders,
+    pub partition_key: String,  // raw; the sink decides whether to null it
+}
+```
+
+Storage-agnostic and fully owned. It carries everything a sink needs to
+produce a record, so the sink does no serialization and holds no reference
+back into the request. `Bytes` makes it cheap to clone across a dual-write.
+
+### Sequential vs parallel
+
+```text
+  events.len() < SCATTER_GATHER_MIN_BATCH (8)
+    └── serialize inline on the request task (no spawn overhead)
+
+  events.len() >= 8
+    └── Arc<Vec<E>> + Arc<RequestContext>
+        └── JoinSet of spawn_blocking tasks, one per event index
+            └── each task: catch_unwind(prepare_one(&events[i], &ctx))
+        └── collect by index → preserves input order
+```
+
+Small batches stay inline because a `JoinSet` of `spawn_blocking` tasks
+costs more than the serialization itself for a handful of events. Large
+batches fan out across the blocking pool to cut tail latency on big
+payloads. Both paths produce identical output (ordering, skips, failures)
+— verified by parity tests in `prepare.rs`.
+
+### Panic isolation
+
+Each event is serialized inside `std::panic::catch_unwind`. A panic in one
+event's `serialize` becomes a `SerializationFailure { is_panic: true }`
+for that event only; the rest of the batch is unaffected. Regular `Err`
+returns become `SerializationFailure::from_error`. Both are fatal
+(non-retriable) — re-running the same bytes would panic/err again.
+
+### Ownership (Arc::try_unwrap)
+
+`spawn_blocking` requires `'static`, so the parallel path wraps the events
+in `Arc<Vec<E>>` and tasks borrow by index. After the `JoinSet` drains,
+every task has dropped its `Arc` clone, so `Arc::try_unwrap` reclaims the
+sole-owner `Vec<E>` and hands it back to the caller. This is why
+`serialize_batch` can be parallel yet still return owned events.
+
+### Metrics
+
+| Metric | Type | Labels | When |
+|---|---|---|---|
+| `capture_v1_serialize_duration_seconds` | histogram | `mode`, `path`, `batch_size` | Per-batch serialize wall-time (sequential or parallel) |
+| `capture_v1_serialize_failed_total` | counter | `mode`, `path` | Per event that failed to serialize |
+| `capture_v1_serialize_panic_total` | counter | `mode`, `path` | Per event whose `serialize` panicked |
+
+These are sink- and product-agnostic (serialization happens before any
+sink is chosen). Per-mode faceting comes from the deployment
+(`capture-analytics` / `-replay` / `-ai`), so no `cluster`/`destination`
+labels are needed here.
+
+---
+
 ## 3. SinkResult and outcome model
 
 ### The SinkResult trait
@@ -309,6 +429,11 @@ backend-agnostic: callers never need to know which backend produced a
 result. The per-event heap allocation is a deliberate trade-off for
 simplicity; at current batch sizes the cost is negligible compared to
 Kafka I/O.
+
+Two types implement `SinkResult`: `KafkaResult` (sink-level produce
+outcomes) and `SerializationFailure` (pre-sink serialize failures from
+`serialize_batch`). `process_batch` concatenates both into one
+`Vec<Box<dyn SinkResult>>` before correlating outcomes back to events.
 
 ### Outcome
 
@@ -344,10 +469,13 @@ Captures every failure mode within a single configured sink:
 | Variant | Outcome | When |
 |---|---|---|
 | `SinkUnavailable` | `RetriableError` | Producer health gate failed |
-| `SerializationFailed(String)` | `FatalError` | `serialize` returned `Err` |
 | `Produce(ProduceError)` | Depends on `ProduceError::is_retriable()` | rdkafka send or delivery error |
 | `Timeout` | `Timeout` | Ack not received within `produce_timeout` |
 | `TaskPanicked` | `RetriableError` | Ack task panicked (should not happen with `FuturesUnordered`) |
+
+Serialization failures are no longer a sink concern — they are produced by
+`serialize_batch` as `SerializationFailure` (see
+[section 2a](#2a-serialize_batch-scatter-gather)) before any sink runs.
 
 ### BatchSummary
 
@@ -428,13 +556,11 @@ corresponds 1:1 to a published event.
   ┌──────────────────────────▼───────────────────────────────────────┐
   │ Phase 1: Enqueue (sequential, per-partition ordering preserved)  │
   │                                                                 │
-  │   for each event:                                               │
-  │     ├── should_publish()? → skip if false                       │
+  │   input: &[PreparedEvent] (already serialized by serialize_batch)│
+  │   for each prepared event:                                      │
   │     ├── topic_for(destination)? → skip if Drop/None             │
-  │     ├── event.serialize(ctx) → payload String                   │
-  │     ├── event.headers(ctx) → CapturedEventHeaders               │
-  │     ├── should_null_partition_key(headers, dest)?                │
-  │     │     └── false → event.partition_key(ctx) → Some(key)      │
+  │     ├── payload: prepared.payload (Bytes, no re-encode)         │
+  │     ├── effective_partition_key(prepared.partition_key, dest)?  │
   │     ├── CapturedEventHeaders → OwnedHeaders (via From)          │
   │     └── producer.send(ProduceRecord)                            │
   │           ├── Ok(ack_future) → push to FuturesUnordered         │
@@ -480,18 +606,17 @@ corresponds 1:1 to a published event.
 
 ### Phase 1 — Enqueue
 
-Events are sent sequentially to preserve per-partition ordering. Two
-reusable `String` buffers (`payload_buf`, `key_buf`) are cleared and
-rewritten each iteration, amortizing allocations to zero after the first
-event.
+Events arrive already serialized as `PreparedEvent`s, so Phase 1 does no
+encoding — it reads `prepared.payload` (`Bytes`) directly. Events are sent
+sequentially to preserve per-partition ordering.
 
 If `producer.send()` returns `QueueFull`, the event is failed immediately
 as a retriable error. Backpressure is handled by librdkafka's internal
 queue and the client-level retry mechanism, not an app-level sleep loop.
 
-After serialization and header construction, `effective_partition_key()`
-(`kafka/sink.rs`) decides whether the partition key should be nulled.
-Events always write a key via `partition_key()`; the sink nulls it when
+`effective_partition_key()` (`kafka/sink.rs`) decides whether the
+prepared key should be nulled. Prepared events always carry a key;
+the sink nulls it when
 `force_disable_person_processing` is set and the destination is
 `AnalyticsMain` or `Overflow`. In that case `None` is passed to rdkafka
 so it round-robins; passing `Some("")` would hash to a single
@@ -752,7 +877,7 @@ Constructed by `KafkaProducer::new(sink, &KafkaConfig, handle, capture_mode)`:
 pub struct ProduceRecord<'a> {
     pub topic: &'a str,
     pub key: Option<&'a str>,
-    pub payload: &'a str,
+    pub payload: &'a [u8],
     pub headers: OwnedHeaders,
 }
 ```
@@ -891,7 +1016,11 @@ request-level context (`path`, `attempt`).
 | `capture_v1_kafka_publish_total` | counter | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Every event outcome (success, error, timeout, reject) |
 | `capture_v1_kafka_ack_duration_seconds` | histogram | `mode`, `cluster`, `outcome`, `path`, `attempt` (capped at "6+"), `destination` | Per-event broker-ack latency (successful send → ack resolution), including `outcome="timeout"` for acks that miss `produce_timeout` |
 | `capture_v1_kafka_enqueue_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+") | Per-batch enqueue wall-time (the `enqueue_events` call), isolated from broker-ack latency |
-| `capture_v1_kafka_serialize_duration_seconds` | histogram | `mode`, `cluster`, `path`, `attempt` (capped at "6+"), `batch_size` | Per-batch serialization time (serialize + partition-key + enqueue loop), bucketed by batch size for latency/size correlation |
+
+Serialization timing now lives in `capture_v1_serialize_duration_seconds`
+(emitted by `serialize_batch`, see
+[section 2a](#2a-serialize_batch-scatter-gather)) — it is no longer a
+sink-path metric.
 
 Cardinality note: the `destination` label is bounded at 9 values
 (`Destination::as_tag()` collapses all `Custom(_)` topics to `custom`)
@@ -920,7 +1049,7 @@ All error-related metrics use stable, low-cardinality tags derived from:
 - `error_code_tag()` — maps `RDKafkaErrorCode` variants to snake_case strings
   (e.g. `queue_full`, `message_size_too_large`, `all_brokers_down`)
 - `KafkaSinkError::as_tag()` — sink-level tags
-  (e.g. `sink_unavailable`, `serialization_failed`, `timeout`)
+  (e.g. `sink_unavailable`, `timeout`, `task_panicked`)
 - `ProduceError::as_tag()` — producer-level tags
   (e.g. `event_too_big`, `delivery_cancelled`)
 
@@ -935,7 +1064,6 @@ request-scoped context (token, path, attempt) to the log line.
 | `WARN` (via `ctx_log!`) | Partial batch failure | `kafka/sink.rs` |
 | `ERROR` (via `ctx_log!`) | Full batch failure | `kafka/sink.rs` |
 | `ERROR` (via `ctx_log!`) | Producer not ready | `kafka/sink.rs` |
-| `ERROR` (via `ctx_log!`) | Event serialization failed | `kafka/sink.rs` |
 | `error!` | rdkafka client error callback | `kafka/context.rs` |
 | `error!` | All brokers down | `kafka/context.rs` |
 | `info!` | Producer connected | `kafka/producer.rs` |
@@ -978,7 +1106,8 @@ keeping the Sink trait unaware of topic names.
 Partition key construction is split between the `Event` implementation
 and the sink:
 
-1. **`Event::partition_key(ctx)`** returns an owned key String.
+1. **`Event::partition_key(ctx)`** returns an owned key String, captured
+   into `PreparedEvent.partition_key` by `serialize_batch`.
    For analytics events (`WrappedEvent`):
 
 ```text
@@ -993,19 +1122,19 @@ and the sink:
 ```
 
 2. **`should_null_partition_key()`** (`kafka/sink.rs`) decides whether
-   the key should be nulled before sending to the producer:
+   the prepared key should be nulled before sending to the producer:
 
 ```rust
-fn effective_partition_key<'a>(
-    key_buf: &'a str,
+fn should_null_partition_key(
     force_disable_person_processing: bool,
     destination: &Destination,
-) -> Option<&'a str>
+) -> bool
 ```
 
    If `force_disable_person_processing` is set and the destination is
-   `AnalyticsMain` or `Overflow`, the function returns `None`. Otherwise
-   it returns `Some(key_buf)`.
+   `AnalyticsMain` or `Overflow`, it returns `true` and the sink passes
+   `None` to rdkafka. Otherwise the sink passes
+   `Some(prepared.partition_key)`.
 
 Key design choices:
 
@@ -1173,8 +1302,9 @@ Sent records are captured as `OwnedProduceRecord` (owned copies of
 ### Test infrastructure (sink_tests.rs)
 
 `FakeEvent` implements `Event` with configurable destination, publish
-flag, partition key, payload (including injectable serialization errors),
-and headers.
+flag, partition key, payload, and headers. Serialize-failure scenarios
+(errors, panics) are covered in `prepare.rs` tests, not the sink — the
+sink only ever sees already-prepared events.
 
 `TestHarness` / `HarnessBuilder` wrap sink construction with a
 `lifecycle::Manager` so tests can verify health heartbeat interactions.

--- a/rust/capture/src/v1/sinks/kafka/constants.rs
+++ b/rust/capture/src/v1/sinks/kafka/constants.rs
@@ -11,10 +11,6 @@ pub(super) const KAFKA_ACK_DURATION_SECONDS: &str = "capture_v1_kafka_ack_durati
 /// Per-batch enqueue wall-time histogram.
 pub(super) const KAFKA_ENQUEUE_DURATION_SECONDS: &str = "capture_v1_kafka_enqueue_duration_seconds";
 
-/// Per-batch serialization time histogram (labeled by batch_size bucket).
-pub(super) const KAFKA_SERIALIZE_DURATION_SECONDS: &str =
-    "capture_v1_kafka_serialize_duration_seconds";
-
 /// Produce-level error counter (distinct from ack errors).
 pub(super) const KAFKA_PRODUCE_ERRORS_TOTAL: &str = "capture_v1_kafka_produce_errors_total";
 

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -14,28 +14,14 @@ use uuid::Uuid;
 
 use crate::config::CaptureMode;
 use crate::v1::context::RequestContext;
-use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
-use crate::v1::sinks::types::{BatchSummary, Destination, Outcome, SinkResult};
+use crate::v1::sinks::types::{BatchSummary, Destination, Outcome, PreparedEvent, SinkResult};
 use crate::v1::sinks::{Config, SinkName};
 
 use super::constants::*;
 use super::producer::ProduceRecord;
 use super::types::{KafkaResult, KafkaSinkError};
 use super::KafkaProducerTrait;
-
-/// Bounded batch-size bucket for the serialize_duration histogram label.
-/// 5 values keeps cardinality manageable while giving visibility into
-/// the batch-size / latency relationship.
-fn batch_size_bucket(n: usize) -> &'static str {
-    match n {
-        0..=1 => "1",
-        2..=8 => "2-8",
-        9..=32 => "9-32",
-        33..=128 => "33-128",
-        _ => "129+",
-    }
-}
 
 /// Returns true when the partition key should be nulled — i.e. when person
 /// processing is force-disabled for Main/Overflow destinations, spreading
@@ -100,18 +86,15 @@ impl<P: KafkaProducerTrait> KafkaSink<P> {
     }
 }
 
-/// Reject every publishable event in `events` as `SinkUnavailable`,
-/// incrementing a single counter for the batch.
-fn reject_publishable(
-    events: &[&(dyn Event + Send + Sync)],
-    labels: &MetricLabels,
-) -> Vec<Box<dyn SinkResult>> {
+/// Reject every event in `events` as `SinkUnavailable`, incrementing a single
+/// counter per destination for the batch. Inputs are already serialized and
+/// publishable (non-publishable events never reach a sink).
+fn reject_all(events: &[PreparedEvent], labels: &MetricLabels) -> Vec<Box<dyn SinkResult>> {
     let enqueued_at = Utc::now();
-    let publishable: Vec<_> = events.iter().filter(|e| e.should_publish()).collect();
     let mut by_dest: std::collections::HashMap<&'static str, u64> =
         std::collections::HashMap::new();
-    for e in &publishable {
-        *by_dest.entry(e.destination().as_tag()).or_default() += 1;
+    for e in events {
+        *by_dest.entry(e.destination.as_tag()).or_default() += 1;
     }
     for (dest_tag, count) in &by_dest {
         counter!(
@@ -125,11 +108,11 @@ fn reject_publishable(
         )
         .increment(*count);
     }
-    publishable
-        .into_iter()
+    events
+        .iter()
         .map(|e| -> Box<dyn SinkResult> {
             Box::new(KafkaResult::err(
-                e.uuid(),
+                e.uuid,
                 KafkaSinkError::SinkUnavailable,
                 enqueued_at,
             ))
@@ -156,81 +139,42 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
     /// preserving per-partition ordering. Returns early results for
     /// serialization / send failures and collects ack futures for events
     /// that were successfully enqueued.
-    #[allow(clippy::too_many_arguments)]
     async fn enqueue_events(
         &self,
-        ctx: &RequestContext,
-        events: &[&(dyn Event + Send + Sync)],
+        events: &[PreparedEvent],
         labels: &MetricLabels,
         enqueued_at: DateTime<Utc>,
         results: &mut Vec<Box<dyn SinkResult>>,
         pending: &mut FuturesUnordered<AckFuture>,
         enqueued_keys: &mut Vec<(Uuid, &'static str, Instant)>,
     ) {
-        let serialize_start = Instant::now();
-
         for event in events {
-            if !event.should_publish() {
-                continue;
-            }
+            let uuid = event.uuid;
+            let dest_tag = event.destination.as_tag();
 
-            let uuid = event.uuid();
-            let dest_tag = event.destination().as_tag();
-
-            let topic = match self.config.kafka.topic_for(event.destination()) {
+            let topic = match self.config.kafka.topic_for(&event.destination) {
                 Some(t) => t,
                 None => continue,
             };
 
-            let payload = match event.serialize(ctx) {
-                Ok(p) => p,
-                Err(e) => {
-                    crate::ctx_log!(
-                        Level::ERROR,
-                        ctx,
-                        sink = labels.sink,
-                        event_uuid = %uuid,
-                        error = %e,
-                        "event serialization failed, dropping event"
-                    );
-                    counter!(
-                        KAFKA_PUBLISH_TOTAL,
-                        "mode" => labels.mode,
-                        "cluster" => labels.sink,
-                        "outcome" => Outcome::FatalError.as_tag(),
-                        "path" => labels.path,
-                        "attempt" => labels.attempt,
-                        "destination" => dest_tag,
-                    )
-                    .increment(1);
-                    results.push(Box::new(KafkaResult::err(
-                        uuid,
-                        KafkaSinkError::SerializationFailed(format!("{e:#}")),
-                        enqueued_at,
-                    )));
-                    continue;
-                }
-            };
-
-            let captured_headers = event.headers(ctx);
-
             let key = if should_null_partition_key(
-                captured_headers
+                event
+                    .headers
                     .force_disable_person_processing
                     .unwrap_or(false),
-                event.destination(),
+                &event.destination,
             ) {
                 None
             } else {
-                Some(event.partition_key(ctx))
+                Some(event.partition_key.as_str())
             };
 
-            let headers: rdkafka::message::OwnedHeaders = captured_headers.into();
+            let headers: rdkafka::message::OwnedHeaders = event.headers.clone().into();
 
             let record = ProduceRecord {
                 topic,
-                key: key.as_deref(),
-                payload: payload.as_ref(),
+                key,
+                payload: event.payload.as_ref(),
                 headers,
             };
 
@@ -261,16 +205,6 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                 }
             }
         }
-
-        histogram!(
-            KAFKA_SERIALIZE_DURATION_SECONDS,
-            "mode" => labels.mode,
-            "cluster" => labels.sink,
-            "path" => labels.path,
-            "attempt" => labels.attempt,
-            "batch_size" => batch_size_bucket(events.len()),
-        )
-        .record(serialize_start.elapsed().as_secs_f64());
     }
 
     /// Phase 2: drain ack futures with a per-sink deadline. Dropping remaining
@@ -409,7 +343,7 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
     async fn publish_batch(
         &self,
         ctx: &RequestContext,
-        events: &[&(dyn Event + Send + Sync)],
+        events: &[PreparedEvent],
     ) -> Vec<Box<dyn SinkResult>> {
         let labels = MetricLabels {
             sink: self.name.as_str(),
@@ -426,7 +360,7 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
                 mode = labels.mode,
                 "producer not ready — rejecting batch"
             );
-            return reject_publishable(events, &labels);
+            return reject_all(events, &labels);
         }
 
         let enqueued_at = Utc::now();
@@ -437,7 +371,6 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
         // Enqueue wall-time, isolated from per-event broker-ack latency.
         let enqueue_start = Instant::now();
         self.enqueue_events(
-            ctx,
             events,
             &labels,
             enqueued_at,

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -11,7 +11,7 @@ use crate::config::CaptureMode;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
-use crate::v1::sinks::types::{BatchSummary, Outcome, PreparedEvent};
+use crate::v1::sinks::types::{BatchSummary, Outcome};
 use crate::v1::sinks::{Config, Destination, SinkName};
 use crate::v1::test_utils::{self, WrappedEventMut};
 
@@ -116,24 +116,7 @@ impl Event for FakeEvent {
     }
 }
 
-/// Serialize publishable events into `PreparedEvent`s the way `serialize_batch`
-/// does, for driving the sink directly. The sink no longer serializes, so tests
-/// feed it already-prepared input; serialize-failure behavior is covered in the
-/// `v1::sinks::prepare` tests. Panics on serialize error (test payloads are
-/// always valid) and skips non-publishable events.
-fn prepared<E: Event>(events: &[&E], ctx: &RequestContext) -> Vec<PreparedEvent> {
-    events
-        .iter()
-        .filter(|e| e.should_publish())
-        .map(|e| PreparedEvent {
-            uuid: e.uuid(),
-            destination: e.destination().clone(),
-            payload: e.serialize(ctx).expect("test payload must serialize"),
-            headers: e.headers(ctx),
-            partition_key: e.partition_key(ctx),
-        })
-        .collect()
-}
+use crate::v1::test_utils::prepared;
 
 // ---------------------------------------------------------------------------
 // TestHarness
@@ -712,6 +695,43 @@ async fn health_refreshed_on_full_success() {
     assert!(
         h.handle.is_healthy(),
         "handle should stay healthy after successful batch"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Health: partial success (some send errors) -> heartbeat still fires
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn health_refreshed_on_partial_success() {
+    let h = TestHarness::builder()
+        .with_liveness(HEALTH_TEST_LIVENESS_DEADLINE, HEALTH_TEST_POLL_INTERVAL)
+        .produce_timeout(HEALTH_TEST_PRODUCE_TIMEOUT)
+        .send_error(|| ProduceError::Kafka {
+            code: RDKafkaErrorCode::QueueFull,
+        })
+        .send_error_count(1)
+        .build();
+    let e1 = FakeEvent::ok("evt-1");
+    let e2 = FakeEvent::ok("evt-2");
+    let e3 = FakeEvent::ok("evt-3");
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+    let outcomes: Vec<Outcome> = results.iter().map(|r| r.outcome()).collect();
+    assert!(
+        outcomes.contains(&Outcome::RetriableError),
+        "at least one event should fail"
+    );
+    assert!(
+        outcomes.contains(&Outcome::Success),
+        "at least one event should succeed"
+    );
+
+    tokio::time::sleep(HEALTH_TEST_HEALTHY_SLEEP).await;
+    assert!(
+        h.handle.is_healthy(),
+        "handle should stay healthy when at least one event succeeds"
     );
 }
 

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -11,7 +11,7 @@ use crate::config::CaptureMode;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
-use crate::v1::sinks::types::{BatchSummary, Outcome};
+use crate::v1::sinks::types::{BatchSummary, Outcome, PreparedEvent};
 use crate::v1::sinks::{Config, Destination, SinkName};
 use crate::v1::test_utils::{self, WrappedEventMut};
 
@@ -76,11 +76,6 @@ impl FakeEvent {
         self
     }
 
-    fn with_payload(mut self, p: Result<String, String>) -> Self {
-        self.payload = p;
-        self
-    }
-
     fn with_partition_key(mut self, k: Option<&str>) -> Self {
         self.partition_key = k.map(String::from);
         self
@@ -119,6 +114,25 @@ impl Event for FakeEvent {
             Err(e) => Err(anyhow::anyhow!(e.clone())),
         }
     }
+}
+
+/// Serialize publishable events into `PreparedEvent`s the way `serialize_batch`
+/// does, for driving the sink directly. The sink no longer serializes, so tests
+/// feed it already-prepared input; serialize-failure behavior is covered in the
+/// `v1::sinks::prepare` tests. Panics on serialize error (test payloads are
+/// always valid) and skips non-publishable events.
+fn prepared<E: Event>(events: &[&E], ctx: &RequestContext) -> Vec<PreparedEvent> {
+    events
+        .iter()
+        .filter(|e| e.should_publish())
+        .map(|e| PreparedEvent {
+            uuid: e.uuid(),
+            destination: e.destination().clone(),
+            payload: e.serialize(ctx).expect("test payload must serialize"),
+            headers: e.headers(ctx),
+            partition_key: e.partition_key(ctx),
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -273,7 +287,7 @@ impl HarnessBuilder {
 async fn single_event_success() {
     let h = TestHarness::new();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -301,7 +315,7 @@ async fn non_publishable_events_skipped() {
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2").with_publish(false);
     let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -319,7 +333,7 @@ async fn non_publishable_events_skipped() {
 async fn destination_drop_skips_without_result() {
     let h = TestHarness::new();
     let event = FakeEvent::ok("evt-1").with_destination(Destination::Drop);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -336,7 +350,7 @@ async fn sink_unavailable() {
     let h = TestHarness::builder().not_ready().build();
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
+    let events = prepared(&[&e1, &e2], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -361,7 +375,7 @@ async fn queue_full_is_immediate_retriable() {
         })
         .build();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -384,7 +398,7 @@ async fn send_error_fatal_event_too_big() {
         })
         .build();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -403,7 +417,7 @@ async fn ack_error_retriable_delivery_cancelled() {
         .ack_error(|| ProduceError::DeliveryCancelled)
         .build();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -429,7 +443,7 @@ async fn ack_error_retriable_topic_auth() {
         })
         .build();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -451,7 +465,7 @@ async fn produce_timeout_single() {
         .produce_timeout(Duration::from_millis(50))
         .build();
     let event = FakeEvent::ok("evt-1");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -470,7 +484,7 @@ async fn produce_timeout_batch_all_pending_get_timeout() {
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
     let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -482,89 +496,7 @@ async fn produce_timeout_batch_all_pending_get_timeout() {
 }
 
 // ---------------------------------------------------------------------------
-// 10. Serialization failure
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn serialization_failure() {
-    let h = TestHarness::new();
-    let event = FakeEvent::ok("evt-1").with_payload(Err("bad json".into()));
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].key(), event.parsed_uuid);
-    assert_eq!(results[0].outcome(), Outcome::FatalError);
-    assert_eq!(results[0].cause(), Some("serialization_failed"));
-    assert!(
-        results[0].detail().unwrap().contains("bad json"),
-        "expected detail to contain 'bad json', got: {:?}",
-        results[0].detail()
-    );
-    assert_eq!(h.producer.record_count(), 0);
-}
-
-// ---------------------------------------------------------------------------
-// 11. Mixed batch (some succeed, some fail)
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn mixed_batch_success_and_serialize_error() {
-    let h = TestHarness::new();
-    let e1 = FakeEvent::ok("evt-1");
-    let e2 = FakeEvent::ok("evt-2").with_payload(Err("serialize error".into()));
-    let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 3);
-
-    // Serialization errors are returned inline before ack results, so evt-2
-    // appears first in the results vec (pushed during Phase 1), while evt-1
-    // and evt-3 are appended during Phase 2 (ack drain). Order among the
-    // ack results may vary, so collect into maps.
-    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
-
-    assert_eq!(by_key[&e1.parsed_uuid].outcome(), Outcome::Success);
-    assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::FatalError);
-    assert_eq!(
-        by_key[&e2.parsed_uuid].cause(),
-        Some("serialization_failed")
-    );
-    assert_eq!(by_key[&e3.parsed_uuid].outcome(), Outcome::Success);
-
-    // Only the two successful events were enqueued
-    assert_eq!(h.producer.record_count(), 2);
-}
-
-// ---------------------------------------------------------------------------
-// 12. BatchSummary correctness
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn batch_summary_from_mixed_results() {
-    let h = TestHarness::new();
-    let e1 = FakeEvent::ok("evt-1");
-    let e2 = FakeEvent::ok("evt-2").with_payload(Err("ser error".into()));
-    let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-    let summary = BatchSummary::from_results(&results);
-
-    assert_eq!(summary.total, 3);
-    assert_eq!(summary.succeeded, 2);
-    assert_eq!(summary.retriable, 0);
-    assert_eq!(summary.fatal, 1);
-    assert_eq!(summary.timed_out, 0);
-    assert!(!summary.all_ok());
-    assert_eq!(summary.errors.get("serialization_failed").copied(), Some(1));
-}
-
-// ---------------------------------------------------------------------------
-// 13. Flush delegates to producer
+// Flush delegates to producer
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -602,7 +534,7 @@ async fn destination_routes_to_correct_topic(
 ) {
     let h = TestHarness::new();
     let event = FakeEvent::ok("evt-1").with_destination(destination);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -625,7 +557,7 @@ async fn batch_summary_with_timeouts() {
         .build();
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
+    let events = prepared(&[&e1, &e2], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
     let summary = BatchSummary::from_results(&results);
@@ -652,7 +584,7 @@ async fn slow_ack_within_timeout_batch_all_succeed() {
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
     let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -694,7 +626,6 @@ enum FailureMode {
     Timeout,
     SendError,
     AckError,
-    SerializationError,
 }
 
 fn health_harness(mode: &FailureMode) -> TestHarness {
@@ -713,17 +644,16 @@ fn health_harness(mode: &FailureMode) -> TestHarness {
         FailureMode::AckError => {
             b = b.ack_error(|| ProduceError::DeliveryCancelled);
         }
-        FailureMode::SerializationError => {}
     }
     b.build()
 }
 
-fn health_events(mode: &FailureMode) -> Vec<FakeEvent> {
-    let make = |id: &str| match mode {
-        FailureMode::SerializationError => FakeEvent::ok(id).with_payload(Err("bad".into())),
-        _ => FakeEvent::ok(id),
-    };
-    vec![make("evt-1"), make("evt-2"), make("evt-3")]
+fn health_events() -> Vec<FakeEvent> {
+    vec![
+        FakeEvent::ok("evt-1"),
+        FakeEvent::ok("evt-2"),
+        FakeEvent::ok("evt-3"),
+    ]
 }
 
 fn expected_outcome(mode: &FailureMode) -> Outcome {
@@ -731,7 +661,6 @@ fn expected_outcome(mode: &FailureMode) -> Outcome {
         FailureMode::Timeout => Outcome::Timeout,
         FailureMode::SendError => Outcome::RetriableError,
         FailureMode::AckError => Outcome::RetriableError,
-        FailureMode::SerializationError => Outcome::FatalError,
     }
 }
 
@@ -739,13 +668,12 @@ fn expected_outcome(mode: &FailureMode) -> Outcome {
 #[case::timeout(FailureMode::Timeout)]
 #[case::send_error(FailureMode::SendError)]
 #[case::ack_error(FailureMode::AckError)]
-#[case::serialization_error(FailureMode::SerializationError)]
 #[tokio::test]
 async fn health_not_refreshed_on_full_failure(#[case] mode: FailureMode) {
     let h = health_harness(&mode);
-    let owned_events = health_events(&mode);
+    let owned_events = health_events();
     let refs: Vec<&FakeEvent> = owned_events.iter().collect();
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![refs[0], refs[1], refs[2]];
+    let events = prepared(&refs, &h.ctx);
     let expected = expected_outcome(&mode);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
@@ -773,7 +701,7 @@ async fn health_refreshed_on_full_success() {
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
     let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
     for r in &results {
@@ -784,33 +712,6 @@ async fn health_refreshed_on_full_success() {
     assert!(
         h.handle.is_healthy(),
         "handle should stay healthy after successful batch"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Health: mixed batch (some succeed, some fail) -> heartbeat refreshed
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn health_refreshed_on_partial_success() {
-    let h = TestHarness::builder()
-        .with_liveness(HEALTH_TEST_LIVENESS_DEADLINE, HEALTH_TEST_POLL_INTERVAL)
-        .produce_timeout(HEALTH_TEST_PRODUCE_TIMEOUT)
-        .build();
-    let e1 = FakeEvent::ok("evt-1");
-    let e2 = FakeEvent::ok("evt-2").with_payload(Err("bad".into()));
-    let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-    let summary = BatchSummary::from_results(&results);
-    assert!(summary.succeeded > 0);
-    assert!(summary.fatal > 0);
-
-    tokio::time::sleep(HEALTH_TEST_HEALTHY_SLEEP).await;
-    assert!(
-        h.handle.is_healthy(),
-        "handle should stay healthy when at least one event succeeded"
     );
 }
 
@@ -840,7 +741,7 @@ async fn force_disable_null_key_policy(
         .with_partition_key(Some("phc_test:user-1"))
         .with_destination(destination)
         .with_headers(headers);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -855,7 +756,7 @@ async fn force_disable_null_key_policy(
 async fn some_partition_key_propagates_as_some() {
     let h = TestHarness::new();
     let event = FakeEvent::ok("evt-1").with_partition_key(Some("phc_test:user-1"));
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+    let events = prepared(&[&event], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -877,7 +778,7 @@ async fn some_partition_key_propagates_as_some() {
 async fn realistic_single_pageview_round_trip() {
     let h = TestHarness::new();
     let wrapped = test_utils::realistic_pageview("user-42");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -911,7 +812,7 @@ async fn realistic_single_pageview_round_trip() {
 async fn realistic_batch_round_trip() {
     let h = TestHarness::new();
     let batch = test_utils::realistic_batch();
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&batch[0], &batch[1], &batch[2]];
+    let events = prepared(&[&batch[0], &batch[1], &batch[2]], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -949,7 +850,7 @@ async fn realistic_event_with_destination_mutation() {
     let h = TestHarness::new();
     let wrapped = test_utils::realistic_pageview("user-42")
         .with_destination(Destination::AnalyticsHistorical);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -967,7 +868,7 @@ async fn realistic_dropped_event_not_published() {
     let h = TestHarness::new();
     let wrapped = test_utils::realistic_pageview("user-42")
         .with_result(EventResult::Drop, Some("rate_limited"));
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -996,7 +897,7 @@ async fn mixed_send_error_and_ack_error_in_batch() {
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
     let e3 = FakeEvent::ok("evt-3");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+    let events = prepared(&[&e1, &e2, &e3], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1034,7 +935,7 @@ async fn partial_timeout_with_send_error() {
         .build();
     let e1 = FakeEvent::ok("evt-1");
     let e2 = FakeEvent::ok("evt-2");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
+    let events = prepared(&[&e1, &e2], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1050,37 +951,6 @@ async fn partial_timeout_with_send_error() {
     assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("timeout"));
 }
 
-// ---------------------------------------------------------------------------
-// Partial timeout: serialization failure + timeout in one batch.
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn partial_timeout_with_serialization_error() {
-    let h = TestHarness::builder()
-        .ack_delay(Duration::from_secs(60))
-        .produce_timeout(Duration::from_millis(50))
-        .build();
-    let e1 = FakeEvent::ok("evt-1").with_payload(Err("bad".into()));
-    let e2 = FakeEvent::ok("evt-2");
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
-
-    let results = h.sink.publish_batch(&h.ctx, &events).await;
-
-    assert_eq!(results.len(), 2);
-    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
-
-    // evt-1: serialization failure (immediate, fatal)
-    assert_eq!(by_key[&e1.parsed_uuid].outcome(), Outcome::FatalError);
-    assert_eq!(
-        by_key[&e1.parsed_uuid].cause(),
-        Some("serialization_failed")
-    );
-
-    // evt-2: enqueued, times out
-    assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::Timeout);
-    assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("timeout"));
-}
-
 // ===========================================================================
 // Realistic WrappedEvent — destination routing, property injection, options
 // ===========================================================================
@@ -1090,7 +960,7 @@ async fn realistic_exception_routes_to_exception_topic() {
     let h = TestHarness::new();
     let wrapped = test_utils::wrapped_event("$exception", "user-1")
         .with_destination(Destination::ExceptionErrorTracking);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1106,7 +976,7 @@ async fn realistic_heatmap_routes_to_heatmap_topic() {
     let h = TestHarness::new();
     let wrapped =
         test_utils::wrapped_event("$$heatmap", "user-1").with_destination(Destination::HeatmapMain);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1122,7 +992,7 @@ async fn realistic_session_id_injected_into_properties() {
     let h = TestHarness::new();
     let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
     wrapped.event.session_id = Some("sess-123".to_string());
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1142,7 +1012,7 @@ async fn realistic_window_id_injected_into_properties() {
     let h = TestHarness::new();
     let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
     wrapped.event.window_id = Some("win-456".to_string());
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1162,7 +1032,7 @@ async fn realistic_cookieless_partition_key() {
     let h = TestHarness::new();
     let mut wrapped = test_utils::wrapped_event("$pageview", "user-1");
     wrapped.event.options.cookieless_mode = Some(true);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1190,7 +1060,7 @@ async fn realistic_spread_destinations_routes_correctly(
     let h = TestHarness::new();
     let all = test_utils::realistic_spread_destinations();
     let ev = &all[idx];
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![ev];
+    let events = prepared(&[ev], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 
@@ -1215,7 +1085,7 @@ async fn realistic_force_disable_pp_null_partition_key() {
     let wrapped = test_utils::wrapped_event("$pageview", "user-1")
         .with_force_disable_person_processing(true)
         .with_destination(Destination::AnalyticsMain);
-    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+    let events = prepared(&[&wrapped], &h.ctx);
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
 

--- a/rust/capture/src/v1/sinks/kafka/types.rs
+++ b/rust/capture/src/v1/sinks/kafka/types.rs
@@ -56,7 +56,6 @@ pub fn error_code_tag(code: RDKafkaErrorCode) -> &'static str {
 #[derive(Debug)]
 pub enum KafkaSinkError {
     SinkUnavailable,
-    SerializationFailed(String),
     Produce(ProduceError),
     Timeout,
     TaskPanicked,
@@ -66,7 +65,6 @@ impl KafkaSinkError {
     pub fn outcome(&self) -> Outcome {
         match self {
             Self::SinkUnavailable => Outcome::RetriableError,
-            Self::SerializationFailed(_) => Outcome::FatalError,
             Self::Produce(e) => {
                 if e.is_retriable() {
                     Outcome::RetriableError
@@ -82,7 +80,6 @@ impl KafkaSinkError {
     pub fn as_tag(&self) -> &'static str {
         match self {
             Self::SinkUnavailable => "sink_unavailable",
-            Self::SerializationFailed(_) => "serialization_failed",
             Self::Produce(e) => e.as_tag(),
             Self::Timeout => "timeout",
             Self::TaskPanicked => "task_panicked",
@@ -92,7 +89,6 @@ impl KafkaSinkError {
     pub fn detail(&self) -> Cow<'_, str> {
         match self {
             Self::SinkUnavailable => Cow::Borrowed("sink unavailable"),
-            Self::SerializationFailed(m) => Cow::Owned(format!("serialization failed: {m}")),
             Self::Produce(e) => Cow::Owned(format!("{e}")),
             Self::Timeout => Cow::Borrowed("produce timeout"),
             Self::TaskPanicked => Cow::Borrowed("task panicked during delivery"),

--- a/rust/capture/src/v1/sinks/prepare.rs
+++ b/rust/capture/src/v1/sinks/prepare.rs
@@ -10,7 +10,7 @@
 //! tasks and gather back in input order. Per-event panics are isolated so one
 //! bad event never fails the whole request.
 
-use std::panic::AssertUnwindSafe;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -71,7 +71,7 @@ fn prepare_one<E: Event>(ev: &E, ctx: &RequestContext) -> anyhow::Result<Option<
 /// the batch / poisoning the worker.
 fn run_one<E: Event>(ev: &E, ctx: &RequestContext) -> Slot {
     let uuid = ev.uuid();
-    match std::panic::catch_unwind(AssertUnwindSafe(|| prepare_one(ev, ctx))) {
+    match catch_unwind(AssertUnwindSafe(|| prepare_one(ev, ctx))) {
         Ok(Ok(Some(prepared))) => Slot::Prepared(prepared),
         Ok(Ok(None)) => Slot::Skipped,
         Ok(Err(e)) => Slot::Failed(SerializationFailure::from_error(uuid, format!("{e:#}"))),

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -5,9 +5,8 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
 use crate::v1::context::RequestContext;
-use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
-use crate::v1::sinks::types::SinkResult;
+use crate::v1::sinks::types::{PreparedEvent, SinkResult};
 use crate::v1::sinks::SinkName;
 
 // ---------------------------------------------------------------------------
@@ -57,12 +56,12 @@ impl Router {
         self.sinks.keys().copied().collect()
     }
 
-    /// Publish a batch of events to the named sink.
+    /// Publish a batch of already-serialized events to the named sink.
     pub async fn publish_batch(
         &self,
         sink: SinkName,
         ctx: &RequestContext,
-        events: &[&(dyn Event + Send + Sync)],
+        events: &[PreparedEvent],
     ) -> Result<Vec<Box<dyn SinkResult>>, RouterError> {
         let target = self
             .sinks
@@ -76,9 +75,11 @@ impl Router {
         &self,
         sink: SinkName,
         ctx: &RequestContext,
-        event: &(dyn Event + Send + Sync),
+        event: &PreparedEvent,
     ) -> Result<Option<Box<dyn SinkResult>>, RouterError> {
-        let results = self.publish_batch(sink, ctx, &[event]).await?;
+        let results = self
+            .publish_batch(sink, ctx, std::slice::from_ref(event))
+            .await?;
         Ok(results.into_iter().next())
     }
 
@@ -122,12 +123,28 @@ mod tests {
     use crate::v1::sinks::kafka::mock::MockProducer;
     use crate::v1::sinks::kafka::sink::KafkaSink;
     use crate::v1::sinks::sink::Sink;
-    use crate::v1::sinks::types::Outcome;
+    use crate::v1::sinks::types::{Outcome, PreparedEvent};
     use crate::v1::sinks::{Config, Destination, SinkName};
 
     use super::*;
 
     // -- Test helpers --------------------------------------------------------
+
+    /// Serialize publishable FakeEvents into PreparedEvents for driving the
+    /// router (which now publishes already-serialized events).
+    fn prepared(events: &[&FakeEvent], ctx: &RequestContext) -> Vec<PreparedEvent> {
+        events
+            .iter()
+            .filter(|e| e.should_publish())
+            .map(|e| PreparedEvent {
+                uuid: e.uuid(),
+                destination: e.destination().clone(),
+                payload: e.serialize(ctx).unwrap(),
+                headers: e.headers(ctx),
+                partition_key: e.partition_key(ctx),
+            })
+            .collect()
+    }
 
     struct FakeEvent {
         parsed_uuid: Uuid,
@@ -142,11 +159,6 @@ mod tests {
                 publish: true,
                 destination: Destination::AnalyticsMain,
             }
-        }
-
-        fn with_publish(mut self, p: bool) -> Self {
-            self.publish = p;
-            self
         }
     }
 
@@ -251,7 +263,7 @@ mod tests {
             test_router(SinkName::Msk, &[SinkName::Msk, SinkName::Ws]);
         let ctx = test_ctx();
         let event = FakeEvent::ok("evt-1");
-        let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+        let events = prepared(&[&event], &ctx);
 
         let results = router
             .publish_batch(SinkName::Msk, &ctx, &events)
@@ -266,7 +278,7 @@ mod tests {
         let (router, _handle, _monitor) = test_router(SinkName::Msk, &[SinkName::Msk]);
         let ctx = test_ctx();
         let event = FakeEvent::ok("evt-1");
-        let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+        let events = prepared(&[&event], &ctx);
 
         match router.publish_batch(SinkName::Ws, &ctx, &events).await {
             Err(RouterError::SinkNotFound(SinkName::Ws)) => {}
@@ -280,20 +292,14 @@ mod tests {
         let (router, _handle, _monitor) = test_router(SinkName::Msk, &[SinkName::Msk]);
         let ctx = test_ctx();
         let event = FakeEvent::ok("evt-1");
+        let prepared = prepared(&[&event], &ctx);
 
-        let result = router.publish(SinkName::Msk, &ctx, &event).await.unwrap();
+        let result = router
+            .publish(SinkName::Msk, &ctx, &prepared[0])
+            .await
+            .unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().outcome(), Outcome::Success);
-    }
-
-    #[tokio::test]
-    async fn publish_single_non_publishable_returns_none() {
-        let (router, _handle, _monitor) = test_router(SinkName::Msk, &[SinkName::Msk]);
-        let ctx = test_ctx();
-        let event = FakeEvent::ok("evt-1").with_publish(false);
-
-        let result = router.publish(SinkName::Msk, &ctx, &event).await.unwrap();
-        assert!(result.is_none());
     }
 
     #[tokio::test]
@@ -301,8 +307,9 @@ mod tests {
         let (router, _handle, _monitor) = test_router(SinkName::Msk, &[SinkName::Msk]);
         let ctx = test_ctx();
         let event = FakeEvent::ok("evt-1");
+        let prepared = prepared(&[&event], &ctx);
 
-        match router.publish(SinkName::Ws, &ctx, &event).await {
+        match router.publish(SinkName::Ws, &ctx, &prepared[0]).await {
             Err(RouterError::SinkNotFound(SinkName::Ws)) => {}
             Err(e) => panic!("expected SinkNotFound(Ws), got: {e}"),
             Ok(_) => panic!("expected error, got Ok"),

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -123,28 +123,14 @@ mod tests {
     use crate::v1::sinks::kafka::mock::MockProducer;
     use crate::v1::sinks::kafka::sink::KafkaSink;
     use crate::v1::sinks::sink::Sink;
-    use crate::v1::sinks::types::{Outcome, PreparedEvent};
+    use crate::v1::sinks::types::Outcome;
     use crate::v1::sinks::{Config, Destination, SinkName};
 
     use super::*;
 
     // -- Test helpers --------------------------------------------------------
 
-    /// Serialize publishable FakeEvents into PreparedEvents for driving the
-    /// router (which now publishes already-serialized events).
-    fn prepared(events: &[&FakeEvent], ctx: &RequestContext) -> Vec<PreparedEvent> {
-        events
-            .iter()
-            .filter(|e| e.should_publish())
-            .map(|e| PreparedEvent {
-                uuid: e.uuid(),
-                destination: e.destination().clone(),
-                payload: e.serialize(ctx).unwrap(),
-                headers: e.headers(ctx),
-                partition_key: e.partition_key(ctx),
-            })
-            .collect()
-    }
+    use crate::v1::test_utils::prepared;
 
     struct FakeEvent {
         parsed_uuid: Uuid,

--- a/rust/capture/src/v1/sinks/sink.rs
+++ b/rust/capture/src/v1/sinks/sink.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 
 use crate::v1::context::RequestContext;
-use crate::v1::sinks::event::Event;
-use crate::v1::sinks::types::SinkResult;
+use crate::v1::sinks::types::{PreparedEvent, SinkResult};
 use crate::v1::sinks::SinkName;
 
 /// Backend-agnostic publishing interface for a single sink target.
@@ -11,12 +10,13 @@ pub trait Sink: Send + Sync {
     /// Identity of this sink (used for metrics and logging).
     fn name(&self) -> SinkName;
 
-    /// Publish a batch of events. Returns one result per published event --
-    /// skipped events (should_publish false / Destination::Drop) produce no result.
+    /// Publish a batch of already-serialized events. Returns one result per
+    /// event the sink attempted; events the sink itself drops (e.g. a
+    /// destination with no configured topic) produce no result.
     async fn publish_batch(
         &self,
         ctx: &RequestContext,
-        events: &[&(dyn Event + Send + Sync)],
+        events: &[PreparedEvent],
     ) -> Vec<Box<dyn SinkResult>>;
 
     /// Flush the underlying producer for graceful shutdown.

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -12,7 +12,25 @@ use crate::v1::analytics::context::Context as AnalyticsContext;
 use crate::v1::analytics::query::Query;
 use crate::v1::analytics::types::{Event, EventResult, Options, WrappedEvent};
 use crate::v1::context::RequestContext;
+use crate::v1::sinks::event::Event as SinkEvent;
+use crate::v1::sinks::types::PreparedEvent;
 use crate::v1::sinks::Destination;
+
+/// Serialize publishable events into `PreparedEvent`s for driving sinks in tests.
+/// Accepts `&[&dyn Event]` (integration) or `&[&ConcreteType]` (unit) via `?Sized`.
+pub fn prepared<E: SinkEvent + ?Sized>(events: &[&E], ctx: &RequestContext) -> Vec<PreparedEvent> {
+    events
+        .iter()
+        .filter(|e| e.should_publish())
+        .map(|e| PreparedEvent {
+            uuid: e.uuid(),
+            destination: e.destination().clone(),
+            payload: e.serialize(ctx).expect("test payload must serialize"),
+            headers: e.headers(ctx),
+            partition_key: e.partition_key(ctx),
+        })
+        .collect()
+}
 
 pub fn raw_obj(s: &str) -> Box<RawValue> {
     RawValue::from_string(s.to_owned()).unwrap()

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -24,25 +24,9 @@ use capture::v1::sinks::event::Event;
 use capture::v1::sinks::kafka::producer::KafkaProducer;
 use capture::v1::sinks::kafka::KafkaSink;
 use capture::v1::sinks::sink::Sink;
-use capture::v1::sinks::types::{Outcome, PreparedEvent};
+use capture::v1::sinks::types::Outcome;
 use capture::v1::sinks::{Config, SinkName};
-use capture::v1::test_utils::{self, WrappedEventMut};
-
-/// Serialize events into `PreparedEvent`s the way `serialize_batch` does, but
-/// borrowing so the original events stay available for post-publish assertions.
-fn prepared(events: &[&(dyn Event + Send + Sync)], ctx: &RequestContext) -> Vec<PreparedEvent> {
-    events
-        .iter()
-        .filter(|e| e.should_publish())
-        .map(|e| PreparedEvent {
-            uuid: e.uuid(),
-            destination: e.destination().clone(),
-            payload: e.serialize(ctx).expect("test payload must serialize"),
-            headers: e.headers(ctx),
-            partition_key: e.partition_key(ctx),
-        })
-        .collect()
-}
+use capture::v1::test_utils::{self, prepared, WrappedEventMut};
 
 fn v1_kafka_config(topic: &str) -> capture::v1::sinks::kafka::config::Config {
     let env: std::collections::HashMap<String, String> = [

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -24,9 +24,25 @@ use capture::v1::sinks::event::Event;
 use capture::v1::sinks::kafka::producer::KafkaProducer;
 use capture::v1::sinks::kafka::KafkaSink;
 use capture::v1::sinks::sink::Sink;
-use capture::v1::sinks::types::Outcome;
+use capture::v1::sinks::types::{Outcome, PreparedEvent};
 use capture::v1::sinks::{Config, SinkName};
 use capture::v1::test_utils::{self, WrappedEventMut};
+
+/// Serialize events into `PreparedEvent`s the way `serialize_batch` does, but
+/// borrowing so the original events stay available for post-publish assertions.
+fn prepared(events: &[&(dyn Event + Send + Sync)], ctx: &RequestContext) -> Vec<PreparedEvent> {
+    events
+        .iter()
+        .filter(|e| e.should_publish())
+        .map(|e| PreparedEvent {
+            uuid: e.uuid(),
+            destination: e.destination().clone(),
+            payload: e.serialize(ctx).expect("test payload must serialize"),
+            headers: e.headers(ctx),
+            partition_key: e.partition_key(ctx),
+        })
+        .collect()
+}
 
 fn v1_kafka_config(topic: &str) -> capture::v1::sinks::kafka::config::Config {
     let env: std::collections::HashMap<String, String> = [
@@ -103,7 +119,7 @@ async fn v1_single_pageview_round_trip() -> Result<()> {
     let wrapped = test_utils::realistic_pageview("integ-user-1");
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
 
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].key(), wrapped.uuid);
@@ -144,7 +160,7 @@ async fn v1_batch_round_trip() -> Result<()> {
     let batch = test_utils::realistic_batch();
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&batch[0], &batch[1], &batch[2]];
 
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
 
     assert_eq!(results.len(), 3);
     for r in &results {
@@ -185,7 +201,7 @@ async fn v1_kafka_headers_round_trip() -> Result<()> {
     let wrapped = test_utils::realistic_pageview("integ-user-headers");
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
 
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results[0].outcome(), Outcome::Success);
 
     let (_event_json, headers) = topic.next_message_with_headers()?;
@@ -219,7 +235,7 @@ async fn v1_partition_key_round_trip() -> Result<()> {
     let wrapped = test_utils::realistic_pageview("integ-user-pkey");
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
 
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results[0].outcome(), Outcome::Success);
 
     let key = topic.next_message_key()?;
@@ -248,7 +264,7 @@ async fn v1_dropped_event_not_published() -> Result<()> {
     );
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
 
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert!(results.is_empty());
 
     topic.assert_empty();
@@ -274,7 +290,7 @@ async fn v1_exception_event_round_trip() -> Result<()> {
     wrapped.destination = capture::v1::sinks::Destination::ExceptionErrorTracking;
 
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].outcome(), Outcome::Success);
 
@@ -307,7 +323,7 @@ async fn v1_cookieless_mode_partition_key() -> Result<()> {
     wrapped.event.options.cookieless_mode = Some(true);
 
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results[0].outcome(), Outcome::Success);
 
     let key = topic.next_message_key()?;
@@ -345,7 +361,7 @@ async fn v1_all_options_property_injection() -> Result<()> {
     wrapped.event.window_id = Some("win-opt-test".to_string());
 
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results[0].outcome(), Outcome::Success);
 
     let event_json = topic.next_event()?;
@@ -388,7 +404,7 @@ async fn v1_empty_options_no_injection() -> Result<()> {
     wrapped.event.window_id = None;
 
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results[0].outcome(), Outcome::Success);
 
     let event_json = topic.next_event()?;
@@ -424,7 +440,7 @@ async fn v1_multi_destination_batch() -> Result<()> {
         .with_destination(capture::v1::sinks::Destination::Overflow);
 
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&main_ev, &hist_ev, &overflow_ev];
-    let results = sink.publish_batch(&ctx, &events).await;
+    let results = sink.publish_batch(&ctx, &prepared(&events, &ctx)).await;
     assert_eq!(results.len(), 3);
     for r in &results {
         assert_eq!(r.outcome(), Outcome::Success);


### PR DESCRIPTION
## Problem

Final PR in the v1 scatter-gather stack. With `serialize_batch` and `PreparedEvent` in place (#64188), the publish path still threaded raw `Event` trait objects all the way into the sink, which re-coupled serialization to Kafka and blocked fan-out to multiple sinks. This wires the hoisted serialize step into the actual publish path.

Stacked on #64188 (`eli/capture-v1-prepared-event`).

## Changes

- `Sink`/`Router`/`KafkaSink::publish_batch` now take `&[PreparedEvent]` instead of `&[&(dyn Event + Send + Sync)]`. The Kafka enqueue loop no longer serializes — it sends `prepared.payload` (`Bytes`) directly.
- `process_batch` calls `serialize_batch`, then concatenates the resulting `SerializationFailure`s with the sink results before merging into the per-event response.
- Drop the now-dead `KafkaSinkError::SerializationFailed` variant and the per-sink `capture_v1_kafka_serialize_duration_seconds` metric. Serialization is sink-agnostic and timed by `capture_v1_serialize_duration_seconds` (from `prepare.rs`).
- Migrate sink/router/process and `v1_sink_integration` tests to `PreparedEvent` (new `prepared` helpers). Serialize-failure coverage (errors + panics) lives in `prepare.rs`, so the redundant sink-side failure tests are removed.
- Update `sinks/DESIGN.md` for the hoisted-serialization architecture (new section 2a, pipeline diagram, metric table, `&RequestContext` signatures).

## How did you test this code?

I'm an agent (Claude Opus 4.8 in Cursor). Automated tests run locally against the dev Docker stack:

- `cargo clippy -p capture --tests` — clean
- `cargo test -p capture --lib v1::` — 490 passed
- `cargo test -p capture --test v1_sink_integration` — 10 passed (real Kafka round-trip)
- `cargo test -p capture --test v1_pipeline --test v1_http_integration` — 17 + 3 passed

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Opus 4.8 in Cursor as the final layer of a 4-PR green stack. Key decision in this layer: `serialize_batch` returns `(Vec<E>, SerializedBatch)` so `process_batch` keeps ownership of the original events for response building while the sink only ever sees fully-owned `PreparedEvent`s. Removed dead serialize-failure paths from the Kafka sink rather than leaving unreachable variants behind.
