### PR TITLE
fix(kafka): return undelivered count from _KafkaProducer.flush

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -322,11 +322,11 @@ class _KafkaProducer:
 
         return result
 
-    def flush(self, timeout: Optional[float] = None):
-        if timeout is not None:
-            self.producer.flush(timeout)
-        else:
-            self.producer.flush()
+    def flush(self, timeout: Optional[float] = None) -> int:
+        # confluent's flush() returns the count still undelivered (0 once acked);
+        # surface it so callers can detect a partial flush. It rejects a None
+        # timeout, so only pass one when set.
+        return self.producer.flush(timeout) if timeout is not None else self.producer.flush()
 
     def close(self):
         self.producer.flush()

--- a/posthog/kafka_client/test/test_client.py
+++ b/posthog/kafka_client/test/test_client.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
+from parameterized import parameterized
+
 from posthog.kafka_client.client import _KafkaProducer
 from posthog.settings.kafka import KafkaProfileSettings
 
@@ -81,6 +83,22 @@ class KafkaClientTestCase(TestCase):
         _KafkaProducer(test=False)
         config = mock_producer_class.call_args[0][0]
         self.assertEqual(config["security.protocol"], "PLAINTEXT")
+
+    # confluent's flush() returns the count still queued (0 once acked). The
+    # wrapper must surface that int, not swallow it as None, so callers can
+    # detect a partial flush. A None timeout calls flush() with no arg.
+    @parameterized.expand([("with_timeout", 5.0, (5.0,)), ("no_timeout", None, ())])
+    @patch("posthog.kafka_client.client.ConfluentProducer")
+    def test_flush_returns_undelivered_count(
+        self, _name: str, timeout: float | None, expected_call_args: tuple, mock_producer_class: MagicMock
+    ):
+        inner = MagicMock()
+        inner.flush.return_value = 3
+        mock_producer_class.return_value = inner
+        producer = _KafkaProducer(test=False)
+
+        self.assertEqual(producer.flush(timeout=timeout), 3)
+        inner.flush.assert_called_once_with(*expected_call_args)
 
     @override_settings(
         KAFKA_PROFILES=_make_profiles(


### PR DESCRIPTION
## Problem

`_KafkaProducer.flush()` (our sync Kafka producer wrapper) called the underlying `confluent_kafka.Producer.flush()` but discarded its return value, so the wrapper implicitly returned `None`.

`confluent_kafka.Producer.flush()` returns the number of messages still undelivered when it returns (`0` once everything has been acked). Any caller that inspects the result to decide whether the flush succeeded was silently broken.

The surfacing-scoring writeback (`_publish_scores` in the session-replay scoring sweep) does exactly that — it flushes after producing, then checks `if remaining > 0`. With `remaining` coming back as `None`, that comparison raised `'>' not supported between instances of 'NoneType' and 'int'`. The messages had actually been delivered (flush blocks until they are), but the activity still failed and got retried by Temporal, doing redundant work on every chunk.

## Changes

`_KafkaProducer.flush()` now returns the undelivered count from the underlying producer (typed `-> int`), so callers can detect a partial flush instead of always seeing `None`.

The fix is at the source — the surfacing activity's existing `if remaining > 0:` check is now correct as-written, so no change was needed there. A redundant `None`-guard would only mask a future regression of this same contract.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I ran locally:

- New `test_flush_returns_undelivered_count` in `posthog/kafka_client/test/test_client.py` — patches the underlying `ConfluentProducer`, asserts the wrapper returns the inner producer's count for both the `timeout` and no-`timeout` paths, and would have caught the `None` return.
- Full `KafkaClientTestCase` and the surfacing-scoring `test_publish_scores.py` suite (15 tests) pass.
- `ruff` (CI version 0.15.16) clean on the changed files.

The existing `test_flush_timeout_raises_for_activity_retry` already covers the `remaining > 0` raise path in the surfacing activity, which now receives a real int.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @arnohillen.

Root-caused from a production stack trace on the surfacing-scoring sweep activity. The crash surfaced in `_publish_scores`, but the real defect was the wrapper swallowing confluent's flush return value. Chose to fix the shared `_KafkaProducer` wrapper (the source) rather than add a defensive `None`-check in the one caller, since the wrapper's contract should match confluent's and a guard would just hide a future regression. Verified nothing else depended on the old `None` return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `_KafkaProducer.flush()` to return the undelivered message count from the underlying `confluent_kafka.Producer.flush()` instead of discarding it (implicitly returning `None`). This resolves a TypeError crash in the surfacing-scoring writeback that compared the `None` return against an int.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0727359e91bfeff9f3d501582650915cd0fb1b98.</sup>
<!-- /MENDRAL_SUMMARY -->