### PR TITLE
feat(mcp-analytics): add internal/test account filter to dashboard

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5721,9 +5721,9 @@ snapshots:
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
     scenes-app-mcp-analytics--dashboard--dark:
-        hash: v1.k794b7964.ce73116b61c51cdf515f7c449614e819605543194fc8194e3777cdd3fe37e847.V5cyDORCjiV-nUz1h65KpHKbywxm0u-TRuq7W3vJSrY
+        hash: v1.k794b7964.c25b8e1693844d8f9d2b6e8c08a06bea95ea0a6ff0575e468c03004eabcd41f4.kgv_UP8c-JuwxoLHEYC5xFD08QcECeL5ThgVof5i0VU
     scenes-app-mcp-analytics--dashboard--light:
-        hash: v1.k794b7964.ca0753eb512b0d9ccef0d4c4ff92aadcea3b6df1be5651501038556443e5e914.yj6GSJwiP_mA_Eq426rKSfymYSgYCQVBqsnB5hLWwKQ
+        hash: v1.k794b7964.e80fca14f66bcb1dff0d8645f852c51d5b0131a676e246d52ee938ce8bf1205e.zUCTZ71CfSoVdfgE-isvw_ymFWq8OoRQ0y_lv_z2HWY
     scenes-app-mcp-analytics--sessions--dark:
         hash: v1.k794b7964.277463ad445565d14f2549a063a4f8c0c23a81af419bfafc9eefc65577fb0834.woelvjefGWPDW4Acae_sP2fA7YidrA7tkhfvC8u_AQ4
     scenes-app-mcp-analytics--sessions--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -47,7 +47,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-4" data-quill>
-            <div className="flex flex-wrap items-center gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
                 <McpDateFilter
                     dateFrom={dateFilter.dateFrom}
                     dateTo={dateFilter.dateTo}

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { type ChartTheme } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -34,8 +35,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         toolRowsLoading,
         dateFilter,
         interval,
+        filterTestAccounts,
     } = useValues(mcpDashboardOverviewLogic)
-    const { setDateFilter } = useActions(mcpDashboardOverviewLogic)
+    const { setDateFilter, setFilterTestAccounts } = useActions(mcpDashboardOverviewLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
@@ -52,6 +54,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                     onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
                     dataAttr="mcp-dashboard-date-filter"
                 />
+                <TestAccountFilterSwitch checked={filterTestAccounts} onChange={setFilterTestAccounts} />
             </div>
             <section>
                 <h2 className="mb-4 text-xl font-semibold text-primary">Key metrics</h2>

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -54,7 +54,11 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                     onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
                     dataAttr="mcp-dashboard-date-filter"
                 />
-                <TestAccountFilterSwitch checked={filterTestAccounts} onChange={setFilterTestAccounts} />
+                <TestAccountFilterSwitch
+                    checked={filterTestAccounts}
+                    onChange={setFilterTestAccounts}
+                    data-attr="mcp-dashboard-test-account-filter"
+                />
             </div>
             <section>
                 <h2 className="mb-4 text-xl font-semibold text-primary">Key metrics</h2>

--- a/products/mcp_analytics/frontend/dashboard/KpiTiles.tsx
+++ b/products/mcp_analytics/frontend/dashboard/KpiTiles.tsx
@@ -15,6 +15,9 @@ interface TileSpec {
     format: (n: number) => string
     color: string
     loading: boolean
+    // Overrides the default "vs. prior" comparison line — used to flag a tile
+    // whose value isn't scoped by the dashboard filters.
+    subtitle?: string
 }
 
 function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.Element {
@@ -41,7 +44,10 @@ function KPITile({ tile, theme }: { tile: TileSpec; theme: ChartTheme }): JSX.El
                             color={tile.color}
                             goodDirection={metric.goodDirection}
                             formatValue={tile.format}
-                            subtitle={hasComparison ? `vs. ${tile.format(metric.previousValue)} prior` : undefined}
+                            subtitle={
+                                tile.subtitle ??
+                                (hasComparison ? `vs. ${tile.format(metric.previousValue)} prior` : undefined)
+                            }
                             sparklineHeight={50}
                             sparklineClassName="mt-3 -mx-3 -mb-3"
                         />
@@ -103,6 +109,10 @@ export function KpiTiles({
             format: formatNumber,
             color: theme.colors[6],
             loading: false,
+            // Clusters come from the latest clustering snapshot across all sessions, so
+            // unlike the other tiles this count isn't scoped by the date or test-account
+            // filters. Label it so the grid doesn't read as a single consistent scope.
+            subtitle: 'Latest run · all sessions',
         },
     ]
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -1,3 +1,5 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -332,6 +334,19 @@ describe('mcpDashboardOverviewLogic', () => {
             const reloads = reloadCallsSince(callsBefore)
             expect(reloads.length).toBe(6)
             expect(reloads.every((call) => call.filters.filterTestAccounts === enabled)).toBe(true)
+        })
+
+        it('defaults the filter from the team test_account_filters_default_checked setting', async () => {
+            initKeaTests(true, { ...MOCK_DEFAULT_TEAM, test_account_filters_default_checked: true })
+            jest.spyOn(mockApi, 'query').mockResolvedValue({ results: [] } as any)
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            // No explicit toggle, yet every tile filters internal users because the team default is on.
+            const reloads = mockApi.query.mock.calls.map((call) => call[0] as any)
+            expect(reloads.length).toBeGreaterThanOrEqual(6)
+            expect(reloads.every((call) => call.filters.filterTestAccounts === true)).toBe(true)
         })
     })
 })

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -283,7 +283,7 @@ describe('mcpDashboardOverviewLogic', () => {
         })
     })
 
