### PR TITLE
feat(cdp-cyclotron): add migrations for email fair-dequeue

### DIFF
--- a/rust/cyclotron-node-migrations/20260616000001_add_email_fair_dequeue_columns.sql
+++ b/rust/cyclotron-node-migrations/20260616000001_add_email_fair_dequeue_columns.sql
@@ -1,0 +1,23 @@
+-- Fair dequeue for the email queue, scoped to queue_name='email'.
+--
+-- `dequeue_seq` is a precomputed sort key assigned at insert time so the
+-- email worker's dequeue ORDER BY stays cheap (no window functions, no
+-- recursive CTEs). It interleaves jobs across tenants: each tenant's first
+-- job sorts together, then each tenant's second job, etc. A new tenant's
+-- single email no longer waits behind another tenant's 2M-email campaign.
+--
+-- The column is NULL for non-email jobs — completely transparent to the
+-- hog/hogflow worker paths.
+ALTER TABLE cyclotron_jobs
+    ADD COLUMN IF NOT EXISTS dequeue_seq BIGINT;
+
+-- Per-team monotonic counter, used to compute dequeue_seq at insert time:
+--     dequeue_seq = counter × 16,777,216 + team_id
+--
+-- One row per team that has ever sent an email. BIGINT gives ~5 × 10^11
+-- jobs per team of headroom before sort_number overflow at the chosen
+-- block size (decades at any realistic email volume).
+CREATE TABLE IF NOT EXISTS cyclotron_email_team_seq (
+    team_id INT PRIMARY KEY,
+    counter BIGINT NOT NULL
+);

--- a/rust/cyclotron-node-migrations/20260616000002_add_email_fair_dequeue_index.sql
+++ b/rust/cyclotron-node-migrations/20260616000002_add_email_fair_dequeue_index.sql
@@ -1,0 +1,14 @@
+-- no-transaction
+--
+-- Partial index supporting the email worker's fair dequeue ORDER BY.
+-- Tight predicate: only covers email rows that are actually dequeueable.
+-- Hog, hogflow, and any future queues never touch this index — their
+-- dequeue continues to use idx_cyclotron_jobs_dequeue as before.
+--
+-- `NULLS FIRST` matches the worker's `ORDER BY dequeue_seq ASC NULLS FIRST`
+-- in `fairDequeueJobs`. Without aligning the index sort to the query, the
+-- planner can't use the index to satisfy the ORDER BY and falls back to a
+-- full sort of the available set on every dequeue.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_email_fair_dequeue
+    ON cyclotron_jobs (dequeue_seq NULLS FIRST)
+    WHERE status = 'available' AND queue_name = 'email';


### PR DESCRIPTION
## Problem

Splitting the schema for the [email fair-dequeue work](https://github.com/PostHog/posthog/pull/63909) out of the code PR so it can ship and deploy on its own. Per our convention, migrations roll out first; code that depends on them rolls out only after the schema is live everywhere.

Code PR with the consumer: #63909.

## Changes

Two migrations, both targeted at the email queue only. Hog, hogflow, and any future v2 queue are completely unaffected.

**`20260616000001_add_email_fair_dequeue_columns.sql`** — one transaction, both fast:

- `ALTER TABLE cyclotron_jobs ADD COLUMN IF NOT EXISTS dequeue_seq BIGINT` — nullable, no default, no backfill needed. Older code (today's code) that doesn't know about this column ignores it. The follow-up PR populates it at insert time for email jobs only.
- `CREATE TABLE IF NOT EXISTS cyclotron_email_team_seq (team_id INT PRIMARY KEY, counter BIGINT NOT NULL)` — per-team monotonic counter used to compute `dequeue_seq = counter × 16,777,216 + team_id`. One row per team that has ever sent an email. Empty until the consumer PR starts writing to it.

**`20260616000002_add_email_fair_dequeue_index.sql`** — built `CONCURRENTLY` (no-transaction header), partial predicate:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_email_fair_dequeue
    ON cyclotron_jobs (dequeue_seq NULLS FIRST)
    WHERE status = 'available' AND queue_name = 'email';
```

- `NULLS FIRST` matches the consumer's `ORDER BY dequeue_seq ASC NULLS FIRST` in the fair-dequeue path. Without aligning the index sort to the query, the planner can't use the index for the sort and falls back to a full sort of the available set on every dequeue.
- Predicate is tight: only email rows currently dequeueable enter the index, so it stays small no matter how many billions of completed rows accumulate. Non-email rows never touch it.

## How did you test this code?

Local schema applies cleanly against the test cyclotron-node database. The consumer PR (#63909) runs against this schema and has 79 / 79 tests passing.

Did not test on a multi-billion-row prod table — that's a deploy-time concern. Design is non-blocking:

- Adding a nullable column with no default and no backfill: O(milliseconds), no table rewrite, no row-level lock.
- Creating the helper table: trivial, empty.
- The index is `CONCURRENTLY`, so it doesn't take an `ACCESS EXCLUSIVE` lock — writes keep flowing during the build.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #63909 mid-review at the user's request — we can't ship migrations and code in the same PR. The migrations are forward-compatible with the current code (nullable column, empty helper table, partial index), so this PR is safe to merge ahead of the consumer.

Tools: Claude Code (Opus 4.7).