### PR TITLE
feat(phai): interactive AskUserQuestion overlay for sandbox conversations

### DIFF
--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -16,6 +16,7 @@ import { maxThreadLogic } from '../maxThreadLogic'
 import { Option, OptionSelector } from './OptionSelector'
 import { MultiFieldQuestion, QuestionField, isFieldValid } from './QuestionField'
 import { SandboxPermissionInput } from './SandboxPermissionInput'
+import { SandboxQuestionInput } from './SandboxQuestionInput'
 
 function isQuestionComplete(
     q: MultiQuestionFormQuestion,
@@ -463,6 +464,17 @@ export function InputFormArea(): JSX.Element | null {
     // originates from the sandbox stream, so its presence is sufficient — gating on `agent_runtime`
     // would strand approvals on new conversations whose runtime isn't resolved yet.
     if (pendingSandboxPermissionRequest) {
+        // An `AskUserQuestion` rides the same permission rails but is a question, not an approval —
+        // render the interactive question overlay instead of the approve/decline card.
+        if (pendingSandboxPermissionRequest.questions?.length) {
+            return (
+                <SandboxQuestionInput
+                    key={pendingSandboxPermissionRequest.requestId}
+                    streamKey={conversationId}
+                    request={pendingSandboxPermissionRequest}
+                />
+            )
+        }
         return (
             <SandboxPermissionInput
                 key={pendingSandboxPermissionRequest.requestId}

--- a/frontend/src/scenes/max/components/OptionSelector.tsx
+++ b/frontend/src/scenes/max/components/OptionSelector.tsx
@@ -176,7 +176,7 @@ export function OptionSelector({
                             autoFocus={true}
                         />
                     ) : (
-                        <span className="my-1.5">Explain what you'd like instead..</span>
+                        <span className="my-1.5">Explain what you'd like instead.</span>
                     )}
                 </label>
             )}

--- a/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
@@ -1,0 +1,175 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useActions, useValues } from 'kea'
+
+import type { SandboxQuestion } from '../sandboxQuestionUtils'
+import type { PermissionRequestRecord, ToolInvocation } from '../types/sandboxStreamTypes'
+import { SandboxQuestionInput } from './SandboxQuestionInput'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: jest.fn(),
+    useValues: jest.fn(),
+}))
+
+jest.mock('../sandboxStreamLogic', () => ({
+    sandboxStreamLogic: jest.fn(() => ({ __mock: 'sandboxStreamLogicInstance' })),
+}))
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: '',
+    rawToolName: 'AskUserQuestion',
+    resolvedKey: 'AskUserQuestion',
+    input: {},
+    status: 'pending',
+    contentBlocks: [],
+}
+
+function makeRequest(questions: SandboxQuestion[]): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        toolName: 'AskUserQuestion',
+        options: questions[0].options.map((o, idx) => ({
+            optionId: `option_${idx}`,
+            name: o.label,
+            kind: 'allow_once',
+        })),
+        rawToolCall,
+        questions,
+    }
+}
+
+const goalQuestion: SandboxQuestion = {
+    question: 'Which goal matters most?',
+    header: 'Goal',
+    multiSelect: false,
+    options: [{ label: 'Activation', description: 'aha moment' }, { label: 'Revenue' }],
+}
+
+describe('SandboxQuestionInput', () => {
+    const respondToPermission = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(useActions as jest.Mock).mockReturnValue({ respondToPermission })
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: false })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders the header chip, question text, and options via QuestionField', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        expect(screen.getByText('Goal')).toBeInTheDocument()
+        expect(screen.getByText('Which goal matters most?')).toBeInTheDocument()
+        expect(screen.getByText('Activation')).toBeInTheDocument()
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        expect(screen.getByText('aha moment')).toBeInTheDocument()
+    })
+
+    it('submits a single-select answer on pick with the derived optionId', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        // Single-select advances/submits on pick (QuestionField behaviour) — the last question submits.
+        fireEvent.click(screen.getByText('Revenue'))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_1',
+            answers: { 'Which goal matters most?': 'Revenue' },
+            customInput: undefined,
+        })
+    })
+
+    it('joins multiple selections for a multi-select question', () => {
+        const productsQuestion: SandboxQuestion = {
+            question: 'Which products?',
+            header: 'Products',
+            multiSelect: true,
+            options: [{ label: 'Insights' }, { label: 'Replay' }, { label: 'Flags' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([productsQuestion])} />)
+
+        fireEvent.click(screen.getByText('Insights'))
+        fireEvent.click(screen.getByText('Flags'))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which products?': 'Insights, Flags' },
+            customInput: undefined,
+        })
+    })
+
+    it('sends a free-typed answer through the custom path with option_0 fallback', () => {
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        // Open the custom "Type your answer" field, type, and submit.
+        fireEvent.click(screen.getByText("Explain what you'd like instead."))
+        fireEvent.change(screen.getByPlaceholderText('Type your answer...'), { target: { value: 'Cut churn' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which goal matters most?': 'Cut churn' },
+            customInput: 'Cut churn',
+        })
+    })
+
+    it('does not submit a multi-select question with nothing selected', () => {
+        const productsQuestion: SandboxQuestion = {
+            question: 'Which products?',
+            header: 'Products',
+            multiSelect: true,
+            options: [{ label: 'Insights' }, { label: 'Replay' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([productsQuestion])} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(screen.getByText('Select at least one option')).toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+    })
+
+    it('steps through multiple questions and submits all answers at once', () => {
+        const second: SandboxQuestion = {
+            question: 'Which timeframe?',
+            header: 'Timeframe',
+            multiSelect: false,
+            options: [{ label: 'Weekly' }, { label: 'Monthly' }],
+        }
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion, second])} />)
+
+        expect(screen.getByText('1/2')).toBeInTheDocument()
+        // Single-select pick auto-advances to the next question.
+        fireEvent.click(screen.getByText('Activation'))
+        expect(screen.getByText('2/2')).toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+
+        // Picking the last question's answer submits all collected answers.
+        fireEvent.click(screen.getByText('Monthly'))
+
+        expect(respondToPermission).toHaveBeenCalledWith({
+            requestId: 'req-1',
+            optionId: 'option_0',
+            answers: { 'Which goal matters most?': 'Activation', 'Which timeframe?': 'Monthly' },
+            customInput: undefined,
+        })
+    })
+
+    it('shows a sending state and blocks interaction while a reply is in flight', () => {
+        ;(useValues as jest.Mock).mockReturnValue({ respondingToPermission: true })
+        render(<SandboxQuestionInput streamKey="conv-1" request={makeRequest([goalQuestion])} />)
+
+        expect(screen.getByText('Sending response…')).toBeInTheDocument()
+        expect(screen.queryByText('Revenue')).not.toBeInTheDocument()
+        expect(respondToPermission).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/max/components/SandboxQuestionInput.tsx
+++ b/frontend/src/scenes/max/components/SandboxQuestionInput.tsx
@@ -1,0 +1,176 @@
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import { IconChat } from '@posthog/icons'
+import { LemonTag, Spinner } from '@posthog/lemon-ui'
+
+import type { MultiQuestionFormQuestion } from '~/queries/schema/schema-assistant-messages'
+
+import { deriveQuestionOptionId, type SandboxQuestion } from '../sandboxQuestionUtils'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+import type { PermissionRequestRecord } from '../types/sandboxStreamTypes'
+import { QuestionField } from './QuestionField'
+
+interface SandboxQuestionInputProps {
+    streamKey: string
+    request: PermissionRequestRecord
+}
+
+/** Adapt a sandbox question onto the `MultiQuestionFormQuestion` shape `QuestionField` renders. */
+function toFormQuestion(question: SandboxQuestion, index: number): MultiQuestionFormQuestion {
+    return {
+        id: String(index),
+        title: question.header ?? 'Question',
+        question: question.question,
+        type: question.multiSelect ? 'multi_select' : 'select',
+        options: question.options.map((option) => ({ value: option.label, description: option.description })),
+        allow_custom_answer: true,
+    }
+}
+
+function selectedLabels(answer: string | string[] | undefined): string[] {
+    if (Array.isArray(answer)) {
+        return answer
+    }
+    return answer ? [answer] : []
+}
+
+/**
+ * Interactive input-area overlay for an `AskUserQuestion` on a sandbox conversation. The agent (Twig)
+ * routes questions through the ACP permission framework, so this rides the same `pendingPermissionRequest`
+ * rails as `SandboxPermissionInput` but renders the question(s) instead of an approve/decline card.
+ *
+ * It reuses the LangGraph `QuestionField` (and therefore `OptionSelector` / `LemonCheckbox`) for the
+ * options, and mirrors `MultiQuestionFormInput`'s flow: single-select answers advance on pick,
+ * multi-select accumulates behind a Next/Submit button, and the footer label flips to "Submit" on the
+ * last question. On submit it replies via `respondToPermission` with the answers keyed by question
+ * text — the agent reads `_meta.answers`; `optionId` only has to be a valid offered option (derived
+ * from the first question's selection). `respondingToPermission` drives the loading / double-submit guard.
+ */
+export function SandboxQuestionInput({ streamKey, request }: SandboxQuestionInputProps): JSX.Element | null {
+    const boundLogic = sandboxStreamLogic({ streamKey })
+    const { respondToPermission } = useActions(boundLogic)
+    const { respondingToPermission } = useValues(boundLogic)
+
+    // Stable reference so the memoized callbacks below don't re-evaluate every render.
+    const questions = useMemo(() => request.questions ?? [], [request.questions])
+
+    const [currentIndex, setCurrentIndex] = useState(0)
+    const [answers, setAnswers] = useState<Record<number, string | string[]>>({})
+    const answersRef = useRef(answers)
+    answersRef.current = answers
+
+    const submit = useCallback(
+        (finalAnswers: Record<number, string | string[]>) => {
+            const answerMap: Record<string, string> = {}
+            for (let index = 0; index < questions.length; index++) {
+                const labels = selectedLabels(finalAnswers[index])
+                if (labels.length) {
+                    answerMap[questions[index].question] = labels.join(', ')
+                }
+            }
+            // Options only exist on the wire for the first question, so optionId / customInput derive
+            // from it; the answers map carries the rest for the agent.
+            const firstQuestion = questions[0]
+            const firstLabels = selectedLabels(finalAnswers[0])
+            const firstOptionLabels = new Set(firstQuestion.options.map((option) => option.label))
+            respondToPermission({
+                requestId: request.requestId,
+                optionId: deriveQuestionOptionId(firstQuestion, firstLabels),
+                answers: answerMap,
+                customInput: firstLabels.find((label) => !firstOptionLabels.has(label)),
+            })
+        },
+        [questions, request.requestId, respondToPermission]
+    )
+
+    const advanceOrSubmit = useCallback(
+        (updatedAnswers: Record<number, string | string[]>) => {
+            if (currentIndex < questions.length - 1) {
+                setCurrentIndex(currentIndex + 1)
+            } else {
+                submit(updatedAnswers)
+            }
+        },
+        [currentIndex, questions.length, submit]
+    )
+
+    const handleAnswer = useCallback(
+        (value: string | string[] | null) => {
+            if (respondingToPermission) {
+                return
+            }
+            if (value === null) {
+                const cleared = { ...answersRef.current }
+                delete cleared[currentIndex]
+                setAnswers(cleared)
+                answersRef.current = cleared
+                return
+            }
+            const updated = { ...answersRef.current, [currentIndex]: value }
+            setAnswers(updated)
+            answersRef.current = updated
+            advanceOrSubmit(updated)
+        },
+        [advanceOrSubmit, currentIndex, respondingToPermission]
+    )
+
+    const handleMultiSelectChange = useCallback(
+        (value: string[]) => {
+            const updated = { ...answersRef.current, [currentIndex]: value }
+            setAnswers(updated)
+            answersRef.current = updated
+        },
+        [currentIndex]
+    )
+
+    const handleMultiSelectSubmit = useCallback(() => {
+        if (respondingToPermission) {
+            return
+        }
+        advanceOrSubmit(answersRef.current)
+    }, [advanceOrSubmit, respondingToPermission])
+
+    // The dispatcher only mounts this when `questions` is non-empty; keep the guard for type safety.
+    const question = questions[currentIndex]
+    if (!question) {
+        return null
+    }
+
+    if (respondingToPermission) {
+        return (
+            <div className="flex items-center gap-2 text-muted p-3">
+                <Spinner className="size-4" />
+                <span>Sending response…</span>
+            </div>
+        )
+    }
+
+    const isLast = currentIndex === questions.length - 1
+
+    return (
+        <div className="flex flex-col gap-2 p-3">
+            <div className="flex items-center gap-2 text-sm">
+                <IconChat className="text-muted size-4" />
+                <LemonTag size="small" type="muted">
+                    {question.header ?? 'Question'}
+                </LemonTag>
+                {questions.length > 1 && (
+                    <span className="text-muted text-xs">
+                        {currentIndex + 1}/{questions.length}
+                    </span>
+                )}
+            </div>
+            <div className="font-medium text-sm">{question.question}</div>
+            <QuestionField
+                key={currentIndex}
+                question={toFormQuestion(question, currentIndex)}
+                value={answers[currentIndex]}
+                onAnswer={handleAnswer}
+                onChange={handleMultiSelectChange}
+                onSubmit={handleMultiSelectSubmit}
+                submitLabel={isLast ? 'Submit' : 'Next'}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -37,6 +37,7 @@ import { QueryWidget } from './messages/adapters/QueryWidget'
 import { SearchSessionRecordingsWidget } from './messages/adapters/SearchSessionRecordingsWidget'
 import { UpsertDashboardWidget } from './messages/adapters/UpsertDashboardWidget'
 import { FallbackMcpToolRenderer } from './messages/FallbackMcpToolRenderer'
+import { SandboxQuestionRenderer } from './sandbox/SandboxQuestionRenderer'
 
 export interface McpToolRendererProps {
     message: McpToolCallMessage
@@ -191,13 +192,21 @@ const BUILTIN_TOOLS: { keys: string[]; displayName: string; icon: JSX.Element }[
     { keys: ['Skill'], displayName: 'Skill', icon: <IconMagicWand /> },
     { keys: ['ToolSearch'], displayName: 'Tool search', icon: <IconSearch /> },
     { keys: ['ExitPlanMode'], displayName: 'Plan', icon: <IconDocument /> },
-    { keys: ['AskUserQuestion'], displayName: 'Question', icon: <IconAI /> },
 ]
 for (const { keys, displayName, icon } of BUILTIN_TOOLS) {
     for (const key of keys) {
         mcpToolRegistry.register({ key, displayName, icon, Renderer: FallbackMcpToolRenderer })
     }
 }
+
+// AskUserQuestion (the agent asking the user to pick between options) gets a bespoke renderer that
+// lays the question + options out like the LangGraph question recap, rather than the generic JSON card.
+mcpToolRegistry.register({
+    key: 'AskUserQuestion',
+    displayName: 'Question',
+    icon: <IconAI />,
+    Renderer: SandboxQuestionRenderer,
+})
 
 /** Looks up the renderer entry for a resolved tool key, falling back to the generic card. */
 export function lookupMcpToolRenderer(resolvedKey: string): McpToolRegistryEntry {

--- a/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.test.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.test.tsx
@@ -1,0 +1,94 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import type { McpToolCallMessage } from '../maxTypes'
+import { SandboxQuestionRenderer } from './SandboxQuestionRenderer'
+
+function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'AskUserQuestion',
+        rawServerName: '',
+        rawToolName: 'AskUserQuestion',
+        claudeToolName: 'AskUserQuestion',
+        rawInput: {
+            questions: [
+                {
+                    question: 'Which goal matters most?',
+                    header: 'Goal',
+                    multiSelect: false,
+                    options: [{ label: 'Activation' }, { label: 'Revenue' }],
+                },
+            ],
+        },
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+function renderCard(message: McpToolCallMessage): void {
+    render(<SandboxQuestionRenderer message={message} isLastInGroup displayName="Question" />)
+}
+
+describe('SandboxQuestionRenderer', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders the question and the chosen answer once answered, without the per-question header chip', () => {
+        renderCard(makeMessage({ rawOutput: { answers: { 'Which goal matters most?': 'Revenue' } } }))
+
+        expect(screen.getByText('Which goal matters most?')).toBeInTheDocument()
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        expect(screen.getByText('Revenue')).toHaveClass('font-medium')
+        // The header label ("Goal") is dropped from the recap — the answer carries the meaning.
+        expect(screen.queryByText('Goal')).not.toBeInTheDocument()
+    })
+
+    it('does not render the question in place while it is still being asked', () => {
+        renderCard(makeMessage({ status: 'in_progress', rawOutput: undefined }))
+
+        // The overlay owns the unanswered state; the recap body stays empty until an answer arrives.
+        expect(screen.queryByText('Which goal matters most?')).not.toBeInTheDocument()
+        expect(screen.queryByText('Waiting for your answer…')).not.toBeInTheDocument()
+    })
+
+    it('recaps each answer for a multi-question request', () => {
+        renderCard(
+            makeMessage({
+                rawInput: {
+                    questions: [
+                        { question: 'Goal?', header: 'Goal', multiSelect: false, options: [{ label: 'Revenue' }] },
+                        { question: 'When?', header: 'When', multiSelect: false, options: [{ label: 'Weekly' }] },
+                    ],
+                },
+                rawOutput: { answers: { 'Goal?': 'Revenue', 'When?': 'Weekly' } },
+            })
+        )
+
+        expect(screen.getByText('Revenue')).toBeInTheDocument()
+        expect(screen.getByText('Weekly')).toBeInTheDocument()
+    })
+
+    it('falls back to a joined answer string when there is no per-question map', () => {
+        renderCard(makeMessage({ rawOutput: { text: 'User picked Revenue' } }))
+
+        expect(screen.getByText('User picked Revenue')).toBeInTheDocument()
+    })
+
+    it('shows the error message when the call failed', () => {
+        renderCard(makeMessage({ status: 'failed', rawOutput: undefined, error: { message: 'Question timed out' } }))
+
+        expect(screen.getByText('Question timed out')).toBeInTheDocument()
+    })
+
+    it('falls back to the generic tool card when the input has no questions', () => {
+        renderCard(makeMessage({ rawInput: {}, rawOutput: undefined }))
+
+        // The fallback card exposes an "Input" collapse panel; the question recap never mounts.
+        expect(screen.getByText('Input')).toBeInTheDocument()
+        expect(screen.queryByText('Which goal matters most?')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
@@ -1,0 +1,80 @@
+import { IconAI, IconCheck, IconWarning } from '@posthog/icons'
+import { Spinner } from '@posthog/lemon-ui'
+
+import type { McpToolCallMessage } from '../maxTypes'
+import type { McpToolRendererProps } from '../mcpToolRegistry'
+import { FallbackMcpToolRenderer } from '../messages/FallbackMcpToolRenderer'
+import { MessageTemplate } from '../messages/MessageTemplate'
+import {
+    extractSandboxQuestionAnswer,
+    parseSandboxQuestionAnswers,
+    parseSandboxQuestions,
+} from '../sandboxQuestionUtils'
+
+function StatusBadge({ status }: { status: McpToolCallMessage['status'] }): JSX.Element {
+    if (status === 'in_progress' || status === 'pending') {
+        return <Spinner className="text-sm" />
+    }
+    if (status === 'failed') {
+        return <IconWarning className="text-danger text-sm" />
+    }
+    return <IconCheck className="text-success text-sm" />
+}
+
+/**
+ * Thread recap for the `AskUserQuestion` Claude built-in. The interactive answering happens in the
+ * input overlay (`SandboxQuestionInput`); this is the compact transcript record. While a question is
+ * still being asked it contributes nothing here (no recap row) — the overlay owns the unanswered state.
+ * Once answered it shows only the question text and the chosen answer; the "answered" tick lives in the
+ * header `StatusBadge`, and the per-question header label is dropped to keep the recap quiet. Malformed
+ * input falls back to the generic tool card.
+ */
+export function SandboxQuestionRenderer(props: McpToolRendererProps): JSX.Element {
+    const { message, icon, displayName } = props
+    const questions = parseSandboxQuestions(message.rawInput)
+
+    if (questions.length === 0) {
+        return <FallbackMcpToolRenderer {...props} />
+    }
+
+    const answersByKey = parseSandboxQuestionAnswers(message.rawOutput)
+    // When the result didn't carry a per-question map, fall back to a single joined answer string
+    // (Twig's `extractAnswer`) attributed to the first question, so the answer is never lost.
+    const fallbackAnswer =
+        Object.keys(answersByKey).length === 0 ? extractSandboxQuestionAnswer(message.rawOutput) : null
+
+    const answered = questions
+        .map((question, index) => {
+            const answer = answersByKey[question.question] ?? (index === 0 ? fallbackAnswer : null)
+            return answer ? { question: question.question, answer } : null
+        })
+        .filter((entry): entry is { question: string; answer: string } => entry !== null)
+
+    const errorMessage = message.status === 'failed' ? message.error?.message : undefined
+    const hasBody = answered.length > 0 || Boolean(errorMessage)
+
+    return (
+        <MessageTemplate
+            type="ai"
+            header={
+                <div className="flex items-center gap-1.5 text-sm text-secondary mb-1">
+                    <span className="text-base flex items-center">{icon ?? <IconAI className="text-base" />}</span>
+                    <span className="font-medium text-default">{message.title || displayName || 'Question'}</span>
+                    <StatusBadge status={message.status} />
+                </div>
+            }
+        >
+            {hasBody ? (
+                <div className="flex flex-col gap-3">
+                    {errorMessage && <div className="text-danger text-sm">{errorMessage}</div>}
+                    {answered.map((entry, index) => (
+                        <div key={index} className="flex flex-col gap-1 text-sm">
+                            <div className="text-muted">{entry.question}</div>
+                            <span className="font-medium">{entry.answer}</span>
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+        </MessageTemplate>
+    )
+}

--- a/frontend/src/scenes/max/sandboxQuestionUtils.test.ts
+++ b/frontend/src/scenes/max/sandboxQuestionUtils.test.ts
@@ -1,0 +1,103 @@
+import {
+    deriveQuestionOptionId,
+    extractSandboxQuestionAnswer,
+    parseSandboxQuestionAnswers,
+    parseSandboxQuestions,
+    type SandboxQuestion,
+} from './sandboxQuestionUtils'
+
+describe('sandboxQuestionUtils', () => {
+    describe('parseSandboxQuestions', () => {
+        it('parses the { questions: [...] } shape with options and descriptions', () => {
+            const result = parseSandboxQuestions({
+                questions: [
+                    {
+                        question: 'Which goal matters most?',
+                        header: 'Goal',
+                        multiSelect: false,
+                        options: [{ label: 'Activation', description: 'aha moment' }, { label: 'Revenue' }],
+                    },
+                ],
+            })
+
+            expect(result).toEqual([
+                {
+                    question: 'Which goal matters most?',
+                    header: 'Goal',
+                    multiSelect: false,
+                    options: [{ label: 'Activation', description: 'aha moment' }, { label: 'Revenue' }],
+                },
+            ])
+        })
+
+        it('normalizes a single { question, options } shape into a one-element array', () => {
+            const result = parseSandboxQuestions({
+                question: 'Pick one',
+                options: [{ label: 'A' }, { label: 'B' }],
+                multiSelect: true,
+            })
+
+            expect(result).toHaveLength(1)
+            expect(result[0].question).toEqual('Pick one')
+            expect(result[0].multiSelect).toBe(true)
+            expect(result[0].options).toEqual([{ label: 'A' }, { label: 'B' }])
+        })
+
+        it('drops malformed entries and returns [] when nothing is parseable', () => {
+            expect(parseSandboxQuestions({ questions: [{ noQuestion: true }, 'nope'] })).toEqual([])
+            expect(parseSandboxQuestions({})).toEqual([])
+            expect(parseSandboxQuestions(null)).toEqual([])
+        })
+    })
+
+    describe('parseSandboxQuestionAnswers', () => {
+        it('reads a bare answers map keyed by question text', () => {
+            expect(parseSandboxQuestionAnswers({ answers: { 'Which goal?': 'Revenue' } })).toEqual({
+                'Which goal?': 'Revenue',
+            })
+        })
+
+        it('reads an answers map wrapped under output and joins array values', () => {
+            expect(parseSandboxQuestionAnswers({ output: { answers: { Products: ['Insights', 'Flags'] } } })).toEqual({
+                Products: 'Insights, Flags',
+            })
+        })
+
+        it('returns {} when there is no answers map', () => {
+            expect(parseSandboxQuestionAnswers({ text: 'hi' })).toEqual({})
+            expect(parseSandboxQuestionAnswers(undefined)).toEqual({})
+        })
+    })
+
+    describe('extractSandboxQuestionAnswer', () => {
+        const cases: [string, unknown, string | null][] = [
+            ['a bare string', 'Revenue', 'Revenue'],
+            ['an answer field', { answer: 'Revenue' }, 'Revenue'],
+            ['a joined answers map', { answers: { q1: 'A', q2: 'B' } }, 'A, B'],
+            ['a text field', { text: 'done' }, 'done'],
+            ['a content field', { content: 'picked' }, 'picked'],
+            ['nothing usable', { foo: 1 }, null],
+        ]
+
+        it.each(cases)('extracts from %s', (_label, result, expected) => {
+            expect(extractSandboxQuestionAnswer(result)).toEqual(expected)
+        })
+    })
+
+    describe('deriveQuestionOptionId', () => {
+        const question: SandboxQuestion = {
+            question: 'Pick',
+            multiSelect: false,
+            options: [{ label: 'Activation' }, { label: 'Revenue' }],
+        }
+
+        it('uses the index of the first selected option', () => {
+            expect(deriveQuestionOptionId(question, ['Revenue'])).toEqual('option_1')
+        })
+
+        it('falls back to option_0 for a free-typed answer that matches no option', () => {
+            expect(deriveQuestionOptionId(question, ['Cut churn'])).toEqual('option_0')
+            expect(deriveQuestionOptionId(question, [])).toEqual('option_0')
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandboxQuestionUtils.ts
+++ b/frontend/src/scenes/max/sandboxQuestionUtils.ts
@@ -1,0 +1,167 @@
+/**
+ * Parsing + answer helpers for the sandbox `AskUserQuestion` flow, ported from Twig
+ * (`packages/agent/src/adapters/claude/questions/utils.ts` and the mobile `QuestionCard`).
+ *
+ * In the sandbox runtime the agent asks the user to pick between options via the Claude built-in
+ * `AskUserQuestion`. Twig routes it through the ACP permission framework: a single
+ * `permission_request` carries `toolCall._meta.codeToolKind === 'question'` + `_meta.questions`, and
+ * the answer is returned on the existing `permission_response` command as an `answers` map keyed by
+ * question text. These helpers are shared by `sandboxStreamLogic` (parsing the request), the input
+ * overlay (`SandboxQuestionInput`, building the reply), and the thread recap (`SandboxQuestionRenderer`).
+ */
+
+/** The `option_${idx}` ids Twig's `buildQuestionOptions` mints for the first question's options. */
+export const SANDBOX_QUESTION_OPTION_PREFIX = 'option_'
+
+/** One choice the agent offered for a question. */
+export interface SandboxQuestionOption {
+    label: string
+    description?: string
+}
+
+/** One question parsed from an `AskUserQuestion` permission request or tool call. */
+export interface SandboxQuestion {
+    question: string
+    /** Short chip label (≤12 chars in the tool schema) shown above the question. */
+    header?: string
+    multiSelect: boolean
+    options: SandboxQuestionOption[]
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function parseOptions(raw: unknown): SandboxQuestionOption[] {
+    if (!Array.isArray(raw)) {
+        return []
+    }
+    const options: SandboxQuestionOption[] = []
+    for (const entry of raw) {
+        const record = asRecord(entry)
+        if (!record || typeof record.label !== 'string') {
+            continue
+        }
+        options.push({
+            label: record.label,
+            description: typeof record.description === 'string' && record.description ? record.description : undefined,
+        })
+    }
+    return options
+}
+
+function parseQuestionItem(record: Record<string, unknown>): SandboxQuestion | null {
+    if (typeof record.question !== 'string') {
+        return null
+    }
+    return {
+        question: record.question,
+        header: typeof record.header === 'string' && record.header ? record.header : undefined,
+        multiSelect: record.multiSelect === true,
+        options: parseOptions(record.options),
+    }
+}
+
+/**
+ * Parse the questions out of an `AskUserQuestion` payload. Accepts Twig's two input shapes
+ * (`normalizeAskUserQuestionInput`): the preferred `{ questions: [...] }`, or a single
+ * `{ question, header, options, multiSelect }`. Returns `[]` when nothing parseable is present.
+ */
+export function parseSandboxQuestions(raw: unknown): SandboxQuestion[] {
+    const record = asRecord(raw)
+    if (!record) {
+        return []
+    }
+    if (Array.isArray(record.questions)) {
+        const questions: SandboxQuestion[] = []
+        for (const entry of record.questions) {
+            const itemRecord = asRecord(entry)
+            const item = itemRecord ? parseQuestionItem(itemRecord) : null
+            if (item) {
+                questions.push(item)
+            }
+        }
+        return questions
+    }
+    const single = parseQuestionItem(record)
+    return single ? [single] : []
+}
+
+/**
+ * Per-question answers keyed by question text, read from the tool result. The result may be the
+ * bare object or wrapped under an `output` envelope; array values (multi-select) are joined.
+ */
+export function parseSandboxQuestionAnswers(result: unknown): Record<string, string> {
+    const outer = asRecord(result)
+    for (const candidate of [outer, asRecord(outer?.output)]) {
+        const map = asRecord(candidate?.answers)
+        if (!map) {
+            continue
+        }
+        const answers: Record<string, string> = {}
+        for (const [key, value] of Object.entries(map)) {
+            if (typeof value === 'string' && value.trim()) {
+                answers[key] = value.trim()
+            } else if (Array.isArray(value)) {
+                const joined = value
+                    .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+                    .map((v) => v.trim())
+                    .join(', ')
+                if (joined) {
+                    answers[key] = joined
+                }
+            }
+        }
+        if (Object.keys(answers).length) {
+            return answers
+        }
+    }
+    return {}
+}
+
+/**
+ * A single joined answer string for the compact recap — Twig's `extractAnswer`. Falls back through
+ * `answer` / `answers` (joined) / `text` / `content` so an answer is shown even when the result
+ * doesn't match the per-question map shape.
+ */
+export function extractSandboxQuestionAnswer(result: unknown): string | null {
+    if (typeof result === 'string') {
+        return result.trim() || null
+    }
+    const record = asRecord(result)
+    if (!record) {
+        return null
+    }
+    if (typeof record.answer === 'string' && record.answer.trim()) {
+        return record.answer.trim()
+    }
+    const answers = asRecord(record.answers)
+    if (answers) {
+        const joined = Object.values(answers)
+            .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+            .map((v) => v.trim())
+            .join(', ')
+        if (joined) {
+            return joined
+        }
+    }
+    if (typeof record.text === 'string' && record.text.trim()) {
+        return record.text.trim()
+    }
+    if (typeof record.content === 'string' && record.content.trim()) {
+        return record.content.trim()
+    }
+    return null
+}
+
+/**
+ * The ACP `optionId` to send on the reply. Twig builds options server-side as `option_${idx}` over
+ * the FIRST question's options; pick the index of the first selected label, falling back to
+ * `option_0` for a free-typed ("Other") answer that matches no option. The `answers` map carries the
+ * real content for the agent — `optionId` only has to be a valid offered option.
+ */
+export function deriveQuestionOptionId(question: SandboxQuestion, selectedLabels: string[]): string {
+    const first = selectedLabels[0]
+    const idx = first !== undefined ? question.options.findIndex((o) => o.label === first) : -1
+    return `${SANDBOX_QUESTION_OPTION_PREFIX}${idx >= 0 ? idx : 0}`
+}

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -1567,7 +1567,7 @@ describe('sandboxStreamLogic', () => {
             expect(tasksRunsCommandCreate).toHaveBeenCalledWith('997', 'task-1', 'run-1', {
                 jsonrpc: '2.0',
                 method: 'permission_response',
-                params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined },
+                params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined, answers: undefined },
             })
         })
 
@@ -1993,7 +1993,7 @@ describe('sandboxStreamLogic', () => {
                 expect(tasksRunsCommandCreate).toHaveBeenCalledWith('997', 'task-7', 'run-7', {
                     jsonrpc: '2.0',
                     method: 'permission_response',
-                    params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined },
+                    params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined, answers: undefined },
                 })
                 const permRequested = captureSpy.mock.calls.find((c) => c[0] === 'permission_requested')
                 expect(permRequested).not.toBeUndefined()
@@ -2020,7 +2020,7 @@ describe('sandboxStreamLogic', () => {
             expect(tasksRunsCommandCreate).toHaveBeenCalledWith('997', 'task-1', 'run-1', {
                 jsonrpc: '2.0',
                 method: 'permission_response',
-                params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined },
+                params: { requestId: 'req-1', optionId: 'allow_once', customInput: undefined, answers: undefined },
             })
         })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -7,6 +7,7 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
 
+import { parseSandboxQuestions } from './sandboxQuestionUtils'
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
 import { defaultPermissionDecision, findAllowOptionId } from './sandboxToolPolicy'
 import type {
@@ -437,6 +438,11 @@ export function parsePermissionRequestFrame(
     const claudeCode = (meta.claudeCode ?? {}) as Record<string, unknown>
     const toolName = String(claudeCode.toolName ?? toolCall.toolName ?? rawToolName)
 
+    // `AskUserQuestion` is routed through the permission framework by the agent (Twig): the question
+    // payload rides `_meta.codeToolKind === 'question'` + `_meta.questions`. When present, this renders
+    // the interactive question overlay (not the approve/decline card) and is never auto-approved.
+    const questions = meta.codeToolKind === 'question' ? parseSandboxQuestions(meta) : []
+
     return {
         requestId,
         toolCallId,
@@ -444,6 +450,7 @@ export function parsePermissionRequestFrame(
         options,
         title: toolCall.title as string | undefined,
         description: toolCall.description as string | undefined,
+        ...(questions.length > 0 ? { questions } : {}),
         rawToolCall: {
             toolCallId,
             rawServerName,
@@ -532,9 +539,15 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
          * User picked an option on the approval card. POSTs the reply to the sandbox `permission/`
          * endpoint (which routes to the products/tasks `permission_response` command); the pending
          * request clears only once the POST succeeds, so a failure keeps the card for retry.
-         * `customInput` carries `reject_with_feedback` text.
+         * `customInput` carries `reject_with_feedback` text. `answers` carries `AskUserQuestion`
+         * selections (keyed by question text) — the agent reads `_meta.answers` to resolve the question.
          */
-        respondToPermission: (payload: { requestId: string; optionId: string; customInput?: string }) => payload,
+        respondToPermission: (payload: {
+            requestId: string
+            optionId: string
+            customInput?: string
+            answers?: Record<string, string>
+        }) => payload,
         clearPermissionRequest: true,
         /**
          * Cancel a run via the generic tasks relay. With no argument, cancels the streamed run
@@ -1211,7 +1224,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 execution_type: 'sandbox',
             })
         },
-        respondToPermission: async ({ requestId, optionId, customInput }) => {
+        respondToPermission: async ({ requestId, optionId, customInput, answers }) => {
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
             if (!activeRun || values.currentProjectId == null) {
                 // No live run to command — keep the card so the user can retry once the stream resolves.
@@ -1227,7 +1240,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 await tasksRunsCommandCreate(String(values.currentProjectId), activeRun.taskId, activeRun.runId, {
                     jsonrpc: '2.0',
                     method: 'permission_response',
-                    params: { requestId, optionId, customInput },
+                    params: { requestId, optionId, customInput, answers },
                 })
                 actions.markPermissionRequestResolved(requestId)
             } catch (error) {

--- a/frontend/src/scenes/max/sandboxToolPolicy.test.ts
+++ b/frontend/src/scenes/max/sandboxToolPolicy.test.ts
@@ -1,3 +1,4 @@
+import type { SandboxQuestion } from './sandboxQuestionUtils'
 import {
     defaultPermissionDecision,
     findAllowOptionId,
@@ -9,7 +10,13 @@ import type { PermissionRequestRecord, ToolInvocation } from './types/sandboxStr
 import type { PermissionOption } from './types/sandboxWireTypes'
 
 function makeRecord(
-    overrides: { toolName?: string; resolvedKey?: string; innerToolName?: string; options?: PermissionOption[] } = {}
+    overrides: {
+        toolName?: string
+        resolvedKey?: string
+        innerToolName?: string
+        options?: PermissionOption[]
+        questions?: SandboxQuestion[]
+    } = {}
 ): PermissionRequestRecord {
     const rawToolCall: ToolInvocation = {
         toolCallId: 'tc',
@@ -27,6 +34,7 @@ function makeRecord(
         toolName: overrides.toolName ?? 'mcp__posthog__exec',
         options: overrides.options ?? [{ optionId: 'allow', name: 'Yes', kind: 'allow_once' }],
         rawToolCall,
+        ...(overrides.questions ? { questions: overrides.questions } : {}),
     }
 }
 
@@ -74,6 +82,17 @@ describe('sandboxToolPolicy', () => {
                 'prompt',
             ],
             ['other mcp tool', makeRecord({ toolName: 'mcp__other__foo', resolvedKey: 'foo' }), 'prompt'],
+            // AskUserQuestion rides the permission framework with allow_once options, but must never
+            // auto-approve — picking option_0 with no answers gets rejected by the agent.
+            [
+                'question request',
+                makeRecord({
+                    toolName: 'AskUserQuestion',
+                    resolvedKey: 'AskUserQuestion',
+                    questions: [{ question: 'Pick one', multiSelect: false, options: [{ label: 'A' }] }],
+                }),
+                'prompt',
+            ],
         ])('%s → %s', (_case, record, expected) => {
             expect(defaultPermissionDecision(record)).toEqual(expected)
         })

--- a/frontend/src/scenes/max/sandboxToolPolicy.ts
+++ b/frontend/src/scenes/max/sandboxToolPolicy.ts
@@ -34,6 +34,12 @@ export type PermissionDecision = 'auto_allow' | 'prompt'
  * and auto-approves; other MCP servers prompt.
  */
 export function defaultPermissionDecision(record: PermissionRequestRecord): PermissionDecision {
+    // An `AskUserQuestion` rides the permission framework but is not an approval — auto-approving it
+    // would pick the first option with no `answers`, which the agent rejects. Always prompt the user.
+    if (record.questions?.length) {
+        return 'prompt'
+    }
+
     const { toolName } = record
     const { resolvedKey, innerToolName } = record.rawToolCall
 

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -6,6 +6,7 @@
  * `./sandboxWireTypes`) into the `ToolInvocation` / `ThreadItem` state the renderer consumes.
  */
 
+import type { SandboxQuestion } from '../sandboxQuestionUtils'
 import type { PermissionOption } from './sandboxWireTypes'
 
 export type ToolInvocationStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
@@ -155,4 +156,10 @@ export interface PermissionRequestRecord {
     title?: string
     description?: string
     rawToolCall: ToolInvocation
+    /**
+     * Present when this request is an `AskUserQuestion` — Twig routes questions through the permission
+     * framework (`toolCall._meta.codeToolKind === 'question'`, `_meta.questions`). Drives the
+     * interactive question overlay instead of the approve/decline card, and blocks auto-approval.
+     */
+    questions?: SandboxQuestion[]
 }


### PR DESCRIPTION
## Problem

In the sandbox runtime (`agent_runtime === 'sandbox'`), the agent is Claude Code, and it asks the user to choose between options via the built-in **`AskUserQuestion`** tool. The agent (Twig) routes these questions through the ACP permission framework, so they already arrive on the client as a `permission_request`. But the default permission policy classified any non-`mcp__` built-in as auto-approve, so a question was silently auto-approved with **no answers** — which the agent then rejects ("User did not provide answers"). In other words, questions in sandbox conversations were quietly broken: the user never got to answer, and the agent couldn't proceed.

## Changes

Render `AskUserQuestion` as an **interactive overlay on the chat input**, matching how the reference agent's clients do it, and reply over the existing answer channel.

- **Never auto-approve a question.** `defaultPermissionDecision` now returns `prompt` when the permission record carries `questions`, so the user is always asked.
- **Interactive overlay.** A new `SandboxQuestionInput` rides the same `pendingPermissionRequest` rails as the approve/decline card (`SandboxPermissionInput`) but renders the question(s). It **reuses the existing `QuestionField` design-system components** (`OptionSelector` / `LemonCheckbox`) and mirrors the multi-question flow: single-select advances on pick, multi-select accumulates behind a Next/Submit button, custom "Other" answers are supported, and a double-submit guard is wired off the in-flight state.
- **Answer channel.** The reply goes back on the existing `permission_response` command with an `answers` map keyed by question text; the agent reads it and merges it into the tool input. The relay already passes the command `params` through verbatim, so **no backend change is required**.
- **In-thread card → compact recap.** The `AskUserQuestion` thread renderer is now an answered-only recap (question + chosen answer); while a question is still being asked it shows nothing in-thread (the overlay owns that state).
- Small shared fix: the custom-answer label in `OptionSelector` had a double-dot typo (`instead..`), now a single period.

This is a **frontend-only** change.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run the UI manually. Automated coverage I ran on this branch:

- New unit tests: `sandboxQuestionUtils` (parsing both wire shapes, answer extraction, optionId derivation), `SandboxQuestionInput` (single/multi-select submit, custom "Other" path, empty-multi validation, multi-question stepping, sending state), `SandboxQuestionRenderer` (answered recap, unanswered renders nothing, multi-question recap, joined fallback, error, no-questions fallback).
- Updated `sandboxToolPolicy` (question → `prompt`) and `sandboxStreamLogic` (`permission_response` params now carry `answers`).
- Full touched suite: **222 passing**, lint clean (0 errors), TS diagnostics clean.

Note for reviewers: one test in `sandboxStreamLogic.test.ts` (`stream phase › is provisioning … then flips to thinking`) fails on `feat/posthog-ai-sandboxes` **before** this change — it is pre-existing on the base branch and unrelated to this PR.

Manual UX confirmation still worth a human pass: trigger the agent to ask a clarifying question, answer in the overlay (including "Other"), and confirm the agent continues and the thread card collapses to the recap.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed (internal sandbox UX).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Georgiy directed the work and is the DRI.

- **Tool:** Claude Code (Opus 4.8).
- **Shape of the work, as directed:** match the existing Max question UI, but make the question render as an interactive overlay on the input (the way the reference agent does), with the in-thread card showing different, recap-style content. A follow-up pass refined the recap to be answered-only (drop the per-question header chip and the redundant green tick, since the tool card already shows an "answered" status), and fixed the double-dot label.
- **Key decisions:** (1) Questions ride the existing permission rails rather than a new frame type — same dedup/resolve/telemetry, same `permission_response` reply, only forking on "don't auto-approve" + "render the question" + "include `answers`". (2) The answer map is sent via the existing pass-through `params`, so the backend is untouched. (3) The overlay reuses `QuestionField` instead of hand-rolled inputs to stay consistent with the LangGraph question UX. (4) This branch is cut from `feat/posthog-ai-sandboxes` and contains only the AskUserQuestion change; the `sandboxStreamLogic.ts` edit auto-merged cleanly onto the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
