### PR TITLE
fix(cdp): deflake wait_until_time_window e2e test

### DIFF
--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -925,13 +925,19 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
 
     describe('wait_until_time_window: window in the future', () => {
         beforeEach(async () => {
+            // A fixed daily window is "open" during its own minutes every day, so any
+            // run landing inside it (e.g. CI at 09:5x UTC for a 23:5x UTC+14 window)
+            // executes immediately instead of rescheduling. Derive the window a few
+            // minutes ahead of now so it is always strictly in the future.
+            const now = DateTime.utc()
+            const windowStart = now.plus({ minutes: 10 }).toFormat('HH:mm')
+            const windowEnd = now.plus({ minutes: 20 }).toFormat('HH:mm')
             await createWorkflow({
                 actions: {
                     trigger: trigger(),
                     wait_window: {
                         type: 'wait_until_time_window',
-                        // UTC+14 with late-night window ensures it's always in the future
-                        config: { timezone: 'Pacific/Kiritimati', day: 'any', time: ['23:50', '23:59'] },
+                        config: { timezone: 'UTC', day: 'any', time: [windowStart, windowEnd] },
                     },
                     function_1: fetchAction('https://example.com/after-time-window'),
                     exit: exitAction(),


### PR DESCRIPTION
## Problem

`src/cdp/workflows-e2e.test.ts` → _"wait_until_time_window: window in the future › should reschedule to the time window start and execute after it opens"_ is intermittently failing across unrelated PRs (`expect(rescheduled.length).toBe(1)` receives `0`).

The flake is deterministic, not random. The test hardcoded a `wait_until_time_window` with a fixed daily window and assumed it was "always in the future":

```ts
config: { timezone: 'Pacific/Kiritimati', day: 'any', time: ['23:50', '23:59'] } // UTC+14
```

But Kiritimati (UTC+14) `23:50–23:59` is `09:50–09:59` **UTC**. Whenever the real clock is inside that window, `getWaitUntilTime` (`wait_until_time_window.ts`) takes its "we're inside the window, execute now" branch and returns `null` instead of scheduling a future job — so no job matches `status === 'available' && scheduled > now` and the assertion gets `0`. Any run (CI or local) executing this test during that ~10-minute daily window fails. A fixed daily window is open during its own minutes every day, so the "always in the future" premise was simply wrong.

## Changes

Derive the window a few minutes ahead of `now` (in UTC) in the `beforeEach`, so it is always strictly in the future regardless of wall-clock time:

```ts
const now = DateTime.utc()
const windowStart = now.plus({ minutes: 10 }).toFormat('HH:mm')
const windowEnd = now.plus({ minutes: 20 }).toFormat('HH:mm')
config: { timezone: 'UTC', day: 'any', time: [windowStart, windowEnd] }
```

The test still fast-forwards via `UPDATE cyclotron_jobs SET scheduled = NOW()`, so the exact offset doesn't matter beyond "strictly in the future". Root-cause fix — no `sleep`/retry/timeout-bump masking.

**On dropping the non-UTC timezone:** the `Pacific/Kiritimati` zone was never under test here — it was only a (flawed) mechanism to force the window into the future, as the old comment stated. Timezone conversion, DST, and person/geoip-timezone resolution are exhaustively covered by the handler's unit test `wait_until_time_window.test.ts` (`describe('timezone handling')` / `describe('person timezone handling')`, exercising `America/New_York`, `Asia/Tokyo`, `Europe/London`, etc. with a mocked clock). This e2e verifies the orchestration (trigger → reschedule to future → fast-forward → fetch fires); moving it to UTC removes a confounding variable without losing coverage.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run this e2e suite — it requires the full Postgres/Kafka/Cyclotron stack, which isn't available in my environment. The fix was verified by tracing `getWaitUntilTime` for both the normal and midnight-wrap cases: starting the window strictly ahead of `now` always yields exactly one future-scheduled job (the "execute now" branch can't be hit), which is what the assertion expects. CI on this PR exercises the actual suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Test-only change; no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @dmarchuk.

Tool: Claude Code (Opus 4.8). The failure surfaced on an unrelated PR's "Node.js Tests 3/3" job; the docker-compose log dump buried the Jest output, so the failing test was identified from a log excerpt rather than the CI API. Initial suspicion fell on the batching-pipeline PR that hit the failure, but the real cause was traced to this pre-existing CDP e2e test and its timezone assumption — so the fix lands on `master` rather than that branch. Considered mocking the clock across the consumer but rejected it as too invasive for an e2e test; a dynamically-computed future window is the minimal robust fix and matches the test's existing real-time design.

Agent-authored change — requires human review; do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfkpCSSLRKe93T3s8sMLSw