### PR TITLE
fix(error-tracking): normalize client in_app flags for node frames

### DIFF
--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -199,7 +199,9 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
 
         // Demote-only, consistent with the unresolved paths: honor an explicit
         // client in_app=false rather than promoting it back to true on resolution.
-        let in_app = raw_frame.meta.in_app && !source.as_deref().is_some_and(is_dependency_source);
+        // Base on raw_frame.in_app() so the raw filename is still checked when the
+        // resolved source has no name.
+        let in_app = raw_frame.in_app() && !source.as_deref().is_some_and(is_dependency_source);
 
         let mut res = Self {
             frame_id: FrameId::placeholder(),
@@ -349,6 +351,14 @@ mod test {
                 true,
             ),
             (
+                "application frame with no in_app field defaults to true",
+                serde_json::json!({
+                    "filename": "/app/src/index.js",
+                    "function": "main",
+                }),
+                true,
+            ),
+            (
                 "explicit client false is never promoted",
                 serde_json::json!({
                     "filename": "/app/src/handlers/user.js",
@@ -363,15 +373,5 @@ mod test {
             let raw: RawNodeFrame = serde_json::from_value(value).unwrap();
             assert_eq!(raw.in_app(), expected, "{case}");
         }
-    }
-
-    #[test]
-    fn test_unset_in_app_defaults_to_true() {
-        let raw: RawNodeFrame = serde_json::from_value(serde_json::json!({
-            "filename": "/app/src/index.js",
-            "function": "main",
-        }))
-        .unwrap();
-        assert!(raw.meta.in_app);
     }
 }

--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -121,6 +121,17 @@ impl RawNodeFrame {
         format!("{:x}", hasher.finalize())
     }
 
+    // Clients compute in_app from their local layout (and default to true when
+    // unsure), so identical stacks arrive with different in_app masks depending
+    // on the host they were captured on. Fingerprinting selects frames by in_app,
+    // so each mask would mint a new fingerprint for the same crash. Demote frames
+    // that are clearly dependency or runtime code; we never promote, so an explicit
+    // client in_app=false still wins. Mirrors the node_modules check already applied
+    // on the sourcemap-resolved path, extending it to the unresolved frame paths.
+    pub fn in_app(&self) -> bool {
+        self.meta.in_app && !is_dependency_source(&self.filename)
+    }
+
     pub fn get_context(&self) -> Option<Context> {
         let context_line = self.context_line.as_ref()?;
         let lineno = self.lineno?;
@@ -156,7 +167,7 @@ impl From<&RawNodeFrame> for Frame {
             line: raw.lineno,
             column: None,
             source: Some(raw.filename.clone()),
-            in_app: raw.meta.in_app,
+            in_app: raw.in_app(),
             resolved_name: Some(raw.function.clone()),
             lang: "javascript".to_string(),
             resolved: true,
@@ -186,9 +197,9 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
             .and_then(|f| f.name())
             .map(|s| s.to_string());
 
-        let in_app = source
-            .map(|s| !s.contains("node_modules"))
-            .unwrap_or(raw_frame.meta.in_app);
+        // Demote-only, consistent with the unresolved paths: honor an explicit
+        // client in_app=false rather than promoting it back to true on resolution.
+        let in_app = raw_frame.meta.in_app && !source.as_deref().is_some_and(is_dependency_source);
 
         let mut res = Self {
             frame_id: FrameId::placeholder(),
@@ -255,7 +266,7 @@ impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
             line: raw_frame.lineno,
             column: raw_frame.colno,
             source: None,
-            in_app: raw_frame.meta.in_app,
+            in_app: raw_frame.in_app(),
             resolved_name,
             lang: "javascript".to_string(),
             resolved,
@@ -287,4 +298,80 @@ fn context_likely_minified(ctx: &Context) -> bool {
         .sum::<usize>() as f64
         / (ctx.before.len() + ctx.after.len()) as f64;
     avg_len > 300.0
+}
+
+// Source markers that identify non-application Node code: installed dependencies
+// (node_modules) and Node's built-in modules (the `node:` scheme, e.g. `node:fs`).
+fn is_dependency_source(source: &str) -> bool {
+    source.contains("node_modules") || source.starts_with("node:")
+}
+
+#[cfg(test)]
+mod test {
+    use super::RawNodeFrame;
+
+    #[test]
+    fn test_in_app_normalization() {
+        let cases = [
+            (
+                "node_modules frames are demoted",
+                serde_json::json!({
+                    "filename": "/app/node_modules/express/lib/router/index.js",
+                    "function": "handle",
+                    "in_app": true,
+                }),
+                false,
+            ),
+            (
+                "node builtin modules are demoted",
+                serde_json::json!({
+                    "filename": "node:internal/process/task_queues",
+                    "function": "processTicksAndRejections",
+                    "in_app": true,
+                }),
+                false,
+            ),
+            (
+                "unset in_app defaults true but dependency code is still demoted",
+                serde_json::json!({
+                    "filename": "/app/node_modules/pg/lib/client.js",
+                    "function": "query",
+                }),
+                false,
+            ),
+            (
+                "application frames stay in_app",
+                serde_json::json!({
+                    "filename": "/app/src/handlers/user.js",
+                    "function": "getUser",
+                    "in_app": true,
+                }),
+                true,
+            ),
+            (
+                "explicit client false is never promoted",
+                serde_json::json!({
+                    "filename": "/app/src/handlers/user.js",
+                    "function": "getUser",
+                    "in_app": false,
+                }),
+                false,
+            ),
+        ];
+
+        for (case, value, expected) in cases {
+            let raw: RawNodeFrame = serde_json::from_value(value).unwrap();
+            assert_eq!(raw.in_app(), expected, "{case}");
+        }
+    }
+
+    #[test]
+    fn test_unset_in_app_defaults_to_true() {
+        let raw: RawNodeFrame = serde_json::from_value(serde_json::json!({
+            "filename": "/app/src/index.js",
+            "function": "main",
+        }))
+        .unwrap();
+        assert!(raw.meta.in_app);
+    }
 }


### PR DESCRIPTION
## Problem

For Node events, cymbal trusts the client-supplied `in_app` flag on every unresolved frame verbatim, and defaults to `true` when the client omits it. The JS/Node SDK computes `in_app` from the capturing host's filesystem layout (a `node_modules` path check plus a project root), so the flag is a function of the install layout, not of the code: the same logical frame arrives as `in_app=true` from one environment and `in_app=false` from another, and Node built-in frames get defaulted to application code.

Since fingerprinting selects which frames to hash by `in_app`, each distinct flag mask mints a distinct fingerprint for the same crash — the same fingerprint-splitting bug already fixed for Python in #63266.

Cymbal already normalizes `in_app` on the **sourcemap-resolved** Node path (`in_app = !source.contains("node_modules")`), but the two **unresolved** paths — no sourcemap uploaded, or resolution failed/minified — fall back to the raw client flag untouched. Server-side Node without sourcemaps, and any frame whose resolution fails, therefore still split.

## Changes

A demote-only `RawNodeFrame::in_app()` helper (`langs/node.rs`), applied consistently across all three `Frame` construction paths. A frame keeps `in_app=true` only if it is not clearly non-application code, where that means the source/filename:

- contains `node_modules` (installed dependency — the same heuristic already used on the resolved path)
- starts with the `node:` scheme (Node built-in module, e.g. `node:fs`, `node:internal/...`)

The two previously-untouched unresolved paths now run through this helper. The resolved path is also made demote-only for consistency: it now honors an explicit client `in_app=false` (`meta.in_app && !is_dependency_source(source)`) rather than promoting it back to `true` on resolution. In practice the resolved frame's client flag is almost always `true` (it was computed on the app's own bundle), so this is equivalent for the common case while correctly respecting an explicit exclusion.

The demotion is one-directional: an explicit client `in_app=false` is never promoted, so client-side in_app configuration still wins.

This is the Node entry in a per-language rollout of the same normalization; #63266 did Python, and Ruby (`gems/`) / PHP (`vendor/`) are the next candidates.

## How did you test this code?

Agent-authored; automated tests only:

- New table-driven unit test in `langs/node.rs` covering each demotion rule (`node_modules` path, `node:` built-in), the unset-flag-defaults-true-but-still-demoted case, the never-promote guarantee for explicit `in_app=false`, and that application frames stay in_app.
- `cargo test -p cymbal --lib langs::node`: passes.
- `cargo fmt` and `cargo clippy -p cymbal` clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the Python in_app normalization (#63266). While reviewing that change we confirmed Node shares the same client-trust pattern, that cymbal already half-implements the fix on the sourcemap-resolved path, and that the two unresolved Node `Frame` constructors (`From<&RawNodeFrame>` and `From<(&RawNodeFrame, JsResolveErr)>`) still copied `meta.in_app` verbatim. The fix unifies all three paths on a single demote-only helper so the "never promote" invariant lives in one place. Scoped to Node only, per the one-PR-per-language rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
