### PR TITLE
fix(llma): skip properties column read in events backfill when unused

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
@@ -35,6 +35,23 @@ def format_cohort_ids_for_logging(cohort_ids: list[int]) -> str:
     return str(cohort_ids)
 
 
+def bytecode_references_properties(bytecode: Any) -> bool:
+    """Whether a HogVM bytecode program can read the ``properties`` global.
+
+    Behavioral filters that only match on the event name never touch ``properties``, so for those we
+    can skip reading the (large) ``properties`` column entirely. The ``properties`` global is loaded
+    via a ``GET_GLOBAL`` chain whose root is pushed as the literal string ``"properties"``, so if that
+    string appears nowhere in the program, ``properties`` is provably unused. Detection is conservative:
+    a coincidental string literal only makes us keep the column (a missed optimization), never drops a
+    match. Recurses so nested bytecode (e.g. declared functions) is covered.
+    """
+    if isinstance(bytecode, str):
+        return bytecode == "properties"
+    if isinstance(bytecode, list | tuple):
+        return any(bytecode_references_properties(item) for item in bytecode)
+    return False
+
+
 def parse_event_properties(properties_raw: Any, event_uuid: str) -> dict[str, Any]:
     """Parse event properties from ClickHouse, handling both string and dict formats."""
     if isinstance(properties_raw, str):
