### PR TITLE
fix(cdp): thread groups into hog flow function inputs

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
@@ -91,6 +91,7 @@ export class CdpCyclotronWorkerHogFlow extends CdpCyclotronWorker {
                     state: hogFlowInvocationState,
                     hogFlow,
                     person: person ?? undefined,
+                    groups,
                     filterGlobals,
                 })
             })

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -190,6 +190,59 @@ describe('HogFunctionHandler', () => {
         expect(invocationResult.logs[0].message).toContain('[Action:function] Function completed')
     })
 
+    it('should forward groups to the hog function invocation globals', async () => {
+        invocation.groups = {
+            organization: {
+                id: 'org_key',
+                type: 'organization',
+                index: 0,
+                url: '',
+                properties: { owner_name: 'Chris McNeill' },
+            },
+        }
+
+        const buildHogFunctionInvocationSpy = jest.spyOn(mockHogFlowFunctionsService, 'buildHogFunctionInvocation')
+
+        const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
+            queue: 'hog',
+            queuePriority: 0,
+        })
+
+        await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
+
+        const passedGlobals = buildHogFunctionInvocationSpy.mock.calls[0][2]
+        expect(passedGlobals.groups).toEqual(invocation.groups)
+    })
+
+    it('should render a group property referenced in a function input template', async () => {
+        invocation.groups = {
+            organization: {
+                id: 'org_key',
+                type: 'organization',
+                index: 0,
+                url: '',
+                properties: { owner_name: 'Chris McNeill' },
+            },
+        }
+
+        // {groups.organization.properties.owner_name} compiled to hog bytecode
+        action.config.inputs.name = {
+            value: '{groups.organization.properties.owner_name}',
+            templating: 'hog',
+            bytecode: ['_H', 1, 32, 'owner_name', 32, 'properties', 32, 'organization', 32, 'groups', 1, 4],
+        }
+
+        const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
+            queue: 'hog',
+            queuePriority: 0,
+        })
+
+        const handlerResult = await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
+
+        expect(handlerResult.error).toBeUndefined()
+        expect(mockFetch.mock.calls[0][1].body).toContain('"name":"Chris McNeill"')
+    })
+
     it('should throw an error if template is not found', async () => {
         const action = findActionByType(invocation.hogFlow, 'function')!
         action.config.template_id = 'template_123'

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -190,57 +190,51 @@ describe('HogFunctionHandler', () => {
         expect(invocationResult.logs[0].message).toContain('[Action:function] Function completed')
     })
 
-    it('should forward groups to the hog function invocation globals', async () => {
-        invocation.groups = {
-            organization: {
-                id: 'org_key',
-                type: 'organization',
-                index: 0,
-                url: '',
-                properties: { owner_name: 'Chris McNeill' },
-            },
-        }
-
-        const buildHogFunctionInvocationSpy = jest.spyOn(mockHogFlowFunctionsService, 'buildHogFunctionInvocation')
-
-        const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
-            queue: 'hog',
-            queuePriority: 0,
+    describe('with groups', () => {
+        beforeEach(() => {
+            invocation.groups = {
+                organization: {
+                    id: 'org_key',
+                    type: 'organization',
+                    index: 0,
+                    url: '',
+                    properties: { owner_name: 'Chris McNeill' },
+                },
+            }
         })
 
-        await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
+        it('should forward groups to the hog function invocation globals', async () => {
+            const buildHogFunctionInvocationSpy = jest.spyOn(mockHogFlowFunctionsService, 'buildHogFunctionInvocation')
 
-        const passedGlobals = buildHogFunctionInvocationSpy.mock.calls[0][2]
-        expect(passedGlobals.groups).toEqual(invocation.groups)
-    })
+            const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
+                queue: 'hog',
+                queuePriority: 0,
+            })
 
-    it('should render a group property referenced in a function input template', async () => {
-        invocation.groups = {
-            organization: {
-                id: 'org_key',
-                type: 'organization',
-                index: 0,
-                url: '',
-                properties: { owner_name: 'Chris McNeill' },
-            },
-        }
+            await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
 
-        // {groups.organization.properties.owner_name} compiled to hog bytecode
-        action.config.inputs.name = {
-            value: '{groups.organization.properties.owner_name}',
-            templating: 'hog',
-            bytecode: ['_H', 1, 32, 'owner_name', 32, 'properties', 32, 'organization', 32, 'groups', 1, 4],
-        }
-
-        const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
-            queue: 'hog',
-            queuePriority: 0,
+            const passedGlobals = buildHogFunctionInvocationSpy.mock.calls[0][2]
+            expect(passedGlobals.groups).toEqual(invocation.groups)
         })
 
-        const handlerResult = await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
+        it('should render a group property referenced in a function input template', async () => {
+            // {groups.organization.properties.owner_name} compiled to hog bytecode
+            action.config.inputs.name = {
+                value: '{groups.organization.properties.owner_name}',
+                templating: 'hog',
+                bytecode: ['_H', 1, 32, 'owner_name', 32, 'properties', 32, 'organization', 32, 'groups', 1, 4],
+            }
 
-        expect(handlerResult.error).toBeUndefined()
-        expect(mockFetch.mock.calls[0][1].body).toContain('"name":"Chris McNeill"')
+            const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
+                queue: 'hog',
+                queuePriority: 0,
+            })
+
+            const handlerResult = await hogFunctionHandler.execute({ invocation, action, result: invocationResult })
+
+            expect(handlerResult.error).toBeUndefined()
+            expect(mockFetch.mock.calls[0][1].body).toContain('"name":"Chris McNeill"')
+        })
     })
 
     it('should throw an error if template is not found', async () => {

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
@@ -88,6 +88,7 @@ export class HogFunctionHandler implements ActionHandler {
             {
                 event: invocation.state.event,
                 person: invocation.person,
+                groups: invocation.groups,
                 variables: invocation.state.variables,
             }
         )

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -317,6 +317,7 @@ export type CyclotronJobInvocationHogFlow = CyclotronJobInvocation & {
     state?: HogFlowInvocationContext
     hogFlow: HogFlow
     person?: CyclotronPerson
+    groups?: HogFunctionInvocationGlobals['groups']
     filterGlobals: HogFunctionFilterGlobals
 }
 


### PR DESCRIPTION
## Problem

Hog flow ("workflow") function-action input templates that reference a **group** property — e.g. `{groups.organization.properties.owner_name}` — fail at runtime with `Could not execute bytecode for input field: <field>`. The failure is deterministic: it happens every time a function action that references `groups.*` actually executes, so workflows appear to "work most of the time" only because the failing branch is often skipped.

Root cause: there are two distinct globals shapes.

- **Filter/conditional evaluation** uses `HogFunctionFilterGlobals`, where groups are exposed **index-keyed** (`group_0.properties.owner_name`). This is hydrated, so conditions that read group properties work.
- **Function-action input templating** uses `HogFunctionInvocationGlobals`, which expects groups **name-keyed** (`groups.organization.properties.owner_name`).

The hog flow worker fetched groups via `getGroupsForEvent`, used them only to build the index-keyed `filterGlobals`, and discarded the name-keyed map. So when a function input template was rendered, `globals.groups` was `undefined`, the non-null-safe bytecode chain dereferenced `undefined`, and rendering threw. Regular (non-flow) destinations don't hit this because their worker calls `groupsManager.addGroupsToGlobals(...)`.

Net effect: there was **no working way** to reference a group property from a hog flow function input.

## Changes

Thread the name-keyed `groups` map alongside the existing `person` / `filterGlobals` on the hog flow invocation and forward it into the function invocation globals, mirroring the destination worker.

- `CyclotronJobInvocationHogFlow` gains an optional `groups` field.
- The hog flow cyclotron worker attaches the already-fetched `groups` (no extra DB call — `loadHogFlows` re-hydrates each step).
- The function action handler forwards `groups` into the globals passed to `buildHogFunctionInvocation`. This covers `function`, `function_email`, and `function_sms`, which share the handler.

No change was needed in `hogflow-functions.service.ts` — it already spreads the passed globals through to input rendering.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** perform manual testing. Automated coverage and checks I actually ran:

- Added two tests to `hog_function.test.ts`:
  - asserts `groups` is forwarded into the globals passed to `buildHogFunctionInvocation`;
  - renders a `{groups.organization.properties.owner_name}` function input end-to-end and asserts it resolves to the expected value instead of throwing.
- `tsc --noEmit -p .` (nodejs): clean for all changed files (only pre-existing, unrelated `@posthog/cyclotron` native-module errors remain).
- `prettier --write` on all changed files: no formatting changes needed.

The new tests are integration tests that require the local stack (Postgres/Kafka/Redis), which was not available in my environment, so they were not executed locally — **CI will run them**.

## Publish to changelog?

no

## 🤖 Agent context

- Tool/agent: PostHog Code (Claude). Investigation used the PostHog MCP (`workflows-get`, `workflows-list-invocations`, `workflows-logs`, `cdp-function-templates-retrieve`, `execute-sql`) to confirm the failure pattern on a live workflow, then a codebase exploration to locate where globals are assembled.
- Diagnosis path: confirmed the same group property succeeded via the conditional branch (index-keyed `group_0`) but failed in the function input (name-keyed `groups`), which isolated the bug to globals assembly in the hog flow path rather than the data or the template.
- Considered a config-only workaround for the affected workflow and rejected it: because `groups` was never threaded, every `{groups.*}` reference in a function input would throw, so a backend fix is the correct resolution.
- Making the new type field optional avoids breaking existing invocation constructors/fixtures.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
