### PR TITLE
fix(replay): acknowledge async exports immediately on kickoff

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
@@ -103,43 +103,66 @@ describe('exportsLogic', () => {
         // Let the fire-and-forget IIFE in the createExport loader run to its toast.
         const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
-        it('acknowledges an async export immediately and tracks it as undownloaded', async () => {
-            const asyncAsset = asset({ id: 11, export_format: ExporterFormat.MP4, has_content: false })
-            jest.spyOn(api.exports, 'create').mockResolvedValue(asyncAsset)
+        const createCases: {
+            label: string
+            response?: ExportedAssetType
+            rejectWith?: Error
+            format: ExporterFormat
+            toast: { fn: 'success' | 'error'; args: any[] }
+            expectsDownload: boolean
+            freshIds: number[]
+        }[] = [
+            {
+                label: 'async export is acknowledged immediately and tracked as undownloaded',
+                response: asset({ id: 11, export_format: ExporterFormat.MP4, has_content: false }),
+                format: ExporterFormat.MP4,
+                toast: {
+                    fn: 'success',
+                    args: ['Export started', expect.objectContaining({ button: expect.any(Object) })],
+                },
+                expectsDownload: false,
+                freshIds: [11],
+            },
+            {
+                label: 'blocking export with content is downloaded and confirmed',
+                response: asset({ id: 12, export_format: ExporterFormat.CSV, has_content: true }),
+                format: ExporterFormat.CSV,
+                toast: { fn: 'success', args: ['Export complete!'] },
+                expectsDownload: true,
+                freshIds: [],
+            },
+            {
+                label: 'export that failed in the request surfaces the error',
+                response: asset({ id: 13, export_format: ExporterFormat.MP4, exception: 'boom' }),
+                format: ExporterFormat.MP4,
+                toast: { fn: 'error', args: ['Export failed: boom'] },
+                expectsDownload: false,
+                freshIds: [],
+            },
+            {
+                label: 'create request that throws surfaces the error from the catch',
+                rejectWith: new Error('network down'),
+                format: ExporterFormat.MP4,
+                toast: { fn: 'error', args: ['Export failed: network down'] },
+                expectsDownload: false,
+                freshIds: [],
+            },
+        ]
 
-            logic.actions.createExport({ exportData: { export_format: ExporterFormat.MP4 } })
+        it.each(createCases)('$label', async ({ response, rejectWith, format, toast, expectsDownload, freshIds }) => {
+            const createSpy = jest.spyOn(api.exports, 'create')
+            if (rejectWith) {
+                createSpy.mockRejectedValue(rejectWith)
+            } else {
+                createSpy.mockResolvedValue(response!)
+            }
+
+            logic.actions.createExport({ exportData: { export_format: format } })
             await flush()
 
-            expect(lemonToast.success).toHaveBeenCalledWith(
-                'Export started',
-                expect.objectContaining({ button: expect.any(Object) })
-            )
-            expect(downloadExportedAsset).not.toHaveBeenCalled()
-            expect(logic.values.freshUndownloadedExports.map((a) => a.id)).toEqual([11])
-        })
-
-        it('downloads and confirms a blocking export that already has content', async () => {
-            const doneAsset = asset({ id: 12, export_format: ExporterFormat.CSV, has_content: true })
-            jest.spyOn(api.exports, 'create').mockResolvedValue(doneAsset)
-
-            logic.actions.createExport({ exportData: { export_format: ExporterFormat.CSV } })
-            await flush()
-
-            expect(downloadExportedAsset).toHaveBeenCalledWith(doneAsset)
-            expect(lemonToast.success).toHaveBeenCalledWith('Export complete!')
-            expect(logic.values.freshUndownloadedExports).toEqual([])
-        })
-
-        it('surfaces an export that failed during the request', async () => {
-            const failedAsset = asset({ id: 13, export_format: ExporterFormat.MP4, exception: 'boom' })
-            jest.spyOn(api.exports, 'create').mockResolvedValue(failedAsset)
-
-            logic.actions.createExport({ exportData: { export_format: ExporterFormat.MP4 } })
-            await flush()
-
-            expect(lemonToast.error).toHaveBeenCalledWith('Export failed: boom')
-            expect(downloadExportedAsset).not.toHaveBeenCalled()
-            expect(logic.values.freshUndownloadedExports).toEqual([])
+            expect(lemonToast[toast.fn]).toHaveBeenCalledWith(...toast.args)
+            expect(jest.mocked(downloadExportedAsset).mock.calls).toEqual(expectsDownload ? [[response]] : [])
+            expect(logic.values.freshUndownloadedExports.map((a) => a.id)).toEqual(freshIds)
         })
     })
 })

