### PR TITLE
chore: add CDC schedule link to schema admin page

### DIFF
--- a/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
+++ b/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
@@ -255,6 +255,16 @@
             <a href="{{ temporal_ui_host }}/namespaces/{{ temporal_namespace }}/schedules/{{ original.id }}"
                target="_blank">View schedule in Temporal</a>
         </div>
+        {% if cdc_extraction_schedule_id %}
+        <div class="form-row" style="padding: 10px;">
+            <a href="{{ temporal_ui_host }}/namespaces/{{ temporal_namespace }}/schedules/{{ cdc_extraction_schedule_id }}"
+               target="_blank">View CDC extraction schedule in Temporal</a>
+            <p class="help">
+                For CDC schemas, the per-schema schedule above is paused once streaming starts.
+                This source-level schedule is what drives the actual change capture.
+            </p>
+        </div>
+        {% endif %}
     </fieldset>
 
     <fieldset class="module aligned">

--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -17,7 +17,6 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFo
 from posthog.temporal.utils import ExternalDataWorkflowInputs
 
 from products.data_warehouse.backend.data_load.service import (
-    _get_cdc_extraction_schedule_id,
     pause_external_data_schedule,
     unpause_external_data_schedule,
 )
@@ -398,7 +397,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             # CDC schemas stream via a source-level extraction schedule; the per-schema schedule
             # above is paused once streaming starts, so surface the real one too.
             if obj.is_cdc:
-                extra_context["cdc_extraction_schedule_id"] = _get_cdc_extraction_schedule_id(str(obj.source_id))
+                extra_context["cdc_extraction_schedule_id"] = f"cdc-extraction-{obj.source_id}"
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 
     @admin.display(description="Team")

--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -17,6 +17,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFo
 from posthog.temporal.utils import ExternalDataWorkflowInputs
 
 from products.data_warehouse.backend.data_load.service import (
+    _get_cdc_extraction_schedule_id,
     pause_external_data_schedule,
     unpause_external_data_schedule,
 )
@@ -393,6 +394,11 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             extra_context["unpause_schedule_url"] = reverse(
                 "admin:external_data_schema_unpause_schedule", args=[obj.id]
             )
+
+            # CDC schemas stream via a source-level extraction schedule; the per-schema schedule
+            # above is paused once streaming starts, so surface the real one too.
+            if obj.is_cdc:
+                extra_context["cdc_extraction_schedule_id"] = _get_cdc_extraction_schedule_id(str(obj.source_id))
         return super().change_view(request, object_id, form_url, extra_context=extra_context)
 
     @admin.display(description="Team")


### PR DESCRIPTION
## Problem

We currently only link to the (paused) 'conventional' sync schedule in Temporal when CDC syncs are enabled.

## Changes

When CDC syncs are enabled for a schema, link to that in addition to the paused schedule. Make it clear in the wording that the schedule is source level, not specific to the schema.