### PR TITLE
feat(insights): A/A/B test add-to-dashboard affordances

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -430,6 +430,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_FUNNELS_COMPARE: 'product-analytics-funnels-compare', // owner: @thmsobrmlr #team-product-analytics, gates "Compare to previous" toggle on funnel insights
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
+    INSIGHT_ADD_TO_DASHBOARD_AAB: 'insight-add-to-dashboard-aab', // owner: @pauldambra #team-product-analytics multivariate=control,control_2,test
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUILL_SQL_CHARTS: 'product-analytics-quill-sql-charts', // owner: #team-data-tools, gates rendering DataVisualization line/area charts via @posthog/quill-charts
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -55,12 +55,13 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight } = useActions(
         insightLogic(insightLogicProps)
     )
-    const { openAddToDashboardModal, openAddToDashboardModalAfterSave } = useActions(
-        insightModalsLogic(insightLogicProps)
-    )
+    const { openAddToDashboardModal, saveAndAddToDashboard } = useActions(insightModalsLogic(insightLogicProps))
 
     // B branch of the add-to-dashboard A/A/B test (control + control_2 keep current behavior).
     const isAddToDashboardTest = useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')
+
+    // A saved insight with its own short_id — the precondition for every view-mode action in this header.
+    const isPersistedInsight = !!isSavedInsight && !!insight.short_id
 
     // New insights need a target folder; existing ones save in place. Shared by every save trigger in this header.
     const saveInsightToFolder = (redirectToViewMode?: boolean): void => {
@@ -168,23 +169,20 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             </LemonButton>
                         )}
 
-                        {insightMode !== ItemMode.Edit &&
-                            isAddToDashboardTest &&
-                            isSavedInsight &&
-                            insight.short_id && (
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    icon={<IconPlusSmall />}
-                                    data-attr="insight-add-to-dashboard-prominent-button"
-                                    onClick={() => openAddToDashboardModal()}
-                                >
-                                    Add to dashboard
-                                </LemonButton>
-                            )}
+                        {insightMode !== ItemMode.Edit && isAddToDashboardTest && isPersistedInsight && (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                icon={<IconPlusSmall />}
+                                data-attr="insight-add-to-dashboard-prominent-button"
+                                onClick={() => openAddToDashboardModal()}
+                            >
+                                Add to dashboard
+                            </LemonButton>
+                        )}
 
