### PR TITLE
chore(quill-charts): complete TooltipContext mock in DefaultTooltip test

### DIFF
--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.test.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.test.tsx
@@ -9,7 +9,15 @@ const SCALES = { x: () => 0, y: (v: number) => v, yTicks: () => [] }
 const SERIES_DATA: TooltipContext['seriesData'] = [{ series: { key: 'a', label: 'A', data: [] }, value: 19402, color: '#000' }]
 
 function renderTooltip(valueFormatter?: (v: number) => string): void {
-    const ctx: TooltipContext = { label: 'When', seriesData: SERIES_DATA }
+    const ctx: TooltipContext = {
+        dataIndex: 0,
+        label: 'When',
+        seriesData: SERIES_DATA,
+        position: { x: 0, y: 0 },
+        hoverPosition: null,
+        canvasBounds: new DOMRect(),
+        isPinned: false,
+    }
     renderOverlayInChart(<DefaultTooltip {...ctx} valueFormatter={valueFormatter} />, makeOverlayContext(SCALES))
 }
 


### PR DESCRIPTION
## Problem

Frontend typechecking is currently red on `master` (and therefore on every open PR, since PRs are typechecked merged with `master`).

`packages/quill/packages/charts/src/overlays/DefaultTooltip.test.tsx` constructs a `TooltipContext` with only `label` and `seriesData`, but the interface requires `dataIndex`, `position`, `hoverPosition`, `canvasBounds`, and `isPinned`. `tsgo --noEmit` fails with:

```
DefaultTooltip.test.tsx(12,11): error TS2739: Type '{ label: string; seriesData: ... }' is missing the following properties from type 'TooltipContext<unknown>': dataIndex, position, hoverPosition, canvasBounds, isPinned
```

This was introduced by #64229 and is unrelated to any single PR — it blocks the whole repo's typecheck.

## Changes

Fill in the missing required fields on the mock `TooltipContext` in the test. `DefaultTooltip` only reads `label`/`seriesData`/`valueFormatter`, so the rendered output and the existing assertions are unchanged — this only satisfies the type. `canvasBounds` uses `new DOMRect()`, matching existing usage in the package (`useRadialInteraction.ts`).

## How did you test this code?

I'm an agent; I did not test manually. Automated verification I actually ran:

- `pnpm --filter=@posthog/frontend typescript:check` in a freshly-installed worktree. With the fix, `DefaultTooltip.test.tsx` produces no errors; reverting the fix in the same workspace reproduces the exact `TS2739` above. (Other errors in that local run come from unbuilt workspace artifacts — `@posthog/quill-tokens`, kea typegen — which CI builds first; they are unrelated to this change.)

The jest assertions in this file are untouched (the change only widens the mock object), and the frontend jest environment is jsdom, which provides `DOMRect`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of @andehen, who spotted the red Frontend typechecking check while reviewing an unrelated backend PR and asked for a standalone fix once we traced it to this master-wide breakage. Considered narrowing `DefaultTooltipProps` to `Pick<TooltipContext, ...>` instead, but chose to complete the test mock as the smallest, test-only, zero-runtime-risk unblock; the component's prop shape can be revisited separately.
