### PR TITLE
fix(experiments): guard isLegacyExperiment against null metric fields

### DIFF
--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -988,17 +988,6 @@ describe('hasLegacyMetrics', () => {
 
         expect(isLegacyExperiment(experiment)).toBe(false)
     })
-
-    it('does not crash when metric fields are null or undefined', () => {
-        const experiment = {
-            ...experimentJson,
-            metrics: null,
-            metrics_secondary: undefined,
-            saved_metrics: null,
-        } as unknown as Experiment
-
-        expect(isLegacyExperiment(experiment)).toBe(false)
-    })
 })
 
 describe('getOrderedMetricsWithResults', () => {

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -988,6 +988,17 @@ describe('hasLegacyMetrics', () => {
 
         expect(isLegacyExperiment(experiment)).toBe(false)
     })
+
+    it('does not crash when metric fields are null or undefined', () => {
+        const experiment = {
+            ...experimentJson,
+            metrics: null,
+            metrics_secondary: undefined,
+            saved_metrics: null,
+        } as unknown as Experiment
+
+        expect(isLegacyExperiment(experiment)).toBe(false)
+    })
 })
 
 describe('getOrderedMetricsWithResults', () => {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -711,10 +711,10 @@ export const isLegacyExperimentQuery = (query: unknown): query is ExperimentTren
  */
 export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }: Experiment): boolean => {
     // saved_metrics has a different structure and so we need to check for it separately
-    if (saved_metrics.some(isLegacySharedMetric)) {
+    if ((saved_metrics ?? []).some(isLegacySharedMetric)) {
         return true
     }
-    return [...metrics, ...metrics_secondary].some(isLegacyExperimentQuery)
+    return [...(metrics ?? []), ...(metrics_secondary ?? [])].some(isLegacyExperimentQuery)
 }
 
 export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLegacyExperimentQuery(query)


### PR DESCRIPTION
## Problem

The Experiments list crashed for at least one org with `TypeError: Spread syntax requires ...iterable not be null or undefined`. The list cell renderer calls `isLegacyExperiment`, which spreads `metrics` and `metrics_secondary` directly. When an experiment has those fields as `null`/`undefined` at runtime (the TS types say they're always arrays, but the data disagreed), the spread throws and takes down the whole list render.

## Changes

Add nullish guards in `isLegacyExperiment` so `metrics`, `metrics_secondary`, and `saved_metrics` each fall back to `[]` before being iterated.

## How did you test this code?

I'm an agent. This is a small nullish-coalescing guard; I could not run the frontend test suite in this environment (jest not installed). Please rely on CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an Error tracking issue surfaced in a mission-control digest. Traced the resolved stack frame (`isLegacyExperiment` at `utils.ts:716`, rendered via `Experiments.tsx` → `LemonTable`) to the unguarded array spread on line 717, confirmed the `Experiment` type declares the fields as required arrays while production data had them null, and added the guard.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1781685012074269?thread_ts=1781685012.074269&cid=C07PXH2GTGV)*
