### PR TITLE
feat(integrations): add request access flow for non-admin members

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6732,6 +6732,10 @@ snapshots:
         hash: v1.k794b7964.7012e3f23570ed0bdf0af3b947fa8b09bb1a40edd59928bea76c9472eef444a1.yWbx-kU4Sx_plVguU1neQn8eHFiPseBMjmr8tCiy6O0
     scenes-other-integration-landing-page--connected--light:
         hash: v1.k794b7964.ecea4a3cebed2c5fba619695c4ca576cfa0ce3a9a818af498791c1080be2675e.nkq28LhIVvheqMxYLdV5Od1eeCXKI1AFgIKfcbUOAEw
+    scenes-other-integration-landing-page--no-permission--dark:
+        hash: v1.k794b7964.a17a0acea1830a870a6ff984cc5c523497f678d8c8413f3fef8ea2a470eb8d43.yjPhd5PJM817w4ybixhkzCHCR0Gq_Qtp9EyGUehuunM
+    scenes-other-integration-landing-page--no-permission--light:
+        hash: v1.k794b7964.f4e806a53bd611cbfab6c96c8a53d0fc5754cb922328953e32028fcfac971f78.Fhy7_1HTcf09dpHknO0udUiW_B_1kNWLU6JVuOIj4lg
     scenes-other-integration-landing-page--not-connected--dark:
         hash: v1.k794b7964.cbc1efc83f9f31ee7ed22a7da2be3ec19e7e6f6568a5b43ade5f75ee4aaccbc5.u1nKAJkTALr_RPPMm4EA68pFFF4JE03AJBqWleTvbJk
     scenes-other-integration-landing-page--not-connected--light:

--- a/frontend/src/lib/components/RestrictedArea.tsx
+++ b/frontend/src/lib/components/RestrictedArea.tsx
@@ -51,9 +51,11 @@ export function useRestrictedArea({
             }
             scopeAccessLevel = currentOrganization.membership_level
         }
+
         if (scopeAccessLevel === null) {
             return `You don't have access to the current ${scope}.`
         }
