### PR TITLE
fix: support slack emoji react in thread

### DIFF
--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -334,6 +334,32 @@ class TestHandleSupportReactionBackfill(BaseTest):
     @patch(f"{MODULE}._backfill_thread_replies")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
     @patch(f"{MODULE}.get_slack_client")
+    def test_resolves_root_from_thread_ts_when_replies_returns_only_reply(
+        self, mock_client, mock_create, mock_backfill
+    ):
+        # Hardening for the case where conversations.replies returns only the reacted reply
+        # (not the root-first thread): the root must still come from the reply's thread_ts.
+        reply_ts = "1700000000.000500"
+        client = MagicMock()
+        client.conversations_replies.return_value = {
+            "messages": [
+                {"user": "U_CUSTOMER", "text": "screenshots", "ts": reply_ts, "thread_ts": PARENT_TS},
+            ]
+        }
+        mock_client.return_value = client
+        mock_create.return_value = MagicMock(spec=Ticket)
+
+        handle_support_reaction(self._reaction_event(ts=reply_ts), self.team, SLACK_TEAM)
+
+        assert mock_create.call_args.kwargs["thread_ts"] == PARENT_TS
+        assert mock_create.call_args.kwargs["text"] == "screenshots"
+        mock_backfill.assert_called_once_with(
+            client, self.team, mock_create.return_value, CHANNEL, PARENT_TS, after_ts=reply_ts
+        )
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    @patch(f"{MODULE}.get_slack_client")
     def test_falls_back_to_bounded_history_for_standalone_message(self, mock_client, mock_create, mock_backfill):
         client = MagicMock()
         client.conversations_replies.return_value = {"messages": []}

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -195,6 +195,24 @@ class TestBackfillThreadReplies(BaseTest):
         assert mock_user.call_count == 2
         mock_user.assert_has_calls([call(client, "U_SAME"), call(client, "U_OTHER")], any_order=True)
 
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": None, "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_after_ts_excludes_earlier_replies(self, _mock_files, _mock_user, _mock_bot):
+        replies = [
+            _make_slack_reply(PARENT_TS, text="parent"),
+            _make_slack_reply("1700000000.000200", text="before reacted"),
+            _make_slack_reply("1700000000.000300", text="reacted message"),
+            _make_slack_reply("1700000000.000400", text="after reacted"),
+        ]
+        client = self._mock_client(replies)
+
+        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL, PARENT_TS, after_ts="1700000000.000300")
+
+        comments = Comment.objects.filter(item_id=str(self.ticket.id)).order_by("created_at")
+        assert comments.count() == 1
+        assert comments[0].content == "after reacted"
+
     def test_no_op_when_only_parent_in_thread(self):
         replies = [_make_slack_reply(PARENT_TS, text="parent")]
         client = self._mock_client(replies)
@@ -271,7 +289,7 @@ class TestHandleSupportReactionBackfill(BaseTest):
     @patch(f"{MODULE}.get_slack_client")
     def test_calls_backfill_after_ticket_creation(self, mock_client, mock_create, mock_backfill):
         client = MagicMock()
-        client.conversations_history.return_value = {"messages": [{"user": "U1", "text": "Help me", "ts": PARENT_TS}]}
+        client.conversations_replies.return_value = {"messages": [{"user": "U1", "text": "Help me", "ts": PARENT_TS}]}
         mock_client.return_value = client
         mock_create.return_value = MagicMock(spec=Ticket)
 
@@ -279,14 +297,93 @@ class TestHandleSupportReactionBackfill(BaseTest):
 
         mock_create.assert_called_once()
         assert mock_create.call_args.kwargs["is_thread_reply"] is False
