### PR TITLE
feat(sidebar): add experiment with cmd+k hint

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -180,9 +180,9 @@ export function Nav(): JSX.Element {
                             iconOnly
                             data-attr="nav-search"
                             tooltip={
-                                <>
+                                <div className="flex items-center gap-2">
                                     <span>Search</span> <RenderKeybind keybind={[keyBinds.search]} />
-                                </>
+                                </div>
                             }
                             tooltipPlacement={isLayoutNavCollapsed ? 'right' : undefined}
                             onClick={() => {

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -5,10 +5,9 @@ import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { lazy, Suspense, useEffect, useRef } from 'react'
 
-import { IconApps, IconChat, IconChevronRight, IconSearch } from '@posthog/icons'
+import { IconApps, IconChat, IconChevronRight } from '@posthog/icons'
 
 import { NewAccountMenu } from 'lib/components/Account/NewAccountMenu'
-import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
@@ -32,6 +31,7 @@ import {
 import { navigation3000Logic } from '../../navigation-3000/navigationLogic'
 import { NavBarFooter } from '../NavBarFooter'
 import { PanelLayoutPanels } from './PanelLayoutPanels'
+import { SearchButton } from './SearchButton'
 import { NavTabBrowse } from './tabs/NavTabBrowse'
 const NavTabChat = lazy(() => import('./tabs/NavTabChat').then((m) => ({ default: m.NavTabChat })))
 
@@ -176,22 +176,7 @@ export function Nav(): JSX.Element {
                     >
                         <NewAccountMenu isLayoutNavCollapsed={isLayoutNavCollapsed} />
 
-                        <ButtonPrimitive
-                            iconOnly
-                            data-attr="nav-search"
-                            tooltip={
-                                <div className="flex items-center gap-2">
-                                    <span>Search</span> <RenderKeybind keybind={[keyBinds.search]} />
-                                </div>
-                            }
-                            tooltipPlacement={isLayoutNavCollapsed ? 'right' : undefined}
-                            onClick={() => {
-                                posthog.capture('nav search clicked')
-                                toggleCommand()
-                            }}
-                        >
-                            <IconSearch className="size-4 text-secondary" />
-                        </ButtonPrimitive>
+                        <SearchButton isLayoutNavCollapsed={isLayoutNavCollapsed} toggleCommand={toggleCommand} />
 
                         {isLayoutNavCollapsed && (
                             <ButtonPrimitive

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -28,10 +28,10 @@ import {
     panelLayoutLogic,
 } from '~/layout/panel-layout/panelLayoutLogic'
 
+import { NavSearchButton } from '../../../lib/components/NavSearchButton/NavSearchButton'
 import { navigation3000Logic } from '../../navigation-3000/navigationLogic'
 import { NavBarFooter } from '../NavBarFooter'
 import { PanelLayoutPanels } from './PanelLayoutPanels'
-import { SearchButton } from './SearchButton'
 import { NavTabBrowse } from './tabs/NavTabBrowse'
 const NavTabChat = lazy(() => import('./tabs/NavTabChat').then((m) => ({ default: m.NavTabChat })))
 
@@ -176,7 +176,7 @@ export function Nav(): JSX.Element {
                     >
                         <NewAccountMenu isLayoutNavCollapsed={isLayoutNavCollapsed} />
 
-                        <SearchButton isLayoutNavCollapsed={isLayoutNavCollapsed} toggleCommand={toggleCommand} />
+                        <NavSearchButton isLayoutNavCollapsed={isLayoutNavCollapsed} toggleCommand={toggleCommand} />
 
                         {isLayoutNavCollapsed && (
                             <ButtonPrimitive

--- a/frontend/src/layout/panel-layout/ai-first/SearchButton.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/SearchButton.tsx
@@ -1,0 +1,32 @@
+import { IconSearch } from '@posthog/icons'
+
+import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import posthog from 'lib/posthog-typed'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+
+interface SearchButtonProps {
+    isLayoutNavCollapsed: boolean
+    toggleCommand: () => void
+}
+
+export function SearchButton({ isLayoutNavCollapsed, toggleCommand }: SearchButtonProps): JSX.Element {
+    return (
+        <ButtonPrimitive
+            iconOnly
+            data-attr="nav-search"
+            tooltip={
+                <div className="flex items-center gap-2">
+                    <span>Search</span> <RenderKeybind keybind={[keyBinds.search]} />
+                </div>
+            }
+            tooltipPlacement={isLayoutNavCollapsed ? 'right' : undefined}
+            onClick={() => {
+                posthog.capture('nav search clicked')
+                toggleCommand()
+            }}
+        >
+            <IconSearch className="size-4 text-secondary" />
+        </ButtonPrimitive>
+    )
+}

--- a/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
@@ -52,9 +52,10 @@ function getShortcutIcon(shortcut: AppShortcutType): JSX.Element | null {
 interface RenderKeybindProps {
     keybind: string[][]
     className?: string
+    minimal?: boolean
 }
 
-export function RenderKeybind({ keybind, className }: RenderKeybindProps): JSX.Element {
+export function RenderKeybind({ keybind, className, minimal }: RenderKeybindProps): JSX.Element {
     return (
         <span className={cn('inline-flex items-center gap-1', className)}>
             {keybind.map((keybindOption, index) => {
@@ -79,6 +80,7 @@ export function RenderKeybind({ keybind, className }: RenderKeybindProps): JSX.E
                         <KeyboardShortcut
                             {...Object.fromEntries(keybindOption.map((key: string) => [key, true]))}
                             className="text-xs"
+                            minimal={minimal}
                         />
                     </React.Fragment>
                 )

--- a/frontend/src/lib/components/NavSearchButton/NavSearchButton.tsx
+++ b/frontend/src/lib/components/NavSearchButton/NavSearchButton.tsx
@@ -1,3 +1,5 @@
+import { useValues } from 'kea'
+
 import { IconSearch } from '@posthog/icons'
 
 import { RenderKeybind } from 'lib/components/AppShortcuts/AppShortcutMenu'
@@ -5,15 +7,19 @@ import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import posthog from 'lib/posthog-typed'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
-interface SearchButtonProps {
+import { searchButtonLogic } from './searchButtonLogic'
+
+interface NavSearchButtonProps {
     isLayoutNavCollapsed: boolean
     toggleCommand: () => void
 }
 
-export function SearchButton({ isLayoutNavCollapsed, toggleCommand }: SearchButtonProps): JSX.Element {
+export function NavSearchButton({ isLayoutNavCollapsed, toggleCommand }: NavSearchButtonProps): JSX.Element {
+    const { showHint } = useValues(searchButtonLogic)
+
     return (
         <ButtonPrimitive
-            iconOnly
+            iconOnly={!showHint}
             data-attr="nav-search"
             tooltip={
                 <div className="flex items-center gap-2">
@@ -25,8 +31,18 @@ export function SearchButton({ isLayoutNavCollapsed, toggleCommand }: SearchButt
                 posthog.capture('nav search clicked')
                 toggleCommand()
             }}
+            className="gap-0"
         >
-            <IconSearch className="size-4 text-secondary" />
+            <IconSearch className="size-4 shrink-0 text-secondary" />
+            <div
+                className={`overflow-hidden whitespace-nowrap transition-[max-width,opacity] duration-300 ease-in-out ${
+                    showHint ? 'max-w-xs opacity-100' : 'max-w-0 opacity-0'
+                }`}
+            >
+                <span className="flex items-center gap-1 pl-1 text-xs text-secondary">
+                    <RenderKeybind keybind={[keyBinds.search]} minimal />
+                </span>
+            </div>
         </ButtonPrimitive>
     )
 }

--- a/frontend/src/lib/components/NavSearchButton/searchButtonLogic.tsx
+++ b/frontend/src/lib/components/NavSearchButton/searchButtonLogic.tsx
@@ -1,0 +1,41 @@
+import { kea, connect, path, actions, reducers, selectors, afterMount } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import type { searchButtonLogicType } from './searchButtonLogicType'
+
+export const searchButtonLogic = kea<searchButtonLogicType>([
+    path(['lib', 'components', 'NavSearchButton', 'searchButtonLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
+    })),
+    actions(() => ({
+        hideHint: true,
+    })),
+    reducers(() => ({
+        hintVisible: [
+            true,
+            {
+                hideHint: () => false,
+            },
+        ],
+    })),
+    selectors(() => ({
+        isHintEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags) => featureFlags[FEATURE_FLAGS.SIDEBAR_SEARCH_COMMAND_HINT] === 'test',
+        ],
+        showHint: [
+            (s) => [s.hintVisible, s.isHintEnabled],
+            (hintVisible, isHintEnabled) => hintVisible && isHintEnabled,
+        ],
+    })),
+    afterMount(({ actions, cache }) => {
+        cache.disposables.add(() => {
+            const id = setTimeout(() => actions.hideHint(), 5000)
+
+            return () => clearTimeout(id)
+        }, 'hintTimer')
+    }),
+])

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -470,6 +470,7 @@ export const FEATURE_FLAGS = {
     SHOW_DATA_PIPELINES_NAV_ITEM: 'show-data-pipelines-nav-item', // owner: @raquelmsmith
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
+    SIDEBAR_SEARCH_COMMAND_HINT: 'sidebar-search-command-hint', // owner: @fercgomes
     SIGNUP_AA_TEST_4_WAY: 'signup-aa-test-4-way', // owner: @andehen #team-experiments multivariate=control,test-1,test-2,test-3
     SLACK_DWH: 'slack-dwh', // owner: @MarconLP #team-warehouse-sources
     SNAPCHAT_ADS_SOURCE: 'snapchat-ads-source', // owner: @jabahamondes #team-web-analytics


### PR DESCRIPTION
## Problem

People aren't discovering the Cmd+K menu, which helps a lot with navigation.

## Changes

Adds a teensy experiment that shows a Cmd+K hint besides the Nav search icon for 5 seconds on page load, and goes away.

https://github.com/user-attachments/assets/69432326-5d0e-445c-9996-37b327998f5a


## 🤖 Agent context

No agents used here whatsoever. I've built this with my bare hands like a chad.
