### PR TITLE
fix(flags): apply default release conditions to UI-created flags

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1,4 +1,4 @@
-import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
+import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_PROJECT, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
@@ -1134,6 +1134,82 @@ describe('validateFeatureFlagKey', () => {
 
     it('accepts key at exactly 400 characters', () => {
         expect(validateFeatureFlagKey('a'.repeat(400))).toBeUndefined()
+    })
+})
+
+describe('default release conditions for new flags', () => {
+    // Regression test for #63662: the project "Default Release Conditions" setting must be
+    // applied to flags created via the UI. The value is loaded by
+    // defaultReleaseConditionsLogic, and featureFlagLogic must await that load before building
+    // the new-flag form — otherwise the value is still null and the configured default is lost.
+    const DEFAULT_GROUPS = [
+        {
+            properties: [
+                {
+                    key: 'email',
+                    type: PropertyFilterType.Person,
+                    value: 'is_set',
+                    operator: PropertyOperator.IsSet,
+                },
+            ],
+            rollout_percentage: 42,
+            variant: null,
+        },
+    ]
+
+    const mountNewFlag = async (): Promise<ReturnType<typeof featureFlagLogic.build>> => {
+        // Park the router at a non-matching path so the `new`-keyed logic's afterMount takes the
+        // plain `loadFeatureFlag()` branch (no sourceId/type/template/intent prefetch).
+        router.actions.push('/')
+        const newLogic = featureFlagLogic({ id: 'new' })
+        newLogic.mount()
+        await expectLogic(newLogic).toDispatchActions(['loadFeatureFlagSuccess'])
+        return newLogic
+    }
+
+    it('applies configured default release conditions to a new flag', async () => {
+        useMocks({
+            get: {
+                [`/api/environments/${MOCK_TEAM_ID}/default_release_conditions/`]: () => [
+                    200,
+                    { enabled: true, default_groups: DEFAULT_GROUPS },
+                ],
+            },
+        })
+        initKeaTests()
+
+        const newLogic = await mountNewFlag()
+        await expectLogic(newLogic).toMatchValues({
+            featureFlag: partial({
+                filters: partial({
+                    groups: DEFAULT_GROUPS,
+                }),
+            }),
+        })
+        newLogic.unmount()
+    })
+
+    it('does not apply default release conditions when the setting is disabled', async () => {
+        useMocks({
+            get: {
+                [`/api/environments/${MOCK_TEAM_ID}/default_release_conditions/`]: () => [
+                    200,
+                    { enabled: false, default_groups: DEFAULT_GROUPS },
+                ],
+            },
+        })
+        initKeaTests()
+
+        const newLogic = await mountNewFlag()
+        await expectLogic(newLogic).toMatchValues({
+            featureFlag: partial({
+                filters: partial({
+                    // Falls back to NEW_FLAG's default empty group when disabled.
+                    groups: NEW_FLAG.filters.groups,
+                }),
+            }),
+        })
+        newLogic.unmount()
     })
 })
 

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1167,46 +1167,46 @@ describe('default release conditions for new flags', () => {
         return newLogic
     }
 
-    it('applies configured default release conditions to a new flag', async () => {
+    it.each([
+        {
+            label: 'applies the configured groups when the setting is enabled',
+            response: [200, { enabled: true, default_groups: DEFAULT_GROUPS }],
+            expectedAction: 'loadDefaultReleaseConditionsSuccess',
+            // Match the distinguishing rollout_percentage (42) so the assertion tolerates the
+            // per-group sort_key uuid that ensureSortKeys adds for React, while still proving the
+            // configured default — not NEW_FLAG's 0% group — was applied.
+            expectedGroups: [partial({ rollout_percentage: 42 })],
+        },
+        {
+            label: 'falls back to NEW_FLAG groups when the setting is disabled',
+            response: [200, { enabled: false, default_groups: DEFAULT_GROUPS }],
+            expectedAction: 'loadDefaultReleaseConditionsSuccess',
+            expectedGroups: NEW_FLAG.filters.groups,
+        },
+        {
+            label: 'falls back to NEW_FLAG groups when the load fails',
+            response: [500, { detail: 'error' }],
+            expectedAction: 'loadDefaultReleaseConditionsFailure',
+            expectedGroups: NEW_FLAG.filters.groups,
+        },
+    ])('$label', async ({ response, expectedAction, expectedGroups }) => {
         useMocks({
             get: {
-                [`/api/environments/${MOCK_TEAM_ID}/default_release_conditions/`]: () => [
-                    200,
-                    { enabled: true, default_groups: DEFAULT_GROUPS },
-                ],
+                [`/api/environments/${MOCK_TEAM_ID}/default_release_conditions/`]: () => response,
             },
         })
         initKeaTests()
 
         const newLogic = await mountNewFlag()
+        // Require the default-conditions load to have actually run before checking groups.
+        // Without this, the disabled/error cases are tautologies that also pass on master:
+        // a null or disabled config leaves the groups as NEW_FLAG.filters.groups either way, so
+        // asserting the load dispatched is what proves the loader awaited it before building the
+        // flag. The 500 case also exercises the catch/fallback branch in featureFlagLogic.
+        await expectLogic(newLogic).toDispatchActions([expectedAction])
         await expectLogic(newLogic).toMatchValues({
             featureFlag: partial({
-                filters: partial({
-                    groups: DEFAULT_GROUPS,
-                }),
-            }),
-        })
-        newLogic.unmount()
-    })
-
-    it('does not apply default release conditions when the setting is disabled', async () => {
-        useMocks({
-            get: {
-                [`/api/environments/${MOCK_TEAM_ID}/default_release_conditions/`]: () => [
-                    200,
-                    { enabled: false, default_groups: DEFAULT_GROUPS },
-                ],
-            },
-        })
-        initKeaTests()
-
-        const newLogic = await mountNewFlag()
-        await expectLogic(newLogic).toMatchValues({
-            featureFlag: partial({
-                filters: partial({
-                    // Falls back to NEW_FLAG's default empty group when disabled.
-                    groups: NEW_FLAG.filters.groups,
-                }),
+                filters: partial({ groups: expectedGroups }),
             }),
         })
         newLogic.unmount()

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1288,7 +1288,20 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     }
 
                     if (flagType !== 'remote_config') {
-                        const conditionsConfig = values.defaultReleaseConditions
+                        // Default release conditions are loaded fire-and-forget by
+                        // defaultReleaseConditionsLogic.afterMount, which races with this loader.
+                        // Explicitly await the load so the value is populated before we build the
+                        // new flag, otherwise the configured project default is silently dropped.
+                        let conditionsConfig = values.defaultReleaseConditions
+                        try {
+                            conditionsConfig =
+                                (await defaultReleaseConditionsLogic.asyncActions.loadDefaultReleaseConditions()) ??
+                                conditionsConfig
+                        } catch (error) {
+                            // If loading default release conditions fails, fall back to the
+                            // already-loaded value (if any) and continue without defaults.
+                            console.warn('Failed to load default release conditions:', error)
+                        }
                         if (conditionsConfig?.enabled && conditionsConfig.default_groups?.length > 0) {
                             baseFlagConfig = {
                                 ...baseFlagConfig,


### PR DESCRIPTION
## Problem

The "Default Release Conditions" project setting wasn't applied to new feature flags created in the UI. The new-flag loader read `values.defaultReleaseConditions` synchronously, but that value is loaded fire-and-forget and raced with flag construction, so it was still `null` and the configured default was dropped.

## Fix

Await the default-release-conditions load before building the new flag (idiomatic kea `asyncActions`), falling back gracefully on error. Scope: UI-created flags only (the feature's original design); the REST/serializer create path is unchanged.

## Tests

Added cases to `featureFlagLogic.test.ts`: a new flag picks up configured defaults; disabled setting falls back to the standard new-flag groups.

Fixes #63662