### PR TITLE
feat(mcp): theme-aware canvas and inline title for all visualizers

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4037,17 +4037,17 @@ snapshots:
     mcp-apps-feature-flags--testing-no-match--light:
         hash: v1.k794b7964.b5eec4d4100dc834d4c7c891e4962c9effa643ff190f3b0957d816d82ebb7269.9Hg0pCpNp895WlYr8k2m97K0fvniLuzPcRSAIWUCtg8
     mcp-apps-funnels--steep-dropoff--light:
-        hash: v1.k794b7964.cc26937830dc95deb164b13bda7327a6a7bed094f2670332b6ea0885ffb15733.j8pxbf3h92E8pkD9KCSQrlBeFY3UUEmF7E_6XJg47kQ
+        hash: v1.k794b7964.9b1c95cfbfaa751ecc06b1b998af2a9e79304f9d6bb463e83639fea231a786f8.A2qfI1EvER2HUN40tOYPTXKw9MB1Q10TEY7XdsWr-m4
     mcp-apps-funnels--three-step--light:
-        hash: v1.k794b7964.a4cf6cff88ffb74e40e2dbe91cc266054f699eeae2d39d40019f3ed184ba030e.g12F2_uMZw3-VDO3TX1BqQu01X5UDRFTag0fO0WcrTc
+        hash: v1.k794b7964.ea34a8cf895551499ca3bacabcde98ea445e2caea7fdc5b9f75de7d1d6dd8e6b.UfvafB3BxwBsJ8t1xHzxTmm5sRu0_xMGrAp6e4ldb5Y
     mcp-apps-insight-actors--event-counts--light:
         hash: v1.k794b7964.f3ff99b4ec1920b2df7c65cb407482896b99b2ea34d4bfbb4cad722b05d25f9a.6K2QCgM8Znsuz_zMA2jTZW884aJ29-cvc1OWldMEzgc
     mcp-apps-insight-actors--with-recordings--light:
         hash: v1.k794b7964.af9ec36dd0d406f45eec2bf3fafb8dbe63b0eba139c5fff4b33e83cf24668f8e.hQ3brX3MIHwfCM95Re7Ti6Z8bsY2zq-He2uM63uuvUw
     mcp-apps-lifecycle--grouped--light:
-        hash: v1.k794b7964.fa32f317c7015ae73b5b5c38e11209e6a51967de4e0457ae29f7eedb8ea8fce8._OUjY62EdIDs4LQbOyr1ORBmTYMn9AZ5BHWC9e4Bx5c
+        hash: v1.k794b7964.5c33ba0a4dbe6cf279197eadea244d7b9838b99d80b8ba2b899df7ca881e066b.GNSIWjjq4NaJTgY9UUDYIXoxNuzz74X5yRL5TuFPO_Y
     mcp-apps-lifecycle--stacked--light:
-        hash: v1.k794b7964.9ae65eadce145d0cbade09760b4d774eab2861bf0bf9bd0bdf36f1dd1389a620.qYdACXQ2q-w43FAjwS-g7JDwiZiGs6-Mc5lsUs79byA
+        hash: v1.k794b7964.6d00ea357f1a270a0b0a6a4d61339c00a298f946d4f7a8fe9ed70b289aa3b60b.6ijtbv39zAumhoMFY5BSCxCkLHO9rYpeBUjUykvvgK8
     mcp-apps-retention-actors--daily--light:
         hash: v1.k794b7964.0a701acbd2d9dac54c345d22841a6d92b6c2b3728421e8fa5fd574a769514e04.Rhb4Qb0bfRbA3ZB2_4f4WM5507JnwCgoox1RbE9y8Ks
     mcp-apps-surveys--active-popover--light:
@@ -4063,9 +4063,9 @@ snapshots:
     mcp-apps-trends--area-chart--light:
         hash: v1.k794b7964.fea141e4555bf7c84c7df7d28f440f1967cf46eed78c9df63daa191b42156569.osoYKiT_8UiEIKvjzLfRzJxA6gY3cT4eD1g66S-kD5Q
     mcp-apps-trends--bar-value-few-series--light:
-        hash: v1.k794b7964.17235de255bc7d04240957e537b7bc76027c19471525218a28582af1298cd0b3.aA5Dz0x9KR6knEKP4CvKEtRoVS7z6TeKEtTY4_qoML0
+        hash: v1.k794b7964.505657b65a9af9e493f2628daf104e7a3c39deedfcc86b35341b3dd643c2dced.kHez2Oj8tVir2B5AfU9-2OniwQh16ZlpiaaOxB4WHKM
     mcp-apps-trends--bar-value-many-breakdowns--light:
