### PR TITLE
fix(postgres): recover EDBHANDLEREXITED pooler drop on all message variants

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -141,13 +141,15 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a
 # libpq/PgBouncer signature — it raises its own pooler-internal error as a generic psycopg
-# InternalError_ (SQLSTATE XX000) with the message "(EDBHANDLEREXITED) DbHandler exited. Check
-# logs for more information". The pooler's per-session DbHandler process exits when its backend
-# connection dies (idle cull, backend restart, failover), so it's the same transient class as the
-# libpq drops above and recovers on reconnect. Matched narrowly by the stable "DbHandler exited"
-# text — the surrounding "(EDBHANDLEREXITED)" code and trailing "Check logs..." vary and are
-# excluded — so genuine XX000 internal errors (data corruption, etc.) stay non-recoverable.
-_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("dbhandler exited",)
+# InternalError_ (SQLSTATE XX000) carrying the "(EDBHANDLEREXITED)" code. The trailing message
+# varies — both "(EDBHANDLEREXITED) DbHandler exited. Check logs for more information" and
+# "(EDBHANDLEREXITED) connection to database closed. Check logs for more information" have been
+# observed for the same condition — but the EDBHANDLEREXITED code is the stable signal: the
+# pooler's per-session DbHandler process exited because its backend connection died (idle cull,
+# backend restart, failover). That's the same transient class as the libpq drops above and
+# recovers on reconnect, so match the code itself rather than any one message wording. Genuine
+# XX000 internal errors (data corruption, etc.) carry a different code and stay non-recoverable.
+_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited",)
 
 # Exception types that can carry a connection-dropped error. ProtocolViolation is
 # PgBouncer's synthetic error packet; OperationalError is libpq detecting the dead

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -614,9 +614,13 @@ class TestIsConnectionDroppedError:
             psycopg.errors.IdleInTransactionSessionTimeout(),
             # Supavisor (Supabase's connection pooler) tears down a session whose backend connection
             # died and surfaces it as a generic XX000 InternalError_ — a transient drop, not a libpq
-            # signature, so it's matched on the pooler's own "DbHandler exited" text.
+            # signature, so it's matched on the pooler's own "(EDBHANDLEREXITED)" code. The trailing
+            # message wording varies for the same condition, so every observed variant must match.
             psycopg.errors.InternalError_("(EDBHANDLEREXITED) DbHandler exited. Check logs for more information"),
             psycopg.errors.InternalError_("(EDBHANDLEREXITED) DBHANDLER EXITED. Check logs for more information"),
+            psycopg.errors.InternalError_(
+                "(EDBHANDLEREXITED) connection to database closed. Check logs for more information"
+            ),
         ],
     )
     def test_connection_dropped_errors_are_detected(self, error):
@@ -637,7 +641,7 @@ class TestIsConnectionDroppedError:
             ValueError("server conn crashed?"),
             Exception("server conn crashed?"),
             # A genuine XX000 internal error that isn't the Supavisor pooler drop must stay
-            # non-recoverable — the InternalError_ match is scoped to the "DbHandler exited" text.
+            # non-recoverable — the InternalError_ match is scoped to the "(EDBHANDLEREXITED)" code.
             psycopg.errors.InternalError_("XX000: internal error: something went wrong"),
         ],
     )


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `InternalError_` from the Postgres data-warehouse import source:

> `(EDBHANDLEREXITED) connection to database closed. Check logs for more information`

Issue: https://us.posthog.com/project/2/error_tracking/019ed4ff-4f5e-7871-b502-8e68acc8ae57

The stack trace originates in `posthog/temporal/data_imports/sources/postgres/postgres.py` at `get_rows` → `cursor.fetchmany()`, against a Supabase Supavisor pooler connection (port 6543) that had gone `[BAD]` mid-stream.

`EDBHANDLEREXITED` is Supavisor's own pooler-internal error: the per-session DbHandler process exits when its backend connection dies (idle cull, backend restart, failover). We already classify this as a **transient connection drop** and recover from it in-process via offset chunking (for incremental syncs). However, the matcher (`_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS`) keyed off the message tail `"DbHandler exited"`. Supavisor also emits `"connection to database closed"` for the **same** `EDBHANDLEREXITED` condition, so this variant slipped past `_is_connection_dropped_error`, was re-raised by the streaming handler, and surfaced as captured activity-failure noise instead of being recovered.

## Changes

This is a fixable bug, not a user/upstream error — the condition is a transient pooler drop that should stay recoverable/retryable, so it does **not** belong in `NonRetryableErrors`. The matcher was simply too narrow.

- Match on the stable `(EDBHANDLEREXITED)` **code** rather than any one message tail, so every wording variant of the same pooler drop is recognized.
- Genuine XX000 internal errors (data corruption, etc.) carry a different code and remain non-recoverable — unchanged.

## How did you test this code?

I'm an agent (Claude Code). I could not run the full pytest suite in this sandbox (project dependencies aren't installed), so I:

- Extended the existing `TestIsConnectionDroppedError` parametrization to assert the new `"(EDBHANDLEREXITED) connection to database closed"` variant is detected as a connection drop, alongside the existing variants, and kept the negative case (unrelated XX000) asserting it is **not** detected.
- Verified the substring-matching logic against all variants with a standalone script.
- `ruff check` and `ruff format --check` pass on both changed files.

CI will run the full test suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Postgres import source. Confirmed via the PostHog error-tracking MCP tools that the failure originates in this source's `get_rows`/`fetchmany` path (not just serialized log context). Diagnosed that the error is the same Supavisor `EDBHANDLEREXITED` transient pooler drop the code already handles, but with a new message wording the matcher missed. Chose to key the matcher off the stable `EDBHANDLEREXITED` code rather than add another brittle message substring, future-proofing against further Supavisor wording changes. Scoped strictly to this matcher — no change to global retry policy or `NonRetryableErrors`.
