### PR TITLE
feat(ai-observability): make cluster labeling routable through the ai-gateway

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -973,6 +973,11 @@ ELEMENT_STATS_DEFAULT_LIMIT = get_from_env("ELEMENT_STATS_DEFAULT_LIMIT", 50_000
 AI_GATEWAY_INTERNAL_URL = get_from_env("AI_GATEWAY_INTERNAL_URL", "")
 AI_GATEWAY_INTERNAL_TOKEN = get_from_env("AI_GATEWAY_INTERNAL_TOKEN", "")
 
+# AI gateway inference endpoint: OpenAI-compatible URL (include /v1) + phs_ project
+# secret for routing LLM calls through the gateway. Unset = direct to the provider.
+AI_GATEWAY_URL = get_from_env("AI_GATEWAY_URL", "")
+AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
+
 # Sharing configuration settings
 SHARING_TOKEN_GRACE_PERIOD_SECONDS = 60 * 5  # 5 minutes
 

--- a/posthog/temporal/ai_observability/clustering_agent/__init__.py
+++ b/posthog/temporal/ai_observability/clustering_agent/__init__.py
@@ -10,7 +10,7 @@ each individual agent so per-level prompt iteration stays local.
 
 from langchain_openai import ChatOpenAI
 
-from posthog.temporal.ai_observability.llm_endpoint import build_openai_chat_client
+from posthog.temporal.ai_observability.llm_endpoint import build_langchain_chat_client
 from posthog.temporal.ai_observability.trace_clustering.constants import NOISE_CLUSTER_ID
 from posthog.temporal.ai_observability.trace_clustering.models import ClusterLabel
 
@@ -23,7 +23,7 @@ def get_labeling_llm(model: str, timeout: float) -> ChatOpenAI:
     ``posthog.temporal.ai_observability.llm_endpoint``. Enforces the same
     guardrail as before: AI features only run in Cloud or local DEBUG builds.
     """
-    return build_openai_chat_client(model, timeout, ai_product="aio_clustering")
+    return build_langchain_chat_client(model, timeout, ai_product="aio_clustering")
 
 
 def fill_missing_labels(

--- a/posthog/temporal/ai_observability/clustering_agent/__init__.py
+++ b/posthog/temporal/ai_observability/clustering_agent/__init__.py
@@ -23,7 +23,7 @@ def get_labeling_llm(model: str, timeout: float) -> ChatOpenAI:
     ``posthog.temporal.ai_observability.llm_endpoint``. Enforces the same
     guardrail as before: AI features only run in Cloud or local DEBUG builds.
     """
-    return build_openai_chat_client(model, timeout)
+    return build_openai_chat_client(model, timeout, ai_product="aio_clustering")
 
 
 def fill_missing_labels(

--- a/posthog/temporal/ai_observability/clustering_agent/__init__.py
+++ b/posthog/temporal/ai_observability/clustering_agent/__init__.py
@@ -8,37 +8,22 @@ duplicate; the level-specific prompts, tools, and state TypedDicts live with
 each individual agent so per-level prompt iteration stays local.
 """
 
-import os
-
-from django.conf import settings
-
 from langchain_openai import ChatOpenAI
 
-from posthog.cloud_utils import is_cloud
+from posthog.temporal.ai_observability.llm_endpoint import build_openai_chat_client
 from posthog.temporal.ai_observability.trace_clustering.constants import NOISE_CLUSTER_ID
 from posthog.temporal.ai_observability.trace_clustering.models import ClusterLabel
 
 
 def get_labeling_llm(model: str, timeout: float) -> ChatOpenAI:
-    """Return an OpenAI chat client configured for cluster labeling.
+    """Return a ChatOpenAI client for cluster labeling.
 
-    Enforces the same environment guardrails the trace clustering agent has
-    always used: AI features only run in Cloud or local DEBUG builds, and the
-    OpenAI key must be explicitly configured.
+    Shared by the trace and evaluation labeling agents. Routes through the
+    ai-gateway when configured; see
+    ``posthog.temporal.ai_observability.llm_endpoint``. Enforces the same
+    guardrail as before: AI features only run in Cloud or local DEBUG builds.
     """
-    if not settings.DEBUG and not is_cloud():
-        raise Exception("AI features are only available in PostHog Cloud")
-
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise Exception("OpenAI API key is not configured")
-
-    return ChatOpenAI(
-        model=model,
-        api_key=api_key,
-        timeout=timeout,
-        max_retries=2,
-    )
+    return build_openai_chat_client(model, timeout)
 
 
 def fill_missing_labels(

--- a/posthog/temporal/ai_observability/llm_endpoint.py
+++ b/posthog/temporal/ai_observability/llm_endpoint.py
@@ -16,7 +16,7 @@ from posthog.cloud_utils import is_cloud
 logger = structlog.get_logger(__name__)
 
 
-def build_openai_chat_client(model: str, timeout: float, ai_product: str | None = None) -> ChatOpenAI:
+def build_langchain_chat_client(model: str, timeout: float, ai_product: str | None = None) -> ChatOpenAI:
     """Return a ChatOpenAI client for cluster labeling. Cloud/DEBUG only.
 
     Routes through the ai-gateway when AI_GATEWAY_URL + AI_GATEWAY_API_KEY are both set and the

--- a/posthog/temporal/ai_observability/llm_endpoint.py
+++ b/posthog/temporal/ai_observability/llm_endpoint.py
@@ -2,43 +2,68 @@
 ai-gateway when AI_GATEWAY_URL + AI_GATEWAY_API_KEY are set, else direct to OpenAI."""
 
 import os
+import json
 from urllib.parse import urlparse
 
 from django.conf import settings
 
 import httpx
+import structlog
 from langchain_openai import ChatOpenAI
 
 from posthog.cloud_utils import is_cloud
 
+logger = structlog.get_logger(__name__)
 
-def build_openai_chat_client(model: str, timeout: float) -> ChatOpenAI:
+
+def build_openai_chat_client(model: str, timeout: float, ai_product: str | None = None) -> ChatOpenAI:
     """Return a ChatOpenAI client for cluster labeling. Cloud/DEBUG only.
 
-    In gateway mode the ``phs_`` bearer is team-scoped, so no per-team header is needed.
+    Routes through the ai-gateway when AI_GATEWAY_URL + AI_GATEWAY_API_KEY are both set and the
+    URL is well-formed; on a misconfiguration it logs and falls back to direct OpenAI so a
+    half-applied rollout config can't break labeling. In gateway mode the ``phs_`` bearer is
+    team-scoped, so no per-team header is needed; ``ai_product`` (when given) tags the captured
+    ``$ai_generation`` event via the gateway's ``X-PostHog-Properties`` header.
     """
     if not settings.DEBUG and not is_cloud():
         raise Exception("AI features are only available in PostHog Cloud")
 
     url, api_key = settings.AI_GATEWAY_URL, settings.AI_GATEWAY_API_KEY
     if url or api_key:
-        if not (url and api_key):
-            raise Exception("AI_GATEWAY_URL and AI_GATEWAY_API_KEY must be set together")
-        # The SDK appends /chat/completions, so base_url must already carry the /v1 path.
-        if not urlparse(url).path.rstrip("/").endswith("/v1"):
-            raise Exception("AI_GATEWAY_URL must include the OpenAI base path, e.g. https://<host>/v1")
-        return ChatOpenAI(
-            model=model,
-            api_key=api_key,
-            base_url=url,
-            timeout=timeout,
-            max_retries=2,
-            # trust_env=False keeps the in-cluster gateway call off the egress proxy.
-            http_client=httpx.Client(trust_env=False),
-            http_async_client=httpx.AsyncClient(trust_env=False),
-        )
+        misconfig = _gateway_misconfig(url, api_key)
+        if misconfig:
+            logger.warning("ai_gateway_misconfigured_falling_back", reason=misconfig)
+        else:
+            return ChatOpenAI(
+                model=model,
+                api_key=api_key,
+                base_url=url,
+                timeout=timeout,
+                max_retries=2,
+                default_headers=_ai_product_headers(ai_product),
+                # trust_env=False keeps the in-cluster gateway call off the egress proxy.
+                http_client=httpx.Client(trust_env=False),
+                http_async_client=httpx.AsyncClient(trust_env=False),
+            )
 
     direct_key = os.environ.get("OPENAI_API_KEY")
     if not direct_key:
         raise Exception("OPENAI_API_KEY is not configured")
     return ChatOpenAI(model=model, api_key=direct_key, timeout=timeout, max_retries=2)
+
+
+def _gateway_misconfig(url: str, api_key: str) -> str | None:
+    """Return a reason string if the gateway env is half-applied or malformed, else None."""
+    if not (url and api_key):
+        return "AI_GATEWAY_URL and AI_GATEWAY_API_KEY must be set together"
+    # The SDK appends /chat/completions, so base_url must already carry the /v1 path.
+    if not urlparse(url).path.rstrip("/").endswith("/v1"):
+        return "AI_GATEWAY_URL must include the OpenAI base path, e.g. https://<host>/v1"
+    return None
+
+
+def _ai_product_headers(ai_product: str | None) -> dict[str, str] | None:
+    """X-PostHog-Properties header tagging the captured generation with its AIO product."""
+    if not ai_product:
+        return None
+    return {"X-PostHog-Properties": json.dumps({"ai_product": ai_product})}

--- a/posthog/temporal/ai_observability/llm_endpoint.py
+++ b/posthog/temporal/ai_observability/llm_endpoint.py
@@ -1,0 +1,44 @@
+"""OpenAI-compatible client for the cluster-labeling agents, routed through the
+ai-gateway when AI_GATEWAY_URL + AI_GATEWAY_API_KEY are set, else direct to OpenAI."""
+
+import os
+from urllib.parse import urlparse
+
+from django.conf import settings
+
+import httpx
+from langchain_openai import ChatOpenAI
+
+from posthog.cloud_utils import is_cloud
+
+
+def build_openai_chat_client(model: str, timeout: float) -> ChatOpenAI:
+    """Return a ChatOpenAI client for cluster labeling. Cloud/DEBUG only.
+
+    In gateway mode the ``phs_`` bearer is team-scoped, so no per-team header is needed.
+    """
+    if not settings.DEBUG and not is_cloud():
+        raise Exception("AI features are only available in PostHog Cloud")
+
+    url, api_key = settings.AI_GATEWAY_URL, settings.AI_GATEWAY_API_KEY
+    if url or api_key:
+        if not (url and api_key):
+            raise Exception("AI_GATEWAY_URL and AI_GATEWAY_API_KEY must be set together")
+        # The SDK appends /chat/completions, so base_url must already carry the /v1 path.
+        if not urlparse(url).path.rstrip("/").endswith("/v1"):
+            raise Exception("AI_GATEWAY_URL must include the OpenAI base path, e.g. https://<host>/v1")
+        return ChatOpenAI(
+            model=model,
+            api_key=api_key,
+            base_url=url,
+            timeout=timeout,
+            max_retries=2,
+            # trust_env=False keeps the in-cluster gateway call off the egress proxy.
+            http_client=httpx.Client(trust_env=False),
+            http_async_client=httpx.AsyncClient(trust_env=False),
+        )
+
+    direct_key = os.environ.get("OPENAI_API_KEY")
+    if not direct_key:
+        raise Exception("OPENAI_API_KEY is not configured")
+    return ChatOpenAI(model=model, api_key=direct_key, timeout=timeout, max_retries=2)

--- a/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
+++ b/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
@@ -1,0 +1,59 @@
+"""Tests for clustering labeling client construction (ai-gateway vs direct OpenAI)."""
+
+import pytest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from posthog.temporal.ai_observability.llm_endpoint import build_openai_chat_client
+
+GATEWAY_URL = "https://gateway.example/v1"
+GATEWAY_KEY = "phs_project_secret"
+
+
+class TestBuildOpenAIChatClient:
+    @pytest.mark.parametrize(
+        "gateway_url,gateway_key,expected_base,expected_key,custom_http_client",
+        [
+            (GATEWAY_URL, GATEWAY_KEY, GATEWAY_URL, GATEWAY_KEY, True),
+            (None, None, None, "sk-direct", False),
+        ],
+    )
+    def test_routing_resolves_endpoint_and_credentials(
+        self, gateway_url, gateway_key, expected_base, expected_key, custom_http_client
+    ):
+        with (
+            override_settings(DEBUG=True, AI_GATEWAY_URL=gateway_url, AI_GATEWAY_API_KEY=gateway_key),
+            patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False),
+        ):
+            client = build_openai_chat_client("gpt-5.4", 600.0)
+
+        assert client.openai_api_base == expected_base
+        assert client.openai_api_key.get_secret_value() == expected_key
+        # Gateway mode injects a trust_env=False http client; direct mode uses the SDK default.
+        if custom_http_client:
+            assert client.http_client is not None
+            assert client.http_async_client is not None
+        else:
+            assert client.http_client is None
+
+    @pytest.mark.parametrize(
+        "gateway_url,gateway_key",
+        [
+            (GATEWAY_URL, None),
+            (None, GATEWAY_KEY),
+        ],
+    )
+    def test_half_set_gateway_config_raises(self, gateway_url, gateway_key):
+        with (
+            override_settings(DEBUG=True, AI_GATEWAY_URL=gateway_url, AI_GATEWAY_API_KEY=gateway_key),
+            patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False),
+        ):
+            with pytest.raises(Exception, match="must be set together"):
+                build_openai_chat_client("gpt-5.4", 600.0)
+
+    @override_settings(DEBUG=True, AI_GATEWAY_URL="https://gateway.example", AI_GATEWAY_API_KEY=GATEWAY_KEY)
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False)
+    def test_gateway_url_missing_v1_path_raises(self):
+        with pytest.raises(Exception, match="OpenAI base path"):
+            build_openai_chat_client("gpt-5.4", 600.0)

