### PR TITLE
fix(replay): harden AWS error matching against split smithy realms

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -272,6 +272,9 @@ describe('EmailService', () => {
                     () => new TooManyRequestsException({ $metadata: {}, message: 'Too many requests' }),
                 ],
                 ['ThrottlingException', () => new ThrottlingException('Rate exceeded')],
+                // Realm-split fallback: duplicate @smithy/core copies make the SDK throw a bare
+                // `Error` with the code in `.message` (name `Error`) instead of the typed exception.
+                ['bare Error with code in message', () => new Error('ThrottlingException')],
             ]
             it.each(throttleCases)('reschedules instead of failing when SES returns %s', async (_name, makeError) => {
                 sendEmailSpy.mockRejectedValueOnce(makeError())

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -43,7 +43,14 @@ const SES_THROTTLE_ERROR_NAMES = ['TooManyRequestsException', 'ThrottlingExcepti
 type SesThrottleErrorName = (typeof SES_THROTTLE_ERROR_NAMES)[number]
 
 function isSesThrottleError(error: unknown): error is Error & { name: SesThrottleErrorName } {
-    return error instanceof Error && (SES_THROTTLE_ERROR_NAMES as readonly string[]).includes(error.name)
+    if (!(error instanceof Error)) {
+        return false
+    }
+    // Duplicate @smithy/core copies can split the schema TypeRegistry across module realms, in
+    // which case the SDK throws a bare `Error` carrying the code in `.message` (name `Error`)
+    // instead of the typed exception — so match on both `.name` and `.message`.
+    const names = SES_THROTTLE_ERROR_NAMES as readonly string[]
+    return names.includes(error.name) || names.includes(error.message)
 }
 
 /**

--- a/nodejs/src/session-replay/recording-api/recording-service.test.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.test.ts
@@ -186,6 +186,16 @@ describe('RecordingService', () => {
             expect(result).toEqual({ ok: false, error: 'not_found' })
         })
 
+        it('returns not_found when S3 surfaces NoSuchKey as a bare Error (split @smithy/core realm)', async () => {
+            // Duplicate @smithy/core copies make the SDK throw `new Error('NoSuchKey')` (code in
+            // .message, name 'Error') instead of the typed exception — must still map to not_found.
+            mockS3Send.mockRejectedValue(new Error('NoSuchKey'))
+
+            const result = await service.getBlock(validParams)
+
+            expect(result).toEqual({ ok: false, error: 'not_found' })
+        })
+
         it('propagates unexpected S3 errors', async () => {
             mockS3Send.mockRejectedValue(new Error('S3 network error'))
 

--- a/nodejs/src/session-replay/recording-api/recording-service.ts
+++ b/nodejs/src/session-replay/recording-api/recording-service.ts
@@ -136,7 +136,11 @@ export class RecordingService {
             )
             return { ok: true, data: result }
         } catch (error) {
-            if (error instanceof NoSuchKey || (error as Error)?.name === 'NoSuchKey') {
+            // `.message` is matched alongside `.name` because duplicate @smithy/core copies can split
+            // the schema TypeRegistry across module realms, making the SDK throw a bare `Error` with the
+            // code in `.message` (name `Error`) rather than the typed NoSuchKey exception.
+            const s3Error = error as Error
+            if (error instanceof NoSuchKey || s3Error?.name === 'NoSuchKey' || s3Error?.message === 'NoSuchKey') {
                 logger.warn('[RecordingService] S3 object not found (NoSuchKey)', {
                     key,
                     teamId,

--- a/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.test.ts
+++ b/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.test.ts
@@ -104,6 +104,48 @@ describe('DynamoDBKeyStore', () => {
             expect(result.sessionState).toBe('ciphertext')
         })
 
+        // Duplicate @smithy/core copies split the schema TypeRegistry across module realms, so the
+        // SDK can throw an untyped error for a conditional-check failure: a bare `Error` carrying the
+        // code in `.message` (name `Error`), or one carrying it in `.name`. Both must still be treated
+        // as a collision rather than re-thrown.
+        it.each([
+            ['code in message (bare Error)', Object.assign(new Error('ConditionalCheckFailedException'), {})],
+            [
+                'code in name',
+                Object.assign(new Error('Key already exists'), { name: 'ConditionalCheckFailedException' }),
+            ],
+        ])('should treat untyped conditional-check failure (%s) as an existing key', async (_label, thrown) => {
+            const existingEncryptedKey = new Uint8Array([201, 202, 203])
+            const existingPlaintextKey = new Uint8Array([
+                11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+            ])
+
+            ;(mockDynamoDBClient.send as jest.Mock).mockRejectedValueOnce(thrown).mockResolvedValueOnce({
+                Item: {
+                    session_id: { S: 'session-123' },
+                    team_id: { N: '1' },
+                    encrypted_key: { B: existingEncryptedKey },
+                    session_state: { S: 'ciphertext' },
+                },
+            })
+            ;(mockKMSClient.send as jest.Mock)
+                .mockResolvedValueOnce({ Plaintext: mockPlaintextKey, CiphertextBlob: mockEncryptedKey })
+                .mockResolvedValueOnce({ Plaintext: existingPlaintextKey })
+
+            const result = await keyStore.generateKey('session-123', 1)
+
+            expect(result.encryptedKey).toEqual(Buffer.from(existingEncryptedKey))
+            expect(result.sessionState).toBe('ciphertext')
+        })
+
+        it('should re-throw genuinely unrelated DynamoDB errors', async () => {
+            ;(mockDynamoDBClient.send as jest.Mock).mockRejectedValueOnce(
+                Object.assign(new Error('Throughput exceeded'), { name: 'ProvisionedThroughputExceededException' })
+            )
+
+            await expect(keyStore.generateKey('session-123', 1)).rejects.toThrow('Throughput exceeded')
+        })
+
         it('should calculate expiration based on retention days', async () => {
             mockRetentionService.getSessionRetentionDays.mockResolvedValue(90)
 

--- a/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
+++ b/nodejs/src/session-replay/shared/keystore/dynamodb-keystore.ts
@@ -13,6 +13,24 @@ import { DeleteKeyResult, KeyStore, SessionKey } from '../types'
 
 const KEYS_TABLE_NAME = 'session-recording-keys'
 const TOMBSTONE_TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
+const CONDITIONAL_CHECK_FAILED = 'ConditionalCheckFailedException'
+
+/**
+ * Detect a DynamoDB conditional-check failure across the ways the AWS SDK can surface it.
+ *
+ * Normally the SDK throws a typed `ConditionalCheckFailedException`. But when duplicate
+ * @smithy/core copies split the schema TypeRegistry across module realms, the protocol
+ * deserializer can't resolve the error (or even the synthetic base exception) and falls back
+ * to a bare `new Error(errorCode)` — so the code lands in `.message` with `.name === 'Error'`,
+ * defeating both `instanceof` and a `.name` check. Match all three signals to stay robust.
+ */
+function isConditionalCheckFailure(error: unknown): boolean {
+    if (error instanceof ConditionalCheckFailedException) {
+        return true
+    }
+    const { name, message } = (error ?? {}) as { name?: string; message?: string }
+    return name === CONDITIONAL_CHECK_FAILED || message === CONDITIONAL_CHECK_FAILED
+}
 
 /**
  * Keystore backed by DynamoDB and KMS.
@@ -65,10 +83,7 @@ export class DynamoDBKeyStore implements KeyStore {
                 })
             )
         } catch (error) {
-            if (
-                error instanceof ConditionalCheckFailedException ||
-                (error as Error)?.name === 'ConditionalCheckFailedException'
-            ) {
+            if (isConditionalCheckFailure(error)) {
                 // Key already exists — return the existing key instead of overwriting
                 return this.getKey(sessionId, teamId)
             }


### PR DESCRIPTION
## Problem

Ingestion was throwing `ConditionalCheckFailedException` to prod from `DynamoDBKeyStore.generateKey`. That error is the benign concurrent-write race the catch is meant to swallow (two workers create the same session key; the loser reads the existing one).

Duplicate `@smithy/core` copies in `nodejs` split the schema `TypeRegistry` across module realms, so the SDK can't resolve the error class and falls back to `new Error(errorCode)` — a bare `Error` with the code in `.message` and `.name === 'Error'`. That defeats both the `instanceof` and `.name` guards, so the race re-throws.

## Changes

Match on `instanceof`, `.name`, **and** `.message` so the failure is caught however the SDK surfaces it. Applied to three spots with the same exposure:

- `DynamoDBKeyStore.generateKey` — the one currently firing in prod (DynamoDB's realms are misaligned).
- `RecordingService` S3 `NoSuchKey` — latent (S3's realms align today); keeps missing blocks mapping to `not_found`.
- SES throttle detection in `email.service` — latent; keeps throttles rescheduling instead of hard-failing.

Immediate mitigation. The root cause — duplicate `@smithy/core` realms — needs a `pnpm.overrides` dedupe and is tracked separately.

## How did you test this code?

Agent (Claude Code), automated only. Added regression tests for the bare-`Error` shape in each spot. `recording-service` + `keystore` suites green locally (tsc/lint clean); the `email.service` suite needs a test Postgres DB not provisioned in my sandbox, so CI covers that one.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a prod stack trace. Chose the multi-signal guard as the shippable hotfix; the `@smithy/core` dedupe is the durable fix, called out above.