### PR TITLE
fix(signals): make inbox "Newest first" sort lead with created_at

### DIFF
--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
@@ -1,0 +1,20 @@
+import { buildSignalReportListOrdering } from './inboxFiltersLogic'
+
+describe('buildSignalReportListOrdering', () => {
+    it('leads with the selected time field so "Newest first" surfaces the newest reports', () => {
+        // The list is flat, so created_at must be the primary key — not a sub-sort within status buckets.
+        expect(buildSignalReportListOrdering('created_at', 'desc')).toBe('-created_at,status,-updated_at')
+    })
+
+    it('leads with created_at ascending for "Oldest first"', () => {
+        expect(buildSignalReportListOrdering('created_at', 'asc')).toBe('created_at,status,-updated_at')
+    })
+
+    it('leads with updated_at and drops the redundant tiebreak for "Last updated first"', () => {
+        expect(buildSignalReportListOrdering('updated_at', 'desc')).toBe('-updated_at,status')
+    })
+
+    it('leads with priority for "Priority first"', () => {
+        expect(buildSignalReportListOrdering('priority', 'asc')).toBe('priority,status,-updated_at')
+    })
+})

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -32,12 +32,15 @@ export type InboxSortField = 'priority' | 'created_at' | 'updated_at'
 export type InboxSortDirection = 'asc' | 'desc'
 
 /**
- * Build the `ordering` query param. Mirrors desktop `buildSignalReportListOrdering`:
- * 1. Status rank (semantic server-side rank, always applied)
- * 2. Toolbar-selected field (priority, updated_at, created_at)
- * 3. `-updated_at` as a recency tiebreak, so reports tied on status + field
- *    surface most-recently-updated first instead of in arbitrary order.
- *    (Skipped when the selected field is already `updated_at`.)
+ * Build the `ordering` query param. The list is a flat list (no status section
+ * headers), so the toolbar-selected field must lead — otherwise an explicit sort
+ * like "Newest first" only reorders reports *within* each status bucket and the
+ * genuinely newest reports never reach the top:
+ * 1. Toolbar-selected field (priority, updated_at, created_at) with direction
+ * 2. Status rank (semantic server-side rank) as a secondary key, so reports tied
+ *    on the selected field surface in pipeline-status order
+ * 3. `-updated_at` as a final recency tiebreak (skipped when the selected field
+ *    is already `updated_at`).
  *
  * Reviewer scope is NOT an ordering tiebreak. A `-is_suggested_reviewer` sort
  * floats the current user's own reports to the top of the single loaded page,
@@ -47,7 +50,7 @@ export type InboxSortDirection = 'asc' | 'desc'
  */
 export function buildSignalReportListOrdering(field: InboxSortField, direction: InboxSortDirection): string {
     const fieldKey = direction === 'desc' ? `-${field}` : field
-    return field === 'updated_at' ? `status,${fieldKey}` : `status,${fieldKey},-updated_at`
+    return field === 'updated_at' ? `${fieldKey},status` : `${fieldKey},status,-updated_at`
 }
 
 /**


### PR DESCRIPTION
## Problem

Thread: https://posthog.slack.com/archives/C09SK2PAGKF/p1781779291698449

In the Inbox, the "Newest first" sort doesn't actually show the newest entries at the top. The list is a flat list (no status section headers), but the ordering builder always emitted the `status` rank as the *primary* sort key. So "Newest first" (and "Oldest first" / "Last updated first") only reordered reports *within* each status bucket — the genuinely newest reports never surfaced to the top.

## Changes

`buildSignalReportListOrdering` now leads with the toolbar-selected field and demotes `status` rank to a secondary tiebreak:

- "Newest first" → `-created_at,status,-updated_at` (was `status,-created_at,-updated_at`)
- "Oldest first" → `created_at,status,-updated_at`
- "Last updated first" → `-updated_at,status`
- "Priority first" → `priority,status,-updated_at`

Reports tied on the selected field still fall back to pipeline-status order, then most-recently-updated. Added a unit test covering all four sort options.

## How did you test this code?

I'm an agent. Added `inboxFiltersLogic.test.ts` asserting the `ordering` string each sort option produces. I could not run jest in this environment (no installed `node_modules`); the assertions are straightforward pure-function checks. The backend (`SignalReportViewSet`) already whitelists `created_at`/`updated_at`/`priority`/`status` in any order, so no backend change was needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the inbox sort flow from `INBOX_SORT_OPTIONS` → `inboxFiltersLogic.buildSignalReportListOrdering` → `reportListLogic.listApiParams` → `SignalReportViewSet` ordering parser. Root cause was the always-status-first compound ordering, which conflicts with the label's promise once you confirm the list renders flat (no status grouping in `InboxReportList`). Fix is a one-line reordering of the emitted `ordering` string plus a comment correcting the prior "status always leads" rationale, and a unit test. Tools: filesystem exploration + Explore subagents.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781779291698449)*
