### PR TITLE
fix(batch-exports): space rapid backfill requests to de-flake backfill test

### DIFF
--- a/products/batch_exports/backend/management/commands/backfill_batch_export_runs.py
+++ b/products/batch_exports/backend/management/commands/backfill_batch_export_runs.py
@@ -265,7 +265,7 @@ class Command(BaseCommand):
             )
             return False
 
-        for overall_interval_start, overall_interval_end in missing_intervals:
+        for index, (overall_interval_start, overall_interval_end) in enumerate(missing_intervals):
             # We want to trigger backfills based on the interval_end values
             first_interval_end = next_interval_boundary(overall_interval_start, export)
             backfill_start, backfill_end = get_backfill_bounds(export, first_interval_end, overall_interval_end)
@@ -275,6 +275,11 @@ class Command(BaseCommand):
                     f"        Would backfill {overall_interval_start.isoformat()} -> {overall_interval_end.isoformat()}"
                 )
             else:
+                # Space consecutive backfill requests so the schedule registers each one before the
+                # next arrives -- submitting them back-to-back races and can drop an action. Sleep
+                # between requests only, not after the last one.
+                if not no_delay and index > 0:
+                    await asyncio.sleep(2)
                 self.stdout.write(
                     f"        Backfilling {overall_interval_start.isoformat()} -> {overall_interval_end.isoformat()}"
                 )
@@ -284,8 +289,6 @@ class Command(BaseCommand):
                     overlap=overlap_policy,
                 )
                 await handle.backfill(backfill)
-                if not no_delay:
-                    await asyncio.sleep(2)
 
         return True
 

--- a/products/batch_exports/backend/tests/management/test_backfill_batch_export_runs.py
+++ b/products/batch_exports/backend/tests/management/test_backfill_batch_export_runs.py
@@ -396,8 +396,13 @@ def hour_window(hours_back: int) -> tuple[datetime, datetime]:
 
 
 def run_backfill_command(*args, stderr=None):
-    """Run the backfill_batch_export_runs management command with --no-delay and --no-confirm."""
-    call_command("backfill_batch_export_runs", *args, "--no-delay", "--no-confirm", stderr=stderr)
+    """Run the backfill_batch_export_runs management command with --no-confirm.
+
+    Deliberately does NOT pass --no-delay: when multiple non-contiguous intervals are
+    backfilled, the command spaces consecutive Temporal backfill requests apart, and
+    submitting them back-to-back (as --no-delay does) races and can drop an action.
+    """
+    call_command("backfill_batch_export_runs", *args, "--no-confirm", stderr=stderr)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

`TestBackfillCommand::test_backfill_triggers_expected_workflows[non_continuous_gaps]` intermittently fails in CI with:

```
TimeoutError: Timed-out waiting for workflows for schedule ... to be query-able. Found 1 workflows, expected 2
```

It surfaced on an unrelated PR's run ([example](https://github.com/PostHog/posthog/actions/runs/27707427229/job/81961638682)).

### Root cause

`non_continuous_gaps` is the only default-overlap parametrization that issues **two separate `handle.backfill()` calls** (two non-contiguous missing intervals → end offsets `[1, 3]`). The contiguous case `merged_missing_intervals` produces **4** workflows from a **single** backfill call and does *not* flake. If the failure were aggregate Temporal visibility latency, the 4-workflow case would flake more than the 2-workflow case — the opposite is observed. That asymmetry points at the **two back-to-back backfill requests racing**: submitting them with no spacing can cause the schedule to register only one action.

The management command already spaces consecutive backfill requests 2 seconds apart for exactly this reason (`--no-delay` help text: "Skip the 2-second delay between backfill requests"). The test helper passed `--no-delay` for speed, exercising the unsafe path.

## Changes

- **Test helper** (`run_backfill_command`): stop passing `--no-delay`, so the multi-interval path spaces its backfill requests just like production.
- **Command** (`_backfill_export`): sleep *between* backfill requests only, not after the last one. This matches the documented "delay between backfill requests" intent, preserves the exact 2s inter-request spacing that prevents the race, and removes a pointless trailing sleep — so single-interval runs (and the single-interval tests) pay no extra delay.

The polling helper's visibility-lag margin (timeout bump + exponential backoff) was already improved on master, so this PR leaves `wait_for_workflows` untouched.

## How did you test this code?

I'm an agent. I could not run the affected test locally — `TestBackfillCommand` requires a live Temporal server and ClickHouse worker, which aren't available in my sandbox. What I did verify:

- `ruff check` and `ruff format --check` clean on both files.
- `pytest --collect-only` succeeds (33 tests collected, no import/collection errors).
- Traced the inter-request spacing semantics: the 2s gap between consecutive same-schedule backfills is identical before and after; only the final no-op sleep is removed.

CI on this PR runs the full batch-exports suite (Temporal + ClickHouse) and is the real validation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a flaky `batch-exports` CI failure observed on another PR's run, using Claude Code (Bash/Grep/Read/Edit + the GitHub CLI to pull the in-progress job log and pinpoint the failing assertion). Diagnosis was by differential analysis of the parametrized cases (why `non_continuous_gaps` flakes but `merged_missing_intervals` does not) rather than a reproduction, since the test needs live Temporal. Considered three fixes: (1) bump the poll timeout — rejected as the primary fix because it can't address a request-drop race and master had already raised it; (2) remove `--no-delay` only — works but adds a wasteful trailing sleep to every backfill; (3) chosen — drop `--no-delay` in the test *and* make the command sleep between requests instead of after each, which both de-flakes and slightly improves the command. No production behavior change to backfill correctness; only a trailing no-op sleep removed.