### PR TITLE
feat(phai): default sandbox permission mode to auto

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -58,6 +58,7 @@ from products.posthog_ai.backend.context_wrapper import (
 )
 from products.posthog_ai.backend.message_routing import SandboxSession
 from products.posthog_ai.backend.models.assistant import Conversation
+from products.tasks.backend.constants import INITIAL_PERMISSION_MODE_CHOICES
 from products.tasks.backend.models import Task, TaskRun
 
 from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_team_limited
@@ -230,6 +231,14 @@ class SandboxOpenSerializer(serializers.Serializer):
         required=False,
         child=SandboxAttachedContextItemSerializer(),
         help_text="Typed PostHog entities (and free text) attached to this message.",
+    )
+    initial_permission_mode = serializers.ChoiceField(
+        choices=INITIAL_PERMISSION_MODE_CHOICES,
+        required=False,
+        help_text=(
+            "Initial permission mode for the sandbox agent session. "
+            "Defaults to `auto`, which allows safe tool use while preserving explicit confirmations."
+        ),
     )
 
 

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1282,7 +1282,7 @@ class TestConversationSandboxRoute(APIBaseTest):
             m_session.return_value.open.return_value = sentinel
             response = self.client.post(
                 f"/api/environments/{self.team.id}/conversations/{conversation.id}/open/",
-                {"content": "hello", "trace_id": str(uuid.uuid4())},
+                {"content": "hello", "trace_id": str(uuid.uuid4()), "initial_permission_mode": "auto"},
                 format="json",
             )
 
@@ -1290,6 +1290,7 @@ class TestConversationSandboxRoute(APIBaseTest):
         # attached_context_count is internal telemetry plumbing, excluded from the response body.
         self.assertEqual(response.json(), sentinel.model_dump(exclude={"attached_context_count"}))
         m_session.return_value.open.assert_called_once()
+        self.assertEqual(m_session.return_value.open.call_args[0][0]["initial_permission_mode"], "auto")
         # The session receives the resolved conversation, not just an id.
         passed_conversation = m_session.call_args[0][0]
         self.assertEqual(passed_conversation.id, conversation.id)
@@ -1430,6 +1431,7 @@ class TestConversationSandboxRoute(APIBaseTest):
         bad_payloads = [
             {"content": "x" * 40001},  # over the content length cap
             {"content": "hello", "trace_id": "not-a-uuid"},  # malformed trace id
+            {"content": "hello", "initial_permission_mode": "full-access"},  # Codex-only mode, not valid for Claude
         ]
         for payload in bad_payloads:
             with patch("ee.api.conversation.SandboxSession") as m_session:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -231,6 +231,7 @@ import type {
     SessionGroupSummaryType,
     SessionSummariesConfig,
 } from 'products/session_summaries/frontend/types'
