### PR TITLE
chore(clickhouse): mark test_insert_with_http_client django_db

### DIFF
--- a/posthog/clickhouse/client/test/test_connection.py
+++ b/posthog/clickhouse/client/test/test_connection.py
@@ -10,6 +10,7 @@ from posthog.clickhouse.client.connection import (
 from posthog.clickhouse.client.execute import sync_execute
 
 
+@pytest.mark.django_db
 def test_insert_with_http_client():
     sync_execute("DROP TABLE IF EXISTS _test_http_insert")
     sync_execute("CREATE TABLE _test_http_insert (id UInt64) ENGINE = Memory")


### PR DESCRIPTION
## Problem

`test_insert_with_http_client` in `posthog/clickhouse/client/test/test_connection.py` is intermittently failing in CI with `CHQueryErrorUnknownDatabase` (Code 81, "... does not exist").

The test creates a ClickHouse table and runs an `INSERT` through `get_http_client()`, which connects to `settings.CLICKHOUSE_DATABASE` (the test DB). That database is created only by the `django_db_setup` fixture in `posthog/conftest.py` (via `database.create_database()`). The test had no `@pytest.mark.django_db` marker and requested no DB fixture, so when CI's timing-based test sharding scheduled it first in its shard, the test database did not exist yet and the http-client INSERT failed.

It passes locally because the test DB persists between runs, and passes in CI whenever the test happens to run after a DB-using test — hence the intermittency across shards. This is a pre-existing latent ordering bug in the test, not a regression from any recent change.

## Changes

Add `@pytest.mark.django_db` to `test_insert_with_http_client` so `django_db_setup` runs and creates the ClickHouse test database before the test executes. This matches the established convention for ClickHouse tests in the repo (e.g. `posthog/clickhouse/test/test_dmat_dictionary.py`).

Only this one test needs the marker — the other tests in the file (`test_connection_pool_creation_*`) just construct pool objects and never hit the database.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Ran the automated test locally:

```
hogli test posthog/clickhouse/client/test/test_connection.py::test_insert_with_http_client
# 1 passed
```

The ordering failure is hard to reproduce locally because the test DB persists between runs, so this confirms the marker is correct and the test still passes rather than forcing the original failure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Test-only one-line change. Diagnosed as a latent test-ordering bug: the http-client INSERT path depends on the ClickHouse test DB existing, which only `django_db_setup` guarantees. Fix follows the existing `pytest.mark.django_db` convention used by other ClickHouse tests rather than introducing any new fixture or setup.

No repo skills were required for this change.
