### PR TITLE
feat(batch-exports): reject creation of legacy S3 destinations

### DIFF
--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -614,7 +614,7 @@ def team_api_test_factory():
             team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
 
             destination_data = {
-                "type": "S3",
+                "type": "AwsS3",
                 "config": {
                     "bucket_name": "my-production-s3-bucket",
                     "region": "us-east-1",
@@ -665,7 +665,7 @@ def team_api_test_factory():
             team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
 
             destination_data = {
-                "type": "S3",
+                "type": "AwsS3",
                 "config": {
                     "bucket_name": "my-production-s3-bucket",
                     "region": "us-east-1",

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -943,6 +943,14 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 "Delete this batch export and create a new one with the new destination type."
             )
 
+        # The legacy `S3` type is retained only for existing rows; new destinations must use the
+        # refined `AwsS3` or `S3Compatible` types. `instance is None` means we're creating.
+        if instance is None and destination_type == BatchExportDestination.Destination.S3:
+            raise serializers.ValidationError(
+                "The 'S3' destination type is deprecated and can no longer be created. "
+                "Use 'AwsS3' for AWS S3, or 'S3Compatible' for S3-compatible storage."
+            )
+
         merged_config = recursive_dict_merge(existing_config, config)
 
         # SSRF protection for HTTP batch exports

--- a/products/batch_exports/backend/models/batch_export.py
+++ b/products/batch_exports/backend/models/batch_export.py
@@ -28,6 +28,10 @@ TIMEZONES = [(tz, tz) for tz in pytz.all_timezones]
 # Includes the legacy "S3" alias for backwards compatibility.
 S3_FAMILY_TYPES: frozenset[str] = frozenset({"S3", "AwsS3", "S3Compatible"})
 
+# S3-family types that can be created via the API. The legacy "S3" type is excluded:
+# existing rows keep working, but new destinations must use "AwsS3" or "S3Compatible".
+S3_CREATABLE_TYPES: frozenset[str] = frozenset({"AwsS3", "S3Compatible"})
+
 
 class DayOfWeek(IntEnum):
     """Day of the week enum for batch export schedules.

--- a/products/batch_exports/backend/tests/api/backfills/test_cancel.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_cancel.py
@@ -53,7 +53,7 @@ def wait_for_backfill_runs(backfill_id: str, timeout: int = 30) -> list[BatchExp
 def test_cancelling_a_batch_export_backfill(client: HttpClient, organization, team, user, temporal):
     """Test cancelling a BatchExportBackfill."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/backfills/test_create.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_create.py
@@ -35,7 +35,7 @@ def _create_batch_export_ok(
 ):
     """Helper function to create a BatchExport."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -180,7 +180,7 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
     """
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -326,7 +326,7 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
 
 def test_cannot_create_a_batch_export_for_another_organization(client: HttpClient, temporal, organization, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -361,7 +361,7 @@ def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(
     client: HttpClient, temporal, organization, team, user
 ):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -426,7 +426,7 @@ def test_create_batch_export_with_custom_schema(
     """
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -524,7 +524,7 @@ def test_create_batch_export_fails_with_invalid_query(
     """Test creating a BatchExport should fail with an invalid query."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -571,7 +571,7 @@ def test_create_batch_export_fails_with_invalid_query(
             "invalid type: got 'int', expected 'str'",
         ),
         (
-            "S3",
+            "AwsS3",
             {
                 "bucket_name": "my-s3-bucket",
                 "region": "us-east-1",
@@ -672,7 +672,7 @@ def test_creating_batch_export_with_filters(
     """Test validation of the filters field when creating a batch export."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": _S3_FILTER_TEST_CONFIG,
     }
 

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -7,7 +7,7 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from products.batch_exports.backend.models.batch_export import S3_FAMILY_TYPES
+from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -27,9 +27,6 @@ _S3_FAMILY_BASE_CONFIG = {
 @pytest.mark.parametrize(
     "destination_type,extra_config,expected_persisted_type",
     [
-        # Legacy `S3` alias is accepted and persisted as-is (no coercion).
-        ("S3", {}, "S3"),
-        ("S3", {"endpoint_url": "https://localhost:9000"}, "S3"),
         # Refined AwsS3 (with AWS-only encryption field)
         ("AwsS3", {"encryption": "AES256"}, "AwsS3"),
         # Refined S3Compatible (endpoint_url is required)
@@ -46,7 +43,7 @@ def test_create_s3_family_batch_export(
     extra_config,
     expected_persisted_type,
 ):
-    """Posting any S3-family destination type creates a batch export and persists with the expected type."""
+    """Posting a creatable S3-family destination type creates a batch export and persists with the expected type."""
     client.force_login(user)
     response = create_batch_export(
         client,
@@ -64,7 +61,25 @@ def test_create_s3_family_batch_export(
     assert response.json()["destination"]["type"] == expected_persisted_type
 
 
-@pytest.mark.parametrize("destination_type", sorted(S3_FAMILY_TYPES))
+def test_create_legacy_s3_type_is_rejected(client: HttpClient, temporal, organization, team, user):
+    """The legacy `S3` type is deprecated and can no longer be created via the API."""
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {"type": "S3", "config": {**_S3_FAMILY_BASE_CONFIG}},
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert "deprecated" in response.json()["detail"]
+    assert "AwsS3" in response.json()["detail"]
+    assert "S3Compatible" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
 def test_create_s3_family_batch_export_validates_empty_inputs(
     client: HttpClient, temporal, organization, team, user, destination_type
 ):
@@ -95,7 +110,7 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
 @pytest.mark.parametrize(
     "destination_type,missing_field",
     [
-        *((dt, field) for dt in sorted(S3_FAMILY_TYPES) for field in ("aws_access_key_id", "aws_secret_access_key")),
+        *((dt, field) for dt in sorted(S3_CREATABLE_TYPES) for field in ("aws_access_key_id", "aws_secret_access_key")),
         # `endpoint_url` is required only for S3Compatible.
         ("S3Compatible", "endpoint_url"),
     ],
@@ -203,7 +218,7 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
     """Test creating a BatchExport with S3 destination validates file format and compression."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-s3-bucket",
             "region": "us-east-1",
@@ -238,8 +253,8 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
 
 @pytest.mark.parametrize(
     "destination_type",
-    # Only types that accept `endpoint_url` reach the SSRF check.
-    ["S3", "S3Compatible"],
+    # Only creatable types that accept `endpoint_url` reach the SSRF check.
+    ["S3Compatible"],
 )
 @pytest.mark.parametrize(
     "endpoint_url",

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -34,7 +34,7 @@ pytestmark = [
 def test_delete_batch_export(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -92,7 +92,7 @@ async def wait_for_workflow_in_status(
 def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport cancels ongoing BatchExportBackfill."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -149,7 +149,7 @@ def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal, org
 
 def test_cannot_delete_export_of_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -184,7 +184,7 @@ def test_cannot_delete_export_of_other_organizations(client: HttpClient, tempora
 
 def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -218,7 +218,7 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organi
 def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient, temporal, organization, team, user):
     """Test deleting a BatchExport completes even if underlying Schedule was already deleted."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -30,7 +30,7 @@ def test_can_get_exports_for_your_organizations(
     client: HttpClient, temporal, organization, team, user, interval, timezone, offset_day, offset_hour
 ):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -86,7 +86,7 @@ def test_can_get_exports_for_your_organizations(
 
 def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -123,7 +123,7 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     doesn't belong to.
     """
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_list.py
+++ b/products/batch_exports/backend/tests/api/test_list.py
@@ -26,7 +26,7 @@ def test_list_batch_exports(client: HttpClient, organization, team, user):
     client.force_login(user)
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -67,7 +67,7 @@ def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient, o
     other_user = create_user("another-test@user.com", "Another Test User", other_organization)
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -103,7 +103,7 @@ def test_list_is_partitioned_by_team(client: HttpClient, organization, team, use
     another_team = create_team(organization)
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_pause.py
+++ b/products/batch_exports/backend/tests/api/test_pause.py
@@ -29,7 +29,7 @@ def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organizati
     """Test pausing and unpausing a BatchExport."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -78,7 +78,7 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
     client: HttpClient, temporal, organization, team, user
 ):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -141,7 +141,7 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
 
 def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -198,7 +198,7 @@ def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal,
     """Test pausing a BatchExport that is already paused doesn't actually do anything."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -247,7 +247,7 @@ def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, tempo
     """Test unpausing a BatchExport that is already unpaused doesn't actually do anything."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -287,7 +287,7 @@ def test_pause_non_existent_batch_export(client: HttpClient, temporal, organizat
     """Test pausing a BatchExport that doesn't exist."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -325,7 +325,7 @@ def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organizati
     """Test unpausing a BatchExport can trigger a backfill."""
 
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -28,7 +28,7 @@ pytestmark = [
 
 def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -57,7 +57,7 @@ def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal
 
 def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -93,7 +93,7 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     doesn't belong to.
     """
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -135,7 +135,7 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
 def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user):
     """Test cancelling a BatchExportRun."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -30,7 +30,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize("destination", ["S3", "BigQuery", "Snowflake", "Databricks"])
+@pytest.mark.parametrize("destination", ["AwsS3", "BigQuery", "Snowflake", "Databricks"])
 def test_can_get_test_for_destination(client: HttpClient, destination: str, organization, team, user):
     client.force_login(user)
 
@@ -99,7 +99,7 @@ def test_can_run_s3_test_step_for_new_destination(
     client: HttpClient, bucket_name, minio_client, organization, team, user
 ):
     destination_data = {
-        "type": "S3",
+        "type": "S3Compatible",
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",
@@ -136,7 +136,7 @@ def test_can_run_s3_test_step_for_destination(
     client: HttpClient, bucket_name, minio_client, temporal, organization, team, user
 ):
     destination_data = {
-        "type": "S3",
+        "type": "S3Compatible",
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",
@@ -348,7 +348,7 @@ def test_can_run_s3_test_step_with_additional_fields(
     """
 
     destination_data = {
-        "type": "S3",
+        "type": "S3Compatible",
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_update.py
+++ b/products/batch_exports/backend/tests/api/test_update.py
@@ -50,7 +50,7 @@ def bigquery_integration(team, user):
 
 def test_can_put_config(client: HttpClient, temporal, encryption_codec, organization, team, user):
     destination_data: dict[str, t.Any] = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -127,7 +127,7 @@ def test_can_patch_config(client: HttpClient, interval, temporal, encryption_cod
     # use offset of 1 hour for daily exports and None for hourly exports (these don't support offsets)
     offset_hour = None if interval == "hour" else 1
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -162,7 +162,7 @@ def test_can_patch_config(client: HttpClient, interval, temporal, encryption_cod
     # We should be able to update the destination config, excluding the aws
     # credentials. The existing values should be preserved.
     new_destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-new-production-s3-bucket",
             "region": "us-east-1",
@@ -398,7 +398,7 @@ def test_can_patch_schedule_configuration(
     provided, we should keep the existing value.
     """
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -646,7 +646,7 @@ def test_put_rejects_destination_type_change(
 def test_can_patch_hogql_query(client: HttpClient, temporal, encryption_codec, organization, team, user):
     """Test we can patch a schema with a HogQL query."""
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -734,7 +734,7 @@ def test_can_patch_hogql_query(client: HttpClient, temporal, encryption_codec, o
 
 def test_patch_returns_error_on_unsupported_hogql_query(client: HttpClient, temporal, organization, team, user):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_update_s3.py
+++ b/products/batch_exports/backend/tests/api/test_update_s3.py
@@ -4,7 +4,8 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from products.batch_exports.backend.models.batch_export import S3_FAMILY_TYPES
+from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES, BatchExportDestination
+from products.batch_exports.backend.tests.api.fixtures import create_batch_export as create_batch_export_orm
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok, patch_batch_export
 
 pytestmark = [
@@ -13,11 +14,31 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize("destination_type", sorted(S3_FAMILY_TYPES))
+def _assert_empty_inputs_rejected(client: HttpClient, team_id: int, batch_export_id, destination_type: str) -> None:
+    response = patch_batch_export(
+        client,
+        team_id,
+        batch_export_id,
+        {
+            "destination": {
+                "type": destination_type,
+                "config": {
+                    "bucket_name": "my-new-bucket",
+                    "aws_access_key_id": "",
+                    "aws_secret_access_key": "",
+                },
+            },
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
+
+
+@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
 def test_updating_s3_family_batch_export_validates_empty_inputs(
     client: HttpClient, temporal, organization, team, user, destination_type
 ):
-    """Empty required string inputs are rejected when patching every S3-family destination."""
+    """Empty required string inputs are rejected when patching every creatable S3-family destination."""
     initial_config = {
         "bucket_name": "my-s3-bucket",
         "region": "us-east-1",
@@ -42,20 +63,22 @@ def test_updating_s3_family_batch_export_validates_empty_inputs(
         },
     )
 
-    response = patch_batch_export(
-        client,
-        team.pk,
-        batch_export["id"],
-        {
-            "destination": {
-                "type": destination_type,
-                "config": {
-                    "bucket_name": "my-new-bucket",
-                    "aws_access_key_id": "",
-                    "aws_secret_access_key": "",
-                },
-            },
+    _assert_empty_inputs_rejected(client, team.pk, batch_export["id"], destination_type)
+
+
+def test_updating_legacy_s3_batch_export_validates_empty_inputs(client: HttpClient, temporal, organization, team, user):
+    """Legacy `S3` rows can no longer be created, but existing ones must remain patchable and validated."""
+    destination = BatchExportDestination.objects.create(
+        type="S3",
+        config={
+            "bucket_name": "my-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
         },
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
+    batch_export = create_batch_export_orm(team, destination)
+
+    client.force_login(user)
+    _assert_empty_inputs_rejected(client, team.pk, str(batch_export.id), "S3")


### PR DESCRIPTION
## Problem

The S3 batch export destination is being split into two clearer types: `AwsS3` (AWS-native, supports `encryption`/`kms_key_id`, no `endpoint_url`) and `S3Compatible` (requires `endpoint_url`, supports `use_virtual_style_addressing`). The split is already complete across the model, migrations, Temporal dispatch dataclasses, serializer validation, frontend, and tests, and the legacy `S3` type is retained as a permissive superset alias so existing rows keep working.

The frontend already hides `S3` from the destination picker, but the API still accepted `type: "S3"` on creation. New destinations should use one of the two refined types.

## Changes

- **`BatchExportSerializer.validate_destination`** now rejects `type: "S3"` on **create only**. The guard keys off the existing instance detection (`instance is None`), so:
  - `POST` create with `S3` → `400` with a message pointing to `AwsS3` / `S3Compatible`.
  - `run_test_step_new` (the "test before create" flow, no instance) with `S3` → `400`, consistent with the type no longer being creatable.
  - `PATCH`/`PUT` of an existing `S3` row, and `run_test_step` on one (instance present) → unaffected. Legacy rows stay fully editable and testable.
- Added `S3_CREATABLE_TYPES = {"AwsS3", "S3Compatible"}` alongside the existing `S3_FAMILY_TYPES`, reused by the tests.
- Migrated tests that used `S3` only as a convenience fixture to `AwsS3` (no `endpoint_url`) or `S3Compatible` (with `endpoint_url`). Tests that specifically exercise legacy `S3` rows (the rejection test, the `run_test_step` type-change security test, the legacy-row update test, and the Temporal-suite tests) keep `S3` and create rows via the ORM to bypass the create serializer.

No OpenAPI regeneration is required — this is a pure validation guard, not a schema or field change.

## How did you test this code?

I'm an agent (Claude Code). I could not run the batch-export API test suite in my environment: every test in `products/batch_exports/backend/tests/api/` is gated behind the `temporal_worker` fixture, and the environment had no Temporal server, Postgres, or Docker. These need to run in CI (or a local dev stack via `hogli test products/batch_exports/backend/tests/api/`).

What I did verify locally:
- `ruff check` and `ruff format --check` pass on all changed files.
- All changed files compile (`py_compile`).
- Added `test_create_legacy_s3_type_is_rejected` (create `S3` → 400) and `test_updating_legacy_s3_batch_export_validates_empty_inputs` (ORM-created legacy `S3` row remains patchable and validated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of the requester, who was mid-way through splitting the S3 destination into `AwsS3` / `S3Compatible` and wanted the API to stop accepting new `S3` destinations.

- Invoked the `/improving-drf-endpoints` skill before touching the serializer; it confirmed this is a pure validation guard (no new fields/actions), so no schema annotations or OpenAPI regen were needed.
- Chose to enforce in `validate_destination` rather than the nested `BatchExportDestinationSerializer.validate` because the former already distinguishes create from update via instance detection (`instance is None`), which cleanly leaves `PUT`/`PATCH` of existing legacy rows working — the nested serializer only knows `PATCH` vs not, which would have wrongly blocked `PUT` updates of legacy `S3` rows.
- Test migration rule: configs without `endpoint_url` → `AwsS3`; configs with `endpoint_url` → `S3Compatible`; tests that need an actual legacy `S3` row create it via the ORM to bypass the now-rejecting serializer.
