### PR TITLE
fix(buildbetter): drop optional interview fields the account schema rejects

### DIFF
--- a/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
@@ -1,3 +1,4 @@
+import re
 import dataclasses
 from typing import Any
 
@@ -5,14 +6,22 @@ from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from posthog.temporal.data_imports.sources.buildbetter.queries import QUERIES, VIEWER_QUERY
+from posthog.temporal.data_imports.sources.buildbetter.queries import OPTIONAL_QUERY_FIELDS, QUERIES, VIEWER_QUERY
 from posthog.temporal.data_imports.sources.buildbetter.settings import BUILDBETTER_API_URL, BUILDBETTER_ENDPOINTS
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
+_MISSING_FIELD_RE = re.compile(r"field '([^']+)' not found in type")
+
 
 class BuildBetterRetryableError(Exception):
     pass
+
+
+class BuildBetterMissingFieldError(Exception):
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(field_name)
 
 
 @dataclasses.dataclass
@@ -35,6 +44,9 @@ def _make_paginated_request(
     query = QUERIES.get(endpoint_name)
     if not query:
         raise ValueError(f"No GraphQL query for endpoint: {endpoint_name}")
+
+    # Nested fields still present in the query that we will drop if the account's schema rejects them.
+    droppable_fields = dict(OPTIONAL_QUERY_FIELDS.get(endpoint_name, {}))
 
     graphql_query_name = endpoint_config.graphql_query_name or endpoint_name
 
@@ -74,6 +86,10 @@ def _make_paginated_request(
             joined = "; ".join(error_messages)
             if not response.ok:
                 raise Exception(f"{response.status_code} Client Error: {response.reason} (BuildBetter API: {joined})")
+            for msg in error_messages:
+                match = _MISSING_FIELD_RE.search(msg)
+                if match and (field := match.group(1)) in droppable_fields:
+                    raise BuildBetterMissingFieldError(field)
             raise Exception(f"BuildBetter GraphQL error: {joined}")
 
         if not response.ok:
@@ -102,7 +118,14 @@ def _make_paginated_request(
     try:
         while True:
             logger.debug(f"Querying BuildBetter endpoint {endpoint_name} with variables: {variables}")
-            payload = execute(variables)
+            try:
+                payload = execute(variables)
+            except BuildBetterMissingFieldError as e:
+                query = query.replace(droppable_fields.pop(e.field_name), "")
+                logger.warning(
+                    f"BuildBetter: field '{e.field_name}' not available for {endpoint_name}, retrying without it"
+                )
+                continue
 
             data = payload["data"][graphql_query_name]
             if not data:

--- a/posthog/temporal/data_imports/sources/buildbetter/queries.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/queries.py
@@ -1,4 +1,16 @@
-INTERVIEWS_QUERY = """
+# Nested relation that some BuildBetter accounts' schema (role-dependent) does not expose. Kept
+# separate so it can be dropped from the query when the API reports the field is unknown.
+INTERVIEW_MONOLOGUES_FIELD = """
+        monologues(order_by: {start_sec: asc}) {
+            id
+            speaker
+            text
+            start_sec
+            end_sec
+        }"""
+
+INTERVIEWS_QUERY = (
+    """
 query PaginatedInterviews($limit: Int!, $offset: Int!, $where: interview_bool_exp) {
     interview(limit: $limit, offset: $offset, order_by: {updated_at: asc}, where: $where) {
         id
@@ -47,16 +59,12 @@ query PaginatedInterviews($limit: Int!, $offset: Int!, $where: interview_bool_ex
             title
             content
             created_at
-        }
-        monologues(order_by: {start_sec: asc}) {
-            id
-            speaker
-            text
-            start_sec
-            end_sec
-        }
+        }"""
+    + INTERVIEW_MONOLOGUES_FIELD
+    + """
     }
 }"""
+)
 
 EXTRACTIONS_QUERY = """
 query PaginatedExtractions($limit: Int!, $offset: Int!, $where: extraction_bool_exp) {
@@ -172,4 +180,9 @@ QUERIES: dict[str, str] = {
     "extractions": EXTRACTIONS_QUERY,
     "persons": PERSONS_QUERY,
     "companies": COMPANIES_QUERY,
+}
+
+# endpoint -> {field name -> exact query block to drop when the account's schema lacks the field}
+OPTIONAL_QUERY_FIELDS: dict[str, dict[str, str]] = {
+    "interviews": {"monologues": INTERVIEW_MONOLOGUES_FIELD},
 }

--- a/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from typing import Any, cast
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
@@ -131,6 +132,55 @@ class TestMakePaginatedRequest:
 
         saved_offsets = [call.args[0].offset for call in manager.save_state.call_args_list]
         assert saved_offsets == [page_size, page_size * 2]
+
+    def test_drops_optional_field_when_schema_rejects_it(self) -> None:
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+        schema_error = {"errors": [{"message": "field 'monologues' not found in type: 'interview'"}]}
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.make_tracked_session") as session_cls:
+            session = session_cls.return_value
+            session.post.side_effect = [
+                _make_response(schema_error),
+                _make_response(_interview_payload(["i1"])),
+            ]
+
+            batches = list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert batches == [[{"id": "i1"}]]
+        assert session.post.call_count == 2
+        first_query = session.post.call_args_list[0].kwargs["json"]["query"]
+        retried_query = session.post.call_args_list[1].kwargs["json"]["query"]
+        assert "monologues" in first_query
+        assert "monologues" not in retried_query
+        # Same page is retried after dropping the field, not skipped
+        assert session.post.call_args_list[1].kwargs["json"]["variables"]["offset"] == 0
+
+    def test_non_droppable_schema_error_still_raises(self) -> None:
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+        schema_error = {"errors": [{"message": "field 'id' not found in type: 'interview'"}]}
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.make_tracked_session") as session_cls:
+            session = session_cls.return_value
+            session.post.return_value = _make_response(schema_error)
+
+            with pytest.raises(Exception, match="BuildBetter GraphQL error"):
+                list(
+                    _make_paginated_request(
+                        api_key="key",
+                        endpoint_name="interviews",
+                        logger=logger,
+                        resumable_source_manager=manager,
+                    )
+                )
 
     def test_incremental_filter_passes_where_clause(self) -> None:
         manager = _make_manager(can_resume=False)


### PR DESCRIPTION
## Problem

The BuildBetter data-warehouse import surfaced this error in error tracking:

> `BuildBetter GraphQL error: field 'monologues' not found in type: 'interview'`

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019ed807-e3f7-7533-9473-87ef1d69726f) — raised at `posthog/temporal/data_imports/sources/buildbetter/buildbetter.py:77`, across a handful of teams.

BuildBetter's GraphQL API is Hasura-style, where nested-relation visibility is role/permission dependent. For accounts whose API-key role doesn't expose the `monologues` relation, the API rejects the **entire** `interviews` query — so those teams sync **zero** interview rows, even though every other field (`summary`, `transcript_summary`, `attendees`, `summaries`, …) is available. Accounts that do expose it sync fine, which is why only a subset of teams hit this.

## Changes

When BuildBetter reports a **known-optional** nested field is missing from the account's schema, drop that field's block from the query and retry the same page:

- `queries.py`: split the `monologues` block into a reusable constant and register it per endpoint in `OPTIONAL_QUERY_FIELDS`.
- `buildbetter.py`: detect the `field '<name>' not found in type` schema error for a registered optional field, strip it from the query, and retry the same offset. Monologues are kept where available; any other (non-optional) schema error still fails loudly via the existing `Exception` path.

This is a fix rather than a `NonRetryableErrors` entry: marking it non-retryable would permanently leave those customers with no interview data, when we can sync everything except the unavailable relation.

## How did you test this code?

I'm an agent. Automated tests only (no manual run):

- `test_drops_optional_field_when_schema_rejects_it` — first response returns the `monologues` schema error, the retry omits `monologues` from the query (same offset) and yields the data.
- `test_non_droppable_schema_error_still_raises` — a missing non-optional field (`id`) still raises `BuildBetter GraphQL error`, so real schema breakage isn't silently swallowed.
- Full file: `uv run pytest posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py` → 8 passed. Ruff lint + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the exception originates in the source's own code (top in-app frame `buildbetter.py:77`, call path `import_data_sync.py` → pipeline → `buildbetter.py`) before making changes.

Decision: this is a fixable fragility, not a user/upstream credential error. The query hard-requires a nested relation that BuildBetter's Hasura schema only exposes for some account roles; the right fix is graceful degradation (drop-and-retry) scoped to fields we explicitly mark optional, so genuine schema breakage still surfaces. No retry-policy or global pipeline changes.
