### PR TITLE
fix(tracing): stop trace waterfall infinite-scroll from pegging the CPU

### DIFF
--- a/products/tracing/frontend/TraceWaterfallView.test.tsx
+++ b/products/tracing/frontend/TraceWaterfallView.test.tsx
@@ -104,4 +104,43 @@ describe('TraceWaterfallView', () => {
         expect(within(container).queryByLabelText('Collapse child spans')).toBeNull()
         expect(within(container).queryByLabelText('Collapse all spans')).toBeNull()
     })
+
+    it('does not request more spans when hasMore is false', () => {
+        const onLoadMore = jest.fn()
+        render(<TraceWaterfallView spans={[root, child]} hasMore={false} onLoadMore={onLoadMore} />)
+
+        expect(onLoadMore).not.toHaveBeenCalled()
+    })
+
+    it('requests more spans at most once per loaded count, even across rerenders with the same spans', () => {
+        // The runaway bug: a page that returns no new rows leaves the window pinned at the bottom, so
+        // the trigger refires every render. The guard pages once per loaded count — re-rendering with
+        // the same spans (the loading-more flag toggling back) must not refire.
+        const onLoadMore = jest.fn()
+        const { rerender } = render(<TraceWaterfallView spans={[root, child]} hasMore onLoadMore={onLoadMore} />)
+
+        expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+        rerender(<TraceWaterfallView spans={[root, child]} hasMore loadingMore onLoadMore={onLoadMore} />)
+        rerender(<TraceWaterfallView spans={[root, child]} hasMore onLoadMore={onLoadMore} />)
+
+        expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
+
+    it('requests more again once new spans grow the loaded count', () => {
+        const grandchild = makeSpan({
+            uuid: 'uuid-grandchild',
+            span_id: 'span-grandchild',
+            parent_span_id: 'span-child',
+            name: 'grandchild-operation',
+        })
+        const onLoadMore = jest.fn()
+        const { rerender } = render(<TraceWaterfallView spans={[root, child]} hasMore onLoadMore={onLoadMore} />)
+
+        expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+        rerender(<TraceWaterfallView spans={[root, child, grandchild]} hasMore onLoadMore={onLoadMore} />)
+
+        expect(onLoadMore).toHaveBeenCalledTimes(2)
+    })
 })

--- a/products/tracing/frontend/TraceWaterfallView.tsx
+++ b/products/tracing/frontend/TraceWaterfallView.tsx
@@ -553,19 +553,26 @@ export function TraceWaterfallView({
     const listRef = useListRef(null)
 
     // Infinite scroll: fetch the next page once the rendered window nears the end of the loaded spans.
+    // Tracks the span count we last paged against so the trigger fires at most once per loaded count —
+    // without this, a page that returns no new rows (dupes / end of data) leaves the window pinned at
+    // the bottom and the trigger spins on every render, pegging the CPU.
+    const lastRequestedSpanCountRef = useRef(-1)
     const handleRowsRendered = useCallback(
         (
             _visibleRows: { startIndex: number; stopIndex: number },
             allRows: { startIndex: number; stopIndex: number }
         ): void => {
-            if (
-                onLoadMore &&
-                hasMore &&
-                !loadingMore &&
-                allRows.stopIndex >= flatSpans.length - 1 - LOAD_MORE_THRESHOLD
-            ) {
-                onLoadMore()
+            if (!onLoadMore || !hasMore || loadingMore) {
+                return
             }
+            if (allRows.stopIndex < flatSpans.length - 1 - LOAD_MORE_THRESHOLD) {
+                return
+            }
+            if (lastRequestedSpanCountRef.current === flatSpans.length) {
+                return
+            }
+            lastRequestedSpanCountRef.current = flatSpans.length
+            onLoadMore()
         },
         [onLoadMore, hasMore, loadingMore, flatSpans.length]
     )

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -358,8 +358,18 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                     if (values.traceLoadContext?.traceId !== traceId) {
                         return values.traceSpans
                     }
+                    // Dedupe against what's already loaded: the waterfall keys its tree by span_id,
+                    // so a page that overlaps prior pages wouldn't grow the rendered rows but would
+                    // still balloon this array (and pin the infinite-scroll trigger at the bottom,
+                    // spinning the CPU). If a page adds nothing new, stop paging.
+                    const seen = new Set(values.traceSpans.map((s) => s.span_id))
+                    const newSpans = (response.results as Span[]).filter((s) => !seen.has(s.span_id))
+                    if (newSpans.length === 0) {
+                        actions.setTracePagination(false, null)
+                        return values.traceSpans
+                    }
                     actions.setTracePagination(!!response.hasMore, response.nextOffset ?? null)
-                    return [...values.traceSpans, ...(response.results as Span[])]
+                    return [...values.traceSpans, ...newSpans]
                 },
             },
         ],


### PR DESCRIPTION
## Problem

Scrolling to the bottom of a large trace in the APM tracing waterfall could spike CPU to 100%. The infinite-scroll trigger fires whenever the rendered window nears the bottom while `hasMore` is true, but loaded pages were appended to the raw span array **without deduping**, while the rendered row count comes from the span tree keyed by `span_id`. When a page returned spans already loaded — or the backend kept reporting `hasMore` — the deduped row count didn't grow, the window stayed pinned at the bottom, and the trigger refired on every render. Each cycle still grew the raw span array by a page, so the per-render tree rebuild (`buildSpanTree` / `flattenTree` and the `Math.min(...startTimes)` spreads) ran over an ever-larger array, compounding into a runaway.

## Changes

- **Data layer (`tracingDataLogic`):** `loadMoreTraceSpans` now dedupes each page against already-loaded spans by `span_id` and stops paging (`hasMore = false`) when a page adds nothing new. This is the root-cause fix — it keeps the span array from ballooning and prevents the trigger from being pinned at the bottom regardless of backend `hasMore`/offset behavior.
- **View layer (`TraceWaterfallView`):** the infinite-scroll trigger now fires at most once per loaded span count, so a no-progress page can't refire it every render. Defends the same loop independently of the data layer.

No UI/visual change — behavior only.

## How did you test this code?

I'm an agent (PostHog Code). I added and ran automated Jest tests in `TraceWaterfallView.test.tsx`:

- does not request more spans when `hasMore` is false
- requests more at most once per loaded count, even across rerenders with the same spans (the `loadingMore` flag toggling back)
- requests more again once new spans grow the loaded count

All 5 tests in the suite pass locally. I did not perform manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a report of 100% CPU when scrolling to the bottom of the tracing waterfall. Traced it to a mismatch between the deduped, tree-keyed render count and the non-deduped appended span array, which let the infinite-scroll trigger refire indefinitely against non-growing rows. Chose a two-layer fix: dedupe + halt-on-no-progress at the data layer (root cause), plus a once-per-loaded-count guard in the view (defense in depth). Tool: PostHog Code (Claude Opus 4.8).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a CPU-pegging bug in the tracing waterfall infinite-scroll by deduping loaded spans by `span_id` in the data layer and adding a once-per-loaded-count guard in the view layer to prevent the scroll trigger from refiring indefinitely when pages don't grow the rendered tree.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b9a4748071050fdd8a03af4b9ad068594c4785d1.</sup>
<!-- /MENDRAL_SUMMARY -->