### PR TITLE
fix(tracing): correct symbol-stats path matching and lift read cap

### DIFF
--- a/products/tracing/backend/symbol_stats_query_runner.py
+++ b/products/tracing/backend/symbol_stats_query_runner.py
@@ -195,28 +195,38 @@ class TraceSpansSymbolStatsQueryRunner(AnalyticsQueryRunner[TraceSpansSymbolStat
 
     @cached_property
     def settings(self) -> HogQLGlobalSettings:
-        # Fail fast on a runaway scan — the path predicate is not backed by an index, and a wide window
-        # over a hot attribute is expensive.
+        # No byte ceiling. The path predicate can't use an index (suffix match on a Map attribute), so it
+        # full-scans the window — but the logs cluster reads that fast (a 24h scan is single-digit seconds).
+        # A 10GB read cap instead raised exception 307 (TOO_MANY_BYTES) on every window past ~1h, since one
+        # hour alone reads ~6.5GB; max_execution_time is the real runaway backstop. This matches the sibling
+        # attribute-breakdown runner, which scans the same data uncapped.
         return HogQLGlobalSettings(
             allow_experimental_object_type=False,
             max_execution_time=30,
-            max_bytes_to_read=10_000_000_000,
-            read_overflow_mode="throw",
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
         )
 
     def to_query(self) -> ast.SelectQuery:
         req = _normalize_request_path(self.query.filePath)
 
-        # Segment-anchored suffix match: the recorded path equals the request, or ends with
-        # '/' + request. So `feature-flags/src/flags/flag_matching.rs` matches a request for
-        # `src/flags/flag_matching.rs`, while `crate-b/src/mod.rs` does not match `crate-a/src/mod.rs`.
+        # Segment-anchored suffix match in BOTH directions: recorded and request match when one's
+        # segment list is a '/'-anchored suffix of the other's. The leading '/' anchors on a segment
+        # boundary, so `internal/superuser.go` never matches `user.go`.
+        #   - request is a suffix of recorded: `feature-flags/src/flags/flag_matching.rs` matched by
+        #     `src/flags/flag_matching.rs` (the editor sends a shorter, repo-relative path).
+        #   - recorded is a suffix of request: a monorepo editor sends the workspace-prefixed
+        #     `rust/feature-flags/src/flags/flag_matching.rs` while the service recorded only
+        #     `feature-flags/src/flags/flag_matching.rs`.
+        # `crate-b/src/mod.rs` still does not match `crate-a/src/mod.rs` (divergent leading segments).
+        req_slash = "/" + req
         path_predicate = parse_expr(
-            "{path} = {req} OR endsWith({path_dup}, {req_slash})",
+            "endsWith(concat('/', {recorded}), {req_slash}) OR endsWith({req_slash_dup}, concat('/', {recorded_dup}))",
             placeholders={
-                "path": _normalized_file_path_expr(),
-                "path_dup": _normalized_file_path_expr(),
-                "req": ast.Constant(value=req),
-                "req_slash": ast.Constant(value="/" + req),
+                "recorded": _normalized_file_path_expr(),
+                "recorded_dup": _normalized_file_path_expr(),
+                "req_slash": ast.Constant(value=req_slash),
+                "req_slash_dup": ast.Constant(value=req_slash),
             },
         )
 

--- a/products/tracing/backend/tests/test_symbol_stats.py
+++ b/products/tracing/backend/tests/test_symbol_stats.py
@@ -200,6 +200,64 @@ class TestTraceSpansSymbolStats(_TraceSpansTestBase):
         rows = self._symbol_stats(file_path, [{"startLine": 10, "endLine": 30}])
         self.assertEqual([(r["line"], r["count"]) for r in rows], [(10, expected_count)])
 
+    # The recorded path is `feature-flags/src/flags/flag_matching.rs`. Many editor/repo conventions
+    # produce a different spelling for the same source file — each must resolve to it and aggregate
+    # byte-identical spans:
+    #   - request is a segment-suffix of recorded (editor sends a shorter, repo-relative path, down to
+    #     the bare basename),
+    #   - recorded is a segment-suffix of request (a monorepo editor prepends one or more workspace
+    #     segments the service never recorded — the bug this fixes),
+    #   - and request paths that only differ after normalization (leading `./`, leading `/`, Windows
+    #     separators).
+    @parameterized.expand(
+        [
+            ("exact", "feature-flags/src/flags/flag_matching.rs"),
+            ("suffix_drop_one_segment", "src/flags/flag_matching.rs"),
+            ("suffix_drop_two_segments", "flags/flag_matching.rs"),
+            ("suffix_basename_only", "flag_matching.rs"),
+            ("monorepo_one_prefix", "rust/feature-flags/src/flags/flag_matching.rs"),
+            ("monorepo_two_prefixes", "services/rust/feature-flags/src/flags/flag_matching.rs"),
+            ("leading_dot_slash", "./feature-flags/src/flags/flag_matching.rs"),
+            ("leading_slash", "/feature-flags/src/flags/flag_matching.rs"),
+            ("windows_separators", "rust\\feature-flags\\src\\flags\\flag_matching.rs"),
+        ]
+    )
+    def test_segment_suffix_match_across_path_conventions(self, _name, file_path):
+        expected = self._symbol_stats("feature-flags/src/flags/flag_matching.rs", FM_SYMBOLS)
+        self.assertEqual([r["line"] for r in expected], [459, 500, 900])  # baseline actually matched
+        self.assertEqual(self._symbol_stats(file_path, FM_SYMBOLS), expected)
+
+    # Paths that share only a partial segment or divergent leading segments must NOT match — the
+    # leading '/' anchors the suffix test on a segment boundary.
+    @parameterized.expand(
+        [
+            # Partial-segment overlap with `flag_matching.rs`: without the '/' anchor these would
+            # spuriously match (e.g. `flag_matching.rs` endsWith `lag_matching.rs`).
+            ("partial_basename_prefix", "lag_matching.rs", FM_SYMBOLS),
+            ("partial_basename_infix", "_matching.rs", FM_SYMBOLS),
+            ("divergent_middle_segment", "other/flag_matching.rs", FM_SYMBOLS),
+            # Divergent leading segment: `crate-c` shares only the unsent `src/mod.rs` tail with the
+            # recorded `crate-a`/`crate-b` files.
+            ("divergent_leading_segment", "crate-c/src/mod.rs", [{"startLine": 10, "endLine": 30}]),
+        ]
+    )
+    def test_non_segment_aligned_paths_do_not_match(self, _name, file_path, symbols):
+        self.assertEqual(self._symbol_stats(file_path, symbols), [])
+
+    def test_monorepo_match_identical_in_line_and_symbol_mode(self):
+        # Matching happens in the WHERE before bucketing, so a workspace-prefixed request aggregates
+        # the same spans as the exact path in BOTH line mode (no symbols) and symbol mode.
+        prefixed = "rust/feature-flags/src/flags/flag_matching.rs"
+        exact = "feature-flags/src/flags/flag_matching.rs"
+
+        line_exact = self._post(exact)["results"]
+        self.assertNotEqual(line_exact, [])
+        self.assertEqual(self._post(prefixed)["results"], line_exact)
+
+        symbol_exact = self._symbol_stats(exact, FM_SYMBOLS)
+        self.assertNotEqual(symbol_exact, [])
+        self.assertEqual(self._symbol_stats(prefixed, FM_SYMBOLS), symbol_exact)
+
     def test_each_period_window_is_respected(self):
         rows = self._symbol_stats("window/src/file.rs", [{"startLine": 1, "endLine": 50}])
         by_line = {r["line"]: r for r in rows}


### PR DESCRIPTION
## Problem

When a monorepo editor sends a workspace-prefixed file path (e.g. `rust/feature-flags/src/flags/flag_matching.rs`) but the service only recorded the shorter path (`feature-flags/src/flags/flag_matching.rs`), the symbol stats query returned no results. The path predicate only matched when the request was a suffix of the recorded path, not the reverse.

Additionally, the 10 GB byte read cap was causing `TOO_MANY_BYTES` (exception 307) errors on any time window longer than ~1 hour, since a single hour of data already reads ~6.5 GB.

## Changes

The path predicate now performs a bidirectional segment-anchored suffix match:
- **Request is a suffix of recorded** — editor sends a shorter, repo-relative path (existing behaviour).
- **Recorded is a suffix of request** — monorepo editor prepends workspace segments the service never recorded (the bug this fixes).

The leading `/` anchor ensures the match always falls on a segment boundary, so `user.go` cannot spuriously match `superuser.go`.

The `max_bytes_to_read` cap is removed (`None`) and `read_overflow_mode` is cleared. `max_execution_time=30` remains as the real runaway backstop, consistent with the sibling attribute-breakdown runner that scans the same data uncapped.

## How did you test this code?

Automated tests cover:

- **`test_segment_suffix_match_across_path_conventions`** — parameterized over nine path spellings (exact, suffix dropping one/two segments, bare basename, monorepo one/two prefix segments, `./`-prefixed, `/`-prefixed, Windows separators), each expected to resolve to the same results as the canonical recorded path.
- **`test_non_segment_aligned_paths_do_not_match`** — partial-segment overlaps and divergent leading segments must return no results.
- **`test_monorepo_match_identical_in_line_and_symbol_mode`** — confirms the workspace-prefixed request aggregates the same spans as the exact path in both line mode and symbol mode.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The bidirectional suffix predicate was designed to fix the monorepo path mismatch without breaking the existing shorter-path matching. The `endsWith(concat('/', recorded), req_slash)` form was chosen over an equality branch because it subsumes the exact-match case while keeping the segment-boundary anchor. The byte cap removal was a separate finding: profiling showed the 10 GB limit was consistently hit on windows beyond ~1 hour, and removing it aligns this runner with the sibling breakdown runner that already scans uncapped.