### PR TITLE
feat(mcp-analytics): add dashboard-wide time filter

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5625,21 +5625,21 @@ snapshots:
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
     scenes-app-mcp-analytics--dashboard--dark:
-        hash: v1.k794b7964.83c70580c95196511976b284e12102c4fc4b60bfe0c4b5b84ede14177c0f0fc1.ghImisZOBWjSVAnytJWdTHks5jIe2jn032_4NF_-g-c
+        hash: v1.k794b7964.ce73116b61c51cdf515f7c449614e819605543194fc8194e3777cdd3fe37e847.V5cyDORCjiV-nUz1h65KpHKbywxm0u-TRuq7W3vJSrY
     scenes-app-mcp-analytics--dashboard--light:
-        hash: v1.k794b7964.c64d5d43c4eaa79d3008e9dd40857d9bee879832e68a8f8e9464657ff670773f.yKxStICPwIMCMEnf_zQhK0BuXu5BIxaUKmgPYHAEzYo
+        hash: v1.k794b7964.ca0753eb512b0d9ccef0d4c4ff92aadcea3b6df1be5651501038556443e5e914.yj6GSJwiP_mA_Eq426rKSfymYSgYCQVBqsnB5hLWwKQ
     scenes-app-mcp-analytics--sessions--dark:
         hash: v1.k794b7964.c316f0028a9cc9b6a8e2b85d95b5e5ab65548805d4069f001c5cbbbcfbac970c.u4rZzVUZRlEBb11eUbRTRsVFfH_5gb3qRI5BEuAN7qw
     scenes-app-mcp-analytics--sessions--light:
         hash: v1.k794b7964.497d9ae69307438f3ef9ebfc80bb948ffd70d285eda4192f6b2e21f1a66d3eba.XI5y0bJbIitncOcXS_6Gxcr4pgGCK1moA7JIAstwuL4
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--dark:
-        hash: v1.k794b7964.695d298349258e60b3b8f0c8775e1554ffd9ad3a3b9d4d750df124550bf65c51.cpBNQ-OwnkymJacZsj27ScYkVTr_36Yb8Z27xINlTN8
+        hash: v1.k794b7964.921f819d1e55f6b1df74b8d4990bba635aa6f7db8ab7a75a232009bbac5f2e43.qy4SEtXqEIFBeEw5gzgTLCCbKUL61bV7pvuMq_cdTzA
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--light:
-        hash: v1.k794b7964.3dfc5ce2265a673956f3eab4e61f354d521843fa67e204a55b00d9a477059dff.5usCphh504ZrBw5hriydx544vV8-RLHdGmrR-lJipNU
+        hash: v1.k794b7964.5d9dd4393c052649a915d9fc01f0f07234778e6f07f876a2fb912692b967788e.xDH1R5rcnjKd-BMTqKjYRI3ILq3GIZKLCfvQCkBA6gE
     scenes-app-mcp-analytics-dashboard-cards--daily-tool-breakdown--dark:
-        hash: v1.k794b7964.830c208da94ba09d6c4ebbf829d48e8d8647ac7e6f10005d0ece25d8b1452826.H6z3crTfy2qeI7IGNmP1sVidoSC2oOUayUHiftQFGK4
+        hash: v1.k794b7964.236335937faad628b44dd754d4ce16dd3420dfc7a6d490441aadd4d4c7617477.MSc20kR_NgLKYepX3fzKiFeTN7RWZBJrLsiUG6gXePI
     scenes-app-mcp-analytics-dashboard-cards--daily-tool-breakdown--light:
-        hash: v1.k794b7964.08616349eeae04cabd327dde6ab1cf6bd40a19a609f175554044ac2c0bceb271.qccwqFpHII7zSOEe3-1rqQpODEHCZ4B5uOyojP6oO9Y
+        hash: v1.k794b7964.2310b7364e5f258ea2a43fa99bb9de186017c80b5ab3861419426edbc128acb9.yt5bPk2SSqYNpVVzhYToDVQfoOq_hkz7Ee1dZbk5pQo
     scenes-app-mcp-analytics-dashboard-cards--error-rate-by-tool--dark:
         hash: v1.k794b7964.6d0c0cd5cbb382903fee3b31192a515c1aeaf19d17ef3626f300815b1d0ce3aa.czfgUIwTwO7B3tJ874cZj9pvjWCdKI9wQLAkIl5LIhU
     scenes-app-mcp-analytics-dashboard-cards--error-rate-by-tool--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -43,7 +43,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
     const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
 
     return (
-        <div className="flex flex-col gap-10" data-quill>
+        <div className="flex flex-col gap-4" data-quill>
             <div className="flex flex-wrap items-center gap-3">
                 <McpDateFilter
                     dateFrom={dateFilter.dateFrom}

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -33,6 +33,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         toolRows,
         toolRowsLoading,
         dateFilter,
+        bucketGranularity,
     } = useValues(mcpDashboardOverviewLogic)
     const { setDateFilter } = useActions(mcpDashboardOverviewLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -66,6 +67,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                                 loading={activityRowsLoading}
                                 theme={theme}
                                 timezone={timezone}
+                                interval={bucketGranularity}
                             />
                         </div>
                         <HarnessDonut rows={harnessRows} loading={harnessRawRowsLoading} theme={theme} />
@@ -79,6 +81,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                         loading={toolDailyRowsLoading}
                         theme={theme}
                         timezone={timezone}
+                        interval={bucketGranularity}
                     />
                 </div>
             </section>

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -33,7 +33,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         toolRows,
         toolRowsLoading,
         dateFilter,
-        bucketGranularity,
+        interval,
     } = useValues(mcpDashboardOverviewLogic)
     const { setDateFilter } = useActions(mcpDashboardOverviewLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -67,7 +67,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                                 loading={activityRowsLoading}
                                 theme={theme}
                                 timezone={timezone}
-                                interval={bucketGranularity}
+                                interval={interval}
                             />
                         </div>
                         <HarnessDonut rows={harnessRows} loading={harnessRawRowsLoading} theme={theme} />
@@ -81,7 +81,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                         loading={toolDailyRowsLoading}
                         theme={theme}
                         timezone={timezone}
-                        interval={bucketGranularity}
+                        interval={interval}
                     />
                 </div>
             </section>

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { type ChartTheme } from '@posthog/quill-charts'
@@ -8,6 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
+import { McpDateFilter } from './components/McpDateFilter'
 import { ActivityChart } from './dashboard/ActivityChart'
 import { HarnessDonut } from './dashboard/HarnessDonut'
 import { KpiTiles } from './dashboard/KpiTiles'
@@ -31,7 +32,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         toolDailyRowsLoading,
         toolRows,
         toolRowsLoading,
+        dateFilter,
     } = useValues(mcpDashboardOverviewLogic)
