### PR TITLE
fix(postgres): map pooler missing-tenant error during credential validation

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -54,6 +54,17 @@ PostgresErrors = {
     "password authentication failed for user": "Invalid user or password",
     # libpq reports a bad password via SCRAM with a different wording than the line above.
     "error received from server in SCRAM exchange: Wrong password": "Invalid user or password",
+    # Supabase/Supavisor poolers report a missing tenant/user during credential validation with
+    # "FATAL: (ENOTFOUND) tenant/user <user> not found" — the project is paused/deleted or the
+    # pooler username/host is wrong. `get_non_retryable_errors` already handles this on the
+    # streaming path; map it here too so validation returns an actionable message instead of
+    # surfacing the expected user/upstream condition as captured error noise. Match the stable
+    # fragment and exclude the volatile username/host.
+    "(ENOTFOUND) tenant/user": (
+        "Your database connection pooler couldn't find the tenant or user. This usually means the "
+        "database project is paused or deleted, or the pooler username/host is wrong. Check that "
+        "your database is active and the connection details are correct."
+    ),
     "could not translate host name": "Could not connect to the host",
     "Is the server running on that host and accepting TCP/IP connections": "Could not connect to the host on the port given",
     'database "': "Database does not exist",

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1404,6 +1404,14 @@ class TestValidateCredentialsErrorMapping:
                 "pool_size, or switch it to transaction mode) or reduce the number of concurrent "
                 "connections to your database, then try again.",
             ),
+            # Supabase/Supavisor pooler reports a missing tenant/user with a volatile username/host.
+            (
+                'connection failed: connection to server at "44.216.29.125", port 5432 failed: '
+                "FATAL:  (ENOTFOUND) tenant/user postgres.icjrfprdtrgjpxfpbrvx not found",
+                "Your database connection pooler couldn't find the tenant or user. This usually means the "
+                "database project is paused or deleted, or the pooler username/host is wrong. Check that "
+                "your database is active and the connection details are correct.",
+            ),
             # Unmapped errors fall back to the generic message.
             (
                 "some brand new failure",


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OperationalError` from the Postgres/Supabase data-warehouse import source during credential validation:

```
connection failed: connection to server at "<ip>", port 5432 failed:
FATAL:  (ENOTFOUND) tenant/user <user> not found
```

Issue: https://us.posthog.com/project/2/error_tracking/019ed718-e682-7753-8e0e-6e718716e021

This is an upstream/user condition: a Supabase/Supavisor connection pooler can't resolve the tenant/user, which means the database project is paused or deleted, or the pooler username/host is wrong. There's nothing for us to retry or fix server-side.

The streaming retry path already treats this as non-retryable (`get_non_retryable_errors` matches `(ENOTFOUND) tenant/user`). But the captured exception came from `validate_credentials` (the `database_schema` discovery endpoint), which maps `OperationalError` messages through the separate `PostgresErrors` dict and falls through to `capture_exception` when nothing matches. That fragment wasn't in `PostgresErrors`, so every failed validation against a paused/misconfigured pooler logged noise instead of returning a useful message.

## Changes

- Add the stable `(ENOTFOUND) tenant/user` fragment to `PostgresErrors` (the map `validate_credentials` uses), returning an actionable message and stopping the spurious capture. The match excludes the volatile username/host. `SupabaseSource` inherits this path, so both sources benefit.
- Add a regression case to the parametrized `validate_credentials` error-mapping test.

## How did you test this code?

I'm an agent. I added a regression case and ran the relevant Postgres source tests locally:

- `TestValidateCredentialsErrorMapping` (7 passed, incl. the new case)
- `TestPostgresSourceNonRetryableErrors` + `TestValidateCredentialsErrorMapping` (62 passed)
- `ruff check` and `ruff format --check` clean on both files

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue and a representative event via the PostHog MCP error-tracking tools, confirmed the failure originates in `posthog/temporal/data_imports/sources/postgres/source.py` (`validate_credentials`, reached from the `database_schema` discovery endpoint).

Decision: user/upstream error (paused/deleted project or wrong pooler credentials) — not retryable, not a code bug in the connection logic. The retry path was already covered; the gap was the validation path's `PostgresErrors` map. Scoped the change to mirror the existing `get_non_retryable_errors` entry and the existing `PostgresErrors` handling of `server closed the connection unexpectedly`, matching a stable low-false-positive substring rather than the volatile IP/username.
