### PR TITLE
feat(phai): set posthog ai sandbox interactivity window to 10 minutes

### DIFF
--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -41,6 +41,14 @@ from products.tasks.backend.temporal.client import execute_task_processing_workf
 
 logger = structlog.get_logger(__name__)
 
+# A PostHog AI sandbox session is a live chat: if the user goes quiet for this long
+# they've moved on, so the Run's workflow times out and reclaims the sandbox. Passed
+# as the per-task `inactivity_timeout_seconds` override on every Run we create, so the
+# workflow's idle timer and the SSE relay's freshness window both honor it (both read
+# it from Run state). Shorter than the generic user-origin default, which assumes a
+# human may still return much later.
+SANDBOX_INACTIVITY_TIMEOUT_SECONDS = 10 * 60
+
 
 class SandboxRouteResult(BaseModel):
     """Outcome of routing one sandbox message — the IDs the frontend opens SSE against."""
@@ -190,7 +198,12 @@ class SandboxSession(BaseSandboxService):
         # dispatches the workflow on commit; it is idempotent (an existing non-terminal Run is returned
         # as-is). `systemPrompt` is the one PostHog AI-specific Run-state key the generic warmer can't know.
         try:
-            result = SandboxWarmer(task, user=self.user).warm(extra_state={"systemPrompt": system_prompt})
+            result = SandboxWarmer(task, user=self.user).warm(
+                extra_state={
+                    "systemPrompt": system_prompt,
+                    "inactivity_timeout_seconds": SANDBOX_INACTIVITY_TIMEOUT_SECONDS,
+                }
+            )
         except exceptions.Throttled:
             # Warm-pool cap reached between the pre-check and the lock — best-effort no-op (no handle).
             logger.info(
@@ -237,6 +250,7 @@ class SandboxSession(BaseSandboxService):
             repository=None,
             create_pr=False,
             mode="interactive",
+            inactivity_timeout_seconds=SANDBOX_INACTIVITY_TIMEOUT_SECONDS,
             # Defer the workflow so the initial run state can carry the PostHog AI keys.
             start_workflow=False,
         )
@@ -411,6 +425,7 @@ class SandboxSession(BaseSandboxService):
                 # The full, undeduped list — survives for the life of the new Run.
                 "attached_context": attached_context,
                 "initial_permission_mode": "default",
+                "inactivity_timeout_seconds": SANDBOX_INACTIVITY_TIMEOUT_SECONDS,
             }
             # Carry the prior Run's snapshot forward so the resume reuses its filesystem.
             snapshot_external_id = (run.state or {}).get("snapshot_external_id")

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -8,7 +8,11 @@ from rest_framework import exceptions
 from posthog.exceptions import Conflict, QuotaLimitExceeded
 
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
-from products.posthog_ai.backend.message_routing import SandboxSession, lock_conversation_for_followup
+from products.posthog_ai.backend.message_routing import (
+    SANDBOX_INACTIVITY_TIMEOUT_SECONDS,
+    SandboxSession,
+    lock_conversation_for_followup,
+)
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
@@ -75,6 +79,8 @@ class TestOpenSandboxMessage(APIBaseTest):
         assert kwargs["create_pr"] is False
         assert kwargs["mode"] == "interactive"
         assert kwargs["start_workflow"] is False
+        # The sandbox session pins its short interactivity window as a per-task override.
+        assert kwargs["inactivity_timeout_seconds"] == SANDBOX_INACTIVITY_TIMEOUT_SECONDS
 
         # Run state enriched with the PostHog AI per-Run keys; full undeduped context.
         run.refresh_from_db()
@@ -242,6 +248,7 @@ class TestOpenSandboxMessage(APIBaseTest):
         assert new_run.state["snapshot_external_id"] == "snap-9"
         assert new_run.state["systemPrompt"] == "SYS"
         assert new_run.state["initial_permission_mode"] == "default"
+        assert new_run.state["inactivity_timeout_seconds"] == SANDBOX_INACTIVITY_TIMEOUT_SECONDS
         assert "resume please" in new_run.state["pending_user_message"]
 
         m_workflow.assert_called_once()
@@ -415,6 +422,7 @@ class TestSandboxWarmViaOpen(APIBaseTest):
         assert run.state["systemPrompt"] == "SYS"
         assert run.state["await_user_message"] is True
         assert run.state["initial_permission_mode"] == "default"
+        assert run.state["inactivity_timeout_seconds"] == SANDBOX_INACTIVITY_TIMEOUT_SECONDS
         # No pending message / attached context: the session boots and idles awaiting input.
         assert "pending_user_message" not in run.state
         assert "attached_context" not in run.state


### PR DESCRIPTION
## Problem

A PostHog AI sandbox session is a live chat. Until now its backing Run inherited the generic non-user inactivity default (30 minutes), so a sandbox could stay provisioned for half an hour after the user had clearly moved on — holding a worker longer than the interaction warranted.

We want the interactivity window for these sessions to be a deliberate 10 minutes: if the user goes quiet that long, the Run's workflow times out and reclaims the sandbox.

## Changes

Set a 10-minute interactivity window for every PostHog AI sandbox Run, carried as the existing per-task `inactivity_timeout_seconds` override on the Run's state.

- New product-owned constant `SANDBOX_INACTIVITY_TIMEOUT_SECONDS = 10 * 60` in `products/posthog_ai/backend/message_routing.py`.
- Applied on all three Run-creation paths in `SandboxSession`: warm (`SandboxWarmer.warm` extra_state), first message (`Task.create_and_run(inactivity_timeout_seconds=…)`), and terminal resume (`create_run` extra_state).

Why through Run state rather than a new origin-aware default in the shared `tasks` resolver: both consumers of the timeout — the workflow's idle timer (`TaskProcessingContext.inactivity_timeout()`) and the SSE relay's freshness window (`relay_sandbox_events`) — already read the per-task override from Run state. Passing it this way needs **zero changes to the shared `tasks` module** and keeps the policy owned by the product that sets it.

One behavioral note for reviewers: the per-task override is priority #1 in `resolve_inactivity_timeout`, so it outranks the `TASKS_INACTIVITY_TIMEOUT_SECONDS` env knob and the `TEST` default. This is the documented "most specific signal wins" behavior; the practical effect is that a local `TASKS_INACTIVITY_TIMEOUT_SECONDS` fast-shutdown override no longer applies to PostHog AI Runs.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I ran locally, all passing:

- `products/posthog_ai/backend/test/test_message_routing.py` (34 passed) — extended to assert the 10-minute override lands on run state for the warm and terminal-resume paths and on the `create_and_run` kwargs for the first-message path.
- `products/tasks/backend/temporal/process_task/tests/test_inactivity_timeout.py` (16 passed) — unchanged; confirms the per-task override resolves as expected.

ruff check + format: clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy directed this work in a Claude Code session. The initial implementation keyed the inactivity timeout on the PostHog AI origin inside the shared `resolve_inactivity_timeout`; on Georgiy's prompt ("why don't we pass it through the state?") it was reworked to use the existing per-task `inactivity_timeout_seconds` override carried on Run state, which removed all changes to the shared `tasks` module. No repo skills were invoked.

Stacked on `feat/posthog-ai-sandboxes` because the edited file (`message_routing.py`) doesn't exist on master yet.
