### PR TITLE
refactor(experiments): read variants from the feature flag, not parameters

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
+++ b/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
@@ -25,6 +25,7 @@ import {
     ReactSnippet,
     RubySnippet,
 } from './ExperimentCodeSnippets'
+import { getExperimentVariants } from './utils'
 
 interface ExperimentImplementationDetailsProps {
     experiment: Partial<Experiment> | null
@@ -252,7 +253,7 @@ function PromptExperimentImplementation({
 }
 
 function GenericExperimentImplementation({ experiment }: ExperimentImplementationDetailsProps): JSX.Element {
-    const defaultVariant = experiment?.parameters?.feature_flag_variants?.[1]?.key ?? 'test'
+    const defaultVariant = getExperimentVariants(experiment)[1]?.key ?? 'test'
     const [currentVariant, setCurrentVariant] = useState(defaultVariant)
     const [defaultSelectedOption] = OPTIONS
     const [selectedOption, setSelectedOption] = useState(defaultSelectedOption)
@@ -277,12 +278,10 @@ function GenericExperimentImplementation({ experiment }: ExperimentImplementatio
                                 className="min-w-[5rem]"
                                 onSelect={setCurrentVariant}
                                 value={currentVariant}
-                                options={(experiment?.parameters?.feature_flag_variants || []).map(
-                                    (variant: MultivariateFlagVariant) => ({
-                                        value: variant.key,
-                                        label: variant.key,
-                                    })
-                                )}
+                                options={getExperimentVariants(experiment).map((variant: MultivariateFlagVariant) => ({
+                                    value: variant.key,
+                                    label: variant.key,
+                                }))}
                             />
                         </div>
                         <div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -198,7 +198,8 @@ export function ResumeExperimentModal(): JSX.Element {
 }
 
 export function FinishExperimentModal(): JSX.Element {
-    const { experiment, isSingleVariantShipped, shippedVariantKey, endExperimentLoading } = useValues(experimentLogic)
+    const { experiment, variants, isSingleVariantShipped, shippedVariantKey, endExperimentLoading } =
+        useValues(experimentLogic)
     const { finishExperiment, endExperimentWithoutShipping, restoreUnmodifiedExperiment } = useActions(experimentLogic)
     const { closeFinishExperimentModal } = useActions(modalsLogic)
     const { isFinishExperimentModalOpen } = useValues(modalsLogic)
@@ -210,15 +211,11 @@ export function FinishExperimentModal(): JSX.Element {
     const [releaseToEveryone, setReleaseToEveryone] = useState<boolean>(false)
 
     useEffect(() => {
-        if (experiment.parameters?.feature_flag_variants?.length > 1) {
+        if (variants.length > 1) {
             // First test variant selected by default
-            setSelectedVariantKey(experiment.parameters.feature_flag_variants[1].key)
+            setSelectedVariantKey(variants[1].key)
         }
-    }, [
-        experiment.id,
-        experiment.parameters?.feature_flag_variants?.length,
-        experiment.parameters?.feature_flag_variants,
-    ])
+    }, [experiment.id, variants])
 
     const aggregationTargetName =
         experiment.filters.aggregation_group_type_index != null

--- a/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
+++ b/frontend/src/scenes/experiments/components/ResultsBreakdown/resultsBreakdownLogic.ts
@@ -24,6 +24,7 @@ import {
     getInsight,
     getQuery,
 } from '~/scenes/experiments/metricQueryUtils'
+import { getExperimentVariants } from '~/scenes/experiments/utils'
 import type { Experiment, FunnelStep } from '~/types'
 import {
     BreakdownAttributionType,
@@ -90,7 +91,7 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                     experiment.exposure_criteria?.exposure_config as ExperimentEventExposureConfig,
                     {
                         featureFlagKey: experiment.feature_flag_key,
-                        featureFlagVariants: experiment.parameters.feature_flag_variants,
+                        featureFlagVariants: getExperimentVariants(experiment),
                     }
                 )
 
@@ -198,7 +199,7 @@ export const resultsBreakdownLogic = kea<resultsBreakdownLogicType>([
                         /**
                          * we need to filter the results to remove any non-variant breakdown
                          */
-                        const variants = experiment.parameters.feature_flag_variants.map(({ key }) => key)
+                        const variants = getExperimentVariants(experiment).map(({ key }) => key)
 
                         results = match(results)
                             /**

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2089,13 +2089,18 @@ describe('experimentLogic', () => {
             expected: MultivariateFlagVariant[]
         }>([
             {
-                desc: 'prefers parameters.feature_flag_variants when present',
+                desc: 'prefers the linked flag variants over the parameters mirror',
                 parameterVariants,
                 flagVariants,
+                expected: flagVariants,
+            },
+            {
+                desc: 'falls back to parameters.feature_flag_variants when the flag has no variants (creation flow)',
+                parameterVariants,
                 expected: parameterVariants,
             },
             {
-                desc: 'falls back to the linked flag variants when parameters.feature_flag_variants is absent',
+                desc: 'reads the linked flag variants when parameters has no mirror',
                 flagVariants,
                 expected: flagVariants,
             },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -108,6 +108,7 @@ import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from './SharedMetrics/sharedMetricsLogic'
 import {
     featureFlagEligibleForExperiment,
+    getExperimentVariants,
     getOrderedMetricsWithResults,
     initializeMetricOrdering,
     isLegacyExperiment,
@@ -2689,16 +2690,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 return hasEnded(experiment) && !experiment.archived
             },
         ],
-        variants: [
-            (s) => [s.experiment],
-            (experiment): MultivariateFlagVariant[] => {
-                return (
-                    experiment?.parameters?.feature_flag_variants ??
-                    experiment?.feature_flag?.filters?.multivariate?.variants ??
-                    []
-                )
-            },
-        ],
+        variants: [(s) => [s.experiment], (experiment): MultivariateFlagVariant[] => getExperimentVariants(experiment)],
         excludedVariants: [
             (s) => [s.experiment],
             (experiment: Experiment): string[] => experiment?.parameters?.excluded_variants ?? [],

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -22,6 +22,7 @@ import { Experiment, ExperimentIdType } from '~/types'
 import type { experimentTimeseriesLogicType } from './experimentTimeseriesLogicType'
 import { COLORS } from './MetricsView/shared/colors'
 import { getMetricColors, getVariantInterval } from './MetricsView/shared/utils'
+import { getExperimentVariants } from './utils'
 
 export interface ProcessedTimeseriesDataPoint {
     date: string
@@ -288,15 +289,11 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                     const upperBounds = trimmedData.map((d: ProcessedTimeseriesDataPoint) => d.upper_bound)
                     const lowerBounds = trimmedData.map((d: ProcessedTimeseriesDataPoint) => d.lower_bound)
 
-                    // Get variant index from the experiment's stable feature_flag_variants order
+                    // Get variant index from the experiment's stable variant order (flag-sourced)
                     let variantIndex = 0
-                    if (experiment?.parameters?.feature_flag_variants) {
-                        const idx = experiment.parameters.feature_flag_variants.findIndex(
-                            (v: any) => v.key === variantKey
-                        )
-                        if (idx !== -1) {
-                            variantIndex = idx
-                        }
+                    const idx = getExperimentVariants(experiment).findIndex((v) => v.key === variantKey)
+                    if (idx !== -1) {
+                        variantIndex = idx
                     }
 
                     const variantColor = getSeriesColor(variantIndex)

--- a/frontend/src/scenes/experiments/legacy/metricsView/LegacyErrorChecklist.tsx
+++ b/frontend/src/scenes/experiments/legacy/metricsView/LegacyErrorChecklist.tsx
@@ -9,6 +9,7 @@ import { urls } from 'scenes/urls'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { getInsightType, legacyExperimentLogic } from '~/scenes/experiments/legacy'
+import { getExperimentVariants } from '~/scenes/experiments/utils'
 import { ActivityTab, InsightType } from '~/types'
 
 export enum ResultErrorCode {
@@ -127,7 +128,7 @@ export function LegacyErrorChecklist({ error, metric }: { error: any; metric: an
         return <></>
     }
 
-    const variants = experiment?.parameters?.feature_flag_variants || []
+    const variants = getExperimentVariants(experiment)
 
     const { statusCode, hasDiagnostics } = error
 

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -79,6 +79,17 @@ export function getVariantColor(variantKey: string, featureFlagVariants: Multiva
     return variantIndex !== -1 ? getSeriesColor(variantIndex) : 'var(--muted)'
 }
 
+/**
+ * Variants for an experiment, read flag-first. The linked feature flag is the source of truth;
+ * `parameters.feature_flag_variants` is a legacy mirror that only matters while creating an
+ * experiment, before its flag exists. Saved experiments always resolve from the flag.
+ */
+export function getExperimentVariants(experiment: Partial<Experiment> | null | undefined): MultivariateFlagVariant[] {
+    return (
+        experiment?.feature_flag?.filters?.multivariate?.variants ?? experiment?.parameters?.feature_flag_variants ?? []
+    )
+}
+
 export function formatUnitByQuantity(value: number, unit: string): string {
     return value === 1 ? unit : unit + 's'
 }


### PR DESCRIPTION
## Summary

Group A of the experiments variant-source refactor. Introduces a single `getExperimentVariants()` helper in `utils.ts` (flag-first, with the `parameters` buffer kept only as the creation-flow fallback) and routes every **saved-context** variant read through it or the centralized `variants` selector.

### What landed
- `experimentLogic.tsx` — `variants` selector flipped to flag-first via the helper
- `resultsBreakdownLogic.ts` — both reads (removes the non-optional crash risk)
- `experimentTimeseriesLogic.ts`, `ExperimentModals.tsx` (now consumes the `variants` selector), `ExperimentImplementationDetails.tsx`, `LegacyErrorChecklist.tsx`
- `StepBar.tsx` left untouched — it already read the flag; the change just makes its comment fully true

### Intentionally left on `parameters`
Create-form buffer / write path — these move with the buffer migration in a later step: `experimentWizardLogic.ts`, `VariantsPanelCreateFeatureFlag.tsx`, `createExperimentLogic.ts`, `experimentSubmissionValidation.ts`, and the form-field touch/reset paths in `experimentLogic.tsx`.

### Behavior change worth flagging for review
For a saved experiment whose `parameters.feature_flag_variants` had **drifted** from its flag, the UI will now show the flag's variants — the same set the analysis layer already uses. This makes the UI consistent rather than introducing a new discrepancy. It's the one user-visible delta a reviewer should be aware of.

### Verification
- **Typecheck**: clean on all 8 touched files
- **Jest**: `experimentLogic.test.ts` 116/116 (incl. 4 rewritten `variants` cases asserting flag-first precedence), `utils.test.ts` 63/63
- **Lint/format**: clean

### Follow-ups (not in this PR)
- **Group B** — backend `excluded_variants` / `funnel_steps_data_disabled` / `custom_exposure_filter` reads, new-home-first + fallback (incl. the three query runners)
- **Group C** — blocked on adding the `variant_screenshot_media_ids` / `prompt_metadata` model fields

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*