-        hash: v1.k794b7964.407f0a6b71b45525e4d45d20e1e6af8f0b7a4345748af552b53df223fbcf576a.GnlWLZvvw78tfb9YT0og22-n8GDKTQs3487BrZiQi_8
+        hash: v1.k794b7964.65fb21af9009c23db6db45ea402a0cebb0f61f85747f55a29177d09009b9c682.K9XZ2RtpwhNADOxHtyAambrlpFgk9PnEXBZdFpQkI1M
     mcp-apps-trends--multi-series--light:
         hash: v1.k794b7964.de9682bc3d1cacf6198fa053c98657bc296202e4e1e800c98208b0922724cc5d.17c9wz8bYgE3_74LEk8BY5z_gkAp4NZ95x1pkMvip-s
     mcp-apps-trends--single-series--light:

--- a/services/mcp/src/ui-apps/components/ChartHeader.tsx
+++ b/services/mcp/src/ui-apps/components/ChartHeader.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement, ReactNode } from 'react'
+
+interface ChartHeaderProps {
+    title: string
+    /** Right-aligned controls (chart-type select, options, …). Omit for visualizations with none. */
+    children?: ReactNode
+}
+
+export function ChartHeader({ title, children }: ChartHeaderProps): ReactElement {
+    return (
+        <div className="mb-2 flex items-center gap-2">
+            <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{title}</div>
+            {children && <div className="ml-auto flex items-center gap-2">{children}</div>}
+        </div>
+    )
+}

--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Card, CardContent, Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
 
+import { ChartHeader } from './ChartHeader'
 import { FunnelVisualizer } from './FunnelVisualizer'
 import { inferVisualizationType } from './infer-visualization'
 import { LifecycleVisualizer } from './LifecycleVisualizer'
@@ -43,9 +44,7 @@ export function Component({ data }: ComponentProps): ReactElement {
         return (
             <Card>
                 <CardContent>
-                    <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                        Results
-                    </div>
+                    <ChartHeader title="Results" />
                     <Empty>
                         <EmptyHeader>
                             <EmptyMedia>{emptyStateIllustration('generic')}</EmptyMedia>
@@ -103,33 +102,9 @@ export function Component({ data }: ComponentProps): ReactElement {
         }
     }
 
-    const getTitle = (): string => {
-        switch (visualizationType) {
-            case 'trends':
-                return 'Trends'
-            case 'funnel':
-                return 'Funnel'
-            case 'lifecycle':
-                return 'Lifecycle'
-            case 'retention':
-                return 'Retention'
-            case 'paths':
-                return 'Paths'
-            case 'table':
-                return 'Query results'
-            default:
-                return 'Results'
-        }
-    }
-
     return (
         <Card>
-            <CardContent>
-                <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    {getTitle()}
-                </div>
-                {renderVisualization()}
-            </CardContent>
+            <CardContent>{renderVisualization()}</CardContent>
         </Card>
     )
 }

--- a/services/mcp/src/ui-apps/components/FunnelVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/FunnelVisualizer.tsx
@@ -15,6 +15,8 @@ import { FUNNEL_COLOR, useMcpChartTheme } from './charts/theme'
 import type { FunnelVisualizerProps } from './types'
 import { formatNumber, formatPercent, normalizeFunnelSteps } from './utils'
 
+const TITLE = 'Funnel'
+
 const NOOP = (): void => {}
 
 // The web container hides the x-axis and renders its own StepLegend row; this compact UI app instead
