### PR TITLE
feat(experiments): double canary metric sample per run

### DIFF
--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -61,11 +61,11 @@ class ExperimentPrecomputeCanaryInputs:
 
     experiment_id: int | None = None
     metric_uuids: list[str] | None = None
-    funnel_quota: int = 6
-    mean_quota: int = 3
-    ratio_quota: int = 2
+    funnel_quota: int = 12
+    mean_quota: int = 6
+    ratio_quota: int = 4
     per_experiment_cap: int = 3
-    time_budget_seconds: int = 3600
+    time_budget_seconds: int = 5400
     triggered_manually: bool = False
 
 


### PR DESCRIPTION
## Problem

The experiment precompute canary samples ~11 metrics per daily run (6 funnels / 3 means / 2 ratios). Coverage of query-shape-specific cache issues accumulates only as fast as the sample size, so doubling the per-run sample roughly halves the time to sweep the eligible population.

## Changes

Doubled the default per-run quotas in `ExperimentPrecomputeCanaryInputs`: funnel 6→12, mean 3→6, ratio 2→4 (~11 → ~22 metrics). Raised `time_budget_seconds` 3600→5400 so the larger sample isn't truncated by the wall-clock cap before it finishes; the daily SKIP-overlap schedule leaves ample headroom.

`per_experiment_cap` is unchanged (3), so the extra quota spreads across more experiments rather than deeper into the same ones — more team/shape diversity per run.

## How did you test this code?

Agent-authored. Ran the canary unit + workflow tests (`test_canary_logic.py`, `test_canary_workflow.py`) — 45 pass; ruff clean. The existing sampling tests pass explicit quotas, so they're unaffected by the default change. No behavior change beyond the constants.

Note: the running schedule serializes its inputs at registration time, so this takes effect only after the schedule is re-registered post-deploy (`schedule_temporal_workflows`, which updates the existing schedule).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by the Experiments team lead: increase the canary's per-run metric sample to roughly double. Implemented as a quota-default change plus a proportional time-budget bump to avoid the cap silently undoing the increase. Branch cut against current master; change is a 4-line edit to the inputs dataclass defaults.
