### PR TITLE
feat(posthog-ai): extract sandbox prewarm into shared warm_run helper

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -795,14 +795,8 @@ class ConversationViewSet(
         if request.method == "DELETE":
             service.prewarm_release()
         else:
-            # Same billing gate as message-sending — warming launches a Run, so a quota-limited
-            # team must not be able to keep provisioning sandboxes via prewarm.
-            if is_team_limited(
-                self.team.api_token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
-            ):
-                raise QuotaLimitExceeded(
-                    "Your organization reached its AI credit usage limit. Increase the limits in Billing settings, or ask an org admin to do so."
-                )
+            # The AI-credit quota gate and the warm-pool cap now live inside `warm_run`, which
+            # `prewarm()` delegates to; the HTTP-layer AI rate throttle stays in `check_throttles`.
             service.prewarm()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -29,6 +29,7 @@ from posthog.schema import (
     SpendHistoryItem,
 )
 
+from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.rate_limit import AIBurstRateThrottle
@@ -1431,17 +1432,17 @@ class TestConversationSandboxRoute(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         m_service.assert_not_called()
 
-    def test_prewarm_post_blocked_when_quota_limited(self):
+    def test_prewarm_post_surfaces_quota_error_from_service(self):
+        # The AI-credit gate now lives inside warm_run (which prewarm() delegates to); the action just
+        # surfaces the resulting QuotaLimitExceeded as a 402.
         conversation = self._sandbox_conversation()
-        with (
-            patch("ee.api.conversation.is_team_limited", return_value=True),
-            patch("ee.api.conversation.MessageRoutingService") as m_service,
-        ):
+        with patch("ee.api.conversation.MessageRoutingService") as m_service:
+            m_service.return_value.prewarm.side_effect = QuotaLimitExceeded("over limit")
             response = self.client.post(
                 f"/api/environments/{self.team.id}/conversations/{conversation.id}/prewarm/",
             )
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        m_service.return_value.prewarm.assert_not_called()
+        m_service.return_value.prewarm.assert_called_once()
 
     def test_prewarm_release_is_not_quota_gated(self):
         # Releasing frees a sandbox — a quota-limited team must still be able to do it.

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -37,7 +37,7 @@ from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import send_cancel
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
-from products.tasks.backend.services.warm import enforce_warm_quota, warm_at_capacity, warm_run
+from products.tasks.backend.services.warm import SandboxWarmer
 from products.tasks.backend.temporal.client import execute_task_processing_workflow, signal_task_followup_message
 
 logger = structlog.get_logger(__name__)
@@ -212,16 +212,16 @@ class MessageRoutingService(BaseSandboxService):
         routes through the follow-up branch.
 
         Ensures the conversation's Task exists under the row lock (so two tabs can't
-        create two Tasks), then hands provisioning to the shared `warm_run` helper,
+        create two Tasks), then hands provisioning to the shared `SandboxWarmer`,
         which enforces the AI-credit quota and the warm-pool cap, serializes on the
         Task row, and dispatches the workflow after commit. Idempotent: a non-terminal
         current Run is a no-op.
         """
         # Gate before creating the Task: an over-quota or over-cap warm must not leave the conversation
-        # with a runless Task that the next message can't continue. `warm_run` re-checks both (a cheap
-        # cached read + a state query) so it stays self-contained for any future caller.
-        enforce_warm_quota(Task.OriginProduct.POSTHOG_AI, self.team, self.user)
-        if warm_at_capacity(Task.OriginProduct.POSTHOG_AI, self.team, self.user):
+        # with a runless Task that the next message can't continue. `SandboxWarmer.warm` re-checks both
+        # (a cheap cached read + a state query) so it stays self-contained for any future caller.
+        SandboxWarmer.enforce_quota(Task.OriginProduct.POSTHOG_AI, self.team, self.user)
+        if SandboxWarmer.at_capacity(Task.OriginProduct.POSTHOG_AI, self.team, self.user):
             logger.info(
                 "sandbox_prewarm_capacity_reached",
                 conversation_id=str(self.conversation.id),
@@ -249,11 +249,11 @@ class MessageRoutingService(BaseSandboxService):
                 locked.task = task
                 locked.save(update_fields=["task", "updated_at"])
 
-        # Conversation lock released. `warm_run` provisions under its own Task-row lock and dispatches
-        # the workflow on commit; `systemPrompt` is the one PostHog AI-specific Run-state key the
-        # generic helper can't know.
+        # Conversation lock released. `SandboxWarmer` provisions under its own Task-row lock and
+        # dispatches the workflow on commit; `systemPrompt` is the one PostHog AI-specific Run-state key
+        # the generic warmer can't know.
         try:
-            warm_run(task, user=self.user, extra_state={"systemPrompt": system_prompt})
+            SandboxWarmer(task, user=self.user).warm(extra_state={"systemPrompt": system_prompt})
         except exceptions.Throttled:
             # Warm-pool cap reached. Prewarm is best-effort (fire-and-forget from the composer), so a
             # full pool is a silent no-op rather than a surfaced 429. The AI-credit quota (402) still

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -37,6 +37,7 @@ from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import send_cancel
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
+from products.tasks.backend.services.warm import enforce_warm_quota, warm_at_capacity, warm_run
 from products.tasks.backend.temporal.client import execute_task_processing_workflow, signal_task_followup_message
 
 logger = structlog.get_logger(__name__)
@@ -113,11 +114,6 @@ class MessageRoutingService(BaseSandboxService):
 
     # Run statuses that accept a follow-up signal without creating a successor Run.
     _IN_PROGRESS_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
-
-    # Caps on concurrent non-terminal sandbox Runs reachable via prewarm, bounding resource use
-    # from repeated warm / re-warm calls. Message-sending paths are separately quota-gated.
-    _PREWARM_MAX_PER_USER: int = 2
-    _PREWARM_MAX_PER_ORG: int = 10
 
     def __init__(self, conversation: "Conversation", user: User) -> None:
         super().__init__(team=conversation.team, user=user)
@@ -215,13 +211,17 @@ class MessageRoutingService(BaseSandboxService):
         command. When the user submits, `handle` finds the Run in-progress and
         routes through the follow-up branch.
 
-        Serialized per conversation under the same row lock as a terminal resume, so
-        two tabs warming the same conversation cannot create two Runs. Idempotent: a
-        non-terminal current Run is a no-op. Capped per user and per org.
+        Ensures the conversation's Task exists under the row lock (so two tabs can't
+        create two Tasks), then hands provisioning to the shared `warm_run` helper,
+        which enforces the AI-credit quota and the warm-pool cap, serializes on the
+        Task row, and dispatches the workflow after commit. Idempotent: a non-terminal
+        current Run is a no-op.
         """
