### PR TITLE
chore(ci): refactor dockerfile lint job to use shared path filter

### DIFF
--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -16,7 +16,10 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
+        # Runs on merge_group too so the lint job below (a required check) can consume
+        # its changed-Dockerfile list there. should_build is ignored on merge_group —
+        # posthog_build forces a build regardless via its own `if`.
+        if: github.repository == 'PostHog/posthog'
         name: Determine need to run Docker checks
         permissions:
             contents: read
@@ -33,6 +36,10 @@ jobs:
                     || contains(github.event.pull_request.labels.*.name, 'hobby-preview')
                 }}
             dockerignore_changed: ${{ steps.filter.outputs.dockerignore }}
+            # Drives the Dockerfile lint job: a boolean plus the shell-escaped, space-separated
+            # list of changed Dockerfiles to hand straight to hadolint.
+            dockerfiles_changed: ${{ steps.filter.outputs.dockerfiles }}
+            dockerfiles_files: ${{ steps.filter.outputs.dockerfiles_files }}
         steps:
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
@@ -44,6 +51,9 @@ jobs:
               id: filter
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Emit `<filter>_files` lists (shell-escaped, space-separated) so the
+                  # lint job can feed changed Dockerfiles straight to hadolint.
+                  list-files: shell
                   filters: |
                       # Keep `hobby:` in sync with the same-named filter in ci-hobby.yml —
                       # drift means hobby waits for an image we never build (or vice versa).
@@ -83,6 +93,12 @@ jobs:
                       # to .dockerignore — Dockerfile COPY changes are covered by the image boot check).
                       dockerignore:
                         - .dockerignore
+                      # Drives the hadolint lint job below — the matched paths are passed straight
+                      # to hadolint via the `dockerfiles_files` output.
+                      dockerfiles:
+                        - '**/Dockerfile'
+                        - '**/*.Dockerfile'
+                        - '**/Dockerfile.*'
 
     dockerignore_guard:
         needs: changes
@@ -149,28 +165,21 @@ jobs:
                   echo "- Digest: \`$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
 
     lint:
+        needs: changes
         name: Lint changed Dockerfiles
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        permissions:
+            contents: read
         steps:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  fetch-depth: 0
-                  filter: blob:none
 
-            - name: Check if any Dockerfile has changed
-              id: changed-files
-              uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
-              with:
-                  files: |
-                      **/Dockerfile
-                      **/*.Dockerfile
-                      **/Dockerfile.*
-                  separator: ' '
-
+            # Changed-Dockerfile list comes from the shared paths-filter in `changes`, so no
+            # second changed-files action or full-history checkout. The job still always runs
+            # (only the hadolint step is gated) to keep its required-check status reporting.
             - name: Lint changed Dockerfile(s) with Hadolint
+              if: needs.changes.outputs.dockerfiles_changed == 'true'
               uses: jbergstroem/hadolint-gh-action@2b00b87f8a56783930b6a4749837d7c45c567ff2 # v1.13.0
-              if: steps.changed-files.outputs.any_changed == 'true'
               with:
-                  dockerfile: '${{ steps.changed-files.outputs.all_modified_files }}'
+                  dockerfile: '${{ needs.changes.outputs.dockerfiles_files }}'

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -41,6 +41,9 @@ jobs:
             dockerfiles_changed: ${{ steps.filter.outputs.dockerfiles }}
             dockerfiles_files: ${{ steps.filter.outputs.dockerfiles_files }}
         steps:
+            # paths-filter uses the GitHub API on pull_request, but falls back to git for
+            # merge_group — so the repo must be checked out for the merge-queue run.
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               id: app-token
               if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Problem

The `lint` job in the container images CI workflow was independently detecting changed Dockerfiles using the `step-security/changed-files` action, duplicating logic already present in the `changes` job. This created maintenance overhead and inconsistency between the two detection mechanisms.

## Changes

Refactored the Dockerfile linting workflow to:

1. **Unified change detection**: The `changes` job now detects changed Dockerfiles (matching `**/Dockerfile`, `**/*.Dockerfile`, `**/Dockerfile.*`) and exports them via `dockerfiles_changed` (boolean) and `dockerfiles_files` (shell-escaped list).

2. **Simplified lint job**: Removed the independent `step-security/changed-files` action and full-history checkout from the `lint` job. It now consumes the shared outputs from `changes` via `needs: changes`.

3. **Merge group support**: Updated the `changes` job condition to run on `merge_group` events (in addition to regular PRs and pushes), allowing the lint job's required-check status to report correctly in merge queues. The `should_build` output is still ignored on merge groups via the `posthog_build` job's own conditional.

4. **Output format**: Added `list-files: shell` to the path filter to emit space-separated, shell-escaped file lists suitable for direct consumption by hadolint.

The lint job still always runs (to maintain its required-check status), but the hadolint step is gated on `needs.changes.outputs.dockerfiles_changed == 'true'`.

## How did you test this code?

This is a CI workflow change. The modifications maintain backward compatibility:
- The `changes` job now runs on merge groups (previously excluded), which is safe because the `should_build` output is already gated in the `posthog_build` job.
- The lint job's behavior is unchanged from the user perspective—it still lints changed Dockerfiles, just sourcing the list from a shared filter instead of detecting them independently.
- Existing CI checks and required status checks remain intact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This refactoring consolidates duplicate change-detection logic in the container images CI workflow. The `changes` job already detects multiple file types; extending it to include Dockerfiles and exporting them eliminates the need for the `lint` job to run its own detection. The change also enables the lint job to participate in merge queue workflows by allowing `changes` to run on `merge_group` events.

https://claude.ai/code/session_01Nq2KN38dPsE9nP6fZE9SWG