### PR TITLE
fix(quill): refine button, menu, and combobox interaction styling

### DIFF
--- a/packages/quill/apps/storybook/.storybook/preview.tsx
+++ b/packages/quill/apps/storybook/.storybook/preview.tsx
@@ -82,6 +82,7 @@ const preview: Preview = {
 
             useEffect(() => {
                 document.body.classList.toggle('is-desktop', isDesktop)
+                return () => document.body.classList.remove('is-desktop')
             }, [isDesktop])
 
             return <Story />

--- a/packages/quill/apps/storybook/.storybook/preview.tsx
+++ b/packages/quill/apps/storybook/.storybook/preview.tsx
@@ -23,6 +23,21 @@ function ThemedDocsContainer(props: React.ComponentProps<typeof DocsContainer>):
 }
 
 const preview: Preview = {
+    globalTypes: {
+        desktop: {
+            name: 'Desktop mode',
+            description: 'Toggle the Electron desktop app surface (adds `is-desktop` to <body>)',
+            defaultValue: 'web',
+            toolbar: {
+                icon: 'browser',
+                items: [
+                    { value: 'web', icon: 'browser', title: 'Web (pointer cursor)' },
+                    { value: 'desktop', icon: 'box', title: 'Desktop (default cursor)' },
+                ],
+                dynamicTitle: true,
+            },
+        },
+    },
     parameters: {
         controls: {
             matchers: {
@@ -59,6 +74,18 @@ const preview: Preview = {
         },
     },
     decorators: [
+        // Mirrors the `desktop` toolbar global onto `<body class="is-desktop">`,
+        // matching how the Electron app tags its shell — lets the cursor reset
+        // (and any future desktop-only styling) be previewed live.
+        (Story, context) => {
+            const isDesktop = context.globals.desktop === 'desktop'
+
+            useEffect(() => {
+                document.body.classList.toggle('is-desktop', isDesktop)
+            }, [isDesktop])
+
+            return <Story />
+        },
         // Hooks must run at the decorator's top level — Storybook's preview
         // hooks context (which `useDarkMode` relies on) is only active here,
         // not inside nested components a decorator renders. Syncs the signal to

--- a/packages/quill/packages/primitives/src/button.css
+++ b/packages/quill/packages/primitives/src/button.css
@@ -161,11 +161,7 @@
 
     .quill-button--variant-outline:not(:disabled):hover {
         color: var(--foreground);
-        background-color: color-mix(in oklab, var(--muted) 50%, transparent);
-    }
-
-    :is(.dark, [theme='dark']) .quill-button--variant-outline:not(:disabled):hover {
-        color: var(--foreground);
+        background-color: var(--fill-hover);
     }
 
     .quill-button--variant-outline[aria-expanded='true'] {

--- a/packages/quill/packages/primitives/src/combobox.css
+++ b/packages/quill/packages/primitives/src/combobox.css
@@ -116,7 +116,7 @@
     }
 
     .quill-combobox__item {
-        /* The check indicator is absolutely positioned (end-2) and must anchor
+        /* The check indicator is absolutely positioned (start-2) and must anchor
            to the item, not the scrolling popup. */
         position: relative;
         width: 100%;
@@ -126,6 +126,18 @@
     .quill-combobox__item[data-disabled] {
         pointer-events: none;
         opacity: 0.5;
+    }
+
+    /*
+     * No focus ring on options — the `[data-highlighted]` background fill is the
+     * sole active indicator (combobox uses virtual focus: the input keeps focus,
+     * so options never get `:focus-visible`). Suppress every ring Button can
+     * paint on an option. Scoped under `.quill-combobox__content` so the (0,4,0)
+     * specificity outranks Button's base rules regardless of stylesheet order.
+     */
+    .quill-combobox__content .quill-button--variant-default:is([data-highlighted], :focus-visible) {
+        border-color: transparent;
+        box-shadow: none;
     }
 
     .quill-combobox__item:not([data-variant='destructive'])[data-highlighted] * {

--- a/packages/quill/packages/primitives/src/combobox.tsx
+++ b/packages/quill/packages/primitives/src/combobox.tsx
@@ -162,19 +162,14 @@ function ComboboxItem({
     return (
         <ComboboxPrimitive.Item
             data-slot="combobox-item"
-            className={cn('quill-combobox__item', className)}
+            className={cn('quill-combobox__item quill-menu-item--inset', className)}
             title={title ?? (typeof children === 'string' ? children : undefined)}
-            render={
-                <Button
-                    left
-                    className="min-w-0 aria-selected:pe-7 aria-selected:bg-fill-selected data-highlighted:border-ring data-highlighted:ring-2 data-highlighted:ring-ring/30 ring-offset-1"
-                />
-            }
+            render={<Button left className="min-w-0 aria-selected:bg-fill-selected" />}
             {...props}
         >
             <span className="flex items-center gap-1.5 min-w-0 truncate">{children}</span>
             <ComboboxPrimitive.ItemIndicator
-                render={<span className="pointer-events-none absolute end-2 flex items-center justify-center" />}
+                render={<span className="pointer-events-none absolute start-2 flex items-center justify-center" />}
             >
                 <CheckIcon className="pointer-events-none" />
             </ComboboxPrimitive.ItemIndicator>

--- a/packages/quill/packages/primitives/src/menu.css
+++ b/packages/quill/packages/primitives/src/menu.css
@@ -134,6 +134,20 @@
         border-top-right-radius: 0;
     }
 
+    /*
+     * Menu items show no focus ring — the `[data-highlighted]` background fill
+     * is the sole active-item indicator for both mouse and keyboard. Suppress
+     * both the `data-highlighted` ring and the `:focus-visible` ring Button
+     * carries. (Hover never paints a ring, so `:not(:hover)` only serves to
+     * outrank Button's `[data-highlighted]:not(:hover)` rule regardless of
+     * stylesheet order.)
+     */
+    :is(.quill-menu__content, .quill-menu__sub-content)
+        .quill-button--variant-default:is([data-highlighted], :focus-visible):not(:hover) {
+        border-color: transparent;
+        box-shadow: none;
+    }
+
     /* Menubar root */
     .quill-menubar {
         height: 2.25rem;

--- a/packages/quill/packages/primitives/src/styles/layers.css
+++ b/packages/quill/packages/primitives/src/styles/layers.css
@@ -73,6 +73,28 @@
 }
 
 /*
+ * Desktop-app cursor reset.
+ *
+ * On the web a pointer cursor signals "clickable"; in the Electron desktop app
+ * native chrome uses the default arrow, so the pointer reads as a web tell.
+ * Consumers tag <body class="is-desktop"> to opt every interactive primitive
+ * back to the arrow. Each selector mirrors a `cursor: pointer` rule in the
+ * component CSS. These rules are unlayered, so they beat the component rules
+ * inside `@layer components` by layer precedence (unlayered > layered),
+ * independent of specificity or import order.
+ *
+ * Add a row here whenever a new primitive sets `cursor: pointer`.
+ */
+body.is-desktop .quill-button,
+body.is-desktop .quill-toggle,
+body.is-desktop .quill-accordion__trigger,
+body.is-desktop .quill-checkbox:not(:disabled),
+body.is-desktop .quill-field__label:has(> [data-slot='field']),
+body.is-desktop .group\/field:has(> [role='checkbox']) .quill-label {
+    cursor: default;
+}
+
+/*
  * Tailwind v4 emits `@keyframes` from `@theme` only when the corresponding
  * `animate-*` utility is statically used in JSX. BEM CSS references these
  * animations via `var(--animate-*)`, which the scanner can't detect, so we


### PR DESCRIPTION
## Problem

A few interaction-styling regressions and rough edges accumulated in the quill primitives:

- The `outline` button lost its visible hover background. A token cleanup swapped `--accent` → `--muted` for both rest and hover fills, and since `--muted` is a near-gray ≈ the surface, `muted 50%` over `muted 30%` was imperceptible.
- The desktop (Electron) app surfaces quill components, where the web `cursor: pointer` reads as a web tell — native chrome uses the default arrow.
- Menu/dropdown and combobox options painted a focus ring on `data-highlighted`. Base UI keeps the last item highlighted after the pointer leaves it, so a mouse-driven menu left a stray ring under the cursor's last row.
- The combobox check indicator sat on the right, not matching checkbox/radio menu-item spacing.

## Changes

- **Outline button hover** — restored via the theme-aware `--fill-hover` token (a foreground overlay that stays visible on any surface), matching the `default` variant and the outline's own expanded state.
- **Desktop cursor reset** — `body.is-desktop` flips interactive primitives (button, toggle, accordion trigger, checkbox, field/label rows) from pointer to the default arrow. Centralized in `layers.css` (unlayered, so it beats the `@layer components` rules) with a note to extend it when a new primitive sets `cursor: pointer`. Consumers tag `<body class="is-desktop">`.
- **Focus ring removal on options** — the `data-highlighted` background fill is now the sole active-item indicator for both menus and comboboxes. Menus use real roving DOM focus (so keyboard focus would still ring via `:focus-visible` if wanted, but per design it's suppressed too); comboboxes use virtual focus (the input keeps focus, options never get `:focus-visible`), so the ring is suppressed at the `.quill-combobox__content` scope.
- **Combobox check on the left** — indicator moved to `start-2` with the left column reserved via the same `quill-menu-item--inset` class checkbox/radio use, replacing the old conditional right pad.
- **Storybook** — added a toolbar toggle to preview desktop cursor mode (`is-desktop` on `<body>`), next to the existing dark-mode toggle.

Autocomplete still carries its own focus ring; left as-is intentionally pending a follow-up decision.

## How did you test this code?

I'm an agent (Claude Opus 4.8). I did not run an automated test suite for this change — it's CSS/markup-only styling in the quill primitives with no existing unit coverage for these rules. Verification was visual, in storybook, by the human driver across the affected stories (outline button hover, dropdown/menu highlight, combobox options + check alignment, desktop cursor toggle).

## Docs update

No product docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The human drove iteratively in storybook, pointing at specific components via screenshots; the agent diagnosed each via git history / token definitions / Base UI internals and applied minimal, convention-matching CSS.

Key decisions:
- Outline hover uses `--fill-hover` rather than re-introducing a fixed muted alpha — the token comment explicitly warns fixed grays vanish on `bg-muted`.
- Desktop cursor centralized in `layers.css` (unlayered) rather than scattered per component, for one greppable source of truth that wins by cascade-layer precedence.
- Combobox ring suppression scoped to the `.quill-combobox__content` ancestor (not a compound selector on the option element) because Base UI renders the highlight wrapper and the styled button as separate elements — an earlier same-element selector missed.
