### PR TITLE
fix(insights): show a readable cohort label instead of a raw id in breakdowns

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -214,12 +214,25 @@ describe('formatBreakdownLabel()', () => {
             breakdown_type: 'cohort',
         }
         expect(formatBreakdownLabel(cohort.id, breakdownFilter1, [cohort as any], identity)).toEqual(cohort.name)
+    })
 
-        const breakdownFilter2: BreakdownFilter = {
+    it('falls back to a human-readable label when the cohort is not in the list', () => {
+        const breakdownFilter: BreakdownFilter = {
             breakdown: [3],
             breakdown_type: 'cohort',
         }
-        expect(formatBreakdownLabel(3, breakdownFilter2, [], identity)).toEqual('3')
+        // When the cohorts list isn't loaded/found, never render the bare id — use `Cohort <id>`.
+        expect(formatBreakdownLabel(3, breakdownFilter, [], identity)).toEqual('Cohort 3')
+        expect(formatBreakdownLabel(3, breakdownFilter, undefined, identity)).toEqual('Cohort 3')
+        expect(formatBreakdownLabel('3', breakdownFilter, [], identity)).toEqual('Cohort 3')
+    })
+
+    it('resolves the cohort name when the cohort is present in the list', () => {
+        const breakdownFilter: BreakdownFilter = {
+            breakdown: [cohort.id],
+            breakdown_type: 'cohort',
+        }
+        expect(formatBreakdownLabel(cohort.id, breakdownFilter, [cohort as any], identity)).toEqual(cohort.name)
     })
 
     it('handles cohort breakdowns with all users', () => {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -334,7 +334,7 @@ export function getCohortNameFromId(
     cohorts: CohortType[] | null | undefined
 ): string {
     // :TRICKY: Different endpoints represent the all users cohort breakdown differently
-    if (cohortId === 'all' || cohortId === 0) {
+    if (cohortId === 'all' || cohortId === 0 || cohortId === '0') {
         return 'All Users'
     }
 
@@ -342,7 +342,18 @@ export function getCohortNameFromId(
         return 'Not in cohort'
     }
 
-    return cohorts?.filter((c) => c.id == cohortId)[0]?.name ?? (cohortId || '').toString()
+    const cohortName = cohorts?.filter((c) => c.id == cohortId)[0]?.name
+    if (cohortName) {
+        return cohortName
+    }
+
+    // The cohorts list may not be loaded yet (or the cohort was deleted). Fall back to a
+    // human-readable label rather than leaking a bare numeric id into pills/axis labels.
+    // Keep in sync with BreakdownTag's `Cohort ${id}` convention.
+    if (cohortId == null || cohortId === '') {
+        return ''
+    }
+    return `Cohort ${cohortId}`
 }
 
 export function formatBreakdownLabel(


### PR DESCRIPTION
## Problem

In insight breakdowns, a cohort's raw numeric id leaked into breakdown pills and bar-chart axis labels when the cohorts list wasn't loaded or the cohort wasn't found, because `getCohortNameFromId` fell back to `cohortId.toString()`.

## Fix

Fall back to `Cohort <id>` (matching `BreakdownTag`'s existing convention) instead of a bare number, and handle the string `'0'` all-users case. Frontend-only; the cohorts model is already loaded for these call sites.

## Tests

Updated `utils.test.ts` (the assertion that expected `'3'`) and added coverage for known/unknown ids. Jest, no ClickHouse.

~Fixes #31850~