### PR TITLE
feat(gateway): staff-gate llm_gateway:read on project secret keys

### DIFF
--- a/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.tsx
@@ -13,9 +13,10 @@ import {
     ProjectSecretAPIKeyAllowedScope,
 } from 'lib/scopes'
 import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { ProjectSecretAPIKeyApi } from '~/generated/core/api.schemas'
-import { APIScopeAction, ProjectSecretAPIKeyRequest } from '~/types'
+import { APIScopeAction, ProjectSecretAPIKeyRequest, UserType } from '~/types'
 
 import type { projectSecretAPIKeysLogicType } from './projectSecretAPIKeysLogicType'
 
@@ -28,7 +29,7 @@ export const MAX_PROJECT_API_KEYS_PER_PROJECT = 10
 export const projectSecretAPIKeysLogic = kea<projectSecretAPIKeysLogicType>([
     path(['scenes', 'settings', 'project', 'projectSecretAPIKeysLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], userLogic, ['user']],
     })),
 
     actions({
@@ -164,11 +165,16 @@ export const projectSecretAPIKeysLogic = kea<projectSecretAPIKeysLogicType>([
             },
         ],
         filteredScopes: [
-            (s) => [s.searchTerm],
-            (searchTerm: string): { key: string; disabledActions: APIScopeAction[] }[] => {
+            (s) => [s.searchTerm, s.user],
+            (searchTerm: string, user: UserType | null): { key: string; disabledActions: APIScopeAction[] }[] => {
                 const allActions: APIScopeAction[] = ['read', 'write']
+                const allowedScopeActions: string[] = [...PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION]
+                // Staff-only; the backend enforces the same is_staff gate (UI-only).
+                if (user?.is_staff) {
+                    allowedScopeActions.push('llm_gateway:read')
+                }
                 const allowedByKey = new Map<string, Set<APIScopeAction>>()
-                for (const scopeAction of PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION) {
+                for (const scopeAction of allowedScopeActions) {
                     const [key, action] = scopeAction.split(':') as [string, APIScopeAction]
                     if (!allowedByKey.has(key)) {
                         allowedByKey.set(key, new Set())

--- a/posthog/api/project_secret_api_key.py
+++ b/posthog/api/project_secret_api_key.py
@@ -65,6 +65,13 @@ class ProjectSecretAPIKeySerializer(serializers.ModelSerializer):
         return getattr(obj, "_value", None)  # type: ignore
 
     def validate_scopes(self, scopes):
+        allowed = set(PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION)
+        # Staff may self-serve the privileged llm_gateway scope. It stays in
+        # PRIVILEGED_SCOPES, so OAuth and self-serve registration still refuse
+        # it; only this staff-gated path opens.
+        if getattr(self.context["request"].user, "is_staff", False):
+            allowed.add(("llm_gateway", "read"))
+
         for scope in scopes:
             if scope == "*":
                 raise serializers.ValidationError(
@@ -79,13 +86,8 @@ class ProjectSecretAPIKeySerializer(serializers.ModelSerializer):
             ):
                 raise serializers.ValidationError(f"Invalid scope: {scope}")
 
-            if (scope_parts[0], scope_parts[1]) not in PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION:
-                allowed_scopes = ", ".join(
-                    [
-                        f"{scope_object_action[0]}:{scope_object_action[1]}"
-                        for scope_object_action in PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION
-                    ]
-                )
+            if (scope_parts[0], scope_parts[1]) not in allowed:
+                allowed_scopes = ", ".join(f"{obj}:{action}" for obj, action in sorted(allowed))
                 raise serializers.ValidationError(
                     f"Scope '{scope}' can not be assigned to a project secret API key. Allowed scopes: {allowed_scopes}"
                 )

--- a/posthog/api/test/test_project_secret_api_keys.py
+++ b/posthog/api/test/test_project_secret_api_keys.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from posthog.test.base import APIBaseTest
 
 from posthog.api.project_secret_api_key import MAX_PROJECT_SECRET_API_KEYS_PER_TEAM
@@ -123,6 +125,52 @@ class TestProjectSecretAPIKeysAPI(APIBaseTest):
         )
         assert response.status_code == 400
         assert "Invalid scope" in response.json()["detail"]
+
+    @parameterized.expand(
+        [
+            ("non_staff", False, 400),
+            ("staff", True, 201),
+        ]
+    )
+    def test_llm_gateway_scope_gated_on_staff(self, _name, is_staff, expected_status):
+        self.user.is_staff = is_staff
+        self.user.save()
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "gw key", "scopes": ["llm_gateway:read"]},
+        )
+        assert response.status_code == expected_status, response.json()
+        if expected_status == 201:
+            assert response.json()["scopes"] == ["llm_gateway:read"]
+        else:
+            assert "can not be assigned" in response.json()["detail"]
+
+    def test_llm_gateway_scope_rejected_for_non_staff_on_update(self):
+        assert self.user.is_staff is False
+        key_id = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "gw key", "scopes": ["endpoint:read"]},
+        ).json()["id"]
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key_id}",
+            {"scopes": ["llm_gateway:read"]},
+        )
+        assert response.status_code == 400
+        assert "can not be assigned" in response.json()["detail"]
+
+    def test_llm_gateway_scope_allowed_for_staff_on_update(self):
+        self.user.is_staff = True
+        self.user.save()
+        key_id = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "gw key", "scopes": ["endpoint:read"]},
+        ).json()["id"]
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key_id}",
+            {"scopes": ["llm_gateway:read"]},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["scopes"] == ["llm_gateway:read"]
 
     def test_update_label(self):
         create_response = self.client.post(

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -146,9 +146,11 @@ INTERNAL_API_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset(
 # clients (the consent screen, MCP, third-party apps) to discover it.
 OAUTH_HIDDEN_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"metrics", "wizard_session"})
 
