### PR TITLE
chore(ci): refine geoip canary alert to skip infra failures

### DIFF
--- a/.github/workflows/ci-geoip-canary.yml
+++ b/.github/workflows/ci-geoip-canary.yml
@@ -60,15 +60,19 @@ jobs:
               run: pnpm --filter=@posthog/nodejs... install --frozen-lockfile
 
             - name: Run canary against live database
+              id: canary
               env:
                   GEOIP_LIVE_TEST: '1'
               run: cd nodejs && pnpm jest src/utils/geoip-live.test.ts --runInBand --forceExit
 
-            # A failure here means the live GeoLite2 build dropped location data for the
-            # anchor IPs — i.e. a bad MaxMind release is already baked into production
-            # images. On the schedule nobody is watching the run, so alert explicitly.
+            # Only the canary test itself failing means the live GeoLite2 build dropped
+            # location data for the anchor IPs — i.e. a bad MaxMind release is already
+            # baked into production images. Infra failures upstream (checkout, MaxMind
+            # download, pnpm install) are CI noise, not a degraded database, so don't
+            # page Slack for them. On the schedule nobody is watching the run, so alert
+            # explicitly when the test genuinely fails.
             - name: Notify Slack on canary failure
-              if: failure()
+              if: failure() && steps.canary.outcome == 'failure'
               uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
               with:
                   method: chat.postMessage


### PR DESCRIPTION
## Problem

The GeoIP canary workflow currently alerts Slack on any failure, including upstream infrastructure issues (checkout, MaxMind download, pnpm install). These are CI noise unrelated to database degradation and shouldn't page on-call. We only want to alert when the canary test itself genuinely fails, indicating a bad MaxMind release is baked into production.

## Changes

- Added `id: canary` to the canary test step for result tracking
- Updated the Slack notification condition from `if: failure()` to `if: failure() && steps.canary.outcome == 'failure'` to only alert when the test step specifically fails
- Clarified the comment explaining the distinction between test failures (alert) and infra failures (don't alert)

## How did you test this code?

The change is a CI workflow configuration update. The conditional logic will be validated by GitHub Actions when the workflow runs — it will only trigger the Slack notification if both the overall job fails AND the canary test step specifically failed, filtering out upstream infrastructure issues.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is a straightforward CI workflow refinement to improve alert signal-to-noise ratio. The change uses GitHub Actions' step outcome tracking to distinguish between genuine test failures (which warrant alerts) and transient infrastructure issues (which don't). No code logic or dependencies were modified — only workflow configuration and comments.

https://claude.ai/code/session_017KJ6ygC8VDUc8mz3fubtp9