### PR TITLE
fix(aiobs): tolerate deleted surveys in trace feedback tab

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5140,6 +5140,7 @@ const api = {
                 offset?: number
                 search?: string
                 archived?: boolean
+                ids?: string
             } = {
                 limit: SURVEY_PAGE_SIZE,
             }

--- a/products/ai_observability/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/ai_observability/frontend/feedback-view/feedbackViewLogic.ts
@@ -59,8 +59,8 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
                     if (surveyIds.length === 0) {
                         return {}
                     }
-                    const surveys = await Promise.all(surveyIds.map((id) => api.surveys.get(id)))
-                    return Object.fromEntries(surveys.map((survey) => [survey.id, survey]))
+                    const response = await api.surveys.list({ ids: surveyIds.join(','), limit: surveyIds.length })
+                    return Object.fromEntries(response.results.map((survey) => [survey.id, survey]))
                 },
             },
         ],

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -17,9 +17,10 @@ from django.views.decorators.csrf import csrf_exempt
 
 import nh3
 import structlog
+import django_filters
 import posthoganalytics
 from axes.decorators import axes_dispatch
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -1997,6 +1998,21 @@ class SurveySerializerCreateUpdateOnlySchema(SurveySerializerCreateUpdateOnly):
         }
 
 
+class UUIDInFilter(django_filters.BaseInFilter, django_filters.UUIDFilter):
+    pass
+
+
+class SurveyFilterSet(FilterSet):
+    ids = UUIDInFilter(
+        field_name="id",
+        label="Filter to a comma-separated list of survey IDs. IDs that don't exist are silently omitted rather than erroring.",
+    )
+
+    class Meta:
+        model = Survey
+        fields = ["archived", "type"]
+
+
 @extend_schema_view(
     create=extend_schema(request=SurveySerializerCreateUpdateOnlySchema),
     partial_update=extend_schema(request=SurveySerializerCreateUpdateOnlySchema),
@@ -2016,7 +2032,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         "linked_flag", "linked_insight", "targeting_flag", "internal_targeting_flag"
     ).all()
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["archived", "type"]
+    filterset_class = SurveyFilterSet
 
     def get_serializer_class(self) -> type[serializers.Serializer]:
         if self.request.method == "POST" or self.request.method == "PATCH":

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6821,6 +6821,26 @@ class TestSurveyListTypeFilter(APIBaseTest):
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["name"], "widget survey")
 
+    def test_filter_by_ids(self):
+        first = Survey.objects.create(team=self.team, name="first", type="popover", questions=[])
+        second = Survey.objects.create(team=self.team, name="second", type="popover", questions=[])
+        Survey.objects.create(team=self.team, name="third", type="popover", questions=[])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/surveys/?ids={first.id},{second.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual({s["name"] for s in data["results"]}, {"first", "second"})
+
+    def test_filter_by_ids_silently_omits_unknown_ids(self):
+        survey = Survey.objects.create(team=self.team, name="exists", type="popover", questions=[])
+        missing_id = uuid.uuid4()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/surveys/?ids={survey.id},{missing_id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["id"], str(survey.id))
+
 
 class TestSurveyStatsPerQuestion(ClickhouseTestMixin, APIBaseTest):
     def setUp(self):

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -2132,6 +2132,10 @@ export interface SurveyGlobalStatsResponseApi {
 export type SurveysListParams = {
     archived?: boolean
     /**
+     * Multiple values may be separated by commas.
+     */
+    ids?: string[]
+    /**
      * Number of results to return per page.
      */
     limit?: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -59693,6 +59693,10 @@ export namespace Schemas {
     export type SurveysListParams = {
     archived?: boolean;
     /**
+     * Multiple values may be separated by commas.
+     */
+    ids?: string[];
+    /**
      * Number of results to return per page.
      */
     limit?: number;

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -18,6 +18,7 @@ export const SurveysListParams = /* @__PURE__ */ zod.object({
 
 export const SurveysListQueryParams = /* @__PURE__ */ zod.object({
     archived: zod.boolean().optional(),
+    ids: zod.array(zod.string()).optional().describe('Multiple values may be separated by commas.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -356,6 +356,7 @@ const surveysGetAll = (): ToolBase<typeof SurveysGetAllSchema, WithPostHogUrl<Sc
                 path: `/api/projects/${encodeURIComponent(String(projectId))}/surveys/`,
                 query: {
                     archived: params.archived,
+                    ids: Array.isArray(params.ids) ? params.ids.join(',') || undefined : params.ids,
                     limit: params.limit,
                     offset: params.offset,
                     search: params.search,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/surveys-get-all.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/surveys-get-all.json
@@ -4,6 +4,13 @@
         "archived": {
             "type": "boolean"
         },
+        "ids": {
+            "description": "Multiple values may be separated by commas.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"


### PR DESCRIPTION
## Problem

In AI observability, the trace **Feedback** tab loads every survey referenced by the trace's `survey sent` / `survey shown` events. Surveys are hard-deleted, so when an event references a survey that has since been deleted, fetching that survey returns `404` which currently crashes the whole page.

## Changes

Fixed at the root by **excluding deleted surveys from the listing query** instead of catching 404s

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual UI testing. Automated tests I added and ran locally:

- `TestSurveyListTypeFilter::test_filter_by_ids` — filtering by an ID set returns exactly those surveys.
- `TestSurveyListTypeFilter::test_filter_by_ids_silently_omits_unknown_ids` — a request mixing a valid ID with a non-existent one returns `200` with only the valid survey (the exact behavior behind the bug).
- Re-ran the existing survey list/search/type filter suite to confirm the `filterset_fields` → `filterset_class` swap didn't regress (`23 passed`).
- Frontend `tsc` clean on touched files; `hogli build:openapi` produced a purely additive `ids` diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Carlos directed this from a support ticket investigation.

- Tooling: PostHog Code (Opus 4.8).
- Root-cause path: traced the customer's console errors to the Feedback tab's survey fetch; the user-facing failure was a single deleted survey 404-ing an all-or-nothing `Promise.all`.
- Decision: chose to exclude deleted surveys at the listing-query layer (filter by ID set) over per-call 404 handling, so the absence is structural rather than swallowed. Kept the frontend on the handwritten `api.surveys.list` client (returning the existing `Survey` type) rather than migrating the whole feedback view to generated `SurveyApi` types, to keep the fix surgical.
- Out of scope (noted separately): a `llmSentimentLazyLoaderLogic` "not mounted" KEA console error surfaced in the same ticket — a separate Sentry-noise bug, not addressed here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