+import type { TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 import type { Task, TaskListParams, TaskRun, TaskUpsertProps } from 'products/tasks/frontend/types'
 import type { BlastRadiusApi } from 'products/workflows/frontend/generated/api.schemas'
 import type { OptOutEntry } from 'products/workflows/frontend/OptOuts/types'
@@ -6582,6 +6583,7 @@ const api = {
                 content?: string | null
                 trace_id?: string
                 attached_context?: AttachedContext[]
+                initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi
             }
         ): Promise<{
             task_id: string

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1723,7 +1723,10 @@ describe('maxThreadLogic', () => {
 
             logic.actions.prewarmSandbox()
             await flush()
-            expect(openSpy).toHaveBeenCalledWith(MOCK_CONVERSATION_ID, { content: null })
+            expect(openSpy).toHaveBeenCalledWith(MOCK_CONVERSATION_ID, {
+                content: null,
+                initial_permission_mode: 'auto',
+            })
 
             // User abandons the input before the warm resolves — nothing is warm yet, so the release
             // is deferred (pendingRelease), not dropped, and no cancel fires.
@@ -3466,7 +3469,7 @@ describe('maxThreadLogic', () => {
         })
 
         it('holds the streaming lock until the sandbox turn completes and releases exactly once', async () => {
-            jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+            const openSpy = jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
 
             await expectLogic(logic, () => {
                 logic.actions.streamConversation(
@@ -3474,6 +3477,14 @@ describe('maxThreadLogic', () => {
                     0
                 )
             }).toDispatchActions(['openSandboxSse'])
+
+            expect(openSpy).toHaveBeenCalledWith(
+                MOCK_CONVERSATION_ID,
+                expect.objectContaining({
+                    content: 'hello',
+                    initial_permission_mode: 'auto',
+                })
+            )
 
             // The POST finished, but the turn is still streaming — the lock must still be held
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(1)

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -68,14 +68,20 @@ import { LogEntry, parseLogEvent } from 'products/tasks/frontend/lib/parse-logs'
 
 import { handsFreeLogic } from './handsFreeLogic'
 import { summariseAssistantThread } from './handsFreeUtils'
-import { EnhancedToolCall, MODE_DEFINITIONS, TOOL_DEFINITIONS, ToolRegistration, getModeDisplayName } from './max-constants'
+import {
+    EnhancedToolCall,
+    MODE_DEFINITIONS,
+    TOOL_DEFINITIONS,
+    ToolRegistration,
+    getModeDisplayName,
+} from './max-constants'
 import { MaxBillingContext, MaxBillingContextSubscriptionLevel, maxBillingContextLogic } from './maxBillingContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
 import { AttachedContext, MaxUIContext } from './maxTypes'
 import { posthogAiContextLogic } from './posthogAiContextLogic'
-import { isTerminalRunStatus, sandboxStreamLogic } from './sandboxStreamLogic'
+import { SANDBOX_INITIAL_PERMISSION_MODE, isTerminalRunStatus, sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
 import { getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import {
@@ -717,6 +723,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             content: streamData.content,
                             trace_id: traceId,
                             attached_context: attachedContext,
+                            initial_permission_mode: SANDBOX_INITIAL_PERMISSION_MODE,
                         })
                         if (handle) {
                             // The sent message consumes any in-flight warm — it's now the active run, so
@@ -1077,7 +1084,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 // Warm = open with no message: boots a Run that idles awaiting the first message. The
                 // returned handle lets a later release cancel exactly that Run via the relay (a full
                 // pool returns null — nothing to release).
-                const warm = await api.conversations.open(values.conversationId, { content: null })
+                const warm = await api.conversations.open(values.conversationId, {
+                    content: null,
+                    initial_permission_mode: SANDBOX_INITIAL_PERMISSION_MODE,
+                })
                 cache.warmRun = warm ? { taskId: warm.task_id, runId: warm.run_id } : null
                 cache.prewarmed = true
                 // If the user abandoned the input while this POST was in flight, the blur/empty

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -6,6 +6,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
+import type { TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
 import { defaultPermissionDecision, findAllowOptionId } from './sandboxToolPolicy'
@@ -65,6 +66,7 @@ export const SSE_RECONNECT_MAX_DELAY_MS = 30_000
 export const MAX_CUMULATIVE_RECONNECT_ATTEMPTS = 30
 /** A connection open at least this long before dropping is healthy — its drop is forgiven. */
 export const SSE_HEALTHY_CONNECTION_MS = 60_000
+export const SANDBOX_INITIAL_PERMISSION_MODE: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi = 'auto'
 
 /** The crash-error string the in-sandbox agent server writes on a fatal exception. */
 const AGENT_CRASH_PREFIX = 'Agent server crashed'

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -35,11 +35,14 @@ from products.posthog_ai.backend.models.assistant import Conversation
 from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
 from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message_params, parse_log_entry
+from products.tasks.backend.constants import INITIAL_PERMISSION_MODE_CHOICES, InitialPermissionMode
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.services.warm import SandboxWarmer
 from products.tasks.backend.temporal.client import execute_task_processing_workflow, signal_task_followup_message
 
 logger = structlog.get_logger(__name__)
+
+DEFAULT_INITIAL_PERMISSION_MODE: InitialPermissionMode = "auto"
 
 
 class SandboxRouteResult(BaseModel):
@@ -102,11 +105,12 @@ class SandboxSession(BaseSandboxService):
     def open(
         self, data: Mapping[str, Any], *, resumed_context: str | None = None, convert_to_acp: bool = False
     ) -> SandboxRouteResult | None:
+        initial_permission_mode = self._initial_permission_mode(data.get("initial_permission_mode"))
         content = data.get("content")
         if not isinstance(content, str) or not content.strip():
             # No message — warm intent: boot a Run that idles awaiting the first `user_message`.
             # Returns the warm handle, or None when the pool is full and nothing was provisioned.
-            return self._warm(trace_id=data.get("trace_id"))
+            return self._warm(trace_id=data.get("trace_id"), initial_permission_mode=initial_permission_mode)
 
         trace_id = data.get("trace_id")
         attached_context = self._validate_attached_context(data.get("attached_context"))
@@ -118,6 +122,7 @@ class SandboxSession(BaseSandboxService):
                 content=content,
                 trace_id=trace_id,
                 attached_context=attached_context,
+                initial_permission_mode=initial_permission_mode,
                 resumed_context=resumed_context,
                 convert_to_acp=convert_to_acp,
             )
@@ -147,9 +152,17 @@ class SandboxSession(BaseSandboxService):
             wrapped=wrapped,
             trace_id=trace_id,
             attached_context=attached_context,
+            initial_permission_mode=initial_permission_mode,
         )
 
-    def _warm(self, *, trace_id: str | None) -> SandboxRouteResult | None:
+    def _initial_permission_mode(self, value: Any) -> InitialPermissionMode:
+        if isinstance(value, str) and value in INITIAL_PERMISSION_MODE_CHOICES:
+            return cast(InitialPermissionMode, value)
+        return DEFAULT_INITIAL_PERMISSION_MODE
+
+    def _warm(
+        self, *, trace_id: str | None, initial_permission_mode: InitialPermissionMode
+    ) -> SandboxRouteResult | None:
         """Boot a sandbox Run ahead of the first message (the message-less `open`).
 
         Ensures the conversation's Task exists under the row lock (so two tabs can't create two
@@ -190,7 +203,9 @@ class SandboxSession(BaseSandboxService):
         # dispatches the workflow on commit; it is idempotent (an existing non-terminal Run is returned
         # as-is). `systemPrompt` is the one PostHog AI-specific Run-state key the generic warmer can't know.
         try:
-            result = SandboxWarmer(task, user=self.user).warm(extra_state={"systemPrompt": system_prompt})
+            result = SandboxWarmer(task, user=self.user).warm(
+                extra_state={"systemPrompt": system_prompt, "initial_permission_mode": initial_permission_mode}
+            )
         except exceptions.Throttled:
             # Warm-pool cap reached between the pre-check and the lock — best-effort no-op (no handle).
             logger.info(
@@ -214,6 +229,7 @@ class SandboxSession(BaseSandboxService):
         content: str,
         trace_id: str | None,
         attached_context: list[AttachedContext],
+        initial_permission_mode: InitialPermissionMode,
         resumed_context: str | None = None,
         convert_to_acp: bool = False,
     ) -> SandboxRouteResult:
@@ -252,7 +268,7 @@ class SandboxSession(BaseSandboxService):
         ph_state = PostHogAIRunState(
             system_prompt=system_prompt,
             attached_context=attached_context,
-            initial_permission_mode="default",
+            initial_permission_mode=initial_permission_mode,
             pending_user_message=wrapped,
         )
         run_state: dict[str, Any] = dict(task_run.state or {})
@@ -375,6 +391,7 @@ class SandboxSession(BaseSandboxService):
         wrapped: str,
         trace_id: str | None,
         attached_context: list[AttachedContext],
+        initial_permission_mode: InitialPermissionMode,
     ) -> SandboxRouteResult:
         """Follow-up after the current Run reached a terminal status.
 
@@ -410,7 +427,7 @@ class SandboxSession(BaseSandboxService):
                 "systemPrompt": system_prompt,
                 # The full, undeduped list — survives for the life of the new Run.
                 "attached_context": attached_context,
-                "initial_permission_mode": "default",
+                "initial_permission_mode": initial_permission_mode,
             }
             # Carry the prior Run's snapshot forward so the resume reuses its filesystem.
             snapshot_external_id = (run.state or {}).get("snapshot_external_id")

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -79,7 +79,7 @@ class TestOpenSandboxMessage(APIBaseTest):
         # Run state enriched with the PostHog AI per-Run keys; full undeduped context.
         run.refresh_from_db()
         assert run.state["systemPrompt"] == "SYS"
-        assert run.state["initial_permission_mode"] == "default"
+        assert run.state["initial_permission_mode"] == "auto"
         assert run.state["attached_context"] == [{"type": "dashboard", "id": 123, "name": "Funnel"}]
         assert "<posthog_context>" in run.state["pending_user_message"]
         assert run.state["pending_user_message"].endswith("Why did checkout drop?")
@@ -92,6 +92,21 @@ class TestOpenSandboxMessage(APIBaseTest):
         assert wf_kwargs["create_pr"] is False
         # The agent needs write scopes to create insights/dashboards/notebooks.
         assert wf_kwargs["posthog_mcp_scopes"] == "full"
+
+    def test_first_message_honors_initial_permission_mode(self):
+        task, run = self._stub_task()
+        car, workflow, sysprompt = self._patches(task)
+        with car, workflow, sysprompt:
+            self._service().open(
+                {
+                    "content": "Use plan mode",
+                    "trace_id": "trace-1",
+                    "initial_permission_mode": "plan",
+                }
+            )
+
+        run.refresh_from_db()
+        assert run.state["initial_permission_mode"] == "plan"
 
     def test_first_message_without_context_forwards_bare_content(self):
         task, run = self._stub_task()
@@ -241,7 +256,7 @@ class TestOpenSandboxMessage(APIBaseTest):
         assert new_run.state["resume_from_run_id"] == str(run.id)
         assert new_run.state["snapshot_external_id"] == "snap-9"
         assert new_run.state["systemPrompt"] == "SYS"
-        assert new_run.state["initial_permission_mode"] == "default"
+        assert new_run.state["initial_permission_mode"] == "auto"
         assert "resume please" in new_run.state["pending_user_message"]
 
         m_workflow.assert_called_once()
@@ -414,11 +429,26 @@ class TestSandboxWarmViaOpen(APIBaseTest):
         assert result.just_created_run is True
         assert run.state["systemPrompt"] == "SYS"
         assert run.state["await_user_message"] is True
-        assert run.state["initial_permission_mode"] == "default"
+        assert run.state["initial_permission_mode"] == "auto"
         # No pending message / attached context: the session boots and idles awaiting input.
         assert "pending_user_message" not in run.state
         assert "attached_context" not in run.state
         m_workflow.assert_called_once()
+
+    def test_warm_honors_initial_permission_mode(self):
+        with (
+            patch(f"{WARM}.execute_task_processing_workflow"),
+            patch(f"{WARM}.is_team_limited", return_value=False),
+            patch.object(PromptService, "build", return_value="SYS"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self._service().open({"initial_permission_mode": "plan"})
+
+        assert result is not None
+        self.conversation.refresh_from_db()
+        run = self.conversation.task.latest_run
+        assert run is not None
+        assert run.state["initial_permission_mode"] == "plan"
 
     def test_warm_is_idempotent_when_run_already_in_progress(self):
         task, run = self._stub_task()


### PR DESCRIPTION
## Problem

Sandbox PostHog AI runs currently start in the stricter default permission mode, which creates unnecessary permission prompts for otherwise safe tool use. We still need explicit confirmation for mutating PostHog MCP operations such as update and delete tools.

## Changes

- Default sandbox run creation, warm runs, and terminal resumes to the `auto` initial permission mode.
- Thread `initial_permission_mode` through the sandbox open endpoint and frontend open calls.
- Keep the existing PostHog MCP confirmation policy intact for update/delete-style tools, with tests covering the mode propagation.

## How did you test this code?

Pre-commit hooks ran during commit and completed: `bin/hogli format:js`, `bin/hogli lint:python:fix`, `bin/hogli format:python`, and `uv run ty check`.

I did not run the full focused test suites before opening this PR.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change at the user's direction. Skills invoked: `/adopting-generated-api-types`, `/improving-drf-endpoints`, and `/submit-pr`.

Decision note: I used Claude sandbox permission mode `auto` instead of `bypassPermissions` so the runtime can allow safe operations while still preserving explicit confirmation requests for mutating PostHog MCP tools.