+
         if (scopeAccessLevel < minimumAccessLevel) {
             if (minimumAccessLevel === OrganizationMembershipLevel.Owner) {
                 return `This area is restricted to the ${scope} owner.`

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -183,11 +183,11 @@ export const integrationsLogic = kea<integrationsLogicType>([
         accessRequest: [
             null as IntegrationKind | null,
             {
-                requestIntegrationAccess: async ({ kind, reason }: { kind: IntegrationKind; reason: string }) => {
+                requestIntegrationAccess: async ({ kind }: { kind: IntegrationKind }) => {
                     try {
                         await integrationsRequestAccessCreate(String(values.currentProjectId), {
                             kind: kind as IntegrationKindEnumApi,
-                            reason,
+                            reason: values.accessRequestReason.trim(),
                         })
                         lemonToast.success('Request sent! Your project admins have been notified.')
                         return kind

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -14,8 +14,11 @@ import { urls } from 'scenes/urls'
 
 import { EmailIntegrationDomainGroupedType, IntegrationKind, IntegrationType } from '~/types'
 
-import { integrationsGithubReposRetrieve } from 'products/integrations/frontend/generated/api'
-import type { GitHubRepoApi } from 'products/integrations/frontend/generated/api.schemas'
+import {
+    integrationsGithubReposRetrieve,
+    integrationsRequestAccessCreate,
+} from 'products/integrations/frontend/generated/api'
+import type { GitHubRepoApi, IntegrationKindEnumApi } from 'products/integrations/frontend/generated/api.schemas'
 import { ChannelType } from 'products/workflows/frontend/Channels/MessageChannels'
 
 import type { integrationsLogicType } from './integrationsLogicType'
@@ -58,6 +61,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
             hasMore,
         }),
         loadGitHubRepositoriesPageFailure: (integrationId: number) => ({ integrationId }),
+        setAccessRequestReason: (reason: string) => ({ reason }),
     }),
     reducers({
         newIntegrationModalKind: [
@@ -111,6 +115,20 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 loadGitHubRepositoriesPageFailure: () => false,
             },
         ],
+        requestedAccessKinds: [
+            [] as IntegrationKind[],
+            {
+                requestIntegrationAccessSuccess: (state, { accessRequest }) =>
+                    accessRequest && !state.includes(accessRequest) ? [...state, accessRequest] : state,
+            },
+        ],
+        accessRequestReason: [
+            '',
+            {
+                setAccessRequestReason: (_, { reason }) => reason,
+                requestIntegrationAccessSuccess: () => '',
+            },
+        ],
     }),
     loaders(({ values }) => ({
         integrations: [
@@ -157,6 +175,24 @@ export const integrationsLogic = kea<integrationsLogicType>([
                         return [...(values.integrations ?? []), responseWithIcon]
                     } catch (e) {
                         lemonToast.error('Failed to upload Google Cloud key.')
+                        throw e
+                    }
+                },
+            },
+        ],
+        accessRequest: [
+            null as IntegrationKind | null,
+            {
+                requestIntegrationAccess: async ({ kind, reason }: { kind: IntegrationKind; reason: string }) => {
+                    try {
+                        await integrationsRequestAccessCreate(String(values.currentProjectId), {
+                            kind: kind as IntegrationKindEnumApi,
+                            reason,
+                        })
+                        lemonToast.success('Request sent! Your project admins have been notified.')
+                        return kind
+                    } catch (e) {
+                        toastApiError(e)
                         throw e
                     }
                 },

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -1,8 +1,11 @@
 import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
 import { Meta, StoryObj } from '@storybook/react'
+import { useActions } from 'kea'
+import { useEffect } from 'react'
 
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { TeamMembershipLevel } from 'lib/constants'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { mswDecorator } from '~/mocks/browser'
 import preflightJson from '~/mocks/fixtures/_preflight.json'
@@ -44,16 +47,21 @@ export const Connected: Story = {
 }
 
 // Below project-admin level: the connect button is replaced by the "request access" flow.
+// `useRestrictedArea` reads the level from teamLogic's currentTeam, which Storybook seeds from
+// the (admin-level) app context and never refetches — so we override it directly rather than
+// mocking the environments endpoint, which teamLogic never hits.
 export const NoPermission: Story = {
-    decorators: [
-        mswDecorator({
-            get: {
-                '/api/environments/:id/integrations': { results: [] },
-                '/api/environments/@current/': {
-                    ...MOCK_DEFAULT_TEAM,
-                    effective_membership_level: OrganizationMembershipLevel.Member,
-                },
-            },
-        }),
-    ],
+    decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [] } } })],
+    render: () => {
+        const { loadCurrentTeamSuccess } = useActions(teamLogic)
+
+        useEffect(() => {
+            loadCurrentTeamSuccess({
+                ...MOCK_DEFAULT_TEAM,
+                effective_membership_level: TeamMembershipLevel.Member,
+            })
+        }, [loadCurrentTeamSuccess])
+
+        return <IntegrationFullPage definition={Slack} SettingsSection={Slack.SettingsSection} />
+    },
 }

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -1,11 +1,8 @@
-import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
 import { Meta, StoryObj } from '@storybook/react'
-import { useActions } from 'kea'
-import { useEffect } from 'react'
 
-import { TeamMembershipLevel } from 'lib/constants'
-import { teamLogic } from 'scenes/teamLogic'
+import { OrganizationMembershipLevel } from 'lib/constants'
 
 import { mswDecorator } from '~/mocks/browser'
 import preflightJson from '~/mocks/fixtures/_preflight.json'
@@ -46,22 +43,37 @@ export const Connected: Story = {
     decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [mockIntegration] } } })],
 }
 
+const memberTeam = { ...MOCK_DEFAULT_TEAM, effective_membership_level: OrganizationMembershipLevel.Member }
+const memberOrganization = {
+    ...MOCK_DEFAULT_ORGANIZATION,
+    membership_level: OrganizationMembershipLevel.Member,
+    teams: [memberTeam],
+}
+
 // Below project-admin level: the connect button is replaced by the "request access" flow.
-// `useRestrictedArea` reads the level from teamLogic's currentTeam, which Storybook seeds from
-// the (admin-level) app context and never refetches — so we override it directly rather than
-// mocking the environments endpoint, which teamLogic never hits.
+// `useRestrictedArea` reads the team's `effective_membership_level`, which teamLogic seeds from
+// `getAppContext().current_team` (not an API call) — so we lower it in the app context here.
+// `beforeEach` runs before Kea mounts teamLogic; the cleanup restores it for other stories.
+// organizationLogic still fetches the org, so we mock that to Member too.
 export const NoPermission: Story = {
-    decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [] } } })],
-    render: () => {
-        const { loadCurrentTeamSuccess } = useActions(teamLogic)
-
-        useEffect(() => {
-            loadCurrentTeamSuccess({
-                ...MOCK_DEFAULT_TEAM,
-                effective_membership_level: TeamMembershipLevel.Member,
-            })
-        }, [loadCurrentTeamSuccess])
-
-        return <IntegrationFullPage definition={Slack} SettingsSection={Slack.SettingsSection} />
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:id/integrations': { results: [] },
+                '/api/organizations/@current/': memberOrganization,
+            },
+        }),
+    ],
+    beforeEach: () => {
+        const appContext = window.POSTHOG_APP_CONTEXT
+        const originalTeam = appContext?.current_team
+        if (appContext) {
+            appContext.current_team = memberTeam
+        }
+        return () => {
+            if (appContext) {
+                appContext.current_team = originalTeam ?? null
+            }
+        }
     },
 }

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -1,4 +1,8 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import { Meta, StoryObj } from '@storybook/react'
+
+import { OrganizationMembershipLevel } from 'lib/constants'
 
 import { mswDecorator } from '~/mocks/browser'
 import preflightJson from '~/mocks/fixtures/_preflight.json'