@@ -49,7 +51,7 @@ export function FunnelVisualizer({ results }: FunnelVisualizerProps): ReactEleme
     if (steps.length === 0) {
         return (
             <div>
-                <ChartHeader title="Funnel" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('funnel')}</EmptyMedia>
@@ -62,7 +64,7 @@ export function FunnelVisualizer({ results }: FunnelVisualizerProps): ReactEleme
 
     return (
         <div data-attr="funnel-steps-bar" className="w-full">
-            <ChartHeader title="Funnel" />
+            <ChartHeader title={TITLE} />
             <div className="flex flex-col h-72 w-full">
                 <BarChart
                     series={series}

--- a/services/mcp/src/ui-apps/components/FunnelVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/FunnelVisualizer.tsx
@@ -10,7 +10,8 @@ import {
     type FunnelStepsBarRow,
 } from 'products/product_analytics/frontend/insights/funnels/shared/funnelStepsBarShared'
 
-import { CHART_THEME, FUNNEL_COLOR } from './charts/theme'
+import { ChartHeader } from './ChartHeader'
+import { FUNNEL_COLOR, useMcpChartTheme } from './charts/theme'
 import type { FunnelVisualizerProps } from './types'
 import { formatNumber, formatPercent, normalizeFunnelSteps } from './utils'
 
@@ -41,27 +42,32 @@ function renderTooltip(rows: FunnelStepsBarRow[]) {
 }
 
 export function FunnelVisualizer({ results }: FunnelVisualizerProps): ReactElement {
+    const theme = useMcpChartTheme()
     const steps = normalizeFunnelSteps(results)
     const { series, labels, rows, overall } = buildFunnelStepsBars(steps, { color: FUNNEL_COLOR })
 
     if (steps.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('funnel')}</EmptyMedia>
-                    <EmptyDescription>No funnel data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Funnel" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('funnel')}</EmptyMedia>
+                        <EmptyDescription>No funnel data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
     return (
         <div data-attr="funnel-steps-bar" className="w-full">
+            <ChartHeader title="Funnel" />
             <div className="flex flex-col h-72 w-full">
                 <BarChart
                     series={series}
                     labels={labels}
-                    theme={CHART_THEME}
+                    theme={theme}
                     config={CHART_CONFIG}
                     tooltip={renderTooltip(rows)}
                     onError={NOOP}

--- a/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
@@ -11,6 +11,8 @@ import { lifecycleColor, useMcpChartTheme } from './charts/theme'
 import type { LifecycleVisualizerProps } from './types'
 import { formatDate } from './utils'
 
+const TITLE = 'Lifecycle'
+
 const LIFECYCLE_TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
 
 export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps): ReactElement {
@@ -43,7 +45,7 @@ export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps
     if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
         return (
             <div>
-                <ChartHeader title="Lifecycle" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
@@ -59,7 +61,7 @@ export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps
     // leaving the canvas measured at 0 and unpainted. Funnels/trends render the chart this way too.
     return (
         <div className="w-full">
-            <ChartHeader title="Lifecycle" />
+            <ChartHeader title={TITLE} />
             {showLegend && legendItems.length > 0 && (
                 <div className="mb-2">
                     <Legend items={legendItems} orientation="horizontal" align="center" />

--- a/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
@@ -6,7 +6,8 @@ import { Legend, TimeSeriesBarChart, legendItemsFromSeries } from '@posthog/quil
 
 import { buildLifecycleChartModel } from 'products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms'
 
-import { CHART_THEME, lifecycleColor } from './charts/theme'
+import { ChartHeader } from './ChartHeader'
+import { lifecycleColor, useMcpChartTheme } from './charts/theme'
 import type { LifecycleVisualizerProps } from './types'
 import { formatDate } from './utils'
 
@@ -14,6 +15,7 @@ const LIFECYCLE_TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
 
 export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps): ReactElement {
     const showLegend = query?.lifecycleFilter?.showLegend ?? true
+    const theme = useMcpChartTheme()
 
     const { series, labels, config } = useMemo(
         () =>
@@ -36,16 +38,19 @@ export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps
         [results, query?.lifecycleFilter?.stacked, query?.lifecycleFilter?.toggledLifecycles]
     )
 
-    const legendItems = useMemo(() => legendItemsFromSeries(series, CHART_THEME), [series])
+    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
 
     if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                    <EmptyDescription>No data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Lifecycle" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                        <EmptyDescription>No data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
@@ -54,13 +59,14 @@ export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps
     // leaving the canvas measured at 0 and unpainted. Funnels/trends render the chart this way too.
     return (
         <div className="w-full">
+            <ChartHeader title="Lifecycle" />
             {showLegend && legendItems.length > 0 && (
                 <div className="mb-2">
                     <Legend items={legendItems} orientation="horizontal" align="center" />
                 </div>
             )}
             <div className="flex flex-col w-full h-[400px]">
-                <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={config} />
+                <TimeSeriesBarChart series={series} labels={labels} theme={theme} config={config} />
             </div>
         </div>
     )

--- a/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { DataTable, type DataTableProps, Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
 
+import { ChartHeader } from './ChartHeader'
 import type { PathsVisualizerProps } from './types'
 import { formatDuration, formatNumber } from './utils'
 
@@ -35,12 +36,15 @@ export function PathsVisualizer({ results }: PathsVisualizerProps): ReactElement
 
     if (edges.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('generic')}</EmptyMedia>
-                    <EmptyDescription>No path data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Paths" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('generic')}</EmptyMedia>
+                        <EmptyDescription>No path data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
@@ -74,6 +78,7 @@ export function PathsVisualizer({ results }: PathsVisualizerProps): ReactElement
 
     return (
         <div>
+            <ChartHeader title="Paths" />
             <DataTable columns={tableColumns} data={displayRows} className="rounded-lg border" />
             {hasMore && (
                 <span className="mt-2 block text-center text-xs text-muted-foreground">

--- a/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/PathsVisualizer.tsx
@@ -7,6 +7,8 @@ import { ChartHeader } from './ChartHeader'
 import type { PathsVisualizerProps } from './types'
 import { formatDuration, formatNumber } from './utils'
 
+const TITLE = 'Paths'
+
 // Edges are sorted by user count and the busiest paths lead, so a truncated
 // view stays meaningful; columns are non-sortable to match.
 const MAX_ROWS = 20
@@ -37,7 +39,7 @@ export function PathsVisualizer({ results }: PathsVisualizerProps): ReactElement
     if (edges.length === 0) {
         return (
             <div>
-                <ChartHeader title="Paths" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('generic')}</EmptyMedia>
@@ -78,7 +80,7 @@ export function PathsVisualizer({ results }: PathsVisualizerProps): ReactElement
 
     return (
         <div>
-            <ChartHeader title="Paths" />
+            <ChartHeader title={TITLE} />
             <DataTable columns={tableColumns} data={displayRows} className="rounded-lg border" />
             {hasMore && (
                 <span className="mt-2 block text-center text-xs text-muted-foreground">

--- a/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
@@ -13,6 +13,8 @@ import type { RetentionVisualizerProps } from './types'
 
 type ChartMode = 'line' | 'bar'
 
+const TITLE = 'Retention'
+
 const CHART_MODE_OPTIONS = [
     { value: 'line' as const, label: 'Line' },
     { value: 'bar' as const, label: 'Bar' },
@@ -47,7 +49,7 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
     if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
         return (
             <div>
-                <ChartHeader title="Retention" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
@@ -60,7 +62,7 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
 
     return (
         <div>
-            <ChartHeader title="Retention">
+            <ChartHeader title={TITLE}>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={chartMode} onChange={setChartMode} options={CHART_MODE_OPTIONS} />
             </ChartHeader>

--- a/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
@@ -6,8 +6,9 @@ import { TimeSeriesBarChart, TimeSeriesLineChart, type TooltipConfig } from '@po
 
 import { buildRetentionChartModel } from 'products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms'
 
+import { ChartHeader } from './ChartHeader'
 import { Select } from './charts'
-import { CHART_THEME, colorAt } from './charts/theme'
+import { colorAt, useMcpChartTheme } from './charts/theme'
 import type { RetentionVisualizerProps } from './types'
 
 type ChartMode = 'line' | 'bar'
@@ -21,6 +22,7 @@ const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 
 export function RetentionVisualizer({ query, results }: RetentionVisualizerProps): ReactElement {
     const [chartMode, setChartMode] = useState<ChartMode>('line')
+    const theme = useMcpChartTheme()
 
     // No cohort cap — mirrors the web, which renders every cohort and lets colors wrap past the palette.
     const { series, labels, lineConfig, barConfig } = useMemo(
@@ -44,26 +46,29 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
 
     if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                    <EmptyDescription>No retention data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Retention" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                        <EmptyDescription>No retention data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
     return (
         <div>
-            <div className="mb-2 flex items-center justify-end">
+            <ChartHeader title="Retention">
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={chartMode} onChange={setChartMode} options={CHART_MODE_OPTIONS} />
-            </div>
+            </ChartHeader>
             <div className="flex flex-col w-full h-[400px]">
                 {chartMode === 'bar' ? (
-                    <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={barConfig} />
+                    <TimeSeriesBarChart series={series} labels={labels} theme={theme} config={barConfig} />
                 ) : (
-                    <TimeSeriesLineChart series={series} labels={labels} theme={CHART_THEME} config={lineConfig} />
+                    <TimeSeriesLineChart series={series} labels={labels} theme={theme} config={lineConfig} />
                 )}
             </div>
         </div>

--- a/services/mcp/src/ui-apps/components/TableVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TableVisualizer.tsx
@@ -8,6 +8,8 @@ import { BigNumber, LineChart, type Series } from './charts'
 import type { TableVisualizerProps } from './types'
 import { formatNumber } from './utils'
 
+const TITLE = 'Query results'
+
 // Query results are truncated client-side; sorting a truncated view would
 // mislead, so columns are non-sortable.
 const MAX_ROWS = 20
@@ -126,7 +128,7 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
     if (format.type === 'single-number' && format.value !== undefined) {
         return (
             <div>
-                <ChartHeader title="Query results" />
+                <ChartHeader title={TITLE} />
                 <BigNumber value={format.value} label={format.label} />
             </div>
         )
@@ -146,7 +148,7 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
         )
         return (
             <div>
-                <ChartHeader title="Query results" />
+                <ChartHeader title={TITLE} />
                 <LineChart series={series} labels={labels} maxValue={maxValue} showLegend={false} />
             </div>
         )
@@ -155,7 +157,7 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
     if (rows.length === 0) {
         return (
             <div>
-                <ChartHeader title="Query results" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('table')}</EmptyMedia>
@@ -180,7 +182,7 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
 
     return (
         <div className="flex flex-col gap-2">
-            <ChartHeader title="Query results" />
+            <ChartHeader title={TITLE} />
             <DataTable columns={tableColumns} data={displayRows} />
             {hasMore && (
                 <span className="text-center text-xs text-muted-foreground">

--- a/services/mcp/src/ui-apps/components/TableVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TableVisualizer.tsx
@@ -3,9 +3,10 @@ import type { ReactElement } from 'react'
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { DataTable, type DataTableProps, Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
 
-import { formatNumber } from './utils'
+import { ChartHeader } from './ChartHeader'
 import { BigNumber, LineChart, type Series } from './charts'
 import type { TableVisualizerProps } from './types'
+import { formatNumber } from './utils'
 
 // Query results are truncated client-side; sorting a truncated view would
 // mislead, so columns are non-sortable.
@@ -123,7 +124,12 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
     const format = detectResultFormat(columns, rows)
 
     if (format.type === 'single-number' && format.value !== undefined) {
-        return <BigNumber value={format.value} label={format.label} />
+        return (
+            <div>
+                <ChartHeader title="Query results" />
+                <BigNumber value={format.value} label={format.label} />
+            </div>
+        )
     }
 
     if (
@@ -138,19 +144,27 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
             format.valueColumnIndex,
             valueLabel
         )
-        return <LineChart series={series} labels={labels} maxValue={maxValue} showLegend={false} />
+        return (
+            <div>
+                <ChartHeader title="Query results" />
+                <LineChart series={series} labels={labels} maxValue={maxValue} showLegend={false} />
+            </div>
+        )
     }
 
     if (rows.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('table')}</EmptyMedia>
-                    <EmptyDescription>
-                        {columns.length === 0 ? 'No rows to display' : 'Query returned no rows'}
-                    </EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Query results" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('table')}</EmptyMedia>
+                        <EmptyDescription>
+                            {columns.length === 0 ? 'No rows to display' : 'Query returned no rows'}
+                        </EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
@@ -166,6 +180,7 @@ export function TableVisualizer({ results }: TableVisualizerProps): ReactElement
 
     return (
         <div className="flex flex-col gap-2">
+            <ChartHeader title="Query results" />
             <DataTable columns={tableColumns} data={displayRows} />
             {hasMore && (
                 <span className="text-center text-xs text-muted-foreground">

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -37,6 +37,8 @@ import {
 import type { TrendsResultItem, TrendsVisualizerProps } from './types'
 import { formatDate, formatTooltipDate, getDisplayType, getSeriesLabel } from './utils'
 
+const TITLE = 'Trends'
+
 const CHART_TYPE_OPTIONS = [
     { value: 'line' as const, label: 'Line' },
     { value: 'area' as const, label: 'Area' },
@@ -77,7 +79,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
     if (!results || results.length === 0) {
         return (
             <div>
-                <ChartHeader title="Trends" />
+                <ChartHeader title={TITLE} />
                 <Empty>
                     <EmptyHeader>
                         <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
@@ -93,7 +95,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         const label = results[0] ? getSeriesLabel(results[0], 0) : 'Total'
         return (
             <div>
-                <ChartHeader title="Trends" />
+                <ChartHeader title={TITLE} />
                 <BigNumber value={total} label={label} />
             </div>
         )
@@ -109,7 +111,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         const barConfig = buildTrendsBarValueConfig()
         return (
             <div>
-                <ChartHeader title="Trends" />
+                <ChartHeader title={TITLE} />
                 <div className="flex flex-col w-full h-[400px]">
                     <BarValueChart
                         series={barSeries}
@@ -211,7 +213,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     return (
         <div>
-            <ChartHeader title="Trends">
+            <ChartHeader title={TITLE}>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
                 {effectiveType !== 'slope' && (

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -22,8 +22,9 @@ import {
     buildTrendsSeries,
 } from 'products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms'
 
+import { ChartHeader } from './ChartHeader'
 import { BigNumber, Select } from './charts'
-import { CHART_THEME, colorAt } from './charts/theme'
+import { colorAt, useMcpChartTheme } from './charts/theme'
 import { ChartSettings } from './ChartSettings'
 import {
     type ChartType,
@@ -71,22 +72,31 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
     const displayType = getDisplayType(query)
     const [chartType, setChartType] = useState<ChartType>(defaultChartType(displayType))
     const [chartConfig, setChartConfig] = useState(() => chartConfigFromTrendsFilter(query?.trendsFilter))
+    const theme = useMcpChartTheme()
 
     if (!results || results.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                    <EmptyDescription>No data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                <ChartHeader title="Trends" />
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                        <EmptyDescription>No data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
     if (displayType === 'BoldNumber') {
         const total = calculateTotal(results)
         const label = results[0] ? getSeriesLabel(results[0], 0) : 'Total'
-        return <BigNumber value={total} label={label} />
+        return (
+            <div>
+                <ChartHeader title="Trends" />
+                <BigNumber value={total} label={label} />
+            </div>
+        )
     }
 
     // ActionsBarValue is aggregated totals per series (no days[]) — a horizontal bar, not a time series.
@@ -98,13 +108,16 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         const barSeries = buildTrendsBarValueSeries(items, { getColor: colorAt })
         const barConfig = buildTrendsBarValueConfig()
         return (
-            <div className="flex flex-col w-full h-[400px]">
-                <BarValueChart
-                    series={barSeries}
-                    labels={items.map((item) => item.label)}
-                    theme={CHART_THEME}
-                    config={barConfig}
-                />
+            <div>
+                <ChartHeader title="Trends" />
+                <div className="flex flex-col w-full h-[400px]">
+                    <BarValueChart
+                        series={barSeries}
+                        labels={items.map((item) => item.label)}
+                        theme={theme}
+                        config={barConfig}
+                    />
+                </div>
             </div>
         )
     }
@@ -142,7 +155,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                 <SlopeChart
                     series={slopeSeries}
                     labels={slopeLabels}
-                    theme={CHART_THEME}
+                    theme={theme}
                     config={{ showSeriesLabels: false, legend: { show: true, position: 'bottom' } }}
                 />
             )
@@ -162,7 +175,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                 <TimeSeriesBarChart
                     series={series}
                     labels={labels}
-                    theme={CHART_THEME}
+                    theme={theme}
                     config={config}
                     tooltip={renderDateTooltip}
                 />
@@ -189,7 +202,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
             <TimeSeriesLineChart
                 series={series}
                 labels={labels}
-                theme={CHART_THEME}
+                theme={theme}
                 config={config}
                 tooltip={renderDateTooltip}
             />
@@ -198,7 +211,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     return (
         <div>
-            <div className="mb-2 flex items-center justify-end gap-2">
+            <ChartHeader title="Trends">
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
                 {effectiveType !== 'slope' && (
@@ -210,7 +223,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                         percentStackDisabled={!supportsPercentStack(effectiveType)}
                     />
                 )}
-            </div>
+            </ChartHeader>
             <div className="flex flex-col w-full h-[400px]">{renderChart()}</div>
         </div>
     )

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -1,4 +1,6 @@
-import { type ChartTheme } from '@posthog/quill-charts'
+import { useMemo } from 'react'
+
+import { type ChartTheme, useChartTheme } from '@posthog/quill-charts'
 
 import type { LifecycleStatus } from '../types'
 
@@ -43,9 +45,7 @@ export const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
 export const lifecycleColor = (status: string | undefined): string =>
     LIFECYCLE_COLORS[(status ?? 'new') as LifecycleStatus] ?? LIFECYCLE_COLORS.new
 
-// Single mid-gray for axis labels — readable on both light and dark hosts. Claude
-// Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host
-// theme and adapt at runtime.
+// Static light fallback. Components should use useMcpChartTheme() so the canvas tracks the host theme.
 export const CHART_THEME: ChartTheme = {
     colors: CHART_COLORS,
     backgroundColor: '#ffffff',
@@ -54,4 +54,11 @@ export const CHART_THEME: ChartTheme = {
     crosshairColor: 'rgba(128, 128, 128, 0.5)',
     tooltipBackground: '#ffffff',
     tooltipColor: '#111827',
+}
+
+// Background/axis/grid/tooltip track the host's light/dark CSS vars (bridged to quill's graph
+// tokens in tailwind.css); series colors stay on the curated brand palette.
+export function useMcpChartTheme(): ChartTheme {
+    const base = useChartTheme()
+    return useMemo(() => ({ ...base, colors: CHART_COLORS }), [base])
 }

--- a/services/mcp/src/ui-apps/styles/tailwind.css
+++ b/services/mcp/src/ui-apps/styles/tailwind.css
@@ -57,6 +57,12 @@
     --muted-foreground: var(--color-text-secondary);
     --border: var(--color-border-primary);
     --input: var(--color-border-secondary);
+
+    /* Quill chart canvas tokens (read by useChartTheme) — map onto the host's theme vars
+     * so the canvas tracks light/dark like the rest of the UI. */
+    --color-graph-axis-label: var(--color-text-secondary);
+    --color-graph-axis-line: var(--color-border-primary);
+    --color-graph-crosshair: var(--color-text-secondary);
 }
 
 /* Scan our own source files (apps, components, shared lib) plus product MCP apps and Quill primitives. */


### PR DESCRIPTION
## Problem

The MCP UI app charts (the in-chat visualizations of PostHog query results) had two rough edges:

- The chart **canvas** was hardcoded to a light theme (white background, fixed gray axis), so it ignored the host's light/dark theme even though the surrounding UI already adapted.
- The section title ("Trends", "Funnel", …) was rendered by the shell as a stacked uppercase label above each visualization, disconnected from the chart's own controls.

## Changes

- **Theme-aware canvas.** New `useMcpChartTheme()` reads the host's light/dark CSS variables (bridged onto quill's chart-canvas tokens in `tailwind.css`) so background, axis lines/ticks, labels, and tooltip track the host theme. Series colors stay on the curated brand palette. All four chart visualizers (Trends, Lifecycle, Retention, Funnel) use it; the static `CHART_THEME` remains as a fallback.
- **Inline title for every visualizer.** New shared `ChartHeader` renders the section title inline with each visualization's controls — Trends/Retention put their chart-type select and options there; the rest just show the title. The shell no longer renders a separate stacked title, so there's no per-type special-casing.

No screenshots — the change is visible in the existing Storybook stories under `MCP Apps/*` (each visualizer renders its own header now).

## How did you test this code?

I'm an agent (Claude Code), directed by @sampennington. Automated only — no manual UI testing:

- `pnpm --filter @posthog/mcp typecheck` (tsgo) — clean.
- `pnpm --filter @posthog/mcp vitest run tests/unit/` — 1874 tests pass.

A human eyeball in Storybook is still worth it, especially the dark-mode canvas.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @sampennington. Two related changes to the MCP UI app charts:

- Made the canvas theme-aware by reading the host's ext-apps CSS vars through quill's `useChartTheme()` (bridging the missing `--color-graph-*` tokens) instead of the hardcoded light `CHART_THEME`. Reused quill's hook rather than hand-rolling a CSS-var reader, for reactivity.
- Generalized the inline title — originally prototyped trends-only and reverted — into a shared `ChartHeader` applied uniformly across all six visualizers, dropping the shell's stacked title.

Branched off master after the display-options PR (#63094) merged, so it layers on top of that `TrendsVisualizer`. Caveat: `useChartTheme` re-reads on class/theme attribute changes; a pure OS `prefers-color-scheme` toggle updates on the next render rather than instantly. No skills were invoked.
