### PR TITLE
fix(tasks): allow xhigh effort for gpt-5.5 codex

### DIFF
--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -122,6 +122,11 @@ CODEX_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (
     ReasoningEffort.MEDIUM,
     ReasoningEffort.HIGH,
 )
+CODEX_XHIGH_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (
+    *CODEX_REASONING_EFFORTS,
+    ReasoningEffort.XHIGH,
+)
+CODEX_XHIGH_REASONING_MODELS: frozenset[str] = frozenset({"gpt-5.5"})
 
 
 def get_provider_for_runtime_adapter(
@@ -148,6 +153,8 @@ def get_supported_reasoning_efforts(
     if adapter_value == RuntimeAdapter.CLAUDE.value:
         return CLAUDE_REASONING_EFFORTS_BY_MODEL.get(model, ())
     if adapter_value == RuntimeAdapter.CODEX.value:
+        if model.lower() in CODEX_XHIGH_REASONING_MODELS:
+            return CODEX_XHIGH_REASONING_EFFORTS
         return CODEX_REASONING_EFFORTS
 
     return ()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1764,13 +1764,14 @@ class TestTaskAPI(BaseTaskAPITest):
 
     @parameterized.expand(
         [
-            ("low",),
-            ("medium",),
-            ("high",),
+            ("gpt_5_3_low", "gpt-5.3-codex", "low"),
+            ("gpt_5_3_medium", "gpt-5.3-codex", "medium"),
+            ("gpt_5_3_high", "gpt-5.3-codex", "high"),
+            ("gpt_5_5_xhigh", "gpt-5.5", "xhigh"),
         ]
     )
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_persists_runtime_metadata(self, reasoning_effort, mock_workflow):
+    def test_run_endpoint_persists_runtime_metadata(self, _case_name, model, reasoning_effort, mock_workflow):
         task = self.create_task()
 
         response = self.client.post(
@@ -1778,7 +1779,7 @@ class TestTaskAPI(BaseTaskAPITest):
             {
                 "mode": "interactive",
                 "runtime_adapter": "codex",
-                "model": "gpt-5.3-codex",
+                "model": model,
                 "reasoning_effort": reasoning_effort,
             },
             format="json",
@@ -1789,40 +1790,12 @@ class TestTaskAPI(BaseTaskAPITest):
         task_run = TaskRun.objects.get(id=latest_run["id"])
         assert task_run.state["runtime_adapter"] == "codex"
         assert task_run.state["provider"] == "openai"
-        assert task_run.state["model"] == "gpt-5.3-codex"
+        assert task_run.state["model"] == model
         assert task_run.state["reasoning_effort"] == reasoning_effort
         assert latest_run["runtime_adapter"] == "codex"
         assert latest_run["provider"] == "openai"
-        assert latest_run["model"] == "gpt-5.3-codex"
+        assert latest_run["model"] == model
         assert latest_run["reasoning_effort"] == reasoning_effort
-        mock_workflow.assert_called_once()
-
-    @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_accepts_xhigh_reasoning_effort_for_codex_gpt_5_5(self, mock_workflow):
-        task = self.create_task()
-
-        response = self.client.post(
-            f"/api/projects/@current/tasks/{task.id}/run/",
-            {
-                "mode": "interactive",
-                "runtime_adapter": "codex",
-                "model": "gpt-5.5",
-                "reasoning_effort": "xhigh",
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        latest_run = response.json()["latest_run"]
-        task_run = TaskRun.objects.get(id=latest_run["id"])
-        assert task_run.state["runtime_adapter"] == "codex"
-        assert task_run.state["provider"] == "openai"
-        assert task_run.state["model"] == "gpt-5.5"
-        assert task_run.state["reasoning_effort"] == "xhigh"
-        assert latest_run["runtime_adapter"] == "codex"
-        assert latest_run["provider"] == "openai"
-        assert latest_run["model"] == "gpt-5.5"
-        assert latest_run["reasoning_effort"] == "xhigh"
         mock_workflow.assert_called_once()
 
     @parameterized.expand([("auto",), ("read-only",), ("full-access",)])

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1797,6 +1797,34 @@ class TestTaskAPI(BaseTaskAPITest):
         assert latest_run["reasoning_effort"] == reasoning_effort
         mock_workflow.assert_called_once()
 
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_accepts_xhigh_reasoning_effort_for_codex_gpt_5_5(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "runtime_adapter": "codex",
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        latest_run = response.json()["latest_run"]
+        task_run = TaskRun.objects.get(id=latest_run["id"])
+        assert task_run.state["runtime_adapter"] == "codex"
+        assert task_run.state["provider"] == "openai"
+        assert task_run.state["model"] == "gpt-5.5"
+        assert task_run.state["reasoning_effort"] == "xhigh"
+        assert latest_run["runtime_adapter"] == "codex"
+        assert latest_run["provider"] == "openai"
+        assert latest_run["model"] == "gpt-5.5"
+        assert latest_run["reasoning_effort"] == "xhigh"
+        mock_workflow.assert_called_once()
+
     @parameterized.expand([("auto",), ("read-only",), ("full-access",)])
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_preserves_codex_initial_permission_mode(self, initial_permission_mode, mock_workflow):
@@ -1989,16 +2017,25 @@ class TestTaskAPI(BaseTaskAPITest):
         }
         mock_workflow.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("gpt_5_4_xhigh", "gpt-5.4", "xhigh", "low, medium, high"),
+            ("gpt_5_4_max", "gpt-5.4", "max", "low, medium, high"),
+            ("gpt_5_5_max", "gpt-5.5", "max", "low, medium, high, xhigh"),
+        ]
+    )
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_rejects_unsupported_codex_reasoning_effort(self, mock_workflow):
+    def test_run_endpoint_rejects_unsupported_codex_reasoning_effort(
+        self, _case_name, model, reasoning_effort, supported_values, mock_workflow
+    ):
         task = self.create_task()
 
         response = self.client.post(
             f"/api/projects/@current/tasks/{task.id}/run/",
             {
                 "runtime_adapter": "codex",
-                "model": "gpt-5.4",
-                "reasoning_effort": "max",
+                "model": model,
+                "reasoning_effort": reasoning_effort,
             },
             format="json",
         )
@@ -2008,8 +2045,8 @@ class TestTaskAPI(BaseTaskAPITest):
             "type": "validation_error",
             "code": "invalid_input",
             "detail": (
-                "Reasoning effort 'max' is not supported for runtime_adapter 'codex' "
-                "and model 'gpt-5.4'. Supported values: low, medium, high."
+                f"Reasoning effort '{reasoning_effort}' is not supported for runtime_adapter 'codex' "
+                f"and model '{model}'. Supported values: {supported_values}."
             ),
             "attr": "reasoning_effort",
         }


### PR DESCRIPTION
## Problem

PostHog/code#2658 added runtime-side handling for `xhigh` in PostHog Code, but Codex cloud runs could still fail before the sandbox started because the tasks backend only allowed `low`, `medium`, and `high` for Codex models.

After that runtime-only change, users selecting Extra high reasoning for `gpt-5.5` hit a 400 validation error: `Reasoning effort 'xhigh' is not supported for runtime_adapter 'codex' and model 'gpt-5.5'. Supported values: low, medium, high.`

## Changes

- Allow `xhigh` reasoning effort for Codex runs using `gpt-5.5`.
- Keep existing Codex models capped at `low`, `medium`, and `high`.
- Keep rejecting unsupported Codex effort values, including `max` for `gpt-5.5`.
- Add focused API coverage for accepted and rejected Codex reasoning-effort combinations.

## How did you test this code?

- Added API tests covering `gpt-5.5` Codex runs with `reasoning_effort=xhigh`, older Codex models rejecting `xhigh`, and Codex rejecting `max`.
- Verified the local LLM gateway can call OpenAI Responses API with `gpt-5.5` and `reasoning.effort=xhigh`.
- Ran the focused tasks API tests for the new and updated reasoning-effort cases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex helped trace the failure to tasks backend validation, then made the narrow backend allowlist change and added targeted API coverage. The change intentionally preserves the existing Codex effort limits for non-GPT-5.5 models.