-    describe('date filter wiring', () => {
+    describe('filter wiring', () => {
         beforeEach(() => {
             jest.clearAllMocks()
             initKeaTests()
@@ -314,6 +314,24 @@ describe('mcpDashboardOverviewLogic', () => {
             const kpi = reloads.find((call) => call.query.includes('AS bucket'))
             expect(kpi?.filters.dateRange.date_from).not.toBe('-30d')
             expect(dayjs(kpi?.filters.dateRange.date_from).isValid()).toBe(true)
+        })
+
+        it.each([[false], [true]])('passes filterTestAccounts=%s to every tile', async (enabled) => {
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            // enabled=false is the default mount state; enabled=true reloads after toggling.
+            const callsBefore = enabled ? mockApi.query.mock.calls.length : 0
+
+            if (enabled) {
+                await expectLogic(logic, () => {
+                    logic.actions.setFilterTestAccounts(true)
+                }).toFinishAllListeners()
+            }
+
+            const reloads = reloadCallsSince(callsBefore)
+            expect(reloads.length).toBe(6)
+            expect(reloads.every((call) => call.filters.filterTestAccounts === enabled)).toBe(true)
         })
     })
 })

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -432,7 +432,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     })),
     actions({
         setDateFilter: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
-        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
+        setFilterTestAccounts: (filterTestAccounts: boolean | null) => ({ filterTestAccounts }),
         reloadAll: true,
     }),
     reducers({
@@ -447,7 +447,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         filterTestAccountsOverride: [
             null as boolean | null,
             {
-                setFilterTestAccounts: (_, { filterTestAccounts }): boolean => filterTestAccounts,
+                setFilterTestAccounts: (_, { filterTestAccounts }): boolean | null => filterTestAccounts,
             },
         ],
     }),
@@ -673,7 +673,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             const rawFilter = searchParams.filter_test_accounts
             const filterOverride = rawFilter === undefined ? null : rawFilter === true || rawFilter === 'true'
             const dateChanged = dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo
