### PR TITLE
fix(experiments): use the `query_to` date as the signal for last refresh instead of `completed_at`.

### DIFF
--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -40,6 +40,7 @@ const baseRecalculation = {
     created_at: '2026-06-10T00:00:00Z',
     started_at: null,
     completed_at: null,
+    query_to: null,
     is_existing: false,
     results: [],
 }
@@ -52,6 +53,7 @@ const completedRecalculation = {
     started_at: new Date().toISOString(),
     // Fresh by default (within the 24h window) so tests using this fixture don't auto-trigger.
     completed_at: new Date().toISOString(),
+    query_to: '2026-06-10T00:05:00Z',
     results: [
         { metric_uuid: PRIMARY_METRIC_UUID, status: 'completed', result: primaryResult, error_message: null },
         { metric_uuid: SECONDARY_METRIC_UUID, status: 'completed', result: secondaryResult, error_message: null },
@@ -388,8 +390,7 @@ describe('experimentMetricsLogic', () => {
 
             expect(logic.values.recalculationProgress).toEqual({ completed: 2, total: 2 })
             expect(logic.values.isRecalculating).toBe(false)
-            // lastRefresh comes from the completed run's completion time.
-            expect(logic.values.lastRefresh).toEqual(completedRecalculation.completed_at)
+            expect(logic.values.lastRefresh).toEqual(completedRecalculation.query_to)
         })
 
         it('defaults progress to zeroes and lastRefresh to null when there is no recalculation', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -193,7 +193,7 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 total: recalc?.total_metrics ?? 0,
             }),
         ],
-        lastRefresh: [(s) => [s.currentRecalculation], (recalc): string | null => recalc?.completed_at ?? null],
+        lastRefresh: [(s) => [s.currentRecalculation], (recalc): string | null => recalc?.query_to ?? null],
     }),
     listeners(({ actions, values, props, cache }) => {
         const flagEnabled = (): boolean => !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -382,9 +382,9 @@ class ExperimentMetricsRecalculation(TeamScopedRootMixin, UUIDModel):
     # Internal: written by the discovery activity, used by the service to recompute recalc fingerprints. Not exposed by the API serializer.
     metric_uuids = models.JSONField(default=list)
 
-    # Internal: single data-window end shared by all metrics in the run. Set once when the run starts; every metric
+    # Single data-window end shared by all metrics in the run. Set once when the run starts; every metric
     # (including retries) uses this value so all metrics cover the same window and retries overwrite rather than
-    # orphan rows. Not exposed by the API serializer.
+    # orphan rows. Exposed by the API serializer as the data freshness cutoff for the run's results.
     query_to = models.DateTimeField(null=True, blank=True)
 
     trigger = models.CharField(max_length=30, choices=Trigger, default=Trigger.MANUAL)

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -695,6 +695,14 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField(read_only=True, help_text="When the job was created")
     started_at = serializers.DateTimeField(read_only=True, allow_null=True, help_text="When processing started")
     completed_at = serializers.DateTimeField(read_only=True, allow_null=True, help_text="When processing completed")
+    query_to = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Upper time bound the metrics in this run were calculated against (the data freshness cutoff). "
+            "Shared by every metric in the run; null until processing starts"
+        ),
+    )
     is_existing = serializers.BooleanField(
         read_only=True, required=False, help_text="True if returning an existing job rather than a newly created one"
     )

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -104,6 +104,7 @@ def build_job_payload(
         "created_at": recalc.created_at,
         "started_at": recalc.started_at,
         "completed_at": recalc.completed_at,
+        "query_to": recalc.query_to,
     }
     if is_existing is not None:
         payload["is_existing"] = is_existing

--- a/products/experiments/backend/test/test_metrics_recalculation_serializer.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_serializer.py
@@ -25,6 +25,7 @@ class TestExperimentMetricsRecalculationSerializer(BaseTest):
             "created_at": "2026-05-28T10:00:00Z",
             "started_at": "2026-05-28T10:00:01Z",
             "completed_at": None,
+            "query_to": "2026-05-28T10:00:01Z",
         }
         data = ExperimentMetricsRecalculationSerializer(payload).data
         assert data["status"] == "in_progress"
@@ -32,6 +33,7 @@ class TestExperimentMetricsRecalculationSerializer(BaseTest):
         assert data["experiment_id"] == 7
         assert data["trigger"] == "manual"
         assert data["completed_at"] is None
+        assert data["query_to"] == "2026-05-28T10:00:01Z"
         # Field is metric_errors (not errors) to avoid shadowing DRF's Serializer.errors property.
         assert data["metric_errors"] == {"m1": {"step": "calculation", "message": "boom"}}
         assert "errors" not in data

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -897,6 +897,11 @@ export interface ExperimentMetricsRecalculationApi {
      * @nullable
      */
     readonly completed_at: string | null
+    /**
+     * Upper time bound the metrics in this run were calculated against (the data freshness cutoff). Shared by every metric in the run; null until processing starts
+     * @nullable
+     */
+    readonly query_to: string | null
     /** True if returning an existing job rather than a newly created one */
     readonly is_existing: boolean
     /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20393,6 +20393,11 @@ export namespace Schemas {
          * @nullable
          */
       readonly completed_at: string | null;
+      /**
+         * Upper time bound the metrics in this run were calculated against (the data freshness cutoff). Shared by every metric in the run; null until processing starts
+         * @nullable
+         */
+      readonly query_to: string | null;
       /** True if returning an existing job rather than a newly created one */
       readonly is_existing: boolean;
       /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */


### PR DESCRIPTION
## Problem

On the recalculation flow, the experiment results header shows when metrics were "last refreshed". It was reading `completed_at`, which is when the recalculation *workflow finished*, not when the data is actually fresh up to. A run that takes minutes to compute reports a "last refreshed" time minutes ahead of the data it produced. The metrics are only fresh up to `query_to`, the upper time bound every metric in the run is calculated against, so that is the honest freshness signal.

`query_to` was already persisted on `ExperimentMetricsRecalculation` (set once when the run starts, shared by every metric, retry-safe), it just wasn't exposed to the frontend.

## Changes

This PR exposes `query_to` on the recalculation API and switches the frontend's `lastRefresh` to read it.

### Expose `query_to` on the recalculation serializer

Added `query_to` to `ExperimentMetricsRecalculationSerializer` and to `build_job_payload`, so every recalculation response (latest, create, retrieve) carries it. Updated the model field comment, which previously said the field was internal and not exposed.

- `products/experiments/backend/presentation/serializers.py`
- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/models/experiment.py`
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

### Use `query_to` as the frontend last-refresh signal

The `lastRefresh` selector now reads `currentRecalculation.query_to` instead of `completed_at`. Nothing else in the cell or header changes.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`
- `frontend/src/scenes/experiments/experimentMetricsLogic.test.ts`

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/91ba4d11-160a-457b-954a-c264a8861723)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /improving-drf-endpoints (local)
- /adopting-generated-api-types (local)
- /writing-pull-requests (local)

Relevant decisions:

- Surfaced the existing `ExperimentMetricsRecalculation.query_to` rather than adding a new field. It is already the per-run data-window end, so it is the correct freshness cutoff with no schema change.
- Left the staleness / auto-trigger logic keyed on `completed_at`. "When did the job finish" is the right input for "should we re-run"; only the displayed freshness label moved to `query_to`.
- Regenerated types via `hogli build:openapi`; the `api.schemas.ts` and MCP `generated.ts` changes are generated, not hand-edited.