### PR TITLE
chore: route manage-dashboard-widgets skill to analytics-platform

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -249,6 +249,7 @@ AGENTS.md @PostHog/team-devex
 .claude/agents/ingestion/ @PostHog/team-ingestion
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion
+.agents/skills/manage-dashboard-widgets/ @PostHog/team-analytics-platform
 tools/pr-approval-agent/ @PostHog/team-devex
 tools/phrocs/ @PostHog/team-devex
 tools/query-performance-ai/ @PostHog/team-analytics-platform


### PR DESCRIPTION
## Problem

Editing the `manage-dashboard-widgets` skill docs requests review from `@PostHog/team-devex`, because the skill dir is only matched by the broad `.agents/* @PostHog/team-devex` catch-all in `CODEOWNERS-soft`. The skill belongs to analytics-platform (it documents `products/dashboards`, owned by that team via `product.yaml`).

## Change

Add a more-specific `CODEOWNERS-soft` entry (last-match-wins) pinning the skill dir to `@PostHog/team-analytics-platform`.

## 🤖 Agent context

Surfaced while reviewing reviewer assignment on #64114, where a one-line skill doc edit pulled in dev-ex as owner alongside the actual `products/dashboards` code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a specific CODEOWNERS-soft entry to route the `manage-dashboard-widgets` skill directory to `@PostHog/team-analytics-platform`, overriding the broad `.agents/*` catch-all that was incorrectly assigning reviews to team-devex.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 651ab6cb9304175b48c79072e5e44283f77617e1.</sup>
<!-- /MENDRAL_SUMMARY -->