### PR TITLE
fix(sharing): show upgrade modal above the sharing modal

### DIFF
--- a/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
+++ b/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
@@ -23,7 +23,7 @@ export function UpgradeModal(): JSX.Element {
 
     if (shouldShowPlatformAddonMessage) {
         return (
-            <LemonModal onClose={hideUpgradeModal} isOpen={!!upgradeModalFeatureKey}>
+            <LemonModal onClose={hideUpgradeModal} isOpen={!!upgradeModalFeatureKey} zIndex="1169">
                 <div className="max-w-2xl mt-8">
                     <div className="PayGateMini rounded flex flex-col items-center p-4 text-center bg-primary border border-primary">
                         <div className="mb-3 max-w-72">
@@ -49,7 +49,7 @@ export function UpgradeModal(): JSX.Element {
     }
 
     return (
-        <LemonModal onClose={hideUpgradeModal} isOpen={!!upgradeModalFeatureKey}>
+        <LemonModal onClose={hideUpgradeModal} isOpen={!!upgradeModalFeatureKey} zIndex="1169">
             <div className="max-w-2xl">
                 <PayGateMini
                     feature={upgradeModalFeatureKey}


### PR DESCRIPTION
## Problem

Premium-gated toggles in the sharing modal ("Password protect", untoggling "Show PostHog branding") looked unresponsive for users without the required feature. They _do_ open an upgrade modal explaining the gate, but it rendered behind the already-open sharing modal, so users never saw it — surfacing as reports that password protection "isn't working" in Session replay.

## Changes

`UpgradeModal` used the default modal z-index (1100), but it's triggered from inside the sharing modal which opens higher (replay share dialog 1162, add-password sub-modal 1166). Render it at the top of the modal stack (`zIndex="1169"`) instead, matching the re-authentication modal.

## How did you test this code?

Agent-authored; no automated test (presentational z-index change). Verified the z-index hierarchy by tracing the values; lint passes. Manual in-app check still needs a human pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a "password toggle not working" report; the backend gating works as intended, the real issue was the upsell modal stacking behind the sharing modal. Built with Claude Code.