### PR TITLE
feat(tasks): add non-agent command cloud run workflow

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2721,7 +2721,9 @@ class GitHubIntegration(GitHubIntegrationBase):
         if payload.get("errors"):
             return {"success": False, "error": f"Failed to create signed commit: {payload['errors']}"}
 
-        commit = payload["data"]["createCommitOnBranch"]["commit"]
+        commit = ((payload.get("data") or {}).get("createCommitOnBranch") or {}).get("commit") or {}
+        if "oid" not in commit or "url" not in commit:
+            return {"success": False, "error": "Unexpected response structure from GitHub GraphQL API"}
         return {"success": True, "commit_sha": commit["oid"], "commit_url": commit["url"]}
 
     def get_branch_info(self, repository: str, branch_name: str) -> dict[str, Any]:

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2662,6 +2662,68 @@ class GitHubIntegration(GitHubIntegrationBase):
                 "status_code": response.status_code,
             }
 
+    def create_signed_commit(
+        self,
+        repository: str,
+        branch: str,
+        expected_head_oid: str,
+        headline: str,
+        additions: list[tuple[str, str]],
+        deletions: list[str],
+        body: str = "",
+    ) -> dict[str, Any]:
+        """Create a single commit on an existing branch via the GraphQL createCommitOnBranch mutation.
+
+        Commits created this way are signed/verified by GitHub (the app installation is the committer),
+        so they pass branch protections that require signed commits. `additions` is a list of
+        (path, base64-encoded contents) pairs; `deletions` is a list of paths. `expected_head_oid` must
+        be the branch's current tip (the base SHA returned by `create_branch`).
+        """
+        org = self.organization()
+        access_token = self.integration.sensitive_config["access_token"]
+
+        query = (
+            "mutation($input: CreateCommitOnBranchInput!) {"
+            "  createCommitOnBranch(input: $input) { commit { oid url } }"
+            "}"
+        )
+        variables = {
+            "input": {
+                "branch": {"repositoryNameWithOwner": f"{org}/{repository}", "branchName": branch},
+                "message": {"headline": headline, "body": body},
+                "expectedHeadOid": expected_head_oid,
+                "fileChanges": {
+                    "additions": [{"path": path, "contents": contents} for path, contents in additions],
+                    "deletions": [{"path": path} for path in deletions],
+                },
+            }
+        }
+
+        response = self._github_api_post(
+            "https://api.github.com/graphql",
+            endpoint="/graphql",
+            json_body={"query": query, "variables": variables},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {access_token}",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            },
+        )
+
+        if response.status_code != 200:
+            return {
+                "success": False,
+                "error": f"Failed to create signed commit: {response.text}",
+                "status_code": response.status_code,
+            }
+
+        payload = response.json()
+        if payload.get("errors"):
+            return {"success": False, "error": f"Failed to create signed commit: {payload['errors']}"}
+
+        commit = payload["data"]["createCommitOnBranch"]["commit"]
+        return {"success": True, "commit_sha": commit["oid"], "commit_url": commit["url"]}
+
     def get_branch_info(self, repository: str, branch_name: str) -> dict[str, Any]:
         """Get information about a specific branch."""
         org = self.organization()

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -143,11 +143,13 @@ from .stream.redis_stream import (
     get_task_run_stream_key,
 )
 from .temporal.client import (
+    execute_command_run_workflow,
     execute_posthog_code_agent_relay_workflow,
     execute_task_processing_workflow,
     resume_task_in_cloud_workflow,
     signal_task_followup_message,
 )