--- a/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
+++ b/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
-from posthog.temporal.ai_observability.llm_endpoint import build_openai_chat_client
+from posthog.temporal.ai_observability.llm_endpoint import build_langchain_chat_client
 
 GATEWAY_URL = "https://gateway.example/v1"
 GATEWAY_KEY = "phs_project_secret"
@@ -28,7 +28,7 @@ class TestBuildOpenAIChatClient:
             override_settings(DEBUG=True, AI_GATEWAY_URL=gateway_url, AI_GATEWAY_API_KEY=gateway_key),
             patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False),
         ):
-            client = build_openai_chat_client("gpt-5.4", 600.0)
+            client = build_langchain_chat_client("gpt-5.4", 600.0)
 
         assert client.openai_api_base == expected_base
         api_key = client.openai_api_key
@@ -57,7 +57,7 @@ class TestBuildOpenAIChatClient:
             patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False),
             patch("posthog.temporal.ai_observability.llm_endpoint.logger") as mock_logger,
         ):
-            client = build_openai_chat_client("gpt-5.4", 600.0)
+            client = build_langchain_chat_client("gpt-5.4", 600.0)
 
         assert client.openai_api_base is None
         api_key = client.openai_api_key
@@ -69,7 +69,7 @@ class TestBuildOpenAIChatClient:
     @override_settings(DEBUG=True, AI_GATEWAY_URL=GATEWAY_URL, AI_GATEWAY_API_KEY=GATEWAY_KEY)
     def test_gateway_mode_tags_ai_product_via_posthog_properties_header(self):
         with patch("posthog.temporal.ai_observability.llm_endpoint.ChatOpenAI") as mock_chat:
