### PR TITLE
perf(web-analytics): narrow frustration precompute scan to frustration events

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
@@ -26,7 +26,11 @@ from posthog.models.utils import uuid7
 
 from products.analytics_platform.backend.models.preaggregation_job import PreaggregationJob
 from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
-from products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute import can_use_lazy_precompute
+from products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute import (
+    _FRUSTRATION_EVENT_TYPES,
+    INSERT_QUERY_TEMPLATE,
+    can_use_lazy_precompute,
+)
 
 
 @override_settings(IN_UNIT_TESTING=True)
@@ -134,6 +138,20 @@ class TestWebStatsFrustrationLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_eligible_when_flag_on_and_opt_in_set(self):
         with self._enable_lazy():
             assert can_use_lazy_precompute(self._runner(self._build_query())) is True
+
+    def test_insert_scans_only_frustration_event_types(self):
+        # $pageview/$screen contribute 0 to every metric and their groups are
+        # dropped by the HAVING, so the insert must not scan them — they only
+        # inflate the GROUP BY cardinality that OOMs high-traffic teams.
+        # Result-parity with the live (5-type) scan is covered by
+        # test_lazy_response_matches_live.
+        assert "{event_scan_filter}" in INSERT_QUERY_TEMPLATE
+        assert "$pageview" not in INSERT_QUERY_TEMPLATE
+        assert "$screen" not in INSERT_QUERY_TEMPLATE
+        for frustration_event in ("$rageclick", "$dead_click", "$exception"):
+            assert frustration_event in _FRUSTRATION_EVENT_TYPES
+        assert "$pageview" not in _FRUSTRATION_EVENT_TYPES
+        assert "$screen" not in _FRUSTRATION_EVENT_TYPES
 
     def test_rejected_when_org_flag_off(self):
         # Default mocked-off feature flag: gate refuses.

--- a/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
@@ -19,7 +19,7 @@ from prometheus_client import Counter, Histogram
 from posthog.schema import HogQLQueryModifiers, WebAnalyticsOrderByFields, WebStatsBreakdown
 
 from posthog.hogql import ast
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
@@ -152,6 +152,18 @@ def _breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
     return ast.Field(chain=["events", "properties", "$pathname"])
 
 
+# Frustration metrics only count `$rageclick` / `$dead_click` / `$exception`, so
+# the insert scans only those — see the INSERT template note for why this is
+# result-identical to also scanning `$pageview` / `$screen` and why it matters
+# for memory. The runner is the single place to widen this list if a future
+# breakdown or filter ever needs other event types.
+_FRUSTRATION_EVENT_TYPES = "('$rageclick', '$dead_click', '$exception')"
+
+
+def _event_scan_filter_expr() -> ast.Expr:
+    return parse_expr(f"events.event IN {_FRUSTRATION_EVENT_TYPES}")
+
+
 # HogQL template for the precompute INSERT — a state-converted version of
 # the live `FRUSTRATION_METRICS_INNER_QUERY` + `FrustrationMetricsStrategy`
 # outer aggregation. The lazy_computation framework substitutes the listed
@@ -161,7 +173,8 @@ def _breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
 # `expires_at` to the SELECT.
 #
 # The inner subquery mirrors the live `FRUSTRATION_METRICS_INNER_QUERY`
-# verbatim (per-session counts of rage / dead / exception events), and the
+# (per-session counts of rage / dead / exception events) — bar the narrowed
+# event-scan list noted below, which is result-equivalent — and the
 # outer aggregation mirrors the live `FrustrationMetricsStrategy.build_query`
 # OUTER (sums collapsed by breakdown) — but bucketed hourly so reads can
 # answer arbitrary date ranges via `sumMergeIf`. `sumState(...)` and `sum(...)`
@@ -173,10 +186,19 @@ def _breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
 # `HAVING or(metric > 0, ...)` drops. Saves storing the all-zero rows that
 # the read query would only re-filter via its own `HAVING or(rage > 0, ...)`.
 #
