### PR TITLE
feat(security): audit-log external command execution with request context

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -43,6 +43,11 @@ class PostHogConfig(AppConfig):
         import posthog.caching.organization_serializer_cache  # noqa: F401, PLC0415
         import posthog.models.activity_logging.signal_handlers  # noqa: F401, PLC0415
 
+        if settings.COMMAND_EXEC_AUDIT_ENABLED:
+            from posthog.security.command_exec_audit import install as install_command_exec_audit  # noqa: PLC0415
+
+            install_command_exec_audit()
+
         self._setup_lazy_admin()
         self._prewarm_timezone_offsets_cache()
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"  # ty: ignore[invalid-assignment]

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -60,6 +60,16 @@ _INLINE_ENV_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)=(\S+)")
 # `has_encoded_blob` flag on the entry, keeping the obfuscation itself an alertable signal.
 _BLOB_RE = re.compile(r"[A-Za-z0-9+/]{64,}={0,2}")
 
+# Credentials in URL/DSN userinfo (scheme://user:pass@host) carry no hint word, so name-based
+# redaction misses them — common in code that shells out to git/psql/etc. Redact the userinfo.
+_URL_USERINFO_RE = re.compile(r"://[^/\s@]+@")
+_URL_USERINFO_REPL = f"://{_REDACTED}@"
+
+# Map control chars to spaces so attacker-influenced argv can't forge a second audit line
+# under a non-JSON log renderer (e.g. an embedded newline).
+_CONTROL_CHARS = dict.fromkeys(range(0x20), " ")
+_CONTROL_CHARS[0x7F] = " "
+
 # Characters that let one command string spawn or chain into another.
 _SHELL_OPERATORS = frozenset(";|&$`<>\n")
 
@@ -79,16 +89,22 @@ _QUERY_TAG_FIELDS = (
 )
 
 
+def _to_text(value: Any) -> str:
+    # Raw bytes/path/str -> str, no sanitization (used for detection scans on the real command).
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    if hasattr(value, "__fspath__"):
+        path = os.fspath(value)
+        return path.decode("utf-8", "replace") if isinstance(path, bytes) else path
+    return str(value)
+
+
 def _coerce_str(value: Any) -> str:
+    # Sanitized for storage: neutralize control chars that could forge a second audit line.
     try:
-        if isinstance(value, str):
-            return value
-        if isinstance(value, bytes):
-            return value.decode("utf-8", "replace")
-        if hasattr(value, "__fspath__"):
-            path = os.fspath(value)
-            return path.decode("utf-8", "replace") if isinstance(path, bytes) else path
-        return str(value)
+        return _to_text(value).translate(_CONTROL_CHARS)
     except Exception:
         return _REDACTED
 
@@ -99,7 +115,10 @@ def _is_sensitive(token: str) -> bool:
     return any(hint in normalized for hint in _SECRET_HINTS)
 
 
-def _redact_blobs(text: str) -> str:
+def _redact_value(text: str) -> str:
+    # Value-based redaction for tokens with no secret hint word: URL/DSN userinfo and long
+    # base64 payloads.
+    text = _URL_USERINFO_RE.sub(_URL_USERINFO_REPL, text)
     return _BLOB_RE.sub(_REDACTED, text)
 
 
@@ -115,8 +134,9 @@ def _scrub_args(tokens: Any) -> list[str]:
             redact_next = False
             continue
         if not _is_sensitive(token):
-            # Redact embedded base64 payloads (smuggled secrets or obfuscated commands alike).
-            result.append(_redact_blobs(token)[:_MAX_LEN])
+            # Catch creds with no hint word: URL userinfo and base64 payloads (smuggled secrets
+            # or obfuscated commands alike).
+            result.append(_redact_value(token)[:_MAX_LEN])
             continue
         if "=" in token:
             name = token.split("=", 1)[0]
@@ -140,9 +160,9 @@ def _scrub_command_string(command: str) -> str:
         # Space-join (not shlex.join) keeps the audit string readable — it's for logs, not re-execution.
         return " ".join(_scrub_args(shlex.split(command)))
     except Exception:
