### PR TITLE
fix(postgres): scope statement_timeout for schema discovery query

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -78,6 +78,15 @@ SYSTEM_POSTGRES_SCHEMAS = ["information_schema", "pg_catalog", "pg_toast"]
 # default statement_timeout on the source role.
 SYNC_STATEMENT_TIMEOUT_MS = 1000 * 60 * 10  # 10 mins
 
+# Statement timeout scoped to the schema-discovery metadata query in `_get_table`.
+# `information_schema.columns` computes `numeric_precision`/`numeric_scale` via the per-column
+# `_pg_numeric_*` SQL functions, which can be slow on large catalogs. The setup connection has no
+# statement_timeout we control until `postgres_source` sets one *after* `_get_table` returns, so
+# the query would otherwise inherit whatever (possibly very short) default the source role/server
+# imposes and get cancelled mid-discovery. Scope a generous-but-bounded budget so a too-short
+# default can't kill it.
+METADATA_STATEMENT_TIMEOUT_MS = 1000 * 60 * 10  # 10 mins
+
 # How many times the metadata-gathering phase reconnects and retries when a hot-standby
 # recovery conflict terminates the setup connection. Past this the conflict is treated as
 # sustained and surfaced as the non-retryable "successive SerializationFailure errors" abort.
@@ -1874,10 +1883,25 @@ def _get_table(
 
     _explain_query(cursor, query, logger)
     logger.debug(f"Running query: {query.as_string()}")
-    cursor.execute(query)
+    # Scope a generous statement_timeout to the schema-discovery query. On regular tables it reads
+    # `information_schema.columns`, whose `numeric_precision`/`numeric_scale` columns invoke the
+    # per-column `_pg_numeric_*` SQL functions — slow enough on large catalogs that a short
+    # role/server default `statement_timeout` (some hosted/pooled Postgres set one) cancels the
+    # query with QueryCanceled before discovery finishes. The outer 10-minute setup timeout isn't
+    # set until `postgres_source` continues after `_get_table` returns, so without this the query
+    # inherits that short default. Own transaction so the `SET LOCAL` scopes to this query and
+    # auto-resets (the connection is autocommit, so this is a self-contained BEGIN/COMMIT) without
+    # leaking onto the numeric probe below, which deliberately bounds itself tighter.
+    with cursor.connection.transaction():
+        cursor.execute(
+            sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
+                timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS)
+            )
+        )
+        cursor.execute(query)
+        metadata_rows = cursor.fetchall()
 
     numeric_data_types = {"numeric", "decimal"}
-    metadata_rows = cursor.fetchall()
 
     # For unconstrained numeric columns (declared as `numeric` with no precision/scale),
     # postgres returns NULL for numeric_precision/numeric_scale in information_schema. Falling

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -42,6 +42,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _MAX_SETUP_CONNECTION_DROPPED_RETRIES,
     _MAX_SETUP_RECOVERY_CONFLICT_RETRIES,
     FORCE_UTF8_CLIENT_ENCODING,
+    METADATA_STATEMENT_TIMEOUT_MS,
     SSL_REQUIRED_AFTER_DATE,
     JsonAsStringLoader,
     PostgresDiscoveredSchema,
@@ -2814,7 +2815,55 @@ class TestIsReadReplica:
             assert result is False
 
 
