### PR TITLE
fix(logs): default sparkline dateRange and filterGroup for omitted args

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -740,12 +740,15 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
 
+        date_range_data = query_data.get("dateRange")
+        date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
+
         query = LogsQuery(
-            dateRange=self.get_model(query_data.get("dateRange"), DateRange),
+            dateRange=date_range,
             severityLevels=query_data.get("severityLevels", []),
             serviceNames=query_data.get("serviceNames", []),
             searchTerm=query_data.get("searchTerm", None),
-            filterGroup=query_data.get("filterGroup", None),
+            filterGroup=self._normalize_filter_group(query_data.get("filterGroup", None)),
             resourceFingerprint=query_data.get("resourceFingerprint", None),
             sparklineBreakdownBy=query_data.get("sparklineBreakdownBy"),
         )

--- a/products/logs/backend/test/test_sparkline_api.py
+++ b/products/logs/backend/test/test_sparkline_api.py
@@ -4,6 +4,7 @@ import json
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.clickhouse.client import sync_execute
@@ -34,15 +35,15 @@ class TestSparklineApi(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, expected_status)
         return response.json() if expected_status == status.HTTP_200_OK else response
 
+    @parameterized.expand(
+        [
+            ("with_date_range", {"dateRange": _FIXTURE_WINDOW}, 1011),
+            # No dateRange/filterGroup — MCP/agent callers routinely omit these optional
+            # fields, so defaults must be applied server-side rather than crashing.
+            ("defaults_to_last_hour", {}, 0),
+        ]
+    )
     @freeze_time("2025-12-18T12:00:00Z")
-    def test_sparkline_with_date_range(self):
-        buckets = self._sparkline({"dateRange": _FIXTURE_WINDOW})
-        self.assertEqual(sum(bucket["count"] for bucket in buckets), 1011)
-
-    @freeze_time("2025-12-18T12:00:00Z")
-    def test_sparkline_defaults_date_range_to_last_hour(self):
-        # No dateRange in request — MCP/agent callers routinely omit it because the
-        # field is optional and documented as defaulting to the last hour. The default
-        # must be applied server-side rather than crashing on get_model(None).
-        buckets = self._sparkline({})
-        self.assertEqual(sum(bucket["count"] for bucket in buckets), 0)
+    def test_sparkline(self, _name, query_params, expected_count):
+        buckets = self._sparkline(query_params)
+        self.assertEqual(sum(bucket["count"] for bucket in buckets), expected_count)

--- a/products/logs/backend/test/test_sparkline_api.py
+++ b/products/logs/backend/test/test_sparkline_api.py
@@ -1,0 +1,48 @@
+import os
+import json
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
+
+_FIXTURE_WINDOW = {"date_from": "2025-12-14T00:00:00Z", "date_to": "2025-12-19T00:00:00Z"}
+
+
+class TestSparklineApi(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            sql = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                sql += json.dumps(log_item) + "\n"
+            sync_execute(f"""
+                INSERT INTO logs
+                FORMAT JSONEachRow
+                {sql}
+            """)
+
+    def _sparkline(self, query_params, expected_status=status.HTTP_200_OK):
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/sparkline", data={"query": query_params})
+        self.assertEqual(response.status_code, expected_status)
+        return response.json() if expected_status == status.HTTP_200_OK else response
+
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_sparkline_with_date_range(self):
+        buckets = self._sparkline({"dateRange": _FIXTURE_WINDOW})
+        self.assertEqual(sum(bucket["count"] for bucket in buckets), 1011)
+
+    @freeze_time("2025-12-18T12:00:00Z")
+    def test_sparkline_defaults_date_range_to_last_hour(self):
+        # No dateRange in request — MCP/agent callers routinely omit it because the
+        # field is optional and documented as defaulting to the last hour. The default
+        # must be applied server-side rather than crashing on get_model(None).
+        buckets = self._sparkline({})
+        self.assertEqual(sum(bucket["count"] for bucket in buckets), 0)


### PR DESCRIPTION
## Problem

The `logs-sparkline-query` MCP tool was failing 100% of the time (179/179 calls over the last 30 days). Sibling logs tools (`logs-count`, `query-logs`, `logs-services-create`, `logs-count-ranges`) were all healthy at 1–4% error, so this was specific to the sparkline endpoint.

Root cause: two deterministic crashes in the `sparkline` viewset action, both triggered when the caller omits optional fields — which AI agents do routinely, since `dateRange` and `filterGroup` are optional in the generated MCP schema and `dateRange` is documented as "defaults to last hour".

1. **`dateRange` was never defaulted.** The action called `get_model(query_data.get("dateRange"), DateRange)`, and `DateRange.model_validate(None)` raises (pydantic won't validate `None` as a dict) → HTTP 400. The documented "defaults to last hour" behavior was never actually implemented server-side.
2. **`filterGroup=None` was passed straight into `LogsQuery`**, which pydantic rejects → HTTP 500.

The sibling actions already handle both correctly: `count` defaults `dateRange` to `-1h`, and all of them route `filterGroup` through `_normalize_filter_group(...)`. The sparkline action was the only one missing both.

## Changes

- `sparkline` action now defaults `dateRange` to `DateRange(date_from="-1h")` when omitted (mirrors `count`).
- `sparkline` action now routes `filterGroup` through `_normalize_filter_group(...)` (mirrors `count`/`query`/`services`), so an omitted filter becomes a valid empty group instead of `None`.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing.

- Added `products/logs/backend/test/test_sparkline_api.py` with API-level coverage, including `test_sparkline_defaults_date_range_to_last_hour`, which posts `{}` (no args) and reproduced both crashes before the fix. Both tests fail on the unpatched endpoint and pass after.
- Re-ran the existing `test_sparkline_query_runner.py` — still green.

The gap that let this ship: the only existing sparkline test exercised the query runner directly (bypassing the API + serializer), and the cross-check in `test_count_api.py` always passed an explicit `dateRange` and `filterGroup` (with a comment noting "sparkline currently requires it"). There was no API-level test for the no-args path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog Code (Claude Opus). Used the PostHog MCP analytics (`execute-sql` over `mcp_tool_call` events) to confirm the 100% error rate was isolated to this one tool, then reproduced locally with a new API test.
- Skills invoked: `/improving-drf-endpoints` (before editing the viewset), `/exploring-mcp-tool-quality` (to pull the per-tool error rates).
- Decisions: fixed by mirroring the existing sibling-action conventions rather than inventing new handling, keeping behavior consistent across the logs endpoints. Noted but did not change a separate, lower-severity issue: the endpoint returns a bare JSON array while the declared response schema is `{results: [...]}` — that produces empty (not errored) MCP results and is worth a follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
