### PR TITLE
fix(data-warehouse): show real error in sync failure digest email

### DIFF
--- a/products/data_warehouse/backend/external_data_source/notifications.py
+++ b/products/data_warehouse/backend/external_data_source/notifications.py
@@ -85,8 +85,26 @@ def notify_external_data_sync_failures(team_id: int) -> None:
             for schema in group
         ]
 
+        listed_schemas = ordered_schemas[:MAX_SCHEMAS_PER_DIGEST_EMAIL]
+
+        # The Syncs screen surfaces the failing job's error (ExternalDataJob.latest_error),
+        # but schema.latest_error is frequently null even when the job recorded a real
+        # failure — e.g. a non-retryable error with no friendly message never gets mirrored
+        # onto the schema. Reading only the schema field left the digest showing
+        # "Unknown error" while the UI showed the actual error. Pull the latest failed job's
+        # error per schema so the email matches what the user sees in-app.
+        latest_job_errors = dict(
+            ExternalDataJob.objects.filter(
+                schema_id__in=[schema.id for schema in listed_schemas],
+                status=ExternalDataJob.Status.FAILED,
+            )
+            .order_by("schema_id", "-created_at")
+            .distinct("schema_id")
+            .values_list("schema_id", "latest_error")
+        )
+
         items = []
-        for schema in ordered_schemas[:MAX_SCHEMAS_PER_DIGEST_EMAIL]:
+        for schema in listed_schemas:
             source_url = (
                 f"{settings.SITE_URL}/project/{team_id}/data-management/sources/managed-{schema.source_id}/syncs"
             )
@@ -99,7 +117,7 @@ def notify_external_data_sync_failures(team_id: int) -> None:
                     "source_url": source_url,
                     # The template truncates for display (truncatechars), and the rendered
                     # HTML is what crosses the Celery boundary — no need to cap here.
-                    "error": schema.latest_error or "Unknown error",
+                    "error": latest_job_errors.get(schema.id) or schema.latest_error or "Unknown error",
                     "paused": not schema.should_sync,
                     "url": f"{source_url}?schema={quote(schema.name)}",
                 }

--- a/products/data_warehouse/backend/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_notifications.py
@@ -36,6 +36,26 @@ def _create_team_and_source() -> tuple[Team, ExternalDataSource]:
     return team, source
 
 
+def _create_failed_job(
+    team: Team,
+    source: ExternalDataSource,
+    schema: ExternalDataSchema,
+    latest_error: str,
+    created_at: dt.datetime | None = None,
+) -> ExternalDataJob:
+    job = ExternalDataJob.objects.create(
+        team=team,
+        pipeline=source,
+        schema=schema,
+        status=ExternalDataJob.Status.FAILED,
+        latest_error=latest_error,
+    )
+    if created_at is not None:
+        # created_at is auto_now_add; .update() bypasses it so ordering is deterministic.
+        ExternalDataJob.objects.filter(id=job.id).update(created_at=created_at)
+    return job
+
+
 class TestNotifyExternalDataSyncFailures:
     def test_sends_digest_with_failing_schemas_classified(self):
         team, source = _create_team_and_source()
@@ -112,6 +132,43 @@ class TestNotifyExternalDataSyncFailures:
 
         (_, items) = mock_sender.call_args.args
         assert items[0]["error"] == "Unknown error"
+
+    def test_falls_back_to_latest_failed_job_error_when_schema_error_missing(self):
+        team, source = _create_team_and_source()
+        schema = ExternalDataSchema.objects.create(
+            name="Companies",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            should_sync=False,
+            latest_error=None,
+        )
+        _create_failed_job(team, source, schema, "missing or invalid refresh token")
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        (_, items) = mock_sender.call_args.args
+        assert items[0]["error"] == "missing or invalid refresh token"
+
+    def test_uses_most_recent_failed_job_error(self):
+        team, source = _create_team_and_source()
+        schema = ExternalDataSchema.objects.create(
+            name="Companies",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            latest_error=None,
+        )
+        now = dt.datetime.now(dt.UTC)
+        _create_failed_job(team, source, schema, "older error", created_at=now - dt.timedelta(hours=2))
+        _create_failed_job(team, source, schema, "newest error", created_at=now - dt.timedelta(minutes=5))
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        (_, items) = mock_sender.call_args.args
+        assert items[0]["error"] == "newest error"
 
     def test_swallows_sender_exceptions(self):
         team, source = _create_team_and_source()


### PR DESCRIPTION
## Problem

The data warehouse sync **failure digest email** rendered `Unknown error` for failing schemas even when the actual error was known and clearly visible in-app on the source's Syncs screen.

Root cause: the email and the UI read two different fields.

| Surface | Field read | Behavior |
|---|---|---|
| Syncs screen (`SyncsTab.tsx`) | `ExternalDataJob.latest_error` (latest job) | Always populated → shows the real error |
| Failure digest email (`notifications.py`) | `ExternalDataSchema.latest_error` | Frequently `null` → fell back to `"Unknown error"` |

A failing job always records its raw error on the **job**, but the schema-level `latest_error` only gets written when the non-retryable handler has a non-`None` friendly message for that error. For many failures (e.g. an expired source connection where no friendly message existed at the time) the schema field stays `null`, so the digest had nothing to show — while the UI, reading the job, displayed the error fine.

## Changes

`notify_external_data_sync_failures` now sources each row's error from the **latest failed job** for the schema (one `DISTINCT ON (schema_id)` query over the listed schemas), matching what the Syncs screen shows. The fallback chain is now:

`latest failed job error` → `schema.latest_error` → `"Unknown error"`

So `"Unknown error"` only appears when no error is recorded anywhere.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual/email testing. Automated tests in `test_notifications.py` (21 passing), including new regression coverage:

- `test_falls_back_to_latest_failed_job_error_when_schema_error_missing` — schema error null + a failed job with an error → email shows the job error
- `test_uses_most_recent_failed_job_error` — picks the newest failed job's error
- existing `test_missing_error_defaults_to_unknown` retained — no job and no schema error still yields `"Unknown error"`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code. Investigation started from a digest email showing `Unknown error` for a HubSpot source; used the PostHog MCP to confirm the failing jobs carried a real error (`missing or invalid refresh token`) while the schemas' `latest_error` was `null`, then traced the divergence between `SyncsTab.tsx` (reads the job) and `notifications.py` (reads the schema).
- Decision: fixed at the email layer (read the job error, matching the UI) rather than changing how `schema.latest_error` is populated on failure — the broader population change would touch every schema-reading surface and interacts with the deliberate raw-error-exposure handling in `sync_status.py`, so it was left out of scope.
