### PR TITLE
fix(experiments): eliminate N+1 queries in experiment list endpoint

### DIFF
--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -253,8 +253,12 @@ class EnterpriseExperimentsViewSet(
                 queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
             ),
             Prefetch(
+                # order_by("id") keeps saved metrics in insertion order — select_related below adds
+                # joins that would otherwise leave the row order unspecified.
                 "experimenttosavedmetric_set",
-                queryset=ExperimentToSavedMetric.objects.select_related("saved_metric", "experiment__team"),
+                queryset=ExperimentToSavedMetric.objects.select_related("saved_metric", "experiment__team").order_by(
+                    "id"
+                ),
             ),
         )
         .all()

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -45,6 +45,7 @@ from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricsRecalculation,
     ExperimentTimeseriesRecalculation,
+    ExperimentToSavedMetric,
     experiment_has_legacy_metrics,
 )
 from products.experiments.backend.presentation.serializers import (
@@ -238,17 +239,26 @@ class EnterpriseExperimentsViewSet(
 ):
     scope_object: Literal["experiment"] = "experiment"
     serializer_class = ExperimentSerializer
-    queryset = Experiment.objects.prefetch_related(
-        Prefetch(
-            "feature_flag__flag_evaluation_contexts",
-            queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
-        ),
-        "feature_flag",
-        "created_by",
-        "holdout",
-        "experimenttosavedmetric_set",
-        "saved_metrics",
-    ).all()
+    queryset = (
+        Experiment.objects.select_related(
+            "team",
+            "feature_flag",
+            "created_by",
+            "exposure_cohort",
+            "holdout__created_by",
+        )
+        .prefetch_related(
+            Prefetch(
+                "feature_flag__flag_evaluation_contexts",
+                queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
+            ),
+            Prefetch(
+                "experimenttosavedmetric_set",
+                queryset=ExperimentToSavedMetric.objects.select_related("saved_metric", "experiment__team"),
+            ),
+        )
+        .all()
+    )
     ordering = "-created_at"
 
     def safely_get_queryset(self, queryset) -> QuerySet:

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -6,6 +6,8 @@ from posthog.test.base import ClickhouseTestMixin, FuzzyInt, _create_event, _cre
 from unittest.mock import ANY, MagicMock, patch
 
 from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from dateutil import parser
 from parameterized import parameterized
@@ -28,6 +30,7 @@ from products.experiments.backend.models.experiment import (
 )
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 from products.experiments.backend.models.web_experiment import WebExperiment
+from products.feature_flags.backend.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag, get_feature_flags_for_team_in_cache
 
 from ee.api.test.base import APILicensedTest
@@ -282,7 +285,7 @@ class TestExperimentCRUD(APILicensedTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(FuzzyInt(18, 22)):
+        with self.assertNumQueries(FuzzyInt(13, 17)):
             response = self.client.get(f"/api/projects/{self.team.id}/experiments")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -299,9 +302,70 @@ class TestExperimentCRUD(APILicensedTest):
                 format="json",
             ).json()
 
-        with self.assertNumQueries(FuzzyInt(18, 22)):
+        with self.assertNumQueries(FuzzyInt(13, 17)):
             response = self.client.get(f"/api/projects/{self.team.id}/experiments")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def _create_fully_populated_experiment(self, index: int) -> Experiment:
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key=f"populated-flag-{index}",
+            created_by=self.user,
+        )
+        context = EvaluationContext.objects.create(team=self.team, name=f"context-{index}")
+        FeatureFlagEvaluationContext.objects.create(feature_flag=flag, evaluation_context=context)
+
+        holdout = ExperimentHoldout.objects.create(
+            team=self.team,
+            name=f"Holdout {index}",
+            created_by=self.user,
+            filters=[{"properties": [], "rollout_percentage": 10, "variant": f"holdout-{index}"}],
+        )
+        cohort = Cohort.objects.create(team=self.team, name=f"Cohort {index}")
+
+        experiment = Experiment.objects.create(
+            team=self.team,
+            name=f"Populated experiment {index}",
+            feature_flag=flag,
+            holdout=holdout,
+            exposure_cohort=cohort,
+            created_by=self.user,
+            start_date=datetime(2021, 12, 1, 10, 23, tzinfo=UTC),
+        )
+
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name=f"Saved metric {index}",
+            created_by=self.user,
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "$pageview"},
+            },
+        )
+        ExperimentToSavedMetric.objects.create(experiment=experiment, saved_metric=saved_metric)
+        return experiment
+
+    def test_listing_experiments_with_related_objects_is_not_nplus1(self) -> None:
+        # Each experiment carries a feature flag (+ evaluation context), a holdout (+ created_by),
+        # an exposure cohort, and a saved metric — the relations that previously triggered N+1 queries.
+        self._create_fully_populated_experiment(0)
+
+        with CaptureQueriesContext(connection) as single_row:
+            response = self.client.get(f"/api/projects/{self.team.id}/experiments")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["count"], 1)
+
+        for i in range(1, 5):
+            self._create_fully_populated_experiment(i)
+
+        with CaptureQueriesContext(connection) as five_rows:
+            response = self.client.get(f"/api/projects/{self.team.id}/experiments")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["count"], 5)
+
+        # Query count must stay flat as rows grow — five experiments must not cost more than one.
+        self.assertLessEqual(len(five_rows.captured_queries), len(single_row.captured_queries))
 
     def test_creating_updating_basic_experiment(self):
         ff_key = "a-b-tests"


