### PR TITLE
fix(experiments): show metrics for completed experiments in recalc flow

### DIFF
--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -124,25 +124,39 @@ describe('experimentMetricsLogic', () => {
     })
 
     describe('loadLatestRecalculation', () => {
-        it.each([
-            // Draft: never launched (no start_date, no status).
-            ['draft', { ...EXPERIMENT, status: undefined, start_date: null, end_date: null } as Experiment],
-            // Stopped/completed: launched then ended (has an end_date).
-            ['stopped', { ...EXPERIMENT, status: undefined, end_date: '2025-01-01T00:00:00Z' } as Experiment],
-        ])('does not fetch latest on mount for a %s experiment', async (_label, experiment) => {
+        it('does not fetch latest on mount for a draft experiment', async () => {
+            const draft = { ...EXPERIMENT, status: undefined, start_date: null, end_date: null } as Experiment
             const latestMock = jest.fn(() => [200, completedRecalculation])
             useMocks({
                 get: {
                     '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': latestMock,
                 },
             })
-            logic = experimentMetricsLogic({ experiment })
+            logic = experimentMetricsLogic({ experiment: draft })
             logic.mount()
 
             await expectLogic(logic).toDispatchActions(['loadLatestRecalculation'])
-            // Gated before the request: a non-running experiment has nothing to recalculate.
+            // Gated before the request: a draft has nothing to recalculate yet.
             expect(latestMock).not.toHaveBeenCalled()
             expect(logic.values.currentRecalculation).toBeNull()
+        })
+
+        it('fetches latest on mount for a stopped experiment so completed results still display', async () => {
+            // Stopped/completed: launched then ended (has an end_date).
+            const stopped = { ...EXPERIMENT, status: undefined, end_date: '2025-01-01T00:00:00Z' } as Experiment
+            const latestMock = jest.fn(() => [200, completedRecalculation])
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': latestMock,
+                },
+            })
+            logic = experimentMetricsLogic({ experiment: stopped })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['setCurrentRecalculation', 'setPrimaryMetricsResults'])
+            // A stopped experiment must still load its final results — otherwise the table loads forever.
+            expect(latestMock).toHaveBeenCalled()
+            expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
         })
 
         it('loads the latest completed recalculation and maps results by metric position', async () => {
@@ -307,24 +321,36 @@ describe('experimentMetricsLogic', () => {
     })
 
     describe('triggerRecalculation', () => {
-        it.each([
-            // Draft: never launched (no start_date, no status).
-            ['draft', { ...EXPERIMENT, status: undefined, start_date: null, end_date: null } as Experiment],
-            // Stopped/completed: launched then ended (has an end_date).
-            ['stopped', { ...EXPERIMENT, status: undefined, end_date: '2025-01-01T00:00:00Z' } as Experiment],
-        ])('does not create a recalculation for a %s experiment', async (_label, experiment) => {
+        it('does not create a recalculation for a draft experiment', async () => {
+            const draft = { ...EXPERIMENT, status: undefined, start_date: null, end_date: null } as Experiment
             const createMock = jest.fn(() => [201, pendingRecalculation])
             useMocks({
                 get: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}] },
                 post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
             })
-            logic = experimentMetricsLogic({ experiment })
+            logic = experimentMetricsLogic({ experiment: draft })
             logic.mount()
 
             await expectLogic(logic, () => {
                 logic.actions.triggerRecalculation()
             }).toNotHaveDispatchedActions(['pollRecalculation', 'setCurrentRecalculation'])
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('creates a recalculation for a stopped experiment to compute its final results', async () => {
+            const stopped = { ...EXPERIMENT, status: undefined, end_date: '2025-01-01T00:00:00Z' } as Experiment
+            const createMock = jest.fn(() => [201, pendingRecalculation])
+            useMocks({
+                get: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}] },
+                post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+            })
+            logic = experimentMetricsLogic({ experiment: stopped })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.triggerRecalculation()
+            }).toDispatchActions(['setCurrentRecalculation'])
+            expect(createMock).toHaveBeenCalled()
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -19,7 +19,7 @@ import {
 import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
 
 import type { experimentMetricsLogicType } from './experimentMetricsLogicType'
-import { hasEnded, isLaunched } from './experimentsLogic'
+import { isLaunched } from './experimentsLogic'
 
 type ExperimentSavedMetric = {
     metadata: {
@@ -199,10 +199,12 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
         const flagEnabled = (): boolean => !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]
 
         /**
-         * Recalculations only make sense for a running experiment: a draft has no results to fetch, and a
-         * stopped one is frozen. Gates both the latest-fetch and triggering a new run.
+         * Recalculations only make sense once an experiment has launched: a draft has no results to fetch.
+         * A stopped experiment still has final results to compute and display, so it is included here — this
+         * mirrors the backend, which only rejects recalculation for drafts (`is_launched`). Gates both the
+         * latest-fetch and triggering a new run.
          */
-        const experimentIsRunning = (): boolean => isLaunched(props.experiment) && !hasEnded(props.experiment)
+        const experimentIsLaunched = (): boolean => isLaunched(props.experiment)
 
         /**
          * some local helpers for the listeners closure
@@ -266,8 +268,8 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     actions.setRecalculationLoading(false)
                     return
                 }
-                // Don't fetch for draft or stopped experiments — there's nothing to recalculate.
-                if (!experimentIsRunning()) {
+                // Don't fetch for draft experiments — there's nothing to recalculate yet.
+                if (!experimentIsLaunched()) {
                     actions.setRecalculationLoading(false)
                     return
                 }
@@ -324,10 +326,10 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     return
                 }
                 /**
-                 * Don't recalculate draft or stopped experiments; a config-change edit on either shouldn't
-                 * kick off a run.
+                 * Don't recalculate draft experiments; a config-change edit on a draft shouldn't kick off a
+                 * run. Stopped experiments are allowed — they still need their final results computed.
                  */
-                if (!experimentIsRunning()) {
+                if (!experimentIsLaunched()) {
                     return
                 }
                 /**


### PR DESCRIPTION
## Problem

When the `experiments-metrics-recalculation` feature flag is enabled, metric results for an experiment come from `experimentMetricsLogic` (the recalculation flow) rather than the legacy `experimentLogic` flow. For **completed/stopped** experiments this left the metrics panel stuck on "Loading results…" indefinitely.

## Changes

The recalculation logic gated both fetching the latest recalculation and triggering a new one behind a running-only check:

```ts
const experimentIsRunning = () => isLaunched(experiment) && !hasEnded(experiment)
```

A stopped experiment failed that check, so `loadLatestRecalculation` early-returned and the results arrays stayed empty. But the metrics table derives its loading state from `isLaunched` alone (`!result && !error && isLaunched(experiment)`), and `isLaunched` is `true` for a stopped experiment — so with no result ever arriving, the table loaded forever.

This also disagreed with the backend, which only rejects recalculation for **drafts** (`request_recalculation` raises when `not experiment.is_launched`, i.e. `start_date is None`).

The fix aligns the frontend gate with the backend and with the table's own `isLaunched` check:

- Gate on launch (exclude only drafts) instead of running-and-not-ended.
- Stopped/completed experiments now fetch their latest completed recalculation (showing final results) and can trigger one on a 404 to compute final results.
- Drafts remain excluded — they have nothing to recalculate.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual UI testing. I updated and ran the automated suite:

- `frontend/src/scenes/experiments/experimentMetricsLogic.test.ts` — the two parameterized draft/stopped cases previously asserted the buggy behavior (stopped experiments don't fetch/trigger). Split into per-state cases: drafts still no-op, while stopped experiments now fetch latest and create recalculations. All 22 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and fixed with PostHog Code (Claude Opus). Used read-only Explore subagents to trace the loading-state flow from `MetricsTable` (`isLoading`) back through `experimentMetricsLogic`, and to confirm the backend's recalculation create/latest endpoints only reject drafts — establishing that excluding stopped experiments on the frontend was the inconsistency.

Considered a narrower fix to the table's `isLoading` condition, but the root cause is the logic gate diverging from both the backend contract and the table's `isLaunched` assumption, so aligning the gate (drafts-only exclusion) is the correct layer. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes completed/stopped experiments showing "Loading results…" forever when the `experiments-metrics-recalculation` flag is enabled. Changes the frontend gate from `isLaunched && !hasEnded` to just `isLaunched`, aligning with the backend which only rejects recalculation for drafts.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6c3c1e401a3810fe5f8d3c542ddcd7593eb69fa0.</sup>
<!-- /MENDRAL_SUMMARY -->