### PR TITLE
fix(data-warehouse): surface plain-English custom manifest validation errors

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -276,12 +276,38 @@ def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
             )
 
 
+# Plain-English replacements for the pydantic constraint messages users hit most
+# when hand-authoring a manifest; an unmapped error keeps pydantic's own wording.
+_VALIDATION_MESSAGE_OVERRIDES = {
+    "string_too_short": "must not be empty",
+}
+
+
+def _render_error_location(loc: tuple[Any, ...]) -> str:
+    """Render a pydantic ``loc`` tuple as a path that mirrors the manifest JSON,
+    e.g. ``("resources", 0, "endpoint", "path")`` -> ``resources[0].endpoint.path``."""
+    rendered = ""
+    for part in loc:
+        if isinstance(part, int):
+            rendered += f"[{part}]"
+        elif rendered:
+            rendered += f".{part}"
+        else:
+            rendered = str(part)
+    return rendered
+
+
 def _format_validation_errors(exc: ValidationError) -> str:
-    """Render Pydantic's validation errors as a single user-facing string."""
+    """Render Pydantic's validation errors as a single user-facing string.
+
+    Pydantic's positional loc tuples and raw constraint wording ("String should
+    have at least 1 character") read like internals to someone editing manifest
+    JSON, so mirror the JSON path and swap the common messages for plainer English.
+    """
     messages: list[str] = []
     for error in exc.errors():
-        location = ".".join(str(part) for part in error["loc"])
-        message = error["msg"].removeprefix("Value error, ")
+        location = _render_error_location(error["loc"])
+        message = _VALIDATION_MESSAGE_OVERRIDES.get(error["type"], error["msg"].removeprefix("Value error, "))
         messages.append(f"{location}: {message}" if location else message)
     return "; ".join(messages)
 

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -84,6 +84,17 @@ class TestValidateManifest(SimpleTestCase):
             validate_manifest(manifest)
         assert expected_substring in str(ctx.exception)
 
+    def test_empty_required_strings_give_plain_message(self):
+        # Empty required fields used to surface pydantic's raw "String should have at
+        # least 1 character" with positional paths; assert the friendlier, JSON-mirroring form.
+        manifest = {"client": {"base_url": ""}, "resources": [{"name": "", "endpoint": {"path": ""}}]}
+        with self.assertRaises(ManifestValidationError) as ctx:
+            validate_manifest(manifest)
+        message = str(ctx.exception)
+        assert "client.base_url: must not be empty" in message
+        assert "resources[0].name: must not be empty" in message
+        assert "resources[0].endpoint.path: must not be empty" in message
+
     def test_rejects_duplicate_resource_names(self):
         manifest = _minimal_manifest()
         manifest["resources"].append({**manifest["resources"][0]})


### PR DESCRIPTION
## Problem

When someone creates a Custom REST source with empty required fields in their manifest, the wizard showed raw pydantic output: `resources.0.name: String should have at least 1 character; resources.0.endpoint.path: String should have at least 1 character`. The positional loc paths and pydantic's internal constraint wording read like internals — they don't map cleanly to the JSON the user is editing.

This surfaced in failed source-creation telemetry: every custom-source failure yesterday was this leaked pydantic text.

## Changes

`_format_validation_errors` now:

- Renders the error location to mirror the manifest JSON: `("resources", 0, "endpoint", "path")` → `resources[0].endpoint.path` instead of `resources.0.endpoint.path`.
- Swaps the common `string_too_short` constraint message for `must not be empty` (unmapped error types keep pydantic's wording).

So the example above becomes `resources[0].name: must not be empty; resources[0].endpoint.path: must not be empty`.

No change to which manifests are accepted or rejected — only the wording of the error returned to the user.

## How did you test this code?

I'm an agent. Automated only — no manual testing.

- Added `test_empty_required_strings_give_plain_message` asserting the friendlier output for empty `base_url`, resource name, and endpoint path.
- Ran the full custom-source test file (`posthog/temporal/data_imports/sources/custom/test_custom_source.py`): 151 passed.
- `ruff check` / `ruff format` clean on both touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over yesterday's data-warehouse source-creation failures. Each custom-source failure was leaked pydantic validation text, classified as an internal error reaching the user. The fix is deliberately minimal — it only rewords the message and keeps the existing per-error format (so the dotted field names tests already pin still hold), rather than restructuring validation. Other source types in the same triage either had clear, actionable messages already or are covered by existing open PRs.

No skills were applicable to this change.