@@ -214,6 +231,15 @@ async def backfill_precalculated_events_activity(
     for f in filters:
         filters_by_event.setdefault(f.event_name, []).append(f)
 
+    # Only read the (large) properties column if some bytecode actually references it. Behavioral
+    # cohorts that just count event occurrences never touch properties, so for them we skip reading
+    # the column entirely. Checked across both combined and individual bytecodes, since either can run.
+    candidate_bytecodes: list[Any] = [bc for bc in combined_bytecodes_by_event.values() if bc]
+    candidate_bytecodes.extend(f.bytecode for f in filters)
+    needs_properties = any(bytecode_references_properties(bc) for bc in candidate_bytecodes)
+    if not needs_properties:
+        logger.info("No event filter references properties; skipping the properties column read")
+
     logger.info(
         f"Starting event backfill for time range {inputs.start_time} to {inputs.end_time}, "
         f"scanning {len(event_names)} event names: {event_names}"
@@ -235,19 +261,19 @@ async def backfill_precalculated_events_activity(
             logger.warning("Invalid BACKFILL_EVENTS_KAFKA_FLUSH_BATCH_SIZE, using default 1000")
             KAFKA_FLUSH_BATCH_SIZE = 1000
 
+        # Static column list (no user input) — properties is included only when some bytecode reads it.
+        select_columns = ["uuid", "event", "toDate(timestamp) as date", "distinct_id", "person_id"]
+        if needs_properties:
+            select_columns.append("properties")
+
         # No ORDER BY: each event is evaluated independently and there is no cursor, so ordering is
         # not needed. Events within a day are not physically timestamp-ordered (the events sort key
         # is (team_id, toDate(timestamp), event, ...)), so ORDER BY timestamp would force a full sort
         # of every matched event and block streaming. Without it, ClickHouse streams rows as it reads
         # them in primary-key order — lower memory and faster time-to-first-row.
-        events_query = """
+        events_query = f"""
             SELECT
-                uuid,
-                event,
-                toDate(timestamp) as date,
-                distinct_id,
-                person_id,
-                properties
+                {", ".join(select_columns)}
             FROM events
             WHERE team_id = %(team_id)s
               AND event IN %(event_names)s
@@ -289,7 +315,7 @@ async def backfill_precalculated_events_activity(
                     event_date = str(row["date"])
                     distinct_id = str(row["distinct_id"])
                     person_id = str(row["person_id"])
-                    event_properties = parse_event_properties(row["properties"], event_uuid)
+                    event_properties = parse_event_properties(row["properties"], event_uuid) if needs_properties else {}
 
                     # Look up the combined bytecode for this event name
                     combined_bytecode = combined_bytecodes_by_event.get(event_name)

--- a/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_events_workflow.py
@@ -235,6 +235,11 @@ async def backfill_precalculated_events_activity(
             logger.warning("Invalid BACKFILL_EVENTS_KAFKA_FLUSH_BATCH_SIZE, using default 1000")
             KAFKA_FLUSH_BATCH_SIZE = 1000
 
+        # No ORDER BY: each event is evaluated independently and there is no cursor, so ordering is
+        # not needed. Events within a day are not physically timestamp-ordered (the events sort key
+        # is (team_id, toDate(timestamp), event, ...)), so ORDER BY timestamp would force a full sort
+        # of every matched event and block streaming. Without it, ClickHouse streams rows as it reads
+        # them in primary-key order — lower memory and faster time-to-first-row.
         events_query = """
             SELECT
                 uuid,
@@ -249,7 +254,6 @@ async def backfill_precalculated_events_activity(
               AND timestamp >= %(start_time)s
               AND timestamp < %(end_time)s
               AND person_id IS NOT NULL
-            ORDER BY timestamp
             FORMAT JSONEachRow
         """
 

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -80,9 +80,20 @@ async def get_person_id_ranges_page_activity(inputs: PersonIdRangesPageInputs) -
             )
         )
 
+    # Enumerate person IDs straight off the raw ``person`` table with DISTINCT, not the ``persons``
+    # lazy table. We only need ID range *boundaries* here, not deduplicated / is_deleted-filtered
+    # rows -- the child workflow re-queries each range through ``persons`` with full argMax dedup and
+    # is_deleted filtering, so a deleted/duplicate ID slipping into a boundary just yields no child
+    # rows. The ``persons`` table, by contrast, would rewrite our ``id > cursor`` filter into
+    # ``id IN (SELECT id FROM person WHERE id > cursor)`` with no inner LIMIT, forcing a full
+    # ``GROUP BY id ... HAVING argMax(is_deleted)`` over the entire ID tail on every page before the
+    # outer LIMIT applies -- O(pages x tail). ``SELECT DISTINCT id FROM person WHERE id > cursor
+    # ORDER BY id ASC LIMIT N`` reads the ``(team_id, id)`` primary key in order and stops after N
+    # distinct IDs.
     ranges_query_ast = ast.SelectQuery(
         select=[ast.Alias(alias="person_id", expr=ast.Field(chain=["id"]))],
-        select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
+        distinct=True,
+        select_from=ast.JoinExpr(table=ast.Field(chain=["raw_persons"])),
         where=_combine_where(where_exprs),
         order_by=[ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")],
         limit=ast.Constant(value=query_limit),

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -14,6 +14,8 @@ import temporalio.exceptions
 from structlog.contextvars import bind_contextvars
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLQuerySettings
+from posthog.hogql.database.argmax import argmax_select
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.kafka_client.client import _KafkaProducer
@@ -36,30 +38,25 @@ LOGGER = get_logger(__name__)
 MAX_OPTIMIZED_PROPERTIES = 100  # Safety limit to avoid query complexity issues
 
 
-def build_person_properties_select_exprs(
+def build_person_properties_select_fields(
     person_properties: list[str],
-) -> tuple[list[ast.Alias], dict[str, str]]:
-    """Build HogQL SELECT expressions for the requested person properties.
+) -> tuple[dict[str, list[str | int]], dict[str, str]]:
+    """Map each requested person property to an ``argmax_select`` field chain and its ``prop_N`` alias.
 
-    Property names come from cohort filters, so they must never be substring-concatenated
-    into SQL. Using ``ast.Field(chain=["properties", key])`` keeps the key out of the printed
-    SQL: HogQL either rewrites to a materialized column or routes the key through context
-    parameters when emitting ``JSONExtract``.
+    Property names come from cohort filters, so they must never be substring-concatenated into SQL.
+    Returning ``["properties", key]`` field chains keeps each key inside an ``ast.Field`` chain when
+    ``argmax_select`` wraps it in the per-person ``argMax`` aggregation: HogQL either rewrites to a
+    materialized column or routes the key through context parameters when emitting ``JSONExtract``.
     """
-    selects: list[ast.Alias] = []
+    select_fields: dict[str, list[str | int]] = {}
     alias_mapping: dict[str, str] = {}
 
     for i, prop in enumerate(person_properties):
         alias = f"prop_{i}"
-        selects.append(
-            ast.Alias(
-                alias=alias,
-                expr=ast.Field(chain=["properties", prop]),
-            )
-        )
+        select_fields[alias] = ["properties", prop]
         alias_mapping[alias] = prop
 
-    return selects, alias_mapping
+    return select_fields, alias_mapping
 
 
 def format_cohort_ids_for_logging(cohort_ids: list[int]) -> str:
@@ -485,10 +482,10 @@ async def backfill_precalculated_person_properties_activity(
             # Not in activity context (e.g., during tests), skip metrics
             pass
 
-        # Build the HogQL SELECT list — either targeted property accessors (so HogQL can use
-        # materialized columns when present) or the full ``properties`` JSON as a fallback.
+        # Build the per-property argmax_select fields — either targeted property accessors (so HogQL
+        # can use materialized columns when present) or the full ``properties`` JSON as a fallback.
         property_alias_mapping: dict[str, str] = {}
-        select_exprs: list[ast.Expr] = [ast.Alias(alias="person_id", expr=ast.Field(chain=["id"]))]
+        select_fields: dict[str, list[str | int]] = {}
 
         # A '%' in a property key makes the HogQL printer raise (it can resolve the accessor to a
         # column identifier, and '%' is banned there). Such keys are rare but valid person-property
@@ -497,12 +494,11 @@ async def backfill_precalculated_person_properties_activity(
         has_identifier_unsafe_key = any("%" in prop for prop in person_properties)
 
         if person_properties and len(person_properties) <= MAX_OPTIMIZED_PROPERTIES and not has_identifier_unsafe_key:
-            property_exprs, property_alias_mapping = build_person_properties_select_exprs(person_properties)
-            select_exprs.extend(property_exprs)
+            select_fields, property_alias_mapping = build_person_properties_select_fields(person_properties)
 
             logger.info(f"Optimized query: fetching {len(person_properties)} specific properties via HogQL")
         else:
-            select_exprs.append(ast.Field(chain=["properties"]))
+            select_fields["properties"] = ["properties"]
             if person_properties and len(person_properties) > MAX_OPTIMIZED_PROPERTIES:
                 logger.warning(
                     f"Too many properties ({len(person_properties)} > {MAX_OPTIMIZED_PROPERTIES}) - falling back to fetching all properties for performance"
@@ -537,19 +533,31 @@ async def backfill_precalculated_person_properties_activity(
                 )
             )
 
-        persons_query_ast = ast.SelectQuery(
-            select=select_exprs,
-            # The HogQL ``persons`` table handles ``team_id`` scoping, argMax/FINAL dedup, and
-            # ``is_deleted = 0`` filtering automatically. Note it also adds an implicit
-            # ``argMax(created_at) < now() + 1 day`` clamp, so future-dated persons (clock skew /
-            # backdated imports) are excluded — unlike the old raw-SQL ``person FINAL`` query.
-            select_from=ast.JoinExpr(table=ast.Field(chain=["persons"])),
-            where=ast.And(exprs=where_exprs),
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")],
-            # No explicit limit: compile_hogql_for_streaming uses LimitContext.COHORT_CALCULATION,
-            # which injects LIMIT 1_000_000_000. ID ranges are bounded by batch_size (default
-            # 1000 persons), so this cap is never reached in practice.
+        # Deduplicate straight off the raw ``person`` table with ``argmax_select`` instead of the
+        # ``persons`` lazy table. ``argmax_select`` is the exact helper the ``persons`` table uses
+        # internally, so the semantics are identical: ``team_id`` scoping (added by the printer),
+        # latest-version-per-id dedup, ``is_deleted = 0`` filtering, and the
+        # ``argMax(created_at) < now() + 1 day`` clamp that drops future-dated persons. The win is in
+        # how the ID-range filter is applied: querying ``persons`` rewrites our ``id BETWEEN start AND
+        # end`` predicate into ``id IN (SELECT id FROM person WHERE id BETWEEN start AND end)``, which
+        # scans the range twice (build the IN set, then re-read for the GROUP BY). Setting the range as
+        # a direct ``WHERE`` on the argMax aggregation reads the ``(team_id, id)`` primary key once.
+        # Output column for the person UUID is ``id`` (argmax_select aliases the group field by name).
+        persons_query_ast = argmax_select(
+            table_name="raw_persons",
+            select_fields=select_fields,
+            group_fields=["id"],
+            argmax_field="version",
+            deleted_field="is_deleted",
+            timestamp_field_to_clamp="created_at",
         )
+        persons_query_ast.where = ast.And(exprs=where_exprs)
+        persons_query_ast.order_by = [ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC")]
+        # optimize_aggregation_in_order lets ClickHouse aggregate as it streams the primary key in
+        # order, so the GROUP BY + ORDER BY id never buffers the whole range. No explicit limit:
+        # compile_hogql_for_streaming uses LimitContext.COHORT_CALCULATION (LIMIT 1_000_000_000), and
+        # ID ranges are bounded by batch_size (default 1000 persons), so the cap is never reached.
+        persons_query_ast.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
 
         persons_query, query_params = await compile_hogql_for_streaming(persons_query_ast, team_id=inputs.team_id)
 
@@ -583,11 +591,11 @@ async def backfill_precalculated_person_properties_activity(
                             "First row received from ClickHouse query",
                             team_id=inputs.team_id,
                             time_to_first_row_seconds=round(query_first_row_time - query_start_time, 2),
-                            first_person_id=str(row["person_id"]),
+                            first_person_id=str(row["id"]),
                         )
                         first_row = False
                     batch_count += 1
-                    person_id = str(row["person_id"])
+                    person_id = str(row["id"])
                     last_person_id = person_id  # Track the last person ID for next cursor
 
                     # Handle both optimized (individual property columns) and fallback (full properties JSON) formats

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -498,6 +498,10 @@ async def backfill_precalculated_person_properties_activity(
 
             logger.info(f"Optimized query: fetching {len(person_properties)} specific properties via HogQL")
         else:
+            # The ``"properties"`` key here is also the format discriminator for the row consumer
+            # below: when it is present the query emits a full ``properties`` column, so the consumer
+            # takes the fallback path (`"properties" in row`) instead of reconstructing the dict from
+            # per-property ``prop_N`` columns. Keep this alias name in sync with that check.
             select_fields["properties"] = ["properties"]
             if person_properties and len(person_properties) > MAX_OPTIMIZED_PROPERTIES:
                 logger.warning(

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_events_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_events_workflow.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 import pytest
 from unittest.mock import Mock, patch
 
@@ -7,6 +9,7 @@ from parameterized import parameterized
 from posthog.temporal.messaging.backfill_precalculated_events_workflow import (
     BackfillPrecalculatedEventsInputs,
     backfill_precalculated_events_activity,
+    bytecode_references_properties,
     evaluate_event_combined_filters_sync,
     evaluate_event_filters_with_fallback_sync,
     evaluate_event_individual_filters_sync,
@@ -32,6 +35,41 @@ class TestParseEventProperties:
     )
     def test_parse_event_properties(self, _name, raw_input, expected):
         assert parse_event_properties(raw_input, "test-uuid") == expected
+
+
+class TestBytecodeReferencesProperties:
+    @parameterized.expand(
+        [
+            # Pure event-name filter (event == '$pageview') — never reads properties.
+            (
+                "event_name_only",
+                [
+                    "_H",
+                    1,
+                    Operation.STRING,
+                    "$pageview",
+                    Operation.STRING,
+                    "event",
+                    Operation.GET_GLOBAL,
+                    1,
+                    Operation.EQ,
+                ],
+                False,
+            ),
+            ("constant_true", ["_H", 1, Operation.TRUE], False),
+            ("empty", [], False),
+            # properties.foo access — the global root "properties" is a literal string operand.
+            (
+                "property_access",
+                ["_H", 1, Operation.STRING, "foo", Operation.STRING, "properties", Operation.GET_GLOBAL, 2],
+                True,
+            ),
+            # Nested (e.g. inside a declared function body) is still detected.
+            ("nested", ["_H", 1, [Operation.STRING, "properties", Operation.GET_GLOBAL, 1]], True),
+        ]
+    )
+    def test_detects_properties_reference(self, _name, bytecode, expected):
+        assert bytecode_references_properties(bytecode) is expected
 
 
 class TestFlushKafkaBatchAsync:
@@ -209,6 +247,98 @@ class TestBackfillPrecalculatedEventsActivity:
 
         assert result.events_processed == 0
         assert result.events_produced == 0
+
+    async def _run_activity_capturing_query(self, filters, event_names, combined_bytecodes, rows):
+        """Run the activity with ClickHouse/Kafka mocked, returning (executed_query, result)."""
+        captured: dict[str, str] = {}
+
+        async def fake_stream(query, query_parameters=None):
+            captured["query"] = query
+            for row in rows:
+                yield row
+
+        mock_client = Mock()
+        mock_client.stream_query_as_jsonl = fake_stream
+
+        @asynccontextmanager
+        async def fake_get_client(**_kwargs):
+            yield mock_client
+
+        @asynccontextmanager
+        async def fake_heartbeater(**_kwargs):
+            yield Mock(details=None)
+
+        inputs = BackfillPrecalculatedEventsInputs(
+            team_id=1,
+            filter_storage_key="some_key",
+            cohort_ids=[1],
+            start_time="2024-01-01T00:00:00+00:00",
+            end_time="2024-01-02T00:00:00+00:00",
+        )
+
+        module = "posthog.temporal.messaging.backfill_precalculated_events_workflow"
+        with (
+            patch(f"{module}.get_event_filters", return_value=(filters, event_names, combined_bytecodes)),
+            patch(f"{module}.get_producer", return_value=Mock()),
+            patch(f"{module}.get_client", fake_get_client),
+            patch(f"{module}.Heartbeater", fake_heartbeater),
+            patch(f"{module}.asyncio.to_thread", side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs)),
+        ):
+            result = await backfill_precalculated_events_activity(inputs)
+
+        return captured["query"], result
+
+    @pytest.mark.asyncio
+    async def test_skips_properties_column_when_no_filter_reads_properties(self):
+        # Pure event-name filter — bytecode never references properties.
+        bytecode = ["_H", 1, Operation.TRUE]
+        filters = [
+            BehavioralEventFilter(
+                condition_hash="hash1",
+                bytecode=bytecode,
+                cohort_ids=[1],
+                event_name="$pageview",
+                time_value=30,
+                time_interval="day",
+            )
+        ]
+        rows = [{"uuid": "u1", "event": "$pageview", "date": "2024-01-01", "distinct_id": "d1", "person_id": "p1"}]
+
+        query, result = await self._run_activity_capturing_query(filters, ["$pageview"], {}, rows)
+
+        assert "properties" not in query
+        # The row carries no properties column, yet evaluation still runs and matches.
+        assert result.events_processed == 1
+
+    @pytest.mark.asyncio
+    async def test_reads_properties_column_when_a_filter_references_properties(self):
+        # properties.foo access — "properties" appears in the bytecode.
+        bytecode = ["_H", 1, Operation.STRING, "foo", Operation.STRING, "properties", Operation.GET_GLOBAL, 2]
+        filters = [
+            BehavioralEventFilter(
+                condition_hash="hash1",
+                bytecode=bytecode,
+                cohort_ids=[1],
+                event_name="$pageview",
+                time_value=30,
+                time_interval="day",
+            )
+        ]
+        rows = [
+            {
+                "uuid": "u1",
+                "event": "$pageview",
+                "date": "2024-01-01",
+                "distinct_id": "d1",
+                "person_id": "p1",
+                "properties": "{}",
+            }
+        ]
+
+        query, result = await self._run_activity_capturing_query(filters, ["$pageview"], {}, rows)
+
+        assert "properties" in query
+        assert result.events_processed == 1
 
 
 class TestBackfillPrecalculatedEventsInputs:

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
@@ -244,6 +244,13 @@ class TestGetPersonIdRangesPageActivity:
         node = captured["node"]
         assert isinstance(node, ast.SelectQuery)
         assert node.where is None
+        # Pagination must enumerate IDs off the raw ``person`` table with DISTINCT, not the
+        # ``persons`` lazy table -- otherwise ``id > cursor`` is wrapped in an unbounded
+        # ``id IN (...)`` subquery that GROUP BYs the whole ID tail on every page.
+        assert node.distinct is True
+        assert isinstance(node.select_from, ast.JoinExpr)
+        assert isinstance(node.select_from.table, ast.Field)
+        assert node.select_from.table.chain == ["raw_persons"]
 
     @pytest.mark.asyncio
     async def test_where_is_single_expr_with_only_after_person_id(self):

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
@@ -320,3 +320,79 @@ class TestGetPersonIdRangesPageActivity:
         ops = {e.op for e in node.where.exprs if isinstance(e, ast.CompareOperation)}
         assert ast.CompareOperationOp.Gt in ops
         assert ast.CompareOperationOp.Eq in ops
+
+
+class TestPageActivityRowConsumption:
+    """Stream real rows through get_person_id_ranges_page_activity.
+
+    The AST tests above stream zero rows, so the row-consumption code — which reads ``row["person_id"]``
+    and batches IDs into ranges — was never exercised. These feed real rows through it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rows_batched_into_ranges(self):
+        rows = [{"person_id": f"p{i}"} for i in range(1, 5)]
+        mock_client = Mock()
+        mock_client.stream_query_as_jsonl = lambda *a, **kw: aiter(rows)
+        module = "posthog.temporal.messaging.backfill_precalculated_person_properties_coordinator_workflow"
+        with (
+            patch(f"{module}.compile_hogql_for_streaming", side_effect=lambda node, *, team_id: ("SELECT 1", {})),
+            patch(f"{module}.get_client", return_value=_AsyncClientContextManager(mock_client)),
+            patch("temporalio.activity.heartbeat"),
+        ):
+            result = await get_person_id_ranges_page_activity(
+                PersonIdRangesPageInputs(team_id=1, batch_size=2, page_size=10, after_person_id=None)
+            )
+        assert result.ranges == [("p1", "p2"), ("p3", "p4")]
+        assert result.cursor is None  # 4 rows < limit (20), no more data
+
+    @pytest.mark.asyncio
+    async def test_has_more_data_sets_cursor(self):
+        # batch_size=2, page_size=1 -> limit=2; a 3rd (limit+1) row signals more data and sets the cursor.
+        rows = [{"person_id": f"p{i}"} for i in range(1, 4)]
+        mock_client = Mock()
+        mock_client.stream_query_as_jsonl = lambda *a, **kw: aiter(rows)
+        module = "posthog.temporal.messaging.backfill_precalculated_person_properties_coordinator_workflow"
+        with (
+            patch(f"{module}.compile_hogql_for_streaming", side_effect=lambda node, *, team_id: ("SELECT 1", {})),
+            patch(f"{module}.get_client", return_value=_AsyncClientContextManager(mock_client)),
+            patch("temporalio.activity.heartbeat"),
+        ):
+            result = await get_person_id_ranges_page_activity(
+                PersonIdRangesPageInputs(team_id=1, batch_size=2, page_size=1, after_person_id=None)
+            )
+        assert result.ranges == [("p1", "p2")]
+        assert result.cursor == "p2"  # last processed ID, used as the next page's after_person_id
+
+
+class TestDrainCompleted:
+    """The coordinator surfaces child failures via _drain_completed -> ApplicationError.
+
+    The workflow test patches asyncio.wait to (set(), set()), so the failure-counting branch was never
+    hit. This exercises _drain_completed directly with a failing handle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_counts_completed_and_failed_and_removes_handles(self):
+        class _Handle:
+            def __init__(self, fail: bool) -> None:
+                self._fail = fail
+
+            def __await__(self):
+                async def _coro():
+                    if self._fail:
+                        raise RuntimeError("child boom")
+                    return None
+
+                return _coro().__await__()
+
+        ok = _Handle(fail=False)
+        bad = _Handle(fail=True)
+        handles = [ok, bad]
+
+        workflow = BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow()
+        completed, failed = await workflow._drain_completed({ok, bad}, handles, Mock())
+
+        assert completed == 1
+        assert failed == 1
+        assert handles == []  # both drained handles removed from the in-flight list

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_coordinator_workflow.py
@@ -391,7 +391,7 @@ class TestDrainCompleted:
         handles = [ok, bad]
 
         workflow = BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow()
-        completed, failed = await workflow._drain_completed({ok, bad}, handles, Mock())
+        completed, failed = await workflow._drain_completed({ok, bad}, handles, Mock())  # type: ignore[arg-type]  # fake handles stand in for ChildWorkflowHandle
 
         assert completed == 1
         assert failed == 1

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -486,7 +486,12 @@ class TestActivityRowConsumption:
 
         produced: list[dict] = []
         producer = Mock()
-        producer.produce = lambda **kwargs: produced.append(kwargs["data"]) or Mock()
+
+        def _produce(**kwargs):
+            produced.append(kwargs["data"])
+            return Mock()
+
+        producer.produce = _produce
 
         mock_client = Mock()
         mock_client.stream_query_as_jsonl = lambda *a, **kw: aiter(rows)

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -73,6 +73,16 @@ class _AsyncClientContextManager:
         return None
 
 
+def aiter(iterable):
+    """Wrap a sync iterable as an async iterator for mocking ``stream_query_as_jsonl``."""
+
+    async def _aiter():
+        for item in iterable:
+            yield item
+
+    return _aiter()
+
+
 class TestFlushKafkaBatchAsync:
     """Tests for the flush_kafka_batch_async helper function."""
 
@@ -438,6 +448,111 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         assert len(properties_aliases) == 1
         assert any(chain[-1:] == ["properties"] for chain in _collect_field_chains(properties_aliases[0]))
         assert all(percent_property not in chain for chain in _collect_field_chains(node))
+
+
+class TestActivityRowConsumption:
+    """End-to-end row streaming through the child activity.
+
+    The other activity tests stream zero rows (``compile`` is patched and the client yields nothing),
+    so the row-consumption code — which now reads ``row["id"]`` and reconstructs properties from
+    ``prop_N`` columns — was never exercised. These feed real rows through it.
+    """
+
+    def _module(self, name: str) -> str:
+        return f"posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.{name}"
+
+    async def _run_with_rows(self, person_properties, rows):
+        """Run the activity over ``rows``; return (result, captured_query_node, produced_messages, eval_globals)."""
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="cond1",
+                bytecode=["_H", 1, Operation.TRUE],
+                cohort_ids=[10],
+                property_key=person_properties[0] if person_properties else None,
+            )
+        ]
+
+        captured: dict[str, object] = {}
+
+        async def compile_stub(node, *, team_id):
+            captured["node"] = node
+            return "SELECT 1", {}
+
+        eval_globals: list[dict] = []
+
+        def eval_stub(combined_bytecode, flts, hog_globals, person_id, detailed_logging=False):
+            eval_globals.append(hog_globals)
+            return {"cond1": True}
+
+        produced: list[dict] = []
+        producer = Mock()
+        producer.produce = lambda **kwargs: produced.append(kwargs["data"]) or Mock()
+
+        mock_client = Mock()
+        mock_client.stream_query_as_jsonl = lambda *a, **kw: aiter(rows)
+
+        inputs = BackfillPrecalculatedPersonPropertiesInputs(
+            team_id=1,
+            filter_storage_key="storage_key",
+            cohort_ids=[10],
+            batch_size=10,
+            start_person_id="00000000-0000-0000-0000-000000000000",
+            end_person_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        )
+
+        with (
+            patch(
+                self._module("get_filters_and_properties"),
+                return_value=(filters, list(person_properties), combine_filter_bytecodes(filters)),
+            ),
+            patch(self._module("compile_hogql_for_streaming"), side_effect=compile_stub),
+            patch(self._module("get_client"), return_value=_AsyncClientContextManager(mock_client)),
+            patch(self._module("evaluate_combined_filters_with_fallback_sync"), side_effect=eval_stub),
+            patch(self._module("get_producer"), return_value=producer),
+            patch(self._module("Heartbeater"), _NoopHeartbeater),
+            patch(self._module("get_person_properties_backfill_success_metric"), return_value=Mock()),
+        ):
+            result = await backfill_precalculated_person_properties_activity(inputs)
+
+        return result, captured.get("node"), produced, eval_globals
+
+    @pytest.mark.asyncio
+    async def test_optimized_rows_reconstruct_properties_and_produce(self):
+        # Optimized format: per-property prop_N columns, no "properties" key, person UUID under "id".
+        pid = "11111111-1111-1111-1111-111111111111"
+        rows = [{"id": pid, "prop_0": "a@b.com"}]
+
+        result, node, produced, eval_globals = await self._run_with_rows(["email"], rows)
+
+        # row["id"] is consumed and reconstruction maps prop_0 -> email.
+        assert result.persons_processed == 1
+        assert result.last_person_id == pid
+        assert eval_globals[0] == {"person": {"properties": {"email": "a@b.com"}}}
+        assert len(produced) == 1
+        assert produced[0]["person_id"] == pid
+        assert produced[0]["condition"] == "cond1"
+
+        # Locks the flat single-pass query shape the child optimization depends on: WHERE filters the
+        # raw_persons scan before the GROUP BY, with no id-IN-subquery indirection.
+        assert isinstance(node, ast.SelectQuery)
+        assert node.where is not None
+        assert node.group_by is not None
+        assert isinstance(node.select_from, ast.JoinExpr)
+        assert isinstance(node.select_from.table, ast.Field)
+        assert node.select_from.table.chain == ["raw_persons"]
+
+    @pytest.mark.asyncio
+    async def test_fallback_rows_use_full_properties_json(self):
+        # Fallback format: a "properties" JSON column is present, so the consumer parses it directly.
+        pid = "22222222-2222-2222-2222-222222222222"
+        rows = [{"id": pid, "properties": '{"email": "c@d.com"}'}]
+
+        result, _node, produced, eval_globals = await self._run_with_rows([], rows)
+
+        assert result.persons_processed == 1
+        assert result.last_person_id == pid
+        assert eval_globals[0] == {"person": {"properties": {"email": "c@d.com"}}}
+        assert len(produced) == 1
 
 
 class TestCombineFilterBytecodes:

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -7,11 +7,12 @@ import temporalio.exceptions
 from parameterized import parameterized
 
 from posthog.hogql import ast
+from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
     backfill_precalculated_person_properties_activity,
-    build_person_properties_select_exprs,
+    build_person_properties_select_fields,
     evaluate_combined_filters_sync,
     flush_kafka_batch_async,
 )
@@ -20,6 +21,22 @@ from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import execute_bytecode
 from common.hogvm.python.operation import Operation
+
+
+class _FieldChainCollector(TraversingVisitor):
+    """Collect every ``ast.Field`` chain reachable from a node (e.g. inside argMax wrappers)."""
+
+    def __init__(self) -> None:
+        self.chains: list[list[str | int]] = []
+
+    def visit_field(self, node: ast.Field) -> None:
+        self.chains.append(list(node.chain))
+
+
+def _collect_field_chains(node: ast.Expr) -> list[list[str | int]]:
+    collector = _FieldChainCollector()
+    collector.visit(node)
+    return collector.chains
 
 
 class _NoopHeartbeater:
@@ -225,22 +242,16 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         # Basic verification that the filter was stored correctly
         assert inputs.filter_storage_key == storage_key
 
-    def test_build_person_properties_select_exprs_keeps_keys_in_field_chain(self):
+    def test_build_person_properties_select_fields_keeps_keys_in_field_chain(self):
         malicious_property = "email') FROM person WHERE team_id != %(team_id)s UNION ALL SELECT sleep(3) --"
 
-        property_exprs, property_alias_mapping = build_person_properties_select_exprs([malicious_property])
+        select_fields, property_alias_mapping = build_person_properties_select_fields([malicious_property])
 
         assert property_alias_mapping == {"prop_0": malicious_property}
-        assert len(property_exprs) == 1
 
-        alias_expr = property_exprs[0]
-        assert isinstance(alias_expr, ast.Alias)
-        assert alias_expr.alias == "prop_0"
-
-        # The malicious key must live inside an ast.Field chain — never inline as a SQL fragment.
-        field_expr = alias_expr.expr
-        assert isinstance(field_expr, ast.Field)
-        assert field_expr.chain == ["properties", malicious_property]
+        # The malicious key must live inside an argmax_select field chain — never inline as a SQL
+        # fragment. argmax_select wraps the chain in an ``ast.Field``, keeping the key parameterized.
+        assert select_fields == {"prop_0": ["properties", malicious_property]}
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -330,10 +341,10 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
             expr for expr in node.select if isinstance(expr, ast.Alias) and expr.alias.startswith("prop_")
         ]
         assert len(property_aliases) == 1
-        # The key lives inside an ast.Field chain — never concatenated into the SQL as a fragment.
-        prop_field = property_aliases[0].expr
-        assert isinstance(prop_field, ast.Field)
-        assert prop_field.chain == ["properties", malicious_property]
+        # The key lives inside an ast.Field chain (wrapped in argMax by argmax_select) — never
+        # concatenated into the SQL as a fragment.
+        prop_chains = _collect_field_chains(property_aliases[0])
+        assert any(chain[-2:] == ["properties", malicious_property] for chain in prop_chains)
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -419,11 +430,14 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         ]
         assert property_aliases == []
 
-        # The full ``properties`` JSON is selected instead, and the '%' key never appears as a field.
-        properties_fields = [
-            expr for expr in node.select if isinstance(expr, ast.Field) and expr.chain == ["properties"]
+        # The full ``properties`` JSON is selected instead (argmax_select aliases it as "properties"),
+        # and the '%' key never appears as a field chain element anywhere in the query.
+        properties_aliases = [
+            expr for expr in node.select if isinstance(expr, ast.Alias) and expr.alias == "properties"
         ]
-        assert len(properties_fields) == 1
+        assert len(properties_aliases) == 1
+        assert any(chain[-1:] == ["properties"] for chain in _collect_field_chains(properties_aliases[0]))
+        assert all(percent_property not in chain for chain in _collect_field_chains(node))
 
 
 class TestCombineFilterBytecodes:


### PR DESCRIPTION
> **Stacked on #64306** (base branch `posthog-code/backfill-person-properties-queries`). Review/merge #64306 first; this PR's diff is the two events backfill commits on top.

## Problem

The precalculated events backfill scans a day of events and evaluates behavioral-cohort bytecode per event. Two inefficiencies: it sorted every matched event by `timestamp` despite evaluating each event independently, and it fetched the full `properties` blob for every event even when no cohort filter reads `properties` (the common count-only case, e.g. "performed `$pageview` N times").

## Changes

1. **Drop needless `ORDER BY`.** Each event is evaluated independently with no cursor, and events within a day are not physically timestamp-ordered (sort key `(team_id, toDate(timestamp), event, …)`), so `ORDER BY timestamp` scanned and sorted every matched event and blocked streaming. Removing it lets ClickHouse stream rows in primary-key order — lower memory, faster time-to-first-row.

2. **Skip the `properties` column when unused.** `bytecode_references_properties()` walks the combined + individual filter bytecodes. The HogVM loads `properties` via a `GET_GLOBAL` chain whose root is pushed as the literal string `"properties"`, so when that string appears in none of the bytecodes the column is provably unused — we then omit it from the `SELECT` and pass an empty dict to the HogVM. Correctness-safe by construction: a coincidental string literal only keeps the column (a missed optimization), never drops a cohort match. The only HogVM globals are `event` and `properties`, so results are identical when `properties` is unreferenced.

The `properties`-skip was chosen over two riskier alternatives, both deliberately rejected: (a) narrowing `properties` to specific referenced keys — correctness-sensitive and benefit-dependent on materialization, unmeasurable without a cluster; and (b) converting the raw single-team SQL to HogQL — risks changing `person_id` semantics.

## How did you test this code?

I'm an agent. I added and ran automated tests (no manual testing):

- Events backfill workflow tests pass (26), including new `bytecode_references_properties` cases and activity-level tests that capture the emitted query to prove `properties` is omitted/included correctly.
- Verified the new test fails when the `properties`-skip is forced off, then passes when restored.
- `ruff` clean on changed files.

**No live ClickHouse / Test Cluster was available, so there are no measured before/after numbers.** Both changes are query-shape reductions that are strictly less work by construction (no sort; no large-column read in the count-only case). Suggested verification before merge: on the Test Cluster (adapted to team 2), compare with vs without each change and check `read_bytes` / `query_duration_ms`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code applying the `optimizing-clickhouse-and-hogql-queries` skill to the events backfill workflow, directed by the assignee. Stacked on #64306 (the person-properties optimizations). Agent-authored — requires human review; not self-merged.
