### PR TITLE
feat(dashboards): include folder in dashboards list response

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -432,6 +432,20 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         assert isoparse(results_by_id[dashboard_recent_id]["last_viewed_at"]) == isoparse("2024-01-01T12:00:00+00:00")
         assert results_by_id[dashboard_unseen_id]["last_viewed_at"] is None
 
+    def test_list_includes_folder_from_filesystem(self):
+        filed_id, _ = self.dashboard_api.create_dashboard(
+            {"name": "Filed dashboard", "_create_in_folder": "Marketing/Website"}
+        )
+        unfiled_id, _ = self.dashboard_api.create_dashboard({"name": "Unfiled dashboard"})
+
+        response = self.dashboard_api.list_dashboards(parent="environment")
+        results_by_id = {dashboard["id"]: dashboard for dashboard in response["results"]}
+
+        # The folder is the file system path without the dashboard's own name
+        assert results_by_id[filed_id]["folder"] == "Marketing/Website"
+        # Dashboards created without an explicit folder land in the default unfiled folder
+        assert results_by_id[unfiled_id]["folder"] == "Unfiled/Dashboards"
+
     @snapshot_postgres_queries
     def test_retrieve_dashboard(self):
         dashboard = Dashboard.objects.create(team=self.team, name="private dashboard", created_by=self.user)

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -14,7 +14,19 @@ from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import URLValidator
 from django.db import IntegrityError, transaction
-from django.db.models import CharField, Count, DateTimeField, F, FilteredRelation, Prefetch, Q, QuerySet, Value
+from django.db.models import (
+    CharField,
+    Count,
+    DateTimeField,
+    F,
+    FilteredRelation,
+    OuterRef,
+    Prefetch,
+    Q,
+    QuerySet,
+    Subquery,
+    Value,
+)
 from django.db.models.functions import Cast
 from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -25,7 +37,7 @@ import pydantic_core
 import posthoganalytics
 from asgiref.sync import sync_to_async
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field, extend_schema_view
 from opentelemetry import trace
 from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -50,7 +62,8 @@ from posthog.exceptions_capture import capture_exception
 from posthog.helpers import create_dashboard_from_template
 from posthog.helpers.dashboard_templates import create_from_template, dashboard_template_from_creation_payload
 from posthog.helpers.trigram_search import DESCRIPTION_FIELD, MAX_SEARCH_LENGTH, NAME_FIELD, apply_trigram_search
