### PR TITLE
fix(meta_ads): treat deleted integration as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -40,6 +40,14 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "Failed to refresh token for Meta Ads integration. Please re-authorize the integration.": None,
+            # The data warehouse source still references a `meta_ads_integration_id` whose
+            # Integration row no longer exists for the team (the integration was deleted or
+            # de-authorized). `get_integration` then raises Django's `Integration.DoesNotExist`
+            # ("Integration matching query does not exist."); retrying can never make the row
+            # reappear — the only fix is the user reconnecting the integration.
+            "Integration matching query does not exist.": (
+                "The Meta Ads integration for this source no longer exists. Please reconnect the Meta Ads integration."
+            ),
             # Permanent auth/permission failures from the Graph API (e.g. revoked or expired
             # access tokens, checkpoint-required, invalidated sessions, permission denials).
             # `meta_ads._raise_meta_api_error` prefixes these with this exact message.

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -780,6 +780,9 @@ class TestNonRetryableErrors:
         [
             # Token refresh failure raised by get_integration.
             "Failed to refresh token for Meta Ads integration. Please re-authorize the integration.",
+            # Integration row deleted/de-authorized while the source still references it —
+            # get_integration raises Django's Integration.DoesNotExist with this message.
+            "Integration matching query does not exist.",
             # 400 from Meta when the ad account no longer belongs to the authorised user.
             'Meta API request failed: 400 - {"error":{"message":"(#200) Ad account owner has NOT granted ads_management or ads_read permission.","type":"OAuthException","code":200}}',
             # 400 when a specific endpoint cannot be accessed with the granted permissions.


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `Integration.DoesNotExist` ("Integration matching query does not exist.") originating in the Meta Ads data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed5bd-32b9-7093-9a32-d18ebc6a83cd)).

The failure is raised in `get_integration` (`posthog/temporal/data_imports/sources/meta_ads/meta_ads.py:116`):

```python
integration = Integration.objects.get(id=config.meta_ads_integration_id, team_id=team_id)
```

A Meta Ads source still references a `meta_ads_integration_id` whose `Integration` row no longer exists for the team — the integration was deleted or de-authorized while the source kept pointing at it. This is terminal: retrying the sync can never make the row reappear, so the import burns its full retry budget on every scheduled run before giving up. The only fix is for the user to reconnect the integration.

## Changes

Add the stable Django `DoesNotExist` message `"Integration matching query does not exist."` to `MetaAdsSource.get_non_retryable_errors`, with a user-facing reconnect prompt as the friendly error. The matcher is a substring check scoped to this source, and the chosen substring contains no volatile parts (ids, URLs, timestamps), so it is low-false-positive and only applies when the Integration lookup itself fails.

This mirrors the existing non-retryable handling in this source (token-refresh failures, permanent Graph API auth/permission errors) and the pattern used by the Stripe source.

Extended the parametrized `test_errors_match_pattern` test so the new message is asserted as non-retryable.

### Decision: user/upstream error, not a code bug

The integration row is gone because of user/config state (deleted/de-authorized integration), not a fault in our code or a response shape we mishandle. Per the source's retry conventions, a deleted integration belongs in `NonRetryableErrors` — there is nothing sensible to retry.

## How did you test this code?

I'm an agent. I added an automated test case and ran:

- `pytest posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py -k TestNonRetryableErrors` — 18 passed
- `pytest posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py` (full file) — 60 passed
- `ruff check` and `ruff format` on both changed files — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, confirming the bottom in-app frame is `get_integration` at `meta_ads.py:116` (not just serialized log context). Read the source and the non-retryable-error matching path (`import_data_sync._handle_import_error` → substring match on `str(error)`; the dict value becomes the user-facing "friendly error"). Chose to extend `get_non_retryable_errors` rather than change code, since the integration's absence is user/config state that retrying cannot resolve. Scope kept minimal: one dict entry plus one test case.
