### PR TITLE
fix(hogql): keep NULL rows when filtering by "doesn't contain"

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -507,10 +507,16 @@ def _expr_to_compare_op(
         else:
             # Single value (or single-element array): keep existing NOT ILIKE logic for backward compatibility
             single_value = value[0] if isinstance(value, list) and len(value) == 1 else value
-            return ast.CompareOperation(
-                op=ast.CompareOperationOp.NotILike,
-                left=ast.Call(name="toString", args=[expr]),
-                right=ast.Constant(value=f"%{single_value}%"),
+            return ast.Call(
+                name="ifNull",
+                args=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.NotILike,
+                        left=ast.Call(name="toString", args=[expr]),
+                        right=ast.Constant(value=f"%{single_value}%"),
+                    ),
+                    ast.Constant(value=1),
+                ],
             )
     elif operator == PropertyOperator.ICONTAINS_MULTI:
         # Always expect multiple values for multi-contains operator

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -445,9 +445,20 @@ def _multi_search_found(search_call: ast.Call) -> ast.CompareOperation:
     return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=search_call, right=ast.Constant(value=0))
 
 
-def _multi_search_not_found(search_call: ast.Call) -> ast.CompareOperation:
-    """Create comparison operation to check if multiSearchAnyCaseInsensitive did not find a match."""
-    return ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=search_call, right=ast.Constant(value=0))
+def _multi_search_not_found(search_call: ast.Call) -> ast.Expr:
+    """Check that multiSearchAnyCaseInsensitive did not find a match.
+
+    Wrapped in ifNull(..., 1) so a NULL column keeps the row: toString(NULL)
+    propagates NULL through the `= 0` comparison, which would otherwise drop the
+    row from a negation result. Mirrors the single-value NOT_ICONTAINS path so
+    every "doesn't contain" variant treats a missing value as a match (#24429)."""
+    return ast.Call(
+        name="ifNull",
+        args=[
+            ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=search_call, right=ast.Constant(value=0)),
+            ast.Constant(value=1),
+        ],
+    )
 
 
 def _create_multi_search_call(expr: ast.Expr, value: list) -> ast.Call:

--- a/posthog/hogql/test/test_filters.py
+++ b/posthog/hogql/test/test_filters.py
@@ -201,7 +201,7 @@ class TestFilters(BaseTest):
         )
         self.assertEqual(
             self._print_ast(select),
-            f"SELECT event FROM events WHERE notILike(toString(person.properties.email), '%posthog.com%') LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT event FROM events WHERE ifNull(notILike(toString(person.properties.email), '%posthog.com%'), 1) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_replace_filters_groups_empty(self):

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -198,7 +198,7 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": "3", "operator": "not_icontains"}),
-            self._parse_expr("toString(properties.a) not ilike '%3%'"),
+            self._parse_expr("ifNull(toString(properties.a) not ilike '%3%', 1)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "regex"}),
@@ -525,7 +525,7 @@ class TestProperty(BaseTest):
                 }
             ),
             self._parse_expr(
-                "arrayExists(v -> toString(v) NOT ILIKE '%ValidationError%', JSONExtract(ifNull(properties.$exception_types, ''), 'Array(String)'))"
+                "arrayExists(v -> ifNull(toString(v) NOT ILIKE '%ValidationError%', 1), JSONExtract(ifNull(properties.$exception_types, ''), 'Array(String)'))"
             ),
         )
         self.assertEqual(
@@ -590,7 +590,7 @@ class TestProperty(BaseTest):
                 "operator": "not_icontains",
             }
         )
-        expected = self._parse_expr("toString(properties.a) NOT ILIKE '%single%'")
+        expected = self._parse_expr("ifNull(toString(properties.a) NOT ILIKE '%single%', 1)")
         self.assertEqual(result, expected)
 
         # Test non-string values being stringified

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -201,6 +201,12 @@ class TestProperty(BaseTest):
             self._parse_expr("ifNull(toString(properties.a) not ilike '%3%', 1)"),
         )
         self.assertEqual(
+            # Multi-value negation must also keep NULL rows (same #24429 fix as the
+            # single-value path above), so the multiSearch comparison is ifNull-wrapped.
+            self._property_to_expr({"type": "event", "key": "a", "value": ["3", "4"], "operator": "not_icontains"}),
+            self._parse_expr("ifNull(multiSearchAnyCaseInsensitive(toString(properties.a), ['3', '4']) = 0, 1)"),
+        )
+        self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "regex"}),
             self._parse_expr("ifNull(match(toString(properties.a), '.*'), 0)"),
         )


### PR DESCRIPTION
## Problem

Filtering by "doesn't contain" (`not_icontains`) silently drops rows where the column is NULL — e.g. "Filter out internal/test users" excludes everyone with no email. `col NOT ILIKE '%x%'` evaluates to NULL (not TRUE) for NULL columns, so those rows fail the filter.

## Fix

Wrap the negated comparison in `ifNull(..., 1)` so a NULL column becomes TRUE and the row is kept — mirroring the existing `NOT_REGEX` precedent in the same `_expr_to_compare_op` function.

## Tests

Updated the single-value `not_icontains` assertions in `test_property.py` and the `test_replace_filters_test_accounts` expectation in `test_filters.py` (both codified the buggy SQL). Pure HogQL AST/string assertions — no ClickHouse needed.

Fixes #24429