### PR TITLE
fix(clickhouse): raise kafka broker schedule pool

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -72,7 +72,8 @@
     of the time, in which case a higher number of threads might be required.
     -->
 
-    <background_message_broker_schedule_pool_size>10</background_message_broker_schedule_pool_size>
+    <!-- Must exceed the ~95 kafka_* engine tables, else consumers starve and their MVs stall. -->
+    <background_message_broker_schedule_pool_size>128</background_message_broker_schedule_pool_size>
     <max_thread_pool_size>10000</max_thread_pool_size>
 
     <!-- how many threads merge files, default is 16 -->


### PR DESCRIPTION
## Problem

- `session-recording/consumer.e2e.test.ts` (Node.js Tests shard 3/3) flakes near-deterministically with `sessionCount: 0` — [example failing job](https://github.com/PostHog/posthog/actions/runs/27714113011/job/81982606982).
- Root cause is **ClickHouse Kafka-engine consumer starvation**, not MV merge lag: ~95 `kafka_*` engine tables share a `background_message_broker_schedule_pool_size` of **10** (~10:1 oversubscription). Consumers can't hold partition assignments → the failing-run log is dominated by `Can't get assignment` / `Temporarily pause scheduling` naming `kafka_session_replay_events` → `session_replay_events_mv` never fires → the aggregated table the test polls stays empty.
- Builds on [#64357](https://github.com/PostHog/posthog/pull/64357), which cut topic-teardown churn; the pool oversubscription was the remaining factor keeping the suite flaky.

## Changes

- `docker/clickhouse/config.xml`: `background_message_broker_schedule_pool_size` **10 → 128** (above the ~95-table count, so every consumer stays scheduled). Lightweight scheduler threads; compose-mounted for dev/CI/hobby only — Cloud production uses its own ClickHouse config and is unaffected.
- Targets the starvation directly, not the test's 30s poll timeout (which can't help when the consumer is starved for the whole run).

## How did you test this code?

- Agent (Claude Code). Config-only; **not run locally** (needs the full Kafka + ClickHouse + S3 stack and CI-level contention to reproduce). Validation is via CI on this PR — watch shard 3/3 `consumer.e2e` stop hitting `sessionCount: 0`. Draft until confirmed.

## Docs update

- skip-inkeep-docs — infra config only.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted) — directed by the assignee.
- Tooling: Claude Code; diagnosed from the GitHub Actions logs + the repo's ClickHouse/Kafka config.
- Key call: fixed the root cause (pool size) over the symptom (poll timeout). Follow-up worth doing: decouple the test from the ClickHouse MV path so it asserts on the consumer's own S3 + Kafka outputs.
