### PR TITLE
fix(mssql): treat conversion failures as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -70,6 +70,13 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # whose definition selects a column that's no longer present. Fixed source-data shape,
             # so retrying won't help.
             "Invalid column name": "One of the columns being synced no longer exists in your SQL Server. A column was likely dropped or renamed, or a view's definition references a column that's no longer present. Fix the column or view definition at the source, then re-enable the sync.",
+            # SQL Server error 245 — an implicit type conversion fails on a specific row's value
+            # (e.g. converting the varchar 'SFDR' to int). Our SELECT does no casts and the
+            # incremental predicate only ever compares like types, so this conversion lives in the
+            # view body or a computed column we're reading from. It's fixed by the source data +
+            # view definition, so retrying replays the identical 245. Match the stable error text,
+            # not the volatile value / data type that follow it.
+            "Conversion failed when converting": "A value in one of the tables or views you're syncing can't be converted to the type its query expects (SQL Server error 245) — for example a text value where a number is required. This usually comes from a view definition or computed column that casts or compares mismatched types. Fix the conversion at the source (correct the data or the view), then re-enable the sync.",
             # Raised by the `sshtunnel` library (via the shared `open_ssh_tunnel` helper) when the
             # SSH tunnel can't be brought up — the bastion host is unreachable, the host/port is
             # wrong, the SSH key/credentials are rejected, or a firewall blocks PostHog's IPs. This

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -589,3 +589,19 @@ class TestMSSQLSourceNonRetryableErrors:
     def test_invalid_column_name_is_non_retryable(self, error_msg):
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Real pymssql MSSQLDatabaseException for SQL Server error 245 raised mid-fetch when a
+            # view body implicitly converts a varchar value to int.
+            "SQL Server message 245, severity 16, state 1, procedure b'@\\x88[\\xd4\\xfe\\xff', line 1:\n"
+            "b\"Conversion failed when converting the varchar value 'SFDR' to data type int."
+            'DB-Lib error message 20018, severity 16:\\nGeneral SQL Server error: Check messages from the SQL Server\\n"',
+            # Different value / target type must still match the stable substring.
+            "Conversion failed when converting the nvarchar value 'N/A' to data type bigint.",
+        ],
+    )
+    def test_conversion_failed_is_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg


### PR DESCRIPTION
## Problem

A MSSQL data-warehouse import was failing repeatedly and surfaced in error tracking as `MSSQLDatabaseException` ([issue](https://us.posthog.com/project/2/error_tracking/019ed80a-7cf0-7a30-a960-4d3f17ecc4cd)):

```
SQL Server message 245, severity 16, state 1 ...
Conversion failed when converting the varchar value 'SFDR' to data type int.
```

The stack confirms it originates in `MSSQLImplementation.build_pipeline.get_rows` (`posthog/temporal/data_imports/sources/mssql/mssql.py`) at the `cursor.fetchmany(...)` call. The synced object is a staging view, the sync is a plain full refresh (no incremental field, no `WHERE`, no row filters), so the query we send is just `SELECT <cols> FROM <view>`. SQL Server error 245 fires *inside the view's own definition* (or a computed column) doing an implicit `varchar → int` conversion that fails on a specific row's value.

This is determined entirely by the source data + view definition. Our `SELECT` does no casts, and our incremental predicate only ever compares like types (incremental fields are restricted to date/datetime/integer columns), so we never emit a 245 with a varchar value ourselves. Retrying replays the identical query and the identical error — the job was burning attempts and re-raising.

## Changes

Add SQL Server error 245 to the MSSQL source's `get_non_retryable_errors`, matching the stable substring `Conversion failed when converting` (not the volatile value or target type that follow it), with a user-facing message pointing the customer at fixing the conversion at the source. This mirrors the existing 207 / 208 handling, where a broken view body is likewise treated as a non-retryable customer-side issue.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_conversion_failed_is_non_retryable`) asserting both the real pymssql error 245 message and a different value/target-type variant are recognised as non-retryable, following the existing tests for this source. I could not run `pytest` in this environment (not installed), but verified the substring-matching logic directly and ran `ruff check` / `ruff format` clean on both files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in PostHog error tracking (full stack trace, exception type, representative event, frequency) and verified the failure genuinely originates under `posthog/temporal/data_imports/sources/mssql/`. Decision: user/upstream error (broken view definition / source data we can't fix and shouldn't retry) rather than a fixable bug — our query does no conversions, so the 245 can only come from the view body. Chose to extend `NonRetryableErrors` matching `Conversion failed when converting` for low false-positive coverage of the whole error-245 family. No skills were applicable to this change.