-                        {insightMode !== ItemMode.Edit && isSavedInsight && insight.short_id && (
-                            <InsightSubscribeProminentButton insightShortId={insight.short_id} />
+                        {insightMode !== ItemMode.Edit && isPersistedInsight && (
+                            <InsightSubscribeProminentButton insightShortId={insight.short_id!} />
                         )}
 
                         {insightMode !== ItemMode.Edit ? (
@@ -235,14 +233,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 // Only offered for already-saved insights: the add-to-dashboard modal is keyed by the
                                 // insight id, so saving a brand-new insight navigates to its real id and re-keys the
                                 // modal logic, dropping the open state. New insights use the view-mode button instead.
-                                // The modal opens on save success (not synchronously) so the save response can't
-                                // overwrite a dashboard the user adds while the save is still in flight.
+                                // `saveAndAddToDashboard` owns the save-then-open ordering (see insightModalsLogic).
                                 onSaveAndAddToDashboard={
-                                    isAddToDashboardTest && isSavedInsight
-                                        ? () => {
-                                              openAddToDashboardModalAfterSave()
-                                              saveInsightToFolder(false)
-                                          }
+                                    isAddToDashboardTest && isPersistedInsight
+                                        ? () => saveAndAddToDashboard()
                                         : undefined
                                 }
                             />

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -55,7 +55,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight } = useActions(
         insightLogic(insightLogicProps)
     )
-    const { openAddToDashboardModal } = useActions(insightModalsLogic(insightLogicProps))
+    const { openAddToDashboardModal, openAddToDashboardModalAfterSave } = useActions(
+        insightModalsLogic(insightLogicProps)
+    )
 
     // B branch of the add-to-dashboard A/A/B test (control + control_2 keep current behavior).
     const isAddToDashboardTest = useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')
@@ -232,13 +234,14 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 insightChanged={insightChanged || queryChanged}
                                 // Only offered for already-saved insights: the add-to-dashboard modal is keyed by the
                                 // insight id, so saving a brand-new insight navigates to its real id and re-keys the
-                                // modal logic, dropping the open state. Saved insights keep the same key, so opening the
-                                // modal right after the in-place save is safe. New insights use the view-mode button.
+                                // modal logic, dropping the open state. New insights use the view-mode button instead.
+                                // The modal opens on save success (not synchronously) so the save response can't
+                                // overwrite a dashboard the user adds while the save is still in flight.
                                 onSaveAndAddToDashboard={
                                     isAddToDashboardTest && isSavedInsight
                                         ? () => {
+                                              openAddToDashboardModalAfterSave()
                                               saveInsightToFolder(false)
-                                              openAddToDashboardModal()
                                           }
                                         : undefined
                                 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -60,6 +60,15 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     // B branch of the add-to-dashboard A/A/B test (control + control_2 keep current behavior).
     const isAddToDashboardTest = useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')
 
+    // New insights need a target folder; existing ones save in place. Shared by every save trigger in this header.
+    const saveInsightToFolder = (redirectToViewMode?: boolean): void => {
+        if (insight.short_id) {
+            saveInsight(redirectToViewMode)
+        } else {
+            saveInsight(redirectToViewMode, getLastNewFolder() ?? 'Unfiled/Insights')
+        }
+    }
+
     const { query, queryChanged, insightQuery, generatedInsightMetadataLoading } = useValues(
         insightDataLogic(insightProps)
     )
@@ -216,23 +225,19 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         ) : (
                             <InsightSaveButton
                                 saveAs={() => saveAs(undefined, undefined, 'Unfiled/Insights')}
-                                saveInsight={(redirectToViewMode) =>
-                                    insight.short_id
-                                        ? saveInsight(redirectToViewMode)
-                                        : saveInsight(redirectToViewMode, getLastNewFolder() ?? 'Unfiled/Insights')
-                                }
+                                saveInsight={saveInsightToFolder}
                                 isSaved={isSavedInsight}
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}
                                 insightSaving={insightSaving}
                                 insightChanged={insightChanged || queryChanged}
+                                // Only offered for already-saved insights: the add-to-dashboard modal is keyed by the
+                                // insight id, so saving a brand-new insight navigates to its real id and re-keys the
+                                // modal logic, dropping the open state. Saved insights keep the same key, so opening the
+                                // modal right after the in-place save is safe. New insights use the view-mode button.
                                 onSaveAndAddToDashboard={
-                                    isAddToDashboardTest
+                                    isAddToDashboardTest && isSavedInsight
                                         ? () => {
-                                              if (insight.short_id) {
-                                                  saveInsight(false)
-                                              } else {
-                                                  saveInsight(false, getLastNewFolder() ?? 'Unfiled/Insights')
-                                              }
+                                              saveInsightToFolder(false)
                                               openAddToDashboardModal()
                                           }
                                         : undefined

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useMemo } from 'react'
 
+import { IconPlusSmall } from '@posthog/icons'
+
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
 import { InsightSubscribeProminentButton } from 'lib/components/Scenes/InsightSubscribeProminentButton'
@@ -9,6 +11,7 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightModalsLogic } from 'scenes/insights/insightModalsLogic'
 import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
@@ -52,6 +55,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight } = useActions(
         insightLogic(insightLogicProps)
     )
+    const { openAddToDashboardModal } = useActions(insightModalsLogic(insightLogicProps))
+
+    // B branch of the add-to-dashboard A/A/B test (control + control_2 keep current behavior).
+    const isAddToDashboardTest = useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')
 
     const { query, queryChanged, insightQuery, generatedInsightMetadataLoading } = useValues(
         insightDataLogic(insightProps)
@@ -150,6 +157,21 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             </LemonButton>
                         )}
 
+                        {insightMode !== ItemMode.Edit &&
+                            isAddToDashboardTest &&
+                            isSavedInsight &&
+                            insight.short_id && (
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    icon={<IconPlusSmall />}
+                                    data-attr="insight-add-to-dashboard-prominent-button"
+                                    onClick={() => openAddToDashboardModal()}
+                                >
+                                    Add to dashboard
+                                </LemonButton>
+                            )}
+
                         {insightMode !== ItemMode.Edit && isSavedInsight && insight.short_id && (
                             <InsightSubscribeProminentButton insightShortId={insight.short_id} />
                         )}
@@ -203,6 +225,18 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}
                                 insightSaving={insightSaving}
                                 insightChanged={insightChanged || queryChanged}
