### PR TITLE
feat(session-replay): emit surfacing sweep backlog gauge

### DIFF
--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/README.md
@@ -283,6 +283,7 @@ Temporal SDK metrics (Prometheus on the worker metrics port):
 | `surfacing_scoring_total_fetched`                          | counter   | end of each tick (`total_fetched > 0`) |
 | `surfacing_scoring_total_scored`                           | counter   | end of each tick (`total_scored > 0`)  |
 | `surfacing_scoring_chunks_failed`                          | counter   | end of each tick (`chunks_failed > 0`) |
+| `surfacing_scoring_estimated_backlog`                      | gauge     | start of each tick (`list_chunks`)     |
 | `surfacing_scoring_score_chunk_activity_execution_latency` | histogram | each `score_chunk_activity` run        |
 
 `total_fetched` is rows the feature SELECT returned from ClickHouse;

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
@@ -59,6 +59,7 @@ from posthog.temporal.session_replay.surfacing_scoring_sweep.features import (
     out_of_contract_row_mask,
     validate_features,
 )
+from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import record_backlog_estimate
 from posthog.temporal.session_replay.surfacing_scoring_sweep.scorer import get_feature_names, predict
 from posthog.temporal.session_replay.surfacing_scoring_sweep.types import (
     ChunkResult,
@@ -98,6 +99,7 @@ async def list_chunks_activity(_inputs: ScoreSessionsBatchInputs) -> ListChunksR
 
     sampled = await sync_to_async(_count_unscored_in_one_bucket, thread_sensitive=False)(lookback_days, of_chunks)
     estimated_total = sampled * of_chunks
+    record_backlog_estimate(estimated_total)
 
     chunks = [
         ChunkSpec(

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/metrics.py
@@ -31,6 +31,16 @@ TOTAL_SCORED_DESCRIPTION = "Sessions scored in a surfacing scoring sweep tick"
 CHUNKS_FAILED_COUNTER = "surfacing_scoring_chunks_failed"
 CHUNKS_FAILED_DESCRIPTION = "Hash-partitioned chunks that failed in a surfacing scoring sweep tick"
 
+ESTIMATED_BACKLOG_GAUGE = "surfacing_scoring_estimated_backlog"
+ESTIMATED_BACKLOG_DESCRIPTION = (
+    "Estimated eligible-but-unscored session backlog (one hash bucket sampled, extrapolated)"
+)
+
+
+def record_backlog_estimate(estimated: int) -> None:
+    # Gauge, not counter: it's a standing quantity, and 0 (caught up) is meaningful — emit unconditionally.
+    get_metric_meter().create_gauge(ESTIMATED_BACKLOG_GAUGE, ESTIMATED_BACKLOG_DESCRIPTION).set(max(0, estimated))
+
 
 def record_tick_summary(*, total_scored: int, total_fetched: int, chunks_failed: int) -> None:
     if total_scored <= 0 and total_fetched <= 0 and chunks_failed <= 0:

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_activities.py
@@ -52,6 +52,16 @@ class TestListChunksActivity:
 
         assert result.estimated_unscored_sessions == 42 * DEFAULT_OF_CHUNKS
 
+    @pytest.mark.asyncio
+    async def test_emits_backlog_gauge_with_extrapolated_estimate(self) -> None:
+        with (
+            mock.patch(f"{ACTIVITIES_MODULE}._count_unscored_in_one_bucket", return_value=42),
+            mock.patch(f"{ACTIVITIES_MODULE}.record_backlog_estimate") as record_backlog_mock,
+        ):
+            await ActivityEnvironment().run(list_chunks_activity, ScoreSessionsBatchInputs())
+
+        record_backlog_mock.assert_called_once_with(42 * DEFAULT_OF_CHUNKS)
+
 
 class TestBuildPartialRow:
     def test_naive_datetime_is_treated_as_utc(self) -> None:


### PR DESCRIPTION
## Problem

The surfacing scoring sweep dashboard can chart *flow* (sessions pulled/scored per tick, from existing counters) but not the *standing backlog* — how many eligible-but-unscored sessions remain. There was no metric for it, so you can't see whether the backlog is draining or growing over time.

## Changes

Emit a new gauge `surfacing_scoring_estimated_backlog` from `list_chunks_activity`, reusing the per-tick estimate the sweep **already computes** (`count_unscored_sql` sampled over one hash bucket, extrapolated ×`of_chunks`). That estimate is exactly the eligible-but-unscored pool — unscored, within the lookback window, and eventful (`sum(event_count) > 0`) — so it maps directly to "work left to do."

It's a **gauge** rather than a counter because it's a standing quantity and `0` (caught up) is meaningful, so it's emitted unconditionally each tick. Dashboards should aggregate with `max()` across pods, since the value is set by whichever worker ran `list_chunks` that tick.

No new query cost — the estimate was already being computed and logged every tick; this just also publishes it as a metric.

## How did you test this code?

I'm an agent (Claude Code) — no manual testing. Added a unit test asserting `list_chunks_activity` emits the gauge with the extrapolated estimate (`record_backlog_estimate` called with `sampled * of_chunks`); full `test_activities.py` passes (13 tests), lint + `ty` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the surfacing-sweep fix (#64406). Built with Claude Code to back a new Grafana "backlog drain" chart. Chose to reuse the existing per-tick backlog estimate (already computed in `list_chunks_activity`) rather than add a separate query, and a gauge over a counter since the backlog is a level, not a flow. Confirmed the Temporal SDK `MetricMeter` exposes `create_gauge` before using it. Agent-authored; requires human review.