### PR TITLE
chore(experiments): add tracing spans to the list endpoint

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -9,6 +9,7 @@ ViewSet remains in experiments.py.
 from typing import Any
 
 from drf_spectacular.utils import extend_schema_field
+from opentelemetry import trace
 from pydantic import RootModel as PydanticRootModel
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -39,6 +40,8 @@ from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.clickhouse.views.experiment_holdouts import ExperimentHoldoutSerializer
 from ee.clickhouse.views.experiment_saved_metrics import ExperimentToSavedMetricSerializer
+
+tracer = trace.get_tracer(__name__)
 
 
 class _ExperimentApiMetricsList(PydanticRootModel):
@@ -115,8 +118,10 @@ class ExperimentListSerializer(serializers.ListSerializer):
     serializer context, so a 100-experiment page does one action query instead of hundreds.
     """
 
+    @tracer.start_as_current_span("ExperimentListSerializer.to_representation")
     def to_representation(self, data):
         instances = list(data)
+        trace.get_current_span().set_attribute("experiment_count", len(instances))
 
         metric_queries: list[dict[str, Any] | None] = []
         team: Team | None = None
@@ -345,6 +350,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
     def get_feature_flag(self, obj):
         return MinimalFeatureFlagSerializer(obj.feature_flag).data if obj.feature_flag else None
 
+    @tracer.start_as_current_span("ExperimentSerializer.to_representation")
     def to_representation(self, instance):
         data = super().to_representation(instance)
         # Normalize query date ranges to the experiment's current range
@@ -376,23 +382,26 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
 
         # Update date ranges in saved metrics
         # Note: Action name refresh is handled by ExperimentToSavedMetricSerializer.to_representation
-        for saved_metric in data.get("saved_metrics", []):
-            if saved_metric.get("query"):
-                if saved_metric["query"].get("count_query", {}).get("dateRange"):
-                    saved_metric["query"]["count_query"]["dateRange"] = new_date_range
-                if saved_metric["query"].get("funnels_query", {}).get("dateRange"):
-                    saved_metric["query"]["funnels_query"]["dateRange"] = new_date_range
+        saved_metrics = data.get("saved_metrics", [])
+        with tracer.start_as_current_span("ExperimentSerializer.saved_metric_fingerprints") as span:
+            span.set_attribute("saved_metric_count", len(saved_metrics))
+            for saved_metric in saved_metrics:
+                if saved_metric.get("query"):
+                    if saved_metric["query"].get("count_query", {}).get("dateRange"):
+                        saved_metric["query"]["count_query"]["dateRange"] = new_date_range
+                    if saved_metric["query"].get("funnels_query", {}).get("dateRange"):
+                        saved_metric["query"]["funnels_query"]["dateRange"] = new_date_range
 
-                # Add fingerprint to saved metric returned from API
-                # so that frontend knows what timeseries records to query
-                saved_metric["query"]["fingerprint"] = compute_metric_fingerprint(
-                    saved_metric["query"],
-                    instance.start_date,
-                    get_experiment_stats_method(instance),
-                    instance.exposure_criteria,
-                    only_count_matured_users=instance.only_count_matured_users,
-                    excluded_variants=(instance.parameters or {}).get("excluded_variants"),
-                )
+                    # Add fingerprint to saved metric returned from API
+                    # so that frontend knows what timeseries records to query
+                    saved_metric["query"]["fingerprint"] = compute_metric_fingerprint(
+                        saved_metric["query"],
+                        instance.start_date,
+                        get_experiment_stats_method(instance),
+                        instance.exposure_criteria,
+                        only_count_matured_users=instance.only_count_matured_users,
+                        excluded_variants=(instance.parameters or {}).get("excluded_variants"),
+                    )
 
         return data
 

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -18,6 +18,7 @@ from django.utils.text import slugify
 
 import posthoganalytics
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from opentelemetry import trace
 from rest_framework import viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -85,6 +86,8 @@ from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.models import Survey
 
 from ee.clickhouse.queries.experiments.utils import requires_flag_warning
+
+tracer = trace.get_tracer(__name__)
 
 PROMPT_EXPERIMENTS_FEATURE_FLAG = "experiments-llm-prompts"
 
@@ -276,6 +279,11 @@ class EnterpriseExperimentsViewSet(
     )
     ordering = "-created_at"
 
+    @tracer.start_as_current_span("ExperimentViewSet.list")
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return super().list(request, *args, **kwargs)
+
+    @tracer.start_as_current_span("ExperimentViewSet.safely_get_queryset")
     def safely_get_queryset(self, queryset) -> QuerySet:
         request = getattr(self, "request", None)
         service = ExperimentService(team=self.team, user=getattr(request, "user", None))


### PR DESCRIPTION
## Problem

The experiments list endpoint (the `GET` powering the experiments home page) is slow in production, but we have no way to see *where* the time goes. Our OpenTelemetry traces don't carry a per-request span or any per-serializer detail for this path, and reducing N+1 queries didn't move the needle much — which points at per-row serialization cost rather than query count. This PR adds the instrumentation needed to confirm that from real traffic.

## Changes

Add manual OpenTelemetry spans along the list path, mirroring the existing pattern already used by dashboards, surveys, and insights (`@tracer.start_as_current_span(...)`):

- `ExperimentViewSet.list` — the whole list action
- `ExperimentViewSet.safely_get_queryset` — queryset/filter construction (lazy, so this measures filter building, not query execution)
- `ExperimentListSerializer.to_representation` — the once-per-page batch, with an `experiment_count` attribute
- per-row `ExperimentSerializer.to_representation`, with a nested `ExperimentSerializer.saved_metric_fingerprints` span (and a `saved_metric_count` attribute) wrapping the per-saved-metric `compute_metric_fingerprint` call — the suspected hotspot

This is instrumentation only — no behavior change. Spans are emitted only when the OTEL SDK is enabled, so there's no effect on environments where tracing is off. The nesting gives a clean `list → queryset/DB → serialize → fingerprints` tree, so we can split DB time from Python serialization time and see whether fingerprinting dominates at scale.

## How did you test this code?

I'm an agent (Claude Code). I ran the dev stack with tracing enabled, hit the list endpoint, and confirmed in Jaeger that all five spans emit, nest correctly under `ExperimentViewSet.list`, and that the `experiment_count` / `saved_metric_count` attributes populate. `ruff check` and `ruff format` pass (also run via lint-staged on commit). No automated tests were added — this is instrumentation only and changes no behavior or API contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tool:** Claude Code (Opus 4.8), directed by the assignee.
- **Why:** We were investigating the slow experiments list endpoint and found production traces are fragmented (no Django request span surfaced, and experiments had zero manual instrumentation), so there was nothing useful to inspect. Rather than guess, we added spans following the dashboards/surveys/insights precedent so the next step can be driven by real trace data.
- **Decision:** instrument the serializer hotspot (per-saved-metric fingerprinting) explicitly, because the symptom — N+1 removal not helping — points to CPU in serialization rather than query count. Code-level analysis flags `compute_metric_fingerprint` (a `deepcopy` + `json.dumps` + `sha256` per saved metric, recomputed every request) as the prime suspect.
- **Skills:** none invoked for the code change. Note: `/improving-drf-endpoints` is normally expected for viewset/serializer edits, but this change adds no serializer fields or schema annotations and doesn't touch the API contract, so it's out of that skill's scope.
- Verified locally via Jaeger; did not run the app's automated suite. Agent-authored PR — please review; do not self-merge.