-# The `event IN (...)` filter restricts the scan to events that can possibly
-# contribute to any of the three metrics, plus `$pageview` / `$screen` so the
-# session-start anchoring is correct. The forward pad lets sessions that span
-# a UTC-day boundary aggregate cleanly — same reasoning as overview/paths.
+# The event-scan list (`{event_scan_filter}`) is restricted to the three
+# frustration event types. `$pageview` / `$screen` contribute 0 to every metric
+# and any resulting all-zero `(session, breakdown)` group is dropped by the
+# outer `HAVING`, so scanning them only inflates the
+# `GROUP BY session_id, breakdown_value` cardinality — the dominant cost behind
+# insert OOMs on high-traffic teams. Narrowing is result-identical: session
+# start comes from the `session.$start_timestamp` join (not scanned events), and
+# each frustration event carries its own `$pathname`, so the surviving rows and
+# sums are unchanged (verified by parity, with and without user filters). The
+# runner owns the list via `_event_scan_filter_expr`, so a future breakdown or
+# filter that genuinely needs other event types can widen it there. The forward
+# pad lets sessions spanning a UTC-day boundary aggregate cleanly — same
+# reasoning as overview/paths.
 INSERT_QUERY_TEMPLATE = """
 SELECT
     toStartOfHour(start_timestamp) AS time_window_start,
@@ -195,7 +217,7 @@ FROM (
     FROM events
     WHERE and(
         {events_session_id} IS NOT NULL,
-        events.event IN ('$pageview', '$screen', '$rageclick', '$dead_click', '$exception'),
+        {event_scan_filter},
         timestamp >= {time_window_min},
         timestamp < ({time_window_max} + toIntervalMinute({pad_minutes})),
         {user_filter},
@@ -225,6 +247,7 @@ def ensure_web_stats_frustration_precomputed(
     placeholders: dict[str, ast.Expr] = {
         "events_session_id": _events_session_id_expr(runner),
         "breakdown_value_expr": _breakdown_value_expr(runner),
+        "event_scan_filter": _event_scan_filter_expr(),
         "user_filter": host_filter_expr(runner.query.properties or []),
         "test_account_filter": test_account_filter_expr(
             test_account_filters=runner._test_account_filters, team=runner.team

--- a/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
@@ -19,7 +19,7 @@ from prometheus_client import Counter, Histogram
 from posthog.schema import HogQLQueryModifiers, WebAnalyticsOrderByFields, WebStatsBreakdown
 
 from posthog.hogql import ast
-from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
@@ -157,11 +157,19 @@ def _breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
 # result-identical to also scanning `$pageview` / `$screen` and why it matters
 # for memory. The runner is the single place to widen this list if a future
 # breakdown or filter ever needs other event types.
-_FRUSTRATION_EVENT_TYPES = "('$rageclick', '$dead_click', '$exception')"
+_FRUSTRATION_EVENT_TYPES = ("$rageclick", "$dead_click", "$exception")
 
 
 def _event_scan_filter_expr() -> ast.Expr:
-    return parse_expr(f"events.event IN {_FRUSTRATION_EVENT_TYPES}")
+    # Built as AST (not string-interpolated into parse_expr) so there's no
+    # injection surface — `events.event IN (<frustration types>)`.
+    return ast.Call(
+        name="in",
+        args=[
+            ast.Field(chain=["events", "event"]),
+            ast.Call(name="tuple", args=[ast.Constant(value=event) for event in _FRUSTRATION_EVENT_TYPES]),
+        ],
+    )
 
 
 # HogQL template for the precompute INSERT — a state-converted version of


### PR DESCRIPTION
## Problem

The web-analytics frustration-metrics lazy-precompute INSERT scans `event IN ('$pageview','$screen','$rageclick','$dead_click','$exception')`, but the only metrics it computes are `countIf($rageclick / $dead_click / $exception)`. `$pageview`/`$screen` contribute **0** to every metric, and any all-zero `(session, breakdown)` group is dropped by the outer `HAVING or(rage>0, dead>0, errors>0)`.

On high-traffic teams those pageview/screen rows are the bulk of the `GROUP BY session_id, breakdown_value` cardinality — and that GROUP BY's merge stage is what OOMs the insert. The job hits the per-query memory cap (`MEMORY_LIMIT_EXCEEDED`) and never reaches `READY`, so the warmer retries it every tick.

## Changes

Scan only the three frustration event types. The hardcoded 5-type list in `INSERT_QUERY_TEMPLATE` becomes a runner-supplied `{event_scan_filter}` placeholder (`_event_scan_filter_expr()`), so the runner is the single place to widen it if a future breakdown/filter ever needs other event types.

This is **result-identical** to scanning pageviews too:
- session start comes from the `session.$start_timestamp` join, not scanned events, so bucketing is unchanged;
- each frustration event carries its own `$pathname`, so the breakdown is unchanged;
- pageview/screen only ever formed all-zero groups that the `HAVING` already dropped.

The stale comment claiming pageview/screen are needed "so session-start anchoring is correct" is corrected.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Validated empirically against production data (read-only, on the offline cluster) by replaying the exact INSERT's SELECT:

- **Memory:** the 7-day window that OOM'd at the 42 GiB cap completes at **~1.45 GiB** with the narrowed scan.
- **Parity, no filter:** identical totals and identical surviving-row count vs. the 5-type scan.
- **Parity, with an event-property filter** (`$pathname` = a busy path): identical totals and row count.

Added `test_insert_scans_only_frustration_event_types` (fast guard against re-adding pageview/screen to the scan). The existing `test_lazy_response_matches_live` remains the lazy-vs-live result-parity guard and is unaffected (the change is result-identical).

Earlier alternatives were tested and rejected on the same data: `join_algorithm='grace_hash'` and `distributed_aggregation_memory_efficient=1` both still OOM'd — the bottleneck is the GROUP BY merge cardinality, not the join, so narrowing the scan is the correct lever.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code. Follow-up to the web-analytics precompute OOM work (#64093 weekly-TTL + spill). After #64093, residual insert OOMs were isolated to two breakdowns on one very-high-traffic team. Investigation (replaying the failing query with different settings against prod) showed the residual is driven by `GROUP BY` cardinality, not the join — and that the frustration scan was paying for pageview/screen events that can't contribute to any metric. This PR removes that dead weight for the frustration tile only.

The sibling **paths** breakdown is *not* addressed here — it genuinely breaks down by pageview path, so it can't be narrowed the same way and will be handled separately (finer windowing).

Note: changing the scanned event set changes the precompute cache-key hash, so existing frustration jobs recompute once (cheap with the narrowed scan) and prior rows age out by TTL.
