### PR TITLE
chore(recording-api): fix aws error handling

### DIFF
--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, NoSuchKey, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { ClickHouseClient } from '@clickhouse/client'
 import snappy from 'snappy'
 
@@ -136,7 +136,7 @@ export class RecordingService {
             )
             return { ok: true, data: result }
         } catch (error) {
-            if (error instanceof NoSuchKey) {
+            if ((error as Error)?.name === 'NoSuchKey') {
                 logger.warn('[RecordingService] S3 object not found (NoSuchKey)', {
                     key,
                     teamId,

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand, NoSuchKey, S3Client } from '@aws-sdk/client-s3'
 import { ClickHouseClient } from '@clickhouse/client'
 import snappy from 'snappy'
 
@@ -136,7 +136,7 @@ export class RecordingService {
             )
             return { ok: true, data: result }
         } catch (error) {
-            if ((error as Error)?.name === 'NoSuchKey') {
+            if (error instanceof NoSuchKey || (error as Error)?.name === 'NoSuchKey') {
                 logger.warn('[RecordingService] S3 object not found (NoSuchKey)', {
                     key,
                     teamId,

--- a/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
+++ b/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
@@ -1,10 +1,4 @@
-import {
-    ConditionalCheckFailedException,
-    DynamoDBClient,
-    GetItemCommand,
-    PutItemCommand,
-    UpdateItemCommand,
-} from '@aws-sdk/client-dynamodb'
+import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb'
 import { DecryptCommand, GenerateDataKeyCommand, KMSClient } from '@aws-sdk/client-kms'
 import sodium from 'libsodium-wrappers'
 
@@ -65,7 +59,7 @@ export class DynamoDBKeyStore implements KeyStore {
                 })
             )
         } catch (error) {
-            if (error instanceof ConditionalCheckFailedException) {
+            if ((error as Error)?.name === 'ConditionalCheckFailedException') {
                 // Key already exists — return the existing key instead of overwriting
                 return this.getKey(sessionId, teamId)
             }

--- a/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
+++ b/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
@@ -1,4 +1,10 @@
-import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb'
+import {
+    ConditionalCheckFailedException,
+    DynamoDBClient,
+    GetItemCommand,
+    PutItemCommand,
+    UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb'
 import { DecryptCommand, GenerateDataKeyCommand, KMSClient } from '@aws-sdk/client-kms'
 import sodium from 'libsodium-wrappers'
 
@@ -59,7 +65,10 @@ export class DynamoDBKeyStore implements KeyStore {
                 })
             )
         } catch (error) {
-            if ((error as Error)?.name === 'ConditionalCheckFailedException') {
+            if (
+                error instanceof ConditionalCheckFailedException ||
+                (error as Error)?.name === 'ConditionalCheckFailedException'
+            ) {
                 // Key already exists — return the existing key instead of overwriting
                 return this.getKey(sessionId, teamId)
             }


### PR DESCRIPTION
1) What changed and why

Three sites, one pattern: error instanceof <AwsSdkException> → (error as Error)?.name === '<ExceptionName>'.

Why it was needed: CI is failing on https://github.com/PostHog/posthog/pull/64357.  A recent master dep change (the agent-platform merge, #63988) added more AWS SDK versions, leaving the tree with several @aws-sdk/core / @smithy/core copies. AWS SDK v3 ships each client's exception classes inside the package, so when the SDK is duplicated, an error thrown by one physical copy is not instanceof the class imported from another copy — the guard silently returns false. In the test that meant an expected ResourceNotFoundException was re-thrown, killing all 16 tests in beforeAll. The same latent failure mode sat in two production paths (graceful S3 "not found" becoming a thrown error; the keystore's concurrent-creation path throwing instead of returning the existing key).

## How did you test this code?

see if ci passes