### PR TITLE
feat(session-replay): make surfacing-scoring workflow input optional

### DIFF
--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
@@ -52,6 +52,8 @@ class ScoreSessionsBatchWorkflow(PostHogWorkflow):
     """One tick of the scoring pipeline."""
 
     inputs_cls = ScoreSessionsBatchInputs
+    # Input dataclass is empty, so allow starting with no inputs.
+    inputs_optional = True
 
     @workflow.run
     async def run(self, inputs: ScoreSessionsBatchInputs) -> ScoreSessionsBatchResult:

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
@@ -48,6 +48,13 @@ class TestSummarize:
         assert summary == ScoreSessionsBatchResult(total_scored=10, chunks_dispatched=3, chunks_failed=1)
 
 
+class TestParseInputs:
+    # inputs_optional lets the workflow start with no inputs; "{}" still parses.
+    @pytest.mark.parametrize("inputs", [[], ["{}"]])
+    def test_parse_inputs_returns_default(self, inputs: list[str]) -> None:
+        assert ScoreSessionsBatchWorkflow.parse_inputs(inputs) == ScoreSessionsBatchInputs()
+
+
 @pytest.mark.asyncio
 async def test_workflow_noop_when_plan_has_no_chunks() -> None:
     @activity.defn(name="list_chunks_activity")


### PR DESCRIPTION
## Problem

`ScoreSessionsBatchWorkflow` (the surfacing-scoring sweep) takes an empty input dataclass — all sizing lives in `constants.py`. But `PostHogWorkflow.parse_inputs` defaults to `inputs_optional = False`, so starting the workflow by hand failed:

```
start_temporal_workflow score-sessions-batch
# ValueError: Workflow ScoreSessionsBatchWorkflow requires inputs
```

You had to pass a redundant `{}` to start it. That's pure friction for an input that carries no information.

## Changes

Set `inputs_optional = True` on `ScoreSessionsBatchWorkflow`. With no inputs, `parse_inputs` now builds the default `ScoreSessionsBatchInputs()` instead of raising. Passing JSON inputs still works, and scheduled runs (which already pass a payload) are unaffected.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I ran locally:

- New `TestParseInputs` in `test_workflow.py`: `parse_inputs([])` returns the default instance, and `parse_inputs(["{}"])` still parses.
- `TestParseInputs` + `TestSummarize` pass; `ruff` (0.15.16) clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @arnohillen.

Small operability follow-up split out from the surfacing-scoring work so it can review and merge independently of the Kafka flush fix (#64313). The input dataclass is intentionally empty, so the only behavioral change is that an empty inputs list resolves to the default instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Sets `inputs_optional = True` on `ScoreSessionsBatchWorkflow` so the workflow can be started manually without passing a redundant empty JSON payload, and adds a parametrized test covering both the no-inputs and empty-JSON cases.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2ca95e0c06121628f5e2e4f05324de6f6a4f4ca3.</sup>
<!-- /MENDRAL_SUMMARY -->