### PR TITLE
chore(data-warehouse): add log breadcrumb if no change for a schema via cdc sync

### DIFF
--- a/posthog/temporal/data_imports/cdc/activities.py
+++ b/posthog/temporal/data_imports/cdc/activities.py
@@ -896,11 +896,15 @@ class CDCExtractActivity:
 
     def _finalize_success(self) -> None:
         now = dt.datetime.now(tz=dt.UTC)
+        synced_tables = {tracker.table_name for tracker in self.write_trackers.values()}
         for schema in self.cdc_schemas:
             schema.status = ExternalDataSchema.Status.COMPLETED
             schema.latest_error = None
             schema.last_synced_at = now
             schema.save(update_fields=["status", "latest_error", "last_synced_at", "updated_at"])
+            # Breadcrumb for idle tables; _handle_no_changes only covers the whole-source-quiet case.
+            if schema.name not in synced_tables:
+                self._schema_log(schema).info("cdc_extract_no_changes")
 
 
 @activity.defn

--- a/posthog/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/posthog/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -818,6 +818,59 @@ class TestCDCExtractActivity:
         # Slot should advance to the last event's position
         mock_reader.confirm_position.assert_called_once_with("0/300")
 
+    @patch("posthog.temporal.data_imports.cdc.activities.activity")
+    @patch("posthog.temporal.data_imports.cdc.activities.PostgresProducer")
+    @patch("posthog.temporal.data_imports.cdc.activities.S3BatchWriter")
+    @patch("posthog.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("posthog.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("posthog.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("posthog.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_unchanged_sibling_table_logs_no_changes_breadcrumb(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        MockS3Writer,
+        MockProducer,
+        mock_activity,
+    ):
+        source = _make_source()
+        users_schema = _make_schema("users", cdc_mode="streaming", source=source)
+        orders_schema = _make_schema("orders", cdc_mode="streaming", source=source)
+        # Only `users` changes this run; `orders` is idle.
+        events = [_make_event(op="I", table="users", position="0/100", columns={"id": 1, "name": "Alice"})]
+
+        _setup_mocks(
+            mock_activity,
+            MockProducer,
+            MockS3Writer,
+            mock_get_adapter,
+            mock_get_schemas,
+            MockSourceModel,
+            MockJob,
+            mock_close_conns,
+            source,
+            [users_schema, orders_schema],
+            events,
+        )
+
+        schema_loggers: dict[str, MagicMock] = {}
+
+        def fake_schema_log(schema):
+            return schema_loggers.setdefault(schema.name, MagicMock())
+
+        with patch.object(CDCExtractActivity, "_schema_log", side_effect=fake_schema_log):
+            cdc_extract_activity(CDCExtractInput(team_id=1, source_id=source.id))
+
+        def logged_events(name: str) -> list[str]:
+            return [call.args[0] for call in schema_loggers[name].info.call_args_list]
+
+        assert "cdc_extract_no_changes" in logged_events("orders")
+        assert "cdc_extract_no_changes" not in logged_events("users")
+
     @patch("posthog.temporal.data_imports.cdc.activities.unpause_external_data_schedule", create=True)
     @patch("posthog.temporal.data_imports.cdc.activities.activity")
     @patch("posthog.temporal.data_imports.cdc.activities.PostgresProducer")


### PR DESCRIPTION
## Problem

I was investigating a Postgres source issue which was using CDC, and got confused that it looked like one of the schemas wasn't syncing on schedule.

In the case where no schemas across the source have rows to update, we emit logs for each schema.

But in the case where one or more schemas changed, we only emit logs for those schemas.

## Changes

Emit a log breadcrumb for all schemas, regardless of whether they had an update.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a log breadcrumb (`cdc_extract_no_changes`) for CDC schemas that had no changes during a sync run where other sibling schemas did have changes, improving observability for idle tables.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e7043df335534a844f088fa08fcb8f25e62a19ab.</sup>
<!-- /MENDRAL_SUMMARY -->