### PR TITLE
feat(flags): add rollout summary to flag status endpoint

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -6,6 +6,7 @@ import json
 import math
 import logging
 import functools
+from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
 
@@ -2107,9 +2108,48 @@ class EvaluationReasonsResponseSerializer(serializers.Serializer):
     pass
 
 
+class FeatureFlagRolloutSummarySerializer(serializers.Serializer):
+    effectively_full_rollout = serializers.BooleanField(
+        help_text=(
+            "True if the flag is effectively rolled out to everyone, independent of recent evaluation. "
+            "For boolean flags this means at least one release condition targets 100% with no property "
+            "filters (or there are no release conditions); for multivariate flags it means a single variant "
+            "is served to 100% via a fully rolled out release condition. This is the signal for "
+            "'fully rolled out' / GA — unlike `status`, which only reflects recent evaluation."
+        )
+    )
+    has_targeting_conditions = serializers.BooleanField(
+        help_text=(
+            "True if any release condition has property filters, i.e. the flag is conditionally targeted "
+            "rather than a blanket rollout. When true, `max_rollout_percentage` is a percentage within the "
+            "targeted segment, not of the whole user base."
+        )
+    )
+    max_rollout_percentage = serializers.IntegerField(
+        allow_null=True,
+        help_text=(
+            "Highest rollout percentage (0-100) across the flag's release conditions, treating a missing "
+            "percentage as 100. Null when the flag has no release conditions. Interpret together with "
+            "`has_targeting_conditions`."
+        ),
+    )
+    is_multivariate = serializers.BooleanField(
+        help_text="True if the flag serves multiple variants (has a multivariate variant set)."
+    )
+
+
 class FeatureFlagStatusResponseSerializer(serializers.Serializer):
-    status = serializers.CharField(help_text="Flag status: active, stale, deleted, or unknown")
+    status = serializers.CharField(
+        help_text=(
+            "Flag staleness/evaluation status: active, stale, deleted, or unknown. 'active' means the flag "
+            "was recently evaluated (or has no usage data yet) — it does NOT mean the flag is fully rolled "
+            "out. Use the `rollout` object to determine rollout completeness."
+        )
+    )
     reason = serializers.CharField(help_text="Human-readable explanation of the status")
+    rollout = FeatureFlagRolloutSummarySerializer(
+        help_text="Summary of the flag's rollout configuration, for determining whether it is fully rolled out."
+    )
 
 
 class DependentFlagSerializer(serializers.Serializer):
@@ -3502,9 +3542,10 @@ class FeatureFlagViewSet(
             feature_flag=feature_flag,
         )
         flag_status, reason = checker.get_status()
