### PR TITLE
fix: historic funnel trend sorting

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -414,10 +414,11 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         breakdown = self.context.breakdown
 
         if breakdown:
+            # The query orders breakdown groups by descending value and keeps each group's
+            # rows contiguous, so group without re-sorting to preserve that ordering.
             grouper = lambda row: row["breakdown_value"]
-            sorted_data = sorted(summary, key=grouper)
             final_res = []
-            for key, value in groupby(sorted_data, grouper):
+            for key, value in groupby(summary, grouper):
                 breakdown_res = self._format_single_summary(list(value))
                 final_res.append({**breakdown_res, "breakdown_value": key})
             return final_res

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -1358,6 +1358,61 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
             else:
                 self.fail(msg="Invalid breakdown value")
 
+    def test_funnel_trends_breakdown_ordered_by_value_descending(self):
+        # "Mozilla" has more entrants than "Chrome" but sorts alphabetically later.
+        # Results must be ordered by descending entrant count, not by breakdown value.
+        journeys_for(
+            {
+                "user_one": [
+                    {"event": "step one", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step three", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                ],
+                "user_two": [
+                    {"event": "step one", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step three", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                ],
+                "user_three": [
+                    {"event": "step one", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                    {"event": "step three", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Mozilla"}},
+                ],
+                "user_four": [
+                    {"event": "step one", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Chrome"}},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Chrome"}},
+                    {"event": "step three", "timestamp": datetime(2021, 5, 1), "properties": {"$browser": "Chrome"}},
+                ],
+            },
+            self.team,
+        )
+
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            interval="day",
+            series=[
+                EventsNode(event="step one"),
+                EventsNode(event="step two"),
+                EventsNode(event="step three"),
+            ],
+            breakdownFilter=BreakdownFilter(
+                breakdown="$browser",
+                breakdown_type="event",
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+            ),
+        )
+
+        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+        self.assertEqual([res["breakdown_value"] for res in results], [["Mozilla"], ["Chrome"]])
+
     def test_funnel_step_breakdown_empty(self):
         attribution_types = [
             "all_events",


### PR DESCRIPTION
## Problem

historical funnel trends results with breakdowns are not sorted in descending order 

## Changes
`_format_summarized_results` in `funnel_trends.py` re-sorted the series with `sorted(summary, key=breakdown_value)`, discarding the `ORDER BY sum(reached_from_step_count) ... DESC` the SQL already applies; since that query keeps each breakdown group contiguous, we now `groupby` without re-sorting, preserving the descending-by-value order.

## How did you test this code?

Added `test_funnel_trends_breakdown_ordered_by_value_descending`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

no

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @clr182 (DRI).

Authored with Claude Code (Opus 4.8). The reported symptom was initially ambiguous; after narrowing it to historical funnel trends with a breakdown, investigation found the backend SQL ordered correctly but a Python re-sort downstream threw the order away. A frontend `trendsDataLogic` change was briefly explored for the trends-insight table, then reverted once confirmed that surface already sorts correctly server-side and wasn't the reported bug — keeping the fix narrowly scoped to `funnel_trends.py`.