### PR TITLE
fix(signals): fall back to raw text when scout end-turn JSON parse fails

### DIFF
--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -338,6 +338,11 @@ async def _spawn_and_run(
         # ACTIVITY_SLACK_S) cancels the activity. Default budget (MAX_POLL_SECONDS) exceeds the
         # ceiling and would let the activity die before salvage could return the written summary.
         max_poll_seconds=DEFAULT_MAX_RUNTIME_S,
+        # The close-out is free-text markdown — if the agent ends with prose or malformed JSON
+        # instead of a SignalScoutRunSummary object, keep the raw text as the summary rather than
+        # failing the whole run. A failed run never finalizes, so its scan-position close-out is
+        # lost and the next run inherits a doubled scan delta.
+        fallback_from_text=lambda text: SignalScoutRunSummary(summary=text),
     )
     try:
         # Persist the agent's end-of-turn close-out so non-emitting runs leave a

--- a/products/tasks/backend/services/custom_prompt_internals.py
+++ b/products/tasks/backend/services/custom_prompt_internals.py
@@ -736,5 +736,19 @@ def extract_json_from_text(text: str | None, label: str) -> Any:
             except json.JSONDecodeError:
                 start = brace_pos + 1
 
-    # 4. Last resort — try the whole text as-is
-    return json.loads(text)
+    # 4. Last resort — try the whole text as-is, then surface a classified error so
+    # callers (and operators reading the failure) can tell empty / fenced / prose apart
+    # instead of seeing a bare "Expecting value: line 1 column 1 (char 0)".
+    stripped = text.strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as e:
+        if not stripped:
+            raise ValueError(f"No JSON in {label}: end-turn text was empty or whitespace-only") from e
+        if "```" in text:
+            raise ValueError(
+                f"No valid JSON in {label}: text has a code fence but its contents did not parse as JSON"
+            ) from e
+        raise ValueError(
+            f"No JSON in {label}: end-turn text was prose with no JSON object (starts with {stripped[:60]!r})"
+        ) from e

--- a/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
+++ b/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
@@ -65,6 +65,7 @@ class MultiTurnSession:
         internal: bool = False,
         on_task_run_created: Callable[[TaskRun], Awaitable[None]] | None = None,
         max_poll_seconds: int | None = None,
+        fallback_from_text: Callable[[str], _ModelT] | None = None,
     ) -> tuple[MultiTurnSession, _ModelT]:
         """Start a multi-turn sandbox session and wait for the first structured response.
 
@@ -75,6 +76,14 @@ class MultiTurnSession:
         can resolve the run by id instead of 404ing on a not-yet-created row.
 
         `max_poll_seconds` caps each turn's poll budget — see the field docstring.
+
+        `fallback_from_text`, if given, salvages a turn whose text the agent *did*
+        produce but which failed to parse/validate against `model` (empty, prose, or
+        malformed JSON). Instead of failing the whole run, the callback builds a
+        `model` instance from the raw end-turn text so the caller still gets a result
+        to persist. Single-turn callers (e.g. the Signals scout, whose summary is a
+        free-text markdown close-out) use this so an unparseable end-turn no longer
+        discards the entire run and its scan-position close-out.
         """
         session, last_message = await cls.start_raw(
             prompt=prompt,
@@ -93,6 +102,22 @@ class MultiTurnSession:
         try:
             parsed = cls._parse_and_validate(last_message, model, label="initial turn")
         except (Exception, asyncio.CancelledError) as e:
+            # Salvage path: the agent produced text but it didn't parse/validate. Rather
+            # than discarding the whole run, build the model from the raw text so the caller
+            # can still persist a (degraded) result. Only for real parse failures — never for
+            # a Temporal cancellation (CancelledError), which must propagate and fail the run.
+            if (
+                fallback_from_text is not None
+                and last_message is not None
+                and not isinstance(e, asyncio.CancelledError)
+            ):
+                logger.warning(
+                    "multi_turn: end-turn did not validate against %s for run=%s — salvaging raw text (%s)",
+                    model.__name__,
+                    session.task_run.id,
+                    e,
+                )
+                return session, fallback_from_text(last_message)
             # `start()` is about to raise so the caller never receives the session to run its
             # own teardown. End it here so a first-turn parse failure (or a Temporal timeout,
             # which raises CancelledError — a BaseException) doesn't leave the run wedged in

--- a/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
+++ b/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
@@ -117,7 +117,16 @@ class MultiTurnSession:
                     session.task_run.id,
                     e,
                 )
-                return session, fallback_from_text(last_message)
+                try:
+                    salvaged = fallback_from_text(last_message)
+                except Exception:
+                    # A raising fallback (e.g. a stricter model that also rejects the raw text)
+                    # must not escape before teardown — the caller never received the session,
+                    # so its own finally is unreachable and the run would wedge in IN_PROGRESS.
+                    # Fall through to end the run as failed on the original parse error.
+                    logger.exception("multi_turn: fallback_from_text raised for run=%s", session.task_run.id)
+                else:
+                    return session, salvaged
             # `start()` is about to raise so the caller never receives the session to run its
             # own teardown. End it here so a first-turn parse failure (or a Temporal timeout,
             # which raises CancelledError — a BaseException) doesn't leave the run wedged in