+                                onSaveAndAddToDashboard={
+                                    isAddToDashboardTest
+                                        ? () => {
+                                              if (insight.short_id) {
+                                                  saveInsight(false)
+                                              } else {
+                                                  saveInsight(false, getLastNewFolder() ?? 'Unfiled/Insights')
+                                              }
+                                              openAddToDashboardModal()
+                                          }
+                                        : undefined
+                                }
                             />
                         )}
                     </>

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -39,6 +39,7 @@ export function InsightSaveButton({
                                     onClick={() => saveInsight(false)}
                                     data-attr="insight-save-and-continue"
                                     fullWidth
+                                    loading={insightSaving}
                                 >
                                     {addingToDashboard ? 'Save, add to dashboard' : 'Save'} & continue editing
                                 </LemonButton>
@@ -49,9 +50,8 @@ export function InsightSaveButton({
                                     data-attr="insight-save-and-add-to-dashboard"
                                     fullWidth
                                     loading={insightSaving}
-                                    disabledReason={insightSaving ? 'Saving…' : undefined}
                                 >
-                                    Save & add to dashboard
+                                    Save & add to dashboard…
                                 </LemonButton>
                             )}
                             {saveAsAvailable && (

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -7,6 +7,7 @@ export function InsightSaveButton({
     insightSaving,
     insightChanged,
     addingToDashboard,
+    onSaveAndAddToDashboard,
 }: {
     saveAs: () => void
     saveInsight: (redirectToViewMode?: boolean) => void
@@ -14,6 +15,8 @@ export function InsightSaveButton({
     insightSaving: boolean
     insightChanged: boolean
     addingToDashboard: boolean
+    // When provided (B branch of the add-to-dashboard A/A/B test), adds a "Save & add to dashboard" dropdown option.
+    onSaveAndAddToDashboard?: () => void
 }): JSX.Element {
     const disabled = isSaved && !insightChanged
     const saveAsAvailable = isSaved && !addingToDashboard
@@ -38,6 +41,15 @@ export function InsightSaveButton({
                                     fullWidth
                                 >
                                     {addingToDashboard ? 'Save, add to dashboard' : 'Save'} & continue editing
+                                </LemonButton>
+                            )}
+                            {!disabled && onSaveAndAddToDashboard && (
+                                <LemonButton
+                                    onClick={() => onSaveAndAddToDashboard()}
+                                    data-attr="insight-save-and-add-to-dashboard"
+                                    fullWidth
+                                >
+                                    Save & add to dashboard
                                 </LemonButton>
                             )}
                             {saveAsAvailable && (

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -15,7 +15,7 @@ export function InsightSaveButton({
     insightSaving: boolean
     insightChanged: boolean
     addingToDashboard: boolean
-    // When provided (B branch of the add-to-dashboard A/A/B test), adds a "Save & add to dashboard" dropdown option.
+    // When provided, adds a "Save & add to dashboard" dropdown option that saves then opens the add-to-dashboard modal.
     onSaveAndAddToDashboard?: () => void
 }): JSX.Element {
     const disabled = isSaved && !insightChanged
@@ -48,6 +48,8 @@ export function InsightSaveButton({
                                     onClick={() => onSaveAndAddToDashboard()}
                                     data-attr="insight-save-and-add-to-dashboard"
                                     fullWidth
+                                    loading={insightSaving}
+                                    disabledReason={insightSaving ? 'Saving…' : undefined}
                                 >
                                     Save & add to dashboard
                                 </LemonButton>

--- a/frontend/src/scenes/insights/insightModalsLogic.test.ts
+++ b/frontend/src/scenes/insights/insightModalsLogic.test.ts
@@ -1,0 +1,90 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { sceneLogic } from 'scenes/sceneLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { insightsModel } from '~/models/insightsModel'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { InsightLogicProps, InsightShortId } from '~/types'
+
+import { insightLogic } from './insightLogic'
+import { insightModalsLogic } from './insightModalsLogic'
+
+const Insight42 = '42' as InsightShortId
+
+const savedInsightProps: InsightLogicProps = {
+    dashboardItemId: Insight42,
+    cachedInsight: {
+        id: 42,
+        short_id: Insight42,
+        result: ['result'],
+        saved: true,
+        query: { kind: NodeKind.InsightVizNode, source: { kind: NodeKind.TrendsQuery, series: [] } },
+    } as any,
+}
+
+describe('insightModalsLogic', () => {
+    let logic: ReturnType<typeof insightModalsLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/42': { id: 42, short_id: Insight42, result: ['result'] },
+                '/api/environments/:team_id/insights/': { results: [], count: 0 },
+            },
+            patch: {
+                '/api/environments/:team_id/insights/:id': async ({ request, params }) => {
+                    const payload = (await request.json()) as Record<string, any>
+                    return [200, { ...payload, id: params.id, short_id: Insight42 }]
+                },
+            },
+        })
+        initKeaTests(true, { ...MOCK_DEFAULT_TEAM })
+        teamLogic.mount()
+        sceneLogic.mount()
+        insightsModel.mount()
+        insightLogic(savedInsightProps).mount()
+        logic = insightModalsLogic(savedInsightProps)
+        logic.mount()
+    })
+
+    it('saves first, then opens the add-to-dashboard modal once the save succeeds', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.saveAndAddToDashboard()
+        })
+            .toDispatchActions(['saveAndAddToDashboard', 'saveInsight'])
+            .toMatchValues({ pendingAddToDashboardAfterSave: true })
+            .toDispatchActions(['saveInsightSuccess', 'openAddToDashboardModal'])
+            .toMatchValues({ pendingAddToDashboardAfterSave: false, isAddToDashboardModalOpen: true })
+    })
+
+    it('does not open the modal and clears the pending flag when the save fails', async () => {
+        // Hold the save open so the pending flag stays set, then drive the failure signal directly — this exercises
+        // insightModalsLogic's reaction without depending on insightLogic re-throwing on a real API error.
+        useMocks({ patch: { '/api/environments/:team_id/insights/:id': () => new Promise(() => {}) } })
+
+        await expectLogic(logic, () => {
+            logic.actions.saveAndAddToDashboard()
+        }).toMatchValues({ pendingAddToDashboardAfterSave: true })
+
+        await expectLogic(logic, () => {
+            insightLogic(savedInsightProps).actions.saveInsightFailure()
+        })
+            .toDispatchActions(['saveInsightFailure'])
+            .toNotHaveDispatchedActions(['openAddToDashboardModal'])
+            .toMatchValues({ pendingAddToDashboardAfterSave: false, isAddToDashboardModalOpen: false })
+    })
+
+    it('does not open the modal on a plain save with nothing pending', async () => {
+        await expectLogic(logic, () => {
+            insightLogic(savedInsightProps).actions.saveInsightSuccess()
+        })
+            .toDispatchActions(['saveInsightSuccess'])
+            .toNotHaveDispatchedActions(['openAddToDashboardModal'])
+            .toMatchValues({ pendingAddToDashboardAfterSave: false, isAddToDashboardModalOpen: false })
+    })
+})

--- a/frontend/src/scenes/insights/insightModalsLogic.ts
+++ b/frontend/src/scenes/insights/insightModalsLogic.ts
@@ -12,16 +12,13 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
     path((key) => ['scenes', 'insights', 'insightModalsLogic', key]),
 
     connect((props: InsightLogicProps) => ({
-        actions: [insightLogic(props), ['saveInsightSuccess', 'saveInsightFailure']],
+        actions: [insightLogic(props), ['saveInsight', 'saveInsightSuccess', 'saveInsightFailure']],
     })),
 
     actions({
         openAddToDashboardModal: true,
         closeAddToDashboardModal: true,
-        // Defer opening the add-to-dashboard modal until the in-flight save completes. Opening it concurrently with a
-        // save races the save response (which carries the pre-modal `dashboards` list) against the dashboard the user
-        // picks, silently overwriting that addition. Setting the flag and opening on `saveInsightSuccess` serializes them.
-        openAddToDashboardModalAfterSave: true,
+        saveAndAddToDashboard: true,
         openTerraformModal: true,
         closeTerraformModal: true,
     }),
@@ -37,7 +34,7 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
         pendingAddToDashboardAfterSave: [
             false,
             {
-                openAddToDashboardModalAfterSave: () => true,
+                saveAndAddToDashboard: () => true,
                 openAddToDashboardModal: () => false,
                 closeAddToDashboardModal: () => false,
                 saveInsightFailure: () => false,
@@ -53,6 +50,14 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
     }),
 
     listeners(({ actions, values }) => ({
+        // Save first, then open the add-to-dashboard modal once the save lands. Opening it concurrently with the save
+        // races the save response (which carries the pre-modal `dashboards` list) against the dashboard the user picks,
+        // silently overwriting that addition. `pendingAddToDashboardAfterSave` carries the intent across the save, and
+        // reducers run before listeners, so the flag must NOT be cleared on `saveInsightSuccess` itself — it is read
+        // here and cleared by `openAddToDashboardModal`.
+        saveAndAddToDashboard: () => {
+            actions.saveInsight(false)
+        },
         saveInsightSuccess: () => {
             if (values.pendingAddToDashboardAfterSave) {
                 actions.openAddToDashboardModal()

--- a/frontend/src/scenes/insights/insightModalsLogic.ts
+++ b/frontend/src/scenes/insights/insightModalsLogic.ts
@@ -1,7 +1,8 @@
-import { actions, kea, key, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 
 import { InsightLogicProps } from '~/types'
 
+import { insightLogic } from './insightLogic'
 import type { insightModalsLogicType } from './insightModalsLogicType'
 import { keyForInsightLogicProps } from './sharedUtils'
 
@@ -10,9 +11,17 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'insightModalsLogic', key]),
 
+    connect((props: InsightLogicProps) => ({
+        actions: [insightLogic(props), ['saveInsightSuccess', 'saveInsightFailure']],
+    })),
+
     actions({
         openAddToDashboardModal: true,
         closeAddToDashboardModal: true,
+        // Defer opening the add-to-dashboard modal until the in-flight save completes. Opening it concurrently with a
+        // save races the save response (which carries the pre-modal `dashboards` list) against the dashboard the user
+        // picks, silently overwriting that addition. Setting the flag and opening on `saveInsightSuccess` serializes them.
+        openAddToDashboardModalAfterSave: true,
         openTerraformModal: true,
         closeTerraformModal: true,
     }),
@@ -25,6 +34,15 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
                 closeAddToDashboardModal: () => false,
             },
         ],
+        pendingAddToDashboardAfterSave: [
+            false,
+            {
+                openAddToDashboardModalAfterSave: () => true,
+                openAddToDashboardModal: () => false,
+                closeAddToDashboardModal: () => false,
+                saveInsightFailure: () => false,
+            },
+        ],
         isTerraformModalOpen: [
             false,
             {
@@ -33,4 +51,12 @@ export const insightModalsLogic = kea<insightModalsLogicType>([
             },
         ],
     }),
+
+    listeners(({ actions, values }) => ({
+        saveInsightSuccess: () => {
+            if (values.pendingAddToDashboardAfterSave) {
+                actions.openAddToDashboardModal()
+            }
+        },
+    })),
 ])


### PR DESCRIPTION
## Problem

Adding an insight to a dashboard is buried in the "Actions" side panel, which users find hard to discover (a recurring complaint). We want to test whether surfacing the action more prominently increases dashboard usage — without just shipping it blind.

## Changes

Gated behind a new experiment feature flag `insight-add-to-dashboard-aab` with three variants (`control`, `control_2`, `test`). In the **test (B)** branch only:

- A new **"Save & add to dashboard"** option in the insight save dropdown (edit mode) — saves the insight and opens the add-to-dashboard modal.
- A prominent **"Add to dashboard"** button rendered **before** the Subscribe button (`insight-subscribe-prominent-button`) when viewing a saved insight (not in edit mode).

Both `control` and `control_2` keep the current behavior — the A/A pair validates that the experiment setup produces no false-positive difference, while A/B measures the real effect.

The matching experiment (draft) has been created with two primary metrics: **dashboard visits per user** (mean of `viewed dashboard`) and **7-day dashboard-visit retention**.

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the frontend linter/typecheck — `node_modules` isn't installed in this environment — so these still need to run in CI. Changes are gated behind the experiment flag's `test` variant, so control users are unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack by Paul D'Ambra. Invoked the `creating-experiments` and `configuring-experiment-analytics` skills to set up the A/A/B experiment (id 377997) and its metrics. Code wires `featureFlagLogic` into `InsightPageHeader`; the new save-dropdown option lives in `InsightSaveButton`, and the view-mode button reuses `insightModalsLogic.openAddToDashboardModal`. Chose `viewed dashboard` as the metric event after confirming it exists via `read-data-schema`. Both new affordances carry stable `data-attr`s (`insight-save-and-add-to-dashboard`, `insight-add-to-dashboard-prominent-button`) for downstream analysis.

Experiment: https://us.posthog.com/project/2/experiments/377997

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781773153160299?thread_ts=1781773153.160299&cid=C0ACRAMJUAG)*
