### PR TITLE
feat(agent-platform): drop the concierge's own Slack posting

### DIFF
--- a/products/agent_platform/services/agent-tests/src/examples/agent-concierge/README.md
+++ b/products/agent_platform/services/agent-tests/src/examples/agent-concierge/README.md
@@ -35,20 +35,12 @@ behaviour, diagnoses root causes, and for each concrete fix branches
 a **draft** revision with the change applied (validated, never frozen
 or promoted — drafts are proposals a human reviews). The findings
 land as a structured report in memory (`reports/fleet-audit/{date}.md`
-
-- `latest.md`) and a condensed digest is optionally posted to the
-  team's configured Slack channel.
+plus `latest.md`), which is the deliverable of the sweep.
 
 The run is deliberately read-and-propose: the skill forbids
 freeze / promote / archive / delete, leaving the validated drafts for
 the user to review and promote themselves. See
 [`skills/auditing-the-fleet/SKILL.md`](skills/auditing-the-fleet/SKILL.md).
-
-**Operator config.** Slack delivery is opt-in: set
-`config/fleet-audit.md` in the agent's memory with a
-`slack_channel: C0XXXXXXX` line and set the agent's `SLACK_BOT_TOKEN`
-secret. Without a channel the audit skips the post silently — the
-memory report is the source of truth regardless.
 
 For each mode, the concierge calls the same `agent-applications-*`
 native tools that the authoring AI uses,
@@ -87,7 +79,7 @@ agent-concierge/
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Native             | `@posthog/agent-applications-*` (list, retrieve, revisions, sessions, logs + the draft edit + validate verbs)            | Read agent state — applications, revisions, sessions, logs — as the connected user. Routed through the credential broker; no platform credentials, no impersonation.                                     |
 | Native (telemetry) | `@posthog/query`                                                                                                         | HogQL the agent's LLM-observability events (`$ai_generation` / `$ai_span` / `$ai_trace`) the runner captured into the team's project. Powers debug + improve evidence — see `querying-ai-observability`. |
