### PR TITLE
feat(tasks): tag modal sandboxes with task run identifiers

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -238,14 +238,13 @@ def _build_sandbox_tags(
 
     Modal tag values must be strings; None values are dropped so we don't emit empty tags.
     """
-    # Matches TaskRun.workflow_id so a sandbox links straight back to its Temporal workflow.
-    workflow_id = f"task-processing-{ctx.task_id}-{ctx.run_id}"
-    tags: dict[str, str | None] = {
+    tags: dict[str, str | int | None] = {
         "task_id": ctx.task_id,
         "task_run_id": ctx.run_id,
         "origin_product": ctx.origin_product,
-        "team_id": str(ctx.team_id),
-        "workflow_id": workflow_id,
+        "team_id": ctx.team_id,
+        # Links a sandbox straight back to its Temporal workflow.
+        "workflow_id": TaskRun.get_workflow_id(ctx.task_id, ctx.run_id),
         "image_source": prepared.image_source,
         "sandbox_runtime": "vm" if use_vm_sandbox else "gvisor",
     }

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -229,6 +229,29 @@ def _emit_image_source_log(ctx: TaskProcessingContext, prepared: PrepareSandboxF
         emit_agent_log(ctx.run_id, "debug", f"Creating environment from {prepared.image_source_label}")
 
 
+def _build_sandbox_tags(
+    ctx: TaskProcessingContext,
+    prepared: PrepareSandboxForRepositoryOutput,
+    use_vm_sandbox: bool,
+) -> dict[str, str]:
+    """Tags forwarded to the Modal sandbox so it can be traced back when debugging.
+
+    Modal tag values must be strings; None values are dropped so we don't emit empty tags.
+    """
+    # Matches TaskRun.workflow_id so a sandbox links straight back to its Temporal workflow.
+    workflow_id = f"task-processing-{ctx.task_id}-{ctx.run_id}"
+    tags: dict[str, str | None] = {
+        "task_id": ctx.task_id,
+        "task_run_id": ctx.run_id,
+        "origin_product": ctx.origin_product,
+        "team_id": str(ctx.team_id),
+        "workflow_id": workflow_id,
+        "image_source": prepared.image_source,
+        "sandbox_runtime": "vm" if use_vm_sandbox else "gvisor",
+    }
+    return {key: str(value) for key, value in tags.items() if value is not None}
+
+
 @activity.defn
 @asyncify
 def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> PrepareSandboxForRepositoryOutput:
@@ -375,7 +398,7 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             environment_variables=prepared.environment_variables,
             snapshot_id=prepared.snapshot_id,
             snapshot_external_id=prepared.snapshot_external_id,
-            metadata={"task_id": ctx.task_id},
+            metadata=_build_sandbox_tags(ctx, prepared, use_vm_sandbox),
             vm_runtime=use_vm_sandbox,
         )
 

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -243,7 +243,6 @@ def _build_sandbox_tags(
         "task_run_id": ctx.run_id,
         "origin_product": ctx.origin_product,
         "team_id": ctx.team_id,
-        # Links a sandbox straight back to its Temporal workflow.
         "workflow_id": TaskRun.get_workflow_id(ctx.task_id, ctx.run_id),
         "image_source": prepared.image_source,
         "sandbox_runtime": "vm" if use_vm_sandbox else "gvisor",

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
@@ -8,7 +10,7 @@ from products.tasks.backend.temporal.process_task.activities.provision_sandbox i
 
 
 def _context(**overrides) -> TaskProcessingContext:
-    defaults = {
+    defaults: dict[str, Any] = {
         "task_id": "task-123",
         "run_id": "run-456",
         "team_id": 42,
@@ -25,7 +27,7 @@ def _context(**overrides) -> TaskProcessingContext:
 
 
 def _prepared(**overrides) -> PrepareSandboxForRepositoryOutput:
-    defaults = {
+    defaults: dict[str, Any] = {
         "sandbox_name": "sandbox-name",
         "repository": "posthog/posthog",
         "github_token": "token",

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -1,0 +1,74 @@
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
+    PrepareSandboxForRepositoryOutput,
+    _build_sandbox_tags,
+)
+
+
+def _context(**overrides) -> TaskProcessingContext:
+    defaults = {
+        "task_id": "task-123",
+        "run_id": "run-456",
+        "team_id": 42,
+        "team_uuid": "team-uuid",
+        "organization_id": "org-uuid",
+        "github_integration_id": None,
+        "repository": "posthog/posthog",
+        "distinct_id": "distinct-id",
+        "origin_product": "error_tracking",
+        "state": {},
+    }
+    defaults.update(overrides)
+    return TaskProcessingContext(**defaults)
+
+
+def _prepared(**overrides) -> PrepareSandboxForRepositoryOutput:
+    defaults = {
+        "sandbox_name": "sandbox-name",
+        "repository": "posthog/posthog",
+        "github_token": "token",
+        "branch": "feature-branch",
+        "environment_variables": {},
+        "snapshot_id": None,
+        "snapshot_external_id": None,
+        "used_snapshot": False,
+        "should_create_snapshot": True,
+        "shallow_clone": True,
+        "image_source": "base_image",
+        "image_source_label": "base image",
+    }
+    defaults.update(overrides)
+    return PrepareSandboxForRepositoryOutput(**defaults)
+
+
+def test_build_sandbox_tags_includes_all_identifiers():
+    tags = _build_sandbox_tags(_context(), _prepared(), use_vm_sandbox=False)
+
+    assert tags == {
+        "task_id": "task-123",
+        "task_run_id": "run-456",
+        "origin_product": "error_tracking",
+        "team_id": "42",
+        "workflow_id": "task-processing-task-123-run-456",
+        "image_source": "base_image",
+        "sandbox_runtime": "gvisor",
+    }
+
+
+def test_build_sandbox_tags_marks_vm_runtime():
+    tags = _build_sandbox_tags(_context(), _prepared(), use_vm_sandbox=True)
+
+    assert tags["sandbox_runtime"] == "vm"
+
+
+def test_build_sandbox_tags_reflects_image_source():
+    tags = _build_sandbox_tags(_context(), _prepared(image_source="resume_snapshot"), use_vm_sandbox=False)
+
+    assert tags["image_source"] == "resume_snapshot"
+
+
+def test_build_sandbox_tags_drops_none_values():
+    tags = _build_sandbox_tags(_context(origin_product=None), _prepared(), use_vm_sandbox=False)
+
+    assert "origin_product" not in tags
+    assert all(isinstance(value, str) for value in tags.values())

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -1,3 +1,5 @@
+import pytest
+
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
     PrepareSandboxForRepositoryOutput,
@@ -55,16 +57,18 @@ def test_build_sandbox_tags_includes_all_identifiers():
     }
 
 
-def test_build_sandbox_tags_marks_vm_runtime():
-    tags = _build_sandbox_tags(_context(), _prepared(), use_vm_sandbox=True)
+@pytest.mark.parametrize("use_vm_sandbox, expected", [(True, "vm"), (False, "gvisor")])
+def test_build_sandbox_tags_marks_runtime(use_vm_sandbox, expected):
+    tags = _build_sandbox_tags(_context(), _prepared(), use_vm_sandbox=use_vm_sandbox)
 
-    assert tags["sandbox_runtime"] == "vm"
+    assert tags["sandbox_runtime"] == expected
 
 
-def test_build_sandbox_tags_reflects_image_source():
-    tags = _build_sandbox_tags(_context(), _prepared(image_source="resume_snapshot"), use_vm_sandbox=False)
+@pytest.mark.parametrize("image_source", ["base_image", "resume_snapshot", "repository_snapshot"])
+def test_build_sandbox_tags_reflects_image_source(image_source):
+    tags = _build_sandbox_tags(_context(), _prepared(image_source=image_source), use_vm_sandbox=False)
 
-    assert tags["image_source"] == "resume_snapshot"
+    assert tags["image_source"] == image_source
 
 
 def test_build_sandbox_tags_drops_none_values():


### PR DESCRIPTION
## Problem

When debugging a Modal sandbox in production, it didn't include much information about what it was being used for, this adds more tags for debugging.

## Changes

Adds some tags from the task metadata to make it easier to identify what the sandbox is used for.