-        # Best-effort capacity guard. Counts cross-conversation runs that this conversation's row
-        # lock can't serialize anyway, so check it before taking the lock to keep the lock narrow.
-        if self._prewarm_at_capacity():
+        # Gate before creating the Task: an over-quota or over-cap warm must not leave the conversation
+        # with a runless Task that the next message can't continue. `warm_run` re-checks both (a cheap
+        # cached read + a state query) so it stays self-contained for any future caller.
+        enforce_warm_quota(Task.OriginProduct.POSTHOG_AI, self.team, self.user)
+        if warm_at_capacity(Task.OriginProduct.POSTHOG_AI, self.team, self.user):
             logger.info(
                 "sandbox_prewarm_capacity_reached",
                 conversation_id=str(self.conversation.id),
@@ -231,49 +231,38 @@ class MessageRoutingService(BaseSandboxService):
 
         system_prompt = PromptService(self.team, self.user).build()
 
-        # Decide + write the warm Run under the conversation lock; start the workflow only
-        # after it commits so a rollback can't leave an orphaned sandbox.
-        dispatch: tuple[str, str] | None = None
         with lock_conversation_for_followup(str(self.conversation.id), self.team.pk) as locked:
             current_run = locked.current_run
             if current_run is not None and current_run.status in self._IN_PROGRESS_STATUSES:
+                # A non-terminal Run already exists (warm or active) — nothing to warm.
                 return
-            if locked.task_id is None:
-                dispatch = self._prewarm_first(locked, system_prompt)
-            else:
-                dispatch = self._prewarm_rewarm(locked, current_run, system_prompt)
+            task = locked.task
+            if task is None:
+                task = Task.create_without_run(
+                    team=self.team,
+                    title="",
+                    description="",
+                    origin_product=Task.OriginProduct.POSTHOG_AI,
+                    user_id=self.user.pk,
+                    repository=None,
+                )
+                locked.task = task
+                locked.save(update_fields=["task", "updated_at"])
 
-        if dispatch is None:
-            return
-        task_id, run_id = dispatch
-        execute_task_processing_workflow(
-            task_id=task_id,
-            run_id=run_id,
-            team_id=self.team.id,
-            user_id=self.user.pk,
-            create_pr=False,
-            posthog_mcp_scopes="full",
-        )
-
-    def _prewarm_at_capacity(self) -> bool:
-        """True if the user or org already holds the max concurrent warm sandboxes.
-
-        Counts non-terminal PostHog AI Runs (queued / in-progress) across the user and the
-        org so a POST/DELETE re-warm loop can't spin up unbounded sandboxes. The cross-
-        conversation count isn't serialized, so it may overshoot slightly under heavy
-        concurrency — acceptable for a best-effort resource guard.
-        """
-        non_terminal = TaskRun.objects.filter(
-            task__origin_product=Task.OriginProduct.POSTHOG_AI,
-            status__in=self._IN_PROGRESS_STATUSES,
-        ).exclude(task__deleted=True)
-
-        if non_terminal.filter(task__created_by_id=self.user.pk).count() >= self._PREWARM_MAX_PER_USER:
-            return True
-        return (
-            non_terminal.filter(task__team__organization_id=self.team.organization_id).count()
-            >= self._PREWARM_MAX_PER_ORG
-        )
+        # Conversation lock released. `warm_run` provisions under its own Task-row lock and dispatches
+        # the workflow on commit; `systemPrompt` is the one PostHog AI-specific Run-state key the
+        # generic helper can't know.
+        try:
+            warm_run(task, user=self.user, extra_state={"systemPrompt": system_prompt})
+        except exceptions.Throttled:
+            # Warm-pool cap reached. Prewarm is best-effort (fire-and-forget from the composer), so a
+            # full pool is a silent no-op rather than a surfaced 429. The AI-credit quota (402) still
+            # propagates — it is enforced above, before the Task is created.
+            logger.info(
+                "sandbox_prewarm_capacity_reached",
+                conversation_id=str(self.conversation.id),
+                user_id=self.user.pk,
+            )
 
     def prewarm_release(self) -> None:
         """Release a warm Run if the user abandons the input.
@@ -306,73 +295,6 @@ class MessageRoutingService(BaseSandboxService):
             return None
         distinct_id = self.user.distinct_id or f"user_{self.user.id}"
         return create_sandbox_connection_token(run, user_id=self.user.id, distinct_id=distinct_id)
-
-    def _prewarm_first(self, conversation: "Conversation", system_prompt: str) -> tuple[str, str]:
-        """First warm — create the Task + Run, mirroring `_handle_first_message`
-        but without a pending user message or attached context.
-
-        DB writes only; runs inside the caller's conversation lock. Returns the
-        `(task_id, run_id)` the caller starts the workflow against after commit.
-        """
-        task = Task.create_and_run(
-            team=self.team,
-            title="",
-            description="",
-            origin_product=Task.OriginProduct.POSTHOG_AI,
-            user_id=self.user.pk,
-            repository=None,
-            create_pr=False,
-            mode="interactive",
-            # Defer the workflow so the initial run state can carry the PostHog AI keys.
-            start_workflow=False,
-        )
-
-        task_run = task.latest_run
-        if task_run is None:
-            raise exceptions.ValidationError("Failed to create sandbox prewarm run.")
-
-        # No pending_user_message / attached_context: the session idles awaiting input.
-        # `exclude_unset` keeps the merge to exactly these keys so model defaults don't leak.
-        ph_state = PostHogAIRunState(
-            system_prompt=system_prompt,
-            initial_permission_mode="default",
-            await_user_message=True,
-        )
-        run_state: dict[str, Any] = dict(task_run.state or {})
-        run_state.update(ph_state.model_dump(mode="json", by_alias=True, exclude_unset=True))
-        task_run.state = run_state
-        task_run.save(update_fields=["state"])
-        conversation.task = task
-        conversation.save(update_fields=["task", "updated_at"])
-        return str(task.id), str(task_run.id)
-
-    def _prewarm_rewarm(
-        self, conversation: "Conversation", current_run: "TaskRun | None", system_prompt: str
-    ) -> tuple[str, str] | None:
-        """Re-warm on an existing Task whose current Run is terminal.
-
-        Creates a fresh successor Run carrying the prior Run's snapshot so the warm
-        session reuses the filesystem. DB writes only; runs inside the caller's
-        conversation lock. Returns the `(task_id, run_id)` to start after commit.
-        """
-        task = conversation.task
-        if task is None:
-            return None
-
-        ph_state = PostHogAIRunState(
-            system_prompt=system_prompt,
-            initial_permission_mode="default",
-            await_user_message=True,
-        )
-        extra_state: dict[str, Any] = ph_state.model_dump(mode="json", by_alias=True, exclude_unset=True)
-        if current_run is not None:
-            extra_state["resume_from_run_id"] = str(current_run.id)
-            snapshot_external_id = (current_run.state or {}).get("snapshot_external_id")
-            if snapshot_external_id:
-                extra_state["snapshot_external_id"] = snapshot_external_id
-
-        new_run = task.create_run(mode="interactive", extra_state=extra_state)
-        return str(task.id), str(new_run.id)
 
     def _handle_first_message(
         self,
@@ -506,6 +428,15 @@ class MessageRoutingService(BaseSandboxService):
                 error=str(e),
             )
             raise Conflict("The sandbox run is no longer accepting messages. Please try again.") from e
+
+        # The Run has received its first human message, so it is no longer speculative — drop the
+        # warm flag so the warm-pool cap stops counting it (it's now an active Run governed by AI
+        # credits). Best-effort: a failure only over-counts the warm pool until the Run terminates,
+        # and the key is simply absent on Runs that were never warm (the remove is then a no-op).
+        try:
+            TaskRun.update_state_atomic(run.id, remove_keys=["await_user_message"])
+        except Exception as e:
+            logger.warning("sandbox_followup_activation_flip_failed", run_id=str(run.id), error=str(e))
 
         try:
             # Persist only after the signal was accepted, so the log never records a message the

--- a/products/posthog_ai/backend/run_state.py
+++ b/products/posthog_ai/backend/run_state.py
@@ -23,4 +23,7 @@ class PostHogAIRunState(RunState):
     attached_context: list[AttachedContext] | None = None
     # Set on a pre-warmed Run created with no pending user message: it tells the agent-server to
     # open the ACP session and idle awaiting the first ``user_message`` rather than starting a turn.
+    # Keep this field alias-free: the warm-pool cap filters on the JSON key directly
+    # (``state__await_user_message=True`` in products/tasks/backend/services/warm.py), so an alias
+    # here would change the stored key and silently stop the filter from matching — opening the cap.
     await_user_message: bool = False

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -21,12 +21,12 @@ from products.posthog_ai.backend.system_prompt import PromptService
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import CommandResult
 from products.tasks.backend.services.connection_token import reset_sandbox_jwt_key_cache
-from products.tasks.backend.services.warm import ORIGIN_PRODUCT_WARM_CAPS
+from products.tasks.backend.services.warm import SandboxWarmer
 from products.tasks.backend.tests.test_api import TEST_RSA_PRIVATE_KEY
 
 ROUTING = "products.posthog_ai.backend.message_routing"
 WARM = "products.tasks.backend.services.warm"
-_CAPS = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
+_CAPS = SandboxWarmer.ORIGIN_PRODUCT_CAPS[Task.OriginProduct.POSTHOG_AI]
 
 
 class TestHandleSandboxMessage(APIBaseTest):
@@ -549,7 +549,7 @@ class TestSandboxPrewarm(APIBaseTest):
         m_workflow.assert_called_once()
 
     def test_prewarm_over_quota_raises_and_creates_no_task(self):
-        # The AI-credit gate now lives in warm_run; an over-quota warm must not leave a runless Task.
+        # The AI-credit gate now lives in SandboxWarmer; an over-quota warm must not leave a runless Task.
         with (
             patch(f"{WARM}.is_team_limited", return_value=True),
             patch.object(PromptService, "build", return_value="SYS"),

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 
 from rest_framework import exceptions
 
-from posthog.exceptions import Conflict
+from posthog.exceptions import Conflict, QuotaLimitExceeded
 
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
 from products.posthog_ai.backend.message_routing import (
@@ -16,13 +16,17 @@ from products.posthog_ai.backend.message_routing import (
     lock_conversation_for_followup,
 )
 from products.posthog_ai.backend.models.assistant import Conversation
+from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.agent_command import CommandResult
 from products.tasks.backend.services.connection_token import reset_sandbox_jwt_key_cache
+from products.tasks.backend.services.warm import ORIGIN_PRODUCT_WARM_CAPS
 from products.tasks.backend.tests.test_api import TEST_RSA_PRIVATE_KEY
 
 ROUTING = "products.posthog_ai.backend.message_routing"
+WARM = "products.tasks.backend.services.warm"
+_CAPS = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
 
 
 class TestHandleSandboxMessage(APIBaseTest):
@@ -171,6 +175,24 @@ class TestHandleSandboxMessage(APIBaseTest):
         logged_entries = m_append.call_args[0][0]
         meta = logged_entries[0]["notification"]["params"]["_meta"]
         assert meta["attached_context"] == [{"type": "insight", "id": "abc"}]
+
+    def test_in_progress_followup_clears_warm_flag(self):
+        # A warm Run that receives its first human message is no longer speculative — the warm flag is
+        # cleared so the warm-pool cap stops counting it (it becomes an active, AI-credit-governed Run).
+        task, run = self._stub_task()
+        run.status = TaskRun.Status.IN_PROGRESS
+        run.state = {**(run.state or {}), "await_user_message": True}
+        run.save(update_fields=["status", "state"])
+        self._attach_task(task)
+
+        with (
+            patch(f"{ROUTING}.signal_task_followup_message"),
+            patch.object(TaskRun, "append_log"),
+        ):
+            self._service().handle({"content": "go", "attached_context": []})
+
+        run.refresh_from_db()
+        assert "await_user_message" not in run.state
 
     def test_in_progress_followup_raises_conflict_when_signal_fails(self):
         task, run = self._stub_task()
@@ -463,25 +485,26 @@ class TestSandboxPrewarm(APIBaseTest):
         return task, run
 
     def test_prewarm_first_creates_warm_run_without_pending_message(self):
-        task, run = self._stub_task()
         with (
-            patch.object(Task, "create_and_run", return_value=task) as m_car,
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
-        m_car.assert_called_once()
-
-        run.refresh_from_db()
+        self.conversation.refresh_from_db()
+        assert self.conversation.task_id is not None
+        task = self.conversation.task
+        assert task.origin_product == Task.OriginProduct.POSTHOG_AI
+        run = task.latest_run
+        assert run is not None
         assert run.state["systemPrompt"] == "SYS"
         assert run.state["await_user_message"] is True
+        assert run.state["initial_permission_mode"] == "default"
         # No pending message / attached context: the session boots and idles awaiting input.
         assert "pending_user_message" not in run.state
         assert "attached_context" not in run.state
-
-        self.conversation.refresh_from_db()
-        assert self.conversation.task_id == task.id
         m_workflow.assert_called_once()
 
     def test_prewarm_is_noop_when_run_already_in_progress(self):
@@ -492,14 +515,15 @@ class TestSandboxPrewarm(APIBaseTest):
         self.conversation.save(update_fields=["task"])
 
         with (
-            patch.object(Task, "create_and_run") as m_car,
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
-        m_car.assert_not_called()
         m_workflow.assert_not_called()
+        assert task.runs.count() == 1
 
     def test_prewarm_rewarms_after_terminal_run(self):
         task, run = self._stub_task()
@@ -509,18 +533,32 @@ class TestSandboxPrewarm(APIBaseTest):
         self.conversation.save(update_fields=["task"])
 
         with (
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self._service().prewarm()
+
+        new_run = task.latest_run
+        assert new_run is not None
+        assert new_run.id != run.id
+        assert new_run.state["await_user_message"] is True
+        assert new_run.state["systemPrompt"] == "SYS"
+        assert new_run.state["resume_from_run_id"] == str(run.id)
+        m_workflow.assert_called_once()
+
+    def test_prewarm_over_quota_raises_and_creates_no_task(self):
+        # The AI-credit gate now lives in warm_run; an over-quota warm must not leave a runless Task.
+        with (
+            patch(f"{WARM}.is_team_limited", return_value=True),
+            patch.object(PromptService, "build", return_value="SYS"),
+            self.assertRaises(QuotaLimitExceeded),
         ):
             self._service().prewarm()
 
         self.conversation.refresh_from_db()
-        new_run = self.conversation.current_run
-        assert new_run is not None
-        assert new_run.id != run.id
-        assert new_run.state["await_user_message"] is True
-        assert new_run.state["resume_from_run_id"] == str(run.id)
-        m_workflow.assert_called_once()
+        assert self.conversation.task_id is None
 
     def test_release_cancels_warm_run(self):
         task, run = self._stub_task()
@@ -551,7 +589,7 @@ class TestSandboxPrewarm(APIBaseTest):
         m_cancel.assert_not_called()
 
     def _warm_run(self, *, created_by=None) -> TaskRun:
-        """A non-terminal sandbox run that counts toward the prewarm caps."""
+        """A non-terminal warm Run (awaiting its first message) that counts toward the warm-pool cap."""
         task = Task.objects.create(
             team=self.team,
             title="",
@@ -559,71 +597,100 @@ class TestSandboxPrewarm(APIBaseTest):
             origin_product=Task.OriginProduct.POSTHOG_AI,
             created_by=created_by or self.user,
         )
-        return task.create_run(mode="interactive")  # QUEUED
+        return task.create_run(mode="interactive", extra_state={"await_user_message": True})  # QUEUED
 
     def test_prewarm_skips_when_user_at_capacity(self):
-        for _ in range(MessageRoutingService._PREWARM_MAX_PER_USER):
+        for _ in range(_CAPS.per_user):
             self._warm_run()
 
         with (
-            patch.object(Task, "create_and_run") as m_car,
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
-        m_car.assert_not_called()
         m_workflow.assert_not_called()
+        # The cap is pre-checked before Task creation, so a brand-new conversation gets no runless Task.
         self.conversation.refresh_from_db()
         assert self.conversation.task_id is None
 
     def test_prewarm_skips_when_org_at_capacity(self):
         other = self._create_user("warmer@posthog.com")
         # Stay under the per-user cap (a different creator) but fill the org cap.
-        for _ in range(MessageRoutingService._PREWARM_MAX_PER_ORG):
+        for _ in range(_CAPS.per_org):
             self._warm_run(created_by=other)
 
         with (
-            patch.object(Task, "create_and_run") as m_car,
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
-        m_car.assert_not_called()
         m_workflow.assert_not_called()
 
     def test_prewarm_ignores_terminal_runs_for_capacity(self):
         # Terminal runs don't hold a sandbox, so they must not count toward the cap.
-        for _ in range(MessageRoutingService._PREWARM_MAX_PER_USER + 1):
+        for _ in range(_CAPS.per_user + 1):
             run = self._warm_run()
             run.status = TaskRun.Status.COMPLETED
             run.save(update_fields=["status"])
 
-        task, run = self._stub_task()
         with (
-            patch.object(Task, "create_and_run", return_value=task) as m_car,
-            patch(f"{ROUTING}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
-        m_car.assert_called_once()
+        m_workflow.assert_called_once()
+        self.conversation.refresh_from_db()
+        assert self.conversation.task_id is not None
+
+    def test_prewarm_ignores_activated_runs_for_capacity(self):
+        # Activated Runs (await_user_message cleared) are active, not warm, so they don't count toward
+        # the warm cap — the warm and AI-credit budgets are disjoint.
+        for _ in range(_CAPS.per_user + 1):
+            run = self._warm_run()
+            TaskRun.update_state_atomic(run.id, remove_keys=["await_user_message"])
+
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+            patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            self._service().prewarm()
+
         m_workflow.assert_called_once()
 
     def test_prewarm_first_serializes_on_conversation_lock(self):
-        # The first warm runs under the same row lock as a terminal resume, so a second
-        # concurrent warm can't create a duplicate Task on a task-less conversation.
-        task, _ = self._stub_task()
+        # The first warm runs under the conversation row lock, so a second concurrent warm can't
+        # create a duplicate Task on a task-less conversation.
         with (
-            patch.object(Task, "create_and_run", return_value=task),
-            patch(f"{ROUTING}.execute_task_processing_workflow"),
+            patch(f"{WARM}.execute_task_processing_workflow"),
+            patch(f"{WARM}.is_team_limited", return_value=False),
             patch.object(PromptService, "build", return_value="SYS"),
             patch(f"{ROUTING}.lock_conversation_for_followup", wraps=lock_conversation_for_followup) as m_lock,
+            self.captureOnCommitCallbacks(execute=True),
         ):
             self._service().prewarm()
 
         m_lock.assert_called_once_with(str(self.conversation.id), self.team.pk)
+
+
+class TestAwaitUserMessageStoredKey:
+    """Guards the warm-pool cap, which filters on `state__await_user_message` directly."""
+
+    def test_await_user_message_is_stored_under_its_literal_key(self):
+        # The cap query (products/tasks/backend/services/warm.py) filters on the JSON key literally.
+        # Adding an alias to this field would change the stored key and silently open the cap.
+        dumped = PostHogAIRunState(await_user_message=True).model_dump(by_alias=True, exclude_unset=True)
+        assert dumped == {"await_user_message": True}
 
 
 class TestSandboxFirstMessageConversion(APIBaseTest):

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -2358,6 +2358,14 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     status=status.HTTP_502_BAD_GATEWAY,
                 )
 
+            # A warm Run has now received a human message — drop the warm flag so the warm-pool cap
+            # (see products/tasks/backend/services/warm.py) stops counting it. No-op for Runs that
+            # were never warm; best-effort, since a failure only over-counts the pool until terminal.
+            try:
+                TaskRun.update_state_atomic(task_run.id, remove_keys=["await_user_message"])
+            except Exception:
+                logger.warning("Failed to clear await_user_message for task run %s", task_run.id)
+
             response_payload: dict[str, Any] = {
                 "jsonrpc": request.validated_data["jsonrpc"],
                 "result": {"queued": True},

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -315,20 +315,16 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         raise Exception("Cannot hard delete Task. Use soft_delete() instead.")
 
     @staticmethod
-    def create_and_run(
+    def _build_task(
         *,
         team: Team,
         title: str,
         description: str,
         origin_product: "Task.OriginProduct",
-        user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
-        repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
-        create_pr: bool = True,
-        mode: str = "background",
+        user_id: int,
+        repository: str | None = None,
         slack_thread_context: Optional["SlackThreadContext"] = None,
         slack_thread_url: str | None = None,
-        start_workflow: bool = True,
-        posthog_mcp_scopes: PosthogMcpScopes = "full",
         branch: str | None = None,
         signal_report_id: str | None = None,
         sandbox_environment_id: str | None = None,
@@ -337,9 +333,13 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         interaction_origin: str | None = None,
         model: str | None = None,
         initial_permission_mode: str | None = None,
-    ) -> "Task":
-        from products.tasks.backend.temporal.client import execute_task_processing_workflow
+    ) -> tuple["Task", dict[str, str]]:
+        """Create the Task row and assemble the initial run's `extra_state`.
 
+        Shared by `create_and_run` (which then creates and dispatches the run) and
+        `create_without_run` (which discards the run state). One path keeps the
+        GitHub-integration resolution and authorship logic from drifting between them.
+        """
         created_by = User.objects.get(id=user_id)
 
         from products.tasks.backend.services.sandbox import is_public_sandbox_repo
@@ -439,6 +439,99 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
 
         if initial_permission_mode:
             extra_state["initial_permission_mode"] = initial_permission_mode
+
+        return task, extra_state
+
+    @staticmethod
+    def create_without_run(
+        *,
+        team: Team,
+        title: str,
+        description: str,
+        origin_product: "Task.OriginProduct",
+        user_id: int,
+        repository: str | None = None,
+        slack_thread_context: Optional["SlackThreadContext"] = None,
+        slack_thread_url: str | None = None,
+        branch: str | None = None,
+        signal_report_id: str | None = None,
+        sandbox_environment_id: str | None = None,
+        internal: bool = False,
+        output_schema: type[BaseModel] | dict | None = None,
+        interaction_origin: str | None = None,
+        model: str | None = None,
+        initial_permission_mode: str | None = None,
+    ) -> "Task":
+        """Create the Task row without an initial run or workflow.
+
+        For callers that own run creation themselves — e.g. the sandbox warm path
+        (`products/tasks/backend/services/warm.py`), which creates the first run with its
+        own state. The run `extra_state` assembled by `_build_task` is discarded here.
+        """
+        task, _ = Task._build_task(
+            team=team,
+            title=title,
+            description=description,
+            origin_product=origin_product,
+            user_id=user_id,
+            repository=repository,
+            slack_thread_context=slack_thread_context,
+            slack_thread_url=slack_thread_url,
+            branch=branch,
+            signal_report_id=signal_report_id,
+            sandbox_environment_id=sandbox_environment_id,
+            internal=internal,
+            output_schema=output_schema,
+            interaction_origin=interaction_origin,
+            model=model,
+            initial_permission_mode=initial_permission_mode,
+        )
+        return task
+
+    @staticmethod
+    def create_and_run(
+        *,
+        team: Team,
+        title: str,
+        description: str,
+        origin_product: "Task.OriginProduct",
+        user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
+        repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
+        create_pr: bool = True,
+        mode: str = "background",
+        slack_thread_context: Optional["SlackThreadContext"] = None,
+        slack_thread_url: str | None = None,
+        start_workflow: bool = True,
+        posthog_mcp_scopes: PosthogMcpScopes = "full",
+        branch: str | None = None,
+        signal_report_id: str | None = None,
+        sandbox_environment_id: str | None = None,
+        internal: bool = False,
+        output_schema: type[BaseModel] | dict | None = None,
+        interaction_origin: str | None = None,
+        model: str | None = None,
+        initial_permission_mode: str | None = None,
+    ) -> "Task":
+        from products.tasks.backend.temporal.client import execute_task_processing_workflow
+
+        task, extra_state = Task._build_task(
+            team=team,
+            title=title,
+            description=description,
+            origin_product=origin_product,
+            user_id=user_id,
+            repository=repository,
+            slack_thread_context=slack_thread_context,
+            slack_thread_url=slack_thread_url,
+            branch=branch,
+            signal_report_id=signal_report_id,
+            sandbox_environment_id=sandbox_environment_id,
+            internal=internal,
+            output_schema=output_schema,
+            interaction_origin=interaction_origin,
+            model=model,
+            initial_permission_mode=initial_permission_mode,
+        )
 
         task_run = task.create_run(mode=mode, extra_state=extra_state or None, branch=branch)
 

--- a/products/tasks/backend/services/tests/test_warm.py
+++ b/products/tasks/backend/services/tests/test_warm.py
@@ -6,13 +6,13 @@ from rest_framework.exceptions import PermissionDenied, Throttled
 from posthog.exceptions import QuotaLimitExceeded
 
 from products.tasks.backend.models import Task, TaskRun
-from products.tasks.backend.services.warm import ORIGIN_PRODUCT_WARM_CAPS, warm_at_capacity, warm_run
+from products.tasks.backend.services.warm import SandboxWarmer
 
 WARM = "products.tasks.backend.services.warm"
-_CAPS = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
+_CAPS = SandboxWarmer.ORIGIN_PRODUCT_CAPS[Task.OriginProduct.POSTHOG_AI]
 
 
-class TestWarmRun(APIBaseTest):
+class TestSandboxWarmerWarm(APIBaseTest):
     def _task(self, *, origin=Task.OriginProduct.POSTHOG_AI, created_by=None) -> Task:
         return Task.objects.create(
             team=self.team,
@@ -33,7 +33,7 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.is_team_limited", return_value=False),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            result = warm_run(task, user=self.user, extra_state={"systemPrompt": "SYS"})
+            result = SandboxWarmer(task, user=self.user).warm(extra_state={"systemPrompt": "SYS"})
 
         assert result.just_created is True
         run = result.run
@@ -58,7 +58,7 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.is_team_limited", return_value=False),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            result = warm_run(task, user=self.user)
+            result = SandboxWarmer(task, user=self.user).warm()
 
         assert result.just_created is False
         assert result.run.id == existing.id
@@ -76,7 +76,7 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.is_team_limited", return_value=False),
             self.captureOnCommitCallbacks(execute=True),
         ):
-            result = warm_run(task, user=self.user)
+            result = SandboxWarmer(task, user=self.user).warm()
 
         assert result.just_created is True
         assert result.run.id != terminal.id
@@ -94,7 +94,7 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
             patch(f"{WARM}.is_team_limited", return_value=False),
         ):
-            result = warm_run(task, user=self.user)
+            result = SandboxWarmer(task, user=self.user).warm()
             m_workflow.assert_not_called()
 
         assert result.just_created is True
@@ -107,7 +107,7 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.is_team_limited", return_value=True),
         ):
             with self.assertRaises(QuotaLimitExceeded):
-                warm_run(task, user=self.user)
+                SandboxWarmer(task, user=self.user).warm()
 
         assert task.runs.count() == 0
         m_workflow.assert_not_called()
@@ -116,7 +116,7 @@ class TestWarmRun(APIBaseTest):
         # Fail-closed: only origin products with a registered quota gate may warm.
         task = self._task(origin=Task.OriginProduct.USER_CREATED)
         with self.assertRaises(PermissionDenied):
-            warm_run(task, user=self.user)
+            SandboxWarmer(task, user=self.user).warm()
         assert task.runs.count() == 0
 
     def test_over_cap_raises_throttled(self):
@@ -129,13 +129,13 @@ class TestWarmRun(APIBaseTest):
             patch(f"{WARM}.is_team_limited", return_value=False),
         ):
             with self.assertRaises(Throttled):
-                warm_run(task, user=self.user)
+                SandboxWarmer(task, user=self.user).warm()
 
         assert task.runs.count() == 0
         m_workflow.assert_not_called()
 
 
-class TestWarmAtCapacity(APIBaseTest):
+class TestSandboxWarmerAtCapacity(APIBaseTest):
     def _warm_run_on_new_task(self, *, created_by=None, status=TaskRun.Status.QUEUED, warm=True) -> TaskRun:
         task = Task.objects.create(
             team=self.team,
@@ -152,30 +152,28 @@ class TestWarmAtCapacity(APIBaseTest):
         return run
 
     def test_counts_only_warm_non_terminal_runs(self):
-        caps = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
         origin = Task.OriginProduct.POSTHOG_AI
 
         # Terminal warm runs drop from the count via the status filter.
-        for _ in range(caps.per_user):
+        for _ in range(_CAPS.per_user):
             self._warm_run_on_new_task(status=TaskRun.Status.CANCELLED)
-        assert warm_at_capacity(origin, self.team, self.user) is False
+        assert SandboxWarmer.at_capacity(origin, self.team, self.user) is False
 
         # Activated (await_user_message cleared) non-terminal runs drop via the state filter.
-        for _ in range(caps.per_user):
+        for _ in range(_CAPS.per_user):
             self._warm_run_on_new_task(warm=False)
-        assert warm_at_capacity(origin, self.team, self.user) is False
+        assert SandboxWarmer.at_capacity(origin, self.team, self.user) is False
 
         # Genuine warm runs do count.
-        for _ in range(caps.per_user):
+        for _ in range(_CAPS.per_user):
             self._warm_run_on_new_task()
-        assert warm_at_capacity(origin, self.team, self.user) is True
+        assert SandboxWarmer.at_capacity(origin, self.team, self.user) is True
 
     def test_per_org_cap_counts_across_users(self):
-        caps = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
         origin = Task.OriginProduct.POSTHOG_AI
         other = self._create_user("warmer@posthog.com")
-        for _ in range(caps.per_org):
+        for _ in range(_CAPS.per_org):
             self._warm_run_on_new_task(created_by=other)
 
         # The requesting user holds no warm runs, but the org cap is full.
-        assert warm_at_capacity(origin, self.team, self.user) is True
+        assert SandboxWarmer.at_capacity(origin, self.team, self.user) is True

--- a/products/tasks/backend/services/tests/test_warm.py
+++ b/products/tasks/backend/services/tests/test_warm.py
@@ -1,0 +1,181 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework.exceptions import PermissionDenied, Throttled
+
+from posthog.exceptions import QuotaLimitExceeded
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.services.warm import ORIGIN_PRODUCT_WARM_CAPS, warm_at_capacity, warm_run
+
+WARM = "products.tasks.backend.services.warm"
+_CAPS = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
+
+
+class TestWarmRun(APIBaseTest):
+    def _task(self, *, origin=Task.OriginProduct.POSTHOG_AI, created_by=None) -> Task:
+        return Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=origin,
+            created_by=created_by or self.user,
+        )
+
+    def _warm_run_on_new_task(self, *, created_by=None) -> TaskRun:
+        task = self._task(created_by=created_by)
+        return task.create_run(mode="interactive", extra_state={"await_user_message": True})
+
+    def test_provisions_warm_run_when_task_has_no_runs(self):
+        task = self._task()
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = warm_run(task, user=self.user, extra_state={"systemPrompt": "SYS"})
+
+        assert result.just_created is True
+        run = result.run
+        assert run.state["await_user_message"] is True
+        assert run.state["initial_permission_mode"] == "default"
+        assert run.state["systemPrompt"] == "SYS"
+        assert run.state["mode"] == "interactive"
+        assert "resume_from_run_id" not in run.state
+
+        m_workflow.assert_called_once()
+        _, kwargs = m_workflow.call_args
+        assert kwargs["run_id"] == str(run.id)
+        assert kwargs["create_pr"] is False
+        assert kwargs["posthog_mcp_scopes"] == "full"
+
+    def test_idempotent_when_non_terminal_run_exists(self):
+        task = self._task()
+        existing = task.create_run(mode="interactive", extra_state={"await_user_message": True})
+
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = warm_run(task, user=self.user)
+
+        assert result.just_created is False
+        assert result.run.id == existing.id
+        assert task.runs.count() == 1
+        m_workflow.assert_not_called()
+
+    def test_rewarms_with_resume_after_terminal_run(self):
+        task = self._task()
+        terminal = task.create_run(mode="interactive", extra_state={"snapshot_external_id": "snap-1"})
+        terminal.status = TaskRun.Status.COMPLETED
+        terminal.save(update_fields=["status"])
+
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = warm_run(task, user=self.user)
+
+        assert result.just_created is True
+        assert result.run.id != terminal.id
+        assert result.run.state["await_user_message"] is True
+        assert result.run.state["resume_from_run_id"] == str(terminal.id)
+        # Snapshot carried forward so the warm session reuses the prior Run's filesystem.
+        assert result.run.state["snapshot_external_id"] == "snap-1"
+        m_workflow.assert_called_once()
+
+    def test_dispatch_is_deferred_to_commit(self):
+        # No captureOnCommitCallbacks: the test transaction never commits, so the on_commit dispatch
+        # must not fire — proving provisioning isn't done inside the atomic block.
+        task = self._task()
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+        ):
+            result = warm_run(task, user=self.user)
+            m_workflow.assert_not_called()
+
+        assert result.just_created is True
+        assert task.runs.count() == 1
+
+    def test_over_quota_raises_and_creates_no_run(self):
+        task = self._task()
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=True),
+        ):
+            with self.assertRaises(QuotaLimitExceeded):
+                warm_run(task, user=self.user)
+
+        assert task.runs.count() == 0
+        m_workflow.assert_not_called()
+
+    def test_unregistered_origin_product_is_rejected(self):
+        # Fail-closed: only origin products with a registered quota gate may warm.
+        task = self._task(origin=Task.OriginProduct.USER_CREATED)
+        with self.assertRaises(PermissionDenied):
+            warm_run(task, user=self.user)
+        assert task.runs.count() == 0
+
+    def test_over_cap_raises_throttled(self):
+        for _ in range(_CAPS.per_user):
+            self._warm_run_on_new_task()
+
+        task = self._task()
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow") as m_workflow,
+            patch(f"{WARM}.is_team_limited", return_value=False),
+        ):
+            with self.assertRaises(Throttled):
+                warm_run(task, user=self.user)
+
+        assert task.runs.count() == 0
+        m_workflow.assert_not_called()
+
+
+class TestWarmAtCapacity(APIBaseTest):
+    def _warm_run_on_new_task(self, *, created_by=None, status=TaskRun.Status.QUEUED, warm=True) -> TaskRun:
+        task = Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=created_by or self.user,
+        )
+        extra = {"await_user_message": True} if warm else {}
+        run = task.create_run(mode="interactive", extra_state=extra)
+        if status != TaskRun.Status.QUEUED:
+            run.status = status
+            run.save(update_fields=["status"])
+        return run
+
+    def test_counts_only_warm_non_terminal_runs(self):
+        caps = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
+        origin = Task.OriginProduct.POSTHOG_AI
+
+        # Terminal warm runs drop from the count via the status filter.
+        for _ in range(caps.per_user):
+            self._warm_run_on_new_task(status=TaskRun.Status.CANCELLED)
+        assert warm_at_capacity(origin, self.team, self.user) is False
+
+        # Activated (await_user_message cleared) non-terminal runs drop via the state filter.
+        for _ in range(caps.per_user):
+            self._warm_run_on_new_task(warm=False)
+        assert warm_at_capacity(origin, self.team, self.user) is False
+
+        # Genuine warm runs do count.
+        for _ in range(caps.per_user):
+            self._warm_run_on_new_task()
+        assert warm_at_capacity(origin, self.team, self.user) is True
+
+    def test_per_org_cap_counts_across_users(self):
+        caps = ORIGIN_PRODUCT_WARM_CAPS[Task.OriginProduct.POSTHOG_AI]
+        origin = Task.OriginProduct.POSTHOG_AI
+        other = self._create_user("warmer@posthog.com")
+        for _ in range(caps.per_org):
+            self._warm_run_on_new_task(created_by=other)
+
+        # The requesting user holds no warm runs, but the org cap is full.
+        assert warm_at_capacity(origin, self.team, self.user) is True

--- a/products/tasks/backend/services/warm.py
+++ b/products/tasks/backend/services/warm.py
@@ -7,7 +7,7 @@ quota gate and a warm-pool concurrency cap — live here so every product warms 
 one implementation rather than reimplementing provisioning, quota, and idempotency.
 
 The trigger (when to warm) and Task ownership (birth + linking to the product's own
-entity) stay per-product: ``warm_run`` operates on an *existing* Task. PostHog AI's
+entity) stay per-product: ``SandboxWarmer`` operates on an *existing* Task. PostHog AI's
 prewarm is the only caller today; the registries below are fail-closed, so a product
 must opt in with a quota gate before it can warm.
 """
@@ -32,9 +32,6 @@ from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_tea
 
 logger = structlog.get_logger(__name__)
 
-# A warm Run is non-terminal and idling; these are the statuses it can hold before activation.
-_NON_TERMINAL_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
-
 
 @dataclass
 class WarmResult:
@@ -44,12 +41,10 @@ class WarmResult:
     just_created: bool
 
 
-# --- Quota dispatch (per origin_product) -------------------------------------------------------
-# Each checker returns None or raises a DRF APIException; the in-process caller can't return an
-# HTTP Response, so the contract is exception-based and DRF renders the status from any depth.
-# Keyed on (team, user) rather than the Task so a caller can gate *before* creating the Task — an
-# over-quota warm must not leave behind a runless Task the next message can't continue.
-QuotaChecker = Callable[[Team, User], None]
+@dataclass(frozen=True)
+class WarmPoolCaps:
+    per_user: int
+    per_org: int
 
 
 def _ai_credits_checker(team: Team, user: User) -> None:
@@ -60,129 +55,123 @@ def _ai_credits_checker(team: Team, user: User) -> None:
         )
 
 