-| Native (audit I/O) | `@posthog/memory-search`, `@posthog/memory-read`, `@posthog/memory-write`, `@posthog/slack-post-message`                 | Durable outputs of a fleet audit — persist the report to memory, post the digest to Slack (reads the agent's own `SLACK_BOT_TOKEN`).                                                                     |
+| Native (audit I/O) | `@posthog/memory-search`, `@posthog/memory-read`, `@posthog/memory-write`                                                | Durable output of a fleet audit — persist the report to memory.                                                                                                                                          |
 | Client             | `focus_tab`, `focus_file`, `focus_revision`, `focus_session`, `focus_spec_section`, `toast`, `get_context`, `set_secret` | Drive the console's read panel + read the user's current view. No-op outside the console.                                                                                                                |
 
 ## Auth model

--- a/products/agent_platform/services/agent-tests/src/examples/agent-concierge/agent.md
+++ b/products/agent_platform/services/agent-tests/src/examples/agent-concierge/agent.md
@@ -167,7 +167,7 @@ is a routine cause of confusion; keep the table in mind.
 | Native             | `@posthog/agent-applications-list`, `@posthog/agent-applications-retrieve`, `@posthog/agent-applications-sessions-retrieve`, `@posthog/agent-applications-session-logs` (etc.) | The bulk of your work. Read agent state — applications, revisions, sessions, logs — as the connected user. Each takes a `project_id` (see hard rule #7).                                                                                                                   |
 | Native (projects)  | `@posthog/list-projects`                                                                                                                                                       | Enumerate the projects the user can act in (id + name). Use to resolve `project_id` when `get_context` didn't supply one or the user's intent is ambiguous — show them and ask which to use.                                                                               |
 | Native (telemetry) | `@posthog/query`                                                                                                                                                               | HogQL the agent's LLM-observability events (`$ai_generation` / `$ai_span` / `$ai_trace`) the runner captured into the team's project. Use when debugging or improving an agent — load `skills/querying-ai-observability` for the event contract + the queries that matter. |
-| Native (audit I/O) | `@posthog/memory-search`, `@posthog/memory-read`, `@posthog/memory-write`, `@posthog/slack-post-message`                                                                       | The durable outputs of a fleet audit — persist the report to memory, optionally post a digest to Slack. Used by `skills/auditing-the-fleet` when a user asks for a fleet-wide sweep.                                                                                       |
+| Native (audit I/O) | `@posthog/memory-search`, `@posthog/memory-read`, `@posthog/memory-write`                                                                                                      | The durable output of a fleet audit — persist the report to memory. Used by `skills/auditing-the-fleet` when a user asks for a fleet-wide sweep.                                                                                                                           |
 | Client             | `focus_tab`, `focus_file`, `focus_revision`, `focus_session`, `focus_spec_section`, `toast`, `get_context`                                                                     | Driving the host UI / reading the user's current view. Implementation lives in the connecting client (the dock).                                                                                                                                                           |
 
 ### The agent-management tools
@@ -292,13 +292,10 @@ Every `focus_*` returns `{ focused: true, kind }` on success or `{ focused: fals
 
 If a client tool returns `unhandled_client_tool: <id>` or `client_tool_timeout`, you're in an environment that doesn't implement it (MCP / IDE / etc.). Degrade to text — don't keep retrying.
 
-You have `@posthog/slack-post-message` for posting to Slack on the
-team's behalf — e.g. a fleet-audit digest when a user asks for a sweep
-(see `skills/auditing-the-fleet`). It reads the agent's own
-`SLACK_BOT_TOKEN`. You don't need it to reply to the person you're
-talking to: your own triggers are chat + MCP, where the platform
-streams your text back to the client — there, your reply _is_ the
-channel.
+You don't post to Slack yourself — your own triggers are chat + MCP,
+where the platform streams your text back to the client, so your reply
+_is_ the channel. (A fleet-audit sweep lands its report in memory, not
+Slack — see `skills/auditing-the-fleet`.)
 
 **The same now holds for the Slack-triggered agents you build.** The
 platform relays each finalized assistant message into the originating

--- a/products/agent_platform/services/agent-tests/src/examples/agent-concierge/skills/auditing-the-fleet/SKILL.md
+++ b/products/agent_platform/services/agent-tests/src/examples/agent-concierge/skills/auditing-the-fleet/SKILL.md
@@ -158,27 +158,11 @@ Report shape:
 Lead with the delta. A reviewer skimming the report wants "what's new
 or worse" in the first five lines, not a re-read of the last sweep.
 
-### 6. Post the Slack digest
+### 6. Done — the memory report is the deliverable
 
-The condensed projection of the TL;DR + the agents that need
-action. `slack-post-message` to the team's fleet-audit channel.
-
-**Resolving the channel.** The channel id is operator config, not
-something you invent:
-
-1. Look for it in memory: `memory-read` `config/fleet-audit.md`
-   (a `slack_channel: C0XXXXXXX` line). That's the source of truth.
-2. If it's not set, **skip the Slack post silently** — do not guess a
-   channel, do not fail the run. The memory report is complete on its
-   own; note `slack: not configured` in the report so the operator
-   knows to set `config/fleet-audit.md` if they want the digest.
-
-Slack mrkdwn, not markdown: bold is `*text*`, links are
-`<url|text>`, headers don't render. Keep it phone-readable — ~10–15
-lines, worst-first, link nothing the reader can't act on. If
-`slack-post-message` errors (`SLACK_BOT_TOKEN` missing / bad
-channel), log it in the report (`slack: failed — <reason>`) and
-finish — the report already landed, the run is not a failure.
+The structured report in memory (`reports/fleet-audit/{date}.md` plus
+`latest.md`) is the complete output of the sweep. Point the operator at
+it. There is no Slack post step — the concierge doesn't post to Slack.
 
 ## Scope guard — what this run must NOT do
 

--- a/products/agent_platform/services/agent-tests/src/examples/agent-concierge/spec.json
+++ b/products/agent_platform/services/agent-tests/src/examples/agent-concierge/spec.json
@@ -107,10 +107,6 @@
         },
         {
             "kind": "native",
-            "id": "@posthog/slack-post-message"
-        },
-        {
-            "kind": "native",
             "id": "@posthog/agent-applications-create"
         },
         {
@@ -410,7 +406,7 @@
         }
     ],
     "integrations": [],
-    "secrets": ["SLACK_BOT_TOKEN"],
+    "secrets": [],
     "limits": {
         "max_turns": 80,
         "max_tool_calls": 300,


### PR DESCRIPTION
## What

Removes the agent-concierge bundle's **own** Slack-posting capability so it deploys with **zero secret config**.

The bundle declared `secrets: ["SLACK_BOT_TOKEN"]` (used by `@posthog/slack-post-message` to post a fleet-audit digest to Slack). Declared secrets **gate promote**, so deploying/seeding the concierge required setting a Slack token — for an optional, rarely-wired extra. The fleet audit's real deliverable is the structured **memory report**, which it already writes regardless.

## Changes

- **`spec.json`** — `secrets: []` (was `["SLACK_BOT_TOKEN"]`) and removed the `@posthog/slack-post-message` native tool (42 → 41 tools). This is what unblocks promote with no secret.
- **`skills/auditing-the-fleet/SKILL.md`** — dropped the "post the Slack digest" step; the memory report is the deliverable.
- **`agent.md`** — removed slack-post-message from the concierge's tool table and the "you have slack-post-message" note (it no longer posts to Slack itself).
- **`README.md`** — docs hygiene to match.

## Kept intact

All the Slack **teaching** content — `setting-up-slack-app`, `secrets-and-integrations`, and the `agent.md` guidance on wiring Slack into the agents the concierge *builds for users*. The concierge still helps people build Slack-triggered agents; it just doesn't post to Slack on its own.

## Test

`pnpm --filter @posthog/agent-tests test cases/example-agent-concierge` → **11/11 green** (every remaining native tool resolves, both triggers present, client tools + approval gates intact).

## Why now

Lets the concierge be seeded to prod (e.g. prod-US, PostHog's primary org) via `services/agent-tests/src/examples/seed.py` without juggling a `SLACK_BOT_TOKEN` / `SEED_DUMMY_SECRETS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)