### PR TITLE
chore(ci): attribute unowned rust crates in CODEOWNERS-soft

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -91,6 +91,8 @@ products/revenue_analytics/** @rafaeelaudibert @PostHog/team-web-analytics
 # Feature Flags (Rust evaluator + remaining monolith tests) - owned by @PostHog/team-feature-flags
 # Note: the Django models and API moved to products/feature_flags/ (covered by products/feature_flags/product.yaml).
 rust/feature-flags/ @PostHog/team-feature-flags
+rust/flags-consumer/ @PostHog/team-feature-flags
+rust/flags_read_store_migrations/ @PostHog/team-feature-flags
 posthog/test/test_feature_flag_analytics.py @PostHog/team-feature-flags
 
 # Cohorts - owned by @PostHog/team-feature-flags
@@ -120,6 +122,7 @@ posthog/temporal/data_modeling/** @PostHog/team-data-modeling
 # and also hard owned by the @PostHog/hogql on `CODEOWNERS` file
 posthog/hogql/** @PostHog/team-data-tools
 posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
+rust/hogql/ @PostHog/team-data-tools
 
 # Tracing/Metrics — owned by @PostHog/logs (logs itself comes from products/logs/product.yaml)
 products/tracing/** @PostHog/logs
@@ -133,6 +136,8 @@ products/error_tracking/mcp/** @PostHog/team-error-tracking
 products/error_tracking/skills/** @PostHog/team-error-tracking
 cli/** @PostHog/team-error-tracking
 rust/cymbal/** @PostHog/team-error-tracking
+rust/cymbal-resolution/** @PostHog/team-error-tracking
+rust/cymbal-proto/** @PostHog/team-error-tracking
 rust/common/symbol_data/** @PostHog/team-error-tracking
 
 # Notebooks - owned by @PostHog/team-platform-features
@@ -329,6 +334,25 @@ posthog/dags/detach_distinct_id.py @PostHog/team-ingestion
 posthog/dags/fix_missing_person_overrides.py @PostHog/team-ingestion
 posthog/dags/fix_person_id_overrides.py @PostHog/team-ingestion
 posthog/dags/person_property_reconciliation.py @PostHog/team-ingestion
+
+# Ingestion (Rust capture + Kafka + property defs) - owned by @PostHog/team-ingestion
+rust/capture/ @PostHog/team-ingestion
+rust/ingestion-consumer/ @PostHog/team-ingestion
+rust/kafka-deduplicator/ @PostHog/team-ingestion
+rust/kafka-assigner/ @PostHog/team-ingestion
+rust/kafka-assigner-proto/ @PostHog/team-ingestion
+rust/property-defs-rs/ @PostHog/team-ingestion
+rust/property-vals-rs/ @PostHog/team-ingestion
+
+# Personhog (persons gRPC service) - owned by @PostHog/team-ingestion
+rust/personhog-router/ @PostHog/team-ingestion
+rust/personhog-replica/ @PostHog/team-ingestion
+rust/personhog-leader/ @PostHog/team-ingestion
+rust/personhog-writer/ @PostHog/team-ingestion
+rust/personhog-coordination/ @PostHog/team-ingestion
+rust/personhog-common/ @PostHog/team-ingestion
+rust/personhog-proto/ @PostHog/team-ingestion
+rust/behavioral_cohorts_migrations/ @PostHog/team-ingestion
 
 # User interviews - owned by individuals (no team); product.yaml only auto-assigns team slugs
 products/user_interviews/** @pauldambra @fivestarspicy @ksvat


### PR DESCRIPTION
## Problem

`.github/CODEOWNERS-soft` is the backup ownership source for code outside `products/`, and the entire `rust/` tree was nearly absent from it. An audit (via the `establishing-code-ownership` skill's `ownership.js unowned`) found ~916 unowned files under `rust/`, despite each crate being a clean single-service boundary, the easiest possible case to attribute. Unowned code means the CI reviewer auto-assigner can't route review, and "who owns this" lookups fall through to the stale handbook.

## Changes

Maps 20 previously-unowned rust crates (514 files) to a team. Each attribution is backed by either an already-owned sibling crate or concentrated git authorship from that team's engineers:

| Team | Crates | Evidence |
|------|--------|----------|
| `team-feature-flags` | `flags-consumer`, `flags_read_store_migrations` | sibling `rust/feature-flags/` already owned |
| `team-error-tracking` | `cymbal-resolution`, `cymbal-proto` | sibling `rust/cymbal/**` already owned |
| `team-data-tools` | `hogql` | matches existing `posthog/hogql/**` soft-ownership |
| `team-ingestion` | `capture`, `ingestion-consumer`, `kafka-deduplicator`, `kafka-assigner`, `kafka-assigner-proto`, `property-defs-rs`, `property-vals-rs`, `personhog-*` (7 crates), `behavioral_cohorts_migrations` | sibling `rust/persons_migrations/**` already owned; authorship is the ingestion crew |

This drops repo-wide unowned files from 10,966 to 10,452.

### Deliberately left unowned (ambiguous, need a human call)

`rust/capture-logs` (authors differ from the ingestion crew; could be the `logs` team), `rust/cyclotron-*`, `rust/common`, `rust/batch-import-worker`, `rust/embedding-worker`, `rust/hypercache-server`, `rust/affected-services`. Teams should confirm these separately.

## How did you test this code?

I'm an agent (Claude Code). No manual testing. I verified each of the 20 crates resolves to the expected team using the repo's own GitHub-faithful matcher via `ownership.js file <path>` (the same matcher the CI reviewer auto-assigner uses), and confirmed the net unowned count dropped by 514 with no existing rule disturbed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, who asked me to run the `establishing-code-ownership` skill's unowned-file check and attribute any major parts that were easily attributable. Skills invoked: `/establishing-code-ownership`.

Approach: ran `ownership.js unowned`, bucketed the 10,966 unowned files by directory, and found `rust/` was the standout gap (clean per-crate boundaries, almost no coverage). For each candidate crate I corroborated ownership two ways before attributing: an already-owned sibling crate, plus git commit-author concentration. I deliberately excluded crates where authorship was mixed or a competing team plausibly owns them (notably `capture-logs` and the `cyclotron-*` family) rather than guess. The other large unowned buckets (Django migrations, `frontend/public`, `frontend/src/lib`, the `services/mcp` framework) are shared/multi-team by nature and intentionally not touched here.
