### PR TITLE
fix(stripe): translate config errors instead of leaking internals at validation

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -361,6 +361,16 @@ If automatic creation failed due to a permissions error and you're using a restr
             if e.missing_permissions:
                 message += f". Additionally lacks permissions for {', '.join(e.missing_permissions.keys())}"
             return False, message
+        except ValueError as e:
+            # `_get_api_key` raises ValueError for deterministic config problems (missing API key,
+            # missing integration ID, missing access token). The user-facing wording already lives
+            # in `get_non_retryable_errors`; reuse it so this path doesn't leak the internal
+            # "Missing Stripe integration ID" string. Fall back to the raw message if unmapped.
+            raw = str(e)
+            for pattern, friendly in self.get_non_retryable_errors().items():
+                if friendly and pattern in raw:
+                    return False, friendly
+            return False, raw
         except Exception as e:
             return False, str(e)
 

--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,5 +1,6 @@
 import pytest
 
+from posthog.temporal.data_imports.sources.generated_configs import StripeAuthMethodConfig, StripeSourceConfig
 from posthog.temporal.data_imports.sources.stripe.source import StripeSource
 
 
@@ -38,3 +39,23 @@ class TestStripeSource:
     def test_non_retryable_errors_do_not_match_transient(self, other_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+    def test_validate_credentials_missing_integration_id_returns_friendly_message(self):
+        # OAuth selected but the integration was never linked (or was deleted): `_get_api_key`
+        # raises ValueError("Missing Stripe integration ID"), an internal string the user can't
+        # act on. validate_credentials must translate it to the reconnect guidance.
+        config = StripeSourceConfig(auth_method=StripeAuthMethodConfig(selection="oauth", stripe_integration_id=None))
+
+        ok, message = self.source.validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert message == "Stripe integration ID is not configured. Please reconnect your Stripe account."
+        assert "Missing Stripe integration ID" not in (message or "")
+
+    def test_validate_credentials_missing_api_key_returns_friendly_message(self):
+        config = StripeSourceConfig(auth_method=StripeAuthMethodConfig(selection="api_key", stripe_secret_key=None))
+
+        ok, message = self.source.validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert message == "Stripe API key is not configured. Please update the source configuration."


### PR DESCRIPTION
## Problem

Creating a Stripe source whose OAuth link was never completed (or was deleted) failed validation with the raw message _"Missing Stripe integration ID"_. The "integration ID" is a PostHog-internal database identifier — the user never enters it and has no way to act on that message. The API-key variant (_"Missing Stripe API key"_) leaked the same way.

These come from `_get_api_key`, which raises `ValueError` for deterministic config problems. In `validate_credentials` they were caught by the generic `except Exception` and returned verbatim. Friendly, actionable wording for exactly these cases already exists in `get_non_retryable_errors`, but that mapping was only consumed by the sync/refresh path — not by the `database_schema` validation the wizard calls.

## Changes

- Add a `ValueError` branch to `StripeSource.validate_credentials` that translates the message using the existing `get_non_retryable_errors` map (missing API key, missing integration ID, missing access token), falling back to the raw message if unmapped. The validation path and the sync path now surface the same guidance ("Please reconnect your Stripe account" / "Please update the source configuration").

No change to sync behavior or to the messages themselves — this only routes the validation path through the wording that already existed.

## How did you test this code?

I'm an agent. I added two tests to `TestStripeSource`:

- `test_validate_credentials_missing_integration_id_returns_friendly_message` — asserts the reconnect message and that the internal "Missing Stripe integration ID" string is gone.
- `test_validate_credentials_missing_api_key_returns_friendly_message`.

All 11 tests in the file pass; `ruff check` is clean over the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored with Claude Code during a triage of data-warehouse source-creation failures. Reused the existing non-retryable-error wording rather than inventing new strings, so the two code paths can't drift.