### PR TITLE
fix(postgres): stop capturing RLS lookup errors on a dropped connection

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -801,15 +801,21 @@ def _rls_active_from_conn(
         # discovery). When one of those fails on a non-Postgres engine — e.g. a Redshift-incompatible
         # `pg_catalog` query — its exception is caught upstream but the connection's transaction is
         # left in `INERROR`, so our first statement here fails with `InFailedSqlTransaction` purely as
-        # a downstream symptom. That's an already-handled condition, not a bug in this lookup, so
-        # don't re-capture it (mirrors `_get_partition_settings`).
+        # a downstream symptom. A harsher variant of the same thing: an earlier probe (or a transient
+        # drop — SSH-tunnel hiccup, idle cull, failover) leaves the shared connection closed/broken,
+        # so our `cursor()` call surfaces as `OperationalError: the connection is closed`. Both are
+        # already-handled downstream symptoms, not bugs in this lookup, so don't re-capture them
+        # (mirrors `_get_partition_settings` and the caller's own connection-level handler).
         #
         # Postgres-wire-compatible engines (DuckDB/Flight-SQL proxies, etc.) accept our connection
         # but don't implement `row_security_active`. RLS is a Postgres-only concept there, so a
         # missing-function error is an expected "no RLS" answer, not a bug — degrade quietly rather
         # than flooding error tracking. Still capture genuinely unexpected failures.
-        if not isinstance(e, psycopg.errors.InFailedSqlTransaction) and not _is_unsupported_function_error(
-            e, "row_security_active"
+        if (
+            not connection.closed
+            and not connection.broken
+            and not isinstance(e, psycopg.errors.InFailedSqlTransaction)
+            and not _is_unsupported_function_error(e, "row_security_active")
         ):
             capture_exception(e)
         return {}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4219,6 +4219,8 @@ class TestRlsActiveFromConnErrorHandling:
     @staticmethod
     def _conn_raising(exc: Exception):
         conn = mock.MagicMock()
+        conn.closed = False
+        conn.broken = False
         conn.cursor.return_value.__enter__.return_value.execute.side_effect = exc
         return conn
 
@@ -4249,6 +4251,22 @@ class TestRlsActiveFromConnErrorHandling:
                 "current transaction is aborted, commands ignored until end of transaction block"
             )
         )
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+            result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
+        assert result == {}
+        capture_mock.assert_not_called()
+
+    @pytest.mark.parametrize("attr", ["closed", "broken"])
+    def test_dropped_connection_is_not_captured(self, attr):
+        # The shared connection can be dropped by an earlier best-effort probe or a transient blip
+        # (SSH-tunnel hiccup, idle cull), so our `cursor()` call raises `OperationalError: the
+        # connection is closed`. That's a downstream symptom the caller already degrades quietly —
+        # don't flood error tracking with it.
+        conn = mock.MagicMock()
+        conn.closed = False
+        conn.broken = False
+        setattr(conn, attr, True)
+        conn.cursor.side_effect = psycopg.OperationalError("the connection is closed")
         with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
             result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
         assert result == {}


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OperationalError: the connection is closed` raised from `_rls_active_from_conn` in `posthog/temporal/data_imports/sources/postgres/postgres.py` ([issue](https://us.posthog.com/project/2/error_tracking/019ed97f-c878-77f2-aaa9-71dd75f69ac3)). It fires during data-warehouse source-schema discovery (the table picker), with `mechanism.handled = true` — so it is a `capture_exception` call, not a crash. The schema listing itself still succeeds.

`_rls_active_from_conn` is a best-effort lookup that powers the advisory row-level-security warning in the table picker. It runs on a connection **shared** with earlier best-effort metadata probes (primary-key and leading-index discovery). When that connection has already been dropped/closed — a transient SSH-tunnel hiccup, an idle cull, a failover, or an earlier probe killing it — the very first `connection.cursor()` here raises `OperationalError: the connection is closed`.

The function already swallows the failure and returns `{}` (degrading to "no RLS warning"), but its inner `except` calls `capture_exception` for this case. That floods error tracking with a non-actionable downstream symptom — exactly the noise the caller's own connection-level handler (`source.py`) was written to avoid.

## Changes

This is a noise/over-capture bug, not a retry-policy or upstream-credentials issue. The connection being unusable here is a downstream symptom of an earlier drop, conceptually identical to the `InFailedSqlTransaction` case the handler already skips. The fix extends that same skip: don't `capture_exception` when `connection.closed` or `connection.broken` is true. Genuinely unexpected failures on a healthy connection are still captured.

No change to retry behaviour — this function never propagates; it always returns `{}`.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_dropped_connection_is_not_captured`, covering both `closed` and `broken`) asserting the closed-connection error is not captured, and updated the shared test helper to model a live connection so the existing "unexpected error is still captured" case keeps exercising the capture path. Ran the `TestRlsActiveFromConnErrorHandling` suite (5 passed) and `ruff check` / `ruff format` on both files (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Confirmed the failure originates in this source's code (top in-app frame `_rls_active_from_conn`, line 762, `connection.cursor()` on a `[BAD]` connection) and that it is handled/swallowed rather than fatal. Decided it's a fixable over-capture bug rather than a `NonRetryableErrors` candidate: the function does not feed retry logic, and the closed-connection state is an already-handled downstream symptom. Scoped the fix to the existing inner handler, mirroring the adjacent `InFailedSqlTransaction` / unsupported-function skips. No skills were applicable to this change.
