### PR TITLE
chore: migrate internal feature-flag payload reads to getFeatureFlagResult

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -11,7 +11,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic, getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { retryWithBackoff } from 'lib/utils/async'
 import { toParams } from 'lib/utils/url'
@@ -683,9 +683,7 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 try {
                     let importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
 
-                    const flagPayload = posthog.getFeatureFlagResult('changelog-notification', {
-                        send_event: false,
-                    })?.payload
+                    const flagPayload = getFeatureFlagPayload('changelog-notification')
                     const changelogNotifications = flagPayload
                         ? (flagPayload as JsonRecord[]).map(
                               (notification) =>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -683,7 +683,9 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 try {
                     let importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
 
-                    const flagPayload = posthog.getFeatureFlagPayload('changelog-notification')
+                    const flagPayload = posthog.getFeatureFlagResult('changelog-notification', {
+                        send_event: false,
+                    })?.payload
                     const changelogNotifications = flagPayload
                         ? (flagPayload as JsonRecord[]).map(
                               (notification) =>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -11,7 +11,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { featureFlagLogic, getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { retryWithBackoff } from 'lib/utils/async'
 import { toParams } from 'lib/utils/url'
@@ -683,7 +683,10 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 try {
                     let importantChangesHumanized = humanize(importantChanges?.results || [], describerFor, true)
 
-                    const flagPayload = getFeatureFlagPayload('changelog-notification')
+                    // 'changelog-notification' is an externally managed flag, not a FEATURE_FLAGS key, so it's read directly.
+                    const flagPayload = posthog.getFeatureFlagResult('changelog-notification', {
+                        send_event: false,
+                    })?.payload
                     const changelogNotifications = flagPayload
                         ? (flagPayload as JsonRecord[]).map(
                               (notification) =>

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -87,7 +87,7 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
 }
 
 export function getFeatureFlagPayload(flag: FeatureFlagKey): any {
-    return posthog.getFeatureFlagPayload(flag)
+    return posthog.getFeatureFlagResult(flag, { send_event: false })?.payload
 }
 
 export const featureFlagLogic = kea<featureFlagLogicType>([


### PR DESCRIPTION
## Problem

PostHog's own frontend reads feature-flag payloads through `posthog.getFeatureFlagPayload`, which is now deprecated in `posthog-js` in favor of `getFeatureFlagResult(key)?.payload`. Keeping the deprecated call around means the app builds against a deprecated SDK API (and is the last internal consumer of it).

## Changes

Behavior-preserving migration of the two actual call sites:

- `lib/logic/featureFlagLogic.ts` — the shared `getFeatureFlagPayload(flag)` helper now returns `posthog.getFeatureFlagResult(flag, { send_event: false })?.payload`. This single change covers every indirect caller (`dashboardLogic`, `maxChangelogLogic`, `feedbackPromptLogic`, `FlaggedFeature`, `NavPanelAdvertisement`, `ProductCarousel`, `LegacyProductSelection`). The exported helper name is intentionally unchanged so importers don't need touching.
- `sidePanelNotificationsLogic.tsx` — the one direct caller, migrated the same way.

`{ send_event: false }` preserves the existing behavior exactly — `getFeatureFlagPayload` never sent a `$feature_flag_called` event, and neither does this. No flag values or payloads change.

**Left as-is:** the `toolbar/shims/featureFlagLogic.ts` no-op shim (returns `undefined`, no SDK call), the backend snippet generator in `FeatureFlagSnippets.tsx`, and the `<code>getFeatureFlagPayload</code>` help text in `FeatureFlagForm.tsx` (user-facing product copy — separate concern).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Final internal cleanup of a cross-SDK/cross-repo `getFeatureFlagPayload` → `getFeatureFlagResult` deprecation sweep. Verified `getFeatureFlagResult` is present in the installed `posthog-js` types and that the browser option key is `send_event` (matching the `@posthog/react` hook). Formatted with `oxfmt`.

## Review feedback

- **Greptile (P2)** — suggested routing the `sidePanelNotificationsLogic` payload read through the centralized `getFeatureFlagPayload` helper. Applied first, but it broke `Frontend typechecking`: the helper is typed to `FeatureFlagKey` (registered `FEATURE_FLAGS` keys only), and `'changelog-notification'` is an externally managed flag, not a registered key.
- **mendral (P1)** — flagged the same tsgo type error.
- ✅ **Resolved (`2aa102f`)** — kept `changelog-notification` as a direct `posthog.getFeatureFlagResult('changelog-notification', { send_event: false })?.payload` call (matching how the original code read it, and still off the deprecated `getFeatureFlagPayload`), rather than registering a one-off content flag in `FEATURE_FLAGS`. Added a one-line comment so it isn't re-flagged.