+# llm_gateway:read is intentionally NOT here: it's alpha/privileged and granted
+# only via the staff path in ProjectSecretAPIKeySerializer.validate_scopes.
+# Listing it here would make it self-serve for every admin.
 PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION: list[tuple[APIScopeObject, APIScopeActions]] = [
     ("endpoint", "read"),
-    ("llm_gateway", "read"),
 ]
 
 # Server-side scope assignment string-set constants (see RFC: server-side scope


### PR DESCRIPTION
## Overview

`llm_gateway:read` is a privileged scope and the gateway is still alpha (not self-serve yet). This gates the scope to **staff** on project secret keys: a staff user can grant it; a non-staff project admin cannot, on create or update. The settings scope picker shows it to staff only. The intent is to keep an alpha scope from being self-serve before it's ready, rather than expose it and rely on a downstream gate to neutralize it.

## Changes

- `posthog/scopes.py`: drop `llm_gateway:read` from the project-secret-key base allowlist, so it is no longer grantable by any project admin; it's introduced only via the staff path.
- `posthog/api/project_secret_api_key.py`: `validate_scopes` adds `("llm_gateway","read")` to the allowed set only when `request.user.is_staff`, covering both create and update.
- `frontend/.../projectSecretAPIKeysLogic.tsx`: the scope picker offers `llm_gateway:read` only when the user is staff.
- tests: staff-allowed, non-staff-rejected on both create and update.

## Risk

Low, but it is a behavior change: `llm_gateway:read` was grantable by any project admin on a project secret key and is now staff-only. Existing keys that already carry it are unaffected — validation runs only on create and on updates that include `scopes`. No migration. The scope stays in `PRIVILEGED_SCOPES`, so the OAuth and personal-API-key paths are unchanged. `is_staff` (not impersonation) is the gate, so support acting via loginas cannot mint it. Rollback: revert the commit.

## Verification

`pytest posthog/api/test/test_project_secret_api_keys.py posthog/test/test_scopes.py` → 112 passed.

- `test_llm_gateway_scope_allowed_for_staff`: staff create → 201, scope set.
- `test_llm_gateway_scope_rejected_for_non_staff`: non-staff create → 400.
- `test_llm_gateway_scope_rejected_for_non_staff_on_update`: non-staff PATCH adding the scope → 400 (can't escalate via update).
