### PR TITLE
chore: Add addditional loggging to heatmaps

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -90,6 +90,7 @@ from products.streamlit_apps.backend.facade.api import (
     prune_old_streamlit_app_versions,
     stop_idle_streamlit_sandboxes,
 )
+from products.web_analytics.backend.tasks.heatmap_screenshot import report_stuck_heatmap_screenshots
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
 
@@ -311,6 +312,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="*/5"),
         feature_flags_local_eval_canary_task.s(),
         name="feature flags local-eval canary",
+        expires_seconds=5 * 60,
+    )
+
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*/5"),
+        report_stuck_heatmap_screenshots.s(),
+        name="report stuck heatmap screenshots",
         expires_seconds=5 * 60,
     )
 

--- a/products/web_analytics/backend/api/heatmaps_api.py
+++ b/products/web_analytics/backend/api/heatmaps_api.py
@@ -1,14 +1,18 @@
 from datetime import date, datetime, timedelta
 from json import JSONDecodeError, loads
+from time import perf_counter
 from typing import Any, List, Literal, cast  # noqa: UP035
 
 from django.core.exceptions import FieldError
 from django.db.models import Q
 from django.http import HttpResponse
 
+import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_field
+from opentelemetry import trace
+from prometheus_client import Counter, Histogram
 from rest_framework import request, response, serializers, status, viewsets
 
 from posthog.schema import DateRange, HogQLFilters, HogQLQueryResponse, ProductKey
@@ -47,6 +51,21 @@ from products.web_analytics.backend.tasks.heatmap_screenshot import generate_hea
 STALE_PROCESSING_THRESHOLD = timedelta(minutes=10)
 
 HEATMAPS_COHORT_FILTER_FLAG = "heatmaps-cohort-filter"
+
+logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
+
+HEATMAP_CONTENT_REQUESTS = Counter(
+    "heatmap_screenshot_content_requests",
+    "Heatmap screenshot content endpoint responses",
+    labelnames=["outcome"],
+)
+HEATMAP_CONTENT_SERVE_SECONDS = Histogram(
+    "heatmap_screenshot_content_serve_duration_seconds",
+    "Time to read and serve a heatmap screenshot content response",
+    labelnames=["outcome"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, float("inf")),
+)
 
 
 def _heatmaps_cohort_filter_enabled(user: User, team: Team) -> bool:
@@ -823,47 +842,96 @@ class HeatmapScreenshotViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(methods=["GET"], detail=True)
     def content(self, request: request.Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        screenshot = self.get_object()
-        if screenshot.deleted:
-            return response.Response(status=status.HTTP_404_NOT_FOUND)
+        started = perf_counter()
+        with tracer.start_as_current_span("heatmap.serve_content") as span:
+            screenshot = self.get_object()
+            span.set_attribute("heatmap.screenshot_id", str(screenshot.id))
+            span.set_attribute("team_id", screenshot.team_id)
 
-        # Pick requested width or default
-        try:
-            requested_width = int(request.query_params.get("width", 1024))
-        except (ValueError, TypeError):
-            return response.Response(
-                {"error": "Invalid width parameter, must be an integer"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            def _finish(resp: HttpResponse, outcome: str, **attrs: Any) -> HttpResponse:
+                elapsed = perf_counter() - started
+                HEATMAP_CONTENT_REQUESTS.labels(outcome=outcome).inc()
+                HEATMAP_CONTENT_SERVE_SECONDS.labels(outcome=outcome).observe(elapsed)
+                span.set_attribute("heatmap.outcome", outcome)
+                for key, value in attrs.items():
+                    span.set_attribute(f"heatmap.{key}", value)
+                log = logger.warning if outcome in ("bad_request", "not_implemented") else logger.info
+                log(
+                    "heatmap_screenshot.content_request",
+                    screenshot_id=str(screenshot.id),
+                    team_id=screenshot.team_id,
+                    outcome=outcome,
+                    status_code=resp.status_code,
+                    duration_ms=round(elapsed * 1000),
+                    **attrs,
+                )
+                return resp
 
-        # Try exact match snapshot
-        snapshot = screenshot.snapshots.filter(width=requested_width).first()
+            if screenshot.deleted:
+                return _finish(response.Response(status=status.HTTP_404_NOT_FOUND), "not_found")
 
-        # If not found, pick closest by absolute difference among available snapshots
-        if not snapshot:
-            all_snaps = list(screenshot.snapshots.all())
-            if all_snaps:
-                snapshot = min(all_snaps, key=lambda s: abs(s.width - requested_width))
+            try:
+                requested_width = int(request.query_params.get("width", 1024))
+            except (ValueError, TypeError):
+                return _finish(
+                    response.Response(
+                        {"error": "Invalid width parameter, must be an integer"}, status=status.HTTP_400_BAD_REQUEST
+                    ),
+                    "bad_request",
+                )
 
-        if not snapshot:
-            # Nothing generated yet
-            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-            return response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED)
+            snapshot = screenshot.snapshots.filter(width=requested_width).first()
+            exact = snapshot is not None
 
-        if snapshot.content:
-            http_response = HttpResponse(snapshot.content, content_type="image/jpeg")
-            http_response["Content-Disposition"] = (
-                f'attachment; filename="screenshot-{screenshot.id}-{snapshot.width}.jpg"'
-            )
-            return http_response
-        elif snapshot.content_location:
-            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-            return response.Response(
-                {**response_serializer.data, "error": "Content location not implemented yet"},
-                status=status.HTTP_501_NOT_IMPLEMENTED,
-            )
-        else:
-            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-            return response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED)
+            if not snapshot:
+                all_snaps = list(screenshot.snapshots.all())
+                if all_snaps:
+                    snapshot = min(all_snaps, key=lambda s: abs(s.width - requested_width))
+
+            if not snapshot:
+                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+                return _finish(
+                    response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
+                    "generating",
+                    requested_width=requested_width,
+                    reason="no_snapshot",
+                    screenshot_status=screenshot.status,
+                )
+
+            if snapshot.content:
+                http_response = HttpResponse(snapshot.content, content_type="image/jpeg")
+                http_response["Content-Disposition"] = (
+                    f'attachment; filename="screenshot-{screenshot.id}-{snapshot.width}.jpg"'
+                )
+                return _finish(
+                    http_response,
+                    "served",
+                    requested_width=requested_width,
+                    served_width=snapshot.width,
+                    bytes=len(snapshot.content),
+                    exact=exact,
+                )
+            elif snapshot.content_location:
+                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+                return _finish(
+                    response.Response(
+                        {**response_serializer.data, "error": "Content location not implemented yet"},
+                        status=status.HTTP_501_NOT_IMPLEMENTED,
+                    ),
+                    "not_implemented",
+                    requested_width=requested_width,
+                    served_width=snapshot.width,
+                )
+            else:
+                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+                return _finish(
+                    response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
+                    "generating",
+                    requested_width=requested_width,
+                    served_width=snapshot.width,
+                    reason="content_pending",
+                    screenshot_status=screenshot.status,
+                )
 
 
 _URL_PATTERN_CHARS = set("*+?^${}()|[]\\")

--- a/products/web_analytics/backend/api/heatmaps_api.py
+++ b/products/web_analytics/backend/api/heatmaps_api.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timedelta
 from json import JSONDecodeError, loads
-from time import perf_counter
 from typing import Any, List, Literal, cast  # noqa: UP035
 
 from django.core.exceptions import FieldError
@@ -11,8 +10,7 @@ import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_field
-from opentelemetry import trace
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter
 from rest_framework import request, response, serializers, status, viewsets
 
 from posthog.schema import DateRange, HogQLFilters, HogQLQueryResponse, ProductKey
@@ -53,18 +51,11 @@ STALE_PROCESSING_THRESHOLD = timedelta(minutes=10)
 HEATMAPS_COHORT_FILTER_FLAG = "heatmaps-cohort-filter"
 
 logger = structlog.get_logger(__name__)
-tracer = trace.get_tracer(__name__)
 
 HEATMAP_CONTENT_REQUESTS = Counter(
     "heatmap_screenshot_content_requests",
     "Heatmap screenshot content endpoint responses",
     labelnames=["outcome"],
-)
-HEATMAP_CONTENT_SERVE_SECONDS = Histogram(
-    "heatmap_screenshot_content_serve_duration_seconds",
-    "Time to read and serve a heatmap screenshot content response",
-    labelnames=["outcome"],
-    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, float("inf")),
 )
 
 
