### PR TITLE
feat(quill): MenuLabel renders a div by default with render passthrough

### DIFF
--- a/packages/quill/packages/primitives/src/menu-label.tsx
+++ b/packages/quill/packages/primitives/src/menu-label.tsx
@@ -1,10 +1,25 @@
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
 import * as React from 'react'
 
 import { cn } from './lib/utils'
 import './menu-label.css'
 
-function MenuLabel({ className, ...props }: React.ComponentProps<'label'>): React.ReactElement {
-    return <label data-quill data-slot="menu-label" className={cn('quill-menu-label', className)} {...props} />
+// Section label for menus/lists. Defaults to a <div>; pass render=<label /> to
+// bind it to a control.
+function MenuLabel({ className, render, ...props }: useRender.ComponentProps<'div'>): React.ReactElement {
+    return useRender({
+        defaultTagName: 'div',
+        props: mergeProps<'div'>(
+            {
+                'data-quill': '',
+                'data-slot': 'menu-label',
+                className: cn('quill-menu-label', className),
+            } as Omit<React.ComponentProps<'div'>, 'ref'>,
+            props
+        ),
+        render,
+    })
 }
 
 export { MenuLabel }


### PR DESCRIPTION
## Problem

`MenuLabel` — the shared section-label primitive used by dropdown/context-menu, combobox, select, and autocomplete group labels — was hardcoded to render a `<label>`. None of those consumers bind the label to a form control, so `<label>` is semantically wrong (and offers no escape hatch for the cases that *do* want one).

## Changes

- `MenuLabel` now renders a `<div>` by default.
- Adds a Base UI `render` passthrough (same `useRender` + `mergeProps` pattern as `Text`/`Heading`), so a consumer can opt into a `<label>` (or any element): `<MenuLabel render={<label htmlFor="x" />}>…</MenuLabel>`.

The `quill-menu-label` styling is element-agnostic, so every existing consumer is visually unchanged; the only difference is the underlying tag (`div` instead of `label`). No consumer passes `htmlFor`, so nothing relied on the old `<label>` element.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Type-level/markup change with no unit coverage for this primitive; the `useRender` pattern mirrors the existing `Text` and `Heading` primitives. Verification is visual in storybook (menu/combobox/select group labels render identically).

## Docs update

No product docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Followed the established `useRender`/`mergeProps` convention already used by `Text`/`Heading` rather than inventing a new render-prop mechanism. Confirmed no consumer relied on label-specific behavior (`htmlFor`) and that the CSS makes no element assumptions. No repo skills were invoked.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes `MenuLabel` from a hardcoded `<label>` to a `<div>` by default, adding a Base UI `render` passthrough prop so consumers can opt into any element. Follows the existing `useRender`/`mergeProps` pattern used by `Text` and `Heading`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8dfce75d47ff4971ad63328490af1b8a06c107b5.</sup>
<!-- /MENDRAL_SUMMARY -->