@@ -37,4 +41,19 @@ export const NotConnected: Story = {
 
 export const Connected: Story = {
     decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [mockIntegration] } } })],
+}
+
+// Below project-admin level: the connect button is replaced by the "request access" flow.
+export const NoPermission: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:id/integrations': { results: [] },
+                '/api/environments/@current/': {
+                    ...MOCK_DEFAULT_TEAM,
+                    effective_membership_level: OrganizationMembershipLevel.Member,
+                },
+            },
+        }),
+    ],
 }

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -135,7 +135,7 @@ function RequestAccessSection({ definition }: { definition: IntegrationDefinitio
                 center
                 loading={accessRequestLoading}
                 disabledReason={!accessRequestReason.trim() ? 'Add a short note for your admins' : undefined}
-                onClick={() => requestIntegrationAccess({ kind: definition.kind, reason: accessRequestReason.trim() })}
+                onClick={() => requestIntegrationAccess({ kind: definition.kind })}
             >
                 Request {definition.name}
             </LemonButton>

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -1,8 +1,10 @@
 import { useActions, useValues } from 'kea'
 
 import { IconArrowLeft, IconCheckCircle, IconWarning } from '@posthog/icons'
-import { LemonButton, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTextArea, Link, Spinner } from '@posthog/lemon-ui'
 
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
@@ -65,6 +67,11 @@ function ConnectView({
     SettingsSection: SettingsSectionComponent
 }): JSX.Element {
     const { reportIntegrationConnectClicked } = useActions(eventUsageLogic)
+    // Connecting an integration requires project admin access (enforced again in the backend).
+    const restrictionReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
 
     const onConnectClick = (): void => {
         reportIntegrationConnectClicked(definition.slug, definition.kind)
@@ -79,10 +86,14 @@ function ConnectView({
 
             <div className="text-center text-sm">{definition.description}</div>
 
-            {/* onClickCapture fires before the connect button triggers its OAuth redirect */}
-            <div onClickCapture={onConnectClick}>
-                <SettingsSection next={urls.integration(definition.slug)} />
-            </div>
+            {restrictionReason ? (
+                <RequestAccessSection definition={definition} />
+            ) : (
+                // onClickCapture fires before the connect button triggers its OAuth redirect
+                <div onClickCapture={onConnectClick}>
+                    <SettingsSection next={urls.integration(definition.slug)} />
+                </div>
+            )}
 
             {definition.docsUrl ? (
                 <Link to={definition.docsUrl} target="_blank" className="text-sm">
@@ -90,6 +101,45 @@ function ConnectView({
                 </Link>
             ) : null}
         </>
+    )
+}
+
+function RequestAccessSection({ definition }: { definition: IntegrationDefinition }): JSX.Element {
+    const { accessRequestReason, accessRequestLoading, requestedAccessKinds } = useValues(integrationsLogic)
+    const { setAccessRequestReason, requestIntegrationAccess } = useActions(integrationsLogic)
+
+    if (requestedAccessKinds.includes(definition.kind)) {
+        return (
+            <LemonBanner type="success" className="w-full">
+                Request sent. Your project admins have been notified and can connect {definition.name}.
+            </LemonBanner>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3 w-full">
+            <LemonBanner type="info" className="w-full">
+                Connecting {definition.name} requires admin access. Tell your project admins why you need it and we'll
+                email them.
+            </LemonBanner>
+            <LemonTextArea
+                value={accessRequestReason}
+                onChange={setAccessRequestReason}
+                placeholder={`Why does your team need ${definition.name}?`}
+                minRows={3}
+                maxLength={2000}
+            />
+            <LemonButton
+                type="primary"
+                fullWidth
+                center
+                loading={accessRequestLoading}
+                disabledReason={!accessRequestReason.trim() ? 'Add a short note for your admins' : undefined}
+                onClick={() => requestIntegrationAccess({ kind: definition.kind, reason: accessRequestReason.trim() })}
+            >
+                Request {definition.name}
+            </LemonButton>
+        </div>
     )
 }
 

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -75,6 +75,7 @@ from posthog.permissions import (
 )
 from posthog.rate_limit import GitHubRepositoryRefreshThrottle
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+from posthog.tasks.email import send_integration_access_request
 
 from products.cdp.backend.services.integration_usage import get_enabled_hog_functions_using_integration
 from products.workflows.backend.services.integration_usage import get_active_hog_flows_using_integration
@@ -298,6 +299,25 @@ class SlackChannelsResponseSerializer(serializers.Serializer):
     has_more = serializers.BooleanField(
         required=False,
         help_text="Whether more channels match the current search beyond this page.",
+    )
+
+
+class IntegrationAccessRequestSerializer(serializers.Serializer):
+    kind = serializers.ChoiceField(
+        choices=Integration.IntegrationKind.choices,
+        help_text="The kind of integration the member is requesting be connected (e.g. 'slack', 'github').",
+    )
+    reason = serializers.CharField(
+        max_length=2000,
+        allow_blank=False,
+        trim_whitespace=True,
+        help_text="Explanation from the requester of why this integration is needed. Shown to admins in the notification email.",
+    )
+
+
+class IntegrationAccessRequestResponseSerializer(serializers.Serializer):
+    success = serializers.BooleanField(
+        help_text="Whether the access request was accepted and the project admins were notified."
     )
 
 
@@ -649,6 +669,7 @@ class IntegrationViewSet(
         "anthropic_managed_agents",
         "anthropic_managed_agent_environments",
         "anthropic_managed_agent_vaults",
+        "request_access",
     ]
     scope_object_write_actions = [
         "create",
@@ -674,6 +695,14 @@ class IntegrationViewSet(
                 AccessControlPermission(),
                 TeamMemberAccessPermission(),
                 TeamMemberLightManagementPermission(),
+            ]
+        # Any project member may ask an admin to connect an integration — connecting still requires admin.
+        if self.action == "request_access":
+            return [
+                IsAuthenticated(),
+                APIScopePermission(),
+                AccessControlPermission(),
+                TeamMemberAccessPermission(),
             ]
         raise NotImplementedError()
 
@@ -1197,6 +1226,23 @@ class IntegrationViewSet(
             else None,
         )
         return Response({"oauth_url": oauth_url})
+
+    @extend_schema(
+        request=IntegrationAccessRequestSerializer,
+        responses={200: IntegrationAccessRequestResponseSerializer},
+    )
+    @action(methods=["POST"], detail=False, url_path="request_access")
+    def request_access(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Notify project admins that a member is requesting an integration be connected."""
+        serializer = IntegrationAccessRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        send_integration_access_request.delay(
+            team_id=self.team_id,
+            requesting_user_id=cast(User, request.user).id,
+            kind=serializer.validated_data["kind"],
+            reason=serializer.validated_data["reason"],
+        )
+        return Response({"success": True})
 
     @extend_schema(request=None, responses={200: GitHubReposRefreshResponseSerializer})
     @action(methods=["POST"], detail=True, url_path="github_repos/refresh")

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -669,7 +669,6 @@ class IntegrationViewSet(
         "anthropic_managed_agents",
         "anthropic_managed_agent_environments",
         "anthropic_managed_agent_vaults",
-        "request_access",
     ]
     scope_object_write_actions = [
         "create",
@@ -680,6 +679,8 @@ class IntegrationViewSet(
         "refresh_github_repos",
         "github_link_existing",
         "github_oauth_authorize",
+        # Side-effecting POST (emails admins) — a read-only token must not be able to trigger it.
+        "request_access",
     ]
     permission_classes = [TeamMemberStrictManagementPermission]
     queryset = defer_repository_cache_fields(Integration.objects.all())

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -14,7 +14,7 @@ import structlog
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import mixins, serializers, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -31,7 +31,7 @@ from posthog.auth import SessionAuthentication
 from posthog.domain_connect import discover_domain_connect, extract_root_domain_and_host, get_available_providers
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.fuzzy_search import fuzzy_filter
-from posthog.models import User
+from posthog.models import OrganizationMembership, User
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.integration import (
     ANTHROPIC_DEFAULT_INTEGRATION_ID_PREFIX,
@@ -1235,6 +1235,11 @@ class IntegrationViewSet(
     @action(methods=["POST"], detail=False, url_path="request_access")
     def request_access(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Notify project admins that a member is requesting an integration be connected."""
+        # Members only — admins can connect integrations themselves, so there's nobody to ask.
+        requesting_level = self.user_permissions.current_team.effective_membership_level
+        if requesting_level is None or requesting_level >= OrganizationMembership.Level.ADMIN:
+            raise PermissionDenied("Only members can request access; admins can connect integrations directly.")
+
         serializer = IntegrationAccessRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         send_integration_access_request.delay(

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3666,14 +3666,17 @@ class TestIntegrationDeletionHogFunctionGuard:
 
 
 class TestIntegrationRequestAccessAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # The endpoint is members-only, so default the requester to a plain member.
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
     def _url(self) -> str:
         return f"/api/projects/{self.team.id}/integrations/request_access/"
 
     @patch("posthog.api.integration.send_integration_access_request")
     def test_member_can_request_access(self, mock_task):
-        self.organization_membership.level = OrganizationMembership.Level.MEMBER
-        self.organization_membership.save()
-
         response = self.client.post(self._url(), {"kind": "slack", "reason": "We need Slack alerts"}, format="json")
 
         assert response.status_code == status.HTTP_200_OK, response.content
@@ -3685,17 +3688,23 @@ class TestIntegrationRequestAccessAPI(APIBaseTest):
             reason="We need Slack alerts",
         )
 
+    @parameterized.expand(
+        [
+            ("admin", OrganizationMembership.Level.ADMIN),
+            ("owner", OrganizationMembership.Level.OWNER),
+        ]
+    )
     @patch("posthog.api.integration.send_integration_access_request")
-    def test_admin_can_request_access(self, mock_task):
-        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+    def test_admins_cannot_request_access(self, _name, level, mock_task):
+        self.organization_membership.level = level
         self.organization_membership.save()
 
         response = self.client.post(
             self._url(), {"kind": "github", "reason": "Link issues from error tracking"}, format="json"
         )
 
-        assert response.status_code == status.HTTP_200_OK, response.content
-        mock_task.delay.assert_called_once()
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+        mock_task.delay.assert_not_called()
 
     @parameterized.expand(
         [

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from urllib.parse import quote
 
 import pytest
+from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings as django_settings
@@ -3662,3 +3663,51 @@ class TestIntegrationDeletionHogFunctionGuard:
         assert "Slack flow" in content
         assert "Slack notifier" in content
         assert Integration.objects.filter(id=self.integration.id).exists()
+
+
+class TestIntegrationRequestAccessAPI(APIBaseTest):
+    def _url(self) -> str:
+        return f"/api/projects/{self.team.id}/integrations/request_access/"
+
+    @patch("posthog.api.integration.send_integration_access_request")
+    def test_member_can_request_access(self, mock_task):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.post(self._url(), {"kind": "slack", "reason": "We need Slack alerts"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json() == {"success": True}
+        mock_task.delay.assert_called_once_with(
+            team_id=self.team.id,
+            requesting_user_id=self.user.id,
+            kind="slack",
+            reason="We need Slack alerts",
+        )
+
+    @patch("posthog.api.integration.send_integration_access_request")
+    def test_admin_can_request_access(self, mock_task):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        response = self.client.post(
+            self._url(), {"kind": "github", "reason": "Link issues from error tracking"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        mock_task.delay.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("missing_reason", {"kind": "slack"}),
+            ("blank_reason", {"kind": "slack", "reason": "   "}),
+            ("missing_kind", {"reason": "We need it"}),
+            ("invalid_kind", {"kind": "not-a-real-kind", "reason": "We need it"}),
+        ]
+    )
+    @patch("posthog.api.integration.send_integration_access_request")
+    def test_invalid_payload_is_rejected(self, _name, payload, mock_task):
+        response = self.client.post(self._url(), payload, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        mock_task.delay.assert_not_called()

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -122,6 +122,7 @@ CUSTOMER_IO_TEMPLATE_ID_MAP = {
     "delegation_invite": "66",
     "provisioning_welcome": "67",
     "baa_signed_ai_disabled": "68",
+    "integration_access_requested": "70",
 }
 
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1980,3 +1980,80 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
         f"Sent Error Tracking weekly digest to {sent_count} members for org {org_id} "
         f"({len(team_digest_data)} teams with exceptions)"
     )
+
+
+def get_integration_display_name(kind: str) -> str:
+    # Only kinds whose correct casing differs from the title-cased fallback need an override.
+    custom_casing = {"github": "GitHub", "gitlab": "GitLab"}
+    return custom_casing.get(kind, kind.replace("-", " ").title())
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
+@skip_team_scope_audit
+def send_integration_access_request(team_id: int, requesting_user_id: int, kind: str, reason: str) -> None:
+    """Notify project admins that a member is requesting an integration be connected."""
+    team = Team.objects.select_related("organization").filter(id=team_id).first()
+    requester = User.objects.filter(id=requesting_user_id).first()
+    if team is None or requester is None:
+        return
+
+    log_context = {"team_id": team_id, "kind": kind, "requesting_user_id": requesting_user_id}
+    requester_name = sanitize_display_name(
+        requester.first_name,
+        fallback="A teammate",
+        context={"task": "send_integration_access_request", "field": "requester_first_name", **log_context},
+    )
+    org_name = sanitize_display_name(
+        team.organization.name,
+        fallback="your organization",
+        context={"task": "send_integration_access_request", "field": "organization_name", **log_context},
+    )
+    sanitized_reason = sanitize_message_body(
+        reason,
+        fallback="",
+        context={"task": "send_integration_access_request", "field": "reason", **log_context},
+    )
+    integration_name = get_integration_display_name(kind)
+
+    # Deterministic per requester + integration so re-clicking doesn't spam admins (MessagingRecord dedups).
+    campaign_key = f"integration_access_request_{team_id}_{kind}_{requesting_user_id}"
+    subject = f"{requester_name} requested the {integration_name} integration on PostHog"
+
+    # Admins who actually have access to the affected project.
+    memberships = (
+        OrganizationMembership.objects.select_related("user", "organization")
+        .filter(organization_id=team.organization_id, level__gte=OrganizationMembership.Level.ADMIN)
+        .exclude(user_id=requesting_user_id)
+    )
+    recipients = [
+        membership.user
+        for membership in memberships
+        if membership.user.email
+        and UserPermissions(membership.user)
+        .team(team)
+        .effective_membership_level_for_parent_membership(membership.organization, membership)
+        is not None
+    ]
+    if not recipients:
+        return
+
+    message = EmailMessage(
+        use_http=True,
+        campaign_key=campaign_key,
+        subject=subject,
+        template_name="integration_access_requested",
+        template_context={
+            "requester_name": requester_name,
+            "requester_email": requester.email or "",
+            "integration_name": integration_name,
+            "integration_kind": kind,
+            "reason": sanitized_reason,
+            "org_name": org_name,
+            "team_name": team.name,
+            "connect_url": f"{settings.SITE_URL}/project/{team_id}/integrations/{kind}",
+        },
+        reply_to=requester.email or "",
+    )
+    for user in recipients:
+        message.add_user_recipient(user)
+    message.send()

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -2019,21 +2019,13 @@ def send_integration_access_request(team_id: int, requesting_user_id: int, kind:
     campaign_key = f"integration_access_request_{team_id}_{kind}_{requesting_user_id}"
     subject = f"{requester_name} requested the {integration_name} integration on PostHog"
 
-    # Admins who actually have access to the affected project.
+    # Org admins/owners always have access to every project, so the org-level filter is the access check.
     memberships = (
-        OrganizationMembership.objects.select_related("user", "organization")
+        OrganizationMembership.objects.select_related("user")
         .filter(organization_id=team.organization_id, level__gte=OrganizationMembership.Level.ADMIN)
         .exclude(user_id=requesting_user_id)
     )
-    recipients = [
-        membership.user
-        for membership in memberships
-        if membership.user.email
-        and UserPermissions(membership.user)
-        .team(team)
-        .effective_membership_level_for_parent_membership(membership.organization, membership)
-        is not None
-    ]
+    recipients = [membership.user for membership in memberships if membership.user.email]
     if not recipients:
         return
 

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -37,6 +37,7 @@
     'posthog.tasks.email.send_hog_function_disabled',
     'posthog.tasks.email.send_hog_functions_daily_digest',
     'posthog.tasks.email.send_hog_functions_digest_email',
+    'posthog.tasks.email.send_integration_access_request',
     'posthog.tasks.email.send_invite',
     'posthog.tasks.email.send_matview_failure_digest',
     'posthog.tasks.email.send_member_join',

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,0 +1,26 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
+{% block section %}
+<!-- prettier-ignore -->
+<p>
+    <strong>{{ requester_name }}</strong> (<a href="mailto:{{ requester_email }}">{{ requester_email }}</a>) wants the
+    <strong>{{ integration_name }}</strong> integration connected for <strong>{{ team_name }}</strong>. Connecting
+    integrations requires admin access, so they're asking you to set it up.
+</p>
+{% if reason %}
+<div class="invite-message">
+    <div class="invite-message-divider"></div>
+    <p><strong>Why they need it</strong></p>
+    <p>{{ reason }}</p>
+</div>
+{% endif %}
+<div class="mb mt text-center">
+    <a class="button primary" href="{{ connect_url }}">Connect {{ integration_name }}</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{{ connect_url }}">{{ connect_url }}</a>
+    </p>
+</div>
+{% endblock %}

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -336,6 +336,59 @@ export interface GitHubTeamsResponseApi {
     has_more: boolean
 }
 
+export interface IntegrationAccessRequestApi {
+    /** The kind of integration the member is requesting be connected (e.g. 'slack', 'github').
+     *
+     * * `anthropic` - Anthropic
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-analytics` - Google Analytics
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel */
+    kind: IntegrationKindEnumApi
+    /**
+     * Explanation from the requester of why this integration is needed. Shown to admins in the notification email.
+     * @maxLength 2000
+     */
+    reason: string
+}
+
+export interface IntegrationAccessRequestResponseApi {
+    /** Whether the access request was accepted and the project admins were notified. */
+    success: boolean
+}
+
 export type RoleExternalReferencesListParams = {
     /**
      * Number of results to return per page.

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -13,6 +13,8 @@ import type {
     GitHubReposRefreshResponseApi,
     GitHubReposResponseApi,
     GitHubTeamsResponseApi,
+    IntegrationAccessRequestApi,
+    IntegrationAccessRequestResponseApi,
     IntegrationConfigApi,
     IntegrationsChannelsRetrieveParams,
     IntegrationsGithubBranchesRetrieveParams,
@@ -698,5 +700,25 @@ export const integrationsGithubOauthAuthorizeCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(integrationConfigApi),
+    })
+}
+
+export const getIntegrationsRequestAccessCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/integrations/request_access/`
+}
+
+/**
+ * Notify project admins that a member is requesting an integration be connected.
+ */
+export const integrationsRequestAccessCreate = async (
+    projectId: string,
+    integrationAccessRequestApi: IntegrationAccessRequestApi,
+    options?: RequestInit
+): Promise<IntegrationAccessRequestResponseApi> => {
+    return apiMutator<IntegrationAccessRequestResponseApi>(getIntegrationsRequestAccessCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(integrationAccessRequestApi),
     })
 }

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -365,3 +365,63 @@ export const IntegrationsGithubOauthAuthorizeCreateBody = /* @__PURE__ */ zod
         config: zod.unknown().optional(),
     })
     .describe('Standard Integration serializer.')
+
+/**
+ * Notify project admins that a member is requesting an integration be connected.
+ */
+export const integrationsRequestAccessCreateBodyReasonMax = 2000
+
+export const IntegrationsRequestAccessCreateBody = /* @__PURE__ */ zod.object({
+    kind: zod
+        .enum([
+            'anthropic',
+            'apns',
+            'azure-blob',
+            'bing-ads',
+            'clickup',
+            'customerio-app',
+            'customerio-track',
+            'customerio-webhook',
+            'databricks',
+            'email',
+            'firebase',
+            'github',
+            'gitlab',
+            'google-ads',
+            'google-analytics',
+            'google-cloud-service-account',
+            'google-cloud-storage',
+            'google-pubsub',
+            'google-search-console',
+            'google-sheets',
+            'hubspot',
+            'intercom',
+            'jira',
+            'linear',
+            'linkedin-ads',
+            'meta-ads',
+            'pinterest-ads',
+            'postgresql',
+            'reddit-ads',
+            'salesforce',
+            'slack',
+            'slack-posthog-code',
+            'snapchat',
+            'stripe',
+            'tiktok-ads',
+            'twilio',
+            'vercel',
+        ])
+        .describe(
+            '\* `anthropic` - Anthropic\n\* `apns` - Apple Push\n\* `azure-blob` - Azure Blob\n\* `bing-ads` - Bing Ads\n\* `clickup` - Clickup\n\* `customerio-app` - Customerio App\n\* `customerio-track` - Customerio Track\n\* `customerio-webhook` - Customerio Webhook\n\* `databricks` - Databricks\n\* `email` - Email\n\* `firebase` - Firebase\n\* `github` - Github\n\* `gitlab` - Gitlab\n\* `google-ads` - Google Ads\n\* `google-analytics` - Google Analytics\n\* `google-cloud-service-account` - Google Cloud Service Account\n\* `google-cloud-storage` - Google Cloud Storage\n\* `google-pubsub` - Google Pubsub\n\* `google-search-console` - Google Search Console\n\* `google-sheets` - Google Sheets\n\* `hubspot` - Hubspot\n\* `intercom` - Intercom\n\* `jira` - Jira\n\* `linear` - Linear\n\* `linkedin-ads` - Linkedin Ads\n\* `meta-ads` - Meta Ads\n\* `pinterest-ads` - Pinterest Ads\n\* `postgresql` - Postgresql\n\* `reddit-ads` - Reddit Ads\n\* `salesforce` - Salesforce\n\* `slack` - Slack\n\* `slack-posthog-code` - Slack Posthog Code\n\* `snapchat` - Snapchat\n\* `stripe` - Stripe\n\* `tiktok-ads` - Tiktok Ads\n\* `twilio` - Twilio\n\* `vercel` - Vercel'
+        )
+        .describe(
+            "The kind of integration the member is requesting be connected (e.g. 'slack', 'github').\n\n\* `anthropic` - Anthropic\n\* `apns` - Apple Push\n\* `azure-blob` - Azure Blob\n\* `bing-ads` - Bing Ads\n\* `clickup` - Clickup\n\* `customerio-app` - Customerio App\n\* `customerio-track` - Customerio Track\n\* `customerio-webhook` - Customerio Webhook\n\* `databricks` - Databricks\n\* `email` - Email\n\* `firebase` - Firebase\n\* `github` - Github\n\* `gitlab` - Gitlab\n\* `google-ads` - Google Ads\n\* `google-analytics` - Google Analytics\n\* `google-cloud-service-account` - Google Cloud Service Account\n\* `google-cloud-storage` - Google Cloud Storage\n\* `google-pubsub` - Google Pubsub\n\* `google-search-console` - Google Search Console\n\* `google-sheets` - Google Sheets\n\* `hubspot` - Hubspot\n\* `intercom` - Intercom\n\* `jira` - Jira\n\* `linear` - Linear\n\* `linkedin-ads` - Linkedin Ads\n\* `meta-ads` - Meta Ads\n\* `pinterest-ads` - Pinterest Ads\n\* `postgresql` - Postgresql\n\* `reddit-ads` - Reddit Ads\n\* `salesforce` - Salesforce\n\* `slack` - Slack\n\* `slack-posthog-code` - Slack Posthog Code\n\* `snapchat` - Snapchat\n\* `stripe` - Stripe\n\* `tiktok-ads` - Tiktok Ads\n\* `twilio` - Twilio\n\* `vercel` - Vercel"
+        ),
+    reason: zod
+        .string()
+        .max(integrationsRequestAccessCreateBodyReasonMax)
+        .describe(
+            'Explanation from the requester of why this integration is needed. Shown to admins in the notification email.'
+        ),
+})

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -159,6 +159,9 @@ tools:
                 - display_name
                 - created_at
                 - created_by
+    integrations-request-access-create:
+        operation: integrations_request_access_create
+        enabled: false
     integrations-twilio-phone-numbers-retrieve:
         operation: integrations_twilio_phone_numbers_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26047,6 +26047,59 @@ export namespace Schemas {
       Vercel: 'vercel',
     } as const;
 
+    export interface IntegrationAccessRequest {
+      /** The kind of integration the member is requesting be connected (e.g. 'slack', 'github').
+       *
+       * * `anthropic` - Anthropic
+       * * `apns` - Apple Push
+       * * `azure-blob` - Azure Blob
+       * * `bing-ads` - Bing Ads
+       * * `clickup` - Clickup
+       * * `customerio-app` - Customerio App
+       * * `customerio-track` - Customerio Track
+       * * `customerio-webhook` - Customerio Webhook
+       * * `databricks` - Databricks
+       * * `email` - Email
+       * * `firebase` - Firebase
+       * * `github` - Github
+       * * `gitlab` - Gitlab
+       * * `google-ads` - Google Ads
+       * * `google-analytics` - Google Analytics
+       * * `google-cloud-service-account` - Google Cloud Service Account
+       * * `google-cloud-storage` - Google Cloud Storage
+       * * `google-pubsub` - Google Pubsub
+       * * `google-search-console` - Google Search Console
+       * * `google-sheets` - Google Sheets
+       * * `hubspot` - Hubspot
+       * * `intercom` - Intercom
+       * * `jira` - Jira
+       * * `linear` - Linear
+       * * `linkedin-ads` - Linkedin Ads
+       * * `meta-ads` - Meta Ads
+       * * `pinterest-ads` - Pinterest Ads
+       * * `postgresql` - Postgresql
+       * * `reddit-ads` - Reddit Ads
+       * * `salesforce` - Salesforce
+       * * `slack` - Slack
+       * * `slack-posthog-code` - Slack Posthog Code
+       * * `snapchat` - Snapchat
+       * * `stripe` - Stripe
+       * * `tiktok-ads` - Tiktok Ads
+       * * `twilio` - Twilio
+       * * `vercel` - Vercel */
+      kind: IntegrationKindEnum;
+      /**
+         * Explanation from the requester of why this integration is needed. Shown to admins in the notification email.
+         * @maxLength 2000
+         */
+      reason: string;
+    }
+
+    export interface IntegrationAccessRequestResponse {
+      /** Whether the access request was accepted and the project admins were notified. */
+      success: boolean;
+    }
+
     /**
      * Standard Integration serializer.
      */


### PR DESCRIPTION
Non-admin project members can now request that an admin connect an integration on their behalf, rather than hitting a dead end when they lack the required permissions.

**What's new:**

- When a user without project admin access visits an integration's connection page, the connect button is replaced by a "Request Access" form. They can write a short note explaining why the integration is needed and submit it.
- Submitting the form calls a new `POST /api/projects/{id}/integrations/request_access/` endpoint, which is open to any project member. The backend validates the request and dispatches an async task.
- The task identifies all project admins (org-level admin or above who have access to the team), then sends each of them an email via the `integration_access_requested` Customer.io template. The email includes the requester's name, email, the integration they want, their reason, and a direct link to the integration's connect page.
- The campaign key is deterministic per requester + integration + team, so repeated submissions don't spam admins.
- After a successful request, the form is replaced with a confirmation banner. The `requestedAccessKinds` reducer tracks which integrations have already been requested in the current session to prevent duplicate submissions.
- A `NoPermission` Storybook story has been added to demonstrate the request-access flow for non-admin users.

![image.png](https://app.graphite.com/user-attachments/assets/5d1e741e-e28a-4e4f-9b92-eb484691d7a8.png)

![image.png](https://app.graphite.com/user-attachments/assets/d939fd08-ecc1-4652-8340-b7adc3cb2345.png)