+        rollout = checker.get_rollout_summary(feature_flag)
 
         return Response(
-            {"status": flag_status, "reason": reason},
+            {"status": flag_status, "reason": reason, "rollout": asdict(rollout)},
             status=status.HTTP_200_OK,
         )
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -381,22 +381,22 @@ def find_dependent_flags_batch(
 def _get_flag_rollout_info(flag: FeatureFlag, checker: FeatureFlagStatusChecker) -> dict[str, Any]:
     """Compute rollout state for a flag to include in bulk delete response.
 
-    Returns a dict with:
+    Thin adapter over ``FeatureFlagStatusChecker.get_rollout_summary`` so the
+    "fully rolled out" determination has a single source of truth. Maps the
+    summary to the bulk-delete vocabulary:
       - rollout_state: "fully_rolled_out", "not_rolled_out", or "partial"
       - active_variant: variant key if a multivariate flag is fully rolled out to one variant
     """
-    multivariate = flag.filters.get("multivariate", None)
+    summary = checker.get_rollout_summary(flag)
 
-    if multivariate:
-        is_fully_rolled_out, variant_key = checker.is_multivariate_flag_fully_rolled_out(flag)
-        if is_fully_rolled_out:
-            return {"rollout_state": "fully_rolled_out", "active_variant": variant_key}
-    elif checker.is_boolean_flag_fully_rolled_out(flag):
-        return {"rollout_state": "fully_rolled_out", "active_variant": None}
+    if summary.effectively_full_rollout:
+        active_variant = None
+        if summary.is_multivariate:
+            _, active_variant = checker.is_multivariate_flag_fully_rolled_out(flag)
+        return {"rollout_state": "fully_rolled_out", "active_variant": active_variant}
 
-    # Check if flag is effectively at 0%: all groups have rollout_percentage == 0
-    groups = flag.filters.get("groups", [])
-    if groups and all(g.get("rollout_percentage", None) == 0 for g in groups):
+    # Effectively at 0%: every release condition is at 0 (max across groups is 0).
+    if summary.max_rollout_percentage == 0:
         return {"rollout_state": "not_rolled_out", "active_variant": None}
 
     return {"rollout_state": "partial", "active_variant": None}

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -392,6 +392,8 @@ def _get_flag_rollout_info(flag: FeatureFlag, checker: FeatureFlagStatusChecker)
     if summary.effectively_full_rollout:
         active_variant = None
         if summary.is_multivariate:
+            # summary already established full rollout; this only fetches the winning variant key.
+            # Both calls read the same in-memory flag, so they cannot disagree.
             _, active_variant = checker.is_multivariate_flag_fully_rolled_out(flag)
         return {"rollout_state": "fully_rolled_out", "active_variant": active_variant}
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -3544,10 +3544,12 @@ class FeatureFlagViewSet(
         flag_status, reason = checker.get_status()
         rollout = checker.get_rollout_summary(feature_flag)
 
-        return Response(
-            {"status": flag_status, "reason": reason, "rollout": asdict(rollout)},
-            status=status.HTTP_200_OK,
+        # Route through the declared serializer so it is the single source of truth for the
+        # response shape and the dataclass cannot silently drift from the OpenAPI/MCP schema.
+        response = FeatureFlagStatusResponseSerializer(
+            {"status": flag_status, "reason": reason, "rollout": asdict(rollout)}
         )
+        return Response(response.data, status=status.HTTP_200_OK)
 
     @validated_request(
         request_serializer=FeatureFlagTestEvaluationRequestSerializer,

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -10699,69 +10699,58 @@ class TestFeatureFlagStatus(APIBaseTest, ClickhouseTestMixin):
             FeatureFlagStatus.ACTIVE,
         )
 
-    def test_flag_status_includes_rollout_summary(self):
+    # (name, filters, expected_rollout) — exercises the rollout summary end-to-end through the serializer.
+    @parameterized.expand(
+        [
+            (
+                "full_rollout",
+                {"groups": [{"rollout_percentage": 100, "properties": []}]},
+                {
+                    "effectively_full_rollout": True,
+                    "has_targeting_conditions": False,
+                    "max_rollout_percentage": 100,
+                    "is_multivariate": False,
+                },
+            ),
+            (
+                "targeted",
+                {"groups": [{"rollout_percentage": 50, "properties": [{"key": "email", "value": "x"}]}]},
+                {
+                    "effectively_full_rollout": False,
+                    "has_targeting_conditions": True,
+                    "max_rollout_percentage": 50,
+                    "is_multivariate": False,
+                },
+            ),
+            # Multivariate flag guards the is_multivariate field through the serializer path.
+            (
+                "multivariate",
+                {
+                    "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+                    "groups": [{"rollout_percentage": 100, "properties": []}],
+                },
+                {
+                    "effectively_full_rollout": True,
+                    "has_targeting_conditions": False,
+                    "max_rollout_percentage": 100,
+                    "is_multivariate": True,
+                },
+            ),
+        ]
+    )
+    def test_flag_status_includes_rollout_summary(self, name, filters, expected_rollout):
         """The status response exposes a rollout summary so callers can determine full rollout / GA."""
-        full_rollout_flag = FeatureFlag.objects.create(
-            name="Fully rolled out flag",
-            key="full-rollout-flag",
+        flag = FeatureFlag.objects.create(
+            name=f"{name} flag",
+            key=f"{name}-flag",
             team=self.team,
             active=True,
-            filters={"groups": [{"rollout_percentage": 100, "properties": []}]},
+            filters=filters,
             last_called_at=datetime.now(UTC),
         )
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{full_rollout_flag.id}/status")
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/status")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json()["rollout"],
-            {
-                "effectively_full_rollout": True,
-                "has_targeting_conditions": False,
-                "max_rollout_percentage": 100,
-                "is_multivariate": False,
-            },
-        )
-
-        targeted_flag = FeatureFlag.objects.create(
-            name="Targeted flag",
-            key="targeted-flag",
-            team=self.team,
-            active=True,
-            filters={"groups": [{"rollout_percentage": 50, "properties": [{"key": "email", "value": "x"}]}]},
-            last_called_at=datetime.now(UTC),
-        )
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{targeted_flag.id}/status")
-        self.assertEqual(
-            response.json()["rollout"],
-            {
-                "effectively_full_rollout": False,
-                "has_targeting_conditions": True,
-                "max_rollout_percentage": 50,
-                "is_multivariate": False,
-            },
-        )
-
-        # Multivariate flag through the full serializer path — guards the is_multivariate field.
-        multivariate_flag = FeatureFlag.objects.create(
-            name="Multivariate flag",
-            key="multivariate-flag",
-            team=self.team,
-            active=True,
-            filters={
-                "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
-                "groups": [{"rollout_percentage": 100, "properties": []}],
-            },
-            last_called_at=datetime.now(UTC),
-        )
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{multivariate_flag.id}/status")
-        self.assertEqual(
-            response.json()["rollout"],
-            {
-                "effectively_full_rollout": True,
-                "has_targeting_conditions": False,
-                "max_rollout_percentage": 100,
-                "is_multivariate": True,
-            },
-        )
+        self.assertEqual(response.json()["rollout"], expected_rollout)
 
     def test_get_flags_with_stale_filter_usage_and_config_based(self):
         """Test filtering by STALE status with both usage and config-based detection"""

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -11286,6 +11286,16 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
                 },
             },
         )
+        # Empty-variants block routes through the boolean branch: a 100% group is fully rolled out.
+        empty_variants = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="empty_variants",
+            filters={
+                "groups": [{"rollout_percentage": 100, "properties": []}],
+                "multivariate": {"variants": []},
+            },
+        )
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/bulk_delete/",
@@ -11295,13 +11305,14 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
                     zero_rollout.id,
                     partial.id,
                     multivariate.id,