-from posthog.models.file_system.file_system import create_or_update_file, delete_file
+from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
+from posthog.models.file_system.file_system import FileSystem, create_or_update_file, delete_file, join_path, split_path
 from posthog.models.quick_filter import QuickFilter
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.team import Team
@@ -825,6 +838,13 @@ class DashboardBasicSerializer(
     access_control_version = serializers.SerializerMethodField()
     is_shared = serializers.BooleanField(source="is_sharing_enabled", read_only=True, required=False)
     last_viewed_at = serializers.DateTimeField(read_only=True, required=False, allow_null=True)
+    folder = serializers.SerializerMethodField(
+        help_text=(
+            "Path of the project-tree folder this dashboard is filed under in the file system, "
+            "e.g. 'Unfiled/Dashboards'. An empty string means the project root; null means the "
+            "dashboard has no file system entry. The dashboard's own name is not part of the path."
+        ),
+    )
 
     class Meta:
         model = Dashboard
@@ -837,6 +857,7 @@ class DashboardBasicSerializer(
             "created_by",
             "last_accessed_at",
             "last_viewed_at",
+            "folder",
             "is_shared",
             "deleted",
             "creation_mode",
@@ -873,6 +894,15 @@ class DashboardBasicSerializer(
         if dashboard.restriction_level > Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT:
             return "v1"
         return "v2"
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_folder(self, dashboard: Dashboard) -> str | None:
+        # `_folder_path` is annotated on the list queryset (DashboardsViewSet.dangerously_get_queryset).
+        # The file system path's last segment is the dashboard's own name; the folder is everything above it.
+        path = getattr(dashboard, "_folder_path", None)
+        if not path:
+            return None
+        return join_path(split_path(path)[:-1])
 
 
 class DashboardMetadataSerializer(DashboardBasicSerializer):
@@ -1994,6 +2024,24 @@ class DashboardsViewSet(
             ).annotate(last_viewed_at=F("recent_dashboard_views__viewed_at"))
         else:
             queryset = queryset.annotate(last_viewed_at=Value(None, output_field=DateTimeField()))
+
+        # Annotate the project-tree folder each dashboard is filed under, so the list page can show it
+        # without an extra round-trip. A single-valued correlated subquery against the file system —
+        # backed by the posthog_fs_team_s_typeref index on (team_id, surface, type, ref) — keeps this cheap
+        # and avoids the row multiplication a join could cause when shortcuts/multiple surfaces exist.
+        queryset = queryset.annotate(_ref_id=Cast(F("id"), output_field=CharField())).annotate(
+            _folder_path=Subquery(
+                FileSystem.objects.filter(
+                    surface_q(DEFAULT_SURFACE),
+                    team_id=OuterRef("team_id"),
+                    type="dashboard",
+                    ref=OuterRef("_ref_id"),
+                )
+                .exclude(shortcut=True)
+                .values("path")[:1],
+                output_field=CharField(),
+            )
+        )
 
         include_deleted = False
         if self.action in ("partial_update", "update") and hasattr(self, "request"):

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -235,6 +235,8 @@ export interface DashboardBasicApi {
     readonly last_accessed_at: string | null
     /** @nullable */
     readonly last_viewed_at: string | null
+    /** Path of the project-tree folder this dashboard is filed under in the file system, e.g. 'Unfiled/Dashboards'. An empty string means the project root; null means the dashboard has no file system entry. The dashboard's own name is not part of the path. */
+    readonly folder: string
     readonly is_shared: boolean
     readonly deleted: boolean
     readonly creation_mode: CreationModeEnumApi

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13863,6 +13863,8 @@ export namespace Schemas {
       readonly last_accessed_at: string | null;
       /** @nullable */
       readonly last_viewed_at: string | null;
+      /** Path of the project-tree folder this dashboard is filed under in the file system, e.g. 'Unfiled/Dashboards'. An empty string means the project root; null means the dashboard has no file system entry. The dashboard's own name is not part of the path. */
+      readonly folder: string;
       readonly is_shared: boolean;
       readonly deleted: boolean;
       readonly creation_mode: CreationModeEnum;


### PR DESCRIPTION
## Problem

The dashboards list page can't show which folder a dashboard lives in. A dashboard's folder isn't stored on the `Dashboard` model — it lives in the project-tree FileSystem — so the list endpoint never returned it, and the frontend would need a separate per-dashboard lookup to display it.

## Changes

Add a read-only `folder` field to `DashboardBasicSerializer` (the serializer used for `GET /api/projects/:id/dashboards/`). It returns the project-tree folder path the dashboard is filed under (e.g. `Unfiled/Dashboards`), an empty string for the project root, or `null` when there's no file system entry.

To keep it performant, the list queryset is annotated with a single-valued correlated `Subquery` against `FileSystem` keyed on `(team_id, surface, type, ref)` — backed by the existing `posthog_fs_team_s_typeref` index. This:
- adds **no extra queries** (it inlines into the existing list `SELECT`, the same approach as the current `last_viewed_at` annotation), and
- avoids the row multiplication a join could introduce when shortcuts/multiple surfaces exist.

The folder is derived from the file system path with the existing `split_path`/`join_path` helpers (the path's last segment is the dashboard's own name, so the folder is everything above it). No new DB migration is required — the supporting index already exists.

## How did you test this code?

I'm an agent (PostHog Slack app). I added an automated test — `test_list_includes_folder_from_filesystem` — asserting a dashboard created under `Marketing/Website` reports `folder == "Marketing/Website"` and a default-created one reports `Unfiled/Dashboards`. I could **not** run the Python suite in my environment (no DB), so this hasn't been executed locally.

Reviewer note: the `.ambr` Postgres-query snapshots for the dashboards-list tests (`@snapshot_postgres_queries`) will need regenerating, since the list query SQL now includes the folder subquery — run the dashboard API tests with `--snapshot-update`. Also run `hogli build:openapi` to pick up the new `folder` field in generated types.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — requested by Matt Pua via Slack.

Authored by the PostHog Slack app (Claude Code / Opus 4.8). Invoked the repo's `/improving-drf-endpoints` skill (per CLAUDE.md) while shaping the serializer change — hence the `help_text` on the new field and `@extend_schema_field(OpenApiTypes.STR)` on `get_folder` so the field flows into generated frontend/MCP types.

Key decisions: chose a correlated `Subquery` over a `FilteredRelation` LEFT JOIN (matching `last_viewed_at`) specifically to guarantee a single value per dashboard and avoid join-driven row multiplication; scoped the field to `DashboardBasicSerializer` only (the list serializer) since the detail serializers redefine `Meta.fields`, so this is intentionally list-only; no migration since `posthog_fs_team_s_typeref` already covers the lookup.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1781711568387049)*
