### PR TITLE
chore(product-analytics): clarify web vitals onboarding copy

### DIFF
--- a/products/product_analytics/frontend/onboarding/steps.tsx
+++ b/products/product_analytics/frontend/onboarding/steps.tsx
@@ -89,7 +89,7 @@ export const productAnalyticsOnboarding: ProductOnboardingProvider = {
             },
             {
                 title: 'Enable web vitals autocapture',
-                description: `Uses Google's web vitals library to automagically capture performance information.`,
+                description: `Uses Google's web vitals library to automatically capture page performance metrics.`,
                 teamProperty: 'autocapture_web_vitals_opt_in',
                 value: ctx.currentTeam?.autocapture_web_vitals_opt_in ?? true,
                 type: 'toggle',


### PR DESCRIPTION
## Problem

The web vitals option in product analytics onboarding described itself as using Google's library to "automagically capture performance information." That wording is vague ("performance information") and informal ("automagically"), so it doesn't clearly tell a new user what enabling the toggle actually does.

## Changes

<img width="816" height="865" alt="web vitals onboarding copy" src="https://github.com/user-attachments/assets/c32b1e7d-6cf9-429e-90dd-92f59fd841d1" />


Reworded the description for the "Enable web vitals autocapture" onboarding option to: "Uses Google's web vitals library to automatically capture page performance metrics." Copy-only change — no behaviour change, the toggle and `autocapture_web_vitals_opt_in` team property are untouched.

## How did you test this code?

I'm an agent (PostHog Code). This is a static copy string with no logic, so there are no automated tests to add. Verified by inspecting the changed string in the diff.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created to validate the product-analytics PR hygiene-check workflow end to end. Sam directed the work.

<!-- re-review: verify label reliability -->