-# Fail-closed: a product warms only once it registers a gate here. An unregistered product would
-# provision sandboxes with no cost ceiling, so warming is rejected until it opts in.
-ORIGIN_PRODUCT_WARM_QUOTA: dict["Task.OriginProduct", QuotaChecker] = {
-    Task.OriginProduct.POSTHOG_AI: _ai_credits_checker,
-}
+class SandboxWarmer:
+    """Idempotently warm a sandbox Run for an existing Task, enforcing the product's quota gate and a
+    state-derived warm-pool cap, then dispatching the processing workflow after commit.
 
-
-def enforce_warm_quota(origin_product: "Task.OriginProduct", team: Team, user: User) -> None:
-    """Raise if ``team`` may not warm a Run for ``origin_product`` (over quota, or product not registered).
-
-    Public so a product can gate before it births the Task; ``warm_run`` also calls it (a cheap cached
-    re-check) so the helper stays self-contained for any future caller.
+    The quota gate and cap are also exposed as classmethods (keyed on team/user, not a Task) so a
+    caller can gate *before* it births a Task — an over-quota or over-cap warm must not leave behind a
+    runless Task the next message can't continue.
     """
-    checker = ORIGIN_PRODUCT_WARM_QUOTA.get(origin_product)
-    if checker is None:
-        raise PermissionDenied(f"Warming is not enabled for origin product '{origin_product}'.")
-    checker(team, user)
 
+    # A warm Run is non-terminal and idling; these are the statuses it can hold before activation.
+    _NON_TERMINAL_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
 
-# --- Warm-pool cap (state-derived; per origin_product) -----------------------------------------
-@dataclass(frozen=True)
-class WarmPoolCaps:
-    per_user: int
-    per_org: int
+    # Each checker returns None or raises a DRF APIException; the in-process caller can't return an HTTP
+    # Response, so the contract is exception-based and DRF renders the status from any depth. Fail-closed:
+    # a product warms only once it registers a gate here, else it would provision sandboxes with no ceiling.
+    ORIGIN_PRODUCT_QUOTA: dict["Task.OriginProduct", Callable[[Team, User], None]] = {
+        Task.OriginProduct.POSTHOG_AI: _ai_credits_checker,
+    }
 
+    ORIGIN_PRODUCT_CAPS: dict["Task.OriginProduct", WarmPoolCaps] = {
+        Task.OriginProduct.POSTHOG_AI: WarmPoolCaps(per_user=2, per_org=10),
+    }
+    _DEFAULT_CAPS: WarmPoolCaps = WarmPoolCaps(per_user=2, per_org=10)
 
-ORIGIN_PRODUCT_WARM_CAPS: dict["Task.OriginProduct", WarmPoolCaps] = {
-    Task.OriginProduct.POSTHOG_AI: WarmPoolCaps(per_user=2, per_org=10),
-}
-_DEFAULT_WARM_CAPS = WarmPoolCaps(per_user=2, per_org=10)
+    def __init__(self, task: "Task", *, user: User) -> None:
+        self.task = task
+        self.user = user
 
+    @classmethod
+    def enforce_quota(cls, origin_product: "Task.OriginProduct", team: Team, user: User) -> None:
+        """Raise if ``team`` may not warm a Run for ``origin_product`` (over quota, or product not registered)."""
+        checker = cls.ORIGIN_PRODUCT_QUOTA.get(origin_product)
+        if checker is None:
+            raise PermissionDenied(f"Warming is not enabled for origin product '{origin_product}'.")
+        checker(team, user)
 
-def warm_at_capacity(origin_product: "Task.OriginProduct", team: Team, user: User) -> bool:
-    """True if the user or org already holds the max concurrent *warm* Runs.
+    @classmethod
+    def at_capacity(cls, origin_product: "Task.OriginProduct", team: Team, user: User) -> bool:
+        """True if the user or org already holds the max concurrent *warm* Runs.
 
-    Counts only Runs still awaiting their first message (``state.await_user_message`` set) — so the
-    warm-pool budget and the active (AI-credit) budget are disjoint: activating a warm Run clears the
-    flag and drops it from this count for free, and a terminal Run drops via the status filter. No
-    increment/decrement counter is kept; the count is derived from state. The cross-task count is not
-    serialized by the per-Task lock, so it may overshoot slightly under heavy concurrency — acceptable
-    for a best-effort resource guard.
+        Counts only Runs still awaiting their first message (``state.await_user_message`` set) — so the
+        warm-pool budget and the active (AI-credit) budget are disjoint: activating a warm Run clears the
+        flag and drops it from this count for free, and a terminal Run drops via the status filter. No
+        increment/decrement counter is kept; the count is derived from state. The cross-task count is not
+        serialized by the per-Task lock, so it may overshoot slightly under heavy concurrency — acceptable
+        for a best-effort resource guard.
+        """
+        caps = cls.ORIGIN_PRODUCT_CAPS.get(origin_product, cls._DEFAULT_CAPS)
+        # `await_user_message` is stored literally (the field is alias-free in PostHogAIRunState); see the
+        # comment there before adding an alias, which would silently break this filter and open the cap.
+        warm_runs = TaskRun.objects.filter(
+            task__origin_product=origin_product,
+            status__in=cls._NON_TERMINAL_STATUSES,
+            state__await_user_message=True,
+        ).exclude(task__deleted=True)
 
