### PR TITLE
fix(workflows): stop email auto-config from touching root domain SPF

### DIFF
--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
@@ -33,7 +33,6 @@
             "pointsTo": "%dkim3%.dkim.amazonses.com",
             "ttl": 3600
         },
-        { "groupId": "spf", "type": "SPFM", "host": "@", "spfRules": "include:amazonses.com", "ttl": 3600 },
         {
             "groupId": "mailfrom",
             "type": "MX",

--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
@@ -33,7 +33,6 @@
             "pointsTo": "%dkim3%.dkim.amazonses.com",
             "ttl": 3600
         },
-        { "groupId": "spf", "type": "SPFM", "host": "@", "spfRules": "include:amazonses.com", "ttl": 3600 },
         {
             "groupId": "mailfrom",
             "type": "MX",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7327,13 +7327,6 @@ export interface EmailSenderDomainStatus {
               status: 'pending' | 'success'
           }
         | {
-              type: 'spf'
-              recordType: 'TXT'
-              recordHostname: '@'
-              recordValue: string
-              status: 'pending' | 'success'
-          }
-        | {
               type: 'mail_from'
               recordType: 'TXT' | 'MX'
               recordHostname: string

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -336,13 +336,6 @@ class TestEmailIntegration:
                     "recordValue": "token1.dkim.amazonses.com",
                     "status": "pending",
                 },
-                {
-                    "type": "spf",
-                    "recordType": "TXT",
-                    "recordHostname": "@",
-                    "recordValue": "v=spf1 include:amazonses.com ~all",
-                    "status": "pending",
-                },
             ],
         }
         mock_client.verify_email_domain.return_value = expected_result

--- a/products/workflows/backend/providers/maildev.py
+++ b/products/workflows/backend/providers/maildev.py
@@ -29,13 +29,6 @@ MAILDEV_MOCK_DNS_RECORDS = [
         "status": "success",
     },
     {
-        "type": "verification",
-        "recordType": "TXT",
-        "recordHostname": "@",
-        "recordValue": "v=spf1 include:amazonses.com ~all",
-        "status": "success",
-    },
-    {
         "type": "mail_from",
         "recordType": "MX",
         "recordHostname": "mail.example.com",

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -153,16 +153,6 @@ class SESProvider:
                 }
             )
 
-        dns_records.append(
-            {
-                "type": "verification",
-                "recordType": "TXT",
-                "recordHostname": "@",
-                "recordValue": "v=spf1 include:amazonses.com ~all",
-                "status": "pending",
-            }
-        )
-
         # Start/ensure MAIL FROM setup (MX + TXT) ---
         try:
             self.ses_client.set_identity_mail_from_domain(

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -169,13 +169,6 @@ class TestSESProvider(TestCase):
                     "status": "pending",
                 },
                 {
-                    "type": "verification",
-                    "recordType": "TXT",
-                    "recordHostname": "@",
-                    "recordValue": "v=spf1 include:amazonses.com ~all",
-                    "status": "pending",
-                },
-                {
                     "recordHostname": "mail.test.posthog.com",
                     "recordType": "MX",
                     "recordValue": "feedback-smtp.us-east-1.amazonses.com",


### PR DESCRIPTION
## Problem

A customer using the workflow-email auto-configuration ("one-click" DNS setup via Domain Connect) found that it wanted to drop DNS records crucial to their operation. The cause: both the Domain Connect email-verification template and the SES verification flow emit an **SPF record at the root domain** (host `@`).

In the template this record is type `SPFM` (SPF merge), so the provider's apply UI proposes to modify the customer's existing root SPF record. We already configure a dedicated MAIL FROM subdomain (e.g. `feedback.example.com`) that carries its own SPF, so SES sending and SPF alignment work entirely off that subdomain. The root SPF is unnecessary — and clobbering the root SPF breaks the customer's other senders (e.g. Google Workspace).

## Changes

- Drop the root `@` SPF record from both region Domain Connect templates (`email-verification-us` / `-eu`).
- Stop emitting the root `@` SPF record from the SES provider verification flow and the maildev mock.
- Remove the now-dead `type: 'spf'` member from the `EmailSenderDomainStatus` frontend type and the matching test expectations.

The MAIL FROM subdomain SPF, domain-verification TXT, DKIM CNAMEs, MX, and DMARC records are all unchanged.

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the test suite in my sandbox (the environment is missing flox-provided Python deps), so I have **not** executed the tests. I updated the affected backend tests (`test_ses_provider.py`, `test_integration.py`) to match the new record set and validated that both template JSON files still parse. CI should exercise the Python and TypeScript checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triggered from a Slack support thread (Papercut bug ticket #1182) asking to fix email auto-configuration dropping crucial DNS records. Traced the symptom to the root-domain SPF: the Domain Connect template used an `SPFM` record at host `@`, which merges into / overwrites the user's existing root SPF. Since the flow already provisions a custom MAIL FROM subdomain with its own SPF, the root SPF is redundant for SES, so the safe fix is to remove it rather than try to merge non-destructively. Kept the change consistent across the template JSON, the SES provider, the maildev mock, and the frontend type so generated/handwritten types and tests stay in sync.

No special skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1779840922303629?thread_ts=1779840922.303629&cid=C0ACRAMJUAG)*
