### PR TITLE
feat(cymbal): link native frames to their debug symbol set via debug_id

### DIFF
--- a/rust/cymbal/src/core/symbolication/symbol/local.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/local.rs
@@ -156,7 +156,7 @@ impl LocalSymbolResolver {
 
         assert!(!resolved.is_empty()); // If this ever happens, we've got a data-dropping bug, and want to crash
 
-        let (set, release) = if let Some(set_ref) = frame.symbol_set_ref() {
+        let (set, release) = if let Some(set_ref) = frame.symbol_set_ref(debug_images) {
             let set_fut = SymbolSetRecord::load(&self.pool, raw_id.team_id, &set_ref);
             let release_fut = async {
                 ReleaseRecord::for_symbol_set_ref(&self.pool, &set_ref, raw_id.team_id)
@@ -456,8 +456,8 @@ mod test {
             .unwrap();
         assert_eq!(count, 1);
 
-        // get the symbol set
-        let set_ref = frame.symbol_set_ref();
+        // get the symbol set (JS frame: debug images are irrelevant)
+        let set_ref = frame.symbol_set_ref(&[]);
         let set = SymbolSetRecord::load(&pool, 0, &set_ref.unwrap())
             .await
             .unwrap()

--- a/rust/cymbal/src/core/types/frames/mod.rs
+++ b/rust/cymbal/src/core/types/frames/mod.rs
@@ -83,20 +83,25 @@ pub enum RawFrame {
 }
 
 impl RawFrame {
-    pub fn symbol_set_ref(&self) -> Option<String> {
+    pub fn symbol_set_ref(&self, debug_images: &[DebugImage]) -> Option<String> {
         match self {
             RawFrame::JavaScriptWeb(frame) | RawFrame::LegacyJS(frame) => frame.symbol_set_ref(),
             RawFrame::JavaScriptNode(frame) => frame.chunk_id.clone(),
             RawFrame::Hermes(frame) => frame.symbol_set_ref(),
             RawFrame::Java(frame) => frame.symbol_set_ref(),
+            // Native frames (apple, rust) resolve against an uploaded debug
+            // symbol set keyed by the matched debug image's debug_id. Surfacing
+            // it as the symbol-set ref links the saved frame records to that
+            // set, so release info attaches and a later (re)upload invalidates
+            // the cached records.
+            RawFrame::Apple(frame) => frame.symbol_set_ref(debug_images),
+            RawFrame::Native(frame) => frame.symbol_set_ref(debug_images),
             // Frames with no symbol sets
             RawFrame::Python(_)
             | RawFrame::Php(_)
             | RawFrame::Ruby(_)
             | RawFrame::Go(_)
             | RawFrame::Dart(_)
-            | RawFrame::Apple(_)
-            | RawFrame::Native(_)
             | RawFrame::Custom(_) => None,
         }
     }

--- a/rust/cymbal/src/core/types/langs/apple.rs
+++ b/rust/cymbal/src/core/types/langs/apple.rs
@@ -346,6 +346,18 @@ impl RawAppleFrame {
         frame
     }
 
+    /// The uploaded dSYM this frame resolves against, identified by the matched
+    /// debug image's `debug_id` (the chunk_id used at upload). None when no
+    /// debug image matches the address, so there is no symbol set to link.
+    pub fn symbol_set_ref(&self, debug_images: &[DebugImage]) -> Option<String> {
+        native::launch_invariant_addr(
+            self.instruction_addr.as_deref(),
+            self.image_addr.as_deref(),
+            debug_images,
+        )
+        .map(|(debug_id, _)| debug_id)
+    }
+
     pub fn frame_id(&self, debug_images: &[DebugImage]) -> String {
         let mut hasher = Sha512::new();
 
@@ -788,6 +800,18 @@ mod test {
             image_type: None,
             arch: None,
         }
+    }
+
+    #[test]
+    fn symbol_set_ref_is_matched_debug_id() {
+        let frame = frame_at(0x100004000, 0x100000000);
+        let images = [image_at("dsym-uuid-1", 0x100000000)];
+        assert_eq!(
+            frame.symbol_set_ref(&images),
+            Some("dsym-uuid-1".to_string())
+        );
+        // No matching debug image -> no symbol set to link.
+        assert_eq!(frame.symbol_set_ref(&[]), None);
     }
 
     #[test]

--- a/rust/cymbal/src/core/types/langs/native.rs
+++ b/rust/cymbal/src/core/types/langs/native.rs
@@ -330,6 +330,19 @@ impl RawNativeFrame {
         }
     }
 
+    /// The uploaded debug symbol set this frame resolves against, identified by
+    /// the matched debug image's `debug_id` (the chunk_id used at upload). None
+    /// when no debug image matches the address, so there is no symbol set to
+    /// link — e.g. a JIT or otherwise unmapped frame.
+    pub fn symbol_set_ref(&self, debug_images: &[DebugImage]) -> Option<String> {
+        launch_invariant_addr(
+            self.instruction_addr.as_deref(),
+            self.image_addr.as_deref(),
+            debug_images,
+        )
+        .map(|(debug_id, _)| debug_id)
+    }
+
     pub fn frame_id(&self, debug_images: &[DebugImage]) -> String {
         let mut hasher = Sha512::new();
 
@@ -695,6 +708,18 @@ mod test {
             image_type: Some("elf".to_string()),
             arch: Some("x86_64".to_string()),
         }
+    }
+
+    #[test]
+    fn symbol_set_ref_is_matched_debug_id() {
+        let frame = native_frame_at(0x1000_4000, 0x1000_0000);
+        let images = [debug_image_at("rust-build-1", 0x1000_0000)];
+        assert_eq!(
+            frame.symbol_set_ref(&images),
+            Some("rust-build-1".to_string())
+        );
+        // No matching debug image -> no symbol set to link.
+        assert_eq!(frame.symbol_set_ref(&[]), None);
     }
 
     // Fixture facts (see tests/static/native/build.sh; constants extracted


### PR DESCRIPTION
## Problem

Native frames (apple + the new rust/native path) resolve against an uploaded debug symbol set by matching the frame address to a `$debug_images` entry and looking the set up by its `debug_id`. But `RawFrame::symbol_set_ref()` returned `None` for both, so `LocalSymbolResolver` saved the resolved frame records with `symbol_set_id = None` and skipped the release lookup. Two consequences (raised in review on #62590):

1. Native stack frames never populate `$exception_releases`, even when the uploaded debug symbols carry release metadata.
2. The saved records aren't linked to the symbol set, so a later (re)upload — which invalidates cached frames via `DELETE FROM posthog_errortrackingstackframe WHERE symbol_set_id = $1` — can't find them.

This was a pre-existing gap shared with Apple (not introduced by the native-frames PR), but worth closing now that native symbolication is landing.

## Changes

- `RawAppleFrame`/`RawNativeFrame` gain `symbol_set_ref(&debug_images)` returning the matched debug image's `debug_id` — the exact key resolution already uses (`OrChunkId::chunk_id(debug_image.debug_id)`), via the shared `launch_invariant_addr` matcher. `None` when no image matches (JIT/unmapped address), so there's nothing to mislink.
- `RawFrame::symbol_set_ref` now takes `&[DebugImage]` and routes the apple/native arms through those helpers; the local resolver passes the event's debug images through.
- Applied to **both** apple and native so the two arms of the shared resolver stay consistent.

Scope note: this links frames and attaches releases for the common workflow where the symbol set already exists at resolve time (CLI uploads symbols + release, then errors arrive). The "upload symbols *after* errors already flowed" case still re-resolves via the unresolved-frame TTL rather than promptly on upload, because — unlike JS via the `Saving` layer — apple/native don't persist a failure `SymbolSetRecord` that a later upload would invalidate. Closing that is a larger, separate change.

## How did you test this code?

Agent-authored (Claude Code, directed by @cat-ph); automated tests only:

- New unit tests in `langs/native.rs` and `langs/apple.rs`: `symbol_set_ref` returns the matched `debug_id`, and `None` with no matching image.
- The ref → `SymbolSetRecord::load` → `symbol_set_id` linkage path is unchanged and already covered by `local.rs::happy_path_test` (it asserts `frame.symbol_set_id == set.id`); this PR only changes what the apple/native arms return into that path.
- `cargo test -p cymbal -p cymbal-resolution` — 212 passed; `cargo clippy --all-targets` / `cargo fmt` clean.
- Structured second-model review (codex): no actionable findings.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal resolution behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) as a follow-up to a review comment on #62590, directed by @cat-ph. Stacked on `ci/cymbal-native-frames`; covers apple + native together to avoid resolver drift.
