### PR TITLE
test(devex): validate hogbox-preview frontend-build path

### DIFF
--- a/frontend/HOGBOX_PREVIEW_VALIDATION.md
+++ b/frontend/HOGBOX_PREVIEW_VALIDATION.md
@@ -1,0 +1,14 @@
+# Hogbox preview — frontend-build CI path validation
+
+Throwaway marker. It exists only to exercise the `hogbox-preview` workflow's
+frontend branch: `Detect frontend changes` matches any path under `frontend/`,
+so this file forces the FE path in `.github/workflows/hogbox-preview-env.yml`
+to run end-to-end:
+
+- `pnpm --filter=@posthog/frontend... install`
+- `bin/turbo --filter=@posthog/frontend build` + `pnpm build:products`
+- tar `frontend/dist` → hand to the tool via `--frontend-dist`
+- in-box: lay the dist in, re-run `collectstatic`, dual-mount `frontend/dist` + `staticfiles`
+
+This PR is based on `feat/devex/hogbox-preview` and gets closed (branch deleted)
+once the path is green. Tracking: PostHog/posthog#62672.


### PR DESCRIPTION
Throwaway validation PR for the one untested piece of #62672 — the **frontend-build CI path**.

Based on `feat/devex/hogbox-preview` with a single marker file under `frontend/`, so `Detect frontend changes` fires and the workflow runs the FE branch end-to-end (pnpm/turbo build → dist tar → in-box swap + collectstatic + dual-mount). Non-FE path was already green on #62672.

Gets the `hogbox-preview` label to trigger, then closed + branch deleted once green. Doubles as a live teardown check (label-removal + close). Not for merge.