### PR TITLE
fix(max): bound dashboard context to the conversation window

### DIFF
--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -57,13 +57,13 @@ from .prompts import (
 NOTEBOOK_MARKDOWN_MAX_LENGTH = 100_000
 
 # A dashboard's executed-results context is bounded so it can't overflow the conversation window
-# (compaction_manager.CONVERSATION_WINDOW_SIZE). If it does overflow, the whole conversation —
+# (compaction_manager.CONVERSATION_WINDOW_SIZE = 100k). If it overflows, the whole conversation —
 # including this dashboard — gets summarized down to a few thousand tokens, so Max loses the
-# dashboard it was just asked about. When the executed results exceed this budget we fall back to
-# schema-only (insight names + queries, no result tables), which still lets Max identify and
-# describe the dashboard and fetch specific numbers via the read_data tool. Token count is
-# estimated with the same ~4-chars/token heuristic the compaction manager uses.
+# dashboard it was just asked about. Over budget, we fall back to schema-only (insight names +
+# queries, no result tables), which still lets Max identify and describe the dashboard and fetch
+# specific numbers via the read_data tool.
 DASHBOARD_CONTEXT_TOKEN_BUDGET = 50_000
+# ~4 chars/token, matching compaction_manager.APPROXIMATE_TOKEN_LENGTH.
 DASHBOARD_CONTEXT_CHAR_BUDGET = DASHBOARD_CONTEXT_TOKEN_BUDGET * 4
 
 
@@ -201,6 +201,9 @@ class AssistantContextManager(AssistantContextMixin):
         dashboard_context = ""
         if ui_context.dashboards:
             dashboard_contexts = []
+            # Budget across ALL attached dashboards, not per dashboard, so several attached
+            # dashboards can't collectively overflow the window even if each one fits on its own.
+            remaining_char_budget = DASHBOARD_CONTEXT_CHAR_BUDGET
             for dashboard in ui_context.dashboards:
                 dashboard_filters = (
                     dashboard.filters.model_dump(exclude_none=True)
@@ -242,15 +245,15 @@ class AssistantContextManager(AssistantContextMixin):
 
                 try:
                     dashboard_text = await dashboard_ctx.execute_and_format()
-                    if len(dashboard_text) > DASHBOARD_CONTEXT_CHAR_BUDGET:
-                        # Results too large for the window — drop to schema-only so the dashboard
-                        # still fits and survives un-summarized (Max keeps the read_data tool for
-                        # specific numbers). format_schema runs no queries.
+                    if len(dashboard_text) > remaining_char_budget:
+                        # Too large for the remaining window budget — drop to schema-only (insight
+                        # names + queries, no result tables) so it survives un-summarized; Max keeps
+                        # the read_data tool for specific numbers. format_schema runs no queries.
                         dashboard_text = await dashboard_ctx.format_schema()
-                        if len(dashboard_text) > DASHBOARD_CONTEXT_CHAR_BUDGET:
-                            dashboard_text = (
-                                dashboard_text[:DASHBOARD_CONTEXT_CHAR_BUDGET] + "\n\n…(dashboard context truncated)"
-                            )
+                        if len(dashboard_text) > remaining_char_budget:
+                            marker = "\n\n…(dashboard context truncated)"
+                            dashboard_text = dashboard_text[: max(0, remaining_char_budget - len(marker))] + marker
+                    remaining_char_budget -= len(dashboard_text)
                     dashboard_contexts.append(
                         format_prompt_string(ROOT_DASHBOARD_CONTEXT_PROMPT, content=dashboard_text)
                     )

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Optional, cast
 from uuid import uuid4
 
+import posthoganalytics
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableConfig
 from posthoganalytics import capture_exception
@@ -23,6 +24,7 @@ from posthog.schema import (
 )
 
 from posthog.constants import AvailableFeature
+from posthog.event_usage import groups
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -184,6 +186,26 @@ class AssistantContextManager(AssistantContextMixin):
 
         return await _get_group_names_sync()
 
+    def _capture_dashboard_budget_exceeded(self, fallbacks: dict[str, list[int]]) -> None:
+        overflowed = fallbacks["schema"] + fallbacks["truncated"]
+        if not overflowed:
+            return
+        distinct_id = self._get_user_distinct_id(self._config)
+        if not distinct_id:
+            return
+        posthoganalytics.capture(
+            distinct_id=distinct_id,
+            event="posthog ai dashboard context budget exceeded",
+            properties={
+                **self._get_debug_props(self._config),
+                "dashboard_ids": overflowed,
+                "budget_chars": DASHBOARD_CONTEXT_CHAR_BUDGET,
+                # "truncated" means schema itself didn't fit — the more-degraded outcome.
+                "fallback": "truncated" if fallbacks["truncated"] else "schema",
+            },
+            groups=groups(None, self._team),
+        )
+
     async def _format_ui_context(self, ui_context: MaxUIContext | None) -> str | None:
         """
         Format UI context into template variables for the prompt.
@@ -204,6 +226,8 @@ class AssistantContextManager(AssistantContextMixin):
             # Budget across ALL attached dashboards, not per dashboard, so several attached
             # dashboards can't collectively overflow the window even if each one fits on its own.
             remaining_char_budget = DASHBOARD_CONTEXT_CHAR_BUDGET
+            # Dashboard ids that overflowed the budget, keyed by fallback kind — emitted as one event below.
+            budget_fallbacks: dict[str, list[int]] = {"schema": [], "truncated": []}
             for dashboard in ui_context.dashboards:
                 dashboard_filters = (
                     dashboard.filters.model_dump(exclude_none=True)
@@ -250,12 +274,16 @@ class AssistantContextManager(AssistantContextMixin):
                         # names + queries, no result tables) so it survives un-summarized; Max keeps
                         # the read_data tool for specific numbers. format_schema runs no queries.
                         dashboard_text = await dashboard_ctx.format_schema()
+                        fallback = "schema"
                         if len(dashboard_text) > remaining_char_budget:
+                            fallback = "truncated"
                             marker = "\n\n…(dashboard context truncated)"
                             # No room for even the marker — stop here so the budget can't go negative.
                             if remaining_char_budget <= len(marker):
+                                budget_fallbacks[fallback].append(dashboard.id)
                                 break
                             dashboard_text = dashboard_text[: remaining_char_budget - len(marker)] + marker
+                        budget_fallbacks[fallback].append(dashboard.id)
                     remaining_char_budget -= len(dashboard_text)
                     dashboard_contexts.append(
                         format_prompt_string(ROOT_DASHBOARD_CONTEXT_PROMPT, content=dashboard_text)
@@ -267,6 +295,8 @@ class AssistantContextManager(AssistantContextMixin):
                         properties=self._get_debug_props(self._config),
                     )
                     continue
+
+            self._capture_dashboard_budget_exceeded(budget_fallbacks)
 
             if dashboard_contexts:
                 joined_dashboards = "\n\n".join(dashboard_contexts)

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -56,6 +56,16 @@ from .prompts import (
 # malicious or buggy client can't blow up the context window.
 NOTEBOOK_MARKDOWN_MAX_LENGTH = 100_000
 
+# A dashboard's executed-results context is bounded so it can't overflow the conversation window
+# (compaction_manager.CONVERSATION_WINDOW_SIZE). If it does overflow, the whole conversation —
+# including this dashboard — gets summarized down to a few thousand tokens, so Max loses the
+# dashboard it was just asked about. When the executed results exceed this budget we fall back to
+# schema-only (insight names + queries, no result tables), which still lets Max identify and
+# describe the dashboard and fetch specific numbers via the read_data tool. Token count is
+# estimated with the same ~4-chars/token heuristic the compaction manager uses.
+DASHBOARD_CONTEXT_TOKEN_BUDGET = 50_000
+DASHBOARD_CONTEXT_CHAR_BUDGET = DASHBOARD_CONTEXT_TOKEN_BUDGET * 4
+
 
 def _sanitize_inline_prompt_value(value: str) -> str:
     """Make a client-supplied string safe to interpolate into a single prompt line."""
@@ -232,6 +242,15 @@ class AssistantContextManager(AssistantContextMixin):
 
                 try:
                     dashboard_text = await dashboard_ctx.execute_and_format()
+                    if len(dashboard_text) > DASHBOARD_CONTEXT_CHAR_BUDGET:
+                        # Results too large for the window — drop to schema-only so the dashboard
+                        # still fits and survives un-summarized (Max keeps the read_data tool for
+                        # specific numbers). format_schema runs no queries.
+                        dashboard_text = await dashboard_ctx.format_schema()
+                        if len(dashboard_text) > DASHBOARD_CONTEXT_CHAR_BUDGET:
+                            dashboard_text = (
+                                dashboard_text[:DASHBOARD_CONTEXT_CHAR_BUDGET] + "\n\n…(dashboard context truncated)"
+                            )
                     dashboard_contexts.append(
                         format_prompt_string(ROOT_DASHBOARD_CONTEXT_PROMPT, content=dashboard_text)
                     )

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -252,7 +252,10 @@ class AssistantContextManager(AssistantContextMixin):
                         dashboard_text = await dashboard_ctx.format_schema()
                         if len(dashboard_text) > remaining_char_budget:
                             marker = "\n\n…(dashboard context truncated)"
-                            dashboard_text = dashboard_text[: max(0, remaining_char_budget - len(marker))] + marker
+                            # No room for even the marker — stop here so the budget can't go negative.
+                            if remaining_char_budget <= len(marker):
+                                break
+                            dashboard_text = dashboard_text[: remaining_char_budget - len(marker)] + marker
                     remaining_char_budget -= len(dashboard_text)
                     dashboard_contexts.append(
                         format_prompt_string(ROOT_DASHBOARD_CONTEXT_PROMPT, content=dashboard_text)

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -2,7 +2,7 @@ import datetime
 from typing import cast
 
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
@@ -40,6 +40,7 @@ from posthog.schema import (
 from posthog.models.organization import OrganizationMembership
 
 from ee.hogai.context import AssistantContextManager
+from ee.hogai.context.context import DASHBOARD_CONTEXT_CHAR_BUDGET
 from ee.hogai.utils.types import AssistantState
 from ee.hogai.utils.types.base import AssistantMessageUnion
 
@@ -189,6 +190,51 @@ class TestAssistantContextManager(BaseTest):
         self.assertIn("Dashboard insights:", result)
         # The insight execution is tested separately - just verify structure here
         self.assertNotIn("# Insights", result)
+
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_falls_back_to_schema_when_results_exceed_budget(self, MockDashboardContext):
+        # A large dashboard's executed results must not be inlined whole — that would overflow the
+        # conversation window and get the dashboard summarized away. Over budget => schema-only.
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value="RESULTS " + "x" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000))
+        inst.format_schema = AsyncMock(return_value="SCHEMA-ONLY dashboard context")
+
+        ui_context = MaxUIContext(
+            dashboards=[
+                MaxDashboardContext(
+                    id=1,
+                    name="Big",
+                    insights=[MaxInsightContext(id="1", name="I", query=TrendsQuery(series=[EventsNode(event="x")]))],
+                    filters=DashboardFilter(),
+                )
+            ]
+        )
+        result = await self.context_manager._format_ui_context(ui_context)
+        inst.format_schema.assert_awaited_once()
+        assert result is not None
+        self.assertIn("SCHEMA-ONLY dashboard context", result)
+        self.assertNotIn("xxxx", result)  # the oversized executed results never reach the prompt
+
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_keeps_full_results_when_under_budget(self, MockDashboardContext):
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value="Full executed dashboard results")
+        inst.format_schema = AsyncMock(return_value="SCHEMA-ONLY")
+
+        ui_context = MaxUIContext(
+            dashboards=[
+                MaxDashboardContext(
+                    id=1,
+                    name="Small",
+                    insights=[MaxInsightContext(id="1", name="I", query=TrendsQuery(series=[EventsNode(event="x")]))],
+                    filters=DashboardFilter(),
+                )
+            ]
+        )
+        result = await self.context_manager._format_ui_context(ui_context)
+        inst.format_schema.assert_not_awaited()
+        assert result is not None
+        self.assertIn("Full executed dashboard results", result)
 
     @patch("ee.hogai.context.notebook.context.NotebookContext.from_short_id")
     async def test_format_ui_context_with_markdown_notebook_insertion_context(self, mock_from_short_id):

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -306,6 +306,39 @@ class TestAssistantContextManager(BaseTest):
         self.assertNotIn("…(dashboard context truncated)", result)
         self.assertLessEqual(result.count("Q"), DASHBOARD_CONTEXT_CHAR_BUDGET)
 
+    @patch("ee.hogai.context.context.posthoganalytics.capture")
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_budget_exceeded_emits_diagnostic_event(self, MockDashboardContext, mock_capture):
+        # Over budget => one diagnostic event so the threshold can be tuned and silent degradation is visible.
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value="x" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000))
+        inst.format_schema = AsyncMock(return_value="SCHEMA")
+
+        config = RunnableConfig(configurable={"distinct_id": "user-123"})
+        context_manager = AssistantContextManager(self.team, self.user, config)
+        result = await context_manager._format_ui_context(self._dashboard_ui_context(1))
+
+        assert result is not None
+        mock_capture.assert_called_once()
+        kwargs = mock_capture.call_args.kwargs
+        self.assertEqual(kwargs["event"], "posthog ai dashboard context budget exceeded")
+        self.assertEqual(kwargs["distinct_id"], "user-123")
+        self.assertEqual(kwargs["properties"]["dashboard_ids"], [1])
+        self.assertEqual(kwargs["properties"]["fallback"], "schema")
+        self.assertEqual(kwargs["properties"]["budget_chars"], DASHBOARD_CONTEXT_CHAR_BUDGET)
+
+    @patch("ee.hogai.context.context.posthoganalytics.capture")
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_under_budget_emits_no_event(self, MockDashboardContext, mock_capture):
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value="small results")
+
+        config = RunnableConfig(configurable={"distinct_id": "user-123"})
+        context_manager = AssistantContextManager(self.team, self.user, config)
+        await context_manager._format_ui_context(self._dashboard_ui_context(1))
+
+        mock_capture.assert_not_called()
+
     @patch("ee.hogai.context.notebook.context.NotebookContext.from_short_id")
     async def test_format_ui_context_with_markdown_notebook_insertion_context(self, mock_from_short_id):
         ui_context = MaxUIContext(

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -191,50 +191,97 @@ class TestAssistantContextManager(BaseTest):
         # The insight execution is tested separately - just verify structure here
         self.assertNotIn("# Insights", result)
 
-    @patch("ee.hogai.context.context.DashboardContext")
-    async def test_dashboard_context_falls_back_to_schema_when_results_exceed_budget(self, MockDashboardContext):
-        # A large dashboard's executed results must not be inlined whole — that would overflow the
-        # conversation window and get the dashboard summarized away. Over budget => schema-only.
-        inst = MockDashboardContext.return_value
-        inst.execute_and_format = AsyncMock(return_value="RESULTS " + "x" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000))
-        inst.format_schema = AsyncMock(return_value="SCHEMA-ONLY dashboard context")
-
-        ui_context = MaxUIContext(
+    @staticmethod
+    def _dashboard_ui_context(*ids: int) -> MaxUIContext:
+        return MaxUIContext(
             dashboards=[
                 MaxDashboardContext(
-                    id=1,
-                    name="Big",
-                    insights=[MaxInsightContext(id="1", name="I", query=TrendsQuery(series=[EventsNode(event="x")]))],
+                    id=i,
+                    name=f"Dashboard {i}",
+                    insights=[
+                        MaxInsightContext(id=str(i), name="I", query=TrendsQuery(series=[EventsNode(event="x")]))
+                    ],
                     filters=DashboardFilter(),
                 )
+                for i in ids
             ]
         )
-        result = await self.context_manager._format_ui_context(ui_context)
-        inst.format_schema.assert_awaited_once()
+
+    @parameterized.expand(
+        [
+            # (name, execute_result, schema_result, expect_schema_fallback, expected_in, expected_not_in)
+            (
+                "under_budget_keeps_full_results",
+                "Full executed results",
+                "SCHEMA",
+                False,
+                "Full executed results",
+                None,
+            ),
+            (
+                "over_budget_falls_back_to_schema",
+                "x" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000),
+                "SCHEMA-ONLY dashboard context",
+                True,
+                "SCHEMA-ONLY dashboard context",
+                "xxxx",
+            ),
+            (
+                "schema_also_over_budget_hard_truncates",
+                "x" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000),
+                "y" * (DASHBOARD_CONTEXT_CHAR_BUDGET + 5000),
+                True,
+                "…(dashboard context truncated)",
+                "xxxx",
+            ),
+        ]
+    )
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_budget(
+        self,
+        _name,
+        execute_result,
+        schema_result,
+        expect_schema_fallback,
+        expected_in,
+        expected_not_in,
+        MockDashboardContext,
+    ):
+        # The dashboard's executed results must not overflow the conversation window (which would
+        # summarize the dashboard away). Over budget => schema-only; schema also over => hard-truncate.
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value=execute_result)
+        inst.format_schema = AsyncMock(return_value=schema_result)
+
+        result = await self.context_manager._format_ui_context(self._dashboard_ui_context(1))
+
         assert result is not None
-        self.assertIn("SCHEMA-ONLY dashboard context", result)
-        self.assertNotIn("xxxx", result)  # the oversized executed results never reach the prompt
+        if expect_schema_fallback:
+            inst.format_schema.assert_awaited_once()
+        else:
+            inst.format_schema.assert_not_awaited()
+        self.assertIn(expected_in, result)
+        if expected_not_in is not None:
+            self.assertNotIn(expected_not_in, result)
+        if _name == "schema_also_over_budget_hard_truncates":
+            # the oversized schema is capped to (roughly) the budget, not inlined whole
+            self.assertLess(result.count("y"), DASHBOARD_CONTEXT_CHAR_BUDGET + 5000)
 
     @patch("ee.hogai.context.context.DashboardContext")
-    async def test_dashboard_context_keeps_full_results_when_under_budget(self, MockDashboardContext):
+    async def test_dashboard_context_budget_is_aggregate_across_dashboards(self, MockDashboardContext):
+        # Each dashboard at ~80% of budget fits alone, but two together would overflow — the running
+        # budget forces the second to fall back to schema-only rather than blow the window.
         inst = MockDashboardContext.return_value
-        inst.execute_and_format = AsyncMock(return_value="Full executed dashboard results")
-        inst.format_schema = AsyncMock(return_value="SCHEMA-ONLY")
+        inst.execute_and_format = AsyncMock(return_value="r" * int(DASHBOARD_CONTEXT_CHAR_BUDGET * 0.8))
+        inst.format_schema = AsyncMock(return_value="SCHEMA")
 
-        ui_context = MaxUIContext(
-            dashboards=[
-                MaxDashboardContext(
-                    id=1,
-                    name="Small",
-                    insights=[MaxInsightContext(id="1", name="I", query=TrendsQuery(series=[EventsNode(event="x")]))],
-                    filters=DashboardFilter(),
-                )
-            ]
-        )
-        result = await self.context_manager._format_ui_context(ui_context)
-        inst.format_schema.assert_not_awaited()
+        result = await self.context_manager._format_ui_context(self._dashboard_ui_context(1, 2))
+
         assert result is not None
-        self.assertIn("Full executed dashboard results", result)
+        inst.format_schema.assert_awaited()  # the 2nd dashboard exceeded the remaining budget
+        self.assertIn("SCHEMA", result)
+        # only the first dashboard's executed results are inlined; total stays within budget
+        self.assertLessEqual(result.count("r"), DASHBOARD_CONTEXT_CHAR_BUDGET)
 
     @patch("ee.hogai.context.notebook.context.NotebookContext.from_short_id")
     async def test_format_ui_context_with_markdown_notebook_insertion_context(self, mock_from_short_id):

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -283,6 +283,24 @@ class TestAssistantContextManager(BaseTest):
         # only the first dashboard's executed results are inlined; total stays within budget
         self.assertLessEqual(result.count("r"), DASHBOARD_CONTEXT_CHAR_BUDGET)
 
+    @patch("ee.hogai.context.context.DashboardContext")
+    async def test_dashboard_context_budget_drops_dashboard_with_no_room_for_marker(self, MockDashboardContext):
+        # The 1st dashboard leaves only a few chars of budget — too little for even the truncation
+        # marker. The 2nd must be dropped entirely rather than emitting a marker that overshoots the
+        # budget (which would drive the running budget negative).
+        # Sentinels are uppercase so they can't collide with the prompt-template prose.
+        inst = MockDashboardContext.return_value
+        inst.execute_and_format = AsyncMock(return_value="Q" * (DASHBOARD_CONTEXT_CHAR_BUDGET - 10))
+        inst.format_schema = AsyncMock(return_value="Z" * 100)
+
+        result = await self.context_manager._format_ui_context(self._dashboard_ui_context(1, 2))
+
+        assert result is not None
+        self.assertEqual(result.count("Q"), DASHBOARD_CONTEXT_CHAR_BUDGET - 10)  # 1st dashboard inlined whole
+        self.assertNotIn("Z", result)  # 2nd dashboard dropped, not marker-truncated
+        self.assertNotIn("…(dashboard context truncated)", result)
+        self.assertLessEqual(result.count("Q"), DASHBOARD_CONTEXT_CHAR_BUDGET)
+
     @patch("ee.hogai.context.notebook.context.NotebookContext.from_short_id")
     async def test_format_ui_context_with_markdown_notebook_insertion_context(self, mock_from_short_id):
         ui_context = MaxUIContext(

--- a/ee/hogai/context/test/test_context.py
+++ b/ee/hogai/context/test/test_context.py
@@ -209,13 +209,16 @@ class TestAssistantContextManager(BaseTest):
 
     @parameterized.expand(
         [
-            # (name, execute_result, schema_result, expect_schema_fallback, expected_in, expected_not_in)
+            # (name, execute_result, schema_result, expect_schema_fallback, expected_in, expected_not_in,
+            #  capped_char) — capped_char, when set, must appear at most DASHBOARD_CONTEXT_CHAR_BUDGET times
+            #  (i.e. the oversized content was bounded, not inlined whole).
             (
                 "under_budget_keeps_full_results",
                 "Full executed results",
                 "SCHEMA",
                 False,
                 "Full executed results",
+                None,
                 None,
             ),
             (
@@ -225,6 +228,7 @@ class TestAssistantContextManager(BaseTest):
                 True,
                 "SCHEMA-ONLY dashboard context",
                 "xxxx",
+                None,
             ),
             (
                 "schema_also_over_budget_hard_truncates",
@@ -233,6 +237,7 @@ class TestAssistantContextManager(BaseTest):
                 True,
                 "…(dashboard context truncated)",
                 "xxxx",
+                "y",
             ),
         ]
     )
@@ -245,6 +250,7 @@ class TestAssistantContextManager(BaseTest):
         expect_schema_fallback,
         expected_in,
         expected_not_in,
+        capped_char,
         MockDashboardContext,
     ):
         # The dashboard's executed results must not overflow the conversation window (which would
@@ -263,9 +269,8 @@ class TestAssistantContextManager(BaseTest):
         self.assertIn(expected_in, result)
         if expected_not_in is not None:
             self.assertNotIn(expected_not_in, result)
-        if _name == "schema_also_over_budget_hard_truncates":
-            # the oversized schema is capped to (roughly) the budget, not inlined whole
-            self.assertLess(result.count("y"), DASHBOARD_CONTEXT_CHAR_BUDGET + 5000)
+        if capped_char is not None:
+            self.assertLessEqual(result.count(capped_char), DASHBOARD_CONTEXT_CHAR_BUDGET)
 
     @patch("ee.hogai.context.context.DashboardContext")
     async def test_dashboard_context_budget_is_aggregate_across_dashboards(self, MockDashboardContext):

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -11,6 +11,8 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { NotebookTarget } from 'scenes/notebooks/types'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -458,10 +460,13 @@ describe('maxThreadLogic', () => {
             )
         })
 
-        it('sends the first message immediately without gating on dashboard load', async () => {
-            // Regression guard: askMax must not block the send on frontend load state. The open
-            // dashboard reaches Max via dashboardLogic.maxContext + the backend; gating here only
-            // added latency and didn't fix the real (large-dashboard) issue.
+        it('sends the first message immediately even while the dashboard scene is still loading', async () => {
+            // Regression guard for the removed #63208 gate: on a Dashboard scene whose
+            // dashboardLogic.dashboard is still null, askMax must send synchronously (no poll/wait).
+            // If the gate were reinstated, stream would not be called until fake timers advanced.
+            const fakeDashboardLogic: any = { selectors: { maxContext: () => [] }, values: { dashboard: null } }
+            jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.Dashboard)
+            jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(fakeDashboardLogic)
             const streamSpy = mockStream()
 
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3,7 +3,6 @@ import { MOCK_DEFAULT_BASIC_USER } from 'lib/api.mock'
 import { router } from 'kea-router'
 import { partial } from 'kea-test-utils'
 import { expectLogic } from 'kea-test-utils'
-import posthog from 'posthog-js'
 import React from 'react'
 
 import api, { ApiError } from 'lib/api'
@@ -12,8 +11,6 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { NotebookTarget } from 'scenes/notebooks/types'
-import { sceneLogic } from 'scenes/sceneLogic'
-import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -34,8 +31,7 @@ import { EnhancedToolCall, TOOL_DEFINITIONS } from './max-constants'
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { maxLogic } from './maxLogic'
-import { MAX_DASHBOARD_CONTEXT_WAIT_MS, maxThreadLogic } from './maxThreadLogic'
-import { MaxContextType } from './maxTypes'
+import { maxThreadLogic } from './maxThreadLogic'
 import {
     MOCK_CONVERSATION,
     MOCK_CONVERSATION_ID,
@@ -462,123 +458,21 @@ describe('maxThreadLogic', () => {
             )
         })
 
-        // Simulate being on a dashboard scene whose data has not loaded yet: dashboardLogic.dashboard
-        // is null, so its maxContext returns []. The first message must wait for the load, otherwise
-        // it ships with no dashboard context and Max can't see the open dashboard.
-        const mockLoadingDashboardScene = (): { values: { dashboard: any } } => {
-            const fakeDashboardLogic: any = {
-                selectors: {
-                    maxContext: () =>
-                        fakeDashboardLogic.values.dashboard
-                            ? [{ type: MaxContextType.DASHBOARD, data: fakeDashboardLogic.values.dashboard }]
-                            : [],
-                },
-                values: { dashboard: null as any },
-            }
-            jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.Dashboard)
-            jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(fakeDashboardLogic)
-            jest.spyOn(sceneLogic.selectors, 'activeLoadedScene').mockReturnValue({
-                paramsToProps: () => ({ id: 1 }),
-                sceneParams: {},
-            } as any)
-            return fakeDashboardLogic
-        }
+        it('sends the first message immediately without gating on dashboard load', async () => {
+            // Regression guard: askMax must not block the send on frontend load state. The open
+            // dashboard reaches Max via dashboardLogic.maxContext + the backend; gating here only
+            // added latency and didn't fix the real (large-dashboard) issue.
+            const streamSpy = mockStream()
 
-        it('waits for the open dashboard to load before sending the first message (regression for #61414)', async () => {
-            jest.useFakeTimers()
-            const captureSpy = jest.spyOn(posthog, 'capture')
-            try {
-                const streamSpy = mockStream()
-                const fakeDashboardLogic = mockLoadingDashboardScene()
+            maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
+            logic.mount()
 
-                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
-                logic.mount()
-
-                // Fire the first message while the dashboard is still loading.
+            await expectLogic(logic, () => {
                 logic.actions.askMax('what am I seeing on this dashboard?')
+            }).toDispatchActions(['askMax'])
 
-                // The gate holds the send while the dashboard is loading.
-                await jest.advanceTimersByTimeAsync(300)
-                expect(streamSpy).toHaveBeenCalledTimes(0)
-
-                // Dashboard finishes loading → gate releases → the message sends WITH the dashboard context.
-                fakeDashboardLogic.values.dashboard = { id: 1, name: 'Test Dashboard', tiles: [] }
-                await jest.advanceTimersByTimeAsync(500)
-
-                expect(streamSpy).toHaveBeenCalledTimes(1)
-                expect(streamSpy).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        ui_context: expect.objectContaining({
-                            dashboards: expect.arrayContaining([expect.objectContaining({ id: 1 })]),
-                        }),
-                    }),
-                    expect.any(Object)
-                )
-                // A normal load must NOT report a timeout.
-                expect(captureSpy).not.toHaveBeenCalledWith('max dashboard context wait timed out', expect.anything())
-            } finally {
-                jest.useRealTimers()
-            }
-        })
-
-        it('reports a telemetry event and still sends if the dashboard never loads within the cap', async () => {
-            jest.useFakeTimers()
-            const captureSpy = jest.spyOn(posthog, 'capture')
-            try {
-                const streamSpy = mockStream()
-                mockLoadingDashboardScene() // dashboard stays null past the wait cap
-
-                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
-                logic.mount()
-
-                logic.actions.askMax('what am I seeing on this dashboard?')
-
-                // Advance past the 8s wait cap without the dashboard ever loading.
-                await jest.advanceTimersByTimeAsync(8100)
-
-                // The cap must never block the user — the message still sends...
-                expect(streamSpy).toHaveBeenCalledTimes(1)
-                // ...but we record that the wait timed out, so the cap's impact is observable in prod.
-                expect(captureSpy).toHaveBeenCalledWith(
-                    'max dashboard context wait timed out',
-                    expect.objectContaining({ dashboard_id: 1, waited_ms: expect.any(Number) })
-                )
-                // waited_ms is real elapsed time, so it must be at least the cap (never under-reported).
-                const timeoutCall = captureSpy.mock.calls.find((c) => c[0] === 'max dashboard context wait timed out')
-                expect(timeoutCall?.[1]?.waited_ms).toBeGreaterThanOrEqual(MAX_DASHBOARD_CONTEXT_WAIT_MS)
-            } finally {
-                jest.useRealTimers()
-            }
-        })
-
-        it('releases the gate and sends if the user navigates away while the dashboard is still loading', async () => {
-            jest.useFakeTimers()
-            try {
-                const streamSpy = mockStream()
-                mockLoadingDashboardScene()
-
-                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
-                logic.mount()
-
-                logic.actions.askMax('what am I seeing on this dashboard?')
-
-                // Still on the (never-loading) dashboard → the gate holds.
-                await jest.advanceTimersByTimeAsync(300)
-                expect(streamSpy).toHaveBeenCalledTimes(0)
-
-                // User leaves the dashboard before it ever loads. The gate re-reads the scene each tick,
-                // so it must stop waiting and send rather than block until the timeout.
-                jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.SavedInsights)
-                jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(null as any)
-                await jest.advanceTimersByTimeAsync(300)
-
-                expect(streamSpy).toHaveBeenCalledTimes(1)
-            } finally {
-                jest.useRealTimers()
-            }
+            expect(streamSpy).toHaveBeenCalledTimes(1)
         })
 
         it('sends form_answers in ui_context when provided', async () => {

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -90,12 +90,6 @@ import { getRandomThinkingMessage } from './utils/thinkingMessages'
 /** Key for persisting pending AI prompts across page reloads (e.g., OAuth redirects) */
 export const PENDING_AI_PROMPT_KEY = 'posthog_ai_pending_prompt'
 
-// On a dashboard, the first message can fire before the dashboard has loaded, when
-// dashboardLogic.maxContext still returns []. askMax waits (bounded) for the load so the
-// dashboard context is included. Bounded so a stuck/failed load never blocks sending.
-export const MAX_DASHBOARD_CONTEXT_WAIT_MS = 8000
-const DASHBOARD_CONTEXT_POLL_INTERVAL_MS = 100
-
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
 export type ThreadMessage = RootAssistantMessage & {
@@ -1006,46 +1000,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearQueuedMessages()
             }
         },
-        askMax: async ({ prompt, addToThread = true, uiContext }, breakpoint) => {
+        askMax: async ({ prompt, addToThread = true, uiContext }) => {
             // Only process if this thread is the currently active one
             if (values.conversationId !== values.activeThreadKey) {
                 return
-            }
-            // Wait for the open dashboard to finish loading before collecting context (see the
-            // constants above for why). The scene is re-read every tick, so the gate releases the
-            // moment the dashboard's metadata lands — and immediately if the user navigates away
-            // mid-wait (no longer on a dashboard, or onto a different one that's already loaded).
-            const isDashboardSceneLoading = (): boolean => {
-                if (sceneLogic.values.activeSceneId !== Scene.Dashboard) {
-                    return false
-                }
-                const activeSceneLogic = sceneLogic.values.activeSceneLogic
-                if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
-                    return false
-                }
-                return !(activeSceneLogic.values as { dashboard?: unknown }).dashboard
-            }
-            // Measure real elapsed time, not tick count: breakpoint() only guarantees a *minimum*
-            // delay, so a busy event loop would make a tick counter under-report the wait — letting
-            // it run past the cap and skewing the telemetry below. performance.now() is monotonic.
-            const dashboardWaitStart = performance.now()
-            while (
-                isDashboardSceneLoading() &&
-                performance.now() - dashboardWaitStart < MAX_DASHBOARD_CONTEXT_WAIT_MS
-            ) {
-                await breakpoint(DASHBOARD_CONTEXT_POLL_INTERVAL_MS)
-            }
-            if (isDashboardSceneLoading()) {
-                // We hit the wait cap while the dashboard was still loading, so the message ships
-                // without dashboard context (the original "Max can't see this dashboard" symptom).
-                // Capture it so we can tell whether the cap is ever the binding constraint in prod.
-                const activeLoadedScene = sceneLogic.values.activeLoadedScene
-                const sceneProps = activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || {}
-                posthog.capture('max dashboard context wait timed out', {
-                    waited_ms: Math.round(performance.now() - dashboardWaitStart),
-                    dashboard_id: (sceneProps as { id?: number | string }).id,
-                    conversation_id: values.conversation?.id || values.conversationId,
-                })
             }
             const contextualTools = Object.fromEntries(values.tools.map((tool) => [tool.identifier, tool.context]))
             // Always send voice_mode as an explicit boolean when handsFreeLogic is mounted,


### PR DESCRIPTION
## Problem

On a dashboard, the first message to PostHog AI ("Max") could come back with "I don't have context about which dashboard you're referring to" — then work correctly on the follow-up message. It only happened on **large** dashboards (e.g. the SLO monitoring dashboard).

Root cause is **not** a first-message timing gap. The backend executes every insight on the dashboard and inlines the **full results** into the prompt, unbounded. Once that context crosses the conversation window (`compaction_manager.CONVERSATION_WINDOW_SIZE = 100_000`), `executables.py` runs the whole conversation through the summarizer (claude-haiku, `max_tokens=8192`) — which compresses the freshly-injected dashboard context down to a vague summary and strips the per-insight detail. Max ends up with no usable dashboard context.

This is why:
- **Small dashboards work** (context stays under the window).
- **Large dashboards fail** (the prod case was a ~299k-token prompt).
- It **"works on the 2nd message"** — by then the first turn's bulk is a small summary and the window has advanced, so the turn-2 prompt lands back under 100k and the re-injected context survives un-summarized.

Reproduced end-to-end on a local stack with a real LLM: a dashboard of 3 insights at `interval: hour` over 5 months (huge result tables) reliably triggered the exact "which dashboard?" reply on turn 1; the same dashboard at daily interval (small results) was described correctly.

## Changes

1. **Bound the dashboard `ui_context`** (`ee/hogai/context/context.py`): build it with executed results as before, but if that exceeds a **50k-token budget**, fall back to `DashboardContext.format_schema()` — insight names + queries, no result tables (a final hard-truncate guards pathological cases). The dashboard then always fits the window and survives un-summarized; Max can still identify and describe it, and pull specific numbers via the `read_data` tool. `format_schema` runs no queries, so the fallback is cheap.
2. **Remove the #63208 8s send-gate** (`maxThreadLogic.askMax`): a bounded busy-wait that polled up to 8s for the dashboard to load before sending. Live repro showed it neither fixed the issue nor was needed (normal dashboards are described correctly on message 1 without it) — it only added latency. Removed the constants, poll loop, `breakpoint` param, and timeout telemetry.

```mermaid
flowchart TD
    A[dashboard ui_context arrives] --> B[execute_and_format: full results]
    B --> C{> 50k-token budget?}
    C -- no --> D[inline full results]
    C -- yes --> E[format_schema: names + queries only]
    E --> F{still over budget?}
    F -- yes --> G[hard-truncate]
    F -- no --> H[bounded schema context]
    D --> I[fits under 100k window → no summarization → Max sees the dashboard on msg 1]
    H --> I
    G --> I
```

## How did you test this code?

I'm an agent; no human manual QA. What I actually ran:

- **Live reproduction + fix verification** on a local stack with a real LLM: the 3-hourly-insight dashboard that returned "which dashboard?" on turn 1 **now describes the dashboard on turn 1** with the fix applied (schema-only fallback engaged). Verified by driving the real Max UI end-to-end.
- **Backend pytest** (`ee/hogai/context/test/test_context.py`): new tests for over-budget → schema-only fallback and under-budget → full results kept, plus the existing dashboard-context test. Green.
- **Frontend jest** (`maxThreadLogic.test.ts`): 107 passed, including a new regression that `askMax` sends immediately without gating on load state.
- **Static:** `tsc --noEmit` 0 errors, ruff + oxfmt + oxlint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — internal context-handling fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @vdekrijger.

Built with Claude Code.

**Investigation:** root-caused by live reproduction, not static guessing — and it overturned an earlier wrong hypothesis. An initial fix (#64009) assumed the frontend sent the dashboard hollow/late on the first message; instrumenting `askMax` on a live stack proved the frontend sends the **full** dashboard on message 1, so that PR targeted the wrong layer (it's being closed). Bisecting dashboard size on the live stack (2 insights ✅, 35 daily ✅, 15 hourly ❌, 3 hourly ❌) isolated the trigger to **context token volume**, not insight count or query load — pinpointing the 100k-window summarization in `executables.py` + the haiku summarizer. The turn-1-fail/turn-2-work asymmetry falls straight out of that (first-turn overhead tips it over; the compacted second turn fits).

**Decision:** chose schema-only-over-budget (50k) for the bound — it guarantees the dashboard is always identifiable/describable on message 1 and never triggers summarization, while keeping result numbers available on demand via the `read_data` tool. Considered truncating results (kept partial numbers but still risks overflow with many insights) and exempting ui_context from summarization (keeps everything but can still hit the model's hard context limit); the schema fallback is the simplest guarantee.

**Reviewer reading order:** the two backend tests in `test_context.py` show the intended behavior; the load-bearing change is the budget + `format_schema` fallback in `context.py`. The `maxThreadLogic` change is a straight removal of the #63208 gate.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bounds the dashboard UI context injected into Max's prompt to a 50k-token budget, falling back to schema-only (then hard-truncate) when exceeded, so large dashboards no longer trigger conversation-window summarization that loses the dashboard context. Also removes the ineffective 8s polling gate from the frontend `askMax` path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dfbc1cf002485d3c4d30c522a2b8286c93a8946a.</sup>
<!-- /MENDRAL_SUMMARY -->