--- a/products/tasks/backend/tests/test_extract_json_from_text.py
+++ b/products/tasks/backend/tests/test_extract_json_from_text.py
@@ -32,3 +32,26 @@ class TestExtractJsonFromText:
     def test_invalid_json_raises(self):
         with pytest.raises(Exception):
             extract_json_from_text("not json at all", label="test")
+
+    @parameterized.expand(
+        [
+            ("empty_string", "", "empty or whitespace-only"),
+            ("whitespace_only", "   \n\t ", "empty or whitespace-only"),
+            ("prose_only", "I checked everything and found nothing worth surfacing.", "prose with no JSON object"),
+            ("fenced_invalid", "```json\nnot: valid json\n```", "code fence but its contents did not parse"),
+        ]
+    )
+    def test_classifies_unparseable_text(self, _name, text, expected_message):
+        with pytest.raises(ValueError, match=expected_message):
+            extract_json_from_text(text, label="initial turn")
+
+    @parameterized.expand(
+        [
+            ("bare_array", "[1, 2, 3]", [1, 2, 3]),
+            ("array_with_whitespace", "  [1, 2, 3]  ", [1, 2, 3]),
+        ]
+    )
+    def test_still_parses_non_object_json(self, _name, text, expected):
+        # The last-resort path must keep parsing valid top-level JSON that isn't an object
+        # (arrays, scalars) — only genuinely unparseable text should raise.
+        assert extract_json_from_text(text, label="test") == expected

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -1376,6 +1376,22 @@ class TestMultiTurnSessionStartFallback:
         session.end.assert_not_awaited()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
+    async def test_raising_fallback_ends_run_instead_of_escaping(self):
+        # A fallback that itself raises (e.g. a stricter model that also rejects the raw text)
+        # must not escape start() before teardown — the run is ended as failed, not left wedged.
+        session = self._fake_session()
+
+        def boom(_text: str) -> _Resp:
+            raise ValueError("stricter model rejects raw text too")
+
+        with patch.object(MultiTurnSession, "start_raw", new=AsyncMock(return_value=(session, "prose only"))):
+            with pytest.raises(ValueError):
+                await MultiTurnSession.start(prompt="x", context=MagicMock(), model=_Resp, fallback_from_text=boom)
+
+        session.end.assert_awaited_once()  # type: ignore[attr-defined]
+        assert session.end.await_args.kwargs.get("status") == "failed"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
     async def test_cancellation_never_salvages(self):
         # A Temporal cancellation must propagate and fail the run even when a fallback is set —
         # salvaging a cancelled turn would mask a genuine timeout as a degraded success.

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -1311,3 +1312,82 @@ class TestCreateTaskAndTriggerForwardsContext:
             await create_task_and_trigger("prompt", context, ai_stage=ai_stage)
 
         assert mock_create.call_args.kwargs["ai_stage"] == expected
