### PR TITLE
fix(mcp): preserve filter/variable overrides in insight-query link

### DIFF
--- a/services/mcp/src/tools/insights/query.ts
+++ b/services/mcp/src/tools/insights/query.ts
@@ -42,6 +42,9 @@ export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (c
     const { insightId, output_format, variables_override, filters_override } = params
     const projectId = await context.stateManager.getProjectId()
 
+    const normalizedVariables = normalizeOverride(variables_override)
+    const normalizedFilters = normalizeOverride(filters_override)
+
     // Threading overrides through the .get() call lets the Django retrieve endpoint
     // merge them server-side (via apply_dashboard_variables_to_dict /
     // apply_dashboard_filters_to_dict). The merged query is then POSTed to /query/
@@ -49,8 +52,8 @@ export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (c
     // mutating the saved insight.
     const insightResult = await context.api.insights({ projectId }).get({
         insightId,
-        variables_override: normalizeOverride(variables_override),
-        filters_override: normalizeOverride(filters_override),
+        variables_override: normalizedVariables,
+        filters_override: normalizedFilters,
     })
 
     if (!insightResult.success) {
@@ -65,7 +68,18 @@ export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (c
         throw new Error(`Failed to query insight: ${queryResult.error.message}`)
     }
 
-    const path = `/insights/${insightResult.data.short_id}`
+    // Carry the overrides into the link as query params so opening the insight in
+    // the UI reflects the same filtered/variabled view that was rendered — matching
+    // the frontend's own `urls.insightView` encoding. Without this the link resolves
+    // to the bare saved insight and silently drops the overrides.
+    const overrideParams = [
+        { key: 'variables_override', value: normalizedVariables },
+        { key: 'filters_override', value: normalizedFilters },
+    ]
+        .filter((p): p is { key: string; value: string } => Boolean(p.value))
+        .map((p) => `${p.key}=${encodeURIComponent(p.value)}`)
+        .join('&')
+    const path = `/insights/${insightResult.data.short_id}${overrideParams ? `?${overrideParams}` : ''}`
     const fullUrl = `${context.api.getProjectBaseUrl(projectId)}${path}`
     const queryInfo = analyzeQuery(insightResult.data.query)
 

--- a/services/mcp/tests/unit/insights-query-handler.test.ts
+++ b/services/mcp/tests/unit/insights-query-handler.test.ts
@@ -27,6 +27,8 @@ interface MockHandles {
 interface QueryResult {
     query: unknown
     results: unknown
+    insight: { url: string }
+    _posthogUrl: string
     [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]?: string
 }
 
@@ -130,6 +132,49 @@ describe('queryHandler — overrides forwarding', () => {
         const call = insightsGet.mock.calls[0]![0] as InsightsCallArgs
         expect(call.variables_override).toBe(JSON.stringify(variablesOverrideObject))
         expect(call.filters_override).toBe(filters_override)
+    })
+})
+
+describe('queryHandler — link reflects overrides', () => {
+    it('links to the bare saved insight when no overrides are passed', async () => {
+        const { context } = createContext()
+
+        const result = (await queryHandler(context, { insightId: '42', output_format: 'json' })) as QueryResult
+
+        expect(result._posthogUrl).toBe('https://us.posthog.com/project/1/insights/abc12345')
+        expect(result.insight.url).toBe('https://us.posthog.com/project/1/insights/abc12345')
+    })
+
+    it('encodes filters_override into the link query string', async () => {
+        const { context } = createContext()
+
+        const result = (await queryHandler(context, {
+            insightId: '42',
+            output_format: 'json',
+            filters_override: filtersOverrideObject as unknown as string,
+        })) as QueryResult
+
+        const expected = `https://us.posthog.com/project/1/insights/abc12345?filters_override=${encodeURIComponent(
+            JSON.stringify(filtersOverrideObject)
+        )}`
+        expect(result._posthogUrl).toBe(expected)
+        expect(result.insight.url).toBe(expected)
+    })
+
+    it('encodes both variables_override and filters_override into the link', async () => {
+        const { context } = createContext()
+
+        const result = (await queryHandler(context, {
+            insightId: '42',
+            output_format: 'json',
+            variables_override: variablesOverrideObject as unknown as string,
+            filters_override: JSON.stringify(filtersOverrideObject),
+        })) as QueryResult
+
+        const expected = `https://us.posthog.com/project/1/insights/abc12345?variables_override=${encodeURIComponent(
+            JSON.stringify(variablesOverrideObject)
+        )}&filters_override=${encodeURIComponent(JSON.stringify(filtersOverrideObject))}`
+        expect(result._posthogUrl).toBe(expected)
     })
 })
 


### PR DESCRIPTION
## Problem

When an insight is rendered through the MCP `insight-query` tool, passing `filters_override` / `variables_override` correctly applies them to the rendered results (the Django retrieve endpoint merges them server-side). But the "View in PostHog" link was built as a bare `/insights/{short_id}`, dropping the overrides. Clicking through opened the saved insight at its default filters instead of the filtered view that was just rendered — so an insight rendered with filters showed up without them in the UI.

## Changes

- Encode `filters_override` / `variables_override` into the `insight-query` link as query-string params (`/insights/{short_id}?filters_override=...&variables_override=...`), matching the frontend's own `urls.insightView` encoding that `insightSceneLogic` reads back.
- Link stays as the bare `/insights/{short_id}` when no overrides are passed.
- Add unit tests covering: no overrides (bare link), `filters_override` only, and both overrides together.

## How did you test this code?

I'm an agent (Claude Code). I ran the unit suite `services/mcp/tests/unit/insights-query-handler.test.ts` (12 tests pass, including the 3 new override-link tests) and type-checked the changed file. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The bug was reported as "rendered MCP insights link to the wrong view — filters added disappear when opened in the UI." Traced through `services/mcp/src/tools/insights/query.ts`: the tool already merges overrides into the queried results server-side, but the generated link ignored them. Confirmed the frontend already supports overrides as URL search params via `urls.insightView` (`frontend/src/products.tsx`) and `insightSceneLogic`'s `urlToAction`, so the fix mirrors that existing contract rather than inventing a new URL shape.

Note: the generated `insight-get` tool (`services/mcp/src/tools/generated/product_analytics.ts`) has the same bug, but it's auto-generated from `tools.yaml` + codegen, so fixing it properly means changing the generator — left out of this PR scope.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Encodes `filters_override` and `variables_override` into the "View in PostHog" link query string generated by the MCP `insight-query` tool, so that opening the link reflects the same filtered view that was rendered. Adds unit tests for the new behavior.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit be31efecec47eeb9d076112830eb492ce65514bf.</sup>
<!-- /MENDRAL_SUMMARY -->