### PR TITLE
chore(skills): correct slope graph as native insight display

### DIFF
--- a/.agents/skills/visualizing-change-over-time/SKILL.md
+++ b/.agents/skills/visualizing-change-over-time/SKILL.md
@@ -8,8 +8,8 @@ description: >
   "changed", "moved", "grew", "dropped", "improved", or "regressed" between two
   points or periods, or mentions "before/after", "period over period", "week over
   week", "delta", "slope graph", "slopegraph", or comparing many series across two
-  snapshots. Surfaces the SlopeChart as one of the options. Not for picking a native
-  insight ChartDisplayType in the product analytics insight editor.
+  snapshots. Surfaces both the `SlopeChart` quill component and the native
+  `ChartDisplayType.SlopeGraph` insight display as options.
 ---
 
 # Visualizing change over time
@@ -76,14 +76,24 @@ charts AGENTS.md for theme wiring and sizing.
 
 ## Scope note
 
-`SlopeChart` is a charts-library component — use it for dashboards, reports, the
-`mcp_analytics` frontend, and custom visualizations. It already backs the **Slope**
-view toggle on Max's inline trends result card
-(`services/mcp/src/ui-apps/components/TrendsVisualizer.tsx`). It is **not** yet a
-native insight `ChartDisplayType`, so it does not appear in the product analytics
-insight chart picker and cannot be created through the `posthog:insight-create` MCP
-tool. If
-a user wants the slope graph as a first-class, one-click insight display, that is a
-larger change: add `ChartDisplayType.SlopeChart` in `frontend/src/types.ts`, a
-picker entry in `ChartFilter.tsx` (gate behind a feature flag), and a rendering path
-in the trends view — mirroring how `BoxPlot` was wired in.
+There are **two** ways to render a slope graph; which you reach for depends on the surface:
+
+- **`SlopeChart`** — the `@posthog/quill-charts` component. Use it when building UI
+  directly: dashboards, reports, the `mcp_analytics` frontend, custom visualizations.
+  It backs the **Slope** view toggle on Max's inline trends result card
+  (`services/mcp/src/ui-apps/components/TrendsVisualizer.tsx`).
+- **`ChartDisplayType.SlopeGraph`** — a first-class insight display (value
+  `'SlopeGraph'` in `frontend/src/types.ts`), rendered by the backend
+  `SlopeGraphTrendsQueryRunner`
+  (`posthog/hogql_queries/insights/trends/slope_graph_trends_query_runner.py`). It
+  takes a `TrendsQuery` and keeps the **first and last bucket** of the date range as
+  the two slope points (the last segment is dashed when it's the current,
+  still-accumulating period). Set it via `trendsFilter.display: "SlopeGraph"`
+  (trends-only).
+  - In the **product insight editor**, the picker entry is gated behind
+    `FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT` (`slope-graph-insight`).
+  - Via the **API / `posthog:insight-create` MCP tool** it works without the flag —
+    pass a `TrendsQuery` with `trendsFilter.display: "SlopeGraph"`. To frame a clean
+    before → after, choose the date range and `interval` so the first bucket is your
+    baseline and the last is "now" (e.g. monthly buckets starting from the baseline
+    month).


### PR DESCRIPTION
## Problem

The `visualizing-change-over-time` skill steers agents wrong: its scope note says `SlopeChart` is "**not** yet a native insight `ChartDisplayType`" and describes adding one (`ChartDisplayType.SlopeChart`, a `ChartFilter.tsx` entry, a trends render path) as future work. That's stale — `ChartDisplayType.SlopeGraph` already ships with a backend `SlopeGraphTrendsQueryRunner` and is creatable today via the insight API / `posthog:insight-create`. An agent following the old text would either rebuild something that exists or wrongly tell a user it isn't possible.

## Changes

Rewrites the scope note to document **both** rendering paths:

- `SlopeChart` (the `@posthog/quill-charts` component) for hand-built UI.
- `ChartDisplayType.SlopeGraph` as a first-class insight display — set `trendsFilter.display: "SlopeGraph"` on a `TrendsQuery`; the backend `SlopeGraphTrendsQueryRunner` keeps the first and last bucket of the range as the two points (last dashed while still accumulating). Notes that the **editor** picker entry is gated behind `FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT` (`slope-graph-insight`), while the **API / MCP** path works without the flag, plus a tip on choosing date range + interval to frame a clean before → after.

Docs-only change to one skill file (`.agents/skills/visualizing-change-over-time/SKILL.md`); the frontmatter `description` is updated to match.

## How did you test this code?

I'm an agent. No automated tests apply (docs-only). I verified the claims against the codebase before writing them: `ChartDisplayType.SlopeGraph = 'SlopeGraph'` in `frontend/src/types.ts`; the runner at `posthog/hogql_queries/insights/trends/slope_graph_trends_query_runner.py` (`_keep_first_and_last_bucket`); the flag-gated picker entry in `frontend/src/lib/components/ChartFilter/ChartFilter.tsx` (`FEATURE_FLAGS.SLOPE_GRAPH_INSIGHT`); and `slope-graph-insight` in `frontend/src/lib/constants.tsx`. I also created a working `SlopeGraph` insight through `posthog:insight-create` to confirm the API path needs no flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while a user asked to render a before/after web-vitals comparison as a slope graph. The skill said it wasn't a native display type, but the user knew otherwise and had tested it — so I verified against the code (display enum, backend runner, flag-gated picker entry, constants) and corrected the skill. Scoped deliberately to the skill doc; no change to the slope feature itself. The `slope-graph-insight` flag is owned by @pauldambra / #team-product-analytics.
