### PR TITLE
chore: restore skills-invoked point in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,6 +47,7 @@
 
 <!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
      - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
+     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
      - decisions made along the way (what was tried, rejected, chosen, and why)
      - anything else that helps reviewers
      Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.


### PR DESCRIPTION
## Problem

#64341 refined the PR template's tone, but during a manual copy-paste it accidentally dropped the "skills invoked" bullet from the 🤖 Agent context section. That bullet helps reviewers see which repo/public skills shaped an agent-authored PR.

## Changes

Restores the "skills invoked" bullet under Agent context.

## How did you test this code?

I'm an agent. No tests apply — this is a markdown template change. Verified the restored line matches the text removed in #64341's diff.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael Matloka flagged in Slack that the skills point removed in #64341 was accidental. Pulled #64341's diff to recover the exact wording and re-inserted it in its original position between the "tools/agent used" and "decisions made" bullets.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1781711930879619?thread_ts=1781711930.879619&cid=C09G8QA6740)*
