### PR TITLE
fix(mcp): Add more retention metric guidance to skills

### DIFF
--- a/products/experiments/skills/configuring-experiment-analytics/SKILL.md
+++ b/products/experiments/skills/configuring-experiment-analytics/SKILL.md
@@ -120,7 +120,14 @@ Examples:
 
 Both can reference the same event — the difference is whether you care about count/magnitude (mean) or yes/no conversion (funnel).
 
-See `references/metric-configuration.md` for the full rendered `ExperimentMetric` schema (all four metric types, with required fields per type) plus WRONG/RIGHT JSON pairs for the failure modes that come up most often (ratio with `is_set` filter instead of `math: "sum"` + `math_property`; retention without `retention_window_start` / `start_handling`). Read it before assembling a ratio or retention payload — the required fields are authoritative.
+**Retention: same vs different start/completion event**
+
+The retention window is measured from the start event, so the events you pick decide what's measured:
+
+- **Different** start and completion events → conversion-style retention ("did they reach the target action within the window?"). `retention_window_start: 0` is fine — same-day completions count.
+- **Same** start and completion event → repeat retention ("did they do it _again_ later?"). This **requires `retention_window_start` ≥ 1** with `start_handling: "first_seen"`. With `From 0` the start occurrence is its own completion, so the metric is always 100%. When a user says "retention of <event>" they usually mean repeat retention, so default to `From 1`.
+
+See `references/metric-configuration.md` for the full rendered `ExperimentMetric` schema (all four metric types, with required fields per type) plus WRONG/RIGHT JSON pairs for the failure modes that come up most often (ratio with `is_set` filter instead of `math: "sum"` + `math_property`; retention without `retention_window_start` / `start_handling`; retention with the same start and completion event and `retention_window_start: 0`, which always reads 100%). Read it before assembling a ratio or retention payload — the required fields are authoritative.
 
 ### Step 3: Primary vs secondary
 

--- a/products/experiments/skills/configuring-experiment-analytics/references/metric-configuration.md.j2
+++ b/products/experiments/skills/configuring-experiment-analytics/references/metric-configuration.md.j2
@@ -159,13 +159,32 @@ required and controls how users with multiple start events are anchored:
 `"first_seen"` (anchor on first occurrence) or `"last_seen"` (anchor on most
 recent).
 
-### Right — 7-day retention
+The window is measured **from the start event** and bucketed by
+`retention_window_unit`, which is `"day"` or `"hour"` (start of day / start of
+hour; the examples below use days). `From 0` includes the start period itself (a
+same-period completion counts); `From N` (N ≥ 1) only counts a completion in a
+later period. So the relationship between the two events is the choice that
+matters:
+
+- **Different events** (e.g. `$pageview` → `uploaded_file`) — conversion-style
+  retention: "did the user reach the target action within the window?" `From 0`
+  is correct (same-day conversions should count).
+- **Same event** (e.g. `promoted_product_clicked` → `promoted_product_clicked`) —
+  repeat retention: "did the user do it _again_ later?" This **requires
+  `retention_window_start` ≥ 1**. With `From 0` the qualifying start occurrence is
+  itself a completion on day 0, so every user is trivially retained and the metric
+  always reads 100%. Use `start_handling: "first_seen"` so the anchor is the user's
+  first occurrence and later repeats fall inside the window — `last_seen` anchors on
+  the most recent occurrence, which by construction has no same-event activity after
+  it inside the experiment window.
+
+### Right — conversion retention (different events, `From 0`)
 
 ```json
 {
   "kind": "ExperimentMetric",
   "metric_type": "retention",
-  "name": "7-day retention",
+  "name": "7-day file-upload retention",
   "start_event": {
     "kind": "EventsNode",
     "event": "$pageview"
@@ -180,6 +199,49 @@ recent).
   "start_handling": "first_seen"
 }
 ```
+
+### Right — repeat retention (same event, `From 1`)
+
+```json
+{
+  "kind": "ExperimentMetric",
+  "metric_type": "retention",
+  "name": "7-day repeat-click retention",
+  "start_event": {
+    "kind": "EventsNode",
+    "event": "promoted_product_clicked"
+  },
+  "completion_event": {
+    "kind": "EventsNode",
+    "event": "promoted_product_clicked"
+  },
+  "retention_window_start": 1,
+  "retention_window_end": 7,
+  "retention_window_unit": "day",
+  "start_handling": "first_seen"
+}
+```
+
+### Wrong — same start/completion event with `retention_window_start: 0` (always 100%)
+
+```json
+{
+  "kind": "ExperimentMetric",
+  "metric_type": "retention",
+  "name": "7-day repeat-click retention",
+  "start_event": { "kind": "EventsNode", "event": "promoted_product_clicked" },
+  "completion_event": { "kind": "EventsNode", "event": "promoted_product_clicked" },
+  "retention_window_start": 0,
+  "retention_window_end": 7,
+  "retention_window_unit": "day",
+  "start_handling": "first_seen"
+}
+```
+
+The start occurrence is its own completion on day 0, so every user is retained and
+the metric always reads 100%. Fix it by setting `retention_window_start` ≥ 1
+(repeat retention) or choosing a different `completion_event` (conversion
+retention).
 
 ### Wrong — missing `retention_window_start` and `start_handling`
 


### PR DESCRIPTION
## Problem

The `configuring-experiment-analytics` skill's only "Right" retention example used `retention_window_start: 0` with two *different* events, and the sole documented retention failure mode was "missing required fields." Nothing warned that the same start and completion event with `From 0` always reads 100%, so agents reproduced that degenerate metric when a user asked for "retention of <event>."

## Changes

- Add distinction between same events (repeat-behavior) and different events (conversion A->B)
- Mention that we support day and hour as retention window unit

## How did you test this code?

I'm an agent (Claude Code). Skill-only change, validated with automated checks: `hogli lint:skills` (87 passed) and `hogli build:skills` (renders cleanly). No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while investigating an experiment whose retention metric
read 100%. Every claim was grounded in `experiment_retention_query_builder.py`