-    Public (and keyed on team/user, not a Task) so a caller can pre-check before it births a Task —
-    an over-cap warm must not leave behind a runless Task the next message can't continue.
-    """
-    caps = ORIGIN_PRODUCT_WARM_CAPS.get(origin_product, _DEFAULT_WARM_CAPS)
-    # `await_user_message` is stored literally (the field is alias-free in PostHogAIRunState); see the
-    # comment there before adding an alias, which would silently break this filter and open the cap.
-    warm_runs = TaskRun.objects.filter(
-        task__origin_product=origin_product,
-        status__in=_NON_TERMINAL_STATUSES,
-        state__await_user_message=True,
-    ).exclude(task__deleted=True)
+        if warm_runs.filter(task__created_by_id=user.pk).count() >= caps.per_user:
+            return True
+        return warm_runs.filter(task__team__organization_id=team.organization_id).count() >= caps.per_org
 
-    if warm_runs.filter(task__created_by_id=user.pk).count() >= caps.per_user:
-        return True
-    return warm_runs.filter(task__team__organization_id=team.organization_id).count() >= caps.per_org
+    def warm(self, *, mode: str = "interactive", extra_state: dict[str, Any] | None = None) -> WarmResult:
+        """Idempotently ensure the Task has a warm Run, then dispatch the processing workflow after commit.
 