@@ -842,19 +833,11 @@ class HeatmapScreenshotViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(methods=["GET"], detail=True)
     def content(self, request: request.Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        started = perf_counter()
-        with tracer.start_as_current_span("heatmap.serve_content") as span:
-            screenshot = self.get_object()
-            span.set_attribute("heatmap.screenshot_id", str(screenshot.id))
-            span.set_attribute("team_id", screenshot.team_id)
+        screenshot = self.get_object()
 
-            def _finish(resp: HttpResponse, outcome: str, **attrs: Any) -> HttpResponse:
-                elapsed = perf_counter() - started
-                HEATMAP_CONTENT_REQUESTS.labels(outcome=outcome).inc()
-                HEATMAP_CONTENT_SERVE_SECONDS.labels(outcome=outcome).observe(elapsed)
-                span.set_attribute("heatmap.outcome", outcome)
-                for key, value in attrs.items():
-                    span.set_attribute(f"heatmap.{key}", value)
+        def _finish(resp: HttpResponse, outcome: str, **attrs: Any) -> HttpResponse:
+            HEATMAP_CONTENT_REQUESTS.labels(outcome=outcome).inc()
+            if outcome in ("not_found", "bad_request", "not_implemented"):
                 log = logger.warning if outcome in ("bad_request", "not_implemented") else logger.info
                 log(
                     "heatmap_screenshot.content_request",
@@ -862,76 +845,60 @@ class HeatmapScreenshotViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     team_id=screenshot.team_id,
                     outcome=outcome,
                     status_code=resp.status_code,
-                    duration_ms=round(elapsed * 1000),
                     **attrs,
                 )
-                return resp
+            return resp
 
-            if screenshot.deleted:
-                return _finish(response.Response(status=status.HTTP_404_NOT_FOUND), "not_found")
+        if screenshot.deleted:
+            return _finish(response.Response(status=status.HTTP_404_NOT_FOUND), "not_found")
 
-            try:
-                requested_width = int(request.query_params.get("width", 1024))
-            except (ValueError, TypeError):
-                return _finish(
-                    response.Response(
-                        {"error": "Invalid width parameter, must be an integer"}, status=status.HTTP_400_BAD_REQUEST
-                    ),
-                    "bad_request",
-                )
+        try:
+            requested_width = int(request.query_params.get("width", 1024))
+        except (ValueError, TypeError):
+            return _finish(
+                response.Response(
+                    {"error": "Invalid width parameter, must be an integer"}, status=status.HTTP_400_BAD_REQUEST
+                ),
+                "bad_request",
+            )
 
-            snapshot = screenshot.snapshots.filter(width=requested_width).first()
-            exact = snapshot is not None
+        snapshot = screenshot.snapshots.filter(width=requested_width).first()
 
-            if not snapshot:
-                all_snaps = list(screenshot.snapshots.all())
-                if all_snaps:
-                    snapshot = min(all_snaps, key=lambda s: abs(s.width - requested_width))
+        if not snapshot:
+            all_snaps = list(screenshot.snapshots.all())
+            if all_snaps:
+                snapshot = min(all_snaps, key=lambda s: abs(s.width - requested_width))
 
-            if not snapshot:
-                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-                return _finish(
-                    response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
-                    "generating",
-                    requested_width=requested_width,
-                    reason="no_snapshot",
-                    screenshot_status=screenshot.status,
-                )
+        if not snapshot:
+            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+            return _finish(
+                response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
+                "generating",
+            )
 
-            if snapshot.content:
-                http_response = HttpResponse(snapshot.content, content_type="image/jpeg")
-                http_response["Content-Disposition"] = (
-                    f'attachment; filename="screenshot-{screenshot.id}-{snapshot.width}.jpg"'
-                )
-                return _finish(
-                    http_response,
-                    "served",
-                    requested_width=requested_width,
-                    served_width=snapshot.width,
-                    bytes=len(snapshot.content),
-                    exact=exact,
-                )
-            elif snapshot.content_location:
-                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-                return _finish(
-                    response.Response(
-                        {**response_serializer.data, "error": "Content location not implemented yet"},
-                        status=status.HTTP_501_NOT_IMPLEMENTED,
-                    ),
-                    "not_implemented",
-                    requested_width=requested_width,
-                    served_width=snapshot.width,
-                )
-            else:
-                response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
-                return _finish(
-                    response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
-                    "generating",
-                    requested_width=requested_width,
-                    served_width=snapshot.width,
-                    reason="content_pending",
-                    screenshot_status=screenshot.status,
-                )
+        if snapshot.content:
+            http_response = HttpResponse(snapshot.content, content_type="image/jpeg")
+            http_response["Content-Disposition"] = (
+                f'attachment; filename="screenshot-{screenshot.id}-{snapshot.width}.jpg"'
+            )
+            return _finish(http_response, "served")
+        elif snapshot.content_location:
+            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+            return _finish(
+                response.Response(
+                    {**response_serializer.data, "error": "Content location not implemented yet"},
+                    status=status.HTTP_501_NOT_IMPLEMENTED,
+                ),
+                "not_implemented",
+                requested_width=requested_width,
+                served_width=snapshot.width,
+            )
+        else:
+            response_serializer = HeatmapScreenshotResponseSerializer(screenshot)
+            return _finish(
+                response.Response(response_serializer.data, status=status.HTTP_202_ACCEPTED),
+                "generating",
+            )
 
 
 _URL_PATTERN_CHARS = set("*+?^${}()|[]\\")

--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -11,12 +11,11 @@ import structlog
 import posthoganalytics
 from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
-from opentelemetry import trace
-from opentelemetry.trace import Status, StatusCode
 from prometheus_client import Counter, Gauge, Histogram
 
 from posthog.exceptions_capture import capture_exception
 from posthog.ph_client import ph_scoped_capture
+from posthog.scoping_audit import skip_team_scope_audit
 from posthog.security.url_validation import is_url_allowed
 from posthog.tasks.utils import CeleryQueue
 
@@ -24,7 +23,6 @@ from products.web_analytics.backend.api.heatmaps_utils import DEFAULT_TARGET_WID
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
 
 logger = structlog.get_logger(__name__)
-tracer = trace.get_tracer(__name__)
 
 # Reclaim a hung worker rather than letting a stuck render hold an EXPORTS slot for the full retry budget.
 HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT = 600  # seconds
@@ -32,6 +30,7 @@ HEATMAP_SCREENSHOT_TIME_LIMIT = HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT + 30
 # Reject implausibly large Browserless responses before they reach worker memory / Postgres.
 HEATMAP_SCREENSHOT_MAX_BYTES = 20 * 1024 * 1024
 HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS = HEATMAP_SCREENSHOT_TIME_LIMIT + 60
+HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE = 20
 
 HEATMAP_SCREENSHOT_SUCCEEDED = Counter(
     "heatmap_screenshot_task_succeeded",
@@ -53,11 +52,6 @@ HEATMAP_BROWSERLESS_REQUEST_SECONDS = Histogram(
     "Latency of a single Browserless /screenshot call",
     labelnames=["outcome", "width_bucket"],
     buckets=(0.5, 1, 2, 5, 10, 20, 30, 60, 120, float("inf")),
-)
-HEATMAP_SCREENSHOT_QUEUE_WAIT_SECONDS = Histogram(
-    "heatmap_screenshot_queue_wait_seconds",
-    "Enqueue-to-start latency for the heatmap screenshot task (EXPORTS queue contention proxy)",
-    buckets=(0.5, 1, 5, 10, 30, 60, 120, 300, 600, float("inf")),
 )
 HEATMAP_SCREENSHOT_STUCK_PROCESSING = Gauge(
     "heatmap_screenshot_stuck_processing",
@@ -155,11 +149,6 @@ def _record_failure(screenshot: SavedHeatmap, e: Exception, *, started_at: float
     if started_at is not None:
         HEATMAP_SCREENSHOT_TIMER.labels(outcome="failed").observe(time.monotonic() - started_at)
 
-    span = trace.get_current_span()
-    span.set_attribute("heatmap.failure_type", failure_type)
-    span.record_exception(e)
-    span.set_status(Status(StatusCode.ERROR))
-
     _capture_mode_usage(screenshot, success=False, error_type=type(e).__name__, failure_type=failure_type)
 
     logger.exception(
@@ -197,15 +186,7 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
         logger.exception("heatmap_screenshot.not_found", screenshot_id=screenshot_id)
         return
 
-    span = trace.get_current_span()
-    span.set_attribute("heatmap.screenshot_id", str(screenshot.id))
-    span.set_attribute("team_id", screenshot.team_id)
-    span.set_attribute("heatmap.url", screenshot.url)
-
     queue_wait_seconds = max((timezone.now() - screenshot.updated_at).total_seconds(), 0.0)
-    HEATMAP_SCREENSHOT_QUEUE_WAIT_SECONDS.observe(queue_wait_seconds)
-    span.set_attribute("heatmap.queue_wait_seconds", round(queue_wait_seconds, 2))
-
     logger.info(
         "heatmap_screenshot.started",
         screenshot_id=screenshot.id,
@@ -229,8 +210,6 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
                 screenshot.save(update_fields=["status", "exception"])
                 HEATMAP_SCREENSHOT_FAILED.labels(failure_type="ssrf_blocked").inc()
                 HEATMAP_SCREENSHOT_TIMER.labels(outcome="failed").observe(time.monotonic() - started_at)
-                span.set_attribute("heatmap.failure_type", "ssrf_blocked")
-                span.set_status(Status(StatusCode.ERROR))
                 logger.warning(
                     "heatmap_screenshot.ssrf_blocked",
                     screenshot_id=screenshot.id,
@@ -248,7 +227,6 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
 
             HEATMAP_SCREENSHOT_SUCCEEDED.inc()
             HEATMAP_SCREENSHOT_TIMER.labels(outcome="succeeded").observe(duration_seconds)
-            span.set_attribute("heatmap.width_count", width_count)
 
             _capture_mode_usage(
                 screenshot,
@@ -398,85 +376,73 @@ def _browserless_screenshot(endpoint_url: str, page_url: str, width: int) -> byt
         settings.HEATMAP_BROWSERLESS_TIMEOUT_MS / 1000 + 30,
     )
     width_bucket = _width_bucket(width)
-    with tracer.start_as_current_span("heatmap.browserless_screenshot") as span:
-        span.set_attribute("heatmap.width", width)
-        span.set_attribute("heatmap.width_bucket", width_bucket)
-        started = time.monotonic()
-        try:
-            response = requests.post(endpoint_url, json=body, timeout=timeout)
-        except Exception as e:
-            elapsed = time.monotonic() - started
-            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
-            err: BrowserlessError = BrowserlessTransientError(
-                f"Browserless screenshot request failed for {_redact_browserless_url(endpoint_url)}: "
-                f"{_sanitize_browserless_error(str(e))}",
-                cause="request_exception",
-            )
-            span.record_exception(err)
-            span.set_status(Status(StatusCode.ERROR))
-            logger.warning(
-                "heatmap_screenshot.browserless_request",
-                width=width,
-                outcome="error",
-                cause="request_exception",
-                latency_ms=round(elapsed * 1000),
-            )
-            raise err from None
-
+    started = time.monotonic()
+    try:
+        response = requests.post(endpoint_url, json=body, timeout=timeout)
+    except Exception as e:
         elapsed = time.monotonic() - started
-        status_code = response.status_code
-        byte_size = len(response.content or b"")
-        span.set_attribute("heatmap.browserless_status", status_code)
-        span.set_attribute("heatmap.latency_ms", round(elapsed * 1000))
-        span.set_attribute("heatmap.bytes", byte_size)
+        HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+        err: BrowserlessError = BrowserlessTransientError(
+            f"Browserless screenshot request failed for {_redact_browserless_url(endpoint_url)}: "
+            f"{_sanitize_browserless_error(str(e))}",
+            cause="request_exception",
+        )
+        logger.warning(
+            "heatmap_screenshot.browserless_request",
+            width=width,
+            outcome="error",
+            cause="request_exception",
+            latency_ms=round(elapsed * 1000),
+        )
+        raise err from None
 
-        if status_code != 200:
-            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
-            message = (
-                f"Browserless screenshot failed ({status_code}) for "
-                f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:500])}"
-            )
-            error_cls = BrowserlessPermanentError if _is_permanent_status(status_code) else BrowserlessTransientError
-            err = error_cls(message, status_code=status_code, cause="http_status")
-            span.record_exception(err)
-            span.set_status(Status(StatusCode.ERROR))
-            logger.warning(
-                "heatmap_screenshot.browserless_request",
-                width=width,
-                browserless_status=status_code,
-                latency_ms=round(elapsed * 1000),
-                bytes=byte_size,
-                outcome="error",
-            )
-            raise err
+    elapsed = time.monotonic() - started
+    status_code = response.status_code
+    byte_size = len(response.content or b"")
 
-        try:
-            content = _validate_screenshot_response(response, endpoint_url)
-        except BrowserlessError as err:
-            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
-            span.record_exception(err)
-            span.set_status(Status(StatusCode.ERROR))
-            logger.warning(
-                "heatmap_screenshot.browserless_request",
-                width=width,
-                browserless_status=status_code,
-                latency_ms=round(elapsed * 1000),
-                bytes=byte_size,
-                outcome="error",
-                cause=err.cause,
-            )
-            raise
-
-        HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="ok", width_bucket=width_bucket).observe(elapsed)
-        logger.info(
+    if status_code != 200:
+        HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+        message = (
+            f"Browserless screenshot failed ({status_code}) for "
+            f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:500])}"
+        )
+        error_cls = BrowserlessPermanentError if _is_permanent_status(status_code) else BrowserlessTransientError
+        err = error_cls(message, status_code=status_code, cause="http_status")
+        logger.warning(
             "heatmap_screenshot.browserless_request",
             width=width,
             browserless_status=status_code,
             latency_ms=round(elapsed * 1000),
-            bytes=len(content),
-            outcome="ok",
+            bytes=byte_size,
+            outcome="error",
         )
-        return content
+        raise err
+
+    try:
+        content = _validate_screenshot_response(response, endpoint_url)
+    except BrowserlessError as err:
+        HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+        logger.warning(
+            "heatmap_screenshot.browserless_request",
+            width=width,
+            browserless_status=status_code,
+            latency_ms=round(elapsed * 1000),
+            bytes=byte_size,
+            outcome="error",
+            cause=err.cause,
+        )
+        raise
+
+    HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="ok", width_bucket=width_bucket).observe(elapsed)
+    logger.info(
+        "heatmap_screenshot.browserless_request",
+        width=width,
+        browserless_status=status_code,
+        latency_ms=round(elapsed * 1000),
+        bytes=len(content),
+        outcome="ok",
+    )
+    return content
 
 
 def _resolve_widths(screenshot: SavedHeatmap) -> list[int]:
