### PR TITLE
fix(batch-exports): fix handling of Snowflake invalid account errors

### DIFF
--- a/products/batch_exports/backend/api/destination_tests/snowflake.py
+++ b/products/batch_exports/backend/api/destination_tests/snowflake.py
@@ -81,7 +81,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
     async def _run_step(self) -> DestinationTestStepResult:
         """Run this test step."""
         import snowflake.connector
-        from snowflake.connector.errors import DatabaseError, InterfaceError, OperationalError
+        from snowflake.connector.errors import DatabaseError, HttpError, InterfaceError, OperationalError
 
         private_key, result = try_load_private_key(self.private_key, self.private_key_passphrase)
         if result is not None:
@@ -98,7 +98,7 @@ class SnowflakeEstablishConnectionTestStep(DestinationTestStep):
                 role=f'"{self.role}"' if self.role is not None else None,
                 session_parameters=_SNOWFLAKE_SESSION_PARAMETERS,
             )
-        except (OperationalError, InterfaceError, DatabaseError) as err:
+        except (OperationalError, InterfaceError, DatabaseError, HttpError) as err:
             if err.msg is not None and "404 Not Found" in err.msg:
                 return DestinationTestStepResult(
                     status=Status.FAILED,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives import serialization
 from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.constants import FIELD_ID_TO_NAME, QueryStatus
 from snowflake.connector.cursor import ResultMetadata
-from snowflake.connector.errors import InterfaceError, OperationalError
+from snowflake.connector.errors import HttpError, InterfaceError, OperationalError
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -604,6 +604,13 @@ class SnowflakeClient:
 
         except InterfaceError as err:
             raise SnowflakeConnectionError(f"Could not connect to Snowflake - {err.errno}: {err.msg}") from err
+
+        # Handle 404 errors (usually indicates the provided account is invalid)
+        except HttpError as err:
+            if err.msg is not None and "404 Not Found" in err.msg:
+                raise SnowflakeConnectionError(
+                    f"Could not establish a connection to Snowflake as the resolved URL does not exist. This usually indicates an invalid Snowflake account."
+                ) from err
 
         self.logger.debug("Connected to Snowflake")
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -611,6 +611,8 @@ class SnowflakeClient:
                 raise SnowflakeConnectionError(
                     f"Could not establish a connection to Snowflake as the resolved URL does not exist. This usually indicates an invalid Snowflake account."
                 ) from err
+            # allow other errors to raise in case they're temporary connection issues
+            raise
 
         self.logger.debug("Connected to Snowflake")
 

--- a/products/batch_exports/backend/tests/api/destination_tests/test_snowflake_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_snowflake_destination_tests.py
@@ -167,7 +167,11 @@ async def test_snowflake_establish_connection_with_wrong_user(snowflake_config):
 
     assert result.status == Status.FAILED
     assert result.message is not None
-    assert "Incorrect username or password was specified." in result.message
+    # error depends on whether we're using password or keypair auth
+    if snowflake_config.get("password", None) is not None:
+        assert "Incorrect username or password was specified." in result.message
+    else:
+        assert "JWT token is invalid" in result.message
 
 
 async def test_snowflake_establish_connection_with_invalid_private_key(snowflake_config):
@@ -307,7 +311,8 @@ def user(snowflake_cursor, password):
     test_user = "EMPTY_TEST_USER"
     snowflake_cursor.execute(f"DROP USER IF EXISTS {test_user}")
 
-    snowflake_cursor.execute(f"CREATE USER {test_user} PASSWORD = '{password}'")
+    # Snowflake now enforces 2FA on many accounts so we need to bypass this for this new user
+    snowflake_cursor.execute(f"CREATE USER {test_user} PASSWORD = '{password}' MINS_TO_BYPASS_MFA = 30")
 
     yield test_user
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/conftest.py
@@ -113,6 +113,7 @@ def snowflake_cursor(snowflake_config: dict[str, str]):
         role=f'"{snowflake_config["role"]}"' if snowflake_config["role"] is not None else None,
         warehouse=f'"{snowflake_config["warehouse"]}"',
         private_key=private_key,
+        login_timeout=5,
     ) as connection:
         connection.telemetry_enabled = False
         cursor = connection.cursor()


### PR DESCRIPTION
## Problem

Snowflake has changed their reporting of invalid accounts and we're no longer handling these correctly; we raise a generic retryable error instead of a specific non-retryable error

## Changes

- Catch `HttpError` in addition to existing error classes
- Update tests which are failing due to MFA enforcement on our test account

## How did you test this code?

- Existing test failed with same error we see in production, so ensured this passes locally
- Ran existing Snowflake test suite locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

A rare human authored PR

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `HttpError` to the caught exception types for Snowflake connections to handle invalid account errors that now manifest as HTTP 404s instead of the previously caught error types. Also updates tests for MFA enforcement changes on the Snowflake test account.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 85e6f94793a8507fb82f9cb17c9b78a10720e1f7.</sup>
<!-- /MENDRAL_SUMMARY -->