### PR TITLE
fix(phai): close orphaned sandbox SSE streams across hot reloads

### DIFF
--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -10,6 +10,7 @@ import { initKeaTests } from '~/test/init'
 import { tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
 
 import {
+    liveEventSourcesByStreamKey,
     mapHttpStatusToStreamError,
     MAX_CUMULATIVE_RECONNECT_ATTEMPTS,
     MAX_SSE_RECONNECT_ATTEMPTS,
@@ -94,6 +95,8 @@ describe('sandboxStreamLogic', () => {
     beforeEach(() => {
         initKeaTests()
         MockEventSource.reset()
+        // The live-connection registry is a module global (survives HMR), so clear it between tests.
+        liveEventSourcesByStreamKey.clear()
         ;(global as any).EventSource = MockEventSource
         projectLogic.mount()
         projectLogic.actions.loadCurrentProjectSuccess({ id: 997 } as any)
@@ -1030,6 +1033,67 @@ describe('sandboxStreamLogic', () => {
             await flushPromises()
 
             expect(logic.values.sseStatus).toEqual('error')
+        })
+    })
+
+    describe('hot-reload connection survival', () => {
+        // Simulates the orphaned connection a hot reload leaves behind: the prior build registered an
+        // EventSource but its `cache` (and the disposable that would close it) was discarded before the
+        // connection was closed. The registry survives module re-evaluation so the new build can find it.
+        function seedOrphanedConnection(): MockEventSource {
+            const orphan = new MockEventSource('orphaned-by-hot-reload')
+            liveEventSourcesByStreamKey.set('test-conversation', orphan as unknown as EventSource)
+            return orphan
+        }
+
+        it('registers the live EventSource under the stream key on open', () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+
+            expect(liveEventSourcesByStreamKey.get('test-conversation')).toBe(
+                MockEventSource.latest() as unknown as EventSource
+            )
+        })
+
+        it('closes a connection orphaned by a prior build before opening a new one', () => {
+            const orphan = seedOrphanedConnection()
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+
+            // The orphan that would otherwise keep streaming (and race the replay, doubling the
+            // thread) is closed, and the registry now points at the single new connection.
+            expect(orphan.closed).toEqual(true)
+            expect(liveEventSourcesByStreamKey.get('test-conversation')).toBe(
+                MockEventSource.latest() as unknown as EventSource
+            )
+        })
+
+        it('reset closes an orphaned connection so the replay bootstrap is not raced', () => {
+            const orphan = seedOrphanedConnection()
+
+            logic.actions.reset()
+
+            expect(orphan.closed).toEqual(true)
+            expect(liveEventSourcesByStreamKey.has('test-conversation')).toEqual(false)
+        })
+
+        it('closeSse closes an orphaned connection', () => {
+            const orphan = seedOrphanedConnection()
+
+            logic.actions.closeSse()
+
+            expect(orphan.closed).toEqual(true)
+            expect(liveEventSourcesByStreamKey.has('test-conversation')).toEqual(false)
+        })
+
+        it('unregisters on disposable cleanup so the registry never points at a dead connection', () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            const source = MockEventSource.latest()
+            expect(liveEventSourcesByStreamKey.get('test-conversation')).toBe(source as unknown as EventSource)
+
+            logic.actions.closeSse()
+
+            expect(source.closed).toEqual(true)
+            expect(liveEventSourcesByStreamKey.has('test-conversation')).toEqual(false)
         })
     })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -69,6 +69,36 @@ export const SSE_HEALTHY_CONNECTION_MS = 60_000
 /** The crash-error string the in-sandbox agent server writes on a fatal exception. */
 const AGENT_CRASH_PREFIX = 'Agent server crashed'
 
+/**
+ * HMR-stable registry of the single live `EventSource` per stream key, hung off a global that
+ * survives module re-evaluation.
+ *
+ * The connection normally lives in `cache.disposables` and is torn down when the logic unmounts.
+ * But `cache` is recreated whenever this module is hot-reloaded, and a reload orphans the previous
+ * build's `EventSource`: editing the logic cascades a rebuild up through `maxThreadLogic`, which
+ * mounts the new build at the same keyed path *before* the old one unmounts — so the disposables
+ * plugin's `isMounted()` guard is still true and the old connection is never closed. The orphan
+ * keeps firing `onmessage` with a stale closure and races the new build's reset-then-replay
+ * bootstrap, defeating the content-dedup and re-folding the whole thread once per reload, so
+ * duplicates pile up across multiple reloads.
+ *
+ * Keying the handle to a global (instead of the per-build `cache`) lets each build close the
+ * connection a prior build left open — before opening or resetting its own — guaranteeing exactly
+ * one live stream per key no matter how many times the module reloads. Exported for tests.
+ */
+export const liveEventSourcesByStreamKey: Map<string, EventSource> = ((
+    globalThis as unknown as { __sandboxLiveEventSources?: Map<string, EventSource> }
+).__sandboxLiveEventSources ??= new Map<string, EventSource>())
+
+/** Close and forget any `EventSource` a prior build (or an earlier open) registered for this key. */
+function closeLiveEventSource(streamKey: string): void {
+    const existing = liveEventSourcesByStreamKey.get(streamKey)
+    if (existing) {
+        existing.close()
+        liveEventSourcesByStreamKey.delete(streamKey)
+    }
+}
+
 const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set(['completed', 'failed', 'cancelled'])
 
 export function isTerminalRunStatus(status: string | null | undefined): boolean {
@@ -1006,8 +1036,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             actions.sseConnecting()
             cache.disposables.dispose('reconnect-backoff')
 
-            // Replace any prior connection.
+            // Replace any prior connection — including one orphaned by a hot reload, whose `cache`
+            // (and thus this disposable) was discarded before the connection was ever closed.
             cache.disposables.dispose('event-source')
+            closeLiveEventSource(props.streamKey)
             // pauseOnPageHidden: false — a live SSE connection must survive tab hides; re-running
             // setup on show would replay the stream from the top and duplicate thread state.
             cache.disposables.add(
@@ -1015,6 +1047,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     const start = startLatest ? '?start=latest' : ''
                     const url = `/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/stream/${start}`
                     const eventSource = new EventSource(url, { withCredentials: true })
+                    // Register as the live connection for this key so a later build (post-HMR) can
+                    // find and close it even after this build's `cache` is gone.
+                    liveEventSourcesByStreamKey.set(props.streamKey, eventSource)
 
                     eventSource.onopen = (): void => actions.sseOpened()
                     eventSource.onmessage = (event: MessageEvent<string>): void => {
@@ -1072,7 +1107,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         actions.sseDropped()
                     })
 
-                    return () => eventSource.close()
+                    return () => {
+                        eventSource.close()
+                        // Only clear the registry if we're still the registered connection — a newer
+                        // (post-HMR) build may have already replaced us.
+                        if (liveEventSourcesByStreamKey.get(props.streamKey) === eventSource) {
+                            liveEventSourcesByStreamKey.delete(props.streamKey)
+                        }
+                    }
                 },
                 'event-source',
                 { pauseOnPageHidden: false }
@@ -1323,6 +1365,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.activeRun = undefined
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
+            closeLiveEventSource(props.streamKey)
         },
         reset: () => {
             // `ingestedFrameHashes` clears via its own reducer on `reset` — keep it Redux-only so the
@@ -1333,6 +1376,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             cache.sseConnectedAtMs = undefined
             cache.disposables.dispose('reconnect-backoff')
             cache.disposables.dispose('event-source')
+            // Kill any connection a prior hot-reload build orphaned, before the caller's bootstrap
+            // replays history — otherwise the stale stream races the replay and doubles the thread.
+            closeLiveEventSource(props.streamKey)
         },
         pushHumanMessage: () => {
             // Stamp the start of the turn this message opens, so per-turn duration metrics on a


### PR DESCRIPTION
## Problem

In the PostHog AI sandbox runtime, repeated hot reloads in local dev grow the thread with duplicated messages — each reload appends another copy of the conversation. A prior fix added content-hash dedup of replayed frames (kept in Redux so it survives an HMR state-preserving reload), which reduced the problem but didn't eliminate it.

The residual cause is a **leaked `EventSource` per hot reload**. The live SSE connection is owned by `cache.disposables`, but `cache` is recreated on every HMR rebuild. Editing `sandboxStreamLogic.ts` cascades a rebuild up through `maxThreadLogic`, and the new build mounts at the same keyed path *before* the old one unmounts — so the disposables plugin's `isMounted()` guard is still `true` and the old connection is never closed. The orphaned stream keeps firing `onmessage` with a stale closure and races the new build's `reset()`-then-replay bootstrap, defeating the content-dedup and re-folding the whole thread. One orphan per reload, so duplicates accumulate.

## Changes

- Added an **HMR-stable registry** (`liveEventSourcesByStreamKey`) of the single live `EventSource` per stream key, hung off a `globalThis` slot that survives module re-evaluation (the per-build `cache` cannot).
- `openSseForRun` now closes any registry-tracked connection (the orphan) before opening, registers the new one, and unregisters on disposable cleanup — guarded so a newer build's entry isn't clobbered.
- `reset` and `closeSse` also close the orphan. `reset` is the important one: `maxThreadLogic` calls `resetSandboxStream()` immediately before re-bootstrapping, so the orphan dies *before* the replay can race it.

Net effect: exactly one live stream per key no matter how many times the module reloads, so the content-dedup is no longer raced and the thread stays clean.

This branch contains only the stream-logic fix; it deliberately excludes unrelated in-progress work on the same feature branch (sandbox questions) authored by another agent.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated coverage only:

- Added a `hot-reload connection survival` test block (5 cases): registration on open; closing an orphaned connection on `openSseForRun` / `reset` / `closeSse`; and unregistration on disposable cleanup. Plus a `beforeEach` clear of the module-global registry for isolation.
- Ran `sandboxStreamLogic.test.ts` in the main working tree: the new tests pass and the existing `reconnect / backoff` (9) and `content dedup` (3) suites are unaffected.
- Lint clean on both files (`oxlint`, 0 errors).

Note: one pre-existing failure in this file (`stream phase › is provisioning … then flips to thinking`) fails identically on the baseline with my changes stashed — it is unrelated to this fix and left untouched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Georgiy directed the work.

- Tool: Claude Code (Opus 4.8). No repo skills were required for this change.
- Root-caused the residual duplication to a leaked `EventSource` surviving HMR via the per-build `cache`, distinct from the already-fixed content-dedup gap.
- Considered making frame dedup more aggressive, but the dedup set and `threadItems` already reset in lockstep within a build — the real defect was the orphaned connection racing the replay, so the fix targets connection lifecycle instead.
- Committed only the two stream-logic files via an isolated git worktree off `origin/feat/posthog-ai-sandboxes`, so a second agent's concurrent uncommitted work on the same feature branch is not included here.