+
+
+class TestMultiTurnSessionStartFallback:
+    """start() salvages an end-turn the agent produced but that didn't validate against the
+    model (empty, prose, or malformed JSON) via fallback_from_text, instead of failing the
+    whole run. Without a fallback — or on a cancellation — it still fails and ends the run."""
+
+    def _fake_session(self) -> MultiTurnSession:
+        session = MultiTurnSession(
+            task=object(),  # type: ignore[arg-type]
+            task_run=FakeTaskRun(),  # type: ignore[arg-type]
+            _workflow_handle=AsyncMock(),
+        )
+        session.end = AsyncMock()  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        return session
+
+    @pytest.mark.asyncio
+    async def test_salvages_unparseable_text_with_fallback(self):
+        # _Resp requires a JSON object with `value`; prose can't validate, so the fallback
+        # builds the model from the raw close-out text instead of failing the run.
+        session = self._fake_session()
+        prose = "No anomalies this run. Scanned 12 commits, remembered the scan marker."
+
+        with patch.object(MultiTurnSession, "start_raw", new=AsyncMock(return_value=(session, prose))):
+            returned_session, parsed = await MultiTurnSession.start(
+                prompt="x",
+                context=MagicMock(),
+                model=_Resp,
+                fallback_from_text=lambda text: _Resp(value=text),
+            )
+
+        assert returned_session is session
+        assert parsed == _Resp(value=prose)
+        # A salvaged run is NOT ended as failed — the caller persists the result and ends normally.
+        session.end.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_fails_and_ends_run_without_fallback(self):
+        session = self._fake_session()
+
+        with patch.object(MultiTurnSession, "start_raw", new=AsyncMock(return_value=(session, "prose only"))):
+            with pytest.raises(ValueError):
+                await MultiTurnSession.start(prompt="x", context=MagicMock(), model=_Resp)
+
+        session.end.assert_awaited_once()  # type: ignore[attr-defined]
+        assert session.end.await_args.kwargs.get("status") == "failed"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_valid_json_parses_without_invoking_fallback(self):
+        session = self._fake_session()
+        fallback = MagicMock()
+
+        with patch.object(
+            MultiTurnSession, "start_raw", new=AsyncMock(return_value=(session, json.dumps({"value": "ok"})))
+        ):
+            _, parsed = await MultiTurnSession.start(
+                prompt="x", context=MagicMock(), model=_Resp, fallback_from_text=fallback
+            )
+
+        assert parsed == _Resp(value="ok")
+        fallback.assert_not_called()
+        session.end.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_never_salvages(self):
+        # A Temporal cancellation must propagate and fail the run even when a fallback is set —
+        # salvaging a cancelled turn would mask a genuine timeout as a degraded success.
+        session = self._fake_session()
+        fallback = MagicMock()
+
+        with (
+            patch.object(MultiTurnSession, "start_raw", new=AsyncMock(return_value=(session, "some text"))),
+            patch.object(MultiTurnSession, "_parse_and_validate", side_effect=asyncio.CancelledError()),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await MultiTurnSession.start(prompt="x", context=MagicMock(), model=_Resp, fallback_from_text=fallback)
+
+        fallback.assert_not_called()
+        session.end.assert_awaited_once()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

A Signals scout meta-scout flagged that the scout fleet was silently losing roughly a quarter of its scheduled runs. On 06-17, 3 of the last ~12 `signals-scout-react-doctor` runs died with the identical `Expecting value: line 1 column 1 (char 0)`.

Root cause: when the agent's final (end-turn) message can't be parsed as `SignalScoutRunSummary` JSON — because it's empty, plain prose, or oddly fenced — `extract_json_from_text` exhausts its four extraction strategies and falls through to a bare `json.loads(text)`, which raises `JSONDecodeError`. `MultiTurnSession.start` catches it, marks the run FAILED, and re-raises with no fallback.

A failed run never finalizes, so it never writes its close-out (`_finalize_run_summary`). Since the scout's scan-position close-out is what future runs read via `runs-list`, the next run inherits a doubled scan delta. The failure also doesn't set `$mcp_is_error`, so it only surfaces on the linked `TaskRun.error_message`.

Found via the inbox report `019ed6f8-c58d-7165-88ca-afdc6b413e91`.

## Changes

- **Salvage path in the generic multi-turn runner.** `MultiTurnSession.start` gains an optional `fallback_from_text` callback. When the end-turn text fails to parse/validate against the model — but the agent *did* produce text and the failure isn't a Temporal cancellation — the callback builds the model from the raw text instead of failing the whole run. Cancellations still propagate and fail the run, so a genuine timeout can't be masked as a degraded success.
- **The Signals scout opts in.** The runner passes `fallback_from_text=lambda text: SignalScoutRunSummary(summary=text)`. Its `summary` is already a free-text markdown close-out, so persisting the agent's raw prose is a clean degraded outcome — the run finalizes and its scan-position close-out survives, killing the doubled-delta cascade.
- **Clearer parse errors.** `extract_json_from_text`'s last-resort failure now classifies the text — empty / whitespace-only, a code fence whose contents didn't parse, or prose with no JSON object — instead of surfacing the opaque `Expecting value: line 1 column 1 (char 0)`. Valid non-object top-level JSON (arrays, scalars) still parses as before.

The salvage is generic and off by default — only the scout opts in. Other `MultiTurnSession` callers (which need strict structured output) are unchanged.

### Note on the scan-position marker

The report flagged confirming where the scout records its last-scanned-commit marker before relying on the close-out. The marker is written mid-run via the scratchpad `remember` tool and the close-out summary is what `runs-list` surfaces to future runs — so persisting the close-out (rather than discarding it) is exactly what restores scan continuity. The `signals-scout-react-doctor` skill itself is a custom project-scoped scout, not in this repo, so no skill change is in scope here.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated tests only — no manual testing:

- `products/tasks/backend/tests/test_extract_json_from_text.py` — added parametrized cases for empty / whitespace / prose / fenced-invalid classification, plus regression that valid non-object JSON still parses.
- `products/tasks/backend/tests/test_multi_turn_session.py::TestMultiTurnSessionStartFallback` — salvages unparseable text via fallback (run not ended as failed); fails and ends the run when no fallback is supplied; valid JSON parses without invoking the fallback; cancellation never salvages.

All 21 tests pass locally. `ruff check`/`format` and `ty check` clean (the latter via the pre-commit hook).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy pointed me at the inbox report and asked for a fix. I verified the report's diagnosis against the actual code (the `json.loads(text)` fall-through and the FAILED re-raise in `MultiTurnSession.start`) before implementing.

Key decision: put the salvage in the *generic* runner behind an opt-in callback rather than making it signals-specific, since `MultiTurnSession` is shared Tasks infrastructure and other callers genuinely want strict structured output. Excluded `CancelledError` from the salvage so a Temporal timeout still fails the run rather than being recorded as a degraded success.

Andy also asked whether the run summary is written as markdown like signal descriptions are — confirmed it already is (the scout prompt instructs GitHub-flavored markdown for the close-out in three places), and the salvaged raw text is the agent's own markdown prose, so degraded summaries stay markdown.

No repo skills were triggered for this change (no DRF/migration/MCP surface touched).
