### PR TITLE
chore(django): wire in personhog ffhko deletion

### DIFF
--- a/posthog/models/team/test_util_deletion.py
+++ b/posthog/models/team/test_util_deletion.py
@@ -2,7 +2,11 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
-from posthog.models.team.util import _delete_group_type_mappings_for_teams, _delete_groups_for_teams
+from posthog.models.team.util import (
+    _delete_group_type_mappings_for_teams,
+    _delete_groups_for_teams,
+    _delete_hash_key_overrides_for_teams,
+)
 
 _CLIENT_PATCH = "posthog.personhog_client.client.get_personhog_client"
 
@@ -145,3 +149,42 @@ class TestDeleteGroupTypeMappingsForTeams(SimpleTestCase):
         _delete_group_type_mappings_for_teams([])
 
         mock_get_client.return_value.delete_group_type_mappings_batch_for_team.assert_not_called()
+
+
+class TestDeleteHashKeyOverridesForTeams(SimpleTestCase):
+    @patch(_CLIENT_PATCH)
+    def test_deletes_via_personhog_in_one_call(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        _delete_hash_key_overrides_for_teams([1, 2, 3])
+
+        assert mock_client.delete_hash_key_overrides_by_teams.call_count == 1
+        req = mock_client.delete_hash_key_overrides_by_teams.call_args[0][0]
+        assert list(req.team_ids) == [1, 2, 3]
+
+    @patch("posthog.models.team.util._raw_delete_batch")
+    @patch(_CLIENT_PATCH)
+    def test_falls_back_to_orm_when_client_none(self, mock_get_client, mock_raw_delete_batch):
+        mock_get_client.return_value = None
+
+        _delete_hash_key_overrides_for_teams([42])
+
+        mock_raw_delete_batch.assert_called_once()
+
+    @patch("posthog.models.team.util._raw_delete_batch")
+    @patch(_CLIENT_PATCH)
+    def test_falls_back_to_orm_on_error(self, mock_get_client, mock_raw_delete_batch):
+        mock_client = MagicMock()
+        mock_client.delete_hash_key_overrides_by_teams.side_effect = Exception("rpc failed")
+        mock_get_client.return_value = mock_client
+
+        _delete_hash_key_overrides_for_teams([42])
+
+        mock_raw_delete_batch.assert_called_once()
+
+    @patch(_CLIENT_PATCH)
+    def test_empty_list_does_nothing(self, mock_get_client):
+        _delete_hash_key_overrides_for_teams([])
+
+        mock_get_client.return_value.delete_hash_key_overrides_by_teams.assert_not_called()

--- a/posthog/models/team/test_util_deletion.py
+++ b/posthog/models/team/test_util_deletion.py
@@ -153,8 +153,11 @@ class TestDeleteGroupTypeMappingsForTeams(SimpleTestCase):
 
 class TestDeleteHashKeyOverridesForTeams(SimpleTestCase):
     @patch(_CLIENT_PATCH)
-    def test_deletes_via_personhog_in_one_call(self, mock_get_client):
+    def test_deletes_via_personhog(self, mock_get_client):
         mock_client = MagicMock()
+        resp = MagicMock()
+        resp.deleted_count = 0
+        mock_client.delete_hash_key_overrides_by_teams.return_value = resp
         mock_get_client.return_value = mock_client
 
         _delete_hash_key_overrides_for_teams([1, 2, 3])
@@ -162,6 +165,23 @@ class TestDeleteHashKeyOverridesForTeams(SimpleTestCase):
         assert mock_client.delete_hash_key_overrides_by_teams.call_count == 1
         req = mock_client.delete_hash_key_overrides_by_teams.call_args[0][0]
         assert list(req.team_ids) == [1, 2, 3]
+        assert req.batch_size == 10000
+
+    @patch(_CLIENT_PATCH)
+    def test_loops_until_zero_deleted(self, mock_get_client):
+        mock_client = MagicMock()
+        resp1 = MagicMock()
+        resp1.deleted_count = 10000
+        resp2 = MagicMock()
+        resp2.deleted_count = 3
+        resp3 = MagicMock()
+        resp3.deleted_count = 0
+        mock_client.delete_hash_key_overrides_by_teams.side_effect = [resp1, resp2, resp3]
+        mock_get_client.return_value = mock_client
+
+        _delete_hash_key_overrides_for_teams([42])
+
+        assert mock_client.delete_hash_key_overrides_by_teams.call_count == 3
 
     @patch("posthog.models.team.util._raw_delete_batch")
     @patch(_CLIENT_PATCH)

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -86,7 +86,12 @@ def _delete_hash_key_overrides_for_teams(team_ids: list[int]) -> None:
     if client is not None:
         try:
             with personhog_caller_tag("team-delete/hash-key-overrides"):
-                client.delete_hash_key_overrides_by_teams(DeleteHashKeyOverridesByTeamsRequest(team_ids=team_ids))
+                while True:
+                    resp = client.delete_hash_key_overrides_by_teams(
+                        DeleteHashKeyOverridesByTeamsRequest(team_ids=team_ids, batch_size=10000)
+                    )
+                    if resp.deleted_count == 0:
+                        break
             PERSONHOG_ROUTING_TOTAL.labels(
                 operation="delete_hash_key_overrides_for_teams", source="personhog", client_name=get_client_name()
             ).inc()

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -52,7 +52,6 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     from products.data_modeling.backend.models import Edge, Node
     from products.early_access_features.backend.models import EarlyAccessFeature
     from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2
-    from products.feature_flags.backend.models.feature_flag import FeatureFlagHashKeyOverride
     from products.product_analytics.backend.models.insight_caching_state import InsightCachingState
 
     # Data modeling Edge/Node must be deleted before the Team row: Team cascades to
@@ -63,10 +62,50 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     _raw_delete_batch(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(ErrorTrackingIssueFingerprintV2.objects.filter(team_id__in=team_ids))
     # FeatureFlagHashKeyOverride references Person, so it must go before persons are deleted.
+    _delete_hash_key_overrides_for_teams(team_ids)
+    _raw_delete_batch(InsightCachingState.objects.filter(team_id__in=team_ids))
+
+
+def _delete_hash_key_overrides_for_teams(team_ids: list[int]) -> None:
+    """Delete FeatureFlagHashKeyOverride rows for the given teams via personhog, falling back to ORM.
+
+    These rows reference Person but have no DB-level cascade (cross-database FK with
+    db_constraint=False), so they must be deleted explicitly before the persons are.
+    """
+    if not team_ids:
+        return
+
+    from posthog.models.person.util import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
+    from posthog.personhog_client.caller_tag import personhog_caller_tag
+    from posthog.personhog_client.client import get_personhog_client
+    from posthog.personhog_client.proto import DeleteHashKeyOverridesByTeamsRequest
+
+    from products.feature_flags.backend.models.feature_flag import FeatureFlagHashKeyOverride
+
+    client = get_personhog_client()
+    if client is not None:
+        try:
+            with personhog_caller_tag("team-delete/hash-key-overrides"):
+                client.delete_hash_key_overrides_by_teams(DeleteHashKeyOverridesByTeamsRequest(team_ids=team_ids))
+            PERSONHOG_ROUTING_TOTAL.labels(
+                operation="delete_hash_key_overrides_for_teams", source="personhog", client_name=get_client_name()
+            ).inc()
+            return
+        except Exception:
+            PERSONHOG_ROUTING_ERRORS_TOTAL.labels(
+                operation="delete_hash_key_overrides_for_teams",
+                source="personhog",
+                error_type="grpc_error",
+                client_name=get_client_name(),
+            ).inc()
+            logger.warning("personhog_delete_hash_key_overrides_for_teams_failure", team_ids=team_ids, exc_info=True)
+
+    PERSONHOG_ROUTING_TOTAL.labels(
+        operation="delete_hash_key_overrides_for_teams", source="django_orm", client_name=get_client_name()
+    ).inc()
     _raw_delete_batch(
         FeatureFlagHashKeyOverride.objects.filter(team_id__in=team_ids)  # nosemgrep: no-direct-persons-db-orm
     )
-    _raw_delete_batch(InsightCachingState.objects.filter(team_id__in=team_ids))
 
 
 def _delete_personless_distinct_ids_for_teams(team_ids: list[int]) -> None:

--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -35,6 +35,8 @@ from posthog.personhog_client.proto import (
     DeleteGroupTypeMappingResponse,
     DeleteGroupTypeMappingsBatchForTeamRequest,
     DeleteGroupTypeMappingsBatchForTeamResponse,
+    DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse,
     DeletePersonsBatchForTeamRequest,
     DeletePersonsBatchForTeamResponse,
     DeletePersonsRequest,
@@ -339,6 +341,13 @@ class PersonHogClient:
         self, request: DeleteGroupTypeMappingsBatchForTeamRequest, timeout: float | None = None
     ) -> DeleteGroupTypeMappingsBatchForTeamResponse:
         return self._stub.DeleteGroupTypeMappingsBatchForTeam(request, timeout=timeout or self._timeout)
+
+    # -- Feature flag hash key overrides --
+
+    def delete_hash_key_overrides_by_teams(
+        self, request: DeleteHashKeyOverridesByTeamsRequest, timeout: float | None = None
+    ) -> DeleteHashKeyOverridesByTeamsResponse:
+        return self._stub.DeleteHashKeyOverridesByTeams(request, timeout=timeout or self._timeout)
 
 
 _client: Optional[PersonHogClient] = None

--- a/posthog/personhog_client/fake_client.py
+++ b/posthog/personhog_client/fake_client.py
@@ -27,7 +27,12 @@ from typing import Any
 from unittest.mock import patch
 
 from posthog.models.person.missing_person import uuidFromDistinctId
-from posthog.personhog_client.proto.generated.personhog.types.v1 import cohort_pb2, group_pb2, person_pb2
+from posthog.personhog_client.proto.generated.personhog.types.v1 import (
+    cohort_pb2,
+    feature_flag_pb2,
+    group_pb2,
+    person_pb2,
+)
 
 
 @dataclass
@@ -539,6 +544,15 @@ class FakePersonHogClient:
             if deleted >= request.batch_size:
                 break
         return group_pb2.DeleteGroupTypeMappingsBatchForTeamResponse(deleted_count=deleted)
+
+    # ── Feature flag hash key overrides ───────────────────────────────
+
+    def delete_hash_key_overrides_by_teams(
+        self, request: feature_flag_pb2.DeleteHashKeyOverridesByTeamsRequest, timeout: float | None = None
+    ) -> feature_flag_pb2.DeleteHashKeyOverridesByTeamsResponse:
+        # The fake does not track hash key overrides; record the call and report nothing deleted.
+        self.calls.append(_Call("delete_hash_key_overrides_by_teams", request))
+        return feature_flag_pb2.DeleteHashKeyOverridesByTeamsResponse(deleted_count=0)
 
     # ── Person deletes ────────────────────────────────────────────────
 

--- a/posthog/personhog_client/proto/__init__.py
+++ b/posthog/personhog_client/proto/__init__.py
@@ -25,6 +25,10 @@ from posthog.personhog_client.proto.generated.personhog.types.v1.cohort_pb2 impo
     ListCohortMemberIdsRequest,
     ListCohortMemberIdsResponse,
 )
+from posthog.personhog_client.proto.generated.personhog.types.v1.feature_flag_pb2 import (
+    DeleteHashKeyOverridesByTeamsRequest,
+    DeleteHashKeyOverridesByTeamsResponse,
+)
 from posthog.personhog_client.proto.generated.personhog.types.v1.group_pb2 import (
     CountGroupTypeMappingsRequest,
     CountGroupTypeMappingsResponse,


### PR DESCRIPTION

## Problem

feature flag hash key override deletion is already supported by personhog, yet not yet wired into django

## Changes

- wire in grpc call
- update deletion call to use personhog, falling back to django on error