@@ -509,18 +475,10 @@ def _resolve_widths(screenshot: SavedHeatmap) -> list[int]:
 
 
 def _persist_snapshot(screenshot: SavedHeatmap, width: int, image_data: bytes) -> None:
-    snapshot, created = HeatmapSnapshot.objects.get_or_create(heatmap=screenshot, width=width)
+    snapshot, _ = HeatmapSnapshot.objects.get_or_create(heatmap=screenshot, width=width)
     snapshot.content = image_data
     snapshot.content_location = None
     snapshot.save()
-    logger.info(
-        "heatmap_screenshot.snapshot_persisted",
-        screenshot_id=screenshot.id,
-        team_id=screenshot.team_id,
-        width=width,
-        bytes=len(image_data),
-        created=created,
-    )
 
 
 def _generate_screenshots(screenshot: SavedHeatmap) -> int:
@@ -550,28 +508,30 @@ def _generate_browserless_screenshots(screenshot: SavedHeatmap, widths: list[int
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.EXPORTS.value)
+@skip_team_scope_audit
 def report_stuck_heatmap_screenshots() -> int:
-    cutoff = timezone.now() - timedelta(seconds=HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS)
     now = timezone.now()
+    cutoff = now - timedelta(seconds=HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS)
     stuck = SavedHeatmap.objects.filter(
         type=SavedHeatmap.Type.SCREENSHOT,
         status=SavedHeatmap.Status.PROCESSING,
         updated_at__lt=cutoff,
-    ).only("id", "team_id", "updated_at")
-    count = 0
-    for screenshot in stuck:
-        logger.warning(
-            "heatmap_screenshot.stuck_processing",
-            screenshot_id=screenshot.id,
-            team_id=screenshot.team_id,
-            age_seconds=round((now - screenshot.updated_at).total_seconds()),
-        )
-        count += 1
+    )
+    count = stuck.count()
     HEATMAP_SCREENSHOT_STUCK_PROCESSING.set(count)
     if count:
