### PR TITLE
fix(postgres): recover from "the connection is lost" drop mid-sync

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -137,6 +137,10 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     "consuming input failed",
     "no connection to the server",
     "terminating connection due to",
+    # psycopg's own message when libpq finds the socket already gone (PGconn.socket
+    # raises this from inside a wait, e.g. the commit at the end of get_connection).
+    # Same transient dead-socket class as the libpq drops above — recover by reconnecting.
+    "the connection is lost",
 )
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -606,6 +606,11 @@ class TestIsConnectionDroppedError:
             psycopg.OperationalError("connection to server was closed unexpectedly"),
             psycopg.OperationalError("consuming input failed: EOF detected"),
             psycopg.OperationalError("terminating connection due to administrator command"),
+            # psycopg's message when libpq finds the socket already gone (raised from
+            # PGconn.socket inside the commit at the end of get_connection). A transient
+            # dead-socket drop the in-process recovery must catch — without this the
+            # reconnect retry gives up and the offset-chunking fallback never triggers.
+            psycopg.OperationalError("the connection is lost"),
             psycopg.errors.ProtocolViolation("SERVER CONN CRASHED?"),
             # SQLSTATE 25P03: the source's idle_in_transaction_session_timeout culled our
             # backend mid-stream. psycopg maps this to InternalError, not OperationalError,


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source surfaced a recurring `OperationalError: the connection is lost` in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed527-733d-7543-be0e-1a5a39128aac)).

The stack originates in this source's own code: `get_rows` → `_connect_with_dropped_retry` → `get_connection`, where psycopg raises `OperationalError("the connection is lost")` from `PGconn.socket` during the `connection.commit()` at the end of `get_connection`. This is psycopg's canonical message for a socket that libpq has already found gone — a transient mid-sync connection drop, the same class as `"server closed the connection unexpectedly"` / `"connection to server was lost"` that the source already recovers from.

The source has dedicated in-process recovery for exactly this: `_connect_with_dropped_retry` retries the reconnect, and `get_rows` falls back to offset-chunking to resume. Both gate on `_is_connection_dropped_error`, whose substring list (`_CONNECTION_DROPPED_ERROR_SUBSTRINGS`) was missing `"the connection is lost"`. So the message slipped through the net: the reconnect retry re-raised on the first attempt and the offset-chunking fallback never triggered. The drop escaped and failed the activity instead of being recovered transparently.

## Changes

Add `"the connection is lost"` to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` so the existing recovery machinery recognises and handles it.

This is a transient infrastructure drop, **not** a user/upstream error, so it deliberately stays retryable at the Temporal activity level — it is **not** added to `NonRetryableErrors`. (An existing test already asserts `"the connection is lost"` must remain retryable there; that behaviour is unchanged.) The fix is narrowly scoped: one substring, no change to retry policy or other error classification.

The matched substring is psycopg's fixed message for a dead socket and cannot appear in the permanent-error messages (auth/SSL/host-not-found), so false-positive risk is minimal.

## How did you test this code?

I'm an agent. I added a regression case to `TestIsConnectionDroppedError.test_connection_dropped_errors_are_detected` asserting `_is_connection_dropped_error(OperationalError("the connection is lost"))` is `True`, and ran the relevant suites:

```
pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestIsConnectionDroppedError \
       ::TestPostgresSourceNonRetryableErrors ::TestConnectWithDroppedRetry
# 72 passed
```

`TestPostgresSourceNonRetryableErrors` still passes, confirming the error remains retryable (not added to `NonRetryableErrors`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Postgres import source with Claude Code (PostHog error-tracking MCP tools to pull the stack trace and frequency; read the source under `posthog/temporal/data_imports/sources/postgres/`).

Decision: classified as a *fixable bug* rather than an upstream/user error. The message is a transient dead-socket drop that the source's own recovery path is designed to handle but missed due to an incomplete substring list — so the right fix is to extend the in-process drop detection, leaving activity-level retry intact, rather than adding to `NonRetryableErrors`.