+        - Idempotent: if the Task already has a non-terminal Run, return it without provisioning.
+        - Fresh: a Task with no Runs gets a new warm Run; a Task whose latest Run is terminal gets a
+          successor that resumes from it (filesystem reuse via ``snapshot_external_id``).
+        - ``extra_state`` carries product-specific Run state the generic warmer can't know (e.g. PostHog
+          AI's ``systemPrompt``); it is merged into the warm Run's initial state.
 
-def warm_run(
-    task: "Task",
-    *,
-    user: User,
-    mode: str = "interactive",
-    extra_state: dict[str, Any] | None = None,
-) -> WarmResult:
-    """Idempotently ensure ``task`` has a warm Run, enforcing the product's quota gate and the
-    warm-pool cap, then dispatch the processing workflow after commit.
+        Raises ``QuotaLimitExceeded`` (402) / ``PermissionDenied`` (403) when gated, and ``Throttled``
+        (429) when the warm pool is full.
+        """
+        # Quota is a gateway/cache call — check it before taking the row lock, never while holding it.
+        self.enforce_quota(self.task.origin_product, self.task.team, self.user)
 
-    - Idempotent: if the Task already has a non-terminal Run, return it without provisioning.
-    - Fresh: a Task with no Runs gets a new warm Run; a Task whose latest Run is terminal gets a
-      successor that resumes from it (filesystem reuse via ``snapshot_external_id``).
-    - ``extra_state`` carries product-specific Run state the generic helper can't know (e.g. PostHog
-      AI's ``systemPrompt``); it is merged into the warm Run's initial state.
+        new_run: TaskRun
+        with transaction.atomic():
+            locked = Task.objects.select_for_update().get(id=self.task.id)
+            existing = locked.latest_run
+            if existing is not None and not existing.is_terminal:
+                # A warm Run already idling, or an active Run in progress — either way, no double-provision.
+                return WarmResult(run=existing, just_created=False)
 
