### PR TITLE
test(storybook): migrate remaining mswDecorator resolvers to MSW v2 signatures

### DIFF
--- a/frontend/src/scenes/annotations/Annotations.stories.tsx
+++ b/frontend/src/scenes/annotations/Annotations.stories.tsx
@@ -20,9 +20,9 @@ const meta: Meta = {
         mswDecorator({
             get: {
                 '/api/projects/:team_id/annotations/': annotations,
-                '/api/projects/:team_id/annotations/:annotationId/': (req) => [
+                '/api/projects/:team_id/annotations/:annotationId/': ({ params }) => [
                     200,
-                    annotations.results.find((r) => r.id === Number(req.params['annotationId'])),
+                    annotations.results.find((r) => r.id === Number(params['annotationId'])),
                 ],
             },
         }),

--- a/frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx
@@ -33,9 +33,9 @@ const meta: Meta = {
                         detail: 'Not found.',
                     },
                 ],
-                '/api/projects/:team_id/feature_flags/:flagId/': (req) => [
+                '/api/projects/:team_id/feature_flags/:flagId/': ({ params }) => [
                     200,
-                    featureFlags.results.find((r) => r.id === Number(req.params['flagId'])),
+                    featureFlags.results.find((r) => r.id === Number(params['flagId'])),
                 ],
                 '/api/projects/:team_id/feature_flags/:flagId/status': () => [
                     200,


### PR DESCRIPTION
## Problem

Recreates the storybook portion of the MSW v2 upgrade (originally [#61622](https://github.com/PostHog/posthog/pull/61622), part 3/4 of #60964) against current master.

Most of that original 61-file migration has since landed on master independently. Only two Storybook resolvers were left on the legacy MSW v1 `(req)` signature, so this PR is just the remaining mechanical cleanup rather than the full original diff (which had too many conflicts to rebase).

## Changes

Migrate the two remaining `mswDecorator` resolvers from the v1 `(req)` signature to the v2 destructured `({ params })` form — no behavior change:

- `frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx`
- `frontend/src/scenes/annotations/Annotations.stories.tsx`

```diff
-'/api/projects/:team_id/feature_flags/:flagId/': (req) => [
+'/api/projects/:team_id/feature_flags/:flagId/': ({ params }) => [
     200,
-    featureFlags.results.find((r) => r.id === Number(req.params['flagId'])),
+    featureFlags.results.find((r) => r.id === Number(params['flagId'])),
 ],
```

A full sweep confirms no other story-file resolvers remain on v1 signatures.

## How did you test this code?

I'm an agent (Claude Code). I ran only automated checks — no manual/visual testing:

- `oxlint` on both touched files: 0 errors.
- v1-pattern sweep across all `*.stories.tsx`: clean after the change.
- `typescript:check` surfaced only pre-existing unrelated errors (missing `@posthog/hogvm` artifact, `eventUsageLogic`, `sourceWizardLogic`); none reference the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Recreated by Claude Code at the user's direction. The original stacked branch was preserved locally, the branch was rebuilt fresh off master, and a diff of the original 61-file commit against current master showed all but two files already migrated. The agent applied the same transformation the original PR used to those two resolvers. No special repo skills were required for this mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Migrates the last two Storybook `mswDecorator` resolvers from the legacy MSW v1 `(req)` signature to the v2 destructured `({ params })` form, completing the MSW v2 upgrade for story files.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit af384bcd0bb1fcebfe5eb96190c4d6d38e2b202f.</sup>
<!-- /MENDRAL_SUMMARY -->