### PR TITLE
chore: use getFeatureFlagResult in client feature flag snippets

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -543,7 +543,7 @@ result.payload?.let { payload ->
     if (payload) {
         return (
             <CodeSnippet language={Language.Kotlin} wrap>
-                {`${clientSuffix}getFeatureFlagPayload("${flagKey}")`}
+                {`${clientSuffix}getFeatureFlagResult("${flagKey}")?.payload`}
             </CodeSnippet>
         )
     }
@@ -594,7 +594,7 @@ if (result.payload != null) {
     if (payload) {
         return (
             <CodeSnippet language={Language.Dart} wrap>
-                {`${clientSuffix}getFeatureFlagPayload('${flagKey}');`}
+                {`(${clientSuffix}getFeatureFlagResult('${flagKey}'))?.payload;`}
             </CodeSnippet>
         )
     }
@@ -646,7 +646,7 @@ if let payload = result.payload {
     if (payload) {
         return (
             <CodeSnippet language={Language.Swift} wrap>
-                {`${clientSuffix}getFeatureFlagPayload("${flagKey}")`}
+                {`${clientSuffix}getFeatureFlagResult("${flagKey}")?.payload`}
             </CodeSnippet>
         )
     }
@@ -703,7 +703,7 @@ const MyComponent = () => {
     if (payload) {
         return (
             <CodeSnippet language={Language.JSX} wrap>
-                {`${clientSuffix}getFeatureFlagPayload('${flagKey}')`}
+                {`${clientSuffix}getFeatureFlagResult('${flagKey}')?.payload`}
             </CodeSnippet>
         )
     }
@@ -809,7 +809,7 @@ export function JSSnippet({
         return (
             <>
                 <CodeSnippet language={Language.JavaScript} wrap>
-                    {`posthog.getFeatureFlagPayload('${flagKey ?? ''}')`}
+                    {`posthog.getFeatureFlagResult('${flagKey ?? ''}')?.payload`}
                 </CodeSnippet>
             </>
         )

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -805,11 +805,12 @@ export function JSSnippet({
     instantlyAvailableProperties,
     samplePropertyName,
 }: FeatureFlagSnippet): JSX.Element {
+    const clientSuffix = 'posthog.'
     if (payload) {
         return (
             <>
                 <CodeSnippet language={Language.JavaScript} wrap>
-                    {`posthog.getFeatureFlagResult('${flagKey ?? ''}')?.payload`}
+                    {`${clientSuffix}getFeatureFlagResult('${flagKey ?? ''}')?.payload`}
                 </CodeSnippet>
             </>
         )
@@ -828,7 +829,6 @@ posthog.${
 
 `
 
-    const clientSuffix = 'posthog.'
     const flagFunction = multivariant ? 'getFeatureFlag' : 'isFeatureEnabled'
 
     const variantSuffix = multivariant ? ` == 'example-variant'` : ''


### PR DESCRIPTION
## Problem

The in-app "implement this flag" snippets (`FeatureFlagSnippets.tsx`) show the deprecated `getFeatureFlagPayload` for client SDKs. `getFeatureFlagPayload` is deprecated in favor of `getFeatureFlagResult` across the client SDKs (browser, RN, web-lite, iOS, Android; companion SDK PRs in flight).

## Changes

Migrate the client-SDK snippets to `getFeatureFlagResult(...)?.payload`, verified per SDK:
- **Android/Kotlin**, **iOS/Swift**, **React Native**, **web JS** — sync, `?.payload`
- **Flutter/Dart** — async, wrapped in parens: `(await Posthog().getFeatureFlagResult('...'))?.payload`

Backend SDKs (Node, Java, Go, Python, Ruby) are intentionally **left unchanged** — they have a different deprecation (`evaluateFlags`), not `getFeatureFlagResult`. The React web snippet uses the `useFeatureFlagPayload` *hook* (separate concern), also left as-is.

Draft — companion to the SDK + docs deprecation PRs.

## How did you test this?

Snippet template-string changes only; verified each SDK's `getFeatureFlagResult` shape (sync vs async/Dart) against the existing remote-config examples in the same file.