+                    empty_variants.id,
                 ]
             },
         )
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data["deleted"]) == 4
+        assert len(data["deleted"]) == 5
 
         by_key = {d["key"]: d for d in data["deleted"]}
 
@@ -11316,6 +11327,9 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
 
         assert by_key["multivariate_full"]["rollout_state"] == "fully_rolled_out"
         assert by_key["multivariate_full"]["active_variant"] == "winner"
+
+        assert by_key["empty_variants"]["rollout_state"] == "fully_rolled_out"
+        assert by_key["empty_variants"]["active_variant"] is None
 
     def test_bulk_delete_with_dependent_flags(self):
         """Test that flags with dependents cannot be deleted."""

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -10699,6 +10699,47 @@ class TestFeatureFlagStatus(APIBaseTest, ClickhouseTestMixin):
             FeatureFlagStatus.ACTIVE,
         )
 
+    def test_flag_status_includes_rollout_summary(self):
+        """The status response exposes a rollout summary so callers can determine full rollout / GA."""
+        full_rollout_flag = FeatureFlag.objects.create(
+            name="Fully rolled out flag",
+            key="full-rollout-flag",
+            team=self.team,
+            active=True,
+            filters={"groups": [{"rollout_percentage": 100, "properties": []}]},
+            last_called_at=datetime.now(UTC),
+        )
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{full_rollout_flag.id}/status")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["rollout"],
+            {
+                "effectively_full_rollout": True,
+                "has_targeting_conditions": False,
+                "max_rollout_percentage": 100,
+                "is_multivariate": False,
+            },
+        )
+
+        targeted_flag = FeatureFlag.objects.create(
+            name="Targeted flag",
+            key="targeted-flag",
+            team=self.team,
+            active=True,
+            filters={"groups": [{"rollout_percentage": 50, "properties": [{"key": "email", "value": "x"}]}]},
+            last_called_at=datetime.now(UTC),
+        )
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{targeted_flag.id}/status")
+        self.assertEqual(
+            response.json()["rollout"],
+            {
+                "effectively_full_rollout": False,
+                "has_targeting_conditions": True,
+                "max_rollout_percentage": 50,
+                "is_multivariate": False,
+            },
+        )
+
     def test_get_flags_with_stale_filter_usage_and_config_based(self):
         """Test filtering by STALE status with both usage and config-based detection"""
         FeatureFlag.objects.all().delete()

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -10740,6 +10740,29 @@ class TestFeatureFlagStatus(APIBaseTest, ClickhouseTestMixin):
             },
         )
 
+        # Multivariate flag through the full serializer path — guards the is_multivariate field.
+        multivariate_flag = FeatureFlag.objects.create(
+            name="Multivariate flag",
+            key="multivariate-flag",
+            team=self.team,
+            active=True,
+            filters={
+                "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+                "groups": [{"rollout_percentage": 100, "properties": []}],
+            },
+            last_called_at=datetime.now(UTC),
+        )
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{multivariate_flag.id}/status")
+        self.assertEqual(
+            response.json()["rollout"],
+            {
+                "effectively_full_rollout": True,
+                "has_targeting_conditions": False,
+                "max_rollout_percentage": 100,
+                "is_multivariate": True,
+            },
+        )
+
     def test_get_flags_with_stale_filter_usage_and_config_based(self):
         """Test filtering by STALE status with both usage and config-based detection"""
         FeatureFlag.objects.all().delete()

--- a/products/feature_flags/backend/flag_status.py
+++ b/products/feature_flags/backend/flag_status.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 
@@ -19,6 +20,18 @@ class FeatureFlagStatus(StrEnum):
     STALE = "stale"
     DELETED = "deleted"
     UNKNOWN = "unknown"
+
+
+@dataclass
+class FeatureFlagRolloutSummary:
+    # Whether the flag is effectively rolled out to everyone, independent of recent evaluation.
+    effectively_full_rollout: bool
+    # Whether any release condition has property filters (conditionally targeted vs. blanket rollout).
+    has_targeting_conditions: bool
+    # Highest rollout percentage across release conditions, or None when there are no conditions.
+    max_rollout_percentage: int | None
+    # Whether the flag serves multiple variants.
+    is_multivariate: bool
 
 
 def filter_flags_by_active_param(queryset: QuerySet, value: str | bool) -> QuerySet:
@@ -176,8 +189,37 @@ class FeatureFlagStatusChecker:
 
         return False, ""
 
