### PR TITLE
fix(mcp): show session sort label instead of raw order value

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5501,9 +5501,9 @@ snapshots:
     scenes-app-mcp-analytics--dashboard--light:
         hash: v1.k794b7964.c64d5d43c4eaa79d3008e9dd40857d9bee879832e68a8f8e9464657ff670773f.yKxStICPwIMCMEnf_zQhK0BuXu5BIxaUKmgPYHAEzYo
     scenes-app-mcp-analytics--sessions--dark:
-        hash: v1.k794b7964.c316f0028a9cc9b6a8e2b85d95b5e5ab65548805d4069f001c5cbbbcfbac970c.u4rZzVUZRlEBb11eUbRTRsVFfH_5gb3qRI5BEuAN7qw
+        hash: v1.k794b7964.277463ad445565d14f2549a063a4f8c0c23a81af419bfafc9eefc65577fb0834.woelvjefGWPDW4Acae_sP2fA7YidrA7tkhfvC8u_AQ4
     scenes-app-mcp-analytics--sessions--light:
-        hash: v1.k794b7964.497d9ae69307438f3ef9ebfc80bb948ffd70d285eda4192f6b2e21f1a66d3eba.XI5y0bJbIitncOcXS_6Gxcr4pgGCK1moA7JIAstwuL4
+        hash: v1.k794b7964.bbe32ae76ef1ed9053d24d860933bc0bf1cca54ed3f601effaf515b8d9a6cd21.saYknnP-f1-BwcwRczq_p6CgUmnH8cmE8YJ_9XpN2Pk
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--dark:
         hash: v1.k794b7964.695d298349258e60b3b8f0c8775e1554ffd9ad3a3b9d4d750df124550bf65c51.cpBNQ-OwnkymJacZsj27ScYkVTr_36Yb8Z27xINlTN8
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--light:

--- a/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionsPlaylist.tsx
@@ -159,7 +159,11 @@ function SessionsListPanel(): JSX.Element {
                             onValueChange={(value) => setSorting(valueToSorting(value as MCPSessionOrderBy))}
                         >
                             <SelectTrigger size="sm" data-attr="mcp-sessions-sort">
-                                <SelectValue />
+                                <SelectValue>
+                                    {(value: MCPSessionOrderBy) =>
+                                        SORT_OPTIONS.find((o) => o.value === value)?.label ?? value
+                                    }
+                                </SelectValue>
                             </SelectTrigger>
                             <SelectContent>
                                 {SORT_OPTIONS.map((option) => (


### PR DESCRIPTION
## Problem

In MCP analytics → Sessions, the sort dropdown trigger showed the raw order value (e.g. `-session_start`) instead of the human-friendly label (`Latest`). The other labels (`Oldest`, `Longest`, `Most tool calls`) were affected the same way on initial render.

<img width="339" height="91" alt="Screenshot 2026-06-17 at 18 57 35" src="https://github.com/user-attachments/assets/db604107-b1ca-4a9f-8f2c-1183b099fc1c" />


## Changes

<img width="331" height="94" alt="Screenshot 2026-06-17 at 18 58 02" src="https://github.com/user-attachments/assets/12fda518-90ad-4890-a2c5-cab43ba85c51" />

The dropdown uses quill's `Select` (a Base UI wrapper). The trigger was a bare `<SelectValue />`, which resolves its label by looking the current value up in the registered `SelectItem` list. Those items only register when the popup (`SelectContent`) is open, so on first render — and any time the popup is closed — the registry is empty and Base UI falls back to rendering the raw `value` string.

Switched the trigger to Base UI's function-as-children form of `SelectValue`, deriving the label directly from the existing `SORT_OPTIONS` array. This bypasses the lazy item registry entirely and matches the established pattern already used in `packages/quill/packages/components/src/date-time-picker.tsx`.

```tsx
<SelectValue>
    {(value: MCPSessionOrderBy) => SORT_OPTIONS.find((o) => o.value === value)?.label ?? value}
</SelectValue>
```

No new types or constants — reuses the existing `SORT_OPTIONS` and `MCPSessionOrderBy`.

## How did you test this code?

I'm an agent. I ran:
- `oxfmt` on the changed file (formatted clean).
- `pnpm --filter=@posthog/frontend typescript:check` — the changed file reports no errors (the remaining errors are pre-existing on master in unrelated products: engineering_analytics, metrics, product_analytics, tracing).

I did not perform manual browser testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and fixed with PostHog Code (Claude Opus). Used an Explore agent to trace the dropdown through `MCPSessionsPlaylist.tsx`, `mcpSessionsLogic.ts`, and the quill `Select`/`SelectValue` primitive, then confirmed the root cause in Base UI's label resolution (registry only populated when the popup is mounted). Chose the function-as-children fix over passing a static `placeholder` or a `find`-based `children` lookup because it's the idiomatic Base UI form and already in use in `date-time-picker.tsx`. No repo skills were required for this single-component frontend change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
