### PR TITLE
fix(data-warehouse): search external data sources by type and prefix

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -1191,7 +1191,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
     queryset = ExternalDataSource.objects.all()
     serializer_class = ExternalDataSourceSerializers
     filter_backends = [filters.SearchFilter]
-    search_fields = ["source_id"]
+    # `source_id` is an opaque internal connection UUID — useless to search by. Callers
+    # (the in-app sources list, the MCP tool) narrow by what they can actually see: the
+    # source type ("Stripe", "Postgres") and the HogQL table prefix.
+    search_fields = ["source_type", "prefix"]
     ordering = "-created_at"
 
     def get_serializer_class(self) -> type[serializers.Serializer]:

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -1087,6 +1087,44 @@ class TestExternalDataSource(APIBaseTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(payload["results"]), 2)
 
+    def test_list_external_data_source_search_matches_type_and_prefix(self):
+        stripe = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type="Stripe",
+            created_by=self.user,
+            prefix="prod_payments",
+        )
+        postgres = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type="Postgres",
+            created_by=self.user,
+            prefix="analytics",
+        )
+
+        base_url = f"/api/environments/{self.team.pk}/external_data_sources/"
+
+        # Search by source type narrows to that source.
+        by_type = self.client.get(f"{base_url}?search=Stripe").json()
+        assert [r["id"] for r in by_type["results"]] == [str(stripe.pk)]
+
+        # Search by prefix narrows to that source, including a partial prefix match.
+        by_prefix = self.client.get(f"{base_url}?search=prod_").json()
+        assert [r["id"] for r in by_prefix["results"]] == [str(stripe.pk)]
+
+        # A term matching neither type nor prefix returns nothing.
+        no_match = self.client.get(f"{base_url}?search=nonexistent").json()
+        assert no_match["results"] == []
+
+        # The opaque internal source_id is no longer a search target.
+        by_source_id = self.client.get(f"{base_url}?search={postgres.source_id}").json()
+        assert by_source_id["results"] == []
+
     def test_connections_returns_lightweight_direct_connection_options(self):
         source = ExternalDataSource.objects.create(
             team_id=self.team.pk,

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -1087,43 +1087,44 @@ class TestExternalDataSource(APIBaseTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(payload["results"]), 2)
 
-    def test_list_external_data_source_search_matches_type_and_prefix(self):
-        stripe = ExternalDataSource.objects.create(
+    def _create_searchable_source(self, source_type: str, prefix: str) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
             team_id=self.team.pk,
             source_id=str(uuid.uuid4()),
             connection_id=str(uuid.uuid4()),
             destination_id=str(uuid.uuid4()),
-            source_type="Stripe",
+            source_type=source_type,
             created_by=self.user,
-            prefix="prod_payments",
-        )
-        postgres = ExternalDataSource.objects.create(
-            team_id=self.team.pk,
-            source_id=str(uuid.uuid4()),
-            connection_id=str(uuid.uuid4()),
-            destination_id=str(uuid.uuid4()),
-            source_type="Postgres",
-            created_by=self.user,
-            prefix="analytics",
+            prefix=prefix,
         )
 
-        base_url = f"/api/environments/{self.team.pk}/external_data_sources/"
+    # Sentinel resolved to a freshly-created source's opaque internal source_id at runtime,
+    # to assert that searching by it no longer matches.
+    SEARCH_BY_INTERNAL_SOURCE_ID = object()
 
-        # Search by source type narrows to that source.
-        by_type = self.client.get(f"{base_url}?search=Stripe").json()
-        assert [r["id"] for r in by_type["results"]] == [str(stripe.pk)]
+    @parameterized.expand(
+        [
+            ("by_source_type", "Stripe", ["prod_payments"]),
+            ("by_source_type_other", "Postgres", ["analytics"]),
+            ("by_prefix_partial", "prod_", ["prod_payments"]),
+            ("by_prefix_full", "analytics", ["analytics"]),
+            ("no_match", "nonexistent", []),
+            ("internal_source_id_is_not_searchable", SEARCH_BY_INTERNAL_SOURCE_ID, []),
+        ]
+    )
+    def test_list_external_data_source_search(self, _name, term, expected_prefixes):
+        sources = {
+            "prod_payments": self._create_searchable_source(source_type="Stripe", prefix="prod_payments"),
+            "analytics": self._create_searchable_source(source_type="Postgres", prefix="analytics"),
+        }
+        if term is self.SEARCH_BY_INTERNAL_SOURCE_ID:
+            term = sources["analytics"].source_id
 
-        # Search by prefix narrows to that source, including a partial prefix match.
-        by_prefix = self.client.get(f"{base_url}?search=prod_").json()
-        assert [r["id"] for r in by_prefix["results"]] == [str(stripe.pk)]
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/?search={term}")
 
-        # A term matching neither type nor prefix returns nothing.
-        no_match = self.client.get(f"{base_url}?search=nonexistent").json()
-        assert no_match["results"] == []
-
-        # The opaque internal source_id is no longer a search target.
-        by_source_id = self.client.get(f"{base_url}?search={postgres.source_id}").json()
-        assert by_source_id["results"] == []
+        assert response.status_code == 200
+        returned_prefixes = sorted(r["prefix"] for r in response.json()["results"])
+        assert returned_prefixes == sorted(expected_prefixes)
 
     def test_connections_returns_lightweight_direct_connection_options(self):
         source = ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

`external-data-sources-list` (both the in-app sources list and the MCP tool) was effectively unusable on projects with many sources. MCP agent feedback flagged two issues; one is a real bug:

- **`search` matched neither source type nor prefix.** The viewset set `search_fields = ["source_id"]` — an opaque internal connection UUID a caller never sees. So `?search=Stripe` and `?search=prod_` returned `count: 0` even on a project with several Stripe and `prod_`-prefixed sources. With no working way to narrow, the tool's documented purpose ("discover what external data sources are connected") was unreachable, because the unfiltered response is large.

The companion complaint — that `limit`/`offset` are "silently ignored" — does **not** reproduce: pagination works (a `limit: 1` call returns `count: 68`, a `next` link, and a single row). The overflow comes from the size of each source's payload (every schema inlines its full table column list), not from a broken `limit`. Once `search` narrows the list, the response is consumable. Trimming the per-source list payload is a reasonable follow-up the team may want, but it touches the shared frontend list contract and is out of scope here.

## Changes

`search_fields = ["source_type", "prefix"]` on `ExternalDataSourceViewSet`, so `?search=` matches what a caller can actually see. Added a regression test covering type match, partial-prefix match, no-match, and that the internal `source_id` is no longer a search target.

`search_fields` is internal viewset config — it does not change the response shape, OpenAPI spec, generated types, or MCP tool schema, so no codegen is required.

## How did you test this code?

I'm an agent (PostHog Code). I added an automated test, `test_list_external_data_source_search_matches_type_and_prefix`, in `products/data_warehouse/backend/api/test/test_external_data_source.py`. I could not run the Python suite in this environment (no local interpreter), so it has not been executed locally — CI will run it. I separately reproduced the original bug live against project 2 via the MCP tool (`search: "Stripe"` → `count: 0`) before making the change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude) from a Slack thread, at Marcus Hof's request. I reproduced both reported symptoms against the live MCP tool, traced the tool to the `ExternalDataSourceViewSet` in this repo, confirmed `limit`/`offset` already work (so the only real defect was `search_fields`), and verified the in-app sources list reads `source.schemas` for counts/status only (never the inlined `table.columns`), which is why the heavy list payload is a separable concern. Chose the minimal, codegen-free fix over restructuring the shared list serializer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AV33BDCJ3/p1781672906666039?thread_ts=1781672906.666039&cid=C0AV33BDCJ3)*