+    def get_rollout_summary(self, flag: FeatureFlag) -> "FeatureFlagRolloutSummary":
+        """
+        Summarize the flag's rollout configuration so callers can determine rollout
+        completeness (e.g. "fully rolled out / GA") without re-parsing ``filters``.
+
+        This is independent of ``get_status``: ``status`` reflects recent evaluation
+        (was the flag called), while this reflects configuration. A flag can be
+        ``active`` while only partially rolled out, or fully rolled out but ``stale``.
+        """
+        filters = flag.filters or {}
+        groups = filters.get("groups") or []
+        multivariate = filters.get("multivariate") or None
+
+        has_targeting_conditions = any(len(group.get("properties") or []) > 0 for group in groups)
+
+        rollout_percentages = [
+            100 if group.get("rollout_percentage") is None else group.get("rollout_percentage") for group in groups
+        ]
+        max_rollout_percentage = max(rollout_percentages) if rollout_percentages else None
+
+        is_fully_rolled_out, _ = self.is_flag_fully_rolled_out(flag)
+
+        return FeatureFlagRolloutSummary(
+            effectively_full_rollout=is_fully_rolled_out,
+            has_targeting_conditions=has_targeting_conditions,
+            max_rollout_percentage=max_rollout_percentage,
+            is_multivariate=bool(multivariate and multivariate.get("variants")),
+        )
+
     def is_flag_fully_rolled_out(self, flag: FeatureFlag) -> tuple[bool, FeatureFlagStatusReason]:
