### PR TITLE
chore: Refine PR template for agents style

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
      Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
        ✅ feat(insights): add retention graph export
        ❌ feat: Added retention export.   (capitalized, period, no scope)
-     Description: high-level rationale, not a step-by-step replay.
+     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
      Public OSS repo: no internal customers, incidents, or operational metrics.
 -->
 
@@ -37,17 +37,16 @@
 
 ## 🤖 Agent context
 
-<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
+<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->
 
 <!-- Autonomy — keep one of the two options on the line below:
      - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
      - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->
 
-**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous
+**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous
 
 <!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
      - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
-     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
      - decisions made along the way (what was tried, rejected, chosen, and why)
      - anything else that helps reviewers
      Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
@@ -60,4 +59,6 @@
      - Agent-authored PRs always require human review — do not self-merge or auto-approve.
      - Do NOT claim manual testing you haven't done.
      - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
+     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
+     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
 -->


### PR DESCRIPTION
## Changes

Agents still verbose in an annoying way, making automated PR descriptions meh.
Proposing a couple rules I use in my own assistants, that keep the tone SV-coded rather than clanker-coded.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refines the PR template for agent-authored PRs: adds a cross-reference to agent rules, removes the "skills invoked" bullet, and adds style guidelines (concise SV tone, sentence case).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 73b3c68a88337434ca88560984ed99838cdb1d57.</sup>
<!-- /MENDRAL_SUMMARY -->