-        # Fall back to redacting inline ``KEY=value`` secrets and base64 blobs when the line
-        # can't be tokenized.
-        return _redact_blobs(
+        # Fall back to redacting inline ``KEY=value`` secrets, URL userinfo, and base64 blobs
+        # when the line can't be tokenized.
+        return _redact_value(
             _INLINE_ENV_RE.sub(
                 lambda m: f"{m.group(1)}={_REDACTED}" if _is_sensitive(m.group(1)) else m.group(0),
                 command,
@@ -206,27 +226,25 @@ def _emit(
     token = _in_audit.set(True)
     try:
         payload: dict[str, Any] = {"component": component, "sink": sink, "shell": bool(shell)}
+        # raw = the real command (un-redacted) for detection scans; scrubbed = what we store.
         if isinstance(command, (list, tuple)):
-            raw = " ".join(_coerce_str(token) for token in command)
+            raw = " ".join(_to_text(token) for token in command)
             scrubbed = _scrub_args(command)
             payload["command"] = scrubbed
             payload["binary"] = binary or (scrubbed[0] if scrubbed else None)
-            scanned = " ".join(scrubbed)
         else:
-            raw = _coerce_str(command)
-            scrubbed_str = _scrub_command_string(raw)
-            payload["command"] = scrubbed_str
+            raw = _to_text(command)
+            payload["command"] = _scrub_command_string(raw)
             payload["binary"] = binary
-            scanned = scrubbed_str
 
-        # Flag shell command lines carrying operators (chaining, pipes, substitution) — the
-        # shape that turns an interpolated value into command injection. Only meaningful when a
-        # shell interprets the line; in argv form (shell=False) these chars are passed literally.
-        if shell and any(char in _SHELL_OPERATORS for char in scanned):
+        # Scan the raw command, not the scrubbed copy: an operator inside a redacted token (e.g.
+        # `--token=$(cat x)`) would otherwise vanish before this check. Only meaningful under a
+        # shell; in argv form (shell=False) these chars are passed literally.
+        if shell and any(char in _SHELL_OPERATORS for char in raw):
             payload["has_shell_operators"] = True
 
-        # Detect on the raw command (the redacted body no longer contains the blob): an encoded
-        # payload is worth surfacing whether it's a smuggled secret or an evasion technique.
+        # An encoded payload is worth surfacing whether it's a smuggled secret or an evasion
+        # technique — even though we redact the body itself from `command`.
         if _BLOB_RE.search(raw):
             payload["has_encoded_blob"] = True
 

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -38,7 +38,7 @@ _SECRET_HINTS = (
     "accesskey",
     "credential",
     "private_key",
-    "auth",
+    "authorization",
 )
 # Only these env var names keep their value in the log; everything else is counted but redacted.
 _ENV_ALLOWLIST = frozenset({"PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "HOME", "USER", "SHELL", "PWD"})
@@ -86,7 +86,8 @@ def _is_sensitive(token: str) -> bool:
 def _scrub_args(tokens: Any) -> list[str]:
     result: list[str] = []
     redact_next = False
-    seq = list(tokens)[:_MAX_ARGS]
+    full = list(tokens)
+    seq = full[:_MAX_ARGS]
     for raw in seq:
         token = _coerce_str(raw)
         if redact_next:
@@ -105,7 +106,7 @@ def _scrub_args(tokens: Any) -> list[str]:
             redact_next = True
         else:
             result.append(_REDACTED)
-    extra = len(list(tokens)) - len(seq)
+    extra = len(full) - len(seq)
     if extra > 0:
         result.append(f"...(+{extra} args truncated)")
     return result
@@ -311,17 +312,24 @@ def _make_exec_wrapper(sink: str, *, takes_env: bool):  # type: ignore[no-untype
 
 
 def _wrap(module: Any, name: str, wrapper: Any) -> None:
-    """Attach a wrapt wrapper, skipping targets that are missing or already wrapped by us."""
-    obj = module
-    *path, attr = name.split(".")
-    for part in path:
-        obj = getattr(obj, part, None)
-        if obj is None:
+    """Attach a wrapt wrapper, skipping targets that are missing or already wrapped by us.
+
+    Never raises: a sink that can't be wrapped (platform restriction, CPython internal
+    change) degrades to "unaudited" with a warning rather than crashing startup.
+    """
+    try:
+        obj = module
+        *path, attr = name.split(".")
+        for part in path:
+            obj = getattr(obj, part, None)
+            if obj is None:
+                return
+        target = getattr(obj, attr, None)
+        if target is None or isinstance(target, wrapt.ObjectProxy):
             return
-    target = getattr(obj, attr, None)
-    if target is None or isinstance(target, wrapt.ObjectProxy):
-        return
-    wrapt.wrap_function_wrapper(module, name, wrapper)
+        wrapt.wrap_function_wrapper(module, name, wrapper)
+    except Exception:
+        logger.warning("command_exec_audit_wrap_failed", target=name, exc_info=True)
 
 
 def install() -> None:
@@ -329,7 +337,6 @@ def install() -> None:
     global _installed
     if _installed:
         return
-    _installed = True
 
     _wrap(subprocess, "Popen.__init__", _popen_wrapper)
     _wrap(os, "system", _system_wrapper)
@@ -339,3 +346,7 @@ def install() -> None:
     _wrap(os, "posix_spawnp", _make_posix_spawn_wrapper("os.posix_spawnp"))
     _wrap(os, "execv", _make_exec_wrapper("os.execv", takes_env=False))
     _wrap(os, "execve", _make_exec_wrapper("os.execve", takes_env=True))
+
+    # Set only after every sink has been attempted, so a mid-install failure doesn't
+    # permanently mark the audit "done" with sinks left unwrapped.
+    _installed = True

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -100,8 +100,9 @@ def _scrub_args(tokens: Any) -> list[str]:
         if "=" in token:
             name = token.split("=", 1)[0]
             result.append(f"{name}={_REDACTED}")
-        elif token[:1] in ("-", "/"):
+        elif token.startswith("-"):
             # Sensitive flag whose value is the following token, e.g. ``--password secret``.
+            # Only flags (``-``) carry a value here — a sensitive *path* gets fully redacted below.
             result.append(token)
             redact_next = True
         else:
@@ -192,9 +193,10 @@ def _emit(
             payload["binary"] = binary
             scanned = scrubbed_str
 
-        # Flag command lines carrying shell operators (chaining, pipes, substitution) — the
-        # shape that turns an interpolated value into command injection.
-        if any(char in _SHELL_OPERATORS for char in scanned):
+        # Flag shell command lines carrying operators (chaining, pipes, substitution) — the
+        # shape that turns an interpolated value into command injection. Only meaningful when a
+        # shell interprets the line; in argv form (shell=False) these chars are passed literally.
+        if shell and any(char in _SHELL_OPERATORS for char in scanned):
             payload["has_shell_operators"] = True
 
         if cwd is not None:
@@ -256,11 +258,13 @@ def _spawnvef_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyp
     # _spawnvef(mode, file, args, env, func) — the funnel for every os.spawn* alias.
     try:
         file = _arg(args, kwargs, 1, "file")
+        # args is argv-style: args[0] is already the program name, so log it as-is and
+        # surface the resolved executable via `binary` instead of duplicating it.
         spawn_args = _arg(args, kwargs, 2, "args") or []
         _emit(
             component="os",
             sink="os.spawn",
-            command=[file, *spawn_args],
+            command=list(spawn_args),
             shell=False,
             env=_arg(args, kwargs, 3, "env"),
             binary=_coerce_str(file),

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -1,0 +1,341 @@
+"""Process-execution audit logging."""
+
+import os
+import re
+import uuid
+import shlex
+import subprocess
+import contextvars
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import wrapt
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Reentrancy guard. Emitting a log touches the query-tag context, which on first access
+# shells out to `git` (see posthog/git.py via query_tagging.__get_constant_tags) — without
+# this guard that subprocess call would recurse straight back into the patched sink.
+_in_audit: contextvars.ContextVar[bool] = contextvars.ContextVar("command_exec_audit_in_progress", default=False)
+
+_installed = False
+
+_REDACTED = "[redacted]"
+_MAX_ARGS = 64
+_MAX_LEN = 4096
+
+# Case-insensitive substrings that mark an argument token or env var name as a secret.
+_SECRET_HINTS = (
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "access_key",
+    "accesskey",
+    "credential",
+    "private_key",
+    "auth",
+)
+# Only these env var names keep their value in the log; everything else is counted but redacted.
+_ENV_ALLOWLIST = frozenset({"PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "HOME", "USER", "SHELL", "PWD"})
+_INLINE_ENV_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)=(\S+)")
+
+# Characters that let one command string spawn or chain into another.
+_SHELL_OPERATORS = frozenset(";|&$`<>\n")
+
+# Context fields pulled from the query-tag ContextVar (set by middleware / Celery / Temporal).
+# Identifiers only — deliberately no PII (e.g. user_email) and nothing that can leak secrets
+# (http_referer / http_user_agent can carry tokens in query strings). Resolve a user/org from
+# the ids out-of-band instead.
+_QUERY_TAG_FIELDS = (
+    "team_id",
+    "user_id",
+    "org_id",
+    "access_method",
+    "is_impersonated",
+    "http_request_id",
+    "product",
+    "kind",
+)
+
+
+def _coerce_str(value: Any) -> str:
+    try:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, bytes):
+            return value.decode("utf-8", "replace")
+        if hasattr(value, "__fspath__"):
+            path = os.fspath(value)
+            return path.decode("utf-8", "replace") if isinstance(path, bytes) else path
+        return str(value)
+    except Exception:
+        return _REDACTED
+
+
+def _is_sensitive(token: str) -> bool:
+    # Normalize hyphens to underscores so ``--api-key`` matches the ``api_key`` hint.
+    normalized = token.lower().replace("-", "_")
+    return any(hint in normalized for hint in _SECRET_HINTS)
+
+
+def _scrub_args(tokens: Any) -> list[str]:
+    result: list[str] = []
+    redact_next = False
+    seq = list(tokens)[:_MAX_ARGS]
+    for raw in seq:
+        token = _coerce_str(raw)
+        if redact_next:
+            result.append(_REDACTED)
+            redact_next = False
+            continue
+        if not _is_sensitive(token):
+            result.append(token[:_MAX_LEN])
+            continue
+        if "=" in token:
+            name = token.split("=", 1)[0]
+            result.append(f"{name}={_REDACTED}")
+        elif token[:1] in ("-", "/"):
+            # Sensitive flag whose value is the following token, e.g. ``--password secret``.
+            result.append(token)
+            redact_next = True
+        else:
+            result.append(_REDACTED)
+    extra = len(list(tokens)) - len(seq)
+    if extra > 0:
+        result.append(f"...(+{extra} args truncated)")
+    return result
+
+
+def _scrub_command_string(command: str) -> str:
+    command = command[:_MAX_LEN]
+    try:
+        # Space-join (not shlex.join) keeps the audit string readable — it's for logs, not re-execution.
+        return " ".join(_scrub_args(shlex.split(command)))
+    except Exception:
+        # Fall back to redacting inline ``KEY=value`` secrets when the line can't be tokenized.
+        return _INLINE_ENV_RE.sub(
+            lambda m: f"{m.group(1)}={_REDACTED}" if _is_sensitive(m.group(1)) else m.group(0),
+            command,
+        )
+
+
+def _summarize_env(env: Any) -> tuple[Optional[dict[str, str]], int]:
+    if not env or not isinstance(env, Mapping):
+        return None, 0
+    allowed: dict[str, str] = {}
+    redacted = 0
+    for key, value in env.items():
+        name = _coerce_str(key)
+        if name in _ENV_ALLOWLIST and not _is_sensitive(name):
+            allowed[name] = _coerce_str(value)[:_MAX_LEN]
+        else:
+            redacted += 1
+    return (allowed or None), redacted
+
+
+def _context() -> dict[str, Any]:
+    ctx: dict[str, Any] = {}
+    try:
+        from posthog.clickhouse.query_tagging import get_query_tags
+
+        tags = get_query_tags()
+        for field in _QUERY_TAG_FIELDS:
+            value = getattr(tags, field, None)
+            if value is not None:
+                ctx[field] = str(value) if isinstance(value, uuid.UUID) else value
+    except Exception:
+        pass
+    try:
+        from posthog.models.activity_logging.utils import activity_storage
+
+        ip_address = activity_storage.get_ip_address()
+        if ip_address:
+            ctx["ip_address"] = ip_address
+        client = activity_storage.get_client()
+        if client:
+            ctx["client"] = client
+    except Exception:
+        pass
+    return ctx
+
+
+def _emit(
+    *,
+    component: str,
+    sink: str,
+    command: Any,
+    shell: bool,
+    env: Any = None,
+    binary: Optional[str] = None,
+    cwd: Any = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    if _in_audit.get():
+        return
+    token = _in_audit.set(True)
+    try:
+        payload: dict[str, Any] = {"component": component, "sink": sink, "shell": bool(shell)}
+        if isinstance(command, (list, tuple)):
+            scrubbed = _scrub_args(command)
+            payload["command"] = scrubbed
+            payload["binary"] = binary or (scrubbed[0] if scrubbed else None)
+            scanned = " ".join(scrubbed)
+        else:
+            scrubbed_str = _scrub_command_string(_coerce_str(command))
+            payload["command"] = scrubbed_str
+            payload["binary"] = binary
+            scanned = scrubbed_str
+
+        # Flag command lines carrying shell operators (chaining, pipes, substitution) — the
+        # shape that turns an interpolated value into command injection.
+        if any(char in _SHELL_OPERATORS for char in scanned):
+            payload["has_shell_operators"] = True
+
+        if cwd is not None:
+            payload["cwd"] = _coerce_str(cwd)
+
+        env_allowed, env_redacted = _summarize_env(env)
+        if env_allowed:
+            payload["env"] = env_allowed
+        if env_redacted:
+            payload["env_redacted_count"] = env_redacted
+        if extra:
+            payload.update(extra)
+        payload.update(_context())
+
+        logger.info("command_execution", **payload)
+    except Exception:
+        try:
+            logger.warning("command_execution_audit_failed", sink=sink, exc_info=True)
+        except Exception:
+            pass
+    finally:
+        _in_audit.reset(token)
+
+
+def _arg(args: tuple, kwargs: dict, index: int, name: str, default: Any = None) -> Any:
+    if len(args) > index:
+        return args[index]
+    return kwargs.get(name, default)
+
+
+def _popen_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+    # wrapt strips `self`, so the first positional is Popen's `args` (the command).
+    try:
+        # When `executable` is given it, not args[0], is the program actually run.
+        executable = _arg(args, kwargs, 2, "executable")
+        _emit(
+            component="subprocess",
+            sink="subprocess.Popen",
+            command=_arg(args, kwargs, 0, "args"),
+            shell=_arg(args, kwargs, 8, "shell", False),
+            env=_arg(args, kwargs, 10, "env"),
+            cwd=_arg(args, kwargs, 9, "cwd"),
+            binary=_coerce_str(executable) if executable else None,
+        )
+    except Exception:
+        pass
+    return wrapped(*args, **kwargs)
+
+
+def _system_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+    try:
+        _emit(component="os", sink="os.system", command=_arg(args, kwargs, 0, "command"), shell=True)
+    except Exception:
+        pass
+    return wrapped(*args, **kwargs)
+
+
+def _spawnvef_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+    # _spawnvef(mode, file, args, env, func) — the funnel for every os.spawn* alias.
+    try:
+        file = _arg(args, kwargs, 1, "file")
+        spawn_args = _arg(args, kwargs, 2, "args") or []
+        _emit(
+            component="os",
+            sink="os.spawn",
+            command=[file, *spawn_args],
+            shell=False,
+            env=_arg(args, kwargs, 3, "env"),
+            binary=_coerce_str(file),
+        )
+    except Exception:
+        pass
+    return wrapped(*args, **kwargs)
+
+
+def _make_posix_spawn_wrapper(sink: str):  # type: ignore[no-untyped-def]
+    def wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+        # posix_spawn(path, argv, env, ...)
+        try:
+            path = _arg(args, kwargs, 0, "path")
+            _emit(
+                component="os",
+                sink=sink,
+                command=list(_arg(args, kwargs, 1, "argv") or []),
+                shell=False,
+                env=_arg(args, kwargs, 2, "env"),
+                binary=_coerce_str(path),
+            )
+        except Exception:
+            pass
+        return wrapped(*args, **kwargs)
+
+    return wrapper
+
+
+def _make_exec_wrapper(sink: str, *, takes_env: bool):  # type: ignore[no-untyped-def]
+    def wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+        # execv(path, args) / execve(path, args, env) — every os.exec* alias funnels here.
+        try:
+            path = _arg(args, kwargs, 0, "path")
+            _emit(
+                component="os",
+                sink=sink,
+                command=list(_arg(args, kwargs, 1, "args") or []),
+                shell=False,
+                env=_arg(args, kwargs, 2, "env") if takes_env else None,
+                binary=_coerce_str(path),
+                extra={"replaces_process": True},
+            )
+        except Exception:
+            pass
+        return wrapped(*args, **kwargs)
+
+    return wrapper
+
+
+def _wrap(module: Any, name: str, wrapper: Any) -> None:
+    """Attach a wrapt wrapper, skipping targets that are missing or already wrapped by us."""
+    obj = module
+    *path, attr = name.split(".")
+    for part in path:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return
+    target = getattr(obj, attr, None)
+    if target is None or isinstance(target, wrapt.ObjectProxy):
+        return
+    wrapt.wrap_function_wrapper(module, name, wrapper)
+
+
+def install() -> None:
+    """Patch the process-execution sinks. Idempotent; safe to call once per process."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+
+    _wrap(subprocess, "Popen.__init__", _popen_wrapper)
+    _wrap(os, "system", _system_wrapper)
+    # All os.spawn* aliases funnel through this private helper.
+    _wrap(os, "_spawnvef", _spawnvef_wrapper)
+    _wrap(os, "posix_spawn", _make_posix_spawn_wrapper("os.posix_spawn"))
+    _wrap(os, "posix_spawnp", _make_posix_spawn_wrapper("os.posix_spawnp"))
+    _wrap(os, "execv", _make_exec_wrapper("os.execv", takes_env=False))
+    _wrap(os, "execve", _make_exec_wrapper("os.execve", takes_env=True))

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -53,6 +53,12 @@ _SECRET_HINTS = (
 # Only these env var names keep their value in the log; everything else is counted but redacted.
 _ENV_ALLOWLIST = frozenset({"PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "HOME", "USER", "SHELL", "PWD"})
 _INLINE_ENV_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)=(\S+)")
+# Long unbroken base64 runs carry encoded payloads — either smuggled file content / secrets
+# (which must not leak into logs) or a command an attacker base64'd to evade detection (which
+# must still be visible). We can't have it both ways: a blob decodable by an analyst is equally
+# decodable by anyone with log access. So we redact the body (no secret leak) but set the
+# `has_encoded_blob` flag on the entry, keeping the obfuscation itself an alertable signal.
+_BLOB_RE = re.compile(r"[A-Za-z0-9+/]{64,}={0,2}")
 
 # Characters that let one command string spawn or chain into another.
 _SHELL_OPERATORS = frozenset(";|&$`<>\n")
@@ -93,6 +99,10 @@ def _is_sensitive(token: str) -> bool:
     return any(hint in normalized for hint in _SECRET_HINTS)
 
 
+def _redact_blobs(text: str) -> str:
+    return _BLOB_RE.sub(_REDACTED, text)
+
+
 def _scrub_args(tokens: Any) -> list[str]:
     result: list[str] = []
     redact_next = False
@@ -105,7 +115,8 @@ def _scrub_args(tokens: Any) -> list[str]:
             redact_next = False
             continue
         if not _is_sensitive(token):
-            result.append(token[:_MAX_LEN])
+            # Redact embedded base64 payloads (smuggled secrets or obfuscated commands alike).
+            result.append(_redact_blobs(token)[:_MAX_LEN])
             continue
         if "=" in token:
             name = token.split("=", 1)[0]
@@ -129,10 +140,13 @@ def _scrub_command_string(command: str) -> str:
         # Space-join (not shlex.join) keeps the audit string readable — it's for logs, not re-execution.
         return " ".join(_scrub_args(shlex.split(command)))
     except Exception:
-        # Fall back to redacting inline ``KEY=value`` secrets when the line can't be tokenized.
-        return _INLINE_ENV_RE.sub(
-            lambda m: f"{m.group(1)}={_REDACTED}" if _is_sensitive(m.group(1)) else m.group(0),
-            command,
+        # Fall back to redacting inline ``KEY=value`` secrets and base64 blobs when the line
+        # can't be tokenized.
+        return _redact_blobs(
+            _INLINE_ENV_RE.sub(
+                lambda m: f"{m.group(1)}={_REDACTED}" if _is_sensitive(m.group(1)) else m.group(0),
+                command,
+            )
         )
 
 
@@ -193,12 +207,14 @@ def _emit(
     try:
         payload: dict[str, Any] = {"component": component, "sink": sink, "shell": bool(shell)}
         if isinstance(command, (list, tuple)):
+            raw = " ".join(_coerce_str(token) for token in command)
             scrubbed = _scrub_args(command)
             payload["command"] = scrubbed
             payload["binary"] = binary or (scrubbed[0] if scrubbed else None)
             scanned = " ".join(scrubbed)
         else:
-            scrubbed_str = _scrub_command_string(_coerce_str(command))
+            raw = _coerce_str(command)
+            scrubbed_str = _scrub_command_string(raw)
             payload["command"] = scrubbed_str
             payload["binary"] = binary
             scanned = scrubbed_str
@@ -208,6 +224,11 @@ def _emit(
         # shell interprets the line; in argv form (shell=False) these chars are passed literally.
         if shell and any(char in _SHELL_OPERATORS for char in scanned):
             payload["has_shell_operators"] = True
+
+        # Detect on the raw command (the redacted body no longer contains the blob): an encoded
+        # payload is worth surfacing whether it's a smuggled secret or an evasion technique.
+        if _BLOB_RE.search(raw):
+            payload["has_encoded_blob"] = True
 
         if cwd is not None:
             payload["cwd"] = _coerce_str(cwd)

--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -6,11 +6,21 @@ import uuid
 import shlex
 import subprocess
 import contextvars
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from types import ModuleType
 from typing import Any, Optional
 
 import wrapt
 import structlog
+
+# C exec primitive under subprocess.Popen; absent on some platforms (Windows/wasm).
+_posixsubprocess: ModuleType | None = None
+try:
+    import _posixsubprocess as _posixsubprocess_module
+
+    _posixsubprocess = _posixsubprocess_module
+except ImportError:  # pragma: no cover
+    pass
 
 logger = structlog.get_logger(__name__)
 
@@ -227,7 +237,7 @@ def _arg(args: tuple, kwargs: dict, index: int, name: str, default: Any = None) 
     return kwargs.get(name, default)
 
 
-def _popen_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+def _popen_wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
     # wrapt strips `self`, so the first positional is Popen's `args` (the command).
     try:
         # When `executable` is given it, not args[0], is the program actually run.
@@ -246,7 +256,23 @@ def _popen_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-
     return wrapped(*args, **kwargs)
 
 
-def _system_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+def _fork_exec_wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
+    # The C exec primitive beneath subprocess.Popen. Popen calls its own cached reference,
+    # so this only fires for code invoking fork_exec directly — i.e. bypassing the Popen hook.
+    try:
+        argv = args[0] if args else None
+        _emit(
+            component="subprocess",
+            sink="_posixsubprocess.fork_exec",
+            command=list(argv) if isinstance(argv, (list, tuple)) else argv,
+            shell=False,
+        )
+    except Exception:
+        pass
+    return wrapped(*args, **kwargs)
+
+
+def _system_wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
     try:
         _emit(component="os", sink="os.system", command=_arg(args, kwargs, 0, "command"), shell=True)
     except Exception:
@@ -254,7 +280,7 @@ def _system_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped
     return wrapped(*args, **kwargs)
 
 
-def _spawnvef_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+def _spawnvef_wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
     # _spawnvef(mode, file, args, env, func) — the funnel for every os.spawn* alias.
     try:
         file = _arg(args, kwargs, 1, "file")
@@ -274,8 +300,8 @@ def _spawnvef_wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyp
     return wrapped(*args, **kwargs)
 
 
-def _make_posix_spawn_wrapper(sink: str):  # type: ignore[no-untyped-def]
-    def wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+def _make_posix_spawn_wrapper(sink: str) -> Callable[..., Any]:
+    def wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
         # posix_spawn(path, argv, env, ...)
         try:
             path = _arg(args, kwargs, 0, "path")
@@ -294,8 +320,8 @@ def _make_posix_spawn_wrapper(sink: str):  # type: ignore[no-untyped-def]
     return wrapper
 
 
-def _make_exec_wrapper(sink: str, *, takes_env: bool):  # type: ignore[no-untyped-def]
-    def wrapper(wrapped, instance, args, kwargs):  # type: ignore[no-untyped-def]
+def _make_exec_wrapper(sink: str, *, takes_env: bool) -> Callable[..., Any]:
+    def wrapper(wrapped: Any, instance: Any, args: tuple, kwargs: dict) -> Any:
         # execv(path, args) / execve(path, args, env) — every os.exec* alias funnels here.
         try:
             path = _arg(args, kwargs, 0, "path")
@@ -343,6 +369,9 @@ def install() -> None:
         return
 
     _wrap(subprocess, "Popen.__init__", _popen_wrapper)
+    # The C exec primitive under Popen — wrapped to catch direct callers that bypass Popen.
+    if _posixsubprocess is not None:
+        _wrap(_posixsubprocess, "fork_exec", _fork_exec_wrapper)
     _wrap(os, "system", _system_wrapper)
     # All os.spawn* aliases funnel through this private helper.
     _wrap(os, "_spawnvef", _spawnvef_wrapper)

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -56,6 +56,12 @@ class TestCommandExecAuditScrubbing(TestCase):
             ),
             # "auth" must not over-match common non-secret flags like git's --author.
             ("author_not_redacted", ["git", "log", "--author=Jane"], ["git", "log", "--author=Jane"]),
+            # A sensitive *path* is fully redacted and must not consume the following token.
+            (
+                "sensitive_path_does_not_eat_next",
+                ["openssl", "-in", "/etc/ssl/private_key.pem", "-out", "/tmp/cert.pem"],
+                ["openssl", "-in", _R, "-out", "/tmp/cert.pem"],
+            ),
         ]
     )
     def test_scrub_args(self, _name: str, args: list[str], expected: list[str]) -> None:
@@ -161,6 +167,15 @@ class TestCommandExecAuditPatching(TestCase):
             subprocess.run(["true"], check=True)
         entry = self._find(logs, "subprocess.Popen")
         assert entry is not None
+        self.assertNotIn("has_shell_operators", entry)
+
+    def test_operator_chars_in_argv_are_not_flagged(self) -> None:
+        # shell=False: operator chars inside an arg are literal, not injection — must not flag.
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["echo", "a > b && c"], check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertFalse(entry["shell"])
         self.assertNotIn("has_shell_operators", entry)
 
     def test_audit_does_not_break_command(self) -> None:

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -96,6 +96,17 @@ class TestCommandExecAuditScrubbing(TestCase):
         # Ordinary short identifiers/flags must survive — blob redaction targets long runs only.
         self.assertEqual(_scrub_args(["ls", "-la", "abc123DEF456"]), ["ls", "-la", "abc123DEF456"])
 
+    def test_url_userinfo_is_redacted(self) -> None:
+        # Credentials in a URL/DSN have no hint word; redact the userinfo segment.
+        self.assertEqual(
+            _scrub_args(["git", "clone", "https://alice:Xy9Zq0pw@github.com/o/r"]),
+            ["git", "clone", f"https://{_R}@github.com/o/r"],
+        )
+
+    def test_coerce_str_neutralizes_control_chars(self) -> None:
+        # Embedded control chars (e.g. newlines) could forge a second audit line — neutralize them.
+        self.assertEqual(command_exec_audit._coerce_str("a\nb\rc\td"), "a b c d")
+
     def test_summarize_env_redacts_non_allowlisted(self) -> None:
         allowed, redacted = _summarize_env({"PATH": "/usr/bin", "AWS_SECRET_KEY": "xxx", "FOO": "bar"})
         self.assertEqual(allowed, {"PATH": "/usr/bin"})
@@ -184,6 +195,16 @@ class TestCommandExecAuditPatching(TestCase):
         entry = self._find(logs, "subprocess.Popen")
         assert entry is not None
         self.assertNotIn("has_shell_operators", entry)
+
+    def test_shell_operators_detected_inside_redacted_token(self) -> None:
+        # The operator scan runs on the raw command, so a `$(...)` inside a redacted token
+        # (here `--token=...`) is still flagged rather than vanishing with the redaction.
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run("true --token=$(echo x)", shell=True, check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertTrue(entry["has_shell_operators"])
+        self.assertNotIn("echo", entry["command"])
 
     def test_encoded_blob_redacted_but_flagged(self) -> None:
         # The base64 body must be unrecoverable, yet the entry still signals an encoded payload.

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -2,6 +2,8 @@ import os
 import uuid
 import shutil
 import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from posthog.test.base import APIBaseTest
 from unittest import TestCase, mock, skipUnless
@@ -95,7 +97,7 @@ class TestCommandExecAuditPatching(TestCase):
         # install() is idempotent and audit-only, so patching the process-global sinks here is safe.
         install()
 
-    def _find(self, logs: list[dict], sink: str) -> dict | None:
+    def _find(self, logs: Sequence[Mapping[str, Any]], sink: str) -> Mapping[str, Any] | None:
         return next((log for log in logs if log.get("event") == "command_execution" and log.get("sink") == sink), None)
 
     def test_subprocess_run_is_logged(self) -> None:
@@ -242,6 +244,32 @@ class TestCommandExecAuditPatching(TestCase):
         assert entry is not None
         self.assertEqual(entry["binary"], true_path)
 
+    def test_fork_exec_wrapper_logs_and_passes_through(self) -> None:
+        # fork_exec is the raw C exec primitive — exercise the wrapper directly rather than forking.
+        received = {}
+
+        def fake_fork_exec(*args, **kwargs):
+            received["called"] = True
+            return 4321
+
+        with structlog.testing.capture_logs() as logs:
+            result = command_exec_audit._fork_exec_wrapper(fake_fork_exec, None, ([b"/bin/ls", b"-la"],), {})
+        self.assertEqual(result, 4321)
+        self.assertTrue(received.get("called"))
+        entry = self._find(logs, "_posixsubprocess.fork_exec")
+        assert entry is not None
+        self.assertEqual(entry["command"], ["/bin/ls", "-la"])
+
+    def test_install_wraps_fork_exec(self) -> None:
+        # Direct callers of the C primitive (bypassing Popen) must still be audited.
+        try:
+            import _posixsubprocess
+        except ImportError:
+            self.skipTest("_posixsubprocess unavailable on this platform")
+        import wrapt
+
+        self.assertIsInstance(_posixsubprocess.fork_exec, wrapt.ObjectProxy)
+
 
 @override_settings(ROOT_URLCONF="posthog.security.test.test_command_exec_audit")
 class TestCommandExecAuditRequestCycle(APIBaseTest):
@@ -251,7 +279,7 @@ class TestCommandExecAuditRequestCycle(APIBaseTest):
         super().setUp()
         install()
 
-    def _probe_log(self, logs: list[dict]) -> dict | None:
+    def _probe_log(self, logs: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
         return next(
             (log for log in logs if log.get("event") == "command_execution" and log.get("sink") == "subprocess.Popen"),
             None,

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -1,0 +1,273 @@
+import os
+import uuid
+import shutil
+import subprocess
+
+from posthog.test.base import APIBaseTest
+from unittest import TestCase, mock, skipUnless
+
+from django.test import override_settings
+from django.urls import path
+
+import structlog
+from parameterized import parameterized
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from posthog.auth import PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.clickhouse.query_tagging import AccessMethod
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.utils import generate_random_token_personal
+from posthog.security import command_exec_audit
+from posthog.security.command_exec_audit import (
+    _REDACTED as _R,
+    _scrub_args,
+    _scrub_command_string,
+    _summarize_env,
+    install,
+)
+
+
+class _ExecProbeView(APIView):
+    authentication_classes = [PersonalAPIKeyAuthentication, SessionAuthentication]
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        subprocess.run(["true"], check=True)
+        return Response({"ok": True})
+
+
+# Test-only URLconf so a real request/response cycle can run a command from a view.
+urlpatterns = [path("api/_exec_audit_probe/", _ExecProbeView.as_view())]
+
+
+class TestCommandExecAuditScrubbing(TestCase):
+    @parameterized.expand(
+        [
+            ("no_secrets", ["ls", "-la", "/tmp"], ["ls", "-la", "/tmp"]),
+            ("flag_value_pair", ["mycli", "--password", "hunter2"], ["mycli", "--password", _R]),
+            ("flag_equals", ["mycli", "--api-key=abc123"], ["mycli", f"--api-key={_R}"]),
+            ("bare_secret", ["mycli", "my_secret_token"], ["mycli", _R]),
+            (
+                "value_then_flag_not_consumed",
+                ["mycli", "--token", "--verbose"],
+                ["mycli", "--token", _R],
+            ),
+        ]
+    )
+    def test_scrub_args(self, _name: str, args: list[str], expected: list[str]) -> None:
+        self.assertEqual(_scrub_args(args), expected)
+
+    def test_scrub_args_truncates(self) -> None:
+        result = _scrub_args([f"a{i}" for i in range(200)])
+        self.assertEqual(len(result), command_exec_audit._MAX_ARGS + 1)
+        self.assertIn("truncated", result[-1])
+
+    def test_scrub_command_string_redacts_secret(self) -> None:
+        self.assertEqual(_scrub_command_string("psql --password supersecret db"), f"psql --password {_R} db")
+
+    def test_summarize_env_redacts_non_allowlisted(self) -> None:
+        allowed, redacted = _summarize_env({"PATH": "/usr/bin", "AWS_SECRET_KEY": "xxx", "FOO": "bar"})
+        self.assertEqual(allowed, {"PATH": "/usr/bin"})
+        self.assertEqual(redacted, 2)
+
+    def test_summarize_env_empty(self) -> None:
+        self.assertEqual(_summarize_env(None), (None, 0))
+
+
+class TestCommandExecAuditPatching(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # install() is idempotent and audit-only, so patching the process-global sinks here is safe.
+        install()
+
+    def _find(self, logs: list[dict], sink: str) -> dict | None:
+        return next((log for log in logs if log.get("event") == "command_execution" and log.get("sink") == sink), None)
+
+    def test_subprocess_run_is_logged(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["true"], check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertEqual(entry["command"], ["true"])
+        self.assertEqual(entry["binary"], "true")
+        self.assertFalse(entry["shell"])
+
+    def test_subprocess_shell_secret_is_scrubbed(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run("echo --password hunter2", shell=True, check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertTrue(entry["shell"])
+        self.assertNotIn("hunter2", entry["command"])
+
+    def test_os_system_is_logged(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            os.system("true")
+        entry = self._find(logs, "os.system")
+        assert entry is not None
+        self.assertTrue(entry["shell"])
+
+    def test_context_is_attached(self) -> None:
+        from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
+
+        org_id = uuid.uuid4()
+        reset_query_tags()
+        # user_email is intentionally set here but must NOT be logged — it's PII.
+        tag_queries(team_id=42, user_id=7, org_id=org_id, user_email="a@b.com")
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["true"], check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertEqual(entry["team_id"], 42)
+        self.assertEqual(entry["user_id"], 7)
+        # org_id is a UUID in the tags; it must be stringified for the log.
+        self.assertEqual(entry["org_id"], str(org_id))
+        self.assertNotIn("user_email", entry)
+
+    def test_cwd_is_logged(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["true"], cwd="/tmp", check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertEqual(entry["cwd"], "/tmp")
+
+    def test_executable_overrides_binary(self) -> None:
+        true_path = shutil.which("true")
+        assert true_path is not None
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["ignored"], executable=true_path, check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertEqual(entry["binary"], true_path)
+
+    def test_shell_operators_are_flagged(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run("true | cat", shell=True, check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertTrue(entry["has_shell_operators"])
+
+    def test_plain_command_has_no_shell_operator_flag(self) -> None:
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["true"], check=True)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertNotIn("has_shell_operators", entry)
+
+    def test_audit_does_not_break_command(self) -> None:
+        result = subprocess.run(["true"], check=False)
+        self.assertEqual(result.returncode, 0)
+
+    def test_command_output_is_preserved(self) -> None:
+        # The patched Popen must still pipe stdout back to the caller untouched.
+        self.assertEqual(subprocess.check_output(["printf", "hello"]), b"hello")
+
+    @parameterized.expand(
+        [
+            ("missing_binary", ["this-binary-does-not-exist-9f3a"], {}, FileNotFoundError),
+            ("nonzero_with_check", ["false"], {"check": True}, subprocess.CalledProcessError),
+        ]
+    )
+    def test_subprocess_exceptions_propagate(self, _name: str, args: list, kwargs: dict, exc: type) -> None:
+        with self.assertRaises(exc):
+            subprocess.run(args, **kwargs)
+
+    def test_os_system_returns_exit_status(self) -> None:
+        self.assertEqual(os.system("exit 0"), 0)
+        self.assertNotEqual(os.system("exit 3"), 0)
+
+    def test_audit_failure_never_breaks_the_command(self) -> None:
+        # If the audit path raises, the wrapped command must still run and return normally.
+        with mock.patch.object(command_exec_audit, "_context", side_effect=RuntimeError("boom")):
+            result = subprocess.run(["true"], check=False)
+        self.assertEqual(result.returncode, 0)
+
+    def test_reentrancy_guard_suppresses_nested_audit(self) -> None:
+        # While an audit is in progress, a nested exec (e.g. the git shell-out in query
+        # tagging) must not emit or recurse back into the patched sink.
+        token = command_exec_audit._in_audit.set(True)
+        try:
+            with structlog.testing.capture_logs() as logs:
+                command_exec_audit._emit(component="os", sink="os.system", command="true", shell=True)
+            self.assertIsNone(self._find(logs, "os.system"))
+        finally:
+            command_exec_audit._in_audit.reset(token)
+
+    def test_install_is_idempotent(self) -> None:
+        # A second install() must not double-wrap and double-log.
+        install()
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["true"], cwd="/", check=True)
+        matches = [
+            log
+            for log in logs
+            if log.get("event") == "command_execution"
+            and log.get("sink") == "subprocess.Popen"
+            and log.get("cwd") == "/"
+        ]
+        self.assertEqual(len(matches), 1)
+
+    @skipUnless(hasattr(os, "posix_spawn"), "posix_spawn unavailable on this platform")
+    def test_posix_spawn_is_logged(self) -> None:
+        true_path = shutil.which("true")
+        assert true_path is not None
+        with structlog.testing.capture_logs() as logs:
+            pid = os.posix_spawn(true_path, [true_path], os.environ)
+            os.waitpid(pid, 0)
+        entry = self._find(logs, "os.posix_spawn")
+        assert entry is not None
+        self.assertEqual(entry["binary"], true_path)
+
+
+@override_settings(ROOT_URLCONF="posthog.security.test.test_command_exec_audit")
+class TestCommandExecAuditRequestCycle(APIBaseTest):
+    PROBE = "/api/_exec_audit_probe/"
+
+    def setUp(self) -> None:
+        super().setUp()
+        install()
+
+    def _probe_log(self, logs: list[dict]) -> dict | None:
+        return next(
+            (log for log in logs if log.get("event") == "command_execution" and log.get("sink") == "subprocess.Popen"),
+            None,
+        )
+
+    def test_session_request_logs_middleware_context(self) -> None:
+        # APIBaseTest auto-logs-in self.user; the middleware should populate user/ip/request context
+        # onto the command log without any manual tagging in the view.
+        with structlog.testing.capture_logs() as logs:
+            response = self.client.get(self.PROBE)
+        self.assertEqual(response.status_code, 200)
+        entry = self._probe_log(logs)
+        assert entry is not None
+        self.assertEqual(entry["user_id"], self.user.pk)
+        self.assertEqual(entry["kind"], "request")
+        self.assertEqual(entry["ip_address"], "127.0.0.1")
+
+    def test_personal_api_key_request_logs_auth_context(self) -> None:
+        # Key-based auth tags team_id + access_method during DRF dispatch, before the command runs.
+        self.client.logout()
+        value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="probe", user=self.user, secure_value=hash_key_value(value), scopes=["*"])
+        with structlog.testing.capture_logs() as logs:
+            response = self.client.get(self.PROBE, headers={"authorization": f"Bearer {value}"})
+        self.assertEqual(response.status_code, 200)
+        entry = self._probe_log(logs)
+        assert entry is not None
+        self.assertEqual(entry["user_id"], self.user.pk)
+        self.assertEqual(entry["team_id"], self.team.pk)
+        self.assertEqual(entry["access_method"], AccessMethod.PERSONAL_API_KEY)
+        self.assertEqual(entry["ip_address"], "127.0.0.1")
+
+    def test_unauthenticated_request_is_still_logged(self) -> None:
+        self.client.logout()
+        with structlog.testing.capture_logs() as logs:
+            response = self.client.get(self.PROBE)
+        self.assertEqual(response.status_code, 200)
+        entry = self._probe_log(logs)
+        assert entry is not None
+        self.assertEqual(entry["command"], ["true"])
+        self.assertNotIn("user_id", entry)

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -82,6 +82,20 @@ class TestCommandExecAuditScrubbing(TestCase):
     def test_scrub_command_string_redacts_secret(self) -> None:
         self.assertEqual(_scrub_command_string("psql --password supersecret db"), f"psql --password {_R} db")
 
+    def test_base64_payload_is_redacted(self) -> None:
+        # A secret written via a b64decode heredoc (as the sandbox does) must not be recoverable.
+        import base64
+
+        blob = base64.b64encode(b"GITHUB_TOKEN=ghp_" + b"x" * 64).decode()
+        token = f"payload = base64.b64decode('{blob}')"
+        scrubbed = _scrub_args([token])[0]
+        self.assertNotIn(blob, scrubbed)
+        self.assertIn(_R, scrubbed)
+
+    def test_short_alphanumeric_args_are_not_blob_redacted(self) -> None:
+        # Ordinary short identifiers/flags must survive — blob redaction targets long runs only.
+        self.assertEqual(_scrub_args(["ls", "-la", "abc123DEF456"]), ["ls", "-la", "abc123DEF456"])
+
     def test_summarize_env_redacts_non_allowlisted(self) -> None:
         allowed, redacted = _summarize_env({"PATH": "/usr/bin", "AWS_SECRET_KEY": "xxx", "FOO": "bar"})
         self.assertEqual(allowed, {"PATH": "/usr/bin"})
@@ -170,6 +184,18 @@ class TestCommandExecAuditPatching(TestCase):
         entry = self._find(logs, "subprocess.Popen")
         assert entry is not None
         self.assertNotIn("has_shell_operators", entry)
+
+    def test_encoded_blob_redacted_but_flagged(self) -> None:
+        # The base64 body must be unrecoverable, yet the entry still signals an encoded payload.
+        import base64
+
+        blob = base64.b64encode(b"GITHUB_TOKEN=ghp_" + b"x" * 64).decode()
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["python3", "-c", f"import base64; base64.b64decode('{blob}')"], check=False)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertNotIn(blob, " ".join(entry["command"]))
+        self.assertTrue(entry["has_encoded_blob"])
 
     def test_operator_chars_in_argv_are_not_flagged(self) -> None:
         # shell=False: operator chars inside an arg are literal, not injection — must not flag.

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -54,6 +54,8 @@ class TestCommandExecAuditScrubbing(TestCase):
                 ["mycli", "--token", "--verbose"],
                 ["mycli", "--token", _R],
             ),
+            # "auth" must not over-match common non-secret flags like git's --author.
+            ("author_not_redacted", ["git", "log", "--author=Jane"], ["git", "log", "--author=Jane"]),
         ]
     )
     def test_scrub_args(self, _name: str, args: list[str], expected: list[str]) -> None:
@@ -63,6 +65,11 @@ class TestCommandExecAuditScrubbing(TestCase):
         result = _scrub_args([f"a{i}" for i in range(200)])
         self.assertEqual(len(result), command_exec_audit._MAX_ARGS + 1)
         self.assertIn("truncated", result[-1])
+
+    def test_scrub_args_truncation_count_correct_for_iterator(self) -> None:
+        # A single-pass iterable must still report the right truncated count.
+        result = _scrub_args(iter([f"a{i}" for i in range(200)]))
+        self.assertEqual(result[-1], f"...(+{200 - command_exec_audit._MAX_ARGS} args truncated)")
 
     def test_scrub_command_string_redacts_secret(self) -> None:
         self.assertEqual(_scrub_command_string("psql --password supersecret db"), f"psql --password {_R} db")

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -25,6 +25,7 @@ TEST = get_from_env(
 # level once the REPL opens, so forcing ERROR would silence its whole session. For
 # `dbshell` there is no Python REPL (it execs the DB client), so nothing to restore.
 IS_INTERACTIVE_SHELL: bool = len(sys.argv) > 1 and sys.argv[1] in ("shell", "dbshell")
+COMMAND_EXEC_AUDIT_ENABLED: bool = get_from_env("COMMAND_EXEC_AUDIT_ENABLED", not TEST, type_cast=str_to_bool)
 STATIC_COLLECTION = get_from_env("STATIC_COLLECTION", False, type_cast=str_to_bool)
 DEMO: bool = get_from_env("DEMO", False, type_cast=str_to_bool)  # Whether this is a managed demo environment
 CLOUD_DEPLOYMENT: str | None = get_from_env(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ dependencies = [
     "google-re2>=1.1.20251105,<2",
     "scrubadub~=2.0.1",
     "braintrust-core>=0.0.59,<1",
+    "wrapt==1.17.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -5688,6 +5688,7 @@ dependencies = [
     { name = "user-agents" },
     { name = "webauthn" },
     { name = "whitenoise" },
+    { name = "wrapt" },
     { name = "xgboost" },
     { name = "xmlsec" },
     { name = "zstd" },
@@ -5962,6 +5963,7 @@ requires-dist = [
     { name = "user-agents", specifier = "~=2.2.0" },
     { name = "webauthn", specifier = ">=2.1.0,<2.3.0" },
     { name = "whitenoise", specifier = "~=6.10.0" },
+    { name = "wrapt", specifier = "==1.17.3" },
     { name = "xgboost", specifier = "==3.2.0" },
     { name = "xmlsec", specifier = "==1.3.17" },
     { name = "zstd", specifier = "==1.5.7.2" },
@@ -9119,33 +9121,21 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "1.17.2"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531, upload-time = "2025-01-14T10:35:45.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/b9/0ffd557a92f3b11d4c5d5e0c5e4ad057bd9eb8586615cdaf901409920b14/wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125", size = 53800, upload-time = "2025-01-14T10:34:21.571Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ef/8be90a0b7e73c32e550c73cfb2fa09db62234227ece47b0e80a05073b375/wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998", size = 38824, upload-time = "2025-01-14T10:34:22.999Z" },
-    { url = "https://files.pythonhosted.org/packages/36/89/0aae34c10fe524cce30fe5fc433210376bce94cf74d05b0d68344c8ba46e/wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5", size = 38920, upload-time = "2025-01-14T10:34:25.386Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/24/11c4510de906d77e0cfb5197f1b1445d4fec42c9a39ea853d482698ac681/wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8", size = 88690, upload-time = "2025-01-14T10:34:28.058Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d7/cfcf842291267bf455b3e266c0c29dcb675b5540ee8b50ba1699abf3af45/wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6", size = 80861, upload-time = "2025-01-14T10:34:29.167Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/66/5d973e9f3e7370fd686fb47a9af3319418ed925c27d72ce16b791231576d/wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc", size = 89174, upload-time = "2025-01-14T10:34:31.702Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d3/8e17bb70f6ae25dabc1aaf990f86824e4fd98ee9cadf197054e068500d27/wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2", size = 86721, upload-time = "2025-01-14T10:34:32.91Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/54/f170dfb278fe1c30d0ff864513cff526d624ab8de3254b20abb9cffedc24/wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b", size = 79763, upload-time = "2025-01-14T10:34:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/98/de07243751f1c4a9b15c76019250210dd3486ce098c3d80d5f729cba029c/wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504", size = 87585, upload-time = "2025-01-14T10:34:36.13Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f0/13925f4bd6548013038cdeb11ee2cbd4e37c30f8bfd5db9e5a2a370d6e20/wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a", size = 36676, upload-time = "2025-01-14T10:34:37.962Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ae/743f16ef8c2e3628df3ddfd652b7d4c555d12c84b53f3d8218498f4ade9b/wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845", size = 38871, upload-time = "2025-01-14T10:34:39.13Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/bc/30f903f891a82d402ffb5fda27ec1d621cc97cb74c16fea0b6141f1d4e87/wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192", size = 56312, upload-time = "2025-01-14T10:34:40.604Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/04/c97273eb491b5f1c918857cd26f314b74fc9b29224521f5b83f872253725/wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b", size = 40062, upload-time = "2025-01-14T10:34:45.011Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ca/3b7afa1eae3a9e7fefe499db9b96813f41828b9fdb016ee836c4c379dadb/wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0", size = 40155, upload-time = "2025-01-14T10:34:47.25Z" },
-    { url = "https://files.pythonhosted.org/packages/89/be/7c1baed43290775cb9030c774bc53c860db140397047cc49aedaf0a15477/wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306", size = 113471, upload-time = "2025-01-14T10:34:50.934Z" },
-    { url = "https://files.pythonhosted.org/packages/32/98/4ed894cf012b6d6aae5f5cc974006bdeb92f0241775addad3f8cd6ab71c8/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb", size = 101208, upload-time = "2025-01-14T10:34:52.297Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/fd/0c30f2301ca94e655e5e057012e83284ce8c545df7661a78d8bfca2fac7a/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681", size = 109339, upload-time = "2025-01-14T10:34:53.489Z" },
-    { url = "https://files.pythonhosted.org/packages/75/56/05d000de894c4cfcb84bcd6b1df6214297b8089a7bd324c21a4765e49b14/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6", size = 110232, upload-time = "2025-01-14T10:34:55.327Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f8/c3f6b2cf9b9277fb0813418e1503e68414cd036b3b099c823379c9575e6d/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6", size = 100476, upload-time = "2025-01-14T10:34:58.055Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b1/0bb11e29aa5139d90b770ebbfa167267b1fc548d2302c30c8f7572851738/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f", size = 106377, upload-time = "2025-01-14T10:34:59.3Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986, upload-time = "2025-01-14T10:35:00.498Z" },
-    { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750, upload-time = "2025-01-14T10:35:03.378Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload-time = "2025-01-14T10:35:44.018Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Today there's no audit trail for external process execution.When backend code (a request handler, Celery task, or Temporal activity) shells out via subprocess, os.system, os.spawn*, or os.exec*, there's no record of what ran or on whose behalf. That's a blind spot for security investigation and incident response.

## Changes

Adds an audit layer that monkeypatches CPython execution sinks using `wrapt` and emit logs using `structlog`.

### Caveats

This will not cover all arbitrary code execution. It's impossible to do that from within the Python process, nor it's the attempt here. This is just one audit layer that has to be combined to other controls we have on the host.

## How did you test this code?

Automated tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->