-            const filterChanged = filterOverride !== null && filterOverride !== values.filterTestAccountsOverride
+            const filterChanged = filterOverride !== values.filterTestAccountsOverride
             // setDateFilter / setFilterTestAccounts each reload via their listeners.
             if (dateChanged) {
                 actions.setDateFilter(dateFrom, dateTo)

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -9,7 +9,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { HogQLFilters, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
-import { IntervalType } from '~/types'
+import { IntervalType, TeamType } from '~/types'
 
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import { categorizeHarness } from './dashboard/harnessRegistry'
@@ -428,7 +428,7 @@ export function buildKPIs(rows: BucketRow[], currentStartBucket: string): KPIDat
 export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     path(['products', 'mcp_analytics', 'frontend', 'mcpDashboardOverviewLogic']),
     connect(() => ({
-        values: [mcpClusteringLogic, ['clusters', 'hasSnapshot'], teamLogic, ['timezone']],
+        values: [mcpClusteringLogic, ['clusters', 'hasSnapshot'], teamLogic, ['timezone', 'currentTeam']],
     })),
     actions({
         setDateFilter: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
@@ -442,8 +442,10 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 setDateFilter: (_, { dateFrom, dateTo }): DateFilter => ({ dateFrom, dateTo }),
             },
         ],
-        filterTestAccounts: [
-            false,
+        // null until the user toggles — the effective value falls back to the team's
+        // test_account_filters_default_checked setting (see the filterTestAccounts selector).
+        filterTestAccountsOverride: [
+            null as boolean | null,
             {
                 setFilterTestAccounts: (_, { filterTestAccounts }): boolean => filterTestAccounts,
             },
@@ -574,6 +576,12 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         ],
     })),
     selectors({
+        // Effective toggle state: the user's explicit override, else the team's default.
+        filterTestAccounts: [
+            (s) => [s.filterTestAccountsOverride, s.currentTeam],
+            (override: boolean | null, currentTeam: TeamType | null): boolean =>
+                override ?? !!currentTeam?.test_account_filters_default_checked,
+        ],
         queryFilters: [
             (s) => [s.dateFilter, s.filterTestAccounts],
             (dateFilter: DateFilter, filterTestAccounts: boolean): HogQLFilters => ({
@@ -643,10 +651,11 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             } else {
                 delete searchParams.date_to
             }
-            if (values.filterTestAccounts) {
-                searchParams.filter_test_accounts = true
-            } else {
+            // Absent param = follow the team default; an explicit override (incl. false) persists.
+            if (values.filterTestAccountsOverride === null) {
                 delete searchParams.filter_test_accounts
+            } else {
+                searchParams.filter_test_accounts = values.filterTestAccountsOverride
             }
             return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
         }
@@ -660,16 +669,17 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             const dateFrom =
                 typeof searchParams.date_from === 'string' ? searchParams.date_from : DEFAULT_DATE_FILTER.dateFrom
             const dateTo = typeof searchParams.date_to === 'string' ? searchParams.date_to : null
-            const filterTestAccounts =
-                searchParams.filter_test_accounts === true || searchParams.filter_test_accounts === 'true'
+            // Absent param leaves the override null (effective value follows the team default).
+            const rawFilter = searchParams.filter_test_accounts
+            const filterOverride = rawFilter === undefined ? null : rawFilter === true || rawFilter === 'true'
             const dateChanged = dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo
-            const filterChanged = filterTestAccounts !== values.filterTestAccounts
+            const filterChanged = filterOverride !== null && filterOverride !== values.filterTestAccountsOverride
             // setDateFilter / setFilterTestAccounts each reload via their listeners.
             if (dateChanged) {
                 actions.setDateFilter(dateFrom, dateTo)
             }
             if (filterChanged) {
-                actions.setFilterTestAccounts(filterTestAccounts)
+                actions.setFilterTestAccounts(filterOverride)
             }
             // URL already matches state (e.g. default filters) and afterMount deferred — load once.
             if (!dateChanged && !filterChanged && !cache.hasLoaded) {

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -432,6 +432,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     })),
     actions({
         setDateFilter: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
+        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
         reloadAll: true,
     }),
     reducers({
@@ -439,6 +440,12 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             DEFAULT_DATE_FILTER,
             {
                 setDateFilter: (_, { dateFrom, dateTo }): DateFilter => ({ dateFrom, dateTo }),
+            },
+        ],
+        filterTestAccounts: [
+            false,
+            {
+                setFilterTestAccounts: (_, { filterTestAccounts }): boolean => filterTestAccounts,
             },
         ],
     }),
@@ -568,9 +575,10 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     })),
     selectors({
         queryFilters: [
-            (s) => [s.dateFilter],
-            (dateFilter: DateFilter): HogQLFilters => ({
+            (s) => [s.dateFilter, s.filterTestAccounts],
+            (dateFilter: DateFilter, filterTestAccounts: boolean): HogQLFilters => ({
                 dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
+                filterTestAccounts,
             }),
         ],
         interval: [
@@ -609,6 +617,9 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         setDateFilter: () => {
             actions.reloadAll()
         },
+        setFilterTestAccounts: () => {
+            actions.reloadAll()
+        },
         reloadAll: () => {
             actions.loadKPIs()
             actions.loadToolRows()
@@ -618,8 +629,8 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             actions.loadToolDailyRows()
         },
     })),
-    actionToUrl(({ values }) => ({
-        setDateFilter: () => {
+    actionToUrl(({ values }) => {
+        const syncUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
             const { currentLocation } = router.values
             const searchParams = { ...currentLocation.searchParams }
             if (values.dateFilter.dateFrom) {
@@ -632,19 +643,36 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             } else {
                 delete searchParams.date_to
             }
+            if (values.filterTestAccounts) {
+                searchParams.filter_test_accounts = true
+            } else {
+                delete searchParams.filter_test_accounts
+            }
             return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
-        },
-    })),
+        }
+        return {
+            setDateFilter: syncUrl,
+            setFilterTestAccounts: syncUrl,
+        }
+    }),
     urlToAction(({ actions, values, cache }) => ({
         [urls.mcpAnalyticsDashboard()]: (_, searchParams) => {
             const dateFrom =
                 typeof searchParams.date_from === 'string' ? searchParams.date_from : DEFAULT_DATE_FILTER.dateFrom
             const dateTo = typeof searchParams.date_to === 'string' ? searchParams.date_to : null
-            if (dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo) {
-                // setDateFilter's listener reloads everything.
+            const filterTestAccounts =
+                searchParams.filter_test_accounts === true || searchParams.filter_test_accounts === 'true'
+            const dateChanged = dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo
+            const filterChanged = filterTestAccounts !== values.filterTestAccounts
+            // setDateFilter / setFilterTestAccounts each reload via their listeners.
+            if (dateChanged) {
                 actions.setDateFilter(dateFrom, dateTo)
-            } else if (!cache.hasLoaded) {
-                // URL already matches state (e.g. default window) and afterMount deferred — load once here.
+            }
+            if (filterChanged) {
+                actions.setFilterTestAccounts(filterTestAccounts)
+            }
+            // URL already matches state (e.g. default filters) and afterMount deferred — load once.
+            if (!dateChanged && !filterChanged && !cache.hasLoaded) {
                 actions.reloadAll()
             }
             cache.hasLoaded = true
@@ -656,7 +684,10 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         // tests, where urlToAction never fires). The cache.hasLoaded guard keeps a
         // deep-linked load from firing twice.
         const { searchParams } = router.values
-        const hasUrlFilters = typeof searchParams.date_from === 'string' || typeof searchParams.date_to === 'string'
+        const hasUrlFilters =
+            typeof searchParams.date_from === 'string' ||
+            typeof searchParams.date_to === 'string' ||
+            typeof searchParams.filter_test_accounts !== 'undefined'
         if (!hasUrlFilters && !cache.hasLoaded) {
             cache.hasLoaded = true
             actions.reloadAll()


### PR DESCRIPTION
## Problem

Even with a time filter, the MCP analytics dashboard counted internal and test traffic (PostHog's own team driving the MCP) alongside real external usage, with no way to exclude it — so error rates, volumes, and harness breakdowns were skewed by our own dogfooding.

## Changes

Adds a "Filter out internal and test users" switch to the dashboard, stacked on top of the time filter PR (#64434).

- Reuses the shared `TestAccountFilterSwitch` (links to the project's internal-user-filtering settings, disables itself when no filters are configured).
- Flows through the dashboard's single `queryFilters` selector, so every tile — KPIs and all breakdowns — respects it via the HogQL `filterTestAccounts` flag.
- Defaults off, and persists in the URL (`filter_test_accounts`) alongside the time filter.

## How did you test this code?

Automated only — I'm an agent and did not manually click through the UI.

- `mcpDashboardOverviewLogic.test.ts`: a parameterized mounted-logic test asserting `filterTestAccounts` reaches every tile's query for both the default (off) and toggled (on) states.
- Full `mcp_analytics` frontend jest suite passes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus), stacked on #64434. The wiring is deliberately minimal: #64434 already centralized all query filters into one `queryFilters` selector, so adding test-account filtering was just one field on that selector plus the toggle UI — every tile picked it up for free.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