-    Raises ``QuotaLimitExceeded`` (402) / ``PermissionDenied`` (403) when gated, and ``Throttled``
-    (429) when the warm pool is full.
-    """
-    # Quota is a gateway/cache call — check it before taking the row lock, never while holding it.
-    enforce_warm_quota(task.origin_product, task.team, user)
+            if self.at_capacity(locked.origin_product, locked.team, self.user):
+                raise Throttled(detail="Warm-pool capacity reached. Release an idle warm session and try again.")
 
-    new_run: TaskRun
-    with transaction.atomic():
-        locked = Task.objects.select_for_update().get(id=task.id)
-        existing = locked.latest_run
-        if existing is not None and not existing.is_terminal:
-            # A warm Run already idling, or an active Run in progress — either way, no double-provision.
-            return WarmResult(run=existing, just_created=False)
+            run_state: dict[str, Any] = {
+                "await_user_message": True,
+                "initial_permission_mode": "default",
+                **(extra_state or {}),
+            }
+            if existing is not None:
+                # Latest Run is terminal — resume into a successor so the warm session reuses its filesystem.
+                run_state["resume_from_run_id"] = str(existing.id)
+                snapshot_external_id = (existing.state or {}).get("snapshot_external_id")
+                if snapshot_external_id:
+                    run_state["snapshot_external_id"] = snapshot_external_id
 
-        if warm_at_capacity(locked.origin_product, locked.team, user):
-            raise Throttled(detail="Warm-pool capacity reached. Release an idle warm session and try again.")
+            new_run = locked.create_run(mode=mode, extra_state=run_state)
 
-        run_state: dict[str, Any] = {
-            "await_user_message": True,
-            "initial_permission_mode": "default",
-            **(extra_state or {}),
-        }
-        if existing is not None:
-            # Latest Run is terminal — resume into a successor so the warm session reuses its filesystem.
-            run_state["resume_from_run_id"] = str(existing.id)
-            snapshot_external_id = (existing.state or {}).get("snapshot_external_id")
-            if snapshot_external_id:
-                run_state["snapshot_external_id"] = snapshot_external_id
-
-        new_run = locked.create_run(mode=mode, extra_state=run_state)
-
-        # Dispatch only after the row commits, so a rollback can't leave an orphaned sandbox.
-        task_id, run_id, team_id, user_id = str(locked.id), str(new_run.id), task.team_id, user.pk
-        transaction.on_commit(
-            lambda: execute_task_processing_workflow(
-                task_id=task_id,
-                run_id=run_id,
-                team_id=team_id,
-                user_id=user_id,
-                create_pr=False,
-                posthog_mcp_scopes="full",
+            # Dispatch only after the row commits, so a rollback can't leave an orphaned sandbox.
+            task_id, run_id, team_id, user_id = str(locked.id), str(new_run.id), self.task.team_id, self.user.pk
+            transaction.on_commit(
+                lambda: execute_task_processing_workflow(
+                    task_id=task_id,
+                    run_id=run_id,
+                    team_id=team_id,
+                    user_id=user_id,
+                    create_pr=False,
+                    posthog_mcp_scopes="full",
+                )
             )
-        )
 
-    logger.info(
-        "sandbox_warm_run_provisioned",
-        task_id=str(task.id),
-        run_id=str(new_run.id),
-        origin_product=task.origin_product,
-    )
-    return WarmResult(run=new_run, just_created=True)
+        logger.info(
+            "sandbox_warm_run_provisioned",
+            task_id=str(self.task.id),
+            run_id=str(new_run.id),
+            origin_product=self.task.origin_product,
+        )
+        return WarmResult(run=new_run, just_created=True)

--- a/products/tasks/backend/services/warm.py
+++ b/products/tasks/backend/services/warm.py
@@ -1,0 +1,188 @@
+"""Generic sandbox warming for products/tasks.
+
+Warming eagerly boots a sandbox + ACP session on an interactive Run that idles
+awaiting the first ``user_message``, so first-token latency drops from a cold boot
+to roughly model-invocation time. The mechanic plus its guardrails — a per-product
+quota gate and a warm-pool concurrency cap — live here so every product warms through
+one implementation rather than reimplementing provisioning, quota, and idempotency.
+
+The trigger (when to warm) and Task ownership (birth + linking to the product's own
+entity) stay per-product: ``warm_run`` operates on an *existing* Task. PostHog AI's
+prewarm is the only caller today; the registries below are fail-closed, so a product
+must opt in with a quota gate before it can warm.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from django.db import transaction
+
+import structlog
+from rest_framework.exceptions import PermissionDenied, Throttled
+
+from posthog.exceptions import QuotaLimitExceeded
+from posthog.models.team import Team
+from posthog.models.user import User
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.client import execute_task_processing_workflow
+
+from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_team_limited
+
+logger = structlog.get_logger(__name__)
+
+# A warm Run is non-terminal and idling; these are the statuses it can hold before activation.
+_NON_TERMINAL_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
+
+
+@dataclass
+class WarmResult:
+    """Outcome of a warm request — the Run to open against, and whether it was just provisioned."""
+
+    run: TaskRun
+    just_created: bool
+
+
+# --- Quota dispatch (per origin_product) -------------------------------------------------------
+# Each checker returns None or raises a DRF APIException; the in-process caller can't return an
+# HTTP Response, so the contract is exception-based and DRF renders the status from any depth.
+# Keyed on (team, user) rather than the Task so a caller can gate *before* creating the Task — an
+# over-quota warm must not leave behind a runless Task the next message can't continue.
+QuotaChecker = Callable[[Team, User], None]
+
+
+def _ai_credits_checker(team: Team, user: User) -> None:
+    if is_team_limited(team.api_token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY):
+        raise QuotaLimitExceeded(
+            "Your organization reached its AI credit usage limit. Increase the limits in Billing settings, "
+            "or ask an org admin to do so."
+        )
+
+
+# Fail-closed: a product warms only once it registers a gate here. An unregistered product would
+# provision sandboxes with no cost ceiling, so warming is rejected until it opts in.
+ORIGIN_PRODUCT_WARM_QUOTA: dict["Task.OriginProduct", QuotaChecker] = {
+    Task.OriginProduct.POSTHOG_AI: _ai_credits_checker,
+}
+
+
+def enforce_warm_quota(origin_product: "Task.OriginProduct", team: Team, user: User) -> None:
+    """Raise if ``team`` may not warm a Run for ``origin_product`` (over quota, or product not registered).
+
+    Public so a product can gate before it births the Task; ``warm_run`` also calls it (a cheap cached
+    re-check) so the helper stays self-contained for any future caller.
+    """
+    checker = ORIGIN_PRODUCT_WARM_QUOTA.get(origin_product)
+    if checker is None:
+        raise PermissionDenied(f"Warming is not enabled for origin product '{origin_product}'.")
+    checker(team, user)
+
+
+# --- Warm-pool cap (state-derived; per origin_product) -----------------------------------------
+@dataclass(frozen=True)
+class WarmPoolCaps:
+    per_user: int
+    per_org: int
+
+
+ORIGIN_PRODUCT_WARM_CAPS: dict["Task.OriginProduct", WarmPoolCaps] = {
+    Task.OriginProduct.POSTHOG_AI: WarmPoolCaps(per_user=2, per_org=10),
+}
+_DEFAULT_WARM_CAPS = WarmPoolCaps(per_user=2, per_org=10)
+
+
+def warm_at_capacity(origin_product: "Task.OriginProduct", team: Team, user: User) -> bool:
+    """True if the user or org already holds the max concurrent *warm* Runs.
+
+    Counts only Runs still awaiting their first message (``state.await_user_message`` set) — so the
+    warm-pool budget and the active (AI-credit) budget are disjoint: activating a warm Run clears the
+    flag and drops it from this count for free, and a terminal Run drops via the status filter. No
+    increment/decrement counter is kept; the count is derived from state. The cross-task count is not
+    serialized by the per-Task lock, so it may overshoot slightly under heavy concurrency — acceptable
+    for a best-effort resource guard.
+
+    Public (and keyed on team/user, not a Task) so a caller can pre-check before it births a Task —
+    an over-cap warm must not leave behind a runless Task the next message can't continue.
+    """
+    caps = ORIGIN_PRODUCT_WARM_CAPS.get(origin_product, _DEFAULT_WARM_CAPS)
+    # `await_user_message` is stored literally (the field is alias-free in PostHogAIRunState); see the
+    # comment there before adding an alias, which would silently break this filter and open the cap.
+    warm_runs = TaskRun.objects.filter(
+        task__origin_product=origin_product,
+        status__in=_NON_TERMINAL_STATUSES,
+        state__await_user_message=True,
+    ).exclude(task__deleted=True)
+
+    if warm_runs.filter(task__created_by_id=user.pk).count() >= caps.per_user:
+        return True
+    return warm_runs.filter(task__team__organization_id=team.organization_id).count() >= caps.per_org
+
+
+def warm_run(
+    task: "Task",
+    *,
+    user: User,
+    mode: str = "interactive",
+    extra_state: dict[str, Any] | None = None,
+) -> WarmResult:
+    """Idempotently ensure ``task`` has a warm Run, enforcing the product's quota gate and the
+    warm-pool cap, then dispatch the processing workflow after commit.
+
+    - Idempotent: if the Task already has a non-terminal Run, return it without provisioning.
+    - Fresh: a Task with no Runs gets a new warm Run; a Task whose latest Run is terminal gets a
+      successor that resumes from it (filesystem reuse via ``snapshot_external_id``).
+    - ``extra_state`` carries product-specific Run state the generic helper can't know (e.g. PostHog
+      AI's ``systemPrompt``); it is merged into the warm Run's initial state.
+
+    Raises ``QuotaLimitExceeded`` (402) / ``PermissionDenied`` (403) when gated, and ``Throttled``
+    (429) when the warm pool is full.
+    """
+    # Quota is a gateway/cache call — check it before taking the row lock, never while holding it.
+    enforce_warm_quota(task.origin_product, task.team, user)
+
+    new_run: TaskRun
+    with transaction.atomic():
+        locked = Task.objects.select_for_update().get(id=task.id)
+        existing = locked.latest_run
+        if existing is not None and not existing.is_terminal:
+            # A warm Run already idling, or an active Run in progress — either way, no double-provision.
+            return WarmResult(run=existing, just_created=False)
+
+        if warm_at_capacity(locked.origin_product, locked.team, user):
+            raise Throttled(detail="Warm-pool capacity reached. Release an idle warm session and try again.")
+
+        run_state: dict[str, Any] = {
+            "await_user_message": True,
+            "initial_permission_mode": "default",
+            **(extra_state or {}),
+        }
+        if existing is not None:
+            # Latest Run is terminal — resume into a successor so the warm session reuses its filesystem.
+            run_state["resume_from_run_id"] = str(existing.id)
+            snapshot_external_id = (existing.state or {}).get("snapshot_external_id")
+            if snapshot_external_id:
+                run_state["snapshot_external_id"] = snapshot_external_id
+
+        new_run = locked.create_run(mode=mode, extra_state=run_state)
+
+        # Dispatch only after the row commits, so a rollback can't leave an orphaned sandbox.
+        task_id, run_id, team_id, user_id = str(locked.id), str(new_run.id), task.team_id, user.pk
+        transaction.on_commit(
+            lambda: execute_task_processing_workflow(
+                task_id=task_id,
+                run_id=run_id,
+                team_id=team_id,
+                user_id=user_id,
+                create_pr=False,
+                posthog_mcp_scopes="full",
+            )
+        )
+
+    logger.info(
+        "sandbox_warm_run_provisioned",
+        task_id=str(task.id),
+        run_id=str(new_run.id),
+        origin_product=task.origin_product,
+    )
+    return WarmResult(run=new_run, just_created=True)