+from .temporal.command_run.constants import DEFAULT_COMMAND_RUN_KIND
 from .temporal.process_task.utils import (
     GitHubCredentialSource,
     PrAuthorshipMode,
@@ -156,6 +158,7 @@ from .temporal.process_task.utils import (
     get_pr_authorship_mode,
     get_provider_for_runtime_adapter,
     get_reasoning_effort_error,
+    normalize_repository,
     parse_run_state,
     resolve_user_github_integration_for_task,
     user_github_integration_is_usable,
@@ -752,8 +755,47 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         logger.info(f"Soft deleting task {task.id}")
         task.soft_delete()
 
+    def _validate_command_run_prerequisites(self, task: Task) -> Response | None:
+        """A command cloud run opens its PR via the GitHub API, so the task must have a
+        connected GitHub integration and a valid 'org/repo' repository. Validate up front
+        so a misconfigured task fails with a 400 instead of provisioning a sandbox and
+        failing mid-run."""
+        if not task.github_integration_id:
+            return Response(
+                {
+                    "type": "validation_error",
+                    "code": "invalid_input",
+                    "detail": "A command cloud run requires the task to have a connected GitHub integration.",
+                    "attr": "command",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if normalize_repository(task.repository) is None:
+            return Response(
+                {
+                    "type": "validation_error",
+                    "code": "invalid_input",
+                    "detail": "A command cloud run requires the task to have a valid 'org/repo' repository.",
+                    "attr": "command",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return None
+
     def _trigger_workflow(self, task: Task, task_run: TaskRun) -> None:
         try:
+            command_run_kind = (task_run.state or {}).get("command_run_kind")
+            if command_run_kind is not None:
+                logger.info(f"Attempting to trigger command cloud run for task {task.id}, run {task_run.id}")
+                execute_command_run_workflow(
+                    task_id=str(task.id),
+                    run_id=str(task_run.id),
+                    team_id=task.team.id,
+                    command_run_kind=command_run_kind,
+                )
+                logger.info(f"Command run trigger completed for task {task.id}, run {task_run.id}")
+                return
+
             logger.info(f"Attempting to trigger task processing workflow for task {task.id}, run {task_run.id}")
             execute_task_processing_workflow(
                 task_id=str(task.id),
@@ -961,6 +1003,13 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         reasoning_effort = request.validated_data.get("reasoning_effort")
         github_user_token = request.validated_data.get("github_user_token")
         initial_permission_mode = request.validated_data.get("initial_permission_mode")
+        command = request.validated_data.get("command")
+        command_run_kind = request.validated_data.get("command_run_kind")
+        if (command is not None or command_run_kind is not None) and run_source is None:
+            run_source = RunSource.CLOUD_RUN
+        if run_source == RunSource.CLOUD_RUN:
+            if (validation_error := self._validate_command_run_prerequisites(task)) is not None:
+                return validation_error
         if run_source == RunSource.SIGNAL_REPORT:
             pr_authorship_mode = PrAuthorshipMode.BOT
 
@@ -1096,6 +1145,18 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+        if run_source == RunSource.CLOUD_RUN:
+            extra_state = extra_state or {}
+            extra_state["command_run_kind"] = command_run_kind or DEFAULT_COMMAND_RUN_KIND
+            for key, value in {
+                "command": command,
+                "pr_title": request.validated_data.get("pr_title"),
+                "pr_body": request.validated_data.get("pr_body"),
+                "base_branch": request.validated_data.get("base_branch"),
+            }.items():
+                if value is not None:
+                    extra_state[key] = value
 
         logger.info(f"Creating task run for task {task.id} with mode={mode}, branch={branch}")
 

--- a/products/tasks/backend/management/commands/run_command_cloud_run.py
+++ b/products/tasks/backend/management/commands/run_command_cloud_run.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.models import Integration, Team, User
+from posthog.models.integration import GitHubIntegration
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
+from products.tasks.backend.temporal.command_run import constants
+from products.tasks.backend.temporal.command_run.activities import open_signed_pr
+from products.tasks.backend.temporal.process_task.utils import RunSource
+
+
+class Command(BaseCommand):
+    help = (
+        "Run a non-agent command cloud run end-to-end against a real repo using the local sandbox, "
+        "bypassing Temporal. Provisions a sandbox, clones the repo, runs the command, then opens a PR "
+        "backed by a GitHub-signed commit and prints the PR URL. DEBUG only."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", type=int, required=True, help="Team ID")
+        parser.add_argument("--user-id", type=int, help="User ID (defaults to the first team member)")
+        parser.add_argument("--repository", default="posthog/hedgebox", help="GitHub repository (owner/repo)")
+        parser.add_argument(
+            "--kind",
+            default=constants.DEFAULT_COMMAND_RUN_KIND,
+            choices=list(constants.COMMAND_RUN_WORKFLOWS.keys()),
+            help="Which command cloud run to mimic. Named kinds run a canned command.",
+        )
+        parser.add_argument("--command", help="Command to run (for the generic 'command' kind)")
+        parser.add_argument("--pr-title", help="Pull request title (generic kind)")
+        parser.add_argument("--pr-body", default="", help="Pull request body (generic kind)")
+        parser.add_argument("--base-branch", help="Base branch for the PR (defaults to repo default)")
+        parser.add_argument("--github-token", help="GitHub token (falls back to the team integration)")
+        parser.add_argument("--no-cleanup", action="store_true", help="Don't soft-delete the test task afterwards")
+        parser.add_argument("--keep-sandbox", action="store_true", help="Don't destroy the sandbox afterwards")
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError("run_command_cloud_run only runs with DEBUG=1")
+
+        team = Team.objects.filter(id=options["team_id"]).first()
+        if team is None:
+            raise CommandError(f"Team {options['team_id']} not found")
+
+        user = self._resolve_user(team, options.get("user_id"))
+        repository = options["repository"]
+        org, _, repo = repository.partition("/")
+        if not org or not repo:
+            raise CommandError("Repository must be in 'owner/repo' format")
+
+        kind = options["kind"]
+        if kind == constants.DEFAULT_COMMAND_RUN_KIND:
+            command = options.get("command") or constants.APPEND_README_COMMAND
+            pr_title = options.get("pr_title") or "Automated change"
+            pr_body = options.get("pr_body") or ""
+        else:
+            # Named leaf: mirror the hardcoded hooks (currently only append_readme).
+            command = constants.APPEND_README_COMMAND
+            pr_title = constants.APPEND_README_PR_TITLE
+            pr_body = constants.APPEND_README_PR_BODY
+
+        github_integration = self._resolve_github_integration(team, org)
+        github_token = options.get("github_token") or (github_integration.sensitive_config or {}).get("access_token")
+
+        task = Task.objects.create(
+            team=team,
+            created_by=user,
+            title=f"Command cloud run: {kind}",
+            description=command,
+            origin_product=Task.OriginProduct.USER_CREATED,
+            github_integration=github_integration,
+            repository=repository,
+        )
+        task_run = task.create_run(
+            extra_state={
+                "run_source": RunSource.CLOUD_RUN.value,
+                "command_run_kind": kind,
+                "command": command,
+                "pr_title": pr_title,
+                "pr_body": pr_body,
+                "base_branch": options.get("base_branch"),
+            }
+        )
+        branch = f"cloud-run/{task_run.id}"
+        self.stdout.write(f"Created task {task.id}, run {task_run.id} (kind={kind}, repo={repository})")
+
+        sandbox = None
+        try:
+            # Deliberately mirrors BaseCloudRunWorkflow's lifecycle (provision → clone → run → open PR)
+            # inline so it runs without a Temporal worker. Keep in sync with command_run/workflow.py.
+            sandbox = Sandbox.create(
+                SandboxConfig(
+                    name=f"command-run-{task_run.id}",
+                    template=SandboxTemplate.DEFAULT_BASE,
+                    environment_variables={"GITHUB_TOKEN": github_token or "", "GH_TOKEN": github_token or ""},
+                )
+            )
+            self.stdout.write(f"Sandbox created: {sandbox.id}")
+
+            clone_result = sandbox.clone_repository(repository, github_token=github_token or "")
+            if clone_result.exit_code != 0:
+                raise CommandError(f"Failed to clone {repository}: {clone_result.stderr[:500]}")
+
+            full_command = f"cd /tmp/workspace/repos/{org.lower()}/{repo.lower()} && {command}"
+            self.stdout.write(f"Running command: {command}")
+            stream = sandbox.execute_stream(full_command, timeout_seconds=30 * 60)
+            for line in stream.iter_stdout():
+                self.stdout.write(f"  | {line.rstrip()}")
+            result = stream.wait()
+            if result.exit_code != 0:
+                raise CommandError(f"Command exited with status {result.exit_code}")
+
+            github = GitHubIntegration(github_integration)
+            if github.access_token_expired():
+                github.refresh_access_token()
+            pr = open_signed_pr(
+                sandbox,
+                github,
+                repository=repository,
+                branch=branch,
+                base_branch=options.get("base_branch"),
+                commit_headline=pr_title,
+                pr_title=pr_title,
+                pr_body=pr_body,
+            )
+
+            task_run.status = TaskRun.Status.COMPLETED
+            task_run.save(update_fields=["status", "updated_at"])
+
+            if not pr.created_pr:
+                self.stdout.write(self.style.WARNING("Command left the repo clean — no PR opened"))
+                return
+
+            output = TaskRun.update_output_atomic(task_run.id, {"pr_url": pr.pr_url, "commit_sha": pr.commit_sha})
+            self.stdout.write(self.style.SUCCESS(f"Opened PR: {pr.pr_url}"))
+            self.stdout.write(f"Run output: {json.dumps(output)}")
+        finally:
+            if sandbox and not options["keep_sandbox"]:
+                sandbox.destroy()
+                self.stdout.write("Sandbox destroyed")
+            elif sandbox:
+                self.stdout.write(self.style.WARNING(f"Sandbox kept alive: {sandbox.id}"))
+            if not options["no_cleanup"]:
+                task.soft_delete()
+                self.stdout.write("Test task cleaned up")
+
+    def _resolve_github_integration(self, team: Team, owner: str) -> Integration:
+        """Find a connected GitHub App installation for `owner`, or fail with a clear message.
+
+        The PR is opened via the GitHub API, which needs a real installation (account name +
+        access token) — not a placeholder row — so we validate up front rather than crashing
+        deep in the GitHub client.
+        """
+        integrations = Integration.objects.filter(team=team, kind="github")
+        if not integrations:
+            raise CommandError(
+                "This team has no connected GitHub integration. Connect the GitHub App from "
+                "Settings → Linked accounts (with access to the target repo) before running a command cloud run."
+            )
+        for integration in integrations:
+            account_name = (integration.config or {}).get("account", {}).get("name")
+            access_token = (integration.sensitive_config or {}).get("access_token")
+            if isinstance(account_name, str) and account_name and access_token:
+                if account_name.lower() == owner.lower():
+                    return integration
+        raise CommandError(
+            f"No connected GitHub App installation for '{owner}' was found for this team. "
+            "Connect the GitHub App for that org from Settings → Linked accounts, or pass a "
+            "--repository owned by an already-connected installation."
+        )
+
+    def _resolve_user(self, team: Team, user_id: int | None) -> User:
+        if user_id is not None:
+            user = User.objects.filter(id=user_id).first()
+            if user is None:
+                raise CommandError(f"User {user_id} not found")
+            return user
+        user = User.objects.filter(organization_membership__organization=team.organization).first()
+        if user is None:
+            raise CommandError(f"No user found for team {team.id}'s organization; pass --user-id")
+        return user

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -780,6 +780,25 @@ class TaskRun(models.Model):
 
         return cls.mutate_state_atomic(run_id, _mutator)
 
+    @classmethod
+    def update_output_atomic(
+        cls,
+        run_id: str | uuid.UUID,
+        updates: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Merge updates into the run's `output` JSON while holding a row lock.
+
+        Mirrors `mutate_state_atomic` for the `output` field so independent
+        writers (e.g. a PR-creating activity) don't clobber each other.
+        """
+        with transaction.atomic():
+            locked_task_run = cls.objects.select_for_update().get(id=run_id)
+            output = dict(locked_task_run.output or {})
+            output.update(updates)
+            locked_task_run.output = output
+            locked_task_run.save(update_fields=["output", "updated_at"])
+            return output
+
     @staticmethod
     def get_workflow_id(task_id: str | uuid.UUID, run_id: str | uuid.UUID) -> str:
         """Get the Temporal workflow ID for a task run."""

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -25,6 +25,7 @@ from .constants import (
 from .models import SandboxEnvironment, Task, TaskAutomation, TaskRun
 from .redis import get_tasks_cache
 from .services.title_generator import generate_task_title
+from .temporal.command_run.constants import COMMAND_RUN_WORKFLOWS
 from .temporal.process_task.utils import (
     PUBLIC_REASONING_EFFORTS,
     LLMProvider,
@@ -964,6 +965,7 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
     RUN_SOURCE_CHOICES = [source.value for source in RunSource]
     RUNTIME_ADAPTER_CHOICES = [adapter.value for adapter in RuntimeAdapter]
     REASONING_EFFORT_CHOICES = [effort.value for effort in PUBLIC_REASONING_EFFORTS]
+    COMMAND_RUN_KIND_CHOICES = list(COMMAND_RUN_WORKFLOWS.keys())
 
     mode = serializers.ChoiceField(
         choices=["interactive", "background"],
@@ -1057,9 +1059,63 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
             "Codex runtimes accept 'auto', 'read-only', and 'full-access'."
         ),
     )
+    command = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        help_text=(
+            "Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, "
+            "clones the repository, runs this command from the repo root, then opens a PR backed by a "
+            "GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter/model)."
+        ),
+    )
+    command_run_kind = serializers.ChoiceField(
+        choices=COMMAND_RUN_KIND_CHOICES,
+        required=False,
+        default=None,
+        help_text=(
+            "Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; "
+            "named kinds run a canned, predefined command instead (in which case `command` is ignored)."
+        ),
+    )
+    pr_title = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        max_length=255,
+        help_text="Title for the pull request opened by a command cloud run.",
+    )
+    pr_body = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=True,
+        help_text="Body for the pull request opened by a command cloud run.",
+    )
+    base_branch = serializers.CharField(
+        required=False,
+        default=None,
+        allow_null=True,
+        max_length=255,
+        help_text="Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch.",
+    )
 
     def validate(self, attrs):
         errors: dict[str, str] = {}
+
+        command = attrs.get("command")
+        command_run_kind = attrs.get("command_run_kind")
+        runtime_selection_fields = ("runtime_adapter", "model", "reasoning_effort")
+        is_command_run = command is not None or command_run_kind is not None
+        if is_command_run:
+            if any(attrs.get(field) is not None for field in runtime_selection_fields):
+                errors["command"] = "Command cloud runs cannot also select an agent runtime."
+            # A generic command run needs an explicit command; named kinds hardcode their own.
+            kind = command_run_kind or "command"
+            if kind == "command" and command is None:
+                errors["command"] = "This field is required for a generic command cloud run."
+            if errors:
+                raise serializers.ValidationError(errors)
+            return attrs
         initial_permission_mode = attrs.get("initial_permission_mode")
         runtime_adapter = attrs.get("runtime_adapter")
         if initial_permission_mode is not None:

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -11,9 +11,12 @@ This module exports:
 
 from __future__ import annotations
 
+import io
 import os
 import re
 import shlex
+import base64
+import tarfile
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -42,6 +45,14 @@ class AgentServerResult:
 
     url: str
     token: str | None = None
+
+
+@dataclass
+class WorkingTreeChanges:
+    """Staged changes collected from a sandbox repo, ready for a GitHub-API signed commit."""
+
+    additions: list[tuple[str, str]]  # (path, base64-encoded contents)
+    deletions: list[str]
 
 
 class SandboxStatus(str, Enum):
@@ -208,6 +219,47 @@ class SandboxBase(ABC):
         )
         _logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
         return self.execute(clone_command, timeout_seconds=5 * 60)
+
+    def stage_and_collect_changes(self, repository: str) -> WorkingTreeChanges:
+        """Stage all working-tree changes and return them as structured file changes.
+
+        Built only on `execute()` so both Docker and Modal sandboxes inherit it. The
+        sandbox image blocks raw `git commit`/`git push` (only signed commits may leave),
+        so instead of committing here we surface the diff for a signed commit created via
+        the GitHub API. `additions` carries (path, base64 contents); `deletions` carries paths.
+        """
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+
+        org, repo = repository.lower().split("/")
+        repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+
+        status = self.execute(
+            f"cd {shlex.quote(repo_path)} && git add -A && "
+            f"git -c core.quotepath=false diff --cached --no-renames --name-status"
+        )
+
+        added_paths: list[str] = []
+        deletions: list[str] = []
+        for line in status.stdout.splitlines():
+            code, _, path = line.partition("\t")
+            if not path:
+                continue
+            (deletions if code.startswith("D") else added_paths).append(path)
+
+        additions: list[tuple[str, str]] = []
+        if added_paths:
+            # One round-trip for all contents (vs. one per file): tar the changed paths and
+            # base64 the archive. tar handles binary and odd filenames cleanly.
+            quoted = " ".join(shlex.quote(path) for path in added_paths)
+            archive = self.execute(f"cd {shlex.quote(repo_path)} && tar -cf - -- {quoted} | base64 -w0")
+            raw = base64.b64decode(archive.stdout.strip())
+            with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
+                for path in added_paths:
+                    extracted = tar.extractfile(tar.getmember(path))
+                    contents = extracted.read() if extracted else b""
+                    additions.append((path, base64.b64encode(contents).decode("ascii")))
+        return WorkingTreeChanges(additions=additions, deletions=deletions)
 
     @abstractmethod
     def setup_repository(self, repository: str) -> ExecutionResult: ...
@@ -417,6 +469,7 @@ __all__ = [
     "ExecutionStream",
     "SANDBOX_TTL_SECONDS",
     "SandboxBase",
+    "WorkingTreeChanges",
     "WORKING_DIR",
     "parse_sandbox_repo_mount_map",
     "get_sandbox_class",

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -117,6 +117,11 @@ class SandboxConfig(BaseModel):
 
 WORKING_DIR = "/tmp/workspace"
 
+# Bounds on what a command cloud run may commit, so a runaway command can't make us
+# materialize an unbounded archive in the worker before GitHub would reject it.
+MAX_CHANGED_FILES = 5000
+MAX_CHANGE_ARCHIVE_BASE64_BYTES = 50 * 1024 * 1024  # ~37 MiB of actual content
+
 PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
 """Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
 # TODO: Remove `posthog/.github` when we switch repo discovery to repo-less agent (now it works as a lightweight dummy)
@@ -231,13 +236,15 @@ class SandboxBase(ABC):
         if not self.is_running():
             raise RuntimeError("Sandbox not in running state.")
 
-        org, repo = repository.lower().split("/")
+        org, repo = repository.lower().split("/", 1)
         repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
 
         status = self.execute(
             f"cd {shlex.quote(repo_path)} && git add -A && "
             f"git -c core.quotepath=false diff --cached --no-renames --name-status"
         )
+        if status.exit_code != 0:
+            raise RuntimeError(f"Failed to stage changes: {status.stderr[:500]}")
 
         added_paths: list[str] = []
         deletions: list[str] = []
@@ -247,14 +254,23 @@ class SandboxBase(ABC):
                 continue
             (deletions if code.startswith("D") else added_paths).append(path)
 
+        if len(added_paths) + len(deletions) > MAX_CHANGED_FILES:
+            raise RuntimeError(
+                f"Too many changed files to commit ({len(added_paths) + len(deletions)} > {MAX_CHANGED_FILES})"
+            )
+
         additions: list[tuple[str, str]] = []
         if added_paths:
             # One round-trip for all contents (vs. one per file): tar the changed paths and
             # base64 the archive. tar handles binary and odd filenames cleanly.
             quoted = " ".join(shlex.quote(path) for path in added_paths)
             archive = self.execute(f"cd {shlex.quote(repo_path)} && tar -cf - -- {quoted} | base64 -w0")
-            raw = base64.b64decode(archive.stdout.strip())
-            with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
+            if archive.exit_code != 0:
+                raise RuntimeError(f"Failed to read changed files: {archive.stderr[:500]}")
+            encoded = archive.stdout.strip()
+            if len(encoded) > MAX_CHANGE_ARCHIVE_BASE64_BYTES:
+                raise RuntimeError("Changed files exceed the size limit for a command cloud run commit")
+            with tarfile.open(fileobj=io.BytesIO(base64.b64decode(encoded)), mode="r:") as tar:
                 for path in added_paths:
                     extracted = tar.extractfile(tar.getmember(path))
                     contents = extracted.read() if extracted else b""

--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -4,6 +4,12 @@ from .code_workstreams.activities.load_pr_urls import load_team_pr_urls
 from .code_workstreams.activities.poll_pull_requests import poll_team_pull_requests
 from .code_workstreams.activities.rebuild_workstreams import rebuild_team_workstreams
 from .code_workstreams.workflow import EvaluateCodeWorkstreamsWorkflow, EvaluateTeamCodeWorkstreamsWorkflow
+from .command_run import (
+    AppendToReadmeCommandCloudRunWorkflow,
+    CommandCloudRunWorkflow,
+    commit_and_open_pr,
+    run_command_in_sandbox,
+)
 from .create_snapshot.activities import (
     cleanup_sandbox as snapshot_cleanup_sandbox,
     clone_repository as snapshot_clone_repository,
@@ -41,6 +47,8 @@ from .slack_relay import PostHogCodeAgentRelayWorkflow, relay_slack_message
 
 WORKFLOWS = [
     ProcessTaskWorkflow,
+    CommandCloudRunWorkflow,
+    AppendToReadmeCommandCloudRunWorkflow,
     CreateSnapshotForRepositoryWorkflow,
     PostHogCodeAgentRelayWorkflow,
     RunTaskAutomationWorkflow,
@@ -73,6 +81,9 @@ ACTIVITIES = [
     get_pr_context,
     relay_slack_message,
     run_task_automation_activity,
+    # command_run activities
+    run_command_in_sandbox,
+    commit_and_open_pr,
     # create_snapshot activities
     get_snapshot_context,
     snapshot_create_sandbox,

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -18,6 +18,8 @@ from posthog.temporal.oauth import PosthogMcpScopes
 from products.tasks.backend.constants import SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.metrics import observe_task_run_workflow_start
 from products.tasks.backend.models import TaskRun
+from products.tasks.backend.temporal.command_run.constants import COMMAND_RUN_WORKFLOWS, DEFAULT_COMMAND_RUN_KIND
+from products.tasks.backend.temporal.command_run.workflow import CloudRunInput
 from products.tasks.backend.temporal.process_task.workflow import ProcessTaskInput
 from products.tasks.backend.temporal.slack_relay.activities import RelaySlackMessageInput
 
@@ -291,6 +293,56 @@ def execute_task_processing_workflow(
             run_id,
             f"Failed to start task workflow: {e}",
         )
+
+
+def execute_command_run_workflow(
+    task_id: str,
+    run_id: str,
+    team_id: int,
+    command_run_kind: str = DEFAULT_COMMAND_RUN_KIND,
+) -> None:
+    """Start a non-agent command cloud run synchronously. Fire-and-forget.
+
+    Resolves the concrete workflow (e.g. the generic command runner or a named leaf)
+    from `command_run_kind` and starts it on the tasks task queue.
+    """
+    workflow_name = COMMAND_RUN_WORKFLOWS.get(command_run_kind)
+    if workflow_name is None:
+        raise ValueError(f"Unknown command_run_kind: {command_run_kind}")
+
+    task_run_for_metrics = _get_task_run_for_metrics(run_id)
+    observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
+    try:
+        Team.objects.get(id=team_id)
+        workflow_id = TaskRun.get_workflow_id(task_id, run_id)
+
+        logger.info(
+            "command_run_starting_workflow",
+            extra={"workflow_id": workflow_id, "workflow_name": workflow_name, "run_id": run_id},
+        )
+
+        client = sync_connect()
+        asyncio.run(
+            client.start_workflow(
+                workflow_name,
+                CloudRunInput(run_id=run_id),
+                id=workflow_id,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                task_queue=settings.TASKS_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+        )
+
+        logger.info("command_run_workflow_started", extra={"task_id": task_id, "run_id": run_id})
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="started", reason="accepted")
+    except Team.DoesNotExist as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="permission_validation")
+        logger.exception("command_run_permission_validation_failed", extra={"run_id": run_id, "error": str(e)})
+        _terminalize_unstarted_task_run(run_id, f"Failed to start command run workflow: permission validation: {e}")
+    except Exception as e:
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="failed", reason="temporal_start")
+        logger.exception("command_run_workflow_start_failed", extra={"run_id": run_id, "error": str(e)})
+        _terminalize_unstarted_task_run(run_id, f"Failed to start command run workflow: {e}")
 
 
 def resume_task_in_cloud_workflow(run_id: str, workflow_id: str) -> None:

--- a/products/tasks/backend/temporal/command_run/__init__.py
+++ b/products/tasks/backend/temporal/command_run/__init__.py
@@ -1,0 +1,21 @@
+from .activities import commit_and_open_pr, run_command_in_sandbox
+from .constants import COMMAND_RUN_WORKFLOWS, DEFAULT_COMMAND_RUN_KIND
+from .workflow import (
+    AppendToReadmeCommandCloudRunWorkflow,
+    BaseCloudRunWorkflow,
+    CloudRunInput,
+    CloudRunOutput,
+    CommandCloudRunWorkflow,
+)
+
+__all__ = [
+    "COMMAND_RUN_WORKFLOWS",
+    "DEFAULT_COMMAND_RUN_KIND",
+    "AppendToReadmeCommandCloudRunWorkflow",
+    "BaseCloudRunWorkflow",
+    "CloudRunInput",
+    "CloudRunOutput",
+    "CommandCloudRunWorkflow",
+    "commit_and_open_pr",
+    "run_command_in_sandbox",
+]

--- a/products/tasks/backend/temporal/command_run/activities.py
+++ b/products/tasks/backend/temporal/command_run/activities.py
@@ -1,0 +1,183 @@
+import shlex
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from temporalio import activity
+
+from posthog.models.integration import GitHubIntegration, Integration
+from posthog.temporal.common.utils import asyncify, close_db_connections
+
+from products.tasks.backend.models import TaskRun
+from products.tasks.backend.services.sandbox import WORKING_DIR, Sandbox
+from products.tasks.backend.temporal.observability import log_with_activity_context
+
+if TYPE_CHECKING:
+    from products.tasks.backend.services.sandbox import SandboxBase
+
+
+@dataclass
+class RunCommandInSandboxInput:
+    run_id: str
+    sandbox_id: str
+    command: str
+    repository: Optional[str] = None
+    timeout_seconds: int = 30 * 60
+
+
+@dataclass
+class RunCommandOutput:
+    exit_code: int
+
+
+@dataclass
+class CommitAndOpenPrInput:
+    run_id: str
+    sandbox_id: str
+    repository: str
+    github_integration_id: int
+    branch: str
+    commit_message: str
+    pr_title: str
+    pr_body: str
+    base_branch: Optional[str] = None
+
+
+@dataclass
+class OpenPrOutput:
+    created_pr: bool
+    pr_url: Optional[str] = None
+    commit_sha: Optional[str] = None
+
+
+def open_signed_pr(
+    sandbox: "SandboxBase",
+    github: GitHubIntegration,
+    *,
+    repository: str,
+    branch: str,
+    base_branch: Optional[str],
+    commit_headline: str,
+    pr_title: str,
+    pr_body: str,
+) -> OpenPrOutput:
+    """Stage the sandbox changes and open a PR backed by a GitHub-signed commit.
+
+    The sandbox image blocks raw git commit/push (only signed commits may leave), so we
+    collect the diff and create a verified commit via the GitHub API instead. Returns
+    early without a PR when the command left the repo unchanged. Shared by the Temporal
+    activity and the local management command so the orchestration lives in one place.
+    """
+    try:
+        github.organization()
+    except ValueError as e:
+        raise RuntimeError(
+            "GitHub integration is not a connected App installation (missing account/org); cannot open a PR."
+        ) from e
+
+    is_clean, _ = sandbox.is_git_clean(repository)
+    if is_clean:
+        return OpenPrOutput(created_pr=False)
+
+    changes = sandbox.stage_and_collect_changes(repository)
+    if not changes.additions and not changes.deletions:
+        return OpenPrOutput(created_pr=False)
+
+    # GitHub resolves the org from the installation, so it wants the bare repo name.
+    repo_name = repository.split("/")[-1]
+    resolved_base = base_branch or github.get_default_branch(repo_name)
+
+    branch_result = github.create_branch(repo_name, branch, resolved_base)
+    if not branch_result.get("success"):
+        raise RuntimeError(f"Failed to create branch: {branch_result.get('error')}")
+
+    commit_result = github.create_signed_commit(
+        repository=repo_name,
+        branch=branch,
+        expected_head_oid=branch_result["sha"],
+        headline=commit_headline,
+        additions=changes.additions,
+        deletions=changes.deletions,
+    )
+    if not commit_result.get("success"):
+        raise RuntimeError(f"Failed to create signed commit: {commit_result.get('error')}")
+
+    pr_result = github.create_pull_request(
+        repository=repo_name,
+        title=pr_title,
+        body=pr_body,
+        head_branch=branch,
+        base_branch=resolved_base,
+    )
+    if not pr_result.get("success"):
+        raise RuntimeError(f"Failed to open pull request: {pr_result.get('error')}")
+
+    return OpenPrOutput(created_pr=True, pr_url=pr_result["pr_url"], commit_sha=commit_result["commit_sha"])
+
+
+def resolve_github_integration(github_integration_id: int) -> GitHubIntegration:
+    integration = Integration.objects.get(id=github_integration_id)
+    github = GitHubIntegration(integration)
+    if github.access_token_expired():
+        github.refresh_access_token()
+    return github
+
+
+@activity.defn
+@asyncify
+@close_db_connections
+def run_command_in_sandbox(input: RunCommandInSandboxInput) -> RunCommandOutput:
+    """Run the cloud run's CLI command inside an already-provisioned sandbox.
+
+    The command runs from the cloned repository's directory so it can mutate the
+    checkout directly. Output is streamed to logs only — never returned to the
+    caller or stored on the run.
+    """
+    sandbox = Sandbox.get_by_id(input.sandbox_id)
+
+    command = input.command
+    if input.repository:
+        org, repo = input.repository.lower().split("/")
+        repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+        command = f"cd {shlex.quote(repo_path)} && {input.command}"
+
+    log_with_activity_context("command_run_started", run_id=input.run_id, repository=input.repository)
+
+    stream = sandbox.execute_stream(command, timeout_seconds=input.timeout_seconds)
+    for line in stream.iter_stdout():
+        log_with_activity_context("command_run_output", run_id=input.run_id, line=line[:2000])
+    result = stream.wait()
+
+    log_with_activity_context("command_run_finished", run_id=input.run_id, exit_code=result.exit_code)
+    return RunCommandOutput(exit_code=result.exit_code)
+
+
+@activity.defn
+@asyncify
+@close_db_connections
+def commit_and_open_pr(input: CommitAndOpenPrInput) -> OpenPrOutput:
+    """Open a PR for the sandbox changes via a GitHub-signed commit and record its URL.
+
+    Returns early without a PR when the command left the repo clean. Only the PR URL and
+    commit SHA are written to `TaskRun.output` — logs are never surfaced.
+    """
+    sandbox = Sandbox.get_by_id(input.sandbox_id)
+    github = resolve_github_integration(input.github_integration_id)
+
+    result = open_signed_pr(
+        sandbox,
+        github,
+        repository=input.repository,
+        branch=input.branch,
+        base_branch=input.base_branch,
+        commit_headline=input.commit_message,
+        pr_title=input.pr_title,
+        pr_body=input.pr_body,
+    )
+
+    if not result.created_pr:
+        log_with_activity_context("command_run_no_changes", run_id=input.run_id, repository=input.repository)
+        return result
+
+    TaskRun.update_output_atomic(input.run_id, {"pr_url": result.pr_url, "commit_sha": result.commit_sha})
+    log_with_activity_context("command_run_pr_opened", run_id=input.run_id, pr_url=result.pr_url)
+    return result

--- a/products/tasks/backend/temporal/command_run/activities.py
+++ b/products/tasks/backend/temporal/command_run/activities.py
@@ -136,7 +136,7 @@ def run_command_in_sandbox(input: RunCommandInSandboxInput) -> RunCommandOutput:
 
     command = input.command
     if input.repository:
-        org, repo = input.repository.lower().split("/")
+        org, repo = input.repository.lower().split("/", 1)
         repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
         command = f"cd {shlex.quote(repo_path)} && {input.command}"
 
@@ -147,6 +147,8 @@ def run_command_in_sandbox(input: RunCommandInSandboxInput) -> RunCommandOutput:
         log_with_activity_context("command_run_output", run_id=input.run_id, line=line[:2000])
     result = stream.wait()
 
+    if result.stderr:
+        log_with_activity_context("command_run_stderr", run_id=input.run_id, stderr=result.stderr[:4000])
     log_with_activity_context("command_run_finished", run_id=input.run_id, exit_code=result.exit_code)
     return RunCommandOutput(exit_code=result.exit_code)
 

--- a/products/tasks/backend/temporal/command_run/constants.py
+++ b/products/tasks/backend/temporal/command_run/constants.py
@@ -1,0 +1,14 @@
+# Maps the `command_run_kind` stored on a run's state to the Temporal workflow that runs it.
+# A generic "command" run carries its command in state; named leaves hardcode their own.
+COMMAND_RUN_WORKFLOWS: dict[str, str] = {
+    "command": "process-command-run",
+    "append_readme": "append-readme-command-run",
+}
+
+DEFAULT_COMMAND_RUN_KIND = "command"
+
+# The single canned command behind AppendToReadmeCommandCloudRunWorkflow. Runs from the
+# repository root (the activity cd's into the checkout first).
+APPEND_README_COMMAND = "printf '\\n_Touched by a PostHog cloud run._\\n' >> README.md"
+APPEND_README_PR_TITLE = "Append PostHog marker to README"
+APPEND_README_PR_BODY = "Automated cloud run: appended a marker line to the end of the README."

--- a/products/tasks/backend/temporal/command_run/tests/test_activities.py
+++ b/products/tasks/backend/temporal/command_run/tests/test_activities.py
@@ -1,0 +1,125 @@
+import pytest
+
+from asgiref.sync import async_to_sync
+
+from products.tasks.backend.services.sandbox import ExecutionResult, Sandbox, WorkingTreeChanges
+from products.tasks.backend.temporal.command_run.activities import (
+    CommitAndOpenPrInput,
+    RunCommandInSandboxInput,
+    commit_and_open_pr,
+    run_command_in_sandbox,
+)
+
+
+class _FakeStream:
+    def __init__(self, lines, exit_code):
+        self._lines = lines
+        self._exit_code = exit_code
+
+    def iter_stdout(self):
+        yield from self._lines
+
+    def wait(self):
+        return ExecutionResult(stdout="", stderr="", exit_code=self._exit_code)
+
+
+def _github_mock(mocker, *, branch_sha="base-sha", commit_sha="commit-sha", pr_url="https://github.com/o/r/pull/3"):
+    github = mocker.Mock()
+    github.access_token_expired.return_value = False
+    github.get_default_branch.return_value = "main"
+    github.create_branch.return_value = {"success": True, "sha": branch_sha}
+    github.create_signed_commit.return_value = {"success": True, "commit_sha": commit_sha}
+    github.create_pull_request.return_value = {"success": True, "pr_url": pr_url}
+    mocker.patch(
+        "products.tasks.backend.temporal.command_run.activities.Integration.objects.get", return_value=mocker.Mock()
+    )
+    mocker.patch("products.tasks.backend.temporal.command_run.activities.GitHubIntegration", return_value=github)
+    return github
+
+
+def _commit_input() -> CommitAndOpenPrInput:
+    return CommitAndOpenPrInput(
+        run_id="run-1",
+        sandbox_id="sandbox-1",
+        repository="posthog/hedgebox",
+        github_integration_id=1,
+        branch="cloud-run/run-1",
+        commit_message="msg",
+        pr_title="title",
+        pr_body="body",
+        base_branch=None,
+    )
+
+
+@pytest.mark.django_db
+def test_run_command_in_sandbox_cds_into_repo_and_returns_exit_code(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-1")
+    sandbox.execute_stream.return_value = _FakeStream(["hello\n"], 0)
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+
+    result = async_to_sync(activity_environment.run)(
+        run_command_in_sandbox,
+        RunCommandInSandboxInput(
+            run_id="run-1", sandbox_id="sandbox-1", command="echo hi", repository="PostHog/Hedgebox"
+        ),
+    )
+
+    assert result.exit_code == 0
+    assert sandbox.execute_stream.call_args.args[0] == "cd /tmp/workspace/repos/posthog/hedgebox && echo hi"
+
+
+@pytest.mark.django_db
+def test_commit_and_open_pr_skips_pr_when_repo_clean(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-1")
+    sandbox.is_git_clean.return_value = (True, "")
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    _github_mock(mocker)
+    update_output = mocker.patch("products.tasks.backend.temporal.command_run.activities.TaskRun.update_output_atomic")
+
+    result = async_to_sync(activity_environment.run)(commit_and_open_pr, _commit_input())
+
+    assert result.created_pr is False
+    assert result.pr_url is None
+    sandbox.stage_and_collect_changes.assert_not_called()
+    update_output.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_commit_and_open_pr_creates_signed_commit_and_records_output(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-1")
+    sandbox.is_git_clean.return_value = (False, " M README.md")
+    sandbox.stage_and_collect_changes.return_value = WorkingTreeChanges(
+        additions=[("README.md", "YmFzZTY0")], deletions=[]
+    )
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    github = _github_mock(mocker)
+    update_output = mocker.patch("products.tasks.backend.temporal.command_run.activities.TaskRun.update_output_atomic")
+
+    result = async_to_sync(activity_environment.run)(commit_and_open_pr, _commit_input())
+
+    assert result.created_pr is True
+    assert result.pr_url == "https://github.com/o/r/pull/3"
+    assert result.commit_sha == "commit-sha"
+    # Bare repo name (org resolved from the integration), branched from the default branch.
+    assert github.create_branch.call_args.args == ("hedgebox", "cloud-run/run-1", "main")
+    commit_kwargs = github.create_signed_commit.call_args.kwargs
+    assert commit_kwargs["expected_head_oid"] == "base-sha"
+    assert commit_kwargs["additions"] == [("README.md", "YmFzZTY0")]
+    update_output.assert_called_once_with(
+        "run-1", {"pr_url": "https://github.com/o/r/pull/3", "commit_sha": "commit-sha"}
+    )
+
+
+@pytest.mark.django_db
+def test_commit_and_open_pr_raises_when_signed_commit_fails(activity_environment, mocker):
+    sandbox = mocker.Mock(id="sandbox-1")
+    sandbox.is_git_clean.return_value = (False, " M README.md")
+    sandbox.stage_and_collect_changes.return_value = WorkingTreeChanges(
+        additions=[("README.md", "YmFzZTY0")], deletions=[]
+    )
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    github = _github_mock(mocker)
+    github.create_signed_commit.return_value = {"success": False, "error": "stale head"}
+
+    with pytest.raises(RuntimeError, match="Failed to create signed commit"):
+        async_to_sync(activity_environment.run)(commit_and_open_pr, _commit_input())

--- a/products/tasks/backend/temporal/command_run/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/command_run/tests/test_workflow.py
@@ -1,0 +1,163 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from products.tasks.backend.temporal.command_run import (
+    constants,
+    workflow as command_run_workflow_module,
+)
+from products.tasks.backend.temporal.command_run.activities import OpenPrOutput, RunCommandOutput
+from products.tasks.backend.temporal.command_run.workflow import (
+    AppendToReadmeCommandCloudRunWorkflow,
+    CloudRunInput,
+    CommandCloudRunWorkflow,
+)
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+
+
+def _build_context(*, repository="posthog/hedgebox", github_integration_id=123, state=None) -> TaskProcessingContext:
+    return TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="organization-id",
+        github_integration_id=github_integration_id,
+        repository=repository,
+        distinct_id="distinct-id",
+        state=state or {},
+    )
+
+
+class TestCommandCloudRunWorkflow:
+    def test_workflow_definitions_are_registered_with_run_methods(self):
+        # The @workflow.run method must live on each concrete class (not inherited).
+        assert CommandCloudRunWorkflow.get_name() == "process-command-run"
+        assert AppendToReadmeCommandCloudRunWorkflow.get_name() == "append-readme-command-run"
+
+    @pytest.mark.parametrize(
+        "state, expected_command, expected_title, expected_body, expected_base",
+        [
+            (
+                {"command": "make migrate", "pr_title": "Run migrations", "pr_body": "body", "base_branch": "main"},
+                "make migrate",
+                "Run migrations",
+                "body",
+                "main",
+            ),
+            ({"command": "echo hi"}, "echo hi", "Automated change", "", None),
+        ],
+    )
+    def test_command_workflow_hooks_read_state(
+        self, state, expected_command, expected_title, expected_body, expected_base
+    ):
+        wf = CommandCloudRunWorkflow()
+        ctx = _build_context(state=state)
+        assert wf._command(ctx) == expected_command
+        assert wf._pr_title(ctx) == expected_title
+        assert wf._pr_body(ctx) == expected_body
+        assert wf._base_branch(ctx) == expected_base
+        assert wf._branch_name(ctx) == "cloud-run/run-id"
+
+    def test_command_workflow_requires_a_command_in_state(self):
+        wf = CommandCloudRunWorkflow()
+        with pytest.raises(RuntimeError, match="No command configured"):
+            wf._command(_build_context(state={}))
+
+    def test_append_readme_leaf_hardcodes_command_and_pr_metadata(self):
+        wf = AppendToReadmeCommandCloudRunWorkflow()
+        ctx = _build_context(state={})  # leaf ignores state entirely
+        assert wf._command(ctx) == constants.APPEND_README_COMMAND
+        assert wf._pr_title(ctx) == constants.APPEND_README_PR_TITLE
+        assert wf._pr_body(ctx) == constants.APPEND_README_PR_BODY
+
+    async def test_run_marks_completed_and_always_cleans_up(self, monkeypatch):
+        wf = CommandCloudRunWorkflow()
+        statuses: list[str] = []
+
+        monkeypatch.setattr(wf, "_provision_sandbox", AsyncMock(return_value="sandbox-1"))
+        monkeypatch.setattr(wf, "_execute", AsyncMock(return_value="https://github.com/o/r/pull/1"))
+        monkeypatch.setattr(wf, "_update_status", AsyncMock(side_effect=lambda status, *a: statuses.append(status)))
+        cleanup_mock = AsyncMock()
+        monkeypatch.setattr(wf, "_cleanup_sandbox", cleanup_mock)
+        monkeypatch.setattr(
+            command_run_workflow_module.workflow,
+            "execute_activity",
+            AsyncMock(return_value=_build_context()),
+        )
+
+        result = await wf.run(CloudRunInput(run_id="run-id"))
+
+        assert result.success is True
+        assert result.pr_url == "https://github.com/o/r/pull/1"
+        assert statuses == ["in_progress", "completed"]
+        cleanup_mock.assert_awaited_once_with("sandbox-1")
+
+    async def test_run_marks_failed_and_cleans_up_on_error(self, monkeypatch):
+        wf = CommandCloudRunWorkflow()
+        statuses: list[str] = []
+
+        monkeypatch.setattr(wf, "_provision_sandbox", AsyncMock(return_value="sandbox-1"))
+        monkeypatch.setattr(wf, "_execute", AsyncMock(side_effect=RuntimeError("command failed")))
+        monkeypatch.setattr(wf, "_update_status", AsyncMock(side_effect=lambda status, *a: statuses.append(status)))
+        cleanup_mock = AsyncMock()
+        monkeypatch.setattr(wf, "_cleanup_sandbox", cleanup_mock)
+        monkeypatch.setattr(
+            command_run_workflow_module.workflow,
+            "execute_activity",
+            AsyncMock(return_value=_build_context()),
+        )
+
+        result = await wf.run(CloudRunInput(run_id="run-id"))
+
+        assert result.success is False
+        assert result.error == "command failed"
+        assert statuses == ["in_progress", "failed"]
+        cleanup_mock.assert_awaited_once_with("sandbox-1")
+
+    async def test_execute_runs_command_then_opens_pr(self, monkeypatch):
+        wf = CommandCloudRunWorkflow()
+        wf._context = _build_context(state={"command": "echo hi"})
+        calls = []
+
+        async def fake_execute_activity(fn, arg, **kwargs):
+            calls.append(fn.__name__)
+            if fn.__name__ == "run_command_in_sandbox":
+                return RunCommandOutput(exit_code=0)
+            return OpenPrOutput(created_pr=True, pr_url="https://github.com/o/r/pull/9", commit_sha="abc")
+
+        monkeypatch.setattr(command_run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        pr_url = await wf._execute("sandbox-1")
+
+        assert pr_url == "https://github.com/o/r/pull/9"
+        assert calls == ["run_command_in_sandbox", "commit_and_open_pr"]
+
+    async def test_execute_raises_on_nonzero_exit_and_skips_pr(self, monkeypatch):
+        wf = CommandCloudRunWorkflow()
+        wf._context = _build_context(state={"command": "false"})
+        calls = []
+
+        async def fake_execute_activity(fn, arg, **kwargs):
+            calls.append(fn.__name__)
+            return RunCommandOutput(exit_code=1)
+
+        monkeypatch.setattr(command_run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        with pytest.raises(RuntimeError, match="non-zero status"):
+            await wf._execute("sandbox-1")
+        assert calls == ["run_command_in_sandbox"]
+
+    @pytest.mark.parametrize(
+        "repository, github_integration_id, match",
+        [
+            (None, 123, "requires a repository"),
+            ("posthog/hedgebox", None, "requires a GitHub integration"),
+        ],
+    )
+    async def test_execute_requires_repository_and_integration(self, repository, github_integration_id, match):
+        wf = CommandCloudRunWorkflow()
+        wf._context = _build_context(
+            repository=repository, github_integration_id=github_integration_id, state={"command": "x"}
+        )
+        with pytest.raises(RuntimeError, match=match):
+            await wf._execute("sandbox-1")

--- a/products/tasks/backend/temporal/command_run/workflow.py
+++ b/products/tasks/backend/temporal/command_run/workflow.py
@@ -1,0 +1,229 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from ..process_task.activities.cleanup_sandbox import CleanupSandboxInput, cleanup_sandbox
+from ..process_task.activities.get_task_processing_context import (
+    GetTaskProcessingContextInput,
+    TaskProcessingContext,
+    get_task_processing_context,
+)
+from ..process_task.activities.provision_sandbox import (
+    CloneRepositoryInSandboxInput,
+    CreateSandboxForRepositoryInput,
+    PrepareSandboxForRepositoryInput,
+    clone_repository_in_sandbox,
+    create_sandbox_for_repository,
+    prepare_sandbox_for_repository,
+)
+from ..process_task.activities.update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
+from . import constants
+from .activities import CommitAndOpenPrInput, RunCommandInSandboxInput, commit_and_open_pr, run_command_in_sandbox
+
+
+@dataclass
+class CloudRunInput:
+    run_id: str
+
+
+@dataclass
+class CloudRunOutput:
+    success: bool
+    pr_url: Optional[str] = None
+    error: Optional[str] = None
+    sandbox_id: Optional[str] = None
+
+
+class BaseCloudRunWorkflow(PostHogWorkflow):
+    """The dumbest possible cloud run: provision a sandbox, clone the repo, do work, clean up.
+
+    Knows nothing about commands, agents, or pull requests — only the lifecycle. Subclasses
+    add capabilities by implementing `_execute()`. This class is intentionally not a Temporal
+    workflow: the SDK requires the `@workflow.run` method to be defined directly on each
+    concrete class (it is not inheritable), so concrete subclasses provide a thin `run()` that
+    delegates to `_run()` here.
+    """
+
+    inputs_cls = CloudRunInput
+
+    def __init__(self) -> None:
+        self._context: Optional[TaskProcessingContext] = None
+
+    @property
+    def context(self) -> TaskProcessingContext:
+        if self._context is None:
+            raise RuntimeError("context accessed before being set")
+        return self._context
+
+    async def _run(self, input: CloudRunInput) -> CloudRunOutput:
+        self._context = await workflow.execute_activity(
+            get_task_processing_context,
+            GetTaskProcessingContextInput(run_id=input.run_id, create_pr=True),
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        await self._update_status("in_progress")
+
+        sandbox_id: Optional[str] = None
+        try:
+            sandbox_id = await self._provision_sandbox()
+            pr_url = await self._execute(sandbox_id)
+            await self._update_status("completed")
+            return CloudRunOutput(success=True, pr_url=pr_url, sandbox_id=sandbox_id)
+        except Exception as e:
+            await self._update_status("failed", str(e))
+            return CloudRunOutput(success=False, error=str(e), sandbox_id=sandbox_id)
+        finally:
+            if sandbox_id:
+                await self._cleanup_sandbox(sandbox_id)
+
+    async def _execute(self, sandbox_id: str) -> Optional[str]:
+        """Do the subclass-specific work inside the provisioned sandbox; return a PR URL if any."""
+        raise NotImplementedError
+
+    async def _provision_sandbox(self) -> str:
+        prepared = await workflow.execute_activity(
+            prepare_sandbox_for_repository,
+            PrepareSandboxForRepositoryInput(context=self.context),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        created = await workflow.execute_activity(
+            create_sandbox_for_repository,
+            CreateSandboxForRepositoryInput(context=self.context, prepared=prepared),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+        if prepared.repository and not prepared.used_snapshot:
+            await workflow.execute_activity(
+                clone_repository_in_sandbox,
+                CloneRepositoryInSandboxInput(
+                    context=self.context,
+                    sandbox_id=created.sandbox_id,
+                    repository=prepared.repository,
+                    github_token=prepared.github_token,
+                    shallow_clone=prepared.shallow_clone,
+                ),
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+        return created.sandbox_id
+
+    async def _cleanup_sandbox(self, sandbox_id: str) -> None:
+        await workflow.execute_activity(
+            cleanup_sandbox,
+            CleanupSandboxInput(sandbox_id=sandbox_id, run_id=self.context.run_id, complete_stream_on_cleanup=False),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+    async def _update_status(self, status: str, error_message: Optional[str] = None) -> None:
+        await workflow.execute_activity(
+            update_task_run_status,
+            UpdateTaskRunStatusInput(run_id=self.context.run_id, status=status, error_message=error_message),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+
+@workflow.defn(name="process-command-run")
+class CommandCloudRunWorkflow(BaseCloudRunWorkflow):
+    """Run a CLI command against the cloned repo, then commit, push, and open a PR.
+
+    Command and PR metadata come from overridable hook methods that default to reading
+    the run's state, so named leaves can hardcode them without touching the lifecycle.
+    """
+
+    @workflow.run
+    async def run(self, input: CloudRunInput) -> CloudRunOutput:
+        return await self._run(input)
+
+    async def _execute(self, sandbox_id: str) -> Optional[str]:
+        ctx = self.context
+        if not ctx.repository:
+            raise RuntimeError("Command cloud run requires a repository")
+        if ctx.github_integration_id is None:
+            raise RuntimeError("Command cloud run requires a GitHub integration to open a PR")
+
+        result = await workflow.execute_activity(
+            run_command_in_sandbox,
+            RunCommandInSandboxInput(
+                run_id=ctx.run_id,
+                sandbox_id=sandbox_id,
+                command=self._command(ctx),
+                repository=ctx.repository,
+            ),
+            start_to_close_timeout=timedelta(minutes=30),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Command exited with non-zero status {result.exit_code}")
+
+        pr = await workflow.execute_activity(
+            commit_and_open_pr,
+            CommitAndOpenPrInput(
+                run_id=ctx.run_id,
+                sandbox_id=sandbox_id,
+                repository=ctx.repository,
+                github_integration_id=ctx.github_integration_id,
+                branch=self._branch_name(ctx),
+                commit_message=self._commit_message(ctx),
+                pr_title=self._pr_title(ctx),
+                pr_body=self._pr_body(ctx),
+                base_branch=self._base_branch(ctx),
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        return pr.pr_url
+
+    def _command(self, ctx: TaskProcessingContext) -> str:
+        command = (ctx.state or {}).get("command")
+        if not command:
+            raise RuntimeError("No command configured for this run")
+        return command
+
+    def _pr_title(self, ctx: TaskProcessingContext) -> str:
+        return (ctx.state or {}).get("pr_title") or "Automated change"
+
+    def _pr_body(self, ctx: TaskProcessingContext) -> str:
+        return (ctx.state or {}).get("pr_body") or ""
+
+    def _base_branch(self, ctx: TaskProcessingContext) -> Optional[str]:
+        return (ctx.state or {}).get("base_branch")
+
+    def _commit_message(self, ctx: TaskProcessingContext) -> str:
+        return (ctx.state or {}).get("commit_message") or self._pr_title(ctx)
+
+    def _branch_name(self, ctx: TaskProcessingContext) -> str:
+        # Deterministic (run_id is fixed for the workflow run) — never random/time-based.
+        return f"cloud-run/{ctx.run_id}"
+
+
+@workflow.defn(name="append-readme-command-run")
+class AppendToReadmeCommandCloudRunWorkflow(CommandCloudRunWorkflow):
+    """A named leaf: appends a marker line to the README and opens a fixed PR.
+
+    Pure parameterization of the parent — it only overrides the hooks. The `run()` method
+    is repeated because the Temporal SDK does not inherit `@workflow.run`.
+    """
+
+    @workflow.run
+    async def run(self, input: CloudRunInput) -> CloudRunOutput:
+        return await self._run(input)
+
+    def _command(self, ctx: TaskProcessingContext) -> str:
+        return constants.APPEND_README_COMMAND
+
+    def _pr_title(self, ctx: TaskProcessingContext) -> str:
+        return constants.APPEND_README_PR_TITLE
+
+    def _pr_body(self, ctx: TaskProcessingContext) -> str:
+        return constants.APPEND_README_PR_BODY

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -41,6 +41,8 @@ class GitHubCredentialSource(StrEnum):
 class RunSource(StrEnum):
     MANUAL = "manual"
     SIGNAL_REPORT = "signal_report"
+    # Non-agent run that executes a fixed CLI command against the repo and opens a PR.
+    CLOUD_RUN = "cloud_run"
 
 
 class RuntimeAdapter(StrEnum):
@@ -387,7 +389,7 @@ def get_user_github_token(github_user_integration_id: str) -> Optional[str]:
     return github_integration.integration.sensitive_config.get("access_token") or None
 
 
-def _normalize_repository(repository: str | None) -> str | None:
+def normalize_repository(repository: str | None) -> str | None:
     if not repository:
         return None
     repository = repository.strip().lower()
@@ -433,7 +435,7 @@ def get_user_github_integration(
     if user is None:
         return None
 
-    normalized_repository = _normalize_repository(repository)
+    normalized_repository = normalize_repository(repository)
     integrations = UserIntegration.objects.filter(user=user, kind="github").order_by("created_at")
     if github_user_integration_id:
         integrations = integrations.filter(id=github_user_integration_id)
@@ -459,7 +461,7 @@ def resolve_user_github_integration_for_task(
     if task.created_by is None:
         return None
 
-    normalized_repository = _normalize_repository(repository or task.repository)
+    normalized_repository = normalize_repository(repository or task.repository)
     selected_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     user_github_integration = get_user_github_integration(
         task.created_by,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -6862,3 +6862,133 @@ class TestGetPosthogCodeUsage(TestCase):
     def test_fails_open_when_no_gateway_url(self, mock_token):
         self.assertIsNone(get_posthog_code_usage(MagicMock(), 1))
         mock_token.assert_not_called()
+
+
+class TestTaskCommandRun(BaseTaskAPITest):
+    def _command_task(self, repository: str = "posthog/hedgebox") -> Task:
+        integration = Integration.objects.create(team=self.team, kind="github", config={"account": {"name": "posthog"}})
+        task = self.create_task()
+        task.github_integration = integration
+        task.repository = repository
+        task.save(update_fields=["github_integration", "repository"])
+        return task
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_command_payload_routes_to_command_workflow(self, mock_command_workflow, mock_agent_workflow):
+        task = self._command_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command": "make migrate", "pr_title": "Run migrations"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        run_id = response.json()["latest_run"]["id"]
+        mock_command_workflow.assert_called_once_with(
+            task_id=str(task.id),
+            run_id=run_id,
+            team_id=task.team.id,
+            command_run_kind="command",
+        )
+        mock_agent_workflow.assert_not_called()
+
+        run = TaskRun.objects.get(id=run_id)
+        self.assertEqual(run.state["command_run_kind"], "command")
+        self.assertEqual(run.state["command"], "make migrate")
+        self.assertEqual(run.state["pr_title"], "Run migrations")
+        self.assertEqual(run.state["run_source"], "cloud_run")
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_named_kind_routes_to_named_workflow_without_command(self, mock_command_workflow, mock_agent_workflow):
+        task = self._command_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command_run_kind": "append_readme"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        run_id = response.json()["latest_run"]["id"]
+        mock_command_workflow.assert_called_once_with(
+            task_id=str(task.id),
+            run_id=run_id,
+            team_id=task.team.id,
+            command_run_kind="append_readme",
+        )
+        mock_agent_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_agent_payload_still_routes_to_agent_workflow(self, mock_command_workflow, mock_agent_workflow):
+        task = self.create_task()
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        mock_agent_workflow.assert_called_once()
+        mock_command_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_command_and_agent_runtime_are_mutually_exclusive(self, mock_command_workflow, mock_agent_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command": "make migrate", "runtime_adapter": "claude", "model": "claude-opus-4-8"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_command_workflow.assert_not_called()
+        mock_agent_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_generic_command_kind_requires_command(self, mock_command_workflow, mock_agent_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command_run_kind": "command"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_command_workflow.assert_not_called()
+        mock_agent_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_command_run_requires_github_integration(self, mock_command_workflow, mock_agent_workflow):
+        task = self.create_task()  # no github_integration
+        task.repository = "posthog/hedgebox"
+        task.save(update_fields=["repository"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command_run_kind": "append_readme"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("GitHub integration", response.json()["detail"])
+        mock_command_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.api.execute_command_run_workflow")
+    def test_command_run_requires_valid_repository(self, mock_command_workflow, mock_agent_workflow):
+        integration = Integration.objects.create(team=self.team, kind="github", config={"account": {"name": "posthog"}})
+        task = self.create_task()
+        task.github_integration = integration  # integration present, but repository unset
+        task.save(update_fields=["github_integration"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"command_run_kind": "append_readme"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("repository", response.json()["detail"])
+        mock_command_workflow.assert_not_called()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -521,12 +521,14 @@ export const PrAuthorshipModeEnumApi = {
 /**
  * * `manual` - manual
  * * `signal_report` - signal_report
+ * * `cloud_run` - cloud_run
  */
 export type RunSourceEnumApi = (typeof RunSourceEnumApi)[keyof typeof RunSourceEnumApi]
 
 export const RunSourceEnumApi = {
     Manual: 'manual',
     SignalReport: 'signal_report',
+    CloudRun: 'cloud_run',
 } as const
 
 /**
@@ -574,6 +576,17 @@ export const ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi = {
 } as const
 
 /**
+ * * `command` - command
+ * * `append_readme` - append_readme
+ */
+export type CommandRunKindEnumApi = (typeof CommandRunKindEnumApi)[keyof typeof CommandRunKindEnumApi]
+
+export const CommandRunKindEnumApi = {
+    Command: 'command',
+    AppendReadme: 'append_readme',
+} as const
+
+/**
  * Request body for creating a new task run
  */
 export interface ClaudeTaskRunCreateSchemaApi {
@@ -607,7 +620,8 @@ export interface ClaudeTaskRunCreateSchemaApi {
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
      *
      * * `manual` - manual
-     * * `signal_report` - signal_report */
+     * * `signal_report` - signal_report
+     * * `cloud_run` - cloud_run */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
@@ -635,6 +649,26 @@ export interface ClaudeTaskRunCreateSchemaApi {
      * * `bypassPermissions` - bypassPermissions
      * * `auto` - auto */
     initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi
+    /** Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter/model). */
+    command?: string
+    /** Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).
+     *
+     * * `command` - command
+     * * `append_readme` - append_readme */
+    command_run_kind?: CommandRunKindEnumApi
+    /**
+     * Title for the pull request opened by a command cloud run.
+     * @maxLength 255
+     */
+    pr_title?: string
+    /** Body for the pull request opened by a command cloud run. */
+    pr_body?: string
+    /**
+     * Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch.
+     * @maxLength 255
+     * @nullable
+     */
+    base_branch?: string | null
 }
 
 /**
@@ -694,7 +728,8 @@ export interface CodexTaskRunCreateSchemaApi {
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
      *
      * * `manual` - manual
-     * * `signal_report` - signal_report */
+     * * `signal_report` - signal_report
+     * * `cloud_run` - cloud_run */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
@@ -720,6 +755,26 @@ export interface CodexTaskRunCreateSchemaApi {
      * * `read-only` - read-only
      * * `full-access` - full-access */
     initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi
+    /** Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter/model). */
+    command?: string
+    /** Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).
+     *
+     * * `command` - command
+     * * `append_readme` - append_readme */
+    command_run_kind?: CommandRunKindEnumApi
+    /**
+     * Title for the pull request opened by a command cloud run.
+     * @maxLength 255
+     */
+    pr_title?: string
+    /** Body for the pull request opened by a command cloud run. */
+    pr_body?: string
+    /**
+     * Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch.
+     * @maxLength 255
+     * @nullable
+     */
+    base_branch?: string | null
 }
 
 export interface TaskRunResumeRequestSchemaApi {
@@ -748,7 +803,8 @@ export interface TaskRunResumeRequestSchemaApi {
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
      *
      * * `manual` - manual
-     * * `signal_report` - signal_report */
+     * * `signal_report` - signal_report
+     * * `cloud_run` - cloud_run */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
@@ -1098,7 +1154,8 @@ export interface TaskRunBootstrapCreateRequestApi {
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
      *
      * * `manual` - manual
-     * * `signal_report` - signal_report */
+     * * `signal_report` - signal_report
+     * * `cloud_run` - cloud_run */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -412,10 +412,18 @@ export const tasksRunCreateBodyOneBranchMax = 255
 
 export const tasksRunCreateBodyOnePendingUserArtifactIdsItemMax = 128
 
+export const tasksRunCreateBodyOnePrTitleMax = 255
+
+export const tasksRunCreateBodyOneBaseBranchMax = 255
+
 export const tasksRunCreateBodyTwoModeDefault = `background`
 export const tasksRunCreateBodyTwoBranchMax = 255
 
 export const tasksRunCreateBodyTwoPendingUserArtifactIdsItemMax = 128
+
+export const tasksRunCreateBodyTwoPrTitleMax = 255
+
+export const tasksRunCreateBodyTwoBaseBranchMax = 255
 
 export const tasksRunCreateBodyThreeModeDefault = `background`
 export const tasksRunCreateBodyThreeBranchMax = 255
@@ -459,11 +467,11 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                     'Whether pull requests for this run should be authored by the user or the bot.\n\n\* `user` - user\n\* `bot` - bot'
                 ),
             run_source: zod
-                .enum(['manual', 'signal_report'])
-                .describe('\* `manual` - manual\n\* `signal_report` - signal_report')
+                .enum(['manual', 'signal_report', 'cloud_run'])
+                .describe('\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run')
                 .optional()
                 .describe(
-                    'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report'
+                    'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run'
                 ),
             signal_report_id: zod
                 .string()
@@ -497,6 +505,32 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .optional()
                 .describe(
                     'Initial permission mode for Claude runtimes.\n\n\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto'
+                ),
+            command: zod
+                .string()
+                .optional()
+                .describe(
+                    'Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter\/model).'
+                ),
+            command_run_kind: zod
+                .enum(['command', 'append_readme'])
+                .describe('\* `command` - command\n\* `append_readme` - append_readme')
+                .optional()
+                .describe(
+                    "Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).\n\n\* `command` - command\n\* `append_readme` - append_readme"
+                ),
+            pr_title: zod
+                .string()
+                .max(tasksRunCreateBodyOnePrTitleMax)
+                .optional()
+                .describe('Title for the pull request opened by a command cloud run.'),
+            pr_body: zod.string().optional().describe('Body for the pull request opened by a command cloud run.'),
+            base_branch: zod
+                .string()
+                .max(tasksRunCreateBodyOneBaseBranchMax)
+                .nullish()
+                .describe(
+                    "Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch."
                 ),
         })
         .describe('Request body for creating a new task run'),
@@ -538,11 +572,11 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                     'Whether pull requests for this run should be authored by the user or the bot.\n\n\* `user` - user\n\* `bot` - bot'
                 ),
             run_source: zod
-                .enum(['manual', 'signal_report'])
-                .describe('\* `manual` - manual\n\* `signal_report` - signal_report')
+                .enum(['manual', 'signal_report', 'cloud_run'])
+                .describe('\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run')
                 .optional()
                 .describe(
-                    'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report'
+                    'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run'
                 ),
             signal_report_id: zod
                 .string()
@@ -574,6 +608,32 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .optional()
                 .describe(
                     'Initial permission mode for Codex runtimes.\n\n\* `auto` - auto\n\* `read-only` - read-only\n\* `full-access` - full-access'
+                ),
+            command: zod
+                .string()
+                .optional()
+                .describe(
+                    'Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter\/model).'
+                ),
+            command_run_kind: zod
+                .enum(['command', 'append_readme'])
+                .describe('\* `command` - command\n\* `append_readme` - append_readme')
+                .optional()
+                .describe(
+                    "Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).\n\n\* `command` - command\n\* `append_readme` - append_readme"
+                ),
+            pr_title: zod
+                .string()
+                .max(tasksRunCreateBodyTwoPrTitleMax)
+                .optional()
+                .describe('Title for the pull request opened by a command cloud run.'),
+            pr_body: zod.string().optional().describe('Body for the pull request opened by a command cloud run.'),
+            base_branch: zod
+                .string()
+                .max(tasksRunCreateBodyTwoBaseBranchMax)
+                .nullish()
+                .describe(
+                    "Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch."
                 ),
         })
         .describe('Request body for creating a new task run'),
@@ -610,11 +670,11 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 'Whether pull requests for this run should be authored by the user or the bot.\n\n\* `user` - user\n\* `bot` - bot'
             ),
         run_source: zod
-            .enum(['manual', 'signal_report'])
-            .describe('\* `manual` - manual\n\* `signal_report` - signal_report')
+            .enum(['manual', 'signal_report', 'cloud_run'])
+            .describe('\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run')
             .optional()
             .describe(
-                'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report'
+                'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run'
             ),
         signal_report_id: zod
             .string()
@@ -768,11 +828,11 @@ export const TasksRunsCreateBody = /* @__PURE__ */ zod
                 'Whether pull requests for this run should be authored by the user or the bot.\n\n\* `user` - user\n\* `bot` - bot'
             ),
         run_source: zod
-            .enum(['manual', 'signal_report'])
-            .describe('\* `manual` - manual\n\* `signal_report` - signal_report')
+            .enum(['manual', 'signal_report', 'cloud_run'])
+            .describe('\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run')
             .optional()
             .describe(
-                'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report'
+                'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report\n\* `cloud_run` - cloud_run'
             ),
         signal_report_id: zod
             .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11874,6 +11874,7 @@ export namespace Schemas {
     /**
      * * `manual` - manual
      * * `signal_report` - signal_report
+     * * `cloud_run` - cloud_run
      */
     export type RunSourceEnum = typeof RunSourceEnum[keyof typeof RunSourceEnum];
 
@@ -11881,6 +11882,7 @@ export namespace Schemas {
     export const RunSourceEnum = {
       Manual: 'manual',
       SignalReport: 'signal_report',
+      CloudRun: 'cloud_run',
     } as const;
 
     /**
@@ -11920,6 +11922,18 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `command` - command
+     * * `append_readme` - append_readme
+     */
+    export type CommandRunKindEnum = typeof CommandRunKindEnum[keyof typeof CommandRunKindEnum];
+
+
+    export const CommandRunKindEnum = {
+      Command: 'command',
+      AppendReadme: 'append_readme',
+    } as const;
+
+    /**
      * Request body for creating a new task run
      */
     export interface ClaudeTaskRunCreateSchema {
@@ -11953,7 +11967,8 @@ export namespace Schemas {
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
        *
        * * `manual` - manual
-       * * `signal_report` - signal_report */
+       * * `signal_report` - signal_report
+       * * `cloud_run` - cloud_run */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -11981,6 +11996,26 @@ export namespace Schemas {
        * * `bypassPermissions` - bypassPermissions
        * * `auto` - auto */
       initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
+      /** Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter/model). */
+      command?: string;
+      /** Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).
+       *
+       * * `command` - command
+       * * `append_readme` - append_readme */
+      command_run_kind?: CommandRunKindEnum;
+      /**
+         * Title for the pull request opened by a command cloud run.
+         * @maxLength 255
+         */
+      pr_title?: string;
+      /** Body for the pull request opened by a command cloud run. */
+      pr_body?: string;
+      /**
+         * Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch.
+         * @maxLength 255
+         * @nullable
+         */
+      base_branch?: string | null;
     }
 
     export type ClickhouseEventProperties = { [key: string]: unknown };
@@ -12298,7 +12333,8 @@ export namespace Schemas {
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
        *
        * * `manual` - manual
-       * * `signal_report` - signal_report */
+       * * `signal_report` - signal_report
+       * * `cloud_run` - cloud_run */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -12324,6 +12360,26 @@ export namespace Schemas {
        * * `read-only` - read-only
        * * `full-access` - full-access */
       initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnum;
+      /** Shell command for a non-agent command cloud run. When set, the run provisions a sandbox, clones the repository, runs this command from the repo root, then opens a PR backed by a GitHub-signed commit. Mutually exclusive with the agent runtime fields (runtime_adapter/model). */
+      command?: string;
+      /** Selects which non-agent command cloud run to start. 'command' runs the supplied `command`; named kinds run a canned, predefined command instead (in which case `command` is ignored).
+       *
+       * * `command` - command
+       * * `append_readme` - append_readme */
+      command_run_kind?: CommandRunKindEnum;
+      /**
+         * Title for the pull request opened by a command cloud run.
+         * @maxLength 255
+         */
+      pr_title?: string;
+      /** Body for the pull request opened by a command cloud run. */
+      pr_body?: string;
+      /**
+         * Base branch for the pull request opened by a command cloud run. Defaults to the repo's default branch.
+         * @maxLength 255
+         * @nullable
+         */
+      base_branch?: string | null;
     }
 
     export type PropertyGroupOperator = typeof PropertyGroupOperator[keyof typeof PropertyGroupOperator];
@@ -46720,7 +46776,8 @@ export namespace Schemas {
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
        *
        * * `manual` - manual
-       * * `signal_report` - signal_report */
+       * * `signal_report` - signal_report
+       * * `cloud_run` - cloud_run */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -46830,7 +46887,8 @@ export namespace Schemas {
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
        *
        * * `manual` - manual
-       * * `signal_report` - signal_report */
+       * * `signal_report` - signal_report
+       * * `cloud_run` - cloud_run */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;


### PR DESCRIPTION
## Non-agent command cloud runs

Introduces a new "command cloud run" execution path that runs a fixed CLI command against a cloned repository and opens a GitHub-signed pull request — without involving an AI agent. We'll use this to run the wizard in the cloud.

### How it works

When a task run request includes a `command` or `command_run_kind` field, the API routes it to a new Temporal workflow (`CommandCloudRunWorkflow`) instead of the existing agent workflow. The workflow:

1. Provisions a sandbox and clones the repository (reusing the existing sandbox provisioning activities)
2. Runs the supplied shell command from the repository root
3. Stages all working-tree changes and collects them as structured file additions/deletions
4. Creates a **GitHub-signed commit** via the GraphQL `createCommitOnBranch` mutation (bypassing branch protections that require signed commits)
5. Opens a pull request and records the PR URL and commit SHA on the task run

### Key design decisions

- **Signed commits via GraphQL**: Raw `git commit`/`git push` is blocked in the sandbox. Instead, `stage_and_collect_changes` tars the modified files, base64-encodes them, and passes them to the new `create_signed_commit` method on `GitHubIntegration`, which calls the GitHub GraphQL API. The resulting commit is verified by GitHub.
- **Named vs. generic kinds**: A `command_run_kind` registry maps kind names to workflow names. The generic `"command"` kind reads the command from run state; named leaves like `"append_readme"` hardcode their command and PR metadata by overriding hook methods on the workflow class.
- **Temporal SDK constraint**: The `@workflow.run` method cannot be inherited, so each concrete workflow class (`CommandCloudRunWorkflow`, `AppendToReadmeCommandCloudRunWorkflow`) defines its own thin `run()` that delegates to `_run()` on the shared `BaseCloudRunWorkflow` base.
- **Prerequisite validation**: The API validates that a command run has a connected GitHub integration and a valid `org/repo` repository before provisioning anything, returning a 400 rather than failing mid-run.
- **Atomic output writes**: A new `TaskRun.update_output_atomic` method merges PR URL and commit SHA into the run's output under a row lock, mirroring the existing `mutate_state_atomic` pattern.

### New `run_source`

A `cloud_run` value is added to `RunSource`. Passing `command` or `command_run_kind` in the request body implicitly sets `run_source = cloud_run`.

### Local testing

A `run_command_cloud_run` management command (DEBUG-only) runs the full lifecycle inline without a Temporal worker, printing the opened PR URL.