### PR TITLE
fix(session-recordings): keep the session list within its container

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -210,7 +210,7 @@ function MainPanel(): JSX.Element {
     }
 
     return (
-        <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow')}>
+        <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow min-h-0')}>
             <Warnings />
 
             {!tab ? (
@@ -286,7 +286,7 @@ export function SessionRecordingsPageTabs(): JSX.Element {
 export function SessionsRecordings(): JSX.Element {
     return (
         <BindLogic logic={sessionReplaySceneLogic} props={{}}>
-            <SceneContent className="h-full">
+            <SceneContent className="h-full min-h-0">
                 <SceneTitleSection
                     name={sceneConfigurations[Scene.Replay].name}
                     resourceType={{

--- a/frontend/src/scenes/session-recordings/playlist/Playlist.scss
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.scss
@@ -19,12 +19,28 @@
 }
 
 .SessionRecordingPlaylistHeightWrapper {
-    // NOTE: Uses flex to fill remaining space so controls stay on-screen even when banners appear above.
-    // height is kept as a fallback for non-flex contexts (e.g. storybook).
-    flex: 1;
+    // In the session-recordings scenes this wrapper is a flex child of a viewport-bounded
+    // column (main > SceneContent > MainPanel). There `flex: 1 1 0` makes it fill only the
+    // space left after its siblings — scene title, tabs, and the dismissible banners — so
+    // the list stays inside the viewport and scrolls within its own container (the inner
+    // `.Playlist__list` already has `overflow-y-auto flex-1 min-h-0`) instead of pushing
+    // the whole page past 100vh.
+    //
+    // `min-height: 0` is the load-bearing part: flex items default to `min-height: auto`,
+    // which refuses to shrink below their content's intrinsic height. That default — not
+    // any single magic number — is what let the list overflow once the banners ate into
+    // the available height. With it (plus matching `min-h-0` on the ancestor flex items)
+    // the content can shrink to fit and scroll internally.
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+
+    // `height` provides a definite size for the non-flex contexts that also reuse this
+    // class (person & group "Recordings" tab panels, storybook), where there is no flex
+    // parent to fill against. In the flex contexts above it acts only as the flex-basis,
+    // and `flex-shrink: 1` + `min-height: 0` let the item shrink below it as needed, so it
+    // no longer forces extra page height when banners are present.
     height: calc(100vh - 12rem);
-    min-height: 25rem;
-    max-height: calc(100vh - 12rem); // Prevent growth beyond initial height
 }
 
 .SessionRecordingPreview {

--- a/frontend/src/scenes/session-recordings/playlist/Playlist.scss
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.scss
@@ -26,20 +26,21 @@
     // `.Playlist__list` already has `overflow-y-auto flex-1 min-h-0`) instead of pushing
     // the whole page past 100vh.
     //
-    // `min-height: 0` is the load-bearing part: flex items default to `min-height: auto`,
-    // which refuses to shrink below their content's intrinsic height. That default — not
-    // any single magic number — is what let the list overflow once the banners ate into
-    // the available height. With it (plus matching `min-h-0` on the ancestor flex items)
-    // the content can shrink to fit and scroll internally.
+    // The explicit `min-height` is the load-bearing part: flex items default to
+    // `min-height: auto`, which refuses to shrink below their content's intrinsic
+    // height — that default is what let the list overflow once the banners ate into the
+    // available height. A small `10rem` floor (rather than `0`) still overrides that
+    // default so the content shrinks to fit and scrolls internally, while keeping the
+    // list from collapsing to an unusable height on very short viewports.
     flex: 1 1 0;
-    min-height: 0;
+    min-height: 10rem;
     overflow: hidden;
 
     // `height` provides a definite size for the non-flex contexts that also reuse this
     // class (person & group "Recordings" tab panels, storybook), where there is no flex
     // parent to fill against. In the flex contexts above it acts only as the flex-basis,
-    // and `flex-shrink: 1` + `min-height: 0` let the item shrink below it as needed, so it
-    // no longer forces extra page height when banners are present.
+    // and `flex-shrink: 1` + the small `min-height` floor let the item shrink below it as
+    // needed, so it no longer forces extra page height when banners are present.
     height: calc(100vh - 12rem);
 }
 


### PR DESCRIPTION
## Problem

The recordings session list overflowed the page on smaller / low-DPI screens when both onboarding banners were shown, because the playlist height wrapper used a fixed `calc(100vh - 12rem)` that didn't account for the banners' height.

## Fix

Let flex fill the actual remaining space (`flex: 1 1 0` + `min-height: 0` down the column) so the list scrolls within its container instead of the whole page — no banner-height magic numbers, robust to one/two/future banners. The no-banner and person/group tab cases are preserved.

## Validation

CSS/layout fix — validated visually (load Recordings with both banners on a small viewport; the list scrolls within its container, no whole-page scrollbar). No brittle layout unit test added.

Fixes #43751