### PR DESCRIPTION
## Problem

Sandbox prewarming — eagerly booting a sandbox + ACP session while the user is still forming intent, so first-token latency drops from a cold boot to roughly model-invocation time — lived entirely inside PostHog AI's conversation layer. But warming is not conversation-specific; it is a generic run-lifecycle optimization any product that drives an interactive sandbox will want. Keeping it conversation-scoped forces every other product to reimplement the hard parts — provisioning, quota gating, concurrency control — and to invent a conversation row it does not need.

## Changes

Extracts the warm **mechanic** and its **guardrails** into a single shared `warm_run` helper on `products/tasks`, leaving each product only the trigger (when to warm) and ownership of the Task being warmed.

- **`products/tasks/backend/services/warm.py` (new)** — `warm_run(task, *, user, extra_state)` enforces a per-`origin_product` quota gate and a state-derived warm-pool cap, serializes on the Task row, and dispatches the workflow on commit. The quota registry is **fail-closed** and currently registers only PostHog AI; every other origin is rejected (`403`) until it opts in.
- **Disjoint budgets** — the cap counts only runs still awaiting their first message (`await_user_message`), so the warm-pool budget and the AI-credit budget never overlap. A run leaves the warm partition the instant a user message is dispatched (the "activation flip"), cleared in both the conversation follow-up path and the generic relay `command` action. The count is derived from state, so a terminal or activated run drops out for free — no counter to keep in sync.
- **`Task.create_and_run` refactor** — the task-construction body is factored into a shared `_build_task`, with a new runless `Task.create_without_run` for the warm path. Pure refactor, behaviour-preserving for existing callers.
- **PostHog AI repoint** — `MessageRoutingService.prewarm` now delegates to `warm_run`; the duplicated AI-credit gate is removed from the conversation viewset, which keeps its HTTP rate throttle.

