### PR TITLE
fix(postgres): treat SASL authentication failure as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -195,6 +195,21 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "and the connection details are correct, then re-enable the sync."
             ),
             "error received from server in SCRAM exchange: Wrong password": None,
+            # The server (commonly Supabase's Supavisor transaction pooler on port 6543) rejects the
+            # SASL/SCRAM credential exchange with "FATAL: SASL authentication failed" instead of
+            # PostgreSQL's "password authentication failed for user" — so none of the password keys
+            # above substring-match it and Temporal keeps retrying a credential mismatch that only the
+            # customer can fix. It surfaces alone via `str(e)`: when `options` is rejected first, the
+            # no-`options` reconnect raises this and the "unsupported startup parameter: options"
+            # error is only its chained context (which `str(e)` drops). Auth rejection is
+            # deterministic, never a transient blip, so stop retrying.
+            "SASL authentication failed": (
+                "Your database rejected the credentials during authentication "
+                '("SASL authentication failed"). This usually means the username or password is '
+                "wrong. Some connection poolers (for example Supabase's transaction pooler) also "
+                "require a pooler-specific username such as postgres.<project-ref>. Check your "
+                "credentials, then re-enable the sync."
+            ),
             "could not translate host name": None,
             "timeout expired connection to server at": None,
             "password authentication failed for user": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -346,6 +346,35 @@ class TestPostgresSourceNonRetryableErrors:
         assert "password authentication failed for user" not in error_msg
         assert any(pattern in error_msg for pattern in non_retryable.keys())
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Supabase's Supavisor transaction pooler (port 6543) rejects bad credentials with
+            # "FATAL: SASL authentication failed" rather than PostgreSQL's "password authentication
+            # failed for user". When `options` is rejected first, this is the message that propagates
+            # via str(e) (the options error is only the chained context). Host/port are volatile.
+            'connection failed: connection to server at "52.57.91.216", port 6543 failed: FATAL:  SASL authentication failed connection to server at "52.57.91.216", port 6543 failed: FATAL:  SASL authentication failed',
+            'OperationalError: connection failed: connection to server at "10.0.0.1", port 6543 failed: FATAL:  SASL authentication failed',
+        ],
+    )
+    def test_sasl_authentication_failed_is_non_retryable(self, source, error_msg):
+        # The PostgreSQL "password authentication failed for user" key doesn't substring-match the
+        # pooler's SASL wording, so confirm the dedicated key recognises it independent of host/port.
+        non_retryable = source.get_non_retryable_errors()
+        assert "SASL authentication failed" in non_retryable
+        assert "password authentication failed for user" not in error_msg
+        assert any(pattern in error_msg for pattern in non_retryable.keys())
+
+    def test_sasl_authentication_failed_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "52.57.91.216", port 6543 failed: '
+            "FATAL:  SASL authentication failed"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "SASL authentication failure should surface an actionable message"
+        assert "credentials" in friendly[0]
+
     def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
         # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,
         # so confirm it's specifically the new key that recognises this message.


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source surfaced a real, recurring error in PostHog error tracking: connection attempts failing with `OperationalError: ... FATAL:  SASL authentication failed`.

This is a rejected SASL/SCRAM credential exchange — most commonly seen against Supabase's Supavisor transaction pooler (port 6543), where it means the username or password is wrong (the pooler also requires a project-ref username such as `postgres.<project-ref>`). It's a user/upstream config problem that no amount of retrying can fix.

None of the existing non-retryable password keys (`password authentication failed for user`, `error received from server in SCRAM exchange: Wrong password`, the RDS Proxy wording, etc.) substring-match this message, so Temporal kept retrying a permanent credential mismatch.

A subtlety from the captured stack: the error appears alongside `unsupported startup parameter: options`, but that one is already handled — `_connect_with_options_fallback` drops `options` and reconnects when a pooler rejects it. The reconnect is what raises the SASL failure, and since it's the propagating exception, `str(e)` (what the non-retryable check matches against) carries the SASL message, not the chained `options` context. So matching `SASL authentication failed` is the correct, effective fix.

## Changes

- Add `"SASL authentication failed"` to `PostgresSource.get_non_retryable_errors()` with an actionable message pointing at credentials and the pooler-username nuance.
- Add regression tests: the message is recognised as non-retryable independent of the volatile host/port, and surfaces the friendly message. Verified the substring doesn't catch any of the existing transient connection cases (pool exhaustion, mid-stream drops).

## How did you test this code?

I'm an agent. Test dependencies (pytest/django) aren't installed in this environment, so I could not execute the suite. I verified:
- the new substring matches both representative SASL error strings and does **not** match the existing transient cases that must stay retryable (pool exhaustion, `the connection is lost`, mid-stream SSL drops), via a standalone string-matching check mirroring the production matcher;
- both changed files compile and pass `ruff check` / `ruff format`.

The added tests (`test_sasl_authentication_failed_is_non_retryable`, `test_sasl_authentication_failed_returns_friendly_message`) mirror the existing `TestPostgresSourceNonRetryableErrors` patterns and should be run in CI.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres source. Investigated the issue's stack trace and code path (`_connect_with_dropped_retry` → `_connect_to_postgres` → `_connect_with_options_fallback`), then decided this is a user/upstream credentials error rather than a code bug — the `options` rejection is already handled gracefully, and the residual SASL failure is a permanent auth rejection. Chose to extend `NonRetryableErrors` (matching a stable, low-false-positive substring) over a code change, mirroring the existing Supabase/RDS-proxy credential entries.
