### PR TITLE
fix(phai): reuse question input for sandbox permissions

### DIFF
--- a/frontend/src/scenes/max/components/InputFormArea.tsx
+++ b/frontend/src/scenes/max/components/InputFormArea.tsx
@@ -432,7 +432,7 @@ export function InputFormArea(): JSX.Element | null {
         pendingApprovalProposalId,
         pendingApprovalsData,
         resolvedApprovalStatuses,
-        conversationId,
+        sandboxConversationKey,
         pendingSandboxPermissionRequest,
     } = useValues(maxThreadLogic)
 
@@ -470,7 +470,7 @@ export function InputFormArea(): JSX.Element | null {
             return (
                 <SandboxQuestionInput
                     key={pendingSandboxPermissionRequest.requestId}
-                    streamKey={conversationId}
+                    streamKey={sandboxConversationKey}
                     request={pendingSandboxPermissionRequest}
                 />
             )
@@ -478,7 +478,7 @@ export function InputFormArea(): JSX.Element | null {
         return (
             <SandboxPermissionInput
                 key={pendingSandboxPermissionRequest.requestId}
-                streamKey={conversationId}
+                streamKey={sandboxConversationKey}
                 request={pendingSandboxPermissionRequest}
             />
         )

--- a/frontend/src/scenes/max/components/SandboxApproval.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxApproval.test.tsx
@@ -31,6 +31,11 @@ jest.mock('../MarkdownMessage', () => ({
     MarkdownMessage: ({ content }: { content: string }) => <div data-attr="markdown">{content}</div>,
 }))
 
+jest.mock('lib/components/CodeSnippet', () => ({
+    CodeSnippet: ({ children }: { children: string }) => <pre data-attr="code-snippet">{children}</pre>,
+    Language: { JSON: 'json', Text: 'text' },
+}))
+
 const rawToolCall: ToolInvocation = {
     toolCallId: 'tc-1',
     rawServerName: 'posthog',
@@ -50,7 +55,6 @@ function makeRequest(overrides: Partial<PermissionRequestRecord> = {}): Permissi
         options: [
             { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
             { optionId: 'opt-reject', name: 'Decline', kind: 'reject' },
-            { optionId: 'opt-feedback', name: 'Decline with feedback', kind: 'reject_with_feedback' },
         ],
         rawToolCall,
         ...overrides,
@@ -71,14 +75,34 @@ describe('Sandbox approval input area', () => {
     })
 
     describe('SandboxPermissionInput', () => {
-        it('renders one button per non-feedback option plus the feedback toggle', () => {
+        it('renders the approval prompt with the same two permission options', () => {
             render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
 
             expect(screen.getByText('Approval required')).toBeInTheDocument()
+            expect(screen.getByText('posthog - insight-create (MCP)')).toBeInTheDocument()
             expect(screen.getByText('Approve')).toBeInTheDocument()
             expect(screen.getByText('Decline')).toBeInTheDocument()
-            // reject_with_feedback is feedback-only: it's the toggle that opens the text field, not a plain button.
-            expect(screen.getByText('Decline with feedback')).toBeInTheDocument()
+            expect(screen.queryByText("Explain what you'd like instead.")).not.toBeInTheDocument()
+        })
+
+        it('renders the unwrapped PostHog exec payload like PostHog Code', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({
+                        rawToolCall: {
+                            ...rawToolCall,
+                            input: { command: 'call execute-sql {"query":"select 1"}' },
+                        },
+                    })}
+                />
+            )
+
+            expect(screen.getByText('posthog - execute-sql (MCP)')).toBeInTheDocument()
+            expect(
+                screen.getByText((_content, element) => element?.getAttribute('data-attr') === 'code-snippet')
+                    .textContent
+            ).toEqual('{\n  "query": "select 1"\n}')
         })
 
         it('posts the chosen optionId on click', () => {
@@ -99,18 +123,27 @@ describe('Sandbox approval input area', () => {
             render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
 
             // Loading message replaces the option list, so nothing can be clicked.
-            expect(screen.getByText('Sending response...')).toBeInTheDocument()
+            expect(screen.getByText('Sending response…')).toBeInTheDocument()
             expect(screen.queryByText('Approve')).not.toBeInTheDocument()
             expect(screen.queryByText('Decline')).not.toBeInTheDocument()
             expect(respondToPermission).not.toHaveBeenCalled()
         })
 
-        it('sends feedback text through the reject_with_feedback option', () => {
-            render(<SandboxPermissionInput streamKey="conv-1" request={makeRequest()} />)
+        it('sends feedback text through the reject_with_feedback option when it is the decline path', () => {
+            render(
+                <SandboxPermissionInput
+                    streamKey="conv-1"
+                    request={makeRequest({
+                        options: [
+                            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+                            { optionId: 'opt-feedback', name: 'Decline with feedback', kind: 'reject_with_feedback' },
+                        ],
+                    })}
+                />
+            )
 
-            // Open the feedback text field via the feedback-only decline toggle.
-            fireEvent.click(screen.getByText('Decline with feedback'))
-            const input = screen.getByPlaceholderText("Explain what you'd like instead...")
+            fireEvent.click(screen.getByText("Explain what you'd like instead."))
+            const input = screen.getByPlaceholderText('Type your answer...')
             fireEvent.change(input, { target: { value: 'Use a funnel instead' } })
             fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 

--- a/frontend/src/scenes/max/components/SandboxPermissionInput.tsx
+++ b/frontend/src/scenes/max/components/SandboxPermissionInput.tsx
@@ -1,38 +1,55 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
-import { IconCheck, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonTextArea, Spinner } from '@posthog/lemon-ui'
+import { IconWarning } from '@posthog/icons'
+import { LemonTag, Spinner } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+import type { MultiQuestionFormQuestion } from '~/queries/schema/schema-assistant-messages'
 
 import { MarkdownMessage } from '../MarkdownMessage'
-import { mapPermissionOptions } from '../sandboxPermissionUtils'
+import { getSandboxPermissionDisplay } from '../sandboxPermissionDisplayUtils'
+import { mapPermissionOptions, type ApprovalCardOption } from '../sandboxPermissionUtils'
 import { sandboxStreamLogic } from '../sandboxStreamLogic'
 import type { PermissionRequestRecord } from '../types/sandboxStreamTypes'
+import { QuestionField } from './QuestionField'
 
 interface SandboxPermissionInputProps {
     streamKey: string
     request: PermissionRequestRecord
 }
 
+const ignoreMultiSelectChange = (_value: string[]): void => undefined
+const ignoreMultiSelectSubmit = (): void => undefined
+
+function toPermissionQuestion(
+    prompt: string,
+    options: ApprovalCardOption[],
+    allowCustomAnswer: boolean
+): MultiQuestionFormQuestion {
+    return {
+        id: 'permission',
+        title: 'Approval',
+        question: prompt,
+        type: 'select',
+        options: options.map((option) => ({ value: option.label })),
+        allow_custom_answer: allowCustomAnswer,
+    }
+}
+
 /**
  * Self-contained input-area renderer for an ACP `permission_request` on a sandbox conversation.
- * Owns its own approve/decline buttons (no shared OptionSelector) so it can model the current ACP
- * shape natively: `mapPermissionOptions` classifies each option by prefix (`allow*` approve, else
- * decline), and `allow_always` stays hidden unless a tool preview opts into rememberable decisions.
- * Every option is a one-click button; only the legacy `reject_with_feedback` kind is feedback-only,
- * reachable through the text field.
+ * Reuses the same `QuestionField` surface as sandbox questions while preserving the ACP option ids
+ * sent back to the runtime. `allow_always` stays hidden unless filtering would leave no choices.
  *
  * Submitting POSTs through `sandboxStreamLogic.respondToPermission`; the logic's
- * `respondingToPermission` drives the loading/double-submit guard and re-enables the controls when
- * the POST fails (the pending request only clears on success).
+ * `respondingToPermission` drives the loading/double-submit guard and re-enables the controls when the
+ * POST fails (the pending request only clears on success).
  */
 export function SandboxPermissionInput({ streamKey, request }: SandboxPermissionInputProps): JSX.Element {
     const boundLogic = sandboxStreamLogic({ streamKey })
     const { respondToPermission } = useActions(boundLogic)
     const { respondingToPermission, currentMode } = useValues(boundLogic)
-
-    const [showFeedback, setShowFeedback] = useState(false)
-    const [feedback, setFeedback] = useState('')
 
     // A request whose every option was filtered out (e.g. only `allow_always` without a rememberable
     // preview) must still be answerable — fall back to showing everything.
@@ -43,10 +60,15 @@ export function SandboxPermissionInput({ streamKey, request }: SandboxPermission
     const feedbackOption = mappedOptions.find((o) => o.requiresFeedback)
     // Every option except the legacy feedback-only one renders as a one-click button.
     const buttonOptions = mappedOptions.filter((o) => !o.requiresFeedback)
+    const hasOneClickDecline = buttonOptions.some((option) => option.decision === 'declined')
+    const allowFeedback = !!feedbackOption && !hasOneClickDecline
 
     // Plan approvals are raised while the agent is in plan mode — the mode is the grounded signal;
     // `toolCall.kind === 'plan'` covers adapters that tag the request directly.
     const isPlan = currentMode === 'plan' || request.rawToolCall.kind === 'plan'
+    const prompt = isPlan ? 'Approve this plan?' : 'Approval required'
+    const display = getSandboxPermissionDisplay(request)
+    const payloadLanguage = display.payload?.trim().match(/^[{[]/) ? Language.JSON : Language.Text
 
     const respond = (optionId: string): void => {
         if (respondingToPermission) {
@@ -55,95 +77,63 @@ export function SandboxPermissionInput({ streamKey, request }: SandboxPermission
         respondToPermission({ requestId: request.requestId, optionId })
     }
 
-    const submitFeedback = (): void => {
-        const trimmed = feedback.trim()
-        if (!feedbackOption || respondingToPermission || !trimmed) {
+    const handleAnswer = (value: string | string[] | null): void => {
+        if (respondingToPermission || value === null || Array.isArray(value)) {
             return
         }
-        respondToPermission({
-            requestId: request.requestId,
-            optionId: feedbackOption.optionId,
-            customInput: trimmed,
-        })
+        const selectedOption = buttonOptions.find((option) => option.label === value)
+        if (selectedOption) {
+            respond(selectedOption.optionId)
+            return
+        }
+        if (allowFeedback && feedbackOption) {
+            respondToPermission({
+                requestId: request.requestId,
+                optionId: feedbackOption.optionId,
+                customInput: value,
+            })
+        }
     }
 
     return (
         <div className="flex flex-col gap-2 p-3">
             <div className="flex items-center gap-2 text-sm">
                 <IconWarning className="text-warning size-4" />
-                <span className="font-medium">{isPlan ? 'Approve this plan?' : 'Approval required'}</span>
+                <LemonTag size="small" type="warning">
+                    {isPlan ? 'Plan approval' : 'Approval'}
+                </LemonTag>
             </div>
+            <div className="font-medium text-sm">{prompt}</div>
+            {display.title && <div className="text-xs text-secondary">{display.title}</div>}
             {(request.title || request.description) && (
-                <div className="max-h-60 overflow-y-auto">
+                <div className="max-h-60 overflow-y-auto text-sm">
                     <MarkdownMessage
                         content={request.description ?? request.title ?? ''}
                         id={`permission-${request.requestId}`}
                     />
                 </div>
             )}
-            <LemonDivider className="my-0 -mx-3 w-[calc(100%+var(--spacing)*6)]" />
+            {display.payload && (
+                <div className="max-h-60 overflow-y-auto">
+                    <CodeSnippet language={payloadLanguage} className="text-xs" compact>
+                        {display.payload}
+                    </CodeSnippet>
+                </div>
+            )}
             {respondingToPermission ? (
-                <div className="flex items-center gap-2 text-muted">
+                <div className="flex items-center gap-2 text-muted pt-1">
                     <Spinner className="size-4" />
-                    <span>Sending response...</span>
+                    <span>Sending response…</span>
                 </div>
             ) : (
-                <div className="flex flex-col gap-1.5">
-                    {buttonOptions.map((o) => (
-                        <LemonButton
-                            key={o.optionId}
-                            type={o.primary ? 'primary' : 'secondary'}
-                            icon={o.decision === 'approved' ? <IconCheck /> : <IconX />}
-                            onClick={() => respond(o.optionId)}
-                            fullWidth
-                            center
-                        >
-                            {o.label}
-                        </LemonButton>
-                    ))}
-                    {feedbackOption &&
-                        (showFeedback ? (
-                            <div className="flex flex-col gap-2">
-                                <LemonTextArea
-                                    placeholder="Explain what you'd like instead..."
-                                    value={feedback}
-                                    onChange={setFeedback}
-                                    minRows={2}
-                                    autoFocus
-                                />
-                                <div className="flex items-center justify-end gap-2">
-                                    <LemonButton
-                                        type="secondary"
-                                        size="small"
-                                        onClick={() => {
-                                            setShowFeedback(false)
-                                            setFeedback('')
-                                        }}
-                                    >
-                                        Cancel
-                                    </LemonButton>
-                                    <LemonButton
-                                        type="primary"
-                                        size="small"
-                                        disabledReason={!feedback.trim() ? 'Please type a response' : undefined}
-                                        onClick={submitFeedback}
-                                    >
-                                        Send
-                                    </LemonButton>
-                                </div>
-                            </div>
-                        ) : (
-                            <LemonButton
-                                type="tertiary"
-                                icon={<IconX />}
-                                onClick={() => setShowFeedback(true)}
-                                fullWidth
-                                center
-                            >
-                                {feedbackOption.label}
-                            </LemonButton>
-                        ))}
-                </div>
+                <QuestionField
+                    question={toPermissionQuestion(prompt, buttonOptions, allowFeedback)}
+                    value={undefined}
+                    onAnswer={handleAnswer}
+                    onChange={ignoreMultiSelectChange}
+                    onSubmit={ignoreMultiSelectSubmit}
+                    submitLabel="Send"
+                />
             )}
         </div>
     )

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
@@ -1,0 +1,91 @@
+import { getPostHogExecDisplay, getSandboxPermissionDisplay } from './sandboxPermissionDisplayUtils'
+import type { PermissionRequestRecord, ToolInvocation } from './types/sandboxStreamTypes'
+
+const rawToolCall: ToolInvocation = {
+    toolCallId: 'tc-1',
+    rawServerName: 'posthog',
+    rawToolName: 'exec',
+    resolvedKey: 'execute-sql',
+    input: {},
+    status: 'pending',
+    contentBlocks: [],
+}
+
+function makeRequest(overrides: Partial<PermissionRequestRecord> = {}): PermissionRequestRecord {
+    return {
+        requestId: 'req-1',
+        toolCallId: 'tc-1',
+        toolName: 'mcp__posthog__exec',
+        options: [
+            { optionId: 'opt-allow', name: 'Approve', kind: 'allow_once' },
+            { optionId: 'opt-reject', name: 'Decline', kind: 'reject' },
+        ],
+        rawToolCall,
+        ...overrides,
+    }
+}
+
+describe('sandboxPermissionDisplayUtils', () => {
+    it('unwraps PostHog exec call commands into an MCP title and pretty JSON payload', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                rawToolCall: {
+                    ...rawToolCall,
+                    input: { command: 'call execute-sql {"query":"select 1"}' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'posthog - execute-sql (MCP)',
+            payload: '{\n  "query": "select 1"\n}',
+        })
+    })
+
+    it('prefers explicit PostHog exec input when present', () => {
+        expect(
+            getPostHogExecDisplay({
+                command: 'call execute-sql {"query":"wrapped"}',
+                input: { query: 'explicit' },
+            })
+        ).toEqual({
+            label: 'execute-sql',
+            input: '{"query":"explicit"}',
+        })
+    })
+
+    it('keeps non-JSON PostHog exec args displayable', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                rawToolCall: {
+                    ...rawToolCall,
+                    input: { command: 'search query-' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'posthog - Search tools (MCP)',
+            payload: 'query-',
+        })
+    })
+
+    it('formats generic MCP tool input as JSON', () => {
+        const display = getSandboxPermissionDisplay(
+            makeRequest({
+                toolName: 'mcp__github__create_issue',
+                rawToolCall: {
+                    ...rawToolCall,
+                    rawServerName: 'github',
+                    rawToolName: 'create_issue',
+                    input: { owner: 'PostHog', repo: 'posthog' },
+                },
+            })
+        )
+
+        expect(display).toEqual({
+            title: 'github - create_issue (MCP)',
+            payload: '{\n  "owner": "PostHog",\n  "repo": "posthog"\n}',
+        })
+    })
+})

--- a/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
+++ b/frontend/src/scenes/max/sandboxPermissionDisplayUtils.ts
@@ -1,0 +1,162 @@
+import type { PermissionRequestRecord } from './types/sandboxStreamTypes'
+
+const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
+const POSTHOG_VERB_RE = /^\s*(tools|search|info|schema|call)(?:\s+([\s\S]*))?\s*$/
+const POSTHOG_CALL_BODY_RE = /^(?:--json\s+)?([a-zA-Z0-9_-]+)\s*([\s\S]*)$/
+const POSTHOG_TOOL_NAME_RE = /^([a-zA-Z0-9_-]+)\s*([\s\S]*)$/
+
+interface PostHogExecDisplay {
+    label: string
+    input?: string
+}
+
+export interface SandboxPermissionDisplay {
+    title?: string
+    payload?: string
+}
+
+function parseMcpToolKey(toolName: string): { serverName: string; toolName: string } | null {
+    const parts = toolName.split('__')
+    if (parts.length < 3 || parts[0] !== 'mcp') {
+        return null
+    }
+    return {
+        serverName: parts[1],
+        toolName: parts.slice(2).join('__'),
+    }
+}
+
+function readExplicitInput(value: unknown): string | undefined {
+    if (value === undefined || value === null) {
+        return undefined
+    }
+    if (typeof value === 'string') {
+        return value.trim() || undefined
+    }
+    try {
+        return JSON.stringify(value)
+    } catch {
+        return undefined
+    }
+}
+
+export function getPostHogExecDisplay(toolInput: unknown): PostHogExecDisplay | null {
+    if (!toolInput || typeof toolInput !== 'object') {
+        return null
+    }
+    const obj = toolInput as { command?: unknown; input?: unknown }
+    if (typeof obj.command !== 'string') {
+        return null
+    }
+
+    const verbMatch = obj.command.match(POSTHOG_VERB_RE)
+    if (!verbMatch) {
+        return null
+    }
+
+    const verb = verbMatch[1] as 'tools' | 'search' | 'info' | 'schema' | 'call'
+    const rest = (verbMatch[2] ?? '').trim()
+    const explicitInput = readExplicitInput(obj.input)
+
+    switch (verb) {
+        case 'tools':
+            return { label: 'List tools', input: undefined }
+        case 'search':
+            return {
+                label: 'Search tools',
+                input: explicitInput ?? (rest.length > 0 ? rest : undefined),
+            }
+        case 'info':
+            return rest.length > 0
+                ? { label: `Read ${rest}`, input: undefined }
+                : { label: 'Read tool', input: undefined }
+        case 'schema': {
+            const match = rest.match(POSTHOG_TOOL_NAME_RE)
+            if (!match) {
+                return { label: 'Inspect schema', input: undefined }
+            }
+            const subTool = match[1]
+            const fieldPath = (match[2] ?? '').trim()
+            const path = explicitInput ?? (fieldPath.length > 0 ? fieldPath : undefined)
+            return {
+                label: path ? `Inspect ${subTool}.${path}` : `Inspect ${subTool} fields`,
+                input: undefined,
+            }
+        }
+        case 'call': {
+            const match = rest.match(POSTHOG_CALL_BODY_RE)
+            if (!match) {
+                return null
+            }
+            const subTool = match[1]
+            const args = (match[2] ?? '').trim()
+            return {
+                label: subTool,
+                input: explicitInput ?? (args.length > 0 ? args : undefined),
+            }
+        }
+    }
+}
+
+export function formatPostHogExecBody(input: string | undefined): string | undefined {
+    if (!input) {
+        return undefined
+    }
+    try {
+        const parsed = JSON.parse(input)
+        if (parsed && typeof parsed === 'object') {
+            return JSON.stringify(parsed, null, 2)
+        }
+    } catch {
+        // Non-JSON args, such as a search regex, are already displayable.
+    }
+    return input
+}
+
+function formatInput(rawInput: unknown): string | undefined {
+    if (!rawInput || typeof rawInput !== 'object') {
+        return undefined
+    }
+    try {
+        const json = JSON.stringify(rawInput, null, 2)
+        return json === '{}' ? undefined : json
+    } catch {
+        return undefined
+    }
+}
+
+export function getSandboxPermissionDisplay(request: PermissionRequestRecord): SandboxPermissionDisplay {
+    const mcpTool = parseMcpToolKey(request.toolName)
+    if (!mcpTool) {
+        return {
+            title: request.title ?? request.rawToolCall.title ?? request.toolName,
+            payload: formatInput(request.rawToolCall.input),
+        }
+    }
+
+    if (POSTHOG_EXEC_TOOL_RE.test(request.toolName)) {
+        const posthogDisplay = getPostHogExecDisplay(request.rawToolCall.input)
+        if (posthogDisplay) {
+            return {
+                title: `posthog - ${posthogDisplay.label} (MCP)`,
+                payload: formatPostHogExecBody(posthogDisplay.input),
+            }
+        }
+        const resolvedName =
+            request.rawToolCall.innerToolName ??
+            (request.rawToolCall.resolvedKey.startsWith('__posthog_exec_')
+                ? undefined
+                : request.rawToolCall.resolvedKey)
+        if (resolvedName) {
+            return {
+                title: `posthog - ${resolvedName} (MCP)`,
+                payload: formatInput(request.rawToolCall.innerInput ?? request.rawToolCall.input),
+            }
+        }
+    }
+
+    return {
+        title: `${mcpTool.serverName} - ${mcpTool.toolName} (MCP)`,
+        payload: formatInput(request.rawToolCall.input),
+    }
+}


### PR DESCRIPTION
## Problem

Sandbox permission prompts in Max used a bespoke approval button stack that no longer matched the newer sandbox question input styling. Users should see the same compact input treatment while still choosing between the same approve and decline permission options, and permission prompts should show MCP payloads in the same unwrapped format used by PostHog Code.

## Changes

- Render sandbox permission choices through the shared `QuestionField` surface used by sandbox questions.
- Preserve ACP `optionId` responses, plan approval copy, the loading guard, the `allow_always` fallback, and the legacy `reject_with_feedback` path when it is the only decline path.
- Port PostHog Code's PostHog MCP `exec` display formatting so permission prompts show titles like `posthog - execute-sql (MCP)` and pretty-print the inner JSON body instead of the outer `{ command }` wrapper.
- Update approval input tests and add display utility coverage for PostHog `exec` call/search and generic MCP payloads.

No screenshot captured; this was verified with focused component and utility tests.

## How did you test this code?

As an agent, I ran:

```bash
hogli test frontend/src/scenes/max/components/SandboxApproval.test.tsx frontend/src/scenes/max/sandboxPermissionDisplayUtils.test.ts
```

`lint-staged` also ran `bin/hogli format:js` on the touched frontend files during commit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this only changes the Max sandbox permission input UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change in response to a request to align sandbox permission prompts with the new sandbox question input UI and match PostHog Code's permission payload formatting. No repo-provided skills were invoked because the change only touched Max frontend components and Jest tests.

The main implementation choice was to adapt mapped permission options into a `QuestionField` single-select question, while keeping the original ACP option ids as the submitted values. The payload formatting mirrors PostHog Code's PostHog MCP `exec` parser so the approval body shows the inner tool and body instead of the dispatcher wrapper.