Scoped to PostHog AI in this pass: the generic HTTP `warm` action and registering other products (e.g. PostHog Code) are deferred. The external agent-server "never-started" idle timer remains the rollout gate before any non-PostHog-AI product is registered.

## How did you test this code?

I'm an agent (Claude Code); I ran only automated tests — no manual testing.

- New `products/tasks/backend/services/tests/test_warm.py` (9): idempotency, fresh provision, re-warm with snapshot carry-forward, quota dispatch (402 over-quota / 403 unregistered origin), over-cap 429, on-commit dispatch, and state-derived cap accounting.
- `products/posthog_ai/backend/test/test_message_routing.py` (42): prewarm equivalence, the activation flip, over-quota, cap behaviour, and a JSON-key-casing regression guarding the cap filter.
- `ee/api/test/test_conversation.py::TestConversationSandboxRoute` (14), `products/tasks/backend/tests/test_api.py` command suite (55), and `products/tasks/backend/tests/test_models.py` (134, `create_and_run` regression) — all green (run with `SANDBOX_PROVIDER=` unset; the devbox sets it to `docker`).
- `ruff` clean; no generated-types drift (no API serializer changed).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8): planned via the repo's plan workflow, then implemented and tested locally. The codebase was already ahead of the source plan's snapshot (`Task.OriginProduct.POSTHOG_AI`, `await_user_message`, the caps, and the row lock all existed), so this is an extraction + generalization rather than greenfield.

Key decisions:
- `warm_run` is the sole creator of the warm run; PostHog AI's first warm births a **runless** Task (via the extracted `Task.create_without_run`) instead of create-and-enrich-a-stub-run — otherwise `warm_run` would idempotently return an un-dispatched stub and never warm it.
- Both the quota gate and the cap live inside `warm_run` so the in-process caller and any future HTTP caller get identical guardrails; they are also pre-checked before the Task is created, so an over-quota/over-cap prewarm never leaves a runless Task the next message can't continue.
- Over-cap prewarm stays a silent best-effort no-op for the fire-and-forget composer trigger (the cap `Throttled` is swallowed); the AI-credit `402` still surfaces.