### PR DESCRIPTION
## Problem

The experiment list view (`GET /api/projects/:id/experiments`) feels slow in production. The endpoint reuses the full `ExperimentSerializer` for every row at a page size of 100, and several related fields were never joined — each one triggered a separate query *per row*, so query count grew linearly with the number of experiments on the page.

## Changes

Reworked the `EnterpriseExperimentsViewSet` queryset so all related data is fetched up front instead of lazily per row:

- `select_related` the single-valued FKs the serializer touches: `team`, `feature_flag`, `created_by`, `exposure_cohort`, and `holdout__created_by`.
- Tightened the saved-metric through-set prefetch with `select_related("saved_metric", "experiment__team")`, so the nested `ExperimentToSavedMetricSerializer` (which reads `instance.saved_metric.*` and `instance.experiment.team`) resolves from cache.
- Removed the redundant bare `"feature_flag"` prefetch (it duplicated the nested evaluation-context `Prefetch` and risked clobbering its cache) and the unused `"saved_metrics"` M2M prefetch (serialization goes through `experimenttosavedmetric_set`).

No serializer changes — the response payload is byte-for-byte identical; only the fetching strategy changed. In tests this also lowered the per-request count for the existing list test (~18–22 → ~15 queries).

Out of scope, left as follow-ups: a lightweight list-only serializer (the list view doesn't render metric contents, yet `refresh_action_names_in_metric` still runs an `Action` lookup per metric per row), and frontend cleanups (multiple API calls on mount, redundant client-sort + server-refetch on column sort).

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing:

- Added `test_listing_experiments_with_related_objects_is_not_nplus1`, which creates experiments fully populated with the previously un-joined relations (feature flag + evaluation context, holdout + created_by, exposure cohort, saved metric) and asserts that 5 experiments cost no more queries than 1. The pre-existing N+1 test only used bare experiments, so it never exercised these paths.
- Updated the existing `test_getting_experiments_is_not_nplus1` query-count range to reflect the reduced count.
- Ran the list/serialization/N+1 subset of `TestExperimentCRUD` (25 tests) — all pass. Ruff + type check clean via pre-commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). The human asked me to inspect the experiment list view for performance smells; I explored the backend serializer/viewset and frontend logic, identified the N+1 sources, and we scoped the fix to the low-risk ORM-level joins only (keeping the payload identical) rather than the larger list-serializer split. The N+1 regression test captures actual query counts with `CaptureQueriesContext` and asserts the count doesn't grow with row count, which tolerates the small request-overhead variance that an exact-count assertion would not.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