-        mock_backfill.assert_called_once_with(client, self.team, mock_create.return_value, CHANNEL, PARENT_TS)
+        assert mock_create.call_args.kwargs["thread_ts"] == PARENT_TS
+        mock_backfill.assert_called_once_with(
+            client, self.team, mock_create.return_value, CHANNEL, PARENT_TS, after_ts=PARENT_TS
+        )
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_seeds_ticket_from_reacted_reply_keyed_on_root(self, mock_client, mock_create, mock_backfill):
+        reply_ts = "1700000000.000500"
+        client = MagicMock()
+        # conversations.replies returns the root first regardless of which message was reacted on.
+        client.conversations_replies.return_value = {
+            "messages": [
+                {"user": "U_ROOT", "text": "Hi Mustafa!", "ts": PARENT_TS},
+                {"user": "U_CUSTOMER", "text": "here are the screenshots", "ts": reply_ts, "thread_ts": PARENT_TS},
+            ]
+        }
+        mock_client.return_value = client
+        mock_create.return_value = MagicMock(spec=Ticket)
+
+        handle_support_reaction(self._reaction_event(ts=reply_ts), self.team, SLACK_TEAM)
+
+        # Ticket seeds from the reacted reply, but is keyed on the thread root for routing.
+        assert mock_create.call_args.kwargs["thread_ts"] == PARENT_TS
+        assert mock_create.call_args.kwargs["text"] == "here are the screenshots"
+        assert mock_create.call_args.kwargs["slack_user_id"] == "U_CUSTOMER"
+        # Backfill only replies posted after the reacted message.
+        mock_backfill.assert_called_once_with(
+            client, self.team, mock_create.return_value, CHANNEL, PARENT_TS, after_ts=reply_ts
+        )
+        # We must never fetch via conversations.history (it can't see thread replies).
+        client.conversations_history.assert_not_called()
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_falls_back_to_bounded_history_for_standalone_message(self, mock_client, mock_create, mock_backfill):
+        client = MagicMock()
+        client.conversations_replies.return_value = {"messages": []}
+        client.conversations_history.return_value = {"messages": [{"user": "U1", "text": "Help me", "ts": PARENT_TS}]}
+        mock_client.return_value = client
+        mock_create.return_value = MagicMock(spec=Ticket)
+
+        handle_support_reaction(self._reaction_event(), self.team, SLACK_TEAM)
+
+        client.conversations_history.assert_called_once_with(
+            channel=CHANNEL, latest=PARENT_TS, oldest=PARENT_TS, inclusive=True, limit=1
+        )
+        assert mock_create.call_args.kwargs["thread_ts"] == PARENT_TS
+        mock_backfill.assert_called_once_with(
+            client, self.team, mock_create.return_value, CHANNEL, PARENT_TS, after_ts=PARENT_TS
+        )
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_skips_when_ticket_already_exists_for_resolved_root(self, mock_client, mock_create, mock_backfill):
+        reply_ts = "1700000000.000500"
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL,
+            slack_thread_ts=PARENT_TS,
+        )
+        client = MagicMock()
+        client.conversations_replies.return_value = {
+            "messages": [
+                {"user": "U_ROOT", "text": "Hi Mustafa!", "ts": PARENT_TS},
+                {"user": "U_CUSTOMER", "text": "screenshots", "ts": reply_ts, "thread_ts": PARENT_TS},
+            ]
+        }
+        mock_client.return_value = client
+
+        handle_support_reaction(self._reaction_event(ts=reply_ts), self.team, SLACK_TEAM)
+
+        mock_create.assert_not_called()
+        mock_backfill.assert_not_called()
 
     @patch(f"{MODULE}._backfill_thread_replies")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
     @patch(f"{MODULE}.get_slack_client")
     def test_skips_backfill_when_ticket_creation_returns_none(self, mock_client, mock_create, mock_backfill):
         client = MagicMock()
