### PR TITLE
fix(hubspot): retry truncated JSON responses instead of crashing

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/posthog/temporal/data_imports/sources/hubspot/hubspot.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 from typing import Any, Optional
 
 import requests
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
@@ -328,7 +329,13 @@ def get_rows(
             logger.error(f"Hubspot API error: status={response.status_code}, body={response.text}, url={page_url}")
             response.raise_for_status()
 
-        return response.json()
+        # Parse inside the retry so a truncated/partial body (JSONDecodeError, e.g. an
+        # "Unterminated string" mid-stream) is reissued like a 429/5xx instead of bubbling
+        # up uncaught and failing the whole import.
+        try:
+            return response.json()
+        except RequestsJSONDecodeError as e:
+            raise HubspotRetryableError(f"Hubspot API malformed JSON response (retryable): url={page_url}") from e
 
     while True:
         data = fetch_page(url)
@@ -422,7 +429,13 @@ def _batch_read_associations(
             )
             response.raise_for_status()
 
-        return response.json()
+        # See fetch_page: a truncated/partial body is transient, so retry rather than crash.
+        try:
+            return response.json()
+        except RequestsJSONDecodeError as e:
+            raise HubspotRetryableError(
+                f"Hubspot v4 associations malformed JSON response (retryable): url={url}"
+            ) from e
 
     for start in range(0, len(ids), ASSOCIATIONS_BATCH_SIZE):
         chunk = ids[start : start + ASSOCIATIONS_BATCH_SIZE]
@@ -564,7 +577,11 @@ def get_rows_via_search(
             logger.error(f"Hubspot search error: status={response.status_code}, body={response.text}, url={search_url}")
             response.raise_for_status()
 
-        return response.json()
+        # See fetch_page: a truncated/partial body is transient, so retry rather than crash.
+        try:
+            return response.json()
+        except RequestsJSONDecodeError as e:
+            raise HubspotRetryableError(f"Hubspot search malformed JSON response (retryable): url={search_url}") from e
 
     def save_progress() -> None:
         resumable_source_manager.save_state(

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
+
 from posthog.temporal.data_imports.sources.hubspot.hubspot import (
     HubspotPathologicalWindowError,
     HubspotResumeConfig,
@@ -942,6 +944,46 @@ class TestGetRowsFullRefresh:
             )
 
         assert captured_urls[0] == "https://api.hubapi.com/resume-here"
+
+    def test_truncated_json_body_is_retried(self) -> None:
+        # Regression: a truncated/partial page body raises requests' JSONDecodeError
+        # ("Unterminated string"). It must be treated as transient and retried, not crash
+        # the whole import.
+        from posthog.temporal.data_imports.sources.hubspot.hubspot import get_rows
+
+        manager = _make_manager()
+        logger = MagicMock()
+
+        truncated = _make_response(200, {"results": [{"id": "1", "properties": {"hs_object_id": "1"}}]})
+        truncated.json.side_effect = RequestsJSONDecodeError("Unterminated string starting at", "doc", 42)
+        good = _make_response(200, {"results": [{"id": "1", "properties": {"hs_object_id": "1"}}]})
+
+        iter_resp = iter([truncated, good])
+        captured_urls: list[str] = []
+
+        def _get(url, headers=None, timeout=None):  # noqa: ARG001
+            captured_urls.append(url)
+            return next(iter_resp)
+
+        with patch(
+            "posthog.temporal.data_imports.sources.hubspot.hubspot.make_tracked_session",
+            new=lambda *_a, **_k: type("_S", (), {"get": staticmethod(_get)})(),
+        ):
+            tables = list(
+                get_rows(
+                    api_key="k",
+                    refresh_token="r",
+                    endpoint="deals",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                    include_custom_props=False,
+                )
+            )
+
+        # The truncated response was reissued (same URL) and the retry yielded the row.
+        assert len(captured_urls) == 2
+        assert captured_urls[0] == captured_urls[1]
+        assert sum(t.num_rows for t in tables) == 1
 
 
 class TestExpectedPropertiesBackfill:


### PR DESCRIPTION
## Problem

The HubSpot data-warehouse import was crashing with an uncaught `JSONDecodeError: Unterminated string starting at: line 1 column ...` surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed518-9733-79e2-a344-a9f440c5f036)).

The stack trace originates in `posthog/temporal/data_imports/sources/hubspot/hubspot.py` inside `fetch_page` (the paginated GET path used by `get_rows`), at the `response.json()` call. The HTTP request itself succeeds (status 200, `response.ok`), but the body is cut off mid-stream — HubSpot occasionally truncates a large response page. `response.json()` then raises `requests.exceptions.JSONDecodeError` ("Unterminated string").

This is a transient transfer failure, not a credential/config problem and not a code-logic bug in how we build requests — the same request almost always succeeds on retry. But the three bespoke fetch helpers in this source parse JSON *outside* the catch scope of their `tenacity` retry (which only retries `HubspotRetryableError`, `ReadTimeout`, `ConnectionError`), so a truncated body bubbled up uncaught and failed the entire import.

## Changes

Parse the response body *inside* the retried fetch helpers and convert `requests.exceptions.JSONDecodeError` into `HubspotRetryableError`, so a truncated/partial body is reissued with the existing exponential backoff instead of crashing the sync. Applied to all three JSON-parsing fetch paths that share the same retry decorator:

- `fetch_page` (GET path — the path in the reported stack trace)
- `_batch_read_associations._post_chunk` (v4 associations batch-read)
- `get_rows_via_search.fetch_search` (incremental search path)

This mirrors the established pattern already used by the shared `rest_source` client (`rest_client.py`), which treats a malformed/truncated body as `RESTClientRetryableError` for exactly this scenario.

A genuinely persistently-malformed response is *not* swallowed: after the existing 5 attempts the retry reraises, so real upstream breakage still surfaces.

This was deliberately **not** added to `NonRetryableErrors`: a truncated body is transient and recoverable, so the correct fix is to retry, not to stop retrying.

## How did you test this code?

I'm an agent. I added a regression test and ran the existing suite — no manual testing.

- Added `TestGetRowsFullRefresh::test_truncated_json_body_is_retried`, which makes the first GET page raise `requests.exceptions.JSONDecodeError` and asserts the request is reissued and the row is ultimately yielded (previously this raised and aborted the import).
- `bin/hogli test posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py` — 43 passed.
- `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the HubSpot import source with Claude Code (PostHog MCP error-tracking tools to confirm the issue, pull the exact stack trace via `execute-sql`, and inspect frequency/affected scope; repo tools to read and edit the source).

Decision path: confirmed the failure genuinely originates in `hubspot.py` `fetch_page` (not just a serialized variable in some other frame). Classified it as a fixable fragility bug rather than a user/upstream error — the request succeeds and only the body is truncated, which is transient. Rejected adding it to `NonRetryableErrors` (that would stop retrying a recoverable failure). Chose to mirror the existing `rest_source` retry-on-malformed-body pattern and scoped the change to the three fetch helpers in this source, with no unrelated refactors.