### PR TITLE
feat(dashboards): surface widget tools in dashboard MCP descriptions

### DIFF
--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -23,7 +23,8 @@ tools:
         description: >
             Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
             from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
-            — use dashboard-insights-run to fetch the actual data for each insight.
+            — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation,
+            see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.
         exclude_params:
             - creation_mode
             - effective_restriction_level
@@ -283,8 +284,9 @@ tools:
             Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and
             restriction level. To update widget tiles, pass `tiles` with each tile's `id` and nested `widget.id` plus
             fields to change (`config`, `name`, `description`) from dashboard-get — the same PATCH path the UI uses.
-            There is no separate PATCH .../widgets/:tile_id/ endpoint. The returned tiles omit insight results to save
-            context — use dashboard-insights-run to fetch the actual data for each insight.
+            There is no separate PATCH .../widgets/:tile_id/ endpoint. To add new widget tiles to this dashboard, use
+            dashboard-widgets-batch-add instead. The returned tiles omit insight results to save context — use
+            dashboard-insights-run to fetch the actual data for each insight.
         exclude_params:
             - creation_mode
             - effective_restriction_level

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1671,7 +1671,7 @@
         }
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -1783,7 +1783,7 @@
         }
     },
     "dashboard-update": {
-        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. To update widget tiles, pass `tiles` with each tile's `id` and nested `widget.id` plus fields to change (`config`, `name`, `description`) from dashboard-get — the same PATCH path the UI uses. There is no separate PATCH .../widgets/:tile_id/ endpoint. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. To update widget tiles, pass `tiles` with each tile's `id` and nested `widget.id` plus fields to change (`config`, `name`, `description`) from dashboard-get — the same PATCH path the UI uses. There is no separate PATCH .../widgets/:tile_id/ endpoint. To add new widget tiles to this dashboard, use dashboard-widgets-batch-add instead. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1687,7 +1687,7 @@
         }
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -1799,7 +1799,7 @@
         }
     },
     "dashboard-update": {
-        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. To update widget tiles, pass `tiles` with each tile's `id` and nested `widget.id` plus fields to change (`config`, `name`, `description`) from dashboard-get — the same PATCH path the UI uses. There is no separate PATCH .../widgets/:tile_id/ endpoint. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Update an existing dashboard by ID. Can update name, description, pinned status, tags, filters, and restriction level. To update widget tiles, pass `tiles` with each tile's `id` and nested `widget.id` plus fields to change (`config`, `name`, `description`) from dashboard-get — the same PATCH path the UI uses. There is no separate PATCH .../widgets/:tile_id/ endpoint. To add new widget tiles to this dashboard, use dashboard-widgets-batch-add instead. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard",


### PR DESCRIPTION
## Problem

- Widget MCP tools exist (`dashboard-widget-catalog-list`, `dashboard-widgets-batch-add`, `dashboard-widgets-run`) but the entry points agents reach for first — `dashboard-create` and `dashboard-update` — never mentioned them.
- Result: widgets undiscoverable unless the agent already knew the dedicated tools.

## Changes

- `dashboard-create` → points at `dashboard-widget-catalog-list` + `dashboard-widgets-batch-add` for adding widgets after creation.
- `dashboard-update` → adds pointer to `dashboard-widgets-batch-add` for adding *new* widget tiles (PATCH only modifies existing ones).
- Descriptions only, no behavior change. Source: `tools.yaml`; regenerated the two schema JSON artifacts to match.

## How did you test this code?

- Agent-authored. Verified hand-edited JSON is byte-identical to `generate-tools` output for the affected entries.
- Scoped JSON edits to just these descriptions to avoid unrelated stale-spec drift. Lint-staged hooks ran on commit; no other test suite run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code (Claude Opus 4.8). Skill: `/implementing-mcp-tools` to confirm the YAML → `generate-tools` → schema JSON pipeline.
- Hand-edited only the two affected JSON entries rather than a full regen (local OpenAPI spec is stale and a full run strips unrelated tools); confirmed edits match generator output.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