-        client.conversations_history.return_value = {"messages": [{"user": "U1", "text": "Help me", "ts": PARENT_TS}]}
+        client.conversations_replies.return_value = {"messages": [{"user": "U1", "text": "Help me", "ts": PARENT_TS}]}
         mock_client.return_value = client
         mock_create.return_value = None
 

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -744,8 +744,15 @@ def _backfill_thread_replies(
     ticket: Ticket,
     channel: str,
     thread_ts: str,
+    after_ts: str | None = None,
 ) -> None:
-    """Fetch existing thread replies and add them as comments on the ticket."""
+    """Fetch existing thread replies and add them as comments on the ticket.
+
+    When ``after_ts`` is given, only replies strictly newer than it are backfilled — used
+    when a ticket is seeded from a mid-thread message (emoji reaction) so earlier history
+    isn't pulled in. Slack ts values are lexicographically ordered, so string comparison is
+    safe.
+    """
     try:
         result = client.conversations_replies(channel=channel, ts=thread_ts, limit=200)
         replies: list[dict] = result.get("messages", [])
@@ -753,7 +760,9 @@ def _backfill_thread_replies(
         logger.warning("slack_support_reaction_backfill_failed", channel=channel, thread_ts=thread_ts)
         return
 
-    thread_replies = [r for r in replies if r.get("ts") != thread_ts]
+    thread_replies = [
+        r for r in replies if r.get("ts") != thread_ts and (after_ts is None or (r.get("ts") or "") > after_ts)
+    ]
     if not thread_replies:
         return
 
@@ -871,8 +880,10 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
     """
     Handle a Slack 'reaction_added' event to create a ticket from a reacted message.
 
-    Fetches the reacted-to message and creates a ticket from it.
-    Subsequent thread replies become ticket messages.
+    Unlike a bot mention (which seeds the ticket from the thread root), an emoji reaction
+    seeds the ticket from the *reacted* message — "create the ticket from here". If that
+    message lives inside a thread, the ticket is still keyed on the thread root so later
+    replies route to it, and only replies posted after the reacted message are backfilled.
     """
     reaction = event.get("reaction", "")
     item = event.get("item", {})
@@ -892,58 +903,80 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
     if not settings_dict.get("slack_enabled"):
         return
 
-    # Check if a ticket already exists for this message thread
-    existing = Ticket.objects.filter(
-        team=team,
-        slack_channel_id=channel,
-        slack_thread_ts=message_ts,
-    ).first()
-
-    if existing:
-        logger.debug("slack_support_reaction_ticket_exists", ticket_id=str(existing.id))
+    # Fast path: a ticket may already be anchored on the reacted message ts itself.
+    if Ticket.objects.filter(team=team, slack_channel_id=channel, slack_thread_ts=message_ts).exists():
+        logger.debug("slack_support_reaction_ticket_exists", channel=channel, thread_ts=message_ts)
         return
 
-    # Fetch the reacted-to message to get its content and author
     client = get_slack_client(team)
-    try:
-        result = client.conversations_history(
-            channel=channel,
-            latest=message_ts,
-            inclusive=True,
-            limit=1,
-        )
-        messages: list[dict] = result.get("messages", [])
-        if not messages:
-            return
 
-        original_msg = messages[0]
-        original_user = original_msg.get("user", "")
-        original_text = original_msg.get("text", "")
-        original_blocks = original_msg.get("blocks")
-        original_files = original_msg.get("files")
+    # Fetch the reacted message together with its thread. conversations.replies returns the
+    # whole thread (root first) whether the reaction landed on the root or on a reply.
+    # conversations.history only sees top-level channel messages, so reacting on a reply
+    # would silently fetch the wrong neighbouring message instead.
+    try:
+        result = client.conversations_replies(channel=channel, ts=message_ts, limit=200)
+        thread_messages: list[dict] = result.get("messages", [])
     except Exception:
         logger.warning("slack_support_reaction_fetch_failed", channel=channel, message_ts=message_ts)
         return
 
+    # A standalone message with no thread can come back empty from conversations.replies —
+    # fetch just that message, bounded to its exact ts so we never grab a neighbour.
+    if not thread_messages:
+        try:
+            history = client.conversations_history(
+                channel=channel,
+                latest=message_ts,
+                oldest=message_ts,
+                inclusive=True,
+                limit=1,
+            )
+            thread_messages = history.get("messages", [])
+        except Exception:
+            logger.warning("slack_support_reaction_fetch_failed", channel=channel, message_ts=message_ts)
+            return
+
+    if not thread_messages:
+        return
+
+    root_ts = thread_messages[0].get("ts") or message_ts
+    # The reacted message itself seeds the ticket ("create from here").
+    reacted_msg = next((m for m in thread_messages if m.get("ts") == message_ts), thread_messages[0])
+
+    # When the reaction lands on a reply, the ticket key (the root) differs from message_ts —
+    # re-check so we don't create a duplicate for an already-tracked thread.
+    if (
+        root_ts != message_ts
+        and Ticket.objects.filter(team=team, slack_channel_id=channel, slack_thread_ts=root_ts).exists()
+    ):
+        logger.debug("slack_support_reaction_ticket_exists", channel=channel, thread_ts=root_ts)
+        return
+
+    reacted_text = reacted_msg.get("text", "")
+    reacted_files = reacted_msg.get("files")
+
     # Require either text or files
-    if not original_text.strip() and not original_files:
+    if not reacted_text.strip() and not reacted_files:
         return
 
     ticket = create_or_update_slack_ticket(
         team=team,
         slack_channel_id=channel,
-        thread_ts=message_ts,
-        slack_user_id=original_user,
-        text=original_text,
-        blocks=original_blocks,
-        files=original_files,
+        thread_ts=root_ts,
+        slack_user_id=reacted_msg.get("user", ""),
+        text=reacted_text,
+        blocks=reacted_msg.get("blocks"),
+        files=reacted_files,
         is_thread_reply=False,
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_EMOJI_REACTION,
     )
 
     if ticket:
-        _backfill_thread_replies(client, team, ticket, channel, message_ts)
+        # Only backfill replies posted after the reacted message; earlier thread history is
+        # intentionally excluded since the ticket starts from the reacted message.
+        _backfill_thread_replies(client, team, ticket, channel, root_ts, after_ts=message_ts)
 
 
 def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -940,9 +940,21 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
     if not thread_messages:
         return
 
-    root_ts = thread_messages[0].get("ts") or message_ts
     # The reacted message itself seeds the ticket ("create from here").
-    reacted_msg = next((m for m in thread_messages if m.get("ts") == message_ts), thread_messages[0])
+    reacted_msg = next((m for m in thread_messages if m.get("ts") == message_ts), None)
+    if reacted_msg is None:
+        # Reacted message wasn't in the fetched window (e.g. a thread with >200 replies that
+        # paginated it out). Seed from the thread root instead of silently picking the wrong one.
+        logger.warning(
+            "slack_support_reaction_message_not_found",
+            channel=channel,
+            message_ts=message_ts,
+            fetched_count=len(thread_messages),
+        )
+        reacted_msg = thread_messages[0]
+    # Slack stamps every threaded message with thread_ts = the true thread root, so derive the
+    # root from the reacted message rather than assuming conversations.replies returns it first.
+    root_ts = reacted_msg.get("thread_ts") or reacted_msg.get("ts") or message_ts
 
     # When the reaction lands on a reply, the ticket key (the root) differs from message_ts —
     # re-check so we don't create a duplicate for an already-tracked thread.


### PR DESCRIPTION
## Problem

[Context](https://posthog.slack.com/archives/C08S2L0S5MZ/p1781690180328139)

## Changes


Trigger | Seed message | Ticket key | Backfill
-- | -- | -- | --
@mention in thread | thread root | root | whole thread
emoji on root | root | root | all replies
emoji on a reply | that reply | root | replies after it