--- a/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
@@ -1,5 +1,4 @@
-import { expectLogic } from 'kea-test-utils'
-
+import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 
 import { initKeaTests } from '~/test/init'
@@ -86,7 +85,7 @@ describe('exportsLogic', () => {
         })
     })
 
-    describe('async export toast resolution', () => {
+    describe('createExport toast', () => {
         let logic: ReturnType<typeof exportsLogic.build>
 
         beforeEach(() => {
@@ -94,39 +93,53 @@ describe('exportsLogic', () => {
             initKeaTests()
             logic = exportsLogic()
             logic.mount()
+            jest.spyOn(api.exports, 'list').mockResolvedValue({ results: [], count: 0 } as any)
         })
 
-        it.each([
-            {
-                label: 'success',
-                finishedAsset: asset({ id: 5, export_format: ExporterFormat.MP4, has_content: true }),
-                expectedToast: { fn: 'success' as const, message: 'Export complete!' },
-                expectsDownload: true,
-            },
-            {
-                label: 'error',
-                finishedAsset: asset({ id: 7, export_format: ExporterFormat.MP4, exception: 'boom' }),
-                expectedToast: { fn: 'error' as const, message: 'Export failed: boom' },
-                expectsDownload: false,
-            },
-        ])(
-            'resolves the per-export toast to $label once a tracked async export finishes',
-            async ({ finishedAsset, expectedToast, expectsDownload }) => {
-                logic.actions.addFresh(asset({ id: finishedAsset.id, export_format: ExporterFormat.MP4 }))
+        afterEach(() => {
+            logic.unmount()
+        })
 
-                await expectLogic(logic, () => {
-                    logic.actions.loadExportsSuccess([finishedAsset])
-                }).toFinishAllListeners()
+        // Let the fire-and-forget IIFE in the createExport loader run to its toast.
+        const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
-                if (expectsDownload) {
-                    expect(downloadExportedAsset).toHaveBeenCalledWith(finishedAsset)
-                } else {
-                    expect(downloadExportedAsset).not.toHaveBeenCalled()
-                }
-                expect(lemonToast.dismiss).toHaveBeenCalledWith(`export-${finishedAsset.id}`)
-                expect(lemonToast[expectedToast.fn]).toHaveBeenCalledWith(expectedToast.message)
-                expect(logic.values.freshUndownloadedExports).toEqual([])
-            }
-        )
+        it('acknowledges an async export immediately and tracks it as undownloaded', async () => {
+            const asyncAsset = asset({ id: 11, export_format: ExporterFormat.MP4, has_content: false })
+            jest.spyOn(api.exports, 'create').mockResolvedValue(asyncAsset)
+
+            logic.actions.createExport({ exportData: { export_format: ExporterFormat.MP4 } })
+            await flush()
+
+            expect(lemonToast.success).toHaveBeenCalledWith(
+                'Export started',
+                expect.objectContaining({ button: expect.any(Object) })
+            )
+            expect(downloadExportedAsset).not.toHaveBeenCalled()
+            expect(logic.values.freshUndownloadedExports.map((a) => a.id)).toEqual([11])
+        })
+
+        it('downloads and confirms a blocking export that already has content', async () => {
+            const doneAsset = asset({ id: 12, export_format: ExporterFormat.CSV, has_content: true })
+            jest.spyOn(api.exports, 'create').mockResolvedValue(doneAsset)
+
+            logic.actions.createExport({ exportData: { export_format: ExporterFormat.CSV } })
+            await flush()
+
+            expect(downloadExportedAsset).toHaveBeenCalledWith(doneAsset)
+            expect(lemonToast.success).toHaveBeenCalledWith('Export complete!')
+            expect(logic.values.freshUndownloadedExports).toEqual([])
+        })
+
+        it('surfaces an export that failed during the request', async () => {
+            const failedAsset = asset({ id: 13, export_format: ExporterFormat.MP4, exception: 'boom' })
+            jest.spyOn(api.exports, 'create').mockResolvedValue(failedAsset)
+
+            logic.actions.createExport({ exportData: { export_format: ExporterFormat.MP4 } })
+            await flush()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Export failed: boom')
+            expect(downloadExportedAsset).not.toHaveBeenCalled()
+            expect(logic.values.freshUndownloadedExports).toEqual([])
+        })
     })
 })

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -37,9 +37,6 @@ export const pickPollDelayMs = (pendingAssets: ExportedAssetType[]): number => {
 const isLocalExport = (context: ExportContext | undefined): context is LocalExportContext =>
     !!(context && 'localData' in context)
 
-// Single source for the per-export toast id so the show and dismiss sites can't drift.
-const exportToastId = (id: number): string => `export-${id}`
-
 export const exportsLogic = kea<exportsLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'exportsLogic']),
 
@@ -119,41 +116,11 @@ export const exportsLogic = kea<exportsLogicType>([
         createExportSuccess: () => {
             actions.loadExports()
         },
-        loadExportsSuccess: async (_, breakpoint) => {
-            // Auto-download (or surface errors for) async exports we kicked off that have now finished.
-            // NB: avoid naming a local `exports` — it shadows the CommonJS module object under
-            // transpilation (jest) and throws a TDZ error.
-            const { exports: exportsList, freshUndownloadedExports } = exportsLogic.values
-            for (const fresh of freshUndownloadedExports) {
-                // The list can be format-filtered (assetFormat), so fetch directly if the tracked export isn't in it.
-                let latest = exportsList.find((asset) => asset.id === fresh.id)
-                if (!latest) {
-                    try {
-                        latest = await api.exports.get(fresh.id)
-                    } catch {
-                        continue
-                    }
-                }
-                if (!latest.has_content && !latest.exception) {
-                    continue
-                }
-                actions.removeFresh(fresh)
-                lemonToast.dismiss(exportToastId(fresh.id))
-                if (latest.has_content) {
-                    await downloadExportedAsset(latest)
-                    lemonToast.success('Export complete!')
-                } else {
-                    lemonToast.error('Export failed: ' + latest.exception)
-                }
-            }
-
-            // Keep polling while the (possibly filtered) list or any tracked async export is still unfinished.
-            const pendingInList = exportsList.some((asset) => !asset.has_content && !asset.exception)
-            const pendingFresh = exportsLogic.values.freshUndownloadedExports.length > 0
-            if (pendingInList || pendingFresh) {
-                await breakpoint(pickPollDelayMs([...exportsList, ...exportsLogic.values.freshUndownloadedExports]))
+        loadExportsSuccess: async ({ exports: exportsList }, breakpoint) => {
+            // Keep the list fresh while any export is still rendering, so the panel reflects completion.
+            if (exportsList.some((asset) => !asset.has_content && !asset.exception)) {
+                await breakpoint(pickPollDelayMs(exportsList))
                 actions.loadExports()
-                return
             }
         },
         createStaticCohort: async ({ query, name }) => {
@@ -255,17 +222,15 @@ export const exportsLogic = kea<exportsLogicType>([
                             actions.loadExportsSuccess(updatedExports)
 
                             if (response && response.has_content) {
-                                // Blocking export already finished — download and confirm.
+                                // Blocking export already finished in the request — download and confirm.
                                 await downloadExportedAsset(response)
                                 lemonToast.success('Export complete!')
                             } else if (response && response.exception) {
                                 lemonToast.error('Export failed: ' + response.exception)
                             } else if (response) {
-                                // Async export (e.g. video render): show a per-export toast that the
-                                // polling loop resolves to success (or error) once the render finishes.
-                                lemonToast.info('Export starting...', {
-                                    toastId: exportToastId(response.id),
-                                    autoClose: false,
+                                // Async export (e.g. video render) is a background job: acknowledge the
+                                // kickoff right away. It surfaces in the Exports panel once the render finishes.
+                                lemonToast.success('Export started', {
                                     button: {
                                         label: 'View exports',
                                         action: () => newInternalTab(urls.exports()),


### PR DESCRIPTION
## Problem

Follow-up to #64115. Async exports (e.g. video renders) became fire-and-forget (#63915), but the frontend kept a persistent "Export starting…" toast open and waited for the whole render to finish (via a poll) before resolving it. That poll only lived while the recording player was mounted and only resolved if the render reported back — so the toast hung indefinitely.

## Changes

- Async export → show a terminal **"Export started"** toast immediately on the create response, with a "View exports" button.
- Blocking export that finished in the request → download + "Export complete!" (unchanged).
- Dropped the wait-and-auto-download poll. The export is still tracked in `freshUndownloadedExports`, so the Exports panel's undownloaded badge and manual download keep working.

## How did you test this code?

Agent (Claude Code), human-driven by @TueHaulund. Automated only: rewrote the `exportsLogic` tests to cover the async / blocking / failed create paths (10/10 pass). No manual end-to-end run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @TueHaulund. Authored with Claude Code.