### PR TITLE
fix(notion): skip pages that 404 during blocks/comments fan-out

### DIFF
--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -48,6 +48,12 @@ class NotionRetryableError(Exception):
         self.retry_after = retry_after
 
 
+class NotionNotFoundError(Exception):
+    """Notion returned 404 for a resource: the page/block was deleted or is no longer shared with
+    the integration. In the per-page fan-out streams (blocks/comments) a single page going missing
+    is recoverable — skip it and keep syncing the rest rather than crashing the whole sync."""
+
+
 @dataclasses.dataclass
 class NotionResumeConfig:
     next_cursor: str
@@ -122,6 +128,12 @@ def _request(
 
     if response.status_code >= 500:
         raise NotionRetryableError(f"Notion API error (retryable): status={response.status_code}, url={url}")
+
+    # A 404 on a per-page resource (a page's comments or block children) means that page was deleted
+    # or unshared between enumeration and fetch. The fan-out streams catch this and skip the page;
+    # on the collection endpoints (search/users) it is unexpected and propagates as a sync failure.
+    if response.status_code == 404:
+        raise NotionNotFoundError(f"Notion resource not found: url={url}")
 
     if not response.ok:
         logger.error(f"Notion API error: status={response.status_code}, body={response.text}, url={url}")
@@ -252,7 +264,15 @@ def _iter_block_children(
         if cursor:
             params["start_cursor"] = cursor
 
-        data = _request(session, "GET", f"/v1/blocks/{block_id}/children", logger, params=params)
+        try:
+            data = _request(session, "GET", f"/v1/blocks/{block_id}/children", logger, params=params)
+        except NotionNotFoundError:
+            logger.warning(
+                "Notion: skipping missing or unshared block while fetching children",
+                page_id=page_id,
+                block_id=block_id,
+            )
+            return
         for block in data.get("results", []):
             block["_page_id"] = page_id
             yield block
@@ -297,7 +317,14 @@ def _comments_stream(session: requests.Session, logger: FilteringBoundLogger) ->
             if cursor:
                 params["start_cursor"] = cursor
 
-            data = _request(session, "GET", "/v1/comments", logger, params=params)
+            try:
+                data = _request(session, "GET", "/v1/comments", logger, params=params)
+            except NotionNotFoundError:
+                logger.warning(
+                    "Notion: skipping comments for missing or unshared page",
+                    page_id=page_id,
+                )
+                break
             for comment in data.get("results", []):
                 comment["_page_id"] = page_id
                 batcher.batch(comment)

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.sources.notion.notion import (
     MAX_CHILD_PAGES_PER_PARENT,
     MAX_RETRY_AFTER_SECONDS,
     NOTION_VERSION,
+    NotionNotFoundError,
     NotionResumeConfig,
     NotionRetryableError,
     _comments_stream,
@@ -205,6 +206,61 @@ class TestNotion:
 
         assert result == {"results": []}
         assert attempts["count"] == 2
+
+    def test_request_404_raises_not_found(self) -> None:
+        # Notion 404s a page/block that was deleted or unshared. It must surface as the typed
+        # NotionNotFoundError so the fan-out streams can skip it instead of crashing.
+        session = FakeSession([FakeResponse({}, status_code=404)])
+        with pytest.raises(NotionNotFoundError):
+            cast(Any, _request).__wrapped__(
+                cast(requests.Session, session), "GET", "/v1/comments", mock.MagicMock(), params={}
+            )
+
+    def test_request_404_is_not_retried(self) -> None:
+        # A 404 is not transient, so tenacity must propagate it immediately rather than burn attempts.
+        attempts = {"count": 0}
+
+        def request(*_args: Any, **_kwargs: Any) -> FakeResponse:
+            attempts["count"] += 1
+            return FakeResponse({}, status_code=404)
+
+        session = mock.MagicMock()
+        session.request.side_effect = request
+
+        with mock.patch(f"{MODULE}._wait_strategy", return_value=0):
+            with pytest.raises(NotionNotFoundError):
+                _request(cast(requests.Session, session), "GET", "/v1/comments", mock.MagicMock(), params={})
+
+        assert attempts["count"] == 1
+
+    def test_comments_stream_skips_missing_page(self) -> None:
+        # One page is deleted/unshared between search and the comments fetch (404). That page must be
+        # skipped without crashing the sync; comments for the surviving page still come through.
+        def responses(index: int) -> FakeResponse:
+            if index == 0:
+                return _list_response([{"id": "p1"}, {"id": "p2"}], has_more=False, next_cursor=None)
+            if index == 1:
+                return FakeResponse({}, status_code=404)  # comments for p1 -> gone
+            return _list_response([{"id": "cm"}], has_more=False, next_cursor=None)  # comments for p2
+
+        session = FakeSession(responses)
+        logger = mock.MagicMock()
+        tables = list(_comments_stream(cast(requests.Session, session), logger))
+
+        total_rows = sum(t.num_rows for t in tables)
+        assert total_rows == 1
+        assert logger.warning.called
+        # search + comments(p1, 404) + comments(p2)
+        assert len(session.calls) == 3
+
+    def test_block_children_skips_missing_block(self) -> None:
+        # A block that 404s (deleted/unshared) must terminate that branch gracefully, yielding nothing.
+        session = FakeSession([FakeResponse({}, status_code=404)])
+        logger = mock.MagicMock()
+        blocks = list(_iter_block_children(cast(requests.Session, session), "gone", "page-1", logger, 0))
+
+        assert blocks == []
+        assert logger.warning.called
 
     @parameterized.expand([("5", 5.0), (None, None), ("not-a-number", None)])
     def test_parse_retry_after(self, value: str | None, expected: float | None) -> None:


### PR DESCRIPTION
## Problem

The Notion data-warehouse import surfaced a real error in production:

> `HTTPError: 404 Client Error: Not Found for url: https://api.notion.com/v1/comments?block_id=...`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ed3ee-dc50-7400-89e1-b883e5fec24f

The `comments` and `blocks` streams enumerate pages via `/v1/search`, then fan out per page:

- comments → `GET /v1/comments?block_id=<page_id>`
- blocks → `GET /v1/blocks/<block_id>/children`

When a page is deleted, archived, or unshared between enumeration and the per-page fetch, Notion returns a `404` for that **single** page. The 404 was raised in `_request` and propagated all the way up, crashing the **entire** sync — losing comments/blocks for every other page in the workspace.

This is not a credentials problem (`401`/`403` are already handled as non-retryable, and the search call itself succeeded, so the token is valid). It is a per-page condition, and the right behavior is to skip the missing page and keep syncing the rest. Adding `404` to `NonRetryableErrors` would be worse — it would permanently abort the whole sync on the first inaccessible page.

## Changes

- Added a typed `NotionNotFoundError`, raised from `_request` on a `404`.
- `_comments_stream` and `_iter_block_children` now catch it, log a warning identifying the skipped page/block, and continue. A `404` on the collection endpoints (`/v1/search`, `/v1/users`) is still unexpected and propagates as a sync failure.
- `404` is deliberately **not** added to the tenacity retry set, so it is not retried (it is not transient).

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests; I did not perform manual testing.

New regression tests in `test_notion.py`:

- `_request` raises `NotionNotFoundError` on `404` and is not retried.
- `_comments_stream` skips a page that returns `404` and still yields comments from the surviving page.
- `_iter_block_children` terminates that branch gracefully on `404`.

Full suite: `pytest posthog/temporal/data_imports/sources/notion/tests/test_notion.py` → 33 passed. `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged an error-tracking issue end to end with Claude Code, using the PostHog error-tracking MCP tools to pull the stack trace, confirm the failing frame (`notion.py` `_comments_stream` → `_request`), and verify a representative event.
- Decision: classified this as a fixable bug (missing graceful-skip), not a non-retryable credential error. Rejected extending `NonRetryableErrors` because a per-page 404 should not abort the whole sync. Extended the fix to the `blocks` stream as well since it shares the identical per-page fan-out and would crash on the same input.
- Scoped strictly to the 404 fan-out handling; no changes to global retry policy.
