### PR TITLE
fix(postgres): treat statement-timeout as non-retryable at activity layer

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -213,6 +213,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "does not exist": None,
             "timestamp too small": None,
             "QueryTimeoutException": None,
+            # `QueryTimeoutException` is the class name, so it only matches once Temporal wraps the
+            # activity failure ("QueryTimeoutException: ...") at the workflow layer. The activity-level
+            # check (`_handle_import_error`) compares against the raw `str(e)` message, which carries
+            # no class name — so without this the converted statement_timeout is treated as retryable
+            # there and the incremental activity re-runs the same 10-min-timing-out query up to 9 times
+            # before the workflow finally stops it. Match the stable phrase from the raised message
+            # ("10 min timeout statement reached. ...") so it's caught at both layers, mirroring the
+            # `InsufficientPrivilege` / "permission denied for" pairing above. This phrase is absent
+            # from the raw QueryCanceled message ("canceling statement due to statement timeout"), so
+            # full-table syncs still re-raise it raw and stay retryable for a fresh re-sync.
+            "timeout statement reached": None,
             "TemporaryFileSizeExceedsLimitException": None,
             "Name or service not known": None,
             # Sibling getaddrinfo failure to "Name or service not known" (EAI_NONAME): EAI_NODATA

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -427,6 +427,31 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw message (what the activity-level check sees via str(e)) — no class name. Without the
+            # message-substring key the timeout would be treated as retryable here and the activity
+            # would re-run the same 10-min-timing-out query up to 9 times before the workflow stopped it.
+            "10 min timeout statement reached. Please ensure your incremental field (updated_at) has an appropriate index created",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "QueryTimeoutException: 10 min timeout statement reached. Please ensure your incremental field (updated_at) has an appropriate index created",
+        ],
+    )
+    def test_statement_timeout_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Statement-timeout error should be non-retryable: {error_msg}"
+
+    def test_raw_query_canceled_stays_retryable(self, source):
+        # Full-table syncs re-raise the raw QueryCanceled (no conversion to QueryTimeoutException) so a
+        # fresh re-sync can reorder rows. Its message must NOT match any non-retryable key, otherwise we
+        # would permanently disable syncs that a retry could complete.
+        error_msg = "canceling statement due to statement timeout"
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, "Raw QueryCanceled (full-table sync) should stay retryable"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "cannot call jsonb_each on a non-object",
             "InvalidParameterValue: cannot call jsonb_each on a non-object",
             "cannot call jsonb_each_text on a non-object",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `QueryCanceled: canceling statement due to statement timeout` originating in the Postgres data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed59d-e00c-76e2-a455-0591f449378a)). The top in-app frame is `postgres_source` in `posthog/temporal/data_imports/sources/postgres/postgres.py`, reached during the table-setup metadata probes.

The source already does the right thing conceptually: a statement timeout on an **incremental** read is converted to a non-retryable `QueryTimeoutException` with an actionable "add an index to your incremental field" message, and `"QueryTimeoutException"` is listed in `get_non_retryable_errors()`.

The gap is *where* that classification takes effect. Non-retryability is matched at two layers:

- **Workflow layer** (`update_external_data_job_model`) matches against the Temporal-wrapped string `"QueryTimeoutException: ..."` — the class-name key works.
- **Activity layer** (`_handle_import_error`) matches against the raw `str(error)`, which is only the *message* and carries no class name — so the class-name-only key does **not** match.

Result: at the activity layer the timeout is treated as retryable, so the incremental import activity re-runs the identical 10-minute-timing-out query (up to 9 attempts in prod) before the workflow finally stops it — wasting load on the customer's database and re-capturing the same exception to error tracking on every attempt.

This is the same two-layer matching issue already documented and fixed for `InsufficientPrivilege` / `"permission denied for"` in this file.

## Changes

Added the stable message substring `"timeout statement reached"` to the Postgres source's `get_non_retryable_errors()`, so the converted statement-timeout is recognised at the activity layer too (not just the workflow layer).

The substring is deliberately chosen to **not** appear in the raw `QueryCanceled` message (`canceling statement due to statement timeout`). Full-table syncs intentionally re-raise the raw `QueryCanceled` (so a fresh re-sync can reorder rows) and must stay retryable — this fix preserves that behavior.

This is a user/upstream condition (the incremental field needs an index, or the table is too large to read within the timeout); retrying the identical query never succeeds, so it belongs in the non-retryable set.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests; I did not perform manual testing.

- `test_statement_timeout_errors_are_non_retryable` — asserts both the raw activity-level message and the Temporal-wrapped workflow-level message are classified non-retryable.
- `test_raw_query_canceled_stays_retryable` — asserts the raw `QueryCanceled` (full-table sync) message stays retryable, guarding the intentional retry path.
- Existing `test_statement_timeout_mapping` cases still pass (incremental → `QueryTimeoutException`, full-table → raw `QueryCanceled`).

All 5 targeted tests pass; the broader non-retryable test suite (46 tests) passes. `ruff check` and `ruff format --check` are clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. Investigation: pulled the issue's stack trace and a representative event via the PostHog MCP error-tracking tools, traced the call path (`postgres_source` → `_get_partition_settings` → psycopg `execute`), and read the source's existing `QueryCanceled`/`QueryTimeoutException` handling plus the activity- and workflow-level non-retryable classification.

Key decision: this is not a missing conversion (the conversion already exists) but a non-retryable match that only fires at the workflow layer. Chose to extend `get_non_retryable_errors()` with a message substring rather than touch retry policy, mirroring the established `InsufficientPrivilege` precedent. Picked `"timeout statement reached"` specifically because it matches the converted `QueryTimeoutException` message but not the raw `QueryCanceled` message, preserving the intentional full-table retry behavior.