+    const { setDateFilter } = useActions(mcpDashboardOverviewLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
@@ -41,12 +44,20 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-10" data-quill>
+            <div className="flex flex-wrap items-center justify-end gap-3">
+                <McpDateFilter
+                    dateFrom={dateFilter.dateFrom}
+                    dateTo={dateFilter.dateTo}
+                    onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
+                    dataAttr="mcp-dashboard-date-filter"
+                />
+            </div>
             <section>
-                <h2 className="mb-4 text-xl font-semibold text-primary">This week's key metrics</h2>
+                <h2 className="mb-4 text-xl font-semibold text-primary">Key metrics</h2>
                 <KpiTiles kpis={kpis} intentClusterCount={intentClusterCount} kpisLoading={kpisLoading} theme={theme} />
             </section>
             <section>
-                <h2 className="mb-4 text-xl font-semibold text-primary">Last month's usage</h2>
+                <h2 className="mb-4 text-xl font-semibold text-primary">Usage</h2>
                 <div className="flex flex-col gap-[22px]">
                     <div className="grid grid-cols-1 gap-[22px] lg:grid-cols-3">
                         <div className="flex lg:col-span-2">

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -44,7 +44,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-10" data-quill>
-            <div className="flex flex-wrap items-center justify-end gap-3">
+            <div className="flex flex-wrap items-center gap-3">
                 <McpDateFilter
                     dateFrom={dateFilter.dateFrom}
                     dateTo={dateFilter.dateTo}

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
@@ -14,9 +14,9 @@ import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
+import { McpDateFilter } from './components/McpDateFilter'
 import { mcpAnalyticsToolQualityLogic } from './mcpAnalyticsToolQualityLogic'
 import { ToolQualityCharts } from './tool-quality/ToolQualityCharts'
-import { ToolQualityDateFilter } from './tool-quality/ToolQualityDateFilter'
 import { ToolQualityTable } from './tool-quality/ToolQualityTable'
 
 function FilterBar(): JSX.Element {
@@ -38,10 +38,11 @@ function FilterBar(): JSX.Element {
                     dataAttr="mcp-tool-quality-category-scope"
                 />
             </div>
-            <ToolQualityDateFilter
+            <McpDateFilter
                 dateFrom={dateFilter.dateFrom}
                 dateTo={dateFilter.dateTo}
                 onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
+                dataAttr="mcp-tool-quality-date-filter"
             />
             {hasScope && sharePct !== null ? (
                 <Tooltip

--- a/products/mcp_analytics/frontend/components/McpDateFilter.tsx
+++ b/products/mcp_analytics/frontend/components/McpDateFilter.tsx
@@ -60,15 +60,10 @@ interface McpDateFilterProps {
     dateFrom: string | null
     dateTo: string | null
     onChange: (dateFrom: string | null, dateTo: string | null) => void
-    dataAttr?: string
+    dataAttr: string
 }
 
-export function McpDateFilter({
-    dateFrom,
-    dateTo,
-    onChange,
-    dataAttr = 'mcp-date-filter',
-}: McpDateFilterProps): JSX.Element {
+export function McpDateFilter({ dateFrom, dateTo, onChange, dataAttr }: McpDateFilterProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const value = toPickerValue(dateFrom, dateTo)
 

--- a/products/mcp_analytics/frontend/components/McpDateFilter.tsx
+++ b/products/mcp_analytics/frontend/components/McpDateFilter.tsx
@@ -56,13 +56,19 @@ function formatTriggerLabel(value: DateTimeValue): string {
     return `${dayjs(value.start).format('MMM D, HH:mm')} – ${dayjs(value.end).format('MMM D, HH:mm')}`
 }
 
-interface ToolQualityDateFilterProps {
+interface McpDateFilterProps {
     dateFrom: string | null
     dateTo: string | null
     onChange: (dateFrom: string | null, dateTo: string | null) => void
+    dataAttr?: string
 }
 
-export function ToolQualityDateFilter({ dateFrom, dateTo, onChange }: ToolQualityDateFilterProps): JSX.Element {
+export function McpDateFilter({
+    dateFrom,
+    dateTo,
+    onChange,
+    dataAttr = 'mcp-date-filter',
+}: McpDateFilterProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const value = toPickerValue(dateFrom, dateTo)
 
@@ -80,7 +86,7 @@ export function ToolQualityDateFilter({ dateFrom, dateTo, onChange }: ToolQualit
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger
                 render={
-                    <Button variant="outline" data-attr="mcp-tool-quality-date-filter">
+                    <Button variant="outline" data-attr={dataAttr}>
                         <IconCalendar />
                         {formatTriggerLabel(value)}
                     </Button>

--- a/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import {
     type ChartTheme,
     type Series,
+    type TimeInterval,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
@@ -16,11 +17,13 @@ export function ActivityChart({
     loading,
     theme,
     timezone,
+    interval,
 }: {
     daily: DailyActivity
     loading: boolean
     theme: ChartTheme
     timezone: string
+    interval: TimeInterval
 }): JSX.Element {
     const series = useMemo<Series[]>(() => {
         const totals = daily.successes.map((s, i) => s + (daily.errors[i] ?? 0))
@@ -34,15 +37,15 @@ export function ActivityChart({
         () => ({
             yAxis: { showGrid: false },
             showAxisLines: true,
-            xAxis: { interval: 'day', timezone },
+            xAxis: { interval, timezone },
             showCrosshair: true,
             tooltip: { placement: 'cursor' },
         }),
-        [timezone]
+        [timezone, interval]
     )
 
     return (
-        <Card className="flex flex-1 flex-col" title="Daily tool calls and errors">
+        <Card className="flex flex-1 flex-col" title="Tool calls and errors">
             <CardState
                 loading={loading}
                 isEmpty={daily.labels.length === 0}

--- a/products/mcp_analytics/frontend/dashboard/DashboardCards.stories.tsx
+++ b/products/mcp_analytics/frontend/dashboard/DashboardCards.stories.tsx
@@ -150,7 +150,9 @@ export const KeyMetrics: Story = {
 }
 
 export const DailyCallsAndErrors: Story = {
-    render: withTheme((theme) => <ActivityChart daily={DAILY_ACTIVITY} loading={false} theme={theme} timezone="UTC" />),
+    render: withTheme((theme) => (
+        <ActivityChart daily={DAILY_ACTIVITY} loading={false} theme={theme} timezone="UTC" interval="day" />
+    )),
 }
 
 export const ShareByHarness: Story = {
@@ -162,7 +164,9 @@ export const ErrorRateByTool: Story = {
 }
 
 export const DailyToolBreakdown: Story = {
-    render: withTheme((theme) => <ToolUsageChart data={TOOL_DAILY} loading={false} theme={theme} timezone="UTC" />),
+    render: withTheme((theme) => (
+        <ToolUsageChart data={TOOL_DAILY} loading={false} theme={theme} timezone="UTC" interval="day" />
+    )),
 }
 
 export const FlaggedSessions: Story = {

--- a/products/mcp_analytics/frontend/dashboard/ToolUsageChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolUsageChart.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
 
-import { type ChartTheme, type Series, TimeSeriesBarChart, type TimeSeriesBarChartConfig } from '@posthog/quill-charts'
+import {
+    type ChartTheme,
+    type Series,
+    type TimeInterval,
+    TimeSeriesBarChart,
+    type TimeSeriesBarChartConfig,
+} from '@posthog/quill-charts'
 import { Skeleton } from '@posthog/quill-primitives'
 
 import { type ToolDailySeries } from '../mcpDashboardOverviewLogic'
@@ -11,11 +17,13 @@ export function ToolUsageChart({
     loading,
     theme,
     timezone,
+    interval,
 }: {
     data: ToolDailySeries
     loading: boolean
     theme: ChartTheme
     timezone: string
+    interval: TimeInterval
 }): JSX.Element {
     const series = useMemo<Series[]>(
         () =>
@@ -33,14 +41,14 @@ export function ToolUsageChart({
             barCornerRadius: 2,
             yAxis: { showGrid: false },
             showAxisLines: true,
-            xAxis: { interval: 'day', timezone },
+            xAxis: { interval, timezone },
             tooltip: { placement: 'cursor' },
         }),
-        [timezone]
+        [timezone, interval]
     )
 
     return (
-        <Card title="Daily breakdown of tool calls">
+        <Card title="Tool call breakdown">
             <CardState
                 loading={loading}
                 isEmpty={data.labels.length === 0}

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -397,8 +397,8 @@ ORDER BY day
         },
     })),
 
-    actionToUrl(({ values }) => ({
-        setSelectedTool: () => {
+    actionToUrl(({ values }) => {
+        const syncUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
             const { currentLocation } = router.values
             const searchParams = { ...currentLocation.searchParams }
             if (values.selectedTool) {
@@ -406,15 +406,35 @@ ORDER BY day
             } else {
                 delete searchParams.tool
             }
+            if (values.dateFilter.dateFrom) {
+                searchParams.date_from = values.dateFilter.dateFrom
+            } else {
+                delete searchParams.date_from
+            }
+            if (values.dateFilter.dateTo) {
+                searchParams.date_to = values.dateFilter.dateTo
+            } else {
+                delete searchParams.date_to
+            }
             return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
-        },
-    })),
+        }
+        return {
+            setSelectedTool: syncUrl,
+            setDateFilter: syncUrl,
+        }
+    }),
 
     urlToAction(({ actions, values }) => ({
         [urls.mcpAnalyticsToolQuality()]: (_, searchParams) => {
             const tool = typeof searchParams.tool === 'string' && searchParams.tool ? searchParams.tool : null
             if (tool !== values.selectedTool) {
                 actions.setSelectedTool(tool)
+            }
+            const dateFrom =
+                typeof searchParams.date_from === 'string' ? searchParams.date_from : values.dateFilter.dateFrom
+            const dateTo = typeof searchParams.date_to === 'string' ? searchParams.date_to : null
+            if (dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo) {
+                actions.setDateFilter(dateFrom, dateTo)
             }
         },
     })),

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -10,6 +10,7 @@ import {
     type BucketRow,
     buildKPIs,
     buildKpiWindow,
+    bucketGranularityForWindow,
     buildToolDailySeries,
     categorizeHarness,
     deltaPct,
@@ -132,23 +133,61 @@ describe('mcpDashboardOverviewLogic', () => {
         })
     })
 
+    describe('bucketGranularityForWindow', () => {
+        it.each([
+            ['-1h', 'minute'],
+            ['-3h', 'minute'],
+            ['-6h', 'hour'],
+            ['-24h', 'hour'],
+            ['-2d', 'hour'],
+            ['-7d', 'day'],
+            ['-30d', 'day'],
+        ])('picks %s -> %s buckets', (dateFrom, expected) => {
+            expect(bucketGranularityForWindow({ dateFrom, dateTo: null }, 'UTC')).toBe(expected)
+        })
+    })
+
     describe('buildKpiWindow', () => {
         it.each([
-            ['2024-01-08', '2024-01-15', '2024-01-08', '2023-12-31'],
-            ['2024-01-01', '2024-01-31', '2024-01-01', '2023-12-01'],
+            ['2024-01-08', '2024-01-15', 'day', '2024-01-08', '2023-12-31'],
+            ['2024-01-01', '2024-01-31', 'day', '2024-01-01', '2023-12-01'],
         ])(
             'extends [%s, %s] back to an equal-length prior window with cutoff at the selected start',
-            (dateFrom, dateTo, expectedCutoff, expectedPriorStart) => {
-                const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC')
-                expect(window.currentStartDay).toBe(expectedCutoff)
+            (dateFrom, dateTo, granularity, expectedCutoff, expectedPriorStart) => {
+                const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC', granularity as 'day')
+                expect(window.currentStartBucket).toBe(expectedCutoff)
                 expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe(expectedPriorStart)
-                // The two halves of the comparison must span an equal number of daily buckets,
-                // otherwise every delta is biased toward whichever side has the extra day.
-                const priorBuckets = dayjs(window.currentStartDay).diff(dayjs(window.dateFrom), 'day')
-                const currentBuckets = dayjs(window.dateTo).diff(dayjs(window.currentStartDay), 'day') + 1
+                // The two halves of the comparison must span an equal number of buckets,
+                // otherwise every delta is biased toward whichever side has the extra bucket.
+                const priorBuckets = dayjs(window.currentStartBucket).diff(dayjs(window.dateFrom), granularity as 'day')
+                const currentBuckets =
+                    dayjs(window.dateTo).diff(dayjs(window.currentStartBucket), granularity as 'day') + 1
                 expect(priorBuckets).toBe(currentBuckets)
             }
         )
+
+        it('produces an hour-aligned cutoff and an equal prior window for sub-day ranges', () => {
+            const window = buildKpiWindow(
+                { dateFrom: '2024-01-08T05:00:00Z', dateTo: '2024-01-08T09:00:00Z' },
+                'UTC',
+                'hour'
+            )
+            // 5 inclusive hour buckets (05:00..09:00), so the prior window steps back 5 hours.
+            expect(window.currentStartBucket).toBe('2024-01-08 05:00:00')
+            expect(dayjs(window.dateFrom).toISOString()).toBe('2024-01-08T00:00:00.000Z')
+        })
+
+        it('resolves the relative -7d default against now with a symmetric prior window', () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+            try {
+                const window = buildKpiWindow({ dateFrom: '-7d', dateTo: null }, 'UTC', 'day')
+                expect(window.currentStartBucket).toBe('2026-06-11')
+                // doubled window: prior 8 day-buckets before the cutoff
+                expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe('2026-06-03')
+            } finally {
+                jest.useRealTimers()
+            }
+        })
     })
 
     describe('buildKPIs', () => {

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -1,15 +1,32 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+
+import { initKeaTests } from '~/test/init'
+
 import {
     aggregateHarnessRows,
     type BucketRow,
     buildKPIs,
+    buildKpiWindow,
     buildToolDailySeries,
     categorizeHarness,
     deltaPct,
     type HarnessRawRow,
+    mcpDashboardOverviewLogic,
     pickNotableSessions,
     type SessionRow,
     type ToolDailyRow,
 } from './mcpDashboardOverviewLogic'
+
+jest.mock('lib/api')
+jest.mock('./generated/api', () => ({
+    mcpAnalyticsIntentClustersRetrieve: jest.fn().mockResolvedValue({ status: 'idle', clusters: [] }),
+    mcpAnalyticsIntentClustersRecompute: jest.fn(),
+}))
+
+const mockApi = api as jest.Mocked<typeof api>
 
 function session(overrides: Partial<SessionRow> & { session_id: string }): SessionRow {
     return {
@@ -23,7 +40,7 @@ function session(overrides: Partial<SessionRow> & { session_id: string }): Sessi
     }
 }
 
-describe('mcpDashboardOverviewLogic helpers', () => {
+describe('mcpDashboardOverviewLogic', () => {
     describe('categorizeHarness', () => {
         it.each([
             ['claude-code/1.0.0', 'Claude Code'],
@@ -115,14 +132,29 @@ describe('mcpDashboardOverviewLogic helpers', () => {
         })
     })
 
+    describe('buildKpiWindow', () => {
+        it.each([
+            ['2024-01-08', '2024-01-15', '2024-01-08', '2024-01-01', 14],
+            ['2024-01-01', '2024-01-31', '2024-01-01', '2023-12-02', 60],
+        ])(
+            'doubles the [%s, %s] window back to %s with cutoff at the selected start',
+            (dateFrom, dateTo, expectedCutoff, expectedPriorStart, expectedSpanDays) => {
+                const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC')
+                expect(window.currentStartDay).toBe(expectedCutoff)
+                expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe(expectedPriorStart)
+                expect(dayjs(window.dateTo).diff(dayjs(window.dateFrom), 'day')).toBe(expectedSpanDays)
+            }
+        )
+    })
+
     describe('buildKPIs', () => {
         it('splits current vs prior buckets and computes values, deltas, and sparklines', () => {
             const rows: BucketRow[] = [
-                { bucket: '2024-01-09', sessions: 20, tool_calls: 200, errors: 15, p95: 300, in_current: true },
-                { bucket: '2024-01-08', sessions: 10, tool_calls: 100, errors: 5, p95: 200, in_current: true },
-                { bucket: '2024-01-01', sessions: 5, tool_calls: 50, errors: 5, p95: 150, in_current: false },
+                { bucket: '2024-01-09', sessions: 20, tool_calls: 200, errors: 15, p95: 300 },
+                { bucket: '2024-01-08', sessions: 10, tool_calls: 100, errors: 5, p95: 200 },
+                { bucket: '2024-01-01', sessions: 5, tool_calls: 50, errors: 5, p95: 150 },
             ]
-            const kpis = buildKPIs(rows)
+            const kpis = buildKPIs(rows, '2024-01-08')
 
             expect(kpis.sessions).toEqual({
                 value: 30,
@@ -149,10 +181,8 @@ describe('mcpDashboardOverviewLogic helpers', () => {
         })
 
         it('returns null deltas when there is no prior-period data', () => {
-            const rows: BucketRow[] = [
-                { bucket: '2024-01-08', sessions: 10, tool_calls: 100, errors: 0, p95: 200, in_current: true },
-            ]
-            expect(buildKPIs(rows).sessions.deltaPct).toBeNull()
+            const rows: BucketRow[] = [{ bucket: '2024-01-08', sessions: 10, tool_calls: 100, errors: 0, p95: 200 }]
+            expect(buildKPIs(rows, '2024-01-08').sessions.deltaPct).toBeNull()
         })
     })
 
@@ -215,6 +245,40 @@ describe('mcpDashboardOverviewLogic helpers', () => {
             // never more than the cap, never the same session twice
             expect(picked).toHaveLength(5)
             expect(new Set(picked.map((p) => p.session.session_id)).size).toBe(5)
+        })
+    })
+
+    describe('date filter wiring', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+            initKeaTests()
+            jest.spyOn(mockApi, 'query').mockResolvedValue({ results: [] } as any)
+        })
+
+        function reloadCallsSince(callIndex: number): { query: string; filters: Record<string, any> }[] {
+            return mockApi.query.mock.calls.slice(callIndex).map((call) => call[0] as any)
+        }
+
+        it('reloads every tile when the date filter changes', async () => {
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const callsBefore = mockApi.query.mock.calls.length
+
+            await expectLogic(logic, () => {
+                logic.actions.setDateFilter('-30d', null)
+            }).toFinishAllListeners()
+
+            const reloads = reloadCallsSince(callsBefore)
+            // Six tiles: KPI + the five breakdown queries.
+            expect(reloads.length).toBe(6)
+            // The five breakdowns pass the raw selected range straight through.
+            const breakdowns = reloads.filter((call) => call.filters.dateRange.date_from === '-30d')
+            expect(breakdowns).toHaveLength(5)
+            // The KPI tile widens to an absolute doubled window so it can compare against the prior period.
+            const kpi = reloads.find((call) => call.query.includes('AS bucket'))
+            expect(kpi?.filters.dateRange.date_from).not.toBe('-30d')
+            expect(dayjs(kpi?.filters.dateRange.date_from).isValid()).toBe(true)
         })
     })
 })

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -134,15 +134,19 @@ describe('mcpDashboardOverviewLogic', () => {
 
     describe('buildKpiWindow', () => {
         it.each([
-            ['2024-01-08', '2024-01-15', '2024-01-08', '2024-01-01', 14],
-            ['2024-01-01', '2024-01-31', '2024-01-01', '2023-12-02', 60],
+            ['2024-01-08', '2024-01-15', '2024-01-08', '2023-12-31'],
+            ['2024-01-01', '2024-01-31', '2024-01-01', '2023-12-01'],
         ])(
-            'doubles the [%s, %s] window back to %s with cutoff at the selected start',
-            (dateFrom, dateTo, expectedCutoff, expectedPriorStart, expectedSpanDays) => {
+            'extends [%s, %s] back to an equal-length prior window with cutoff at the selected start',
+            (dateFrom, dateTo, expectedCutoff, expectedPriorStart) => {
                 const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC')
                 expect(window.currentStartDay).toBe(expectedCutoff)
                 expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe(expectedPriorStart)
-                expect(dayjs(window.dateTo).diff(dayjs(window.dateFrom), 'day')).toBe(expectedSpanDays)
+                // The two halves of the comparison must span an equal number of daily buckets,
+                // otherwise every delta is biased toward whichever side has the extra day.
+                const priorBuckets = dayjs(window.currentStartDay).diff(dayjs(window.dateFrom), 'day')
+                const currentBuckets = dayjs(window.dateTo).diff(dayjs(window.currentStartDay), 'day') + 1
+                expect(priorBuckets).toBe(currentBuckets)
             }
         )
     })

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -10,7 +10,6 @@ import {
     type BucketRow,
     buildKPIs,
     buildKpiWindow,
-    bucketGranularityForWindow,
     buildToolDailySeries,
     categorizeHarness,
     deltaPct,
@@ -133,55 +132,36 @@ describe('mcpDashboardOverviewLogic', () => {
         })
     })
 
-    describe('bucketGranularityForWindow', () => {
-        it.each([
-            ['-1h', 'minute'],
-            ['-3h', 'minute'],
-            ['-6h', 'hour'],
-            ['-24h', 'hour'],
-            ['-2d', 'hour'],
-            ['-7d', 'day'],
-            ['-30d', 'day'],
-        ])('picks %s -> %s buckets', (dateFrom, expected) => {
-            expect(bucketGranularityForWindow({ dateFrom, dateTo: null }, 'UTC')).toBe(expected)
-        })
-    })
-
     describe('buildKpiWindow', () => {
         it.each([
-            ['2024-01-08', '2024-01-15', 'day', '2024-01-08', '2023-12-31'],
-            ['2024-01-01', '2024-01-31', 'day', '2024-01-01', '2023-12-01'],
+            ['2024-01-08', '2024-01-15', 'day', '2024-01-08 00:00:00', '2023-12-31'],
+            ['2024-01-01', '2024-01-31', 'day', '2024-01-01 00:00:00', '2023-12-01'],
         ])(
             'extends [%s, %s] back to an equal-length prior window with cutoff at the selected start',
-            (dateFrom, dateTo, granularity, expectedCutoff, expectedPriorStart) => {
-                const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC', granularity as 'day')
+            (dateFrom, dateTo, interval, expectedCutoff, expectedPriorStart) => {
+                const window = buildKpiWindow({ dateFrom, dateTo }, 'UTC', interval as 'day')
                 expect(window.currentStartBucket).toBe(expectedCutoff)
                 expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe(expectedPriorStart)
-                // The two halves of the comparison must span an equal number of buckets,
-                // otherwise every delta is biased toward whichever side has the extra bucket.
-                const priorBuckets = dayjs(window.currentStartBucket).diff(dayjs(window.dateFrom), granularity as 'day')
-                const currentBuckets =
-                    dayjs(window.dateTo).diff(dayjs(window.currentStartBucket), granularity as 'day') + 1
-                expect(priorBuckets).toBe(currentBuckets)
             }
         )
 
-        it('produces an hour-aligned cutoff and an equal prior window for sub-day ranges', () => {
-            const window = buildKpiWindow(
-                { dateFrom: '2024-01-08T05:00:00Z', dateTo: '2024-01-08T09:00:00Z' },
-                'UTC',
-                'hour'
-            )
-            // 5 inclusive hour buckets (05:00..09:00), so the prior window steps back 5 hours.
-            expect(window.currentStartBucket).toBe('2024-01-08 05:00:00')
-            expect(dayjs(window.dateFrom).toISOString()).toBe('2024-01-08T00:00:00.000Z')
+        it('rolls an hour-level range from now and steps the prior window back equally', () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:30:00Z'))
+            try {
+                // "-1h" resolves to the trailing hour; prior window is the hour before that.
+                const window = buildKpiWindow({ dateFrom: '-1h', dateTo: null }, 'UTC', 'minute')
+                expect(window.currentStartBucket).toBe('2026-06-18 11:30:00')
+                expect(dayjs(window.dateFrom).toISOString()).toBe('2026-06-18T10:29:00.000Z')
+            } finally {
+                jest.useRealTimers()
+            }
         })
 
-        it('resolves the relative -7d default against now with a symmetric prior window', () => {
+        it('resolves the relative -7d default against now', () => {
             jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
             try {
                 const window = buildKpiWindow({ dateFrom: '-7d', dateTo: null }, 'UTC', 'day')
-                expect(window.currentStartBucket).toBe('2026-06-11')
+                expect(window.currentStartBucket).toBe('2026-06-11 00:00:00')
                 // doubled window: prior 8 day-buckets before the cutoff
                 expect(dayjs(window.dateFrom).format('YYYY-MM-DD')).toBe('2026-06-03')
             } finally {

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -4,7 +4,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { dateStringToDayJs } from 'lib/utils/dateFilters'
+import { dateStringToComponents, dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -23,10 +23,11 @@ const DEFAULT_DATE_FILTER: DateFilter = { dateFrom: '-7d', dateTo: null }
 
 // KPI tiles compare the selected window against the immediately preceding window
 // of equal length. The current/previous split is applied in `buildKPIs` against
-// the daily buckets, so the query only needs the doubled date range.
+// the time buckets, so the query only needs the doubled date range. `__BUCKET__`
+// is replaced with the granularity's bucket function at call time.
 const KPI_QUERY = `
 SELECT
-    toDate(timestamp) AS bucket,
+    __BUCKET__ AS bucket,
     countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions,
     count() AS tool_calls,
     countIf(toBool(properties.$mcp_is_error)) AS errors,
@@ -102,7 +103,7 @@ LIMIT 200
 // Daily success/error split powering the activity time-series bar chart.
 const ACTIVITY_QUERY = `
 SELECT
-    toDate(timestamp) AS day,
+    __BUCKET__ AS day,
     countIf(NOT toBool(properties.$mcp_is_error)) AS successes,
     countIf(toBool(properties.$mcp_is_error)) AS errors
 FROM events
@@ -117,7 +118,7 @@ ORDER BY day
 // Daily call counts per tool, powering the tool-usage stacked bar (one segment per tool).
 const TOOL_DAILY_QUERY = `
 SELECT
-    toDate(timestamp) AS day,
+    __BUCKET__ AS day,
     toString(properties.$mcp_tool_name) AS tool,
     count() AS calls
 FROM events
@@ -339,28 +340,75 @@ export function deltaPct(current: number, previous: number): number | null {
     return ((current - previous) / previous) * 100
 }
 
+// Short windows get fine buckets so ranges like "last hour" stay legible; longer
+// windows fall back to coarser buckets to keep the point count sane.
+export type BucketGranularity = 'minute' | 'hour' | 'day'
+
+// ClickHouse bucket function per granularity. These are fixed expressions (never
+// user input), so they're safe to interpolate into the query string.
+const BUCKET_EXPR: Record<BucketGranularity, string> = {
+    minute: 'toStartOfMinute(timestamp)',
+    hour: 'toStartOfHour(timestamp)',
+    day: 'toDate(timestamp)',
+}
+
+// dayjs format that reproduces each bucket function's string output, so the
+// `buildKPIs` cutoff compares like-for-like against the bucket column.
+const BUCKET_CUTOFF_FORMAT: Record<BucketGranularity, string> = {
+    minute: 'YYYY-MM-DD HH:mm:00',
+    hour: 'YYYY-MM-DD HH:00:00',
+    day: 'YYYY-MM-DD',
+}
+
+// Resolve the filter to absolute bounds. Hour-level relative ranges ("-1h") are
+// rolling from now; dateStringToDayJs anchors relative dates to the start of the
+// day, which would inflate a "last hour" window to half a day. Day+ ranges keep
+// that start-of-day anchoring (the established behaviour).
+function resolveWindow(dateFilter: DateFilter, timezone: string): { start: dayjs.Dayjs; end: dayjs.Dayjs } {
+    const now = dayjs().tz(timezone)
+    const end = (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : now) ?? now
+    const components = dateStringToComponents(dateFilter.dateFrom)
+    if (components && components.unit === 'hour' && !dateFilter.dateTo) {
+        // components.amount is signed (negative for the past), so add() walks backwards.
+        return { start: now.add(components.amount, 'hour'), end: now }
+    }
+    const start = dateStringToDayJs(dateFilter.dateFrom, timezone) ?? now.subtract(7, 'day')
+    return { start, end }
+}
+
+export function bucketGranularityForWindow(dateFilter: DateFilter, timezone: string): BucketGranularity {
+    const { start, end } = resolveWindow(dateFilter, timezone)
+    const hours = end.diff(start, 'hour')
+    if (hours <= 3) {
+        return 'minute'
+    }
+    if (hours <= 72) {
+        return 'hour'
+    }
+    return 'day'
+}
+
 export interface KpiWindow {
     dateFrom: string
     dateTo: string
-    currentStartDay: string
+    currentStartBucket: string
 }
 
 // Resolve the selected window to absolute bounds, then extend the query range back
 // so a single query returns both the selected period and an equal-length prior
-// period. `currentStartDay` is the cutoff `buildKPIs` uses to split them.
-export function buildKpiWindow(dateFilter: DateFilter, timezone: string): KpiWindow {
-    const now = dayjs().tz(timezone)
-    const start = dateStringToDayJs(dateFilter.dateFrom, timezone) ?? now.subtract(7, 'day')
-    const end = (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : now) ?? now
-    // The selected period covers the inclusive day-buckets [start, end] — one more
-    // than end.diff(start). Step the prior window back by that same count so the
-    // two halves of the comparison span an equal number of daily buckets.
-    const selectedDays = Math.max(1, end.diff(start, 'day') + 1)
-    const priorStart = start.subtract(selectedDays, 'day')
+// period (measured in whole buckets of the active granularity). `currentStartBucket`
+// is the cutoff `buildKPIs` uses to split them.
+export function buildKpiWindow(dateFilter: DateFilter, timezone: string, granularity: BucketGranularity): KpiWindow {
+    const { start, end } = resolveWindow(dateFilter, timezone)
+    // The selected period covers the inclusive buckets [start, end] — one more than
+    // end.diff(start). Step the prior window back by that same count so the two
+    // halves of the comparison span an equal number of buckets.
+    const selectedBuckets = Math.max(1, end.diff(start, granularity) + 1)
+    const priorStart = start.subtract(selectedBuckets, granularity)
     return {
         dateFrom: priorStart.toISOString(),
         dateTo: end.toISOString(),
-        currentStartDay: start.format('YYYY-MM-DD'),
+        currentStartBucket: start.startOf(granularity).format(BUCKET_CUTOFF_FORMAT[granularity]),
     }
 }
 
@@ -374,11 +422,11 @@ function parseRows(rawRows: unknown[][]): BucketRow[] {
     }))
 }
 
-// Daily buckets at or after `currentStartDay` belong to the selected window; the
+// Buckets at or after `currentStartBucket` belong to the selected window; the
 // rest are the equal-length window immediately before it.
-export function buildKPIs(rows: BucketRow[], currentStartDay: string): KPIData {
-    const current = rows.filter((r) => r.bucket >= currentStartDay).sort((a, b) => a.bucket.localeCompare(b.bucket))
-    const previous = rows.filter((r) => r.bucket < currentStartDay)
+export function buildKPIs(rows: BucketRow[], currentStartBucket: string): KPIData {
+    const current = rows.filter((r) => r.bucket >= currentStartBucket).sort((a, b) => a.bucket.localeCompare(b.bucket))
+    const previous = rows.filter((r) => r.bucket < currentStartBucket)
 
     const curSessions = current.reduce((acc, r) => acc + r.sessions, 0)
     const curCalls = current.reduce((acc, r) => acc + r.tool_calls, 0)
@@ -447,10 +495,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             EMPTY_KPIS,
             {
                 loadKPIs: async (_: void, breakpoint) => {
-                    const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone)
+                    const granularity = values.bucketGranularity
+                    const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone, granularity)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: KPI_QUERY,
+                        query: KPI_QUERY.replace('__BUCKET__', BUCKET_EXPR[granularity]),
                         filters: {
                             ...values.queryFilters,
                             dateRange: { date_from: kpiWindow.dateFrom, date_to: kpiWindow.dateTo },
@@ -458,7 +507,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                     })) as HogQLQueryResponse
                     breakpoint()
                     const rows = parseRows((response?.results as unknown[][]) ?? [])
-                    return buildKPIs(rows, kpiWindow.currentStartDay)
+                    return buildKPIs(rows, kpiWindow.currentStartBucket)
                 },
             },
         ],
@@ -532,7 +581,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 loadActivityRows: async (_: void, breakpoint): Promise<ActivityRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: ACTIVITY_QUERY,
+                        query: ACTIVITY_QUERY.replace('__BUCKET__', BUCKET_EXPR[values.bucketGranularity]),
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
                     breakpoint()
@@ -551,7 +600,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 loadToolDailyRows: async (_: void, breakpoint): Promise<ToolDailyRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: TOOL_DAILY_QUERY,
+                        query: TOOL_DAILY_QUERY.replace('__BUCKET__', BUCKET_EXPR[values.bucketGranularity]),
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
                     breakpoint()
@@ -571,6 +620,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             (dateFilter: DateFilter): HogQLFilters => ({
                 dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
             }),
+        ],
+        bucketGranularity: [
+            (s) => [s.dateFilter, s.timezone],
+            (dateFilter: DateFilter, timezone: string): BucketGranularity =>
+                bucketGranularityForWindow(dateFilter, timezone),
         ],
         harnessRows: [(s) => [s.harnessRawRows], (raw: HarnessRawRow[]): HarnessRow[] => aggregateHarnessRows(raw)],
         dailyActivity: [
@@ -630,18 +684,32 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
         },
     })),
-    urlToAction(({ actions, values }) => ({
+    urlToAction(({ actions, values, cache }) => ({
         [urls.mcpAnalyticsDashboard()]: (_, searchParams) => {
             const dateFrom =
                 typeof searchParams.date_from === 'string' ? searchParams.date_from : DEFAULT_DATE_FILTER.dateFrom
             const dateTo = typeof searchParams.date_to === 'string' ? searchParams.date_to : null
             if (dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo) {
+                // setDateFilter's listener reloads everything.
                 actions.setDateFilter(dateFrom, dateTo)
+            } else if (!cache.hasLoaded) {
+                // URL already matches state (e.g. default window) and afterMount deferred — load once here.
+                actions.reloadAll()
             }
+            cache.hasLoaded = true
         },
     })),
-    afterMount(({ actions }) => {
-        actions.reloadAll()
+    afterMount(({ actions, cache }) => {
+        // urlToAction owns the initial load whenever the dashboard URL carries filter
+        // params; this is the fallback for a param-less mount (and off-route mounts in
+        // tests, where urlToAction never fires). The cache.hasLoaded guard keeps a
+        // deep-linked load from firing twice.
+        const { searchParams } = router.values
+        const hasUrlFilters = typeof searchParams.date_from === 'string' || typeof searchParams.date_to === 'string'
+        if (!hasUrlFilters && !cache.hasLoaded) {
+            cache.hasLoaded = true
+            actions.reloadAll()
+        }
     }),
 ])
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -1,38 +1,48 @@
-import { afterMount, connect, kea, path, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
-import { hogqlQuery } from '~/queries/query'
-import { hogql } from '~/queries/utils'
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+import { dateStringToDayJs } from 'lib/utils/dateFilters'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { HogQLFilters, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
 import type { mcpDashboardOverviewLogicType } from './mcpDashboardOverviewLogicType'
 
-// KPI tiles compare this week against the prior week.
-const LOOKBACK_DAYS = 7
-// Breakdowns and trends (activity, tools, harnesses, notable sessions) use a longer 30-day window.
-const BREAKDOWN_DAYS = 30
+export interface DateFilter {
+    dateFrom: string | null
+    dateTo: string | null
+}
 
-const KPI_QUERY = hogql`
+const DEFAULT_DATE_FILTER: DateFilter = { dateFrom: '-7d', dateTo: null }
+
+// KPI tiles compare the selected window against the immediately preceding window
+// of equal length. The current/previous split is applied in `buildKPIs` against
+// the daily buckets, so the query only needs the doubled date range.
+const KPI_QUERY = `
 SELECT
     toDate(timestamp) AS bucket,
     countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions,
     count() AS tool_calls,
     countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95,
-    timestamp >= now() - INTERVAL ${hogql.raw(String(LOOKBACK_DAYS))} DAY AS in_current
+    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(LOOKBACK_DAYS * 2))} DAY
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
-GROUP BY bucket, in_current
+    AND {filters}
+GROUP BY bucket
 ORDER BY bucket
 `
 
 // Per-session rollup powering the Notable sessions block. The selector
 // applies fixed rules over this set; no per-rule SQL.
-const SESSION_ROWS_QUERY = hogql`
+const SESSION_ROWS_QUERY = `
 SELECT
     toString(properties.$mcp_session_id) AS session_id,
     count() AS tool_calls,
@@ -43,11 +53,11 @@ SELECT
     max(timestamp) AS last_seen
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_session_id IS NOT NULL
     AND properties.$mcp_session_id != ''
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
+    AND {filters}
 GROUP BY session_id
 HAVING tool_calls >= 1
 ORDER BY tool_calls DESC
@@ -56,7 +66,7 @@ LIMIT 500
 
 // Mirrors products/mcp_analytics/backend/templates/tool_quality.sql for the
 // compact reliability matrix on the overview. Limited columns + 50 rows.
-const TOOL_ROWS_QUERY = hogql`
+const TOOL_ROWS_QUERY = `
 SELECT
     toString(properties.$mcp_tool_name) AS tool,
     count() AS total_calls,
@@ -65,15 +75,15 @@ SELECT
     round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_duration_ms
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
+    AND {filters}
 GROUP BY tool
 ORDER BY total_calls DESC
 LIMIT 50
 `
 
-const HARNESS_ROWS_QUERY = hogql`
+const HARNESS_ROWS_QUERY = `
 SELECT
     toString(properties.$mcp_client_name) AS client,
     count() AS total_calls,
@@ -81,40 +91,40 @@ SELECT
     countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_client_name IS NOT NULL
     AND properties.$mcp_client_name != ''
+    AND {filters}
 GROUP BY client
 ORDER BY total_calls DESC
 LIMIT 200
 `
 
 // Daily success/error split powering the activity time-series bar chart.
-const ACTIVITY_QUERY = hogql`
+const ACTIVITY_QUERY = `
 SELECT
     toDate(timestamp) AS day,
     countIf(NOT toBool(properties.$mcp_is_error)) AS successes,
     countIf(toBool(properties.$mcp_is_error)) AS errors
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
+    AND {filters}
 GROUP BY day
 ORDER BY day
 `
 
 // Daily call counts per tool, powering the tool-usage stacked bar (one segment per tool).
-const TOOL_DAILY_QUERY = hogql`
+const TOOL_DAILY_QUERY = `
 SELECT
     toDate(timestamp) AS day,
     toString(properties.$mcp_tool_name) AS tool,
     count() AS calls
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_tool_name IS NOT NULL
     AND properties.$mcp_tool_name != ''
+    AND {filters}
 GROUP BY day, tool
 ORDER BY day
 LIMIT 10000
@@ -126,7 +136,6 @@ export interface BucketRow {
     tool_calls: number
     errors: number
     p95: number
-    in_current: boolean
 }
 
 export interface KPIMetric {
@@ -330,6 +339,28 @@ export function deltaPct(current: number, previous: number): number | null {
     return ((current - previous) / previous) * 100
 }
 
+export interface KpiWindow {
+    dateFrom: string
+    dateTo: string
+    currentStartDay: string
+}
+
+// Resolve the selected window to absolute bounds, then extend back by an equal
+// length so a single query returns both the selected and prior periods. The day
+// the selected window starts is the cutoff `buildKPIs` uses to split them.
+export function buildKpiWindow(dateFilter: DateFilter, timezone: string): KpiWindow {
+    const now = dayjs().tz(timezone)
+    const start = dateStringToDayJs(dateFilter.dateFrom, timezone) ?? now.subtract(7, 'day')
+    const end = (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : now) ?? now
+    const windowDays = Math.max(1, end.diff(start, 'day'))
+    const priorStart = start.subtract(windowDays, 'day')
+    return {
+        dateFrom: priorStart.toISOString(),
+        dateTo: end.toISOString(),
+        currentStartDay: start.format('YYYY-MM-DD'),
+    }
+}
+
 function parseRows(rawRows: unknown[][]): BucketRow[] {
     return rawRows.map((r) => ({
         bucket: String(r[0]),
@@ -337,13 +368,14 @@ function parseRows(rawRows: unknown[][]): BucketRow[] {
         tool_calls: Number(r[2] ?? 0),
         errors: Number(r[3] ?? 0),
         p95: Number(r[4] ?? 0),
-        in_current: Boolean(r[5]),
     }))
 }
 
-export function buildKPIs(rows: BucketRow[]): KPIData {
-    const current = rows.filter((r) => r.in_current).sort((a, b) => a.bucket.localeCompare(b.bucket))
-    const previous = rows.filter((r) => !r.in_current)
+// Daily buckets at or after `currentStartDay` belong to the selected window; the
+// rest are the equal-length window immediately before it.
+export function buildKPIs(rows: BucketRow[], currentStartDay: string): KPIData {
+    const current = rows.filter((r) => r.bucket >= currentStartDay).sort((a, b) => a.bucket.localeCompare(b.bucket))
+    const previous = rows.filter((r) => r.bucket < currentStartDay)
 
     const curSessions = current.reduce((acc, r) => acc + r.sessions, 0)
     const curCalls = current.reduce((acc, r) => acc + r.tool_calls, 0)
@@ -393,16 +425,36 @@ export function buildKPIs(rows: BucketRow[]): KPIData {
 export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     path(['products', 'mcp_analytics', 'frontend', 'mcpDashboardOverviewLogic']),
     connect(() => ({
-        values: [mcpClusteringLogic, ['clusters', 'hasSnapshot']],
+        values: [mcpClusteringLogic, ['clusters', 'hasSnapshot'], teamLogic, ['timezone']],
     })),
-    loaders({
+    actions({
+        setDateFilter: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
+        reloadAll: true,
+    }),
+    reducers({
+        dateFilter: [
+            DEFAULT_DATE_FILTER,
+            {
+                setDateFilter: (_, { dateFrom, dateTo }): DateFilter => ({ dateFrom, dateTo }),
+            },
+        ],
+    }),
+    loaders(({ values }) => ({
         kpis: [
             EMPTY_KPIS,
             {
                 loadKPIs: async () => {
-                    const response = await hogqlQuery(KPI_QUERY)
+                    const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: KPI_QUERY,
+                        filters: {
+                            ...values.queryFilters,
+                            dateRange: { date_from: kpiWindow.dateFrom, date_to: kpiWindow.dateTo },
+                        },
+                    })) as HogQLQueryResponse
                     const rows = parseRows((response?.results as unknown[][]) ?? [])
-                    return buildKPIs(rows)
+                    return buildKPIs(rows, kpiWindow.currentStartDay)
                 },
             },
         ],
@@ -410,7 +462,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             [] as ToolRow[],
             {
                 loadToolRows: async () => {
-                    const response = await hogqlQuery(TOOL_ROWS_QUERY)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: TOOL_ROWS_QUERY,
+                        filters: values.queryFilters,
+                    })) as HogQLQueryResponse
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         tool: String(r[0] ?? ''),
@@ -426,7 +482,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             [] as SessionRow[],
             {
                 loadSessionRows: async () => {
-                    const response = await hogqlQuery(SESSION_ROWS_QUERY)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: SESSION_ROWS_QUERY,
+                        filters: values.queryFilters,
+                    })) as HogQLQueryResponse
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         session_id: String(r[0] ?? ''),
@@ -444,7 +504,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             [] as HarnessRawRow[],
             {
                 loadHarnessRows: async () => {
-                    const response = await hogqlQuery(HARNESS_ROWS_QUERY)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: HARNESS_ROWS_QUERY,
+                        filters: values.queryFilters,
+                    })) as HogQLQueryResponse
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         client: String(r[0] ?? ''),
@@ -459,7 +523,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             [] as ActivityRow[],
             {
                 loadActivityRows: async (): Promise<ActivityRow[]> => {
-                    const response = await hogqlQuery(ACTIVITY_QUERY)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: ACTIVITY_QUERY,
+                        filters: values.queryFilters,
+                    })) as HogQLQueryResponse
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         day: String(r[0] ?? ''),
@@ -473,7 +541,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             [] as ToolDailyRow[],
             {
                 loadToolDailyRows: async (): Promise<ToolDailyRow[]> => {
-                    const response = await hogqlQuery(TOOL_DAILY_QUERY)
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: TOOL_DAILY_QUERY,
+                        filters: values.queryFilters,
+                    })) as HogQLQueryResponse
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         day: String(r[0] ?? ''),
@@ -483,8 +555,14 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 },
             },
         ],
-    }),
+    })),
     selectors({
+        queryFilters: [
+            (s) => [s.dateFilter],
+            (dateFilter: DateFilter): HogQLFilters => ({
+                dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
+            }),
+        ],
         harnessRows: [(s) => [s.harnessRawRows], (raw: HarnessRawRow[]): HarnessRow[] => aggregateHarnessRows(raw)],
         dailyActivity: [
             (s) => [s.activityRows],
@@ -513,13 +591,48 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             }),
         ],
     }),
+    listeners(({ actions }) => ({
+        setDateFilter: () => {
+            actions.reloadAll()
+        },
+        reloadAll: () => {
+            actions.loadKPIs()
+            actions.loadToolRows()
+            actions.loadSessionRows()
+            actions.loadHarnessRows()
+            actions.loadActivityRows()
+            actions.loadToolDailyRows()
+        },
+    })),
+    actionToUrl(({ values }) => ({
+        setDateFilter: () => {
+            const { currentLocation } = router.values
+            const searchParams = { ...currentLocation.searchParams }
+            if (values.dateFilter.dateFrom) {
+                searchParams.date_from = values.dateFilter.dateFrom
+            } else {
+                delete searchParams.date_from
+            }
+            if (values.dateFilter.dateTo) {
+                searchParams.date_to = values.dateFilter.dateTo
+            } else {
+                delete searchParams.date_to
+            }
+            return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
+        },
+    })),
+    urlToAction(({ actions, values }) => ({
+        [urls.mcpAnalyticsDashboard()]: (_, searchParams) => {
+            const dateFrom =
+                typeof searchParams.date_from === 'string' ? searchParams.date_from : DEFAULT_DATE_FILTER.dateFrom
+            const dateTo = typeof searchParams.date_to === 'string' ? searchParams.date_to : null
+            if (dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo) {
+                actions.setDateFilter(dateFrom, dateTo)
+            }
+        },
+    })),
     afterMount(({ actions }) => {
-        actions.loadKPIs()
-        actions.loadToolRows()
-        actions.loadSessionRows()
-        actions.loadHarnessRows()
-        actions.loadActivityRows()
-        actions.loadToolDailyRows()
+        actions.reloadAll()
     }),
 ])
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -345,15 +345,18 @@ export interface KpiWindow {
     currentStartDay: string
 }
 
-// Resolve the selected window to absolute bounds, then extend back by an equal
-// length so a single query returns both the selected and prior periods. The day
-// the selected window starts is the cutoff `buildKPIs` uses to split them.
+// Resolve the selected window to absolute bounds, then extend the query range back
+// so a single query returns both the selected period and an equal-length prior
+// period. `currentStartDay` is the cutoff `buildKPIs` uses to split them.
 export function buildKpiWindow(dateFilter: DateFilter, timezone: string): KpiWindow {
     const now = dayjs().tz(timezone)
     const start = dateStringToDayJs(dateFilter.dateFrom, timezone) ?? now.subtract(7, 'day')
     const end = (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : now) ?? now
-    const windowDays = Math.max(1, end.diff(start, 'day'))
-    const priorStart = start.subtract(windowDays, 'day')
+    // The selected period covers the inclusive day-buckets [start, end] — one more
+    // than end.diff(start). Step the prior window back by that same count so the
+    // two halves of the comparison span an equal number of daily buckets.
+    const selectedDays = Math.max(1, end.diff(start, 'day') + 1)
+    const priorStart = start.subtract(selectedDays, 'day')
     return {
         dateFrom: priorStart.toISOString(),
         dateTo: end.toISOString(),
@@ -443,7 +446,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         kpis: [
             EMPTY_KPIS,
             {
-                loadKPIs: async () => {
+                loadKPIs: async (_: void, breakpoint) => {
                     const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
@@ -453,6 +456,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                             dateRange: { date_from: kpiWindow.dateFrom, date_to: kpiWindow.dateTo },
                         },
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const rows = parseRows((response?.results as unknown[][]) ?? [])
                     return buildKPIs(rows, kpiWindow.currentStartDay)
                 },
@@ -461,12 +465,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         toolRows: [
             [] as ToolRow[],
             {
-                loadToolRows: async () => {
+                loadToolRows: async (_: void, breakpoint) => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: TOOL_ROWS_QUERY,
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         tool: String(r[0] ?? ''),
@@ -481,12 +486,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         sessionRows: [
             [] as SessionRow[],
             {
-                loadSessionRows: async () => {
+                loadSessionRows: async (_: void, breakpoint) => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: SESSION_ROWS_QUERY,
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         session_id: String(r[0] ?? ''),
@@ -503,12 +509,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         harnessRawRows: [
             [] as HarnessRawRow[],
             {
-                loadHarnessRows: async () => {
+                loadHarnessRows: async (_: void, breakpoint) => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: HARNESS_ROWS_QUERY,
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         client: String(r[0] ?? ''),
@@ -522,12 +529,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         activityRows: [
             [] as ActivityRow[],
             {
-                loadActivityRows: async (): Promise<ActivityRow[]> => {
+                loadActivityRows: async (_: void, breakpoint): Promise<ActivityRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: ACTIVITY_QUERY,
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         day: String(r[0] ?? ''),
@@ -540,12 +548,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         toolDailyRows: [
             [] as ToolDailyRow[],
             {
-                loadToolDailyRows: async (): Promise<ToolDailyRow[]> => {
+                loadToolDailyRows: async (_: void, breakpoint): Promise<ToolDailyRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
                         query: TOOL_DAILY_QUERY,
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
+                    breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
                         day: String(r[0] ?? ''),

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -4,11 +4,12 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { dateStringToComponents, dateStringToDayJs } from 'lib/utils/dateFilters'
+import { dateStringToComponents, dateStringToDayJs, getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { HogQLFilters, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { IntervalType } from '~/types'
 
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
@@ -24,7 +25,7 @@ const DEFAULT_DATE_FILTER: DateFilter = { dateFrom: '-7d', dateTo: null }
 // KPI tiles compare the selected window against the immediately preceding window
 // of equal length. The current/previous split is applied in `buildKPIs` against
 // the time buckets, so the query only needs the doubled date range. `__BUCKET__`
-// is replaced with the granularity's bucket function at call time.
+// is replaced with a dateTrunc at the active interval at call time.
 const KPI_QUERY = `
 SELECT
     __BUCKET__ AS bucket,
@@ -340,26 +341,6 @@ export function deltaPct(current: number, previous: number): number | null {
     return ((current - previous) / previous) * 100
 }
 
-// Short windows get fine buckets so ranges like "last hour" stay legible; longer
-// windows fall back to coarser buckets to keep the point count sane.
-export type BucketGranularity = 'minute' | 'hour' | 'day'
-
-// ClickHouse bucket function per granularity. These are fixed expressions (never
-// user input), so they're safe to interpolate into the query string.
-const BUCKET_EXPR: Record<BucketGranularity, string> = {
-    minute: 'toStartOfMinute(timestamp)',
-    hour: 'toStartOfHour(timestamp)',
-    day: 'toDate(timestamp)',
-}
-
-// dayjs format that reproduces each bucket function's string output, so the
-// `buildKPIs` cutoff compares like-for-like against the bucket column.
-const BUCKET_CUTOFF_FORMAT: Record<BucketGranularity, string> = {
-    minute: 'YYYY-MM-DD HH:mm:00',
-    hour: 'YYYY-MM-DD HH:00:00',
-    day: 'YYYY-MM-DD',
-}
-
 // Resolve the filter to absolute bounds. Hour-level relative ranges ("-1h") are
 // rolling from now; dateStringToDayJs anchors relative dates to the start of the
 // day, which would inflate a "last hour" window to half a day. Day+ ranges keep
@@ -376,39 +357,27 @@ function resolveWindow(dateFilter: DateFilter, timezone: string): { start: dayjs
     return { start, end }
 }
 
-export function bucketGranularityForWindow(dateFilter: DateFilter, timezone: string): BucketGranularity {
-    const { start, end } = resolveWindow(dateFilter, timezone)
-    const hours = end.diff(start, 'hour')
-    if (hours <= 3) {
-        return 'minute'
-    }
-    if (hours <= 72) {
-        return 'hour'
-    }
-    return 'day'
-}
-
 export interface KpiWindow {
     dateFrom: string
     dateTo: string
     currentStartBucket: string
 }
 
-// Resolve the selected window to absolute bounds, then extend the query range back
-// so a single query returns both the selected period and an equal-length prior
-// period (measured in whole buckets of the active granularity). `currentStartBucket`
-// is the cutoff `buildKPIs` uses to split them.
-export function buildKpiWindow(dateFilter: DateFilter, timezone: string, granularity: BucketGranularity): KpiWindow {
+// Extend the resolved window back by an equal number of `interval` buckets so a
+// single query returns both the selected period and its prior period.
+// `currentStartBucket` is the cutoff `buildKPIs` splits on — formatted to match
+// dateTrunc's DateTime output.
+export function buildKpiWindow(dateFilter: DateFilter, timezone: string, interval: IntervalType): KpiWindow {
     const { start, end } = resolveWindow(dateFilter, timezone)
     // The selected period covers the inclusive buckets [start, end] — one more than
     // end.diff(start). Step the prior window back by that same count so the two
     // halves of the comparison span an equal number of buckets.
-    const selectedBuckets = Math.max(1, end.diff(start, granularity) + 1)
-    const priorStart = start.subtract(selectedBuckets, granularity)
+    const selectedBuckets = Math.max(1, end.diff(start, interval) + 1)
+    const priorStart = start.subtract(selectedBuckets, interval)
     return {
         dateFrom: priorStart.toISOString(),
         dateTo: end.toISOString(),
-        currentStartBucket: start.startOf(granularity).format(BUCKET_CUTOFF_FORMAT[granularity]),
+        currentStartBucket: start.startOf(interval).format('YYYY-MM-DD HH:mm:ss'),
     }
 }
 
@@ -495,11 +464,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             EMPTY_KPIS,
             {
                 loadKPIs: async (_: void, breakpoint) => {
-                    const granularity = values.bucketGranularity
-                    const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone, granularity)
+                    const { interval } = values
+                    const kpiWindow = buildKpiWindow(values.dateFilter, values.timezone, interval)
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: KPI_QUERY.replace('__BUCKET__', BUCKET_EXPR[granularity]),
+                        query: KPI_QUERY.replace('__BUCKET__', `dateTrunc('${interval}', timestamp)`),
                         filters: {
                             ...values.queryFilters,
                             dateRange: { date_from: kpiWindow.dateFrom, date_to: kpiWindow.dateTo },
@@ -581,7 +550,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 loadActivityRows: async (_: void, breakpoint): Promise<ActivityRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: ACTIVITY_QUERY.replace('__BUCKET__', BUCKET_EXPR[values.bucketGranularity]),
+                        query: ACTIVITY_QUERY.replace('__BUCKET__', `dateTrunc('${values.interval}', timestamp)`),
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
                     breakpoint()
@@ -600,7 +569,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 loadToolDailyRows: async (_: void, breakpoint): Promise<ToolDailyRow[]> => {
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
-                        query: TOOL_DAILY_QUERY.replace('__BUCKET__', BUCKET_EXPR[values.bucketGranularity]),
+                        query: TOOL_DAILY_QUERY.replace('__BUCKET__', `dateTrunc('${values.interval}', timestamp)`),
                         filters: values.queryFilters,
                     })) as HogQLQueryResponse
                     breakpoint()
@@ -621,10 +590,9 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
             }),
         ],
-        bucketGranularity: [
-            (s) => [s.dateFilter, s.timezone],
-            (dateFilter: DateFilter, timezone: string): BucketGranularity =>
-                bucketGranularityForWindow(dateFilter, timezone),
+        interval: [
+            (s) => [s.dateFilter],
+            (dateFilter: DateFilter): IntervalType => getDefaultInterval(dateFilter.dateFrom, dateFilter.dateTo),
         ],
         harnessRows: [(s) => [s.harnessRawRows], (raw: HarnessRawRow[]): HarnessRow[] => aggregateHarnessRows(raw)],
         dailyActivity: [


### PR DESCRIPTION
## Problem

The MCP analytics dashboard tab had no controls — every tile was hardwired to a fixed window (KPI tiles compared the last 7 days against the prior 7; the breakdown charts were stuck on a rolling 30 days). There was no way to zoom into a spike, widen the view, or share a specific time range.

## Changes

Adds a single dashboard-wide date filter that governs every tile, the way a normal PostHog dashboard works.

- All six queries now run through `api.query` with the `{filters}` placeholder, fed by one shared `queryFilters` selector, instead of raw `hogqlQuery` with the interval baked into the SQL.
- KPI tiles compare the **selected** window against the equal-length window immediately before it (`buildKpiWindow` resolves the doubled range; `buildKPIs` splits current vs prior by bucket date).
- The filter persists in the URL (`date_from`/`date_to`), so it survives reloads and tab switches and is shareable.
- The shared date picker (previously `ToolQualityDateFilter`) moves to `components/McpDateFilter` so the dashboard and tool quality tabs share one component.
- Default window is **last 7 days** (matches the tool quality tab). Note this tightens the breakdown charts, which previously defaulted to 30 days.

## How did you test this code?

Automated only — I'm an agent and did not manually click through the UI.

- `mcpDashboardOverviewLogic.test.ts`: unit tests for `buildKpiWindow` (doubled-window math + cutoff) and the updated `buildKPIs` split, plus a mounted-logic test asserting all six tiles reload with the right ranges when the date filter changes (KPI gets the absolute doubled window; the five breakdowns get the raw selected range).
- Full `mcp_analytics` frontend jest suite passes (46 tests).

TypeScript `typescript:check` can't run in this checkout (no generated kea `*LogicType` files, quill packages unbuilt) — CI regenerates these.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). The tricky bit was the KPI comparison: the old query encoded "this week vs last week" with a `now() - INTERVAL` flag, which doesn't generalize to an arbitrary picked range. I moved the current/previous split out of SQL into `buildKPIs`, keyed off the selected window's start day, and widened the query's date range to cover both periods — keeping the comparison semantics while making it window-agnostic. Default window (7d vs 30d) and URL persistence were decided in conversation with the requester.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
