### PR TITLE
chore(docs): clarify skills disclosure in agent PR context

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,6 +47,7 @@
 
 <!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
      - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
+     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
      - decisions made along the way (what was tried, rejected, chosen, and why)
      - anything else that helps reviewers
      Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.


### PR DESCRIPTION
## Problem

The PR template's "Agent context" section didn't explicitly require agents to disclose which repo-provided or public skills were invoked during PR generation. This makes it harder for reviewers to understand how the code was shaped by agent tooling.

## Changes

Updated `.github/pull_request_template.md` to add a new bullet point requiring agents to explicitly call out any skills (e.g. `/django-migrations`, `/improving-drf-endpoints`) that were invoked while producing the PR. This helps reviewers assess the influence of agent tools on the final code.

## How did you test this code?

N/A — documentation-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is a documentation update to the PR template itself, clarifying expectations for future agent-authored PRs. No code changes or automated tests apply.

https://claude.ai/code/session_01DihQKyp2nhxXMQFazHPWHs