+class _RecordingCursor:
+    """Wraps a real cursor, recording executed SQL as text while delegating everything else."""
+
+    def __init__(self, inner: Any):
+        self._inner = inner
+        self.executed: list[str] = []
+
+    def execute(self, query: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            self.executed.append(query.as_string())
+        except Exception:
+            self.executed.append(str(query))
+        return self._inner.execute(query, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
 class TestGetTable:
+    @pytest.mark.django_db
+    def test_schema_discovery_query_runs_under_scoped_statement_timeout(self):
+        """The `information_schema.columns` metadata query is wrapped in its own transaction that
+        first issues a `SET LOCAL statement_timeout`, so a short role/server default can't cancel
+        it mid-discovery — the QueryCanceled on `_pg_numeric_scale` we observed against pooled
+        Postgres. Pin that the timeout is scoped immediately before the query it protects."""
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute(
+                "CREATE TABLE test_get_table_timeout_scope (id INTEGER PRIMARY KEY, amount NUMERIC(10, 2))"
+            )
+            spy = _RecordingCursor(dj_cursor)
+            table = _get_table(cast(Any, spy), "public", "test_get_table_timeout_scope", logger)
+
+            # Real execution still succeeds and returns the expected columns.
+            assert {c.name for c in table.columns} >= {"id", "amount"}
+
+            set_local_idx = next(
+                i
+                for i, q in enumerate(spy.executed)
+                if "SET LOCAL" in q and "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
+            )
+            # The metadata SELECT (not the best-effort EXPLAIN that precedes it) must run directly
+            # after the SET LOCAL, inside the same transaction.
+            info_schema_idx = next(
+                i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
+            )
+            assert info_schema_idx == set_local_idx + 1
+
     @pytest.mark.django_db
     def test_regular_table(self):
         logger = structlog.get_logger()


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports were failing during schema discovery with:

```
QueryCanceled: canceling statement due to statement timeout
CONTEXT:  SQL function "_pg_numeric_scale" statement 1
```

Surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019ed595-ba05-7410-bf03-572d3aaa8ac0

The failure originates in `posthog/temporal/data_imports/sources/postgres/postgres.py::_get_table`. For regular tables it reads `information_schema.columns`, whose `numeric_precision`/`numeric_scale` columns are computed by Postgres via the per-column internal `_pg_numeric_*` SQL functions. On large catalogs that view is slow enough that a short role/server default `statement_timeout` — common on pooled/hosted Postgres — cancels the query before discovery finishes.

The setup connection has no `statement_timeout` we control until `postgres_source` sets a 10-minute budget *after* `_get_table` returns, so the metadata query inherited whatever (possibly very short) default the source imposed. The unconstrained-numeric probe a few lines down already documented and self-protected against this exact gap; the main metadata query was left exposed.

## Changes

Wrap the schema-discovery metadata query in its own transaction with a generous, bounded `SET LOCAL statement_timeout` (`METADATA_STATEMENT_TIMEOUT_MS`, 10 min), mirroring the existing numeric-probe pattern. A too-short inherited default can no longer cancel it, and the timeout is transaction-scoped so it doesn't leak onto the probe (which deliberately bounds itself tighter).

This is treated as a fixable bug rather than a non-retryable error: a statement timeout is a transient/infrastructure-class condition that can arise in many code paths (row streaming, probes, counts), so adding `QueryCanceled` to `NonRetryableErrors` would dangerously swallow real timeouts elsewhere. The right fix is to stop the schema query from inheriting an uncontrolled, too-short timeout.

## How did you test this code?

I'm an agent. I added an automated regression test (`TestGetTable::test_schema_discovery_query_runs_under_scoped_statement_timeout`) that wraps a real cursor in a recording spy and asserts the metadata `SELECT` runs immediately after a scoped `SET LOCAL statement_timeout`, while real execution still returns the expected columns. These `_get_table` tests require a live Postgres and run in CI; I could not execute them in my sandbox (no Postgres server available), but I verified the module imports, ran the non-DB test classes in the same file, and confirmed `ruff check`/`ruff format` are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Postgres warehouse source. Pulled the issue and a representative event via the PostHog error-tracking MCP tools, confirmed the failing frame was `postgres.py::_get_table` (the `information_schema.columns` query at the `_pg_numeric_scale` step), and traced the call path from `postgres_source`.

Decision: user/upstream vs. fixable bug. Rejected extending `NonRetryableErrors` — a statement timeout is transient/infra-class and shared across many query paths, so matching `QueryCanceled` there would mask genuine retryable failures. Chose the code fix: scope a controlled `statement_timeout` to the schema query so a short inherited default can't kill it, reusing the transaction + `SET LOCAL` pattern already present for the numeric probe.