+        sample = stuck.order_by("updated_at").only("id", "team_id", "updated_at")[:HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE]
         logger.warning(
-            "heatmap_screenshot.stuck_sweep_found",
+            "heatmap_screenshot.stuck_processing",
             stuck_count=count,
             threshold_seconds=HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS,
+            sample=[
+                {
+                    "screenshot_id": str(s.id),
+                    "team_id": s.team_id,
+                    "age_seconds": round((now - s.updated_at).total_seconds()),
+                }
+                for s in sample
+            ],
         )
     return count

--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -407,7 +407,7 @@ def _browserless_screenshot(endpoint_url: str, page_url: str, width: int) -> byt
         except Exception as e:
             elapsed = time.monotonic() - started
             HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
-            err = BrowserlessTransientError(
+            err: BrowserlessError = BrowserlessTransientError(
                 f"Browserless screenshot request failed for {_redact_browserless_url(endpoint_url)}: "
                 f"{_sanitize_browserless_error(str(e))}",
                 cause="request_exception",

--- a/products/web_analytics/backend/tasks/heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/heatmap_screenshot.py
@@ -1,14 +1,19 @@
 import re
 import time
+from datetime import timedelta
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from django.conf import settings
+from django.utils import timezone
 
 import requests
 import structlog
 import posthoganalytics
 from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+from prometheus_client import Counter, Gauge, Histogram
 
 from posthog.exceptions_capture import capture_exception
 from posthog.ph_client import ph_scoped_capture
@@ -19,16 +24,54 @@ from products.web_analytics.backend.api.heatmaps_utils import DEFAULT_TARGET_WID
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # Reclaim a hung worker rather than letting a stuck render hold an EXPORTS slot for the full retry budget.
 HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT = 600  # seconds
 HEATMAP_SCREENSHOT_TIME_LIMIT = HEATMAP_SCREENSHOT_SOFT_TIME_LIMIT + 30
 # Reject implausibly large Browserless responses before they reach worker memory / Postgres.
 HEATMAP_SCREENSHOT_MAX_BYTES = 20 * 1024 * 1024
+HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS = HEATMAP_SCREENSHOT_TIME_LIMIT + 60
+
+HEATMAP_SCREENSHOT_SUCCEEDED = Counter(
+    "heatmap_screenshot_task_succeeded",
+    "A heatmap screenshot task succeeded",
+)
+HEATMAP_SCREENSHOT_FAILED = Counter(
+    "heatmap_screenshot_task_failed",
+    "A heatmap screenshot task failed",
+    labelnames=["failure_type"],
+)
+HEATMAP_SCREENSHOT_TIMER = Histogram(
+    "heatmap_screenshot_task_duration_seconds",
+    "End-to-end heatmap screenshot render time",
+    labelnames=["outcome"],
+    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
+)
+HEATMAP_BROWSERLESS_REQUEST_SECONDS = Histogram(
+    "heatmap_screenshot_browserless_request_duration_seconds",
+    "Latency of a single Browserless /screenshot call",
+    labelnames=["outcome", "width_bucket"],
+    buckets=(0.5, 1, 2, 5, 10, 20, 30, 60, 120, float("inf")),
+)
+HEATMAP_SCREENSHOT_QUEUE_WAIT_SECONDS = Histogram(
+    "heatmap_screenshot_queue_wait_seconds",
+    "Enqueue-to-start latency for the heatmap screenshot task (EXPORTS queue contention proxy)",
+    buckets=(0.5, 1, 5, 10, 30, 60, 120, 300, 600, float("inf")),
+)
+HEATMAP_SCREENSHOT_STUCK_PROCESSING = Gauge(
+    "heatmap_screenshot_stuck_processing",
+    "Screenshot heatmaps still processing past the task time limit",
+)
 
 
 class BrowserlessError(Exception):
     """Base class for Browserless /screenshot failures."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, cause: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.cause = cause
 
 
 class BrowserlessTransientError(BrowserlessError):
@@ -39,6 +82,36 @@ class BrowserlessPermanentError(BrowserlessError):
     """A failure that will not be fixed by retrying (4xx, misconfiguration, oversized output)."""
 
 
+def _width_bucket(width: int) -> str:
+    if width < 500:
+        return "mobile"
+    if width < 900:
+        return "tablet"
+    if width < 1440:
+        return "desktop"
+    return "wide"
+
+
+def _classify_failure(e: BaseException) -> str:
+    if isinstance(e, SoftTimeLimitExceeded):
+        return "soft_time_limit"
+    if isinstance(e, BrowserlessError):
+        if e.cause == "not_configured":
+            return "not_configured"
+        if e.cause in ("empty_body", "non_image", "non_jpeg", "oversized"):
+            return "validation_error"
+        if e.cause == "request_exception":
+            return "browserless_timeout"
+        if e.status_code is not None:
+            if e.status_code == 408:
+                return "browserless_timeout"
+            if 400 <= e.status_code < 500:
+                return "browserless_4xx"
+            if e.status_code >= 500:
+                return "browserless_5xx"
+    return "unknown"
+
+
 def _capture_mode_usage(
     screenshot: SavedHeatmap,
     *,
@@ -46,6 +119,7 @@ def _capture_mode_usage(
     width_count: int | None = None,
     duration_seconds: float | None = None,
     error_type: str | None = None,
+    failure_type: str | None = None,
 ) -> None:
     # ph_scoped_capture (not posthoganalytics.capture) — events from Celery tasks are otherwise
     # silently lost; no-ops off PostHog Cloud. Telemetry must never fail the task, so swallow errors.
@@ -61,6 +135,7 @@ def _capture_mode_usage(
                     "width_count": width_count,
                     "duration_seconds": duration_seconds,
                     "error_type": error_type,
+                    "failure_type": failure_type,
                     "team_id": team.id,
                     "screenshot_id": str(screenshot.id),
                 },
@@ -70,18 +145,29 @@ def _capture_mode_usage(
         logger.warning("heatmap_screenshot.usage_capture_failed", screenshot_id=screenshot.id, exc_info=True)
 
 
-def _record_failure(screenshot: SavedHeatmap, e: Exception) -> None:
+def _record_failure(screenshot: SavedHeatmap, e: Exception, *, started_at: float | None = None) -> None:
+    failure_type = _classify_failure(e)
     screenshot.status = SavedHeatmap.Status.FAILED
     screenshot.exception = str(e)
     screenshot.save(update_fields=["status", "exception"])
 
-    _capture_mode_usage(screenshot, success=False, error_type=type(e).__name__)
+    HEATMAP_SCREENSHOT_FAILED.labels(failure_type=failure_type).inc()
+    if started_at is not None:
+        HEATMAP_SCREENSHOT_TIMER.labels(outcome="failed").observe(time.monotonic() - started_at)
+
+    span = trace.get_current_span()
+    span.set_attribute("heatmap.failure_type", failure_type)
+    span.record_exception(e)
+    span.set_status(Status(StatusCode.ERROR))
+
+    _capture_mode_usage(screenshot, success=False, error_type=type(e).__name__, failure_type=failure_type)
 
     logger.exception(
         "heatmap_screenshot.failed",
         screenshot_id=screenshot.id,
         team_id=screenshot.team_id,
         url=screenshot.url,
+        failure_type=failure_type,
         exception=str(e),
         exc_info=True,
     )
@@ -111,6 +197,26 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
         logger.exception("heatmap_screenshot.not_found", screenshot_id=screenshot_id)
         return
 
+    span = trace.get_current_span()
+    span.set_attribute("heatmap.screenshot_id", str(screenshot.id))
+    span.set_attribute("team_id", screenshot.team_id)
+    span.set_attribute("heatmap.url", screenshot.url)
+
+    queue_wait_seconds = max((timezone.now() - screenshot.updated_at).total_seconds(), 0.0)
+    HEATMAP_SCREENSHOT_QUEUE_WAIT_SECONDS.observe(queue_wait_seconds)
+    span.set_attribute("heatmap.queue_wait_seconds", round(queue_wait_seconds, 2))
+
+    logger.info(
+        "heatmap_screenshot.started",
+        screenshot_id=screenshot.id,
+        team_id=screenshot.team_id,
+        url=screenshot.url,
+        retries=self.request.retries,
+        task_id=self.request.id,
+        queue_wait_seconds=round(queue_wait_seconds, 2),
+    )
+
+    started_at = time.monotonic()
     with posthoganalytics.new_context():
         posthoganalytics.tag("team_id", screenshot.team_id)
         posthoganalytics.tag("screenshot_id", screenshot.id)
@@ -121,6 +227,10 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
                 screenshot.status = SavedHeatmap.Status.FAILED
                 screenshot.exception = f"SSRF blocked: {err}"
                 screenshot.save(update_fields=["status", "exception"])
+                HEATMAP_SCREENSHOT_FAILED.labels(failure_type="ssrf_blocked").inc()
+                HEATMAP_SCREENSHOT_TIMER.labels(outcome="failed").observe(time.monotonic() - started_at)
+                span.set_attribute("heatmap.failure_type", "ssrf_blocked")
+                span.set_status(Status(StatusCode.ERROR))
                 logger.warning(
                     "heatmap_screenshot.ssrf_blocked",
                     screenshot_id=screenshot.id,
@@ -130,12 +240,15 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
                 )
                 return
 
-            started_at = time.monotonic()
             width_count = _generate_screenshots(screenshot)
             duration_seconds = round(time.monotonic() - started_at, 2)
 
             screenshot.status = SavedHeatmap.Status.COMPLETED
             screenshot.save()
+
+            HEATMAP_SCREENSHOT_SUCCEEDED.inc()
+            HEATMAP_SCREENSHOT_TIMER.labels(outcome="succeeded").observe(duration_seconds)
+            span.set_attribute("heatmap.width_count", width_count)
 
             _capture_mode_usage(
                 screenshot,
@@ -150,27 +263,34 @@ def generate_heatmap_screenshot(self: Task, screenshot_id: str) -> None:
                 team_id=screenshot.team_id,
                 url=screenshot.url,
                 mode="browserless",
+                width_count=width_count,
                 duration_seconds=duration_seconds,
             )
 
         except (BrowserlessPermanentError, SoftTimeLimitExceeded) as e:
             # Won't succeed on retry (bad request / config / oversized output / timed out) — fail now.
-            _record_failure(screenshot, e)
+            _record_failure(screenshot, e, started_at=started_at)
             raise
         except Exception as e:
             # Transient Browserless failure: retry with backoff, but only record FAILED + emit the
             # failure event once retries are exhausted, so a blip doesn't flap the status or inflate
             # the failure metric.
             if self.request.called_directly or self.request.retries >= self.max_retries:
-                _record_failure(screenshot, e)
+                _record_failure(screenshot, e, started_at=started_at)
                 raise
+            countdown = min(2 ** (self.request.retries + 1), 60)
             logger.warning(
                 "heatmap_screenshot.retrying",
                 screenshot_id=screenshot.id,
+                team_id=screenshot.team_id,
+                url=screenshot.url,
                 retries=self.request.retries,
+                max_retries=self.max_retries,
+                countdown=countdown,
+                failure_type=_classify_failure(e),
                 exception=str(e),
             )
-            raise self.retry(exc=e, countdown=min(2 ** (self.request.retries + 1), 60))
+            raise self.retry(exc=e, countdown=countdown)
 
 
 def _build_browserless_screenshot_url() -> str | None:
@@ -225,21 +345,25 @@ def _validate_screenshot_response(response: requests.Response, endpoint_url: str
     content = response.content
     if len(content) > HEATMAP_SCREENSHOT_MAX_BYTES:
         raise BrowserlessPermanentError(
-            f"Browserless screenshot too large ({len(content)} bytes) for {_redact_browserless_url(endpoint_url)}"
+            f"Browserless screenshot too large ({len(content)} bytes) for {_redact_browserless_url(endpoint_url)}",
+            cause="oversized",
         )
     if not content:
         raise BrowserlessTransientError(
-            f"Browserless returned an empty body for {_redact_browserless_url(endpoint_url)}"
+            f"Browserless returned an empty body for {_redact_browserless_url(endpoint_url)}",
+            cause="empty_body",
         )
     content_type = response.headers.get("content-type", "")
     if not content_type.startswith("image/"):
         raise BrowserlessTransientError(
             f"Browserless returned non-image content-type {content_type!r} for "
-            f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:200])}"
+            f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:200])}",
+            cause="non_image",
         )
     if not content.startswith(b"\xff\xd8\xff"):  # JPEG start-of-image marker
         raise BrowserlessTransientError(
-            f"Browserless returned a non-JPEG body for {_redact_browserless_url(endpoint_url)}"
+            f"Browserless returned a non-JPEG body for {_redact_browserless_url(endpoint_url)}",
+            cause="non_jpeg",
         )
     return content
 
@@ -273,23 +397,86 @@ def _browserless_screenshot(endpoint_url: str, page_url: str, width: int) -> byt
         settings.HEATMAP_BROWSERLESS_CONNECT_TIMEOUT_MS / 1000,
         settings.HEATMAP_BROWSERLESS_TIMEOUT_MS / 1000 + 30,
     )
-    try:
-        response = requests.post(endpoint_url, json=body, timeout=timeout)
-    except Exception as e:
-        # The endpoint URL carries the token; scrub it before it reaches logs / SavedHeatmap.exception.
-        raise BrowserlessTransientError(
-            f"Browserless screenshot request failed for {_redact_browserless_url(endpoint_url)}: "
-            f"{_sanitize_browserless_error(str(e))}"
-        ) from None
-    if response.status_code != 200:
-        message = (
-            f"Browserless screenshot failed ({response.status_code}) for "
-            f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:500])}"
+    width_bucket = _width_bucket(width)
+    with tracer.start_as_current_span("heatmap.browserless_screenshot") as span:
+        span.set_attribute("heatmap.width", width)
+        span.set_attribute("heatmap.width_bucket", width_bucket)
+        started = time.monotonic()
+        try:
+            response = requests.post(endpoint_url, json=body, timeout=timeout)
+        except Exception as e:
+            elapsed = time.monotonic() - started
+            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+            err = BrowserlessTransientError(
+                f"Browserless screenshot request failed for {_redact_browserless_url(endpoint_url)}: "
+                f"{_sanitize_browserless_error(str(e))}",
+                cause="request_exception",
+            )
+            span.record_exception(err)
+            span.set_status(Status(StatusCode.ERROR))
+            logger.warning(
+                "heatmap_screenshot.browserless_request",
+                width=width,
+                outcome="error",
+                cause="request_exception",
+                latency_ms=round(elapsed * 1000),
+            )
+            raise err from None
+
+        elapsed = time.monotonic() - started
+        status_code = response.status_code
+        byte_size = len(response.content or b"")
+        span.set_attribute("heatmap.browserless_status", status_code)
+        span.set_attribute("heatmap.latency_ms", round(elapsed * 1000))
+        span.set_attribute("heatmap.bytes", byte_size)
+
+        if status_code != 200:
+            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+            message = (
+                f"Browserless screenshot failed ({status_code}) for "
+                f"{_redact_browserless_url(endpoint_url)}: {_sanitize_browserless_error(response.text[:500])}"
+            )
+            error_cls = BrowserlessPermanentError if _is_permanent_status(status_code) else BrowserlessTransientError
+            err = error_cls(message, status_code=status_code, cause="http_status")
+            span.record_exception(err)
+            span.set_status(Status(StatusCode.ERROR))
+            logger.warning(
+                "heatmap_screenshot.browserless_request",
+                width=width,
+                browserless_status=status_code,
+                latency_ms=round(elapsed * 1000),
+                bytes=byte_size,
+                outcome="error",
+            )
+            raise err
+
+        try:
+            content = _validate_screenshot_response(response, endpoint_url)
+        except BrowserlessError as err:
+            HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="error", width_bucket=width_bucket).observe(elapsed)
+            span.record_exception(err)
+            span.set_status(Status(StatusCode.ERROR))
+            logger.warning(
+                "heatmap_screenshot.browserless_request",
+                width=width,
+                browserless_status=status_code,
+                latency_ms=round(elapsed * 1000),
+                bytes=byte_size,
+                outcome="error",
+                cause=err.cause,
+            )
+            raise
+
+        HEATMAP_BROWSERLESS_REQUEST_SECONDS.labels(outcome="ok", width_bucket=width_bucket).observe(elapsed)
+        logger.info(
+            "heatmap_screenshot.browserless_request",
+            width=width,
+            browserless_status=status_code,
+            latency_ms=round(elapsed * 1000),
+            bytes=len(content),
+            outcome="ok",
         )
-        if _is_permanent_status(response.status_code):
-            raise BrowserlessPermanentError(message)
-        raise BrowserlessTransientError(message)
-    return _validate_screenshot_response(response, endpoint_url)
+        return content
 
 
 def _resolve_widths(screenshot: SavedHeatmap) -> list[int]:
@@ -301,17 +488,39 @@ def _resolve_widths(screenshot: SavedHeatmap) -> list[int]:
             widths.append(w)
             seen.add(w)
     if not widths:
+        logger.warning(
+            "heatmap_screenshot.no_valid_widths",
+            screenshot_id=screenshot.id,
+            team_id=screenshot.team_id,
+            target_widths=target_widths,
+        )
         return [1024]
+    if len(widths) > MAX_TARGET_WIDTHS:
+        logger.warning(
+            "heatmap_screenshot.widths_capped",
+            screenshot_id=screenshot.id,
+            team_id=screenshot.team_id,
+            requested_count=len(widths),
+            cap=MAX_TARGET_WIDTHS,
+        )
     # Backstop the per-width render fan-out for heatmaps created before the serializer cap (or via the
     # regenerate path), so one heatmap can't spawn an unbounded number of Browserless sessions.
     return widths[:MAX_TARGET_WIDTHS]
 
 
 def _persist_snapshot(screenshot: SavedHeatmap, width: int, image_data: bytes) -> None:
-    snapshot, _ = HeatmapSnapshot.objects.get_or_create(heatmap=screenshot, width=width)
+    snapshot, created = HeatmapSnapshot.objects.get_or_create(heatmap=screenshot, width=width)
     snapshot.content = image_data
     snapshot.content_location = None
     snapshot.save()
+    logger.info(
+        "heatmap_screenshot.snapshot_persisted",
+        screenshot_id=screenshot.id,
+        team_id=screenshot.team_id,
+        width=width,
+        bytes=len(image_data),
+        created=created,
+    )
 
 
 def _generate_screenshots(screenshot: SavedHeatmap) -> int:
@@ -324,10 +533,45 @@ def _generate_browserless_screenshots(screenshot: SavedHeatmap, widths: list[int
     # release each image as it arrives so worker memory holds one full-page JPEG at a time.
     endpoint_url = _build_browserless_screenshot_url()
     if not endpoint_url:
-        raise BrowserlessPermanentError("Browserless screenshot URL is not configured")
+        raise BrowserlessPermanentError("Browserless screenshot URL is not configured", cause="not_configured")
+    logger.info(
+        "heatmap_screenshot.rendering_widths",
+        screenshot_id=screenshot.id,
+        team_id=screenshot.team_id,
+        width_count=len(widths),
+        widths=widths,
+    )
     count = 0
     for w in widths:
         image_data = _browserless_screenshot(endpoint_url, screenshot.url, w)
         _persist_snapshot(screenshot, w, image_data)
         count += 1
+    return count
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.EXPORTS.value)
+def report_stuck_heatmap_screenshots() -> int:
+    cutoff = timezone.now() - timedelta(seconds=HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS)
+    now = timezone.now()
+    stuck = SavedHeatmap.objects.filter(
+        type=SavedHeatmap.Type.SCREENSHOT,
+        status=SavedHeatmap.Status.PROCESSING,
+        updated_at__lt=cutoff,
+    ).only("id", "team_id", "updated_at")
+    count = 0
+    for screenshot in stuck:
+        logger.warning(
+            "heatmap_screenshot.stuck_processing",
+            screenshot_id=screenshot.id,
+            team_id=screenshot.team_id,
+            age_seconds=round((now - screenshot.updated_at).total_seconds()),
+        )
+        count += 1
+    HEATMAP_SCREENSHOT_STUCK_PROCESSING.set(count)
+    if count:
+        logger.warning(
+            "heatmap_screenshot.stuck_sweep_found",
+            stuck_count=count,
+            threshold_seconds=HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS,
+        )
     return count

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -1,23 +1,34 @@
 from contextlib import contextmanager
+from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
 
+from celery.exceptions import SoftTimeLimitExceeded
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 from parameterized import parameterized
 
 from products.web_analytics.backend.api.heatmaps_utils import MAX_TARGET_WIDTHS
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
 from products.web_analytics.backend.tasks.heatmap_screenshot import (
+    HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS,
     BrowserlessError,
     BrowserlessPermanentError,
+    BrowserlessTransientError,
     _browserless_screenshot,
     _build_browserless_screenshot_url,
+    _classify_failure,
     _redact_browserless_url,
     _resolve_widths,
     _sanitize_browserless_error,
     generate_heatmap_screenshot,
+    report_stuck_heatmap_screenshots,
 )
 
 BROWSERLESS_SETTINGS = {
@@ -153,6 +164,7 @@ class TestHeatmapScreenshotTask(APIBaseTest):
         assert self.captured_events[-1]["properties"]["mode"] == "browserless"
         assert self.captured_events[-1]["properties"]["success"] is False
         assert self.captured_events[-1]["properties"]["error_type"] == "BrowserlessTransientError"
+        assert self.captured_events[-1]["properties"]["failure_type"] == "browserless_timeout"
 
     @override_settings(HEATMAP_BROWSERLESS_URL="")
     def test_unconfigured_url_marks_failed_permanently(self) -> None:
@@ -354,3 +366,86 @@ class TestBrowserlessUrlHelpers(SimpleTestCase):
         assert "token=REDACTED" in sanitized
         # The real failure reason is preserved so the error is debuggable
         assert "401" in sanitized
+
+
+class TestClassifyFailure(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("soft_time_limit", SoftTimeLimitExceeded(), "soft_time_limit"),
+            ("not_configured", BrowserlessPermanentError("x", cause="not_configured"), "not_configured"),
+            ("oversized", BrowserlessPermanentError("x", cause="oversized"), "validation_error"),
+            ("empty_body", BrowserlessTransientError("x", cause="empty_body"), "validation_error"),
+            ("non_image", BrowserlessTransientError("x", cause="non_image"), "validation_error"),
+            ("non_jpeg", BrowserlessTransientError("x", cause="non_jpeg"), "validation_error"),
+            ("request_exception", BrowserlessTransientError("x", cause="request_exception"), "browserless_timeout"),
+            ("http_408", BrowserlessTransientError("x", status_code=408, cause="http_status"), "browserless_timeout"),
+            ("http_429", BrowserlessTransientError("x", status_code=429, cause="http_status"), "browserless_4xx"),
+            ("http_404", BrowserlessPermanentError("x", status_code=404, cause="http_status"), "browserless_4xx"),
+            ("http_503", BrowserlessTransientError("x", status_code=503, cause="http_status"), "browserless_5xx"),
+            ("unknown", ValueError("x"), "unknown"),
+        ]
+    )
+    def test_classify_failure(self, _name: str, exc: BaseException, expected: str) -> None:
+        assert _classify_failure(exc) == expected
+
+
+class TestBrowserlessScreenshotTracing(SimpleTestCase):
+    @override_settings(HEATMAP_BROWSERLESS_TIMEOUT_MS=180000, HEATMAP_BROWSERLESS_CONNECT_TIMEOUT_MS=30000)
+    def test_browserless_failure_marks_span_error_with_attributes(self) -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        with (
+            patch("products.web_analytics.backend.tasks.heatmap_screenshot.tracer", provider.get_tracer("test")),
+            patch("products.web_analytics.backend.tasks.heatmap_screenshot.requests") as mock_requests,
+        ):
+            mock_requests.post.return_value = _make_response(b"", status=500, text="boom")
+            with self.assertRaises(BrowserlessError):
+                _browserless_screenshot("https://host/screenshot?token=t", "https://example.com", 1024)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "heatmap.browserless_screenshot"
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes is not None
+        assert span.attributes["heatmap.width"] == 1024
+        assert span.attributes["heatmap.width_bucket"] == "desktop"
+        assert span.attributes["heatmap.browserless_status"] == 500
+
+
+class TestReportStuckHeatmapScreenshots(APIBaseTest):
+    def _make(
+        self, *, status: str, type_: str = SavedHeatmap.Type.SCREENSHOT, age_seconds: int | None = None
+    ) -> SavedHeatmap:
+        heatmap = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            target_widths=[1024],
+            type=type_,
+            status=status,
+        )
+        if age_seconds is not None:
+            SavedHeatmap.objects.filter(id=heatmap.id).update(
+                updated_at=timezone.now() - timedelta(seconds=age_seconds)
+            )
+        return heatmap
+
+    def test_reports_only_old_processing_screenshots_without_mutating_them(self) -> None:
+        old = HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS + 60
+        stuck = self._make(status=SavedHeatmap.Status.PROCESSING, age_seconds=old)
+        fresh = self._make(status=SavedHeatmap.Status.PROCESSING, age_seconds=30)
+        completed = self._make(status=SavedHeatmap.Status.COMPLETED, age_seconds=old)
+        iframe = self._make(status=SavedHeatmap.Status.PROCESSING, type_=SavedHeatmap.Type.IFRAME, age_seconds=old)
+
+        count = report_stuck_heatmap_screenshots()
+
+        assert count == 1
+        for heatmap in (stuck, fresh, completed, iframe):
+            heatmap.refresh_from_db()
+        assert stuck.status == SavedHeatmap.Status.PROCESSING
+        assert fresh.status == SavedHeatmap.Status.PROCESSING
+        assert completed.status == SavedHeatmap.Status.COMPLETED
+        assert iframe.status == SavedHeatmap.Status.PROCESSING

--- a/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
+++ b/products/web_analytics/backend/tasks/test/test_heatmap_screenshot.py
@@ -8,15 +8,13 @@ from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
 from celery.exceptions import SoftTimeLimitExceeded
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import StatusCode
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 
 from products.web_analytics.backend.api.heatmaps_utils import MAX_TARGET_WIDTHS
 from products.web_analytics.backend.models import HeatmapSnapshot, SavedHeatmap
 from products.web_analytics.backend.tasks.heatmap_screenshot import (
+    HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE,
     HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS,
     BrowserlessError,
     BrowserlessPermanentError,
@@ -389,32 +387,6 @@ class TestClassifyFailure(SimpleTestCase):
         assert _classify_failure(exc) == expected
 
 
-class TestBrowserlessScreenshotTracing(SimpleTestCase):
-    @override_settings(HEATMAP_BROWSERLESS_TIMEOUT_MS=180000, HEATMAP_BROWSERLESS_CONNECT_TIMEOUT_MS=30000)
-    def test_browserless_failure_marks_span_error_with_attributes(self) -> None:
-        exporter = InMemorySpanExporter()
-        provider = TracerProvider()
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
-
-        with (
-            patch("products.web_analytics.backend.tasks.heatmap_screenshot.tracer", provider.get_tracer("test")),
-            patch("products.web_analytics.backend.tasks.heatmap_screenshot.requests") as mock_requests,
-        ):
-            mock_requests.post.return_value = _make_response(b"", status=500, text="boom")
-            with self.assertRaises(BrowserlessError):
-                _browserless_screenshot("https://host/screenshot?token=t", "https://example.com", 1024)
-
-        spans = exporter.get_finished_spans()
-        assert len(spans) == 1
-        span = spans[0]
-        assert span.name == "heatmap.browserless_screenshot"
-        assert span.status.status_code == StatusCode.ERROR
-        assert span.attributes is not None
-        assert span.attributes["heatmap.width"] == 1024
-        assert span.attributes["heatmap.width_bucket"] == "desktop"
-        assert span.attributes["heatmap.browserless_status"] == 500
-
-
 class TestReportStuckHeatmapScreenshots(APIBaseTest):
     def _make(
         self, *, status: str, type_: str = SavedHeatmap.Type.SCREENSHOT, age_seconds: int | None = None
@@ -449,3 +421,33 @@ class TestReportStuckHeatmapScreenshots(APIBaseTest):
         assert fresh.status == SavedHeatmap.Status.PROCESSING
         assert completed.status == SavedHeatmap.Status.COMPLETED
         assert iframe.status == SavedHeatmap.Status.PROCESSING
+
+    def test_gauge_reflects_count_and_resets_when_clear(self) -> None:
+        def _gauge() -> float:
+            return REGISTRY.get_sample_value("heatmap_screenshot_stuck_processing") or 0.0
+
+        old = HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS + 60
+        self._make(status=SavedHeatmap.Status.PROCESSING, age_seconds=old)
+        self._make(status=SavedHeatmap.Status.PROCESSING, age_seconds=old)
+
+        assert report_stuck_heatmap_screenshots() == 2
+        assert _gauge() == 2
+
+        SavedHeatmap.objects.update(status=SavedHeatmap.Status.COMPLETED)
+
+        assert report_stuck_heatmap_screenshots() == 0
+        assert _gauge() == 0
+
+    def test_logs_full_count_but_caps_the_sample(self) -> None:
+        old = HEATMAP_SCREENSHOT_STUCK_THRESHOLD_SECONDS + 60
+        over_cap = HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE + 5
+        for _ in range(over_cap):
+            self._make(status=SavedHeatmap.Status.PROCESSING, age_seconds=old)
+
+        with patch("products.web_analytics.backend.tasks.heatmap_screenshot.logger") as mock_logger:
+            count = report_stuck_heatmap_screenshots()
+
+        assert count == over_cap
+        _args, kwargs = mock_logger.warning.call_args
+        assert kwargs["stuck_count"] == over_cap
+        assert len(kwargs["sample"]) == HEATMAP_SCREENSHOT_STUCK_SAMPLE_SIZE

--- a/products/web_analytics/backend/test/test_heatmap_screenshots.py
+++ b/products/web_analytics/backend/test/test_heatmap_screenshots.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 from rest_framework.test import APIClient
 
 from posthog.jwt import PosthogJwtAudience, encode_jwt
@@ -67,6 +68,34 @@ class TestHeatmapsAPI(APIBaseTest):
         self.assertEqual(r.status_code, 200)
         self.assertIn('768.jpg"', r["Content-Disposition"])
         self.assertEqual(r.content, b"jpeg768")
+
+    def test_content_returns_501_when_only_content_location_set(self):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.COMPLETED,
+        )
+        HeatmapSnapshot.objects.create(heatmap=saved, width=1024, content=None, content_location="s3://bucket/key")
+        r = self.client.get(f"/api/environments/{self.team.id}/heatmap_screenshots/{saved.id}/content/?width=1024")
+        self.assertEqual(r.status_code, 501)
+
+    def test_content_served_increments_metric(self):
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.COMPLETED,
+        )
+        HeatmapSnapshot.objects.create(heatmap=saved, width=1024, content=b"jpegdata1024")
+
+        def _served_count() -> float:
+            return REGISTRY.get_sample_value("heatmap_screenshot_content_requests_total", {"outcome": "served"}) or 0.0
+
+        before = _served_count()
+        r = self.client.get(f"/api/environments/{self.team.id}/heatmap_screenshots/{saved.id}/content/?width=1024")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(_served_count() - before, 1)
 
     def test_saved_list_excludes_deleted_and_includes_created_by(self):
         SavedHeatmap.objects.create(team=self.team, url="https://a.example", created_by=self.user)


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
There is currently very little visibility into heatmaps failures.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add tracing, logs, and metrics to heatmap endpoints
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
