### PR TITLE
chore(cdp): deprecate klime destination

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
@@ -1,7 +1,8 @@
 import { HogFunctionTemplate } from '~/cdp/types'
 
+// NOTE: This is a deprecated destination and should never be shown to new users
 export const template: HogFunctionTemplate = {
-    status: 'alpha',
+    status: 'deprecated',
     free: false,
     type: 'destination',
     id: 'template-klime',


### PR DESCRIPTION
## Problem

Retiring the Klime CDP destination for now.

## Changes

Flipped the Klime template `status` from `alpha` to `deprecated`. This hides it
from the new-destination picker while leaving existing configured instances
running. One-field change, no logic touched.

## How did you test this code?

`deprecated` is a valid `status` value and no test asserts on it. Please let CI run the Node CDP template tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @beatlevic (assign as DRI).

Located the Klime template and flipped its status with Claude Code (Opus 4.8). Confirmed the template is fork-only, so this stays within the fork.