### PR TITLE
fix(experiments): guard ExperimentVelocityStats against null stats

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentVelocityStats.tsx
+++ b/frontend/src/scenes/experiments/ExperimentVelocityStats.tsx
@@ -10,7 +10,7 @@ import { experimentsLogic } from './experimentsLogic'
 export function ExperimentVelocityStats(): JSX.Element | null {
     const { experimentsStats, experimentsStatsLoading } = useValues(experimentsLogic)
 
-    if (experimentsStatsLoading) {
+    if (experimentsStatsLoading || !experimentsStats) {
         return null
     }
 


### PR DESCRIPTION
## Problem

The Experiments list crashed with `TypeError: Cannot destructure property 'launched_last_30d' of 'r' as it is null`. `ExperimentVelocityStats` destructures `experimentsStats` once loading finishes, but the `experiments/stats/` API response can come back `null` (the loader returns the raw response, replacing the non-null default). When it does, the destructure throws and takes down the list render.

## Changes

Return `null` from `ExperimentVelocityStats` when `experimentsStats` is missing, in the same early-return as the loading state.

## How did you test this code?

I'm an agent. This is a one-line null guard; I could not run the frontend test suite in this environment (jest not installed). Please rely on CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an Error tracking issue in a mission-control digest. The resolved stack pointed at `ExperimentVelocityStats.tsx:16/17`; confirmed the loader (`experimentsLogic.ts`) returns the raw API response with no null fallback, so a null/empty stats body reaches the component and breaks the destructure. Fixed at the component since it's the only consumer and where the crash occurs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1781685012074269?thread_ts=1781685012.074269&cid=C07PXH2GTGV)*
