### PR TITLE
fix(deletion): make recording-deletion queueing best-effort

### DIFF
--- a/posthog/temporal/delete_teams/workflows.py
+++ b/posthog/temporal/delete_teams/workflows.py
@@ -2,6 +2,7 @@ import datetime as dt
 
 import temporalio.common
 import temporalio.workflow
+import temporalio.exceptions
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.delete_teams.activities import (
@@ -85,14 +86,23 @@ class DeleteTeamsDataWorkflow(PostHogWorkflow):
 
         team_inputs = TeamDataActivityInputs(team_ids=inputs.team_ids, user_id=inputs.user_id)
 
-        # Start the autonomous session-replay recording deletion (fire-and-forget).
-        await temporalio.workflow.execute_activity(
-            queue_recording_deletions_activity,
-            team_inputs,
-            start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
-            heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
-            retry_policy=SIDE_EFFECT_RETRY_POLICY,
-        )
+        # Start the autonomous session-replay recording deletion (fire-and-forget). Best-effort:
+        # queuing recording deletion is not a prerequisite for removing the team's data, so if it
+        # exhausts its retries we log and carry on rather than wedging the whole deletion. Recordings
+        # left behind are reaped by their own retention/TTL.
+        try:
+            await temporalio.workflow.execute_activity(
+                queue_recording_deletions_activity,
+                team_inputs,
+                start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
+                retry_policy=SIDE_EFFECT_RETRY_POLICY,
+            )
+        except temporalio.exceptions.ActivityError:
+            temporalio.workflow.logger.warning(
+                "queue_recording_deletions_activity failed; continuing team deletion without it",
+                exc_info=True,
+            )
 
         for activity in BULKY_POSTGRES_ACTIVITIES:
             await temporalio.workflow.execute_activity(

--- a/posthog/temporal/tests/delete_teams/test_workflows.py
+++ b/posthog/temporal/tests/delete_teams/test_workflows.py
@@ -214,6 +214,21 @@ async def test_transient_error_is_retried():
     assert len(attempts) == 2  # retried once, then succeeded
 
 
+async def test_recording_deletion_failure_does_not_block_workflow():
+    # Queuing recording deletion is best-effort: if it exhausts its retries, the rest of the
+    # team deletion must still run to completion.
+    attempts: list[str] = []
+
+    async def always_fails(inputs: TeamDataActivityInputs) -> None:
+        attempts.append("attempt")
+        raise RuntimeError("recording deletion service unavailable")
+
+    activities = _core_activities_with("queue_recording_deletions_activity", always_fails)
+    await _run_core_with(activities)  # completes despite recording deletion failing
+
+    assert len(attempts) == 5  # exhausted SIDE_EFFECT_RETRY_POLICY, then swallowed
+
+
 async def test_recursion_error_fails_fast_without_retry():
     # A RecursionError is deterministic (e.g. json.loads can't decode a deeply-nested JSON column
     # on a cascaded row), so the retry policy must not loop on it.


### PR DESCRIPTION
## Problem

In the team/org deletion workflow, queuing the session-replay recording deletions is the first step, but it's fire-and-forget — not a prerequisite for removing the team's data. Today a failure there exhausts its retries and fails the entire deletion workflow.

## Changes

- Make `queue_recording_deletions_activity` best-effort: if it exhausts its retries, log and continue the rest of the deletion instead of failing the workflow

> [!NOTE]
> This is independent of the `delete_team_records` `RecursionError` incident — that fails in a later activity, so this change does not unblock that org.

## How did you test this code?

- 1 test added (recording-deletion failure no longer blocks the workflow); full delete_teams workflow suite passes (10 tests).
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested with Claude Code as a standalone resilience improvement while investigating a separate deletion incident. Scoped narrowly to the one fire-and-forget side activity; the core data-deletion activities keep their existing fail-fast behavior. No repo skills shaped the code beyond creating-pull-requests.
