### PR TITLE
feat(signals): tag scout runs with ai_stage="scout"

### DIFF
--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -332,6 +332,11 @@ async def _spawn_and_run(
         step_name=_step_name(skill),
         verbose=verbose,
         origin_product=Task.OriginProduct.SIGNALS_SCOUT,
+        # Tag every scout $ai_generation with a coarse pipeline stage so scout spend is
+        # splittable out of the ai_product='signals' bucket (scouts carry no signal_report_id).
+        # Constant 'scout' keeps ai_stage a low-cardinality stage enum (peer of research /
+        # repo_selection / implementation); per-scout granularity comes from scout_name (task_title).
+        ai_stage="scout",
         on_task_run_created=_create_bridge_row,
         # Keep the per-turn poll budget at the run's runtime cap so the dropped-finalization
         # salvage fires before the activity's `start_to_close_timeout` (DEFAULT_MAX_RUNTIME_S +

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -260,6 +260,36 @@ async def test_successful_run_creates_bridge_row_pointing_at_task_run(ateam, aer
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+async def test_run_tags_session_with_scout_ai_stage(ateam, aerrors_skill):
+    # Scouts pass ai_stage='scout' to the sandbox session so every $ai_generation carries it,
+    # letting scout spend be split out of the ai_product='signals' bucket (scouts have no report id).
+    session, result = await database_sync_to_async(_make_fake_session, thread_sensitive=False)(ateam)
+    captured: dict = {}
+
+    async def _capture_start(*args, on_task_run_created=None, **kwargs):
+        captured.update(kwargs)
+        if on_task_run_created is not None:
+            await on_task_run_created(session.task_run)
+        return session, result
+
+    with (
+        patch("products.signals.backend.scout_harness.runner.MultiTurnSession.start", new=_capture_start),
+        patch(
+            "products.signals.backend.scout_harness.runner.get_or_create_signals_sandbox_env",
+            return_value="env-id",
+        ),
+        patch(
+            "products.signals.backend.scout_harness.runner.resolve_user_id_for_team",
+            return_value=42,
+        ),
+    ):
+        await arun_signals_scout(team_id=ateam.id, skill_name="signals-scout-errors")
+
+    assert captured["ai_stage"] == "scout"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_failed_run_returns_failed_outcome_and_skips_bridge_insert(ateam, aerrors_skill):
     # Failure inside MultiTurnSession.start means we never get a session.task_run
     # to bridge to — the runner's except path returns FAILED without persisting.


### PR DESCRIPTION
## Problem

Scout `$ai_generation` spend is hard to isolate now that scout gens moved from `ai_product='posthog_code'` → `'signals'` (the cutover for launch billing). Scouts carry no `signal_report_id` and no `ai_stage`, so a plain `ai_product='signals'` slice sweeps them into the report-pipeline "grouping/triage" bucket (~$586/day at the moment), muddying per-stage cost attribution for the self-driving cost dashboard.

PR #64367 added an `ai_stage` tag to the rest of the signals flow (`research` / `repo_selection`); scouts were the one path left untagged.

## Changes

Pass `ai_stage="scout"` when the scout harness spins up its sandbox session (`MultiTurnSession.start` in `scout_harness/runner.py`). The whole chain already accepts and threads `ai_stage` after #64367 (`start` → `start_raw` → `create_task_and_trigger` → `Task.create_and_run`, which lifts it onto every `$ai_generation`), so this is a one-line addition plus a test.

Chose a constant `"scout"` rather than the per-scout skill name to keep `ai_stage` a low-cardinality pipeline-stage enum (peer of `research` / `repo_selection` / `implementation`). Per-scout granularity is already available via `scout_name` (parsed from `task_title`) downstream, so encoding ~30 skill names into `ai_stage` would only duplicate that and bloat the dimension.

Result: scout spend becomes splittable with a clean `ai_stage='scout'` filter instead of relying on the `task_origin_product='signals_scout'` workaround.

## How did you test this code?

I'm an agent (Claude Code, opus-4-8). Automated only:

- Added `test_run_tags_session_with_scout_ai_stage` to `test_scout_harness.py` — captures the kwargs passed to `MultiTurnSession.start` and asserts `ai_stage == "scout"`, mirroring the existing `_fake_start_invoking_hook` mocking pattern.
- `ruff check` clean; the pre-commit hook ran `ruff` + `ty check` (type check) clean on both changed files.
- I could not execute the `django_db` test locally — no Postgres in this environment. Note: running `test_scout_harness.py` as an isolated file hits a pre-existing circular-import collection error (`runner` ↔ `temporal.agentic`), reproducible on clean `master`; it resolves under a full-suite collection (CI's path), where the test then only needs the test DB. Relying on CI to run it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this while sense-checking the self-driving cost dashboard numbers in the Signals cost thread, where the missing scout `ai_stage` surfaced as the reason scouts pollute the `ai_product='signals'` grouping bucket.

- Agent: Claude Code (opus-4-8). No repo skills were needed for the code change; the DWH side of the same session used `/phs signals-dwh`.
- Decision: constant `"scout"` over per-scout skill name (see Changes) — keeps `ai_stage` a clean stage enum and avoids duplicating `scout_name`.
- Scope kept minimal deliberately: the threading infra already existed from #64367, so this only wires the one missing call site.
