### PR TITLE
fix(actions): parse escaped dots and digit/hyphen tags in element selectors

### DIFF
--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 
 from posthog.models.team import Team
 
-SELECTOR_ATTRIBUTE_REGEX = r"([a-zA-Z]*)\[(.*)=[\'|\"](.*)[\'|\"]\]"
+SELECTOR_ATTRIBUTE_REGEX = r"([a-zA-Z0-9\-]*)\[(.*)=[\'|\"](.*)[\'|\"]\]"
 
 
 LAST_UPDATED_TEAM_ACTION: dict[int, datetime.datetime] = {}
@@ -46,12 +46,15 @@ class SelectorPart:
             tag = parts[0]
         if "." in tag:
             # Regex pattern that matches dots that are NOT inside square brackets
-            # Uses negative lookahead to ensure the dot is not followed by content ending with ]
-            # without an opening [ in between
-            # Handles Tailwind arbitrary values with square brackets properly.
-            # Example: 'div.shadow-[0_4px_6px_rgba(0,0,0,0.1)].text-blue-500'
-            # Returns: ['div', 'shadow-[0_4px_6px_rgba(0,0,0,0.1)]', 'text-blue-500']
-            pattern = r"\.(?![^\[]*\])"
+            # and are NOT backslash-escaped (a "\." is a literal dot in the class name).
+            # Negative lookbehind ensures escaped dots (e.g. Tailwind's '.py-2\.5') stay
+            # within a single class instead of being treated as a class separator.
+            # Negative lookahead ensures the dot is not followed by content ending with ]
+            # without an opening [ in between, so Tailwind arbitrary values with square
+            # brackets are handled properly.
+            # Example: 'div.shadow-[0_4px_6px_rgba(0,0,0,0.1)].py-2\.5'
+            # Returns: ['div', 'shadow-[0_4px_6px_rgba(0,0,0,0.1)]', 'py-2\.5']
+            pattern = r"(?<!\\)\.(?![^\[]*\])"
             parts = re.split(pattern, tag)
             # Strip all slashes that are not followed by another slash
             self.data["attr_class__contains"] = [self._unescape_class(p) if escape_slashes else p for p in parts[1:]]

--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -54,6 +54,11 @@ class SelectorPart:
             # brackets are handled properly.
             # Example: 'div.shadow-[0_4px_6px_rgba(0,0,0,0.1)].py-2\.5'
             # Returns: ['div', 'shadow-[0_4px_6px_rgba(0,0,0,0.1)]', 'py-2\.5']
+            # Known limitation: `(?<!\\)` only checks for a single preceding backslash,
+            # and Python's `re` has no variable-length lookbehind, so an even run such as
+            # 'foo\\.bar' (an escaped backslash followed by a real separator dot) is not
+            # split. This is extremely rare in real class names — typical selectors like
+            # 'py-2\.5' are handled correctly — so the impact is negligible.
             pattern = r"(?<!\\)\.(?![^\[]*\])"
             parts = re.split(pattern, tag)
             # Strip all slashes that are not followed by another slash

--- a/posthog/models/test/test_event_model.py
+++ b/posthog/models/test/test_event_model.py
@@ -803,3 +803,42 @@ class TestSelectors(BaseTest):
         # Make sure we strip these for full text search to work in the database
         selector1 = Selector("div#root\\:id")
         self.assertEqual(selector1.parts[0].data, {"tag_name": "div", "attr_id": "root:id"})
+
+    def test_class_with_escaped_dot(self):
+        # Tailwind classes such as `py-2.5` are escaped as `py-2\.5` in CSS selectors.
+        # The backslash-escaped dot is a literal part of the class name, not a separator.
+        selector1 = Selector("div.py-2\\.5.text-blue-500")
+
+        self.assertEqual(
+            selector1.parts[0].data,
+            {"tag_name": "div", "attr_class__contains": ["py-2.5", "text-blue-500"]},
+        )
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)
+
+    def test_tag_with_digits_and_attribute(self):
+        # Tags containing digits (e.g. `h1`) must be preserved alongside an attribute selector.
+        selector1 = Selector('h1[data-id="5"] > span')
+
+        self.assertEqual(selector1.parts[0].data, {"tag_name": "span"})
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)
+
+        self.assertEqual(
+            selector1.parts[1].data,
+            {"tag_name": "h1", "attributes__attr__data-id": "5"},
+        )
+        self.assertEqual(selector1.parts[1].direct_descendant, True)
+        self.assertEqual(selector1.parts[1].unique_order, 0)
+
+    def test_tag_with_hyphen_and_attribute(self):
+        # Custom-element tags containing hyphens (e.g. `my-component`) must be preserved
+        # alongside an attribute selector.
+        selector1 = Selector('my-component[data-id="5"]')
+
+        self.assertEqual(
+            selector1.parts[0].data,
+            {"tag_name": "my-component", "attributes__attr__data-id": "5"},
+        )
+        self.assertEqual(selector1.parts[0].direct_descendant, False)
+        self.assertEqual(selector1.parts[0].unique_order, 0)


### PR DESCRIPTION
## Problem

The Actions HTML/CSS selector parser only handled alphanumeric classes: an escaped class dot (`.py-2\.5`) was split into two classes, and tags with digits/hyphens (`h1`, `my-component`) were dropped from attribute selectors — breaking Tailwind/modern-CSS targeting.

## Fix

Respect backslash-escaped dots when splitting classes, and broaden the attribute-selector tag-capture regex to keep digits/hyphens. Scoped to those two parser defects (the thread's other requests — combining classes, cascading DOM, nth-of-type — are out of scope).

## Tests

Added cases to `TestSelectors` in `test_event_model.py` (escaped-dot class, digit/hyphen tags). Parsing-only, no DB.

Fixes #15480