### PR TITLE
chore(product-analytics): clarify web vitals onboarding copy

### DIFF
--- a/products/product_analytics/frontend/onboarding/steps.tsx
+++ b/products/product_analytics/frontend/onboarding/steps.tsx
@@ -89,7 +89,7 @@ export const productAnalyticsOnboarding: ProductOnboardingProvider = {
             },
             {
                 title: 'Enable web vitals autocapture',
-                description: `Uses Google's web vitals library to automagically capture performance information.`,
+                description: `Uses Google's web vitals library to automatically capture page performance metrics.`,
                 teamProperty: 'autocapture_web_vitals_opt_in',
                 value: ctx.currentTeam?.autocapture_web_vitals_opt_in ?? true,
                 type: 'toggle',


### PR DESCRIPTION
## Problem 

The web vitals option in product analytics onboarding described itself as using Google's library to "automagically capture performance information." The wording was vague ("performance information") and informal ("automagically"), which doesn't clearly tell a new user what the toggle actually does.

## Changes
<img width="816" height="865" alt="Screenshot 2026-06-17 at 09 58 44" src="https://github.com/user-attachments/assets/c32b1e7d-6cf9-429e-90dd-92f59fd841d1" />

Updated the description copy for the "Enable web vitals autocapture" onboarding option to be clearer and more specific: it now reads "Uses Google's web vitals library to automatically capture page performance metrics." Copy-only change, no behavior change.

## How did you test this code?

I'm an agent (PostHog Code). This is a static copy string with no logic, so there are no automated tests to add or run. Verified by inspecting the rendered onboarding option text in the diff; the toggle behavior and `autocapture_web_vitals_opt_in` team property are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used to validate the product-analytics PR hygiene-check workflow end to end. Sam directed the work; the change itself is a one-line onboarding copy tweak.

<!-- triggering re-review via edited event -->
