### PR TITLE
feat(error-tracking): gate fingerprint auto-merge behind a global switch

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -130,9 +130,11 @@ LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
 RASTERIZATION_TASK_QUEUE = "rasterization-task-queue"  # Not collapsed in dev — separate Node.js worker process
 
 # Error tracking
-ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS: list[int] = [
-    int(team_id) for team_id in get_list(os.getenv("ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS", "")) if team_id
-]
+# Global on/off switch for auto-merging close fingerprints into their nearest issue.
+# Off by default; enabled per-deployment (e.g. EU).
+ERROR_TRACKING_AUTO_MERGE_ENABLED: bool = get_from_env(
+    "ERROR_TRACKING_AUTO_MERGE_ENABLED", False, type_cast=str_to_bool
+)
 
 # Signals inbox notification: how long to wait for an auto-started implementation PR before
 # notifying anyway, and how often to poll for it.

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -218,7 +218,7 @@ def _merge_fingerprint_into_closest_issue(
 ) -> int:
     closest_fingerprint = closest_fingerprints[0] if closest_fingerprints else None
     team_id = team.id
-    if team_id not in settings.ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS or closest_fingerprint is None:
+    if not settings.ERROR_TRACKING_AUTO_MERGE_ENABLED or closest_fingerprint is None:
         return 0
     if closest_fingerprint.distance >= AUTO_MERGE_DISTANCE_THRESHOLD:
         return 0

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -207,17 +207,18 @@ class TestFingerprintEmbeddingResultActivity:
         assert result.query_duration_ms is not None
         assert result.closest_fingerprints == closest_fingerprints
 
-    def test_merge_fingerprint_skips_teams_without_rollout(self) -> None:
-        result = _merge_fingerprint_into_closest_issue(
-            team=MagicMock(id=1),
-            fingerprint="test-fingerprint",
-            closest_fingerprints=[SimilarFingerprintDistance(fingerprint="fingerprint-1", distance=0.01)],
-        )
+    def test_merge_fingerprint_skips_when_auto_merge_disabled(self) -> None:
+        with override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=False):
+            result = _merge_fingerprint_into_closest_issue(
+                team=MagicMock(id=1),
+                fingerprint="test-fingerprint",
+                closest_fingerprints=[SimilarFingerprintDistance(fingerprint="fingerprint-1", distance=0.01)],
+            )
 
         assert result == 0
 
     def test_merge_fingerprint_skips_distances_above_threshold(self) -> None:
-        with override_settings(ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS=[2]):
+        with override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True):
             result = _merge_fingerprint_into_closest_issue(
                 team=MagicMock(id=2),
                 fingerprint="test-fingerprint",
@@ -232,7 +233,7 @@ class TestFingerprintEmbeddingResultActivity:
         fingerprint_query.filter.return_value.select_related.return_value.order_by.return_value = []
 
         with (
-            override_settings(ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS=[2]),
+            override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.select_for_update",
                 return_value=fingerprint_query,
@@ -263,7 +264,7 @@ class TestFingerprintEmbeddingResultActivity:
         capture_context.__enter__.return_value = capture
 
         with (
-            override_settings(ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS=[2]),
+            override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.select_for_update",
                 return_value=fingerprint_query,
@@ -312,7 +313,7 @@ class TestMergeFingerprintCrossTeamIsolation(BaseTest):
         capture_context.__enter__.return_value = MagicMock()
 
         with (
-            override_settings(ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS=[self.team.id]),
+            override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
                 return_value=capture_context,


### PR DESCRIPTION
## Problem

Error-tracking fingerprint auto-merge was gated by a per-team allowlist env var (`ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS`). Turning the feature on for a whole region (EU) meant maintaining a list of team IDs, which is awkward operationally when the intent is simply "on" or "off" for a deployment.

## Changes

- Replace the `ERROR_TRACKING_AUTO_MERGE_FINGERPRINT_TEAM_IDS` allowlist with a single boolean `ERROR_TRACKING_AUTO_MERGE_ENABLED`, defaulting off.
- The merge activity now gates on this flag instead of team membership; the distance threshold check is unchanged.
- Enable per-deployment with one env variable (e.g. set `ERROR_TRACKING_AUTO_MERGE_ENABLED=true` on the EU error-tracking temporal worker).

Note: this intentionally drops the per-team allowlist, so flipping the flag enables auto-merge for every team in that deployment at once.

## How did you test this code?

I'm an agent (Claude Code). I updated the existing unit tests to use the new flag and ran them locally with `hogli test`: the in-process tests pass (including the switch-on and switch-off cases). The 3 DB-backed tests could not run in this environment because local Postgres was not available — they will run in CI. Pre-commit hooks (ruff lint + format, `ty` type check) passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) at Hugues' direction. The original implementation used a per-team env-var allowlist; the requested change was explicitly "only 1 env variable, a global on/off switch", so the allowlist was dropped rather than augmented. Tools used: Explore agent for codebase discovery, Edit/Bash for the change and local test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
