### PR TITLE
chore(experiments): read web-experiment variants via feature_flag.variants

### DIFF
--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -106,8 +106,7 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         if not obj.feature_flag:
             return obj.variants or {}
 
-        multivariate = obj.feature_flag.filters.get("multivariate", {})
-        variants_list = multivariate.get("variants", [])
+        variants_list = obj.feature_flag.variants
 
         # If no feature flag variants, fall back to experiment variants
         if not variants_list:


### PR DESCRIPTION
## Problem

Follow-up to #64007, which switched the experiments product backend to read feature-flag variants from the flag (the source of truth) via the null-safe `FeatureFlag.variants` property. The `/api/web_experiments` serializer — used by posthog-js to power no-code/web experiments — still read the flag's variant list with the older inline `filters.get("multivariate", {}).get("variants", [])` pattern.

That pattern is fragile: when `multivariate` is explicitly `null` in the flag's JSON filters, `.get("multivariate", {})` returns `None` (not the default `{}`), and the chained `.get(...)` raises `AttributeError`. The `variants` property guards against this.

To be clear, this endpoint never depended on `Experiment.parameters` — it reads the variant list from the feature flag and the per-variant DOM transforms from the dedicated `variants` model field. This is purely a safety/consistency cleanup of the flag read.

## Changes

In `WebExperimentsAPISerializer._get_corrected_variants`, replace the two-line inline read with `obj.feature_flag.variants`. The `obj.feature_flag` None-guard just above it is unchanged, and behavior is identical for well-formed flags.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated checks I actually ran, all green:

- `posthog/api/test/test_web_experiment.py` — 15 passed
- `ruff check` / `ruff format` clean, `ty` type-check passes

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing or API change — internal read hardening only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Small follow-up to #64007. While confirming that the web-experiments SDK path had no dependency on `Experiment.parameters` (it doesn't), we noticed it still used the older, less defensive inline flag-variant read. This switches it to the same `feature_flag.variants` property used everywhere else, closing an `AttributeError` edge case when `multivariate` is explicitly null.
