### PR TITLE
chore: change card styling

### DIFF
--- a/products/ai_observability/frontend/playground/AIObservabilityPlaygroundScene.tsx
+++ b/products/ai_observability/frontend/playground/AIObservabilityPlaygroundScene.tsx
@@ -852,6 +852,19 @@ function ToolsButton({ promptId }: { promptId: string }): JSX.Element {
     )
 }
 
+function getRoleDotClass(role: string): string {
+    switch (role) {
+        case 'user':
+            return 'bg-[var(--color-blue-500)]'
+        case 'assistant':
+            return 'bg-[var(--color-green-500)]'
+        case 'system':
+            return 'bg-[var(--color-purple-500)]'
+        default:
+            return 'bg-muted'
+    }
+}
+
 function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
     const prompt = usePromptConfig(promptId)
     const { promptConfigs, editModal, collapsedSections, linkedSource } = useValues(llmPlaygroundPromptsLogic)
@@ -885,7 +898,7 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
 
     return (
         <>
-            <div className="border rounded p-4 py-2 relative group border-l-4 border-l-[var(--color-purple-500)]">
+            <div className="border rounded p-4 py-2 relative group">
                 <div className="absolute top-2 right-2 flex items-center gap-1">
                     <PlaygroundSaveMenu prompt={prompt} />
                     <LemonDivider vertical className="h-5 mx-0.5" />
@@ -925,7 +938,8 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
                     onClick={() => toggleCollapsed(`system:${promptId}`)}
                 >
                     <CollapsibleChevron collapsed={collapsed} />
-                    <LemonTag type="completion" size="small">
+                    <span className={`w-2 h-2 rounded-full shrink-0 ${getRoleDotClass('system')}`} />
+                    <LemonTag type="default" size="small">
                         System
                     </LemonTag>
                     {linkedContextLabel ? (
@@ -1018,38 +1032,12 @@ function MessageDisplay({
         { label: 'Assistant', value: 'assistant' },
     ]
 
-    const getRoleBorderClass = (role: MessageRole): string => {
-        switch (role) {
-            case 'user':
-                return 'border-l-4 border-l-[var(--color-blue-500)]'
-            case 'assistant':
-                return 'border-l-4 border-l-[var(--color-green-500)]'
-            case 'system':
-                return 'border-l-4 border-l-[var(--color-purple-500)]'
-            default:
-                return ''
-        }
-    }
-
-    const getRoleDotClass = (role: MessageRole): string => {
-        switch (role) {
-            case 'user':
-                return 'bg-[var(--color-blue-500)]'
-            case 'assistant':
-                return 'bg-[var(--color-green-500)]'
-            case 'system':
-                return 'bg-[var(--color-purple-500)]'
-            default:
-                return 'bg-muted'
-        }
-    }
-
     const trimmedContent = message.content.trim()
     const useJsonEditor = trimmedContent.startsWith('{') || trimmedContent.startsWith('[')
 
     return (
         <>
-            <div className={`border rounded p-4 py-2 relative group ${getRoleBorderClass(message.role)}`}>
+            <div className="border rounded p-4 py-2 relative group">
                 <div className="absolute top-4 right-4 flex items-center gap-1">
                     <LemonButton
                         size="small"


### PR DESCRIPTION
## Problem

the cards used in the playground screen have traditional ai slop styles

<img width="1636" height="559" alt="Screenshot 2026-06-17 at 17 57 57" src="https://github.com/user-attachments/assets/5372cc76-0553-4b13-b0fb-bcfcc97d2872" />
## Changes

change the colored card notch into a colored dot

<img width="1692" height="654" alt="Screenshot 2026-06-17 at 18 22 34" src="https://github.com/user-attachments/assets/36f17749-4efe-4446-8c01-a0d05619201e" />