### PR TITLE
feat(agent-platform): authenticate runner→ai-gateway with a static phs_ bearer

### DIFF
--- a/.github/scripts/smoke-test-agent-bundle.sh
+++ b/.github/scripts/smoke-test-agent-bundle.sh
@@ -47,6 +47,7 @@ docker run --rm \
     -e MODAL_TOKEN_ID='smoke-modal-token-id' \
     -e MODAL_TOKEN_SECRET='smoke-modal-token-secret' \
     -e AGENT_USE_AI_GATEWAY='1' \
+    -e POSTHOG_AI_GATEWAY_KEY='phs_smoke-test-gateway-key' \
     -e POSTHOG_AI_GATEWAY_URL='http://127.0.0.1:1/v1' \
     -e POSTHOG_API_BASE_URL='http://127.0.0.1:1' \
     -e HTTPS_PROXY='http://127.0.0.1:1' \

--- a/products/agent_platform/services/agent-runner/src/config.ts
+++ b/products/agent_platform/services/agent-runner/src/config.ts
@@ -79,7 +79,9 @@ export const AgentRunnerConfigSchema = PlatformConfigSchema.extend({
     posthogAiGatewayKey: z
         .string()
         .optional()
-        .describe('PostHog ai-gateway PAT (`phx_...`). First non-empty wins for pi-ai default apiKey.'),
+        .describe(
+            'Static ai-gateway bearer — a `phs_` project secret key with the `llm_gateway:read` scope. On the gateway path it authenticates every model + usage call (required there); on the direct path it falls through as the first-priority provider apiKey.'
+        ),
     anthropicApiKey: z.string().optional().describe('Anthropic API key. Second-priority for pi-ai default apiKey.'),
     openaiApiKey: z.string().optional().describe('OpenAI API key. Third-priority for pi-ai default apiKey.'),
     modelApiKey: z.string().optional().describe('Catch-all model API key. Last-priority for pi-ai default apiKey.'),

--- a/products/agent_platform/services/agent-runner/src/index.ts
+++ b/products/agent_platform/services/agent-runner/src/index.ts
@@ -78,6 +78,14 @@ async function main(): Promise<void> {
         )
     }
 
+    // Gateway path authenticates every call with one static phs_ bearer; without
+    // it every request 401s, so fail fast rather than crash-loop at first turn.
+    if (config.useAiGateway && !config.posthogAiGatewayKey) {
+        throw new Error(
+            'AGENT_USE_AI_GATEWAY requires POSTHOG_AI_GATEWAY_KEY — a phs_ project secret key with the llm_gateway:read scope.'
+        )
+    }
+
     // Outbound HTTP — every tool fetch, gateway fetch, and MCP transport
     // dispatches through here. In prod `config.httpsProxy` points at smokescreen
     // so author-supplied URLs (web-fetch, http-request, external MCPs) get SSRF
@@ -158,9 +166,8 @@ async function main(): Promise<void> {
     await logSink.connect()
 
     // Resolves a team's `phc_` project key from the main PostHog DB (cached per
-    // team). Two consumers: the ai-gateway bearer (below) and the LLM-analytics
-    // sink (next). Constructed unconditionally so analytics can route per-team
-    // even when the gateway is off. See ai-gateway-integration.md §3 (W1).
+    // team) for the LLM-analytics sink's per-team routing (below). The gateway
+    // bearer is a single static phs_ now, so this no longer feeds it.
     const teamApiKeys = new PgTeamApiKeyResolver(posthogDb)
 
     // LLM analytics sink. Captures `$ai_generation` per pi-ai call, `$ai_span`
@@ -300,19 +307,20 @@ async function main(): Promise<void> {
                       baseUrl: config.aiGatewayUrl,
                   })
             : undefined,
-        // The driver streams through pi-ai's `streamSimple`; the per-session
-        // API key flows in here (no more client-level default). Gateway path
-        // → resolve the owning team's `phc_`; direct path → fall back to the
-        // boot-time default (ANTHROPIC_API_KEY / OPENAI_API_KEY / etc).
-        resolveApiKey: config.useAiGateway ? (session) => teamApiKeys.resolve(session.team_id) : () => defaultApiKey,
+        // Per-session bearer for pi-ai's `streamSimple` (no client-level default).
+        // Gateway path → the static phs_ (cost bills to the team that owns it);
+        // direct path → boot-time provider key (ANTHROPIC_API_KEY / OPENAI / etc).
+        resolveApiKey: config.useAiGateway ? () => config.posthogAiGatewayKey : () => defaultApiKey,
         resolveGatewayHeaders: config.useAiGateway
             ? (session) => ({
                   'X-PostHog-Distinct-Id': analyticsDistinctId(session),
                   'X-PostHog-Trace-Id': session.id,
               })
             : undefined,
+        // /v1/usage + /v1/wallet reads use the same static phs_ (the `phc` field
+        // is the read client's bearer; key presence is guaranteed at boot above).
         resolveGatewayUsage: gatewayClient
-            ? async (session) => ({ client: gatewayClient, phc: await teamApiKeys.resolve(session.team_id) })
+            ? () => ({ client: gatewayClient, phc: config.posthogAiGatewayKey! })
             : undefined,
         // On the gateway path pi-ai's cost numbers are client-side estimates;
         // the gateway itself owns billing. We keep token counts. Cost is


### PR DESCRIPTION
## Problem

The ai-gateway (RFC #1103) accepts only `phs_` (project secret key) / `pha_` (OAuth) tokens scoped `llm_gateway:read` and **rejects `phc_`**. The runner was sending each team's `phc_` as the gateway bearer, so every gateway call 401'd (`ai_gateway` auth error on the first turn).

## Change

Use the single `POSTHOG_AI_GATEWAY_KEY` (`phs_`) as the bearer on the gateway path, for both planes:

- **Data plane** — `resolveApiKey` → pi-ai `streamSimple` (the model calls).
- **Read plane** — `resolveGatewayUsage` → `GET /v1/usage/<id>` + `/v1/wallet/balance` (post-turn cost recovery), which sit behind the same auth middleware.

All cost bills to the team that owns the key — the "attribute all cost to a single team config" plan for now. Boot fails fast when `AGENT_USE_AI_GATEWAY=1` but the key is unset, rather than crash-looping at the first turn.

`teamApiKeys` (`PgTeamApiKeyResolver`) is no longer a gateway-bearer source; its sole remaining consumer is the per-team LLM-analytics sink (`RoutingAnalyticsSink`), which is unaffected — agent traffic still shows up in each owning team's LLM Analytics.

The direct (non-gateway) path is unchanged: `resolveApiKey` still returns the boot-time provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / …).

## Coupling

Pairs with charts **#12263**, which provisions `POSTHOG_AI_GATEWAY_KEY` in `agent-platform-shared-secrets` for dev / prod-us / prod-eu and flips dev onto the gateway. Roll them together — once dev's direct-provider bypass is gone, an env without the `phs_` set will 401.

## Follow-up (not in this PR)

The read-client option field is still named `phc` in `gateway-client.ts` / `driver.ts` / `worker.ts` though it now carries a `phs_`. A `phc → bearer` rename would keep it honest but touches shared files an in-flight branch is editing; deferred to avoid the conflict.

## Test

- `pnpm --filter @posthog/agent-runner typescript:check` — clean.
- `oxlint src/index.ts src/config.ts` — 0 warnings.
- `config.test.ts` 18/18; the gateway-cost driver tests pass. (Other driver tests fail locally on `column "is_preview" … does not exist`, a test-DB schema drift unrelated to this diff.)

---

### Agent context

Authored from a Claude Code session (model: Claude Opus 4.8, 1M context) driven by @benwhite. Diagnosis traced back to the ai-gateway `resolver.go` (`SecretKeyPrefix="phs_"`, `RequiredScope="llm_gateway:read"`, `phc_` rejected). Verification claims above were run by the agent in a dedicated git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)