### PR TITLE
fix(bigquery): treat custom quota exceeded as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -86,6 +86,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # proxy). Authentication can't succeed until the key file is fixed, so retrying just
             # hammers the endpoint and spams error tracking.
             BIGQUERY_TOKEN_RESPONSE_ERROR: "We couldn't authenticate with BigQuery — Google's OAuth token endpoint returned an unexpected response. Please re-upload your service account key file and verify its token_uri.",
+            # Raised as a `Forbidden` (403, reason `quotaExceeded`) when the customer's BigQuery
+            # project hits an administrator-configured custom cost control, e.g. "Custom quota
+            # exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, which is set by
+            # your administrator.". This is a deliberate spend cap on the customer's GCP project,
+            # not a transient limit — retrying within the sync's retry window can't recover it (the
+            # cap resets on Google's daily schedule), so it just hammers the endpoint and spams
+            # error tracking. We match the stable "Custom quota exceeded" wording, which is distinct
+            # from transient rate-limit quota errors ("Quota exceeded: ..." / reason
+            # `rateLimitExceeded`) that must stay retryable.
+            "Custom quota exceeded": "Your BigQuery project hit a custom usage quota set by your administrator (for example QueryUsagePerDay). Raise the custom cost-control quota in Google Cloud, or reduce how much data you're syncing, then re-enable the source.",
         }
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -530,6 +530,34 @@ def test_non_retryable_errors_match_federated_upstream_permission_denied(observe
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Administrator-set custom cost control on the customer's BigQuery project — surfaced as a
+        # `Forbidden` whose str() is "403 Custom quota exceeded: ...".
+        str(
+            Forbidden(
+                "Custom quota exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, "
+                "which is set by your administrator. For more information, see "
+                "https://docs.cloud.google.com/bigquery/cost-controls.; reason: quotaExceeded"
+            )
+        ),
+        # Per-user variant of the same custom cost control.
+        str(
+            Forbidden(
+                "Custom quota exceeded: Your usage exceeded the custom quota for "
+                "QueryUsagePerUserPerDay, which is set by your administrator.; reason: quotaExceeded"
+            )
+        ),
+    ],
+)
+def test_non_retryable_errors_match_custom_quota_exceeded(observed_error):
+    """An administrator-set custom cost control (e.g. QueryUsagePerDay) can't be recovered by
+    retrying within the sync's window — the user must raise the quota or sync less data."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert any(key in observed_error for key in non_retryable_errors)
+
+
+@pytest.mark.parametrize(
     "other_error",
     [
         # Transient server / connection errors must stay retryable
@@ -539,6 +567,11 @@ def test_non_retryable_errors_match_federated_upstream_permission_denied(observe
         # A federated-read failure that isn't a permission problem must stay retryable
         "Error while reading data, error message: Failed to fetch row from PostgreSQL server. "
         "Error: ERROR:  connection to server timed out",
+        # Transient rate-limit quota errors ("Quota exceeded" / `rateLimitExceeded`) are NOT the
+        # administrator-set custom cost control and must stay retryable — the "Custom quota
+        # exceeded" key must not catch them.
+        "403 Quota exceeded: Your project exceeded quota for concurrent queries; reason: quotaExceeded",
+        "403 Exceeded rate limits: too many concurrent queries for this project; reason: rateLimitExceeded",
     ],
 )
 def test_non_retryable_errors_does_not_match_transient(other_error):


### PR DESCRIPTION
## Problem

The BigQuery data-warehouse import source surfaced a recurring error in error tracking: a `Forbidden` (403, `reason: quotaExceeded`) raised while running an `INFORMATION_SCHEMA` discovery query during pipeline build. The message is:

> Custom quota exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, which is set by your administrator.

This is BigQuery's *administrator-configured custom cost control* — a deliberate daily spend cap the customer set on their own GCP project. None of the source's existing `NonRetryableErrors` keys matched it, so the sync retried indefinitely and re-fired the exception into error tracking on every attempt across multiple affected sources.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019ed562-ad4d-73b3-898f-2ceb0d332097

The confirmed call path originates in this source's code:

```
source_for_pipeline (common/sql/base.py)
 └─ build_pipeline (bigquery/bigquery.py)
     └─ _build_source_response (bigquery/bigquery.py)   # primary_keys = _get_primary_keys_for_table(...)
         └─ _get_primary_keys_for_table (bigquery/bigquery.py)   # for row in job.result()
```

## Changes

Added `"Custom quota exceeded"` to `BigQuerySource.get_non_retryable_errors()` with an actionable message telling the user to raise the custom cost-control quota in Google Cloud or reduce how much data they're syncing, then re-enable the source.

**Decision — user/upstream config error, not a fixable bug:** the failure is a deliberate cap on the customer's GCP project. Retrying within the sync's retry window can't recover it (the cap resets on Google's daily schedule), so the right behavior is to stop retrying and surface a clear, actionable message.

**Why the match is safe:** `"Custom quota exceeded"` specifically denotes administrator-set custom cost controls. It is distinct from transient rate-limit quota errors, which are phrased `"Quota exceeded: ..."` / `"Exceeded rate limits: ..."` with `reason: rateLimitExceeded`. Those remain retryable — the new key does not catch them. The match is on stable wording only (no URLs, ids, or job ids).

## How did you test this code?

I'm an agent. I added/extended unit tests at the same layer as the change and ran them — no manual testing was performed.

- New `test_non_retryable_errors_match_custom_quota_exceeded` asserts both the `QueryUsagePerDay` and `QueryUsagePerUserPerDay` forms of the `Forbidden` error are recognised as non-retryable.
- Extended `test_non_retryable_errors_does_not_match_transient` with transient `"Quota exceeded"` / `rateLimitExceeded` messages to guard against false positives.
- Full file passes: `pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py` → 60 passed. `ruff check` / `ruff format --check` clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the BigQuery source. Used the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, exception type, representative event, and that the stack genuinely originates in the source's code. Read the source implementation and the Stripe `get_non_retryable_errors` reference to mirror the established pattern.

Considered whether this was a fixable bug (e.g. avoiding the discovery query) but concluded it's a customer-side cost cap with nothing for us to do but stop retrying. Considered matching the broader 403/`Forbidden`, but chose the narrower `"Custom quota exceeded"` substring to avoid swallowing retryable rate-limit quota errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
