### PR TITLE
feat(llma): teach Max where the add-to-dashboard button lives

### DIFF
--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -75,7 +75,7 @@ When users ask about SQL variables or query variables, use SQL mode and query `s
 
 When users ask how to log out, sign out, or where the logout button is: it lives in the account menu at the top of the left navigation sidebar – click the organization logo / project name at the top-left, then "Log out" near the bottom of the menu that opens. It is also reachable from the command palette (Cmd/Ctrl+K → type "logout") and from Settings search ("logout"). Logout is NOT a setting under Project, Organization, or User settings pages – do not direct users there.
 
-When users ask how to add an insight to a dashboard (including when saving or doing "save as"): the "Add to dashboard" button lives in the "Actions" side panel, not in the main insight toolbar. Open it by clicking the "Actions" tab in the right-hand side panel, or by appending `#panel=info` to the insight's URL. Once the Actions panel is open, use the "Add to dashboard" button there.
+When users ask how to add an insight to a dashboard: the "Add to dashboard" button lives in the "Actions" side panel, not in the main insight toolbar. Open it by clicking the "Actions" tab in the right-hand side panel, or by appending `#panel=info` to the insight's URL. Once the Actions panel is open, use the "Add to dashboard" button there.
 </basic_functionality>
 """.strip()
 

--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -74,6 +74,8 @@ When users ask about SQL variables or query variables, use SQL mode and query `s
 `SELECT id, name, code_name, type, default_value, values FROM system.insight_variables WHERE name ILIKE '%term%' OR code_name ILIKE '%term%' LIMIT 20`.
 
 When users ask how to log out, sign out, or where the logout button is: it lives in the account menu at the top of the left navigation sidebar – click the organization logo / project name at the top-left, then "Log out" near the bottom of the menu that opens. It is also reachable from the command palette (Cmd/Ctrl+K → type "logout") and from Settings search ("logout"). Logout is NOT a setting under Project, Organization, or User settings pages – do not direct users there.
+
+When users ask how to add an insight to a dashboard (including when saving or doing "save as"): the "Add to dashboard" button lives in the "Actions" side panel, not in the main insight toolbar. Open it by clicking the "Actions" tab in the right-hand side panel, or by appending `#panel=info` to the insight's URL. Once the Actions panel is open, use the "Add to dashboard" button there.
 </basic_functionality>
 """.strip()
 


### PR DESCRIPTION
## Problem

Users (including a public request on Twitter) find it hard to discover that adding an insight to a dashboard happens via the "Add to dashboard" button in the **Actions** side panel rather than the main insight toolbar. When asked, Max didn't know where this button lives.

## Changes

Adds one line of UI navigation guidance to `BASIC_FUNCTIONALITY_PROMPT`, following the existing logout-button precedent: the "Add to dashboard" button lives in the "Actions" side panel, openable via the Actions tab or by appending `#panel=info` to the insight URL. The single edit flows into both the regular chat agent and plan-mode agent prompts.

## How did you test this code?

I'm an agent (PostHog Slack app). No automated tests were run — this is a prompt-string addition with no logic change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack by Paul D'Ambra. Located the agent prompt building blocks in `ee/hogai/chat_agent/prompts/base.py` and confirmed the `#panel=info` hash mechanism in the frontend (`sidePanelStateLogic.tsx` maps `panel=info` to the side panel tab labeled "Actions", which renders the `InsightPanelActions` "Add to dashboard" button). Added the hint right after the existing logout-navigation example so it matches the established pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781773153160299?thread_ts=1781773153.160299&cid=C0ACRAMJUAG)*
