### PR TITLE
fix(linear): retry transient network errors during import

### DIFF
--- a/posthog/temporal/data_imports/sources/linear/linear.py
+++ b/posthog/temporal/data_imports/sources/linear/linear.py
@@ -90,7 +90,13 @@ def _make_paginated_request(
         reraise=True,
     )
     def execute(variables: dict[str, Any]) -> dict:
-        response = sess.post(LINEAR_API_URL, json={"query": query, "variables": variables}, timeout=60)
+        try:
+            response = sess.post(LINEAR_API_URL, json={"query": query, "variables": variables}, timeout=60)
+        except (requests.ConnectionError, requests.Timeout) as e:
+            # The session's urllib3 Retry only covers idempotent methods, so Linear's POSTs get no
+            # transport-level retry. Route transient network failures (read timeout, connection reset)
+            # through the same backoff path as 5xx/429 instead of failing the whole activity on one blip.
+            raise LinearRetryableError(f"Linear: transient network error - {e}")
 
         if response.status_code >= 500:
             raise LinearRetryableError(f"Linear: server error {response.status_code}")

--- a/posthog/temporal/data_imports/sources/linear/test_linear.py
+++ b/posthog/temporal/data_imports/sources/linear/test_linear.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 import pytest
 from unittest.mock import MagicMock, patch
 
+import requests
 from parameterized import parameterized
 from tenacity import Future, RetryCallState
 
@@ -225,6 +226,68 @@ class TestMakePaginatedRequest:
 
         assert session.post.call_count == 5
 
+    @parameterized.expand(
+        [
+            ("read_timeout", requests.exceptions.ReadTimeout("Read timed out. (read timeout=60)")),
+            ("connection_reset", requests.exceptions.ConnectionError("Connection aborted")),
+        ]
+    )
+    @patch("time.sleep", return_value=None)
+    @patch("posthog.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_transient_network_error_is_retried_then_succeeds(
+        self,
+        _name: str,
+        transient_exc: Exception,
+        mock_session_cls: MagicMock,
+        _mock_sleep: MagicMock,
+    ) -> None:
+        # Linear's POSTs get no transport-level retry, so a transient network error must be folded
+        # into the application-level backoff rather than escaping on the first attempt.
+        session = MagicMock()
+        session.post.side_effect = [transient_exc, _make_response([{"id": "a"}], False, None)]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[{"id": "a"}]]
+        assert session.post.call_count == 2
+
+    @patch("time.sleep", return_value=None)
+    @patch("posthog.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_persistent_network_error_raises_retryable_error(
+        self, mock_session_cls: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        session = MagicMock()
+        session.post.side_effect = [
+            requests.exceptions.ReadTimeout("Read timed out. (read timeout=60)") for _ in range(5)
+        ]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        with pytest.raises(LinearRetryableError):
+            list(
+                _make_paginated_request(
+                    access_token="tok",
+                    endpoint_name="issues",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert session.post.call_count == 5
+
 
 class TestRateLimitBackoff:
     @parameterized.expand(
@@ -338,6 +401,10 @@ class TestLinearSourceNonRetryableErrors:
             ("transient_500", "500 Server Error for url: https://api.linear.app/graphql"),
             ("rate_limited", "Linear: rate limited (429)"),
             ("graphql_error", "Linear GraphQL error: Something failed"),
+            (
+                "read_timeout",
+                "Linear: transient network error - HTTPSConnectionPool(host='api.linear.app', port=443): Read timed out. (read timeout=60)",
+            ),
         ]
     )
     def test_non_retryable_errors_does_not_match_transient(self, _name: str, observed_error: str) -> None:


### PR DESCRIPTION
## Problem

Linear data-warehouse imports were failing with an uncaught `requests.exceptions.ReadTimeout` (`The read operation timed out` — read timeout=60 to `api.linear.app`), surfaced in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ed7a8-cda2-7640-be13-2b0418868bd7)). The failure originates in the Linear source's paginated request path (`linear.py` `execute` → `sess.post`).

The root cause is a gap in retry coverage. Linear's GraphQL calls are `POST` requests, and the shared session's urllib3 `Retry` only retries idempotent methods (`GET`/`HEAD`/`OPTIONS`), so Linear's POSTs get **no** transport-level retry. The source compensates by re-implementing 5xx and 429 retries at the application level — but a transient *network* failure (read timeout, connection reset) is neither a `LinearRetryableError` nor a retried HTTP status, so it escaped both layers and failed the entire import activity on the first blip.

## Changes

Wrap the `sess.post` call in `execute()` and re-raise transient transport failures (`requests.ConnectionError` / `requests.Timeout`) as `LinearRetryableError`, routing them through the existing jittered-backoff retry — exactly how 5xx and 429 are already handled.

This is a transient infrastructure error, so it stays **retryable**: it is deliberately not added to `NonRetryableErrors`. A single slow Linear response now backs off and retries locally instead of killing the whole sync.

## How did you test this code?

I'm an agent; I did not perform manual testing. Automated tests added to `test_linear.py` and run locally (33 passed):

- `test_transient_network_error_is_retried_then_succeeds` — parameterized over `ReadTimeout` and `ConnectionError`: first POST raises, second succeeds, pagination completes, two POSTs issued.
- `test_persistent_network_error_raises_retryable_error` — a persistent timeout exhausts the 5 attempts and reraises `LinearRetryableError`.
- Extended `test_non_retryable_errors_does_not_match_transient` to assert the new `Linear: transient network error - ...` message is not matched by `NonRetryableErrors`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the full stack trace via the PostHog MCP error-tracking tools and confirmed the frame originates in `posthog/temporal/data_imports/sources/linear/linear.py` (the `cycles` endpoint on an incremental sync). Read the source plus the shared `common/http/transport.py` to understand the retry layering.

Decision: classified this as a fixable fragility, not a user/upstream error. A read timeout is transient and must remain retryable, so `NonRetryableErrors` was left untouched. The fix mirrors the existing 5xx/429 handling rather than introducing a new retry mechanism, keeping it scoped. No skills were applicable to this change.