-        multivariate = flag.filters.get("multivariate", None)
+        multivariate = (flag.filters or {}).get("multivariate", None)
         if multivariate:
             is_multivariate_flag_fully_rolled_out, fully_rolled_out_variant_name = (
                 self.is_multivariate_flag_fully_rolled_out(flag)
@@ -199,14 +241,14 @@ class FeatureFlagStatusChecker:
         some_release_condition_fully_rolled_out = False
         fully_rolled_out_release_condition_variant_override: str | None = None
 
-        multivariate = flag.filters.get("multivariate", None)
+        multivariate = (flag.filters or {}).get("multivariate", None)
         variants = multivariate.get("variants", [])
         for variant in variants:
             if variant.get("rollout_percentage") == 100:
                 fully_rolled_out_variant_key = variant.get("key")
                 break
 
-        for release_condition in flag.filters.get("groups", []):
+        for release_condition in (flag.filters or {}).get("groups", []):
             if self.is_group_fully_rolled_out(release_condition):
                 some_release_condition_fully_rolled_out = True
                 fully_rolled_out_release_condition_variant_override = (

--- a/products/feature_flags/backend/flag_status.py
+++ b/products/feature_flags/backend/flag_status.py
@@ -202,12 +202,19 @@ class FeatureFlagStatusChecker:
         groups = filters.get("groups") or []
         multivariate = filters.get("multivariate") or None
 
-        has_targeting_conditions = any(len(group.get("properties") or []) > 0 for group in groups)
-
-        rollout_percentages = [
-            100 if group.get("rollout_percentage") is None else group.get("rollout_percentage") for group in groups
-        ]
-        max_rollout_percentage = max(rollout_percentages) if rollout_percentages else None
+        has_targeting_conditions = False
+        max_rollout_percentage: int | None = None
+        for group in groups:
+            if group.get("properties"):
+                has_targeting_conditions = True
+            # A missing rollout_percentage evaluates to 100% at runtime, so it counts as 100 here.
+            # This is deliberately looser than effectively_full_rollout / is_group_fully_rolled_out,
+            # which require an explicit 100.
+            percentage = group.get("rollout_percentage")
+            percentage = 100 if percentage is None else percentage
+            max_rollout_percentage = (
+                percentage if max_rollout_percentage is None else max(max_rollout_percentage, percentage)
+            )
 
         is_fully_rolled_out, _ = self.is_flag_fully_rolled_out(flag)
 
@@ -220,13 +227,16 @@ class FeatureFlagStatusChecker:
 
     def is_flag_fully_rolled_out(self, flag: FeatureFlag) -> tuple[bool, FeatureFlagStatusReason]:
         multivariate = (flag.filters or {}).get("multivariate", None)
-        if multivariate:
+        # An empty/missing variant list is treated as boolean, matching the STALE SQL filter
+        # (which routes `jsonb_array_length(variants) = 0` into the boolean branch).
+        has_variants = bool(multivariate and multivariate.get("variants"))
+        if has_variants:
             is_multivariate_flag_fully_rolled_out, fully_rolled_out_variant_name = (
                 self.is_multivariate_flag_fully_rolled_out(flag)
             )
-        if multivariate and is_multivariate_flag_fully_rolled_out:
-            return True, f'This flag will always use the variant "{fully_rolled_out_variant_name}"'
-        elif not multivariate and self.is_boolean_flag_fully_rolled_out(flag):
+            if is_multivariate_flag_fully_rolled_out:
+                return True, f'This flag will always use the variant "{fully_rolled_out_variant_name}"'
+        elif self.is_boolean_flag_fully_rolled_out(flag):
             return True, 'This boolean flag will always evaluate to "true"'
 
         return False, ""

--- a/products/feature_flags/backend/flag_status.py
+++ b/products/feature_flags/backend/flag_status.py
@@ -251,7 +251,7 @@ class FeatureFlagStatusChecker:
         some_release_condition_fully_rolled_out = False
         fully_rolled_out_release_condition_variant_override: str | None = None
 
-        multivariate = (flag.filters or {}).get("multivariate", None)
+        multivariate = (flag.filters or {}).get("multivariate") or {}
         variants = multivariate.get("variants", [])
         for variant in variants:
             if variant.get("rollout_percentage") == 100:

--- a/products/feature_flags/backend/flag_status.py
+++ b/products/feature_flags/backend/flag_status.py
@@ -200,7 +200,7 @@ class FeatureFlagStatusChecker:
         """
         filters = flag.filters or {}
         groups = filters.get("groups") or []
-        multivariate = filters.get("multivariate") or None
+        multivariate = filters.get("multivariate")
 
         has_targeting_conditions = False
         max_rollout_percentage: int | None = None

--- a/products/feature_flags/backend/test/test_flag_status.py
+++ b/products/feature_flags/backend/test/test_flag_status.py
@@ -49,6 +49,19 @@ class TestFilterFlagsByActiveParam(BaseTest):
             },
             created_by=self.user,
         )
+        # Empty-variants stale: a present-but-empty multivariate block routes through the boolean
+        # branch (both the SQL filter's jsonb_array_length(variants)=0 and the checker's has_variants).
+        self.stale_empty_variants = FeatureFlag.objects.create(
+            team=self.team,
+            key="stale-empty-variants",
+            active=True,
+            created_at=timezone.now() - timedelta(days=60),
+            filters={
+                "multivariate": {"variants": []},
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+            },
+            created_by=self.user,
+        )
 
     def _filter(self, value):
         return set(
@@ -58,16 +71,28 @@ class TestFilterFlagsByActiveParam(BaseTest):
         )
 
     def test_filters_enabled(self):
-        assert self._filter("true") == {"enabled", "stale", "stale-by-usage", "stale-multivariate"}
+        assert self._filter("true") == {
+            "enabled",
+            "stale",
+            "stale-by-usage",
+            "stale-multivariate",
+            "stale-empty-variants",
+        }
 
     def test_filters_disabled(self):
         assert self._filter("false") == {"disabled"}
 
     def test_filters_stale(self):
-        assert self._filter("STALE") == {"stale", "stale-by-usage", "stale-multivariate"}
+        assert self._filter("STALE") == {"stale", "stale-by-usage", "stale-multivariate", "stale-empty-variants"}
 
     def test_accepts_native_booleans(self):
-        assert self._filter(True) == {"enabled", "stale", "stale-by-usage", "stale-multivariate"}
+        assert self._filter(True) == {
+            "enabled",
+            "stale",
+            "stale-by-usage",
+            "stale-multivariate",
+            "stale-empty-variants",
+        }
         assert self._filter(False) == {"disabled"}
 
     def test_stale_filter_agrees_with_status_checker(self):

--- a/products/feature_flags/backend/test/test_flag_status.py
+++ b/products/feature_flags/backend/test/test_flag_status.py
@@ -4,6 +4,8 @@ from posthog.test.base import BaseTest
 
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from products.feature_flags.backend.flag_status import (
     FeatureFlagStatus,
     FeatureFlagStatusChecker,
@@ -83,66 +85,105 @@ class TestRolloutSummary(BaseTest):
         flag = FeatureFlag.objects.create(team=self.team, key="rollout-flag", filters=filters, created_by=self.user)
         return FeatureFlagStatusChecker(feature_flag=flag).get_rollout_summary(flag)
 
-    def test_blanket_full_rollout(self):
-        summary = self._summary({"groups": [{"properties": [], "rollout_percentage": 100}]})
-        assert summary.effectively_full_rollout is True
-        assert summary.has_targeting_conditions is False
-        assert summary.max_rollout_percentage == 100
-        assert summary.is_multivariate is False
-
-    def test_partial_rollout(self):
-        summary = self._summary({"groups": [{"properties": [], "rollout_percentage": 50}]})
-        assert summary.effectively_full_rollout is False
-        assert summary.has_targeting_conditions is False
-        assert summary.max_rollout_percentage == 50
-
-    def test_targeting_conditions(self):
-        summary = self._summary(
-            {"groups": [{"properties": [{"key": "email", "value": "x"}], "rollout_percentage": 100}]}
-        )
-        assert summary.effectively_full_rollout is False
-        assert summary.has_targeting_conditions is True
-        assert summary.max_rollout_percentage == 100
-
-    def test_missing_rollout_percentage_treated_as_full_for_max_only(self):
-        # A missing rollout_percentage evaluates to 100% at runtime, so max_rollout_percentage
-        # reflects that. effectively_full_rollout stays stricter (requires an explicit 100), to
-        # match the staleness detection it shares logic with.
-        summary = self._summary({"groups": [{"properties": []}]})
-        assert summary.max_rollout_percentage == 100
-        assert summary.effectively_full_rollout is False
-
-    def test_no_groups(self):
-        summary = self._summary({"groups": []})
-        # No release conditions means a boolean flag evaluates to true for everyone.
-        assert summary.effectively_full_rollout is True
-        assert summary.has_targeting_conditions is False
-        assert summary.max_rollout_percentage is None
-
-    def test_multivariate_fully_rolled_out(self):
-        summary = self._summary(
-            {
-                "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-            }
-        )
-        assert summary.is_multivariate is True
-        assert summary.effectively_full_rollout is True
-
-    def test_multivariate_not_fully_rolled_out(self):
-        summary = self._summary(
-            {
-                "multivariate": {
-                    "variants": [
-                        {"key": "control", "rollout_percentage": 50},
-                        {"key": "test", "rollout_percentage": 50},
+    # (name, filters, effectively_full_rollout, has_targeting_conditions, max_rollout_percentage, is_multivariate)
+    @parameterized.expand(
+        [
+            (
+                "blanket_full_rollout",
+                {"groups": [{"properties": [], "rollout_percentage": 100}]},
+                True,
+                False,
+                100,
+                False,
+            ),
+            (
+                "partial_rollout",
+                {"groups": [{"properties": [], "rollout_percentage": 50}]},
+                False,
+                False,
+                50,
+                False,
+            ),
+            (
+                "targeting_conditions",
+                {"groups": [{"properties": [{"key": "email", "value": "x"}], "rollout_percentage": 100}]},
+                False,
+                True,
+                100,
+                False,
+            ),
+            # A missing rollout_percentage evaluates to 100% at runtime, so max_rollout_percentage
+            # reflects that. effectively_full_rollout stays stricter (requires an explicit 100), to
+            # match the staleness detection it shares logic with.
+            ("missing_rollout_percentage", {"groups": [{"properties": []}]}, False, False, 100, False),
+            # No release conditions means a boolean flag evaluates to true for everyone.
+            ("no_groups", {"groups": []}, True, False, None, False),
+            (
+                "max_rollout_percentage_across_multiple_groups",
+                {
+                    "groups": [
+                        {"properties": [{"key": "email", "value": "x"}], "rollout_percentage": 30},
+                        {"properties": [], "rollout_percentage": 75},
                     ]
                 },
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-            }
-        )
-        assert summary.is_multivariate is True
-        assert summary.effectively_full_rollout is False
+                False,
+                True,
+                75,
+                False,
+            ),
+            (
+                "multivariate_fully_rolled_out",
+                {
+                    "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+                True,
+                False,
+                100,
+                True,
+            ),
+            (
+                "multivariate_not_fully_rolled_out",
+                {
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+                False,
+                False,
+                100,
+                True,
+            ),
+            # An empty variant list is treated as a boolean flag, so a 100% blanket group is a full
+            # rollout and is_multivariate is False — consistent with effectively_full_rollout.
+            (
+                "empty_multivariate_variants",
+                {"multivariate": {"variants": []}, "groups": [{"properties": [], "rollout_percentage": 100}]},
+                True,
+                False,
+                100,
+                False,
+            ),
+        ]
+    )
+    def test_rollout_summary(
+        self,
+        _name,
+        filters,
+        effectively_full_rollout,
+        has_targeting_conditions,
+        max_rollout_percentage,
+        is_multivariate,
+    ):
+        summary = self._summary(filters)
+        assert summary.effectively_full_rollout is effectively_full_rollout
+        assert summary.has_targeting_conditions is has_targeting_conditions
+        assert summary.max_rollout_percentage == max_rollout_percentage
+        assert summary.is_multivariate is is_multivariate
 
     def test_handles_none_filters(self):
         flag = FeatureFlag.objects.create(team=self.team, key="none-filters", created_by=self.user)

--- a/products/feature_flags/backend/test/test_flag_status.py
+++ b/products/feature_flags/backend/test/test_flag_status.py
@@ -76,3 +76,78 @@ class TestFilterFlagsByActiveParam(BaseTest):
             if FeatureFlagStatusChecker(feature_flag=flag).get_status()[0] == FeatureFlagStatus.STALE
         }
         assert self._filter("STALE") == checker_stale
+
+
+class TestRolloutSummary(BaseTest):
+    def _summary(self, filters):
+        flag = FeatureFlag.objects.create(team=self.team, key="rollout-flag", filters=filters, created_by=self.user)
+        return FeatureFlagStatusChecker(feature_flag=flag).get_rollout_summary(flag)
+
+    def test_blanket_full_rollout(self):
+        summary = self._summary({"groups": [{"properties": [], "rollout_percentage": 100}]})
+        assert summary.effectively_full_rollout is True
+        assert summary.has_targeting_conditions is False
+        assert summary.max_rollout_percentage == 100
+        assert summary.is_multivariate is False
+
+    def test_partial_rollout(self):
+        summary = self._summary({"groups": [{"properties": [], "rollout_percentage": 50}]})
+        assert summary.effectively_full_rollout is False
+        assert summary.has_targeting_conditions is False
+        assert summary.max_rollout_percentage == 50
+
+    def test_targeting_conditions(self):
+        summary = self._summary(
+            {"groups": [{"properties": [{"key": "email", "value": "x"}], "rollout_percentage": 100}]}
+        )
+        assert summary.effectively_full_rollout is False
+        assert summary.has_targeting_conditions is True
+        assert summary.max_rollout_percentage == 100
+
+    def test_missing_rollout_percentage_treated_as_full_for_max_only(self):
+        # A missing rollout_percentage evaluates to 100% at runtime, so max_rollout_percentage
+        # reflects that. effectively_full_rollout stays stricter (requires an explicit 100), to
+        # match the staleness detection it shares logic with.
+        summary = self._summary({"groups": [{"properties": []}]})
+        assert summary.max_rollout_percentage == 100
+        assert summary.effectively_full_rollout is False
+
+    def test_no_groups(self):
+        summary = self._summary({"groups": []})
+        # No release conditions means a boolean flag evaluates to true for everyone.
+        assert summary.effectively_full_rollout is True
+        assert summary.has_targeting_conditions is False
+        assert summary.max_rollout_percentage is None
+
+    def test_multivariate_fully_rolled_out(self):
+        summary = self._summary(
+            {
+                "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+            }
+        )
+        assert summary.is_multivariate is True
+        assert summary.effectively_full_rollout is True
+
+    def test_multivariate_not_fully_rolled_out(self):
+        summary = self._summary(
+            {
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                },
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+            }
+        )
+        assert summary.is_multivariate is True
+        assert summary.effectively_full_rollout is False
+
+    def test_handles_none_filters(self):
+        flag = FeatureFlag.objects.create(team=self.team, key="none-filters", created_by=self.user)
+        flag.filters = None
+        summary = FeatureFlagStatusChecker(feature_flag=flag).get_rollout_summary(flag)
+        assert summary.effectively_full_rollout is True
+        assert summary.max_rollout_percentage is None
+        assert summary.is_multivariate is False

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -822,11 +822,27 @@ export interface DependentFlagApi {
     name: string
 }
 
+export interface FeatureFlagRolloutSummaryApi {
+    /** True if the flag is effectively rolled out to everyone, independent of recent evaluation. For boolean flags this means at least one release condition targets 100% with no property filters (or there are no release conditions); for multivariate flags it means a single variant is served to 100% via a fully rolled out release condition. This is the signal for 'fully rolled out' / GA — unlike `status`, which only reflects recent evaluation. */
+    effectively_full_rollout: boolean
+    /** True if any release condition has property filters, i.e. the flag is conditionally targeted rather than a blanket rollout. When true, `max_rollout_percentage` is a percentage within the targeted segment, not of the whole user base. */
+    has_targeting_conditions: boolean
+    /**
+     * Highest rollout percentage (0-100) across the flag's release conditions, treating a missing percentage as 100. Null when the flag has no release conditions. Interpret together with `has_targeting_conditions`.
+     * @nullable
+     */
+    max_rollout_percentage: number | null
+    /** True if the flag serves multiple variants (has a multivariate variant set). */
+    is_multivariate: boolean
+}
+
 export interface FeatureFlagStatusResponseApi {
-    /** Flag status: active, stale, deleted, or unknown */
+    /** Flag staleness/evaluation status: active, stale, deleted, or unknown. 'active' means the flag was recently evaluated (or has no usage data yet) — it does NOT mean the flag is fully rolled out. Use the `rollout` object to determine rollout completeness. */
     status: string
     /** Human-readable explanation of the status */
     reason: string
+    /** Summary of the flag's rollout configuration, for determining whether it is fully rolled out. */
+    rollout: FeatureFlagRolloutSummaryApi
 }
 
 export interface FeatureFlagTestEvaluationRequestApi {

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -285,7 +285,10 @@ tools:
         title: Get feature flag status
         description: >
             Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or
-            unknown) and a human-readable reason explaining the status.
+            unknown) and a human-readable reason explaining the status. The status reflects recent evaluation (whether the
+            flag was called), NOT rollout completeness. To determine whether a flag is fully rolled out / GA, use the
+            returned `rollout` object: `effectively_full_rollout` (true when targeted to everyone with no conditions),
+            `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate`.
         param_overrides:
             id:
                 cast: string-int

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -285,10 +285,10 @@ tools:
         title: Get feature flag status
         description: >
             Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or
-            unknown) and a human-readable reason explaining the status. The status reflects recent evaluation (whether the
-            flag was called), NOT rollout completeness. To determine whether a flag is fully rolled out / GA, use the
-            returned `rollout` object: `effectively_full_rollout` (true when targeted to everyone with no conditions),
-            `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate`.
+            unknown) and a human-readable reason explaining the status. The status reflects recent evaluation (whether
+            the flag was called), NOT rollout completeness. To determine whether a flag is fully rolled out / GA, use
+            the returned `rollout` object: `effectively_full_rollout` (true when targeted to everyone with no
+            conditions), `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate`.
         param_overrides:
             id:
                 cast: string-int

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3283,7 +3283,7 @@
         }
     },
     "feature-flags-status-retrieve": {
-        "description": "Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or unknown) and a human-readable reason explaining the status.",
+        "description": "Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or unknown) and a human-readable reason explaining the status. The status reflects recent evaluation (whether the flag was called), NOT rollout completeness. To determine whether a flag is fully rolled out / GA, use the returned `rollout` object: `effectively_full_rollout` (true when targeted to everyone with no conditions), `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate`.",
         "category": "Feature flags",
         "feature": "flags",
         "summary": "Get feature flag status",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3509,7 +3509,7 @@
         }
     },
     "feature-flags-status-retrieve": {
-        "description": "Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or unknown) and a human-readable reason explaining the status.",
+        "description": "Check the health and evaluation status of a feature flag by ID. Returns a status (active, stale, deleted, or unknown) and a human-readable reason explaining the status. The status reflects recent evaluation (whether the flag was called), NOT rollout completeness. To determine whether a flag is fully rolled out / GA, use the returned `rollout` object: `effectively_full_rollout` (true when targeted to everyone with no conditions), `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate`.",
         "category": "Feature flags",
         "feature": "flags",
         "summary": "Get feature flag status",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21851,11 +21851,27 @@ export namespace Schemas {
       bucketing_identifier?: BucketingIdentifierEnum | null;
     }
 
+    export interface FeatureFlagRolloutSummary {
+      /** True if the flag is effectively rolled out to everyone, independent of recent evaluation. For boolean flags this means at least one release condition targets 100% with no property filters (or there are no release conditions); for multivariate flags it means a single variant is served to 100% via a fully rolled out release condition. This is the signal for 'fully rolled out' / GA — unlike `status`, which only reflects recent evaluation. */
+      effectively_full_rollout: boolean;
+      /** True if any release condition has property filters, i.e. the flag is conditionally targeted rather than a blanket rollout. When true, `max_rollout_percentage` is a percentage within the targeted segment, not of the whole user base. */
+      has_targeting_conditions: boolean;
+      /**
+         * Highest rollout percentage (0-100) across the flag's release conditions, treating a missing percentage as 100. Null when the flag has no release conditions. Interpret together with `has_targeting_conditions`.
+         * @nullable
+         */
+      max_rollout_percentage: number | null;
+      /** True if the flag serves multiple variants (has a multivariate variant set). */
+      is_multivariate: boolean;
+    }
+
     export interface FeatureFlagStatusResponse {
-      /** Flag status: active, stale, deleted, or unknown */
+      /** Flag staleness/evaluation status: active, stale, deleted, or unknown. 'active' means the flag was recently evaluated (or has no usage data yet) — it does NOT mean the flag is fully rolled out. Use the `rollout` object to determine rollout completeness. */
       status: string;
       /** Human-readable explanation of the status */
       reason: string;
+      /** Summary of the flag's rollout configuration, for determining whether it is fully rolled out. */
+      rollout: FeatureFlagRolloutSummary;
     }
 
     export interface FeatureFlagTestEvaluationRequest {


### PR DESCRIPTION
## Problem

The feature flag status endpoint (`GET /api/projects/{id}/feature_flags/{id}/status`, exposed as the `feature-flags-status-retrieve` MCP tool) returned only `status` and `reason`. The `status` value (`active`/`stale`/`deleted`) reflects *recent evaluation* — whether the flag was called — not how far it has been rolled out. A flag that returns `active` with reason "Flag was called today" gives no indication of whether it targets everyone at 100% or a small conditional segment.

Consumers that need to determine rollout completeness — e.g. "is this flag fully rolled out / GA?" — had to fetch the full flag definition and re-parse `filters` themselves. The `active` status also reads as if it means "rolled out", which it does not.

## Changes

- Added a rollout summary to the status response under a new `rollout` object:
  - `effectively_full_rollout` — true when the flag targets everyone with no conditions (boolean: a 100% release condition with no property filters, or no conditions at all; multivariate: a single variant served to 100% via a fully rolled out condition). This reuses the existing full-rollout logic that already backs the `STALE` list filter, so the two stay in agreement.
  - `has_targeting_conditions` — whether any release condition has property filters (conditionally targeted vs. blanket rollout).
  - `max_rollout_percentage` — highest rollout percentage across release conditions (null when there are none).
  - `is_multivariate` — whether the flag serves multiple variants.
- Clarified the `status` field documentation to state that it reflects recent evaluation, not rollout completeness, and updated the MCP tool description to point callers at the `rollout` object for GA determination.
- Hardened the full-rollout helpers against null `filters`, since the rollout summary now runs on every status request rather than only the no-usage staleness path.
- Regenerated the OpenAPI-derived frontend types and MCP tool definitions.

Example response:

```json
{
  "status": "active",
  "reason": "Flag was called today",
  "rollout": {
    "effectively_full_rollout": true,
    "has_targeting_conditions": false,
    "max_rollout_percentage": 100,
    "is_multivariate": false
  }
}
```

One deliberate edge case: `max_rollout_percentage` treats a missing `rollout_percentage` as 100 (matching runtime evaluation), while `effectively_full_rollout` requires an explicit `100`, because it shares logic with the staleness SQL filter and the two must classify the same flags. This is documented in code and covered by a test.

## How did you test this code?

Automated tests only:

- `products/feature_flags/backend/test/test_flag_status.py` — new `TestRolloutSummary` covering blanket/partial/targeted/multivariate/no-groups/null-filters cases, plus the existing stale-filter-vs-status-checker agreement test.
- `products/feature_flags/backend/api/test/test_feature_flag.py::TestFeatureFlagStatus` — new `test_flag_status_includes_rollout_summary` asserting the `rollout` object shape, plus the existing `test_flag_status_reasons`.

All passing locally; `ruff check`/`format` clean; OpenAPI regeneration (`hogli build:openapi`) and the commit-time type check both succeed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `rollout` summary object to the feature flag status endpoint response, providing `effectively_full_rollout`, `has_targeting_conditions`, `max_rollout_percentage`, and `is_multivariate` fields. Also hardens existing rollout helpers against null `filters`, consolidates the "fully rolled out" determination into `get_rollout_summary`, and updates MCP tool descriptions and generated types.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f23b5aa4ee76a791da44538ce2e4165b27c7332f.</sup>
<!-- /MENDRAL_SUMMARY -->