-            build_openai_chat_client("gpt-5.4", 600.0, ai_product="aio_clustering")
+            build_langchain_chat_client("gpt-5.4", 600.0, ai_product="aio_clustering")
 
         assert mock_chat.call_args.kwargs["default_headers"] == {
             "X-PostHog-Properties": json.dumps({"ai_product": "aio_clustering"})
@@ -78,6 +78,6 @@ class TestBuildOpenAIChatClient:
     @override_settings(DEBUG=True, AI_GATEWAY_URL=GATEWAY_URL, AI_GATEWAY_API_KEY=GATEWAY_KEY)
     def test_gateway_mode_without_ai_product_omits_header(self):
         with patch("posthog.temporal.ai_observability.llm_endpoint.ChatOpenAI") as mock_chat:
-            build_openai_chat_client("gpt-5.4", 600.0)
+            build_langchain_chat_client("gpt-5.4", 600.0)
 
         assert mock_chat.call_args.kwargs["default_headers"] is None

--- a/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
+++ b/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
@@ -31,7 +31,9 @@ class TestBuildOpenAIChatClient:
             client = build_openai_chat_client("gpt-5.4", 600.0)
 
         assert client.openai_api_base == expected_base
-        assert client.openai_api_key.get_secret_value() == expected_key
+        api_key = client.openai_api_key
+        assert api_key is not None
+        assert api_key.get_secret_value() == expected_key
         # Gateway mode injects a trust_env=False http client; direct mode uses the SDK default.
         if custom_http_client:
             assert client.http_client is not None
@@ -58,7 +60,9 @@ class TestBuildOpenAIChatClient:
             client = build_openai_chat_client("gpt-5.4", 600.0)
 
         assert client.openai_api_base is None
-        assert client.openai_api_key.get_secret_value() == "sk-direct"
+        api_key = client.openai_api_key
+        assert api_key is not None
+        assert api_key.get_secret_value() == "sk-direct"
         mock_logger.warning.assert_called_once()
         assert reason in str(mock_logger.warning.call_args)
 

--- a/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
+++ b/posthog/temporal/ai_observability/tests/test_llm_endpoint.py
@@ -1,5 +1,7 @@
 """Tests for clustering labeling client construction (ai-gateway vs direct OpenAI)."""
 
+import json
+
 import pytest
 from unittest.mock import patch
 
@@ -38,22 +40,40 @@ class TestBuildOpenAIChatClient:
             assert client.http_client is None
 
     @pytest.mark.parametrize(
-        "gateway_url,gateway_key",
+        "gateway_url,gateway_key,reason",
         [
-            (GATEWAY_URL, None),
-            (None, GATEWAY_KEY),
+            (GATEWAY_URL, None, "must be set together"),
+            (None, GATEWAY_KEY, "must be set together"),
+            ("https://gateway.example", GATEWAY_KEY, "OpenAI base path"),
         ],
     )
-    def test_half_set_gateway_config_raises(self, gateway_url, gateway_key):
+    def test_misconfigured_gateway_falls_back_to_direct_and_logs(self, gateway_url, gateway_key, reason):
+        # Radu review: a half-applied / malformed gateway config falls back to the direct provider
+        # rather than failing the call, and logs loudly so a broken rollout config is visible.
         with (
             override_settings(DEBUG=True, AI_GATEWAY_URL=gateway_url, AI_GATEWAY_API_KEY=gateway_key),
             patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False),
+            patch("posthog.temporal.ai_observability.llm_endpoint.logger") as mock_logger,
         ):
-            with pytest.raises(Exception, match="must be set together"):
-                build_openai_chat_client("gpt-5.4", 600.0)
+            client = build_openai_chat_client("gpt-5.4", 600.0)
 
-    @override_settings(DEBUG=True, AI_GATEWAY_URL="https://gateway.example", AI_GATEWAY_API_KEY=GATEWAY_KEY)
-    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-direct"}, clear=False)
-    def test_gateway_url_missing_v1_path_raises(self):
-        with pytest.raises(Exception, match="OpenAI base path"):
+        assert client.openai_api_base is None
+        assert client.openai_api_key.get_secret_value() == "sk-direct"
+        mock_logger.warning.assert_called_once()
+        assert reason in str(mock_logger.warning.call_args)
+
+    @override_settings(DEBUG=True, AI_GATEWAY_URL=GATEWAY_URL, AI_GATEWAY_API_KEY=GATEWAY_KEY)
+    def test_gateway_mode_tags_ai_product_via_posthog_properties_header(self):
+        with patch("posthog.temporal.ai_observability.llm_endpoint.ChatOpenAI") as mock_chat:
+            build_openai_chat_client("gpt-5.4", 600.0, ai_product="aio_clustering")
+
+        assert mock_chat.call_args.kwargs["default_headers"] == {
+            "X-PostHog-Properties": json.dumps({"ai_product": "aio_clustering"})
+        }
+
+    @override_settings(DEBUG=True, AI_GATEWAY_URL=GATEWAY_URL, AI_GATEWAY_API_KEY=GATEWAY_KEY)
+    def test_gateway_mode_without_ai_product_omits_header(self):
+        with patch("posthog.temporal.ai_observability.llm_endpoint.ChatOpenAI") as mock_chat:
             build_openai_chat_client("gpt-5.4", 600.0)
+
+        assert mock_chat.call_args.kwargs["default_headers"] is None


### PR DESCRIPTION
## Problem

Cluster labeling (the LLM call that names trace clusters) talks to OpenAI directly. We want it to route through the ai-gateway, switchable by env, with no behavior change until we deliberately flip it.

## Changes

- `llm_endpoint.py` (new) — `build_openai_chat_client`: when `AI_GATEWAY_URL` and `AI_GATEWAY_API_KEY` are both set, route to the gateway's OpenAI-compatible endpoint with a `phs_` project-secret bearer; otherwise go direct to OpenAI with `OPENAI_API_KEY`.
- `get_labeling_llm` delegates to that helper, so the trace and evaluation labeling agents share one construction.
- Two settings in `settings/web.py`, alongside the existing `AI_GATEWAY_*` family, both default-unset.

## Rollout

Both env vars unset = direct OpenAI (current behavior), so setting the two is the whole cutover; unsetting them is the rollback. Before flipping: confirm the gateway's `/v1/models` lists `gpt-5.4` (the labeling model) so routing stays on the same model rather than failing or downgrading. Note a single `phs_` token attributes all teams' labeling spend to one project, which is fine for this internal feature.

## Not in this PR

The eval-report agent and the Gemini trace-summaries path stay on their current direct providers; routing those has separate model and observability (double-capture) tradeoffs and will follow.

## How did you test this code?

Agent-authored. Ran the new `test_llm_endpoint.py` (gateway mode, direct mode, partial-config fallback) plus the existing trace and evaluation labeling suites: 40 passing. ruff clean. No manual run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The approach was audited against both repos: an initial attempt routing via the Python gateway's `gateway_client.py` was discarded once the target was confirmed to be the Go ai-gateway (slugless `/v1/chat/completions`, `phs_` bearer, no per-product concept), which is what makes the cutover a pure env swap.
