### PR TITLE
feat(logs): expose query runner via facade

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1088,7 +1088,7 @@ def get_query_runner(
     # Registered here for server-side CSV export only (ExportedAsset + Celery).
     # Direct queries are blocked by LogsQueryRunner.validate_query_runner_access.
     if kind == "LogsQuery":
-        from products.logs.backend.logs_query_runner import LogsQueryRunner
+        from products.logs.backend.facade.queries import LogsQueryRunner
 
         return LogsQueryRunner(
             query=query,

--- a/products/logs/backend/facade/__init__.py
+++ b/products/logs/backend/facade/__init__.py
@@ -1,0 +1,1 @@
+"""Public facade for the logs product — the surface other apps import from."""

--- a/products/logs/backend/facade/queries.py
+++ b/products/logs/backend/facade/queries.py
@@ -1,0 +1,13 @@
+"""Facade re-exports for logs HogQL query runners.
+
+Core's query-runner registry (``posthog/hogql_queries/query_runner.py``) dispatches on
+query ``kind`` and constructs ``LogsQueryRunner`` by class identity — it's registered
+there for server-side CSV export only (direct ``LogsQuery`` execution is blocked).
+Re-exporting the class keeps that registry coupling at the facade boundary while the
+heavy HogQL imports stay out of ``facade/api.py``, so config-only consumers don't drag
+them onto the ``django.setup()`` path.
+"""
+
+from products.logs.backend.logs_query_runner import LogsQueryRunner
+
+__all__ = ["LogsQueryRunner"]

--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -90,7 +90,7 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
     from posthog.hogql_queries.ai.trace_query_runner import TraceQueryRunner
 
     from products.error_tracking.backend.facade.queries import ErrorTrackingQueryRunner
-    from products.logs.backend.logs_query_runner import LogsQueryRunner
+    from products.logs.backend.facade.queries import LogsQueryRunner
 
     hogql_filters = HogQLFilters()
     if isinstance(runner, ErrorTrackingQueryRunner):


### PR DESCRIPTION
## Problem

External code importing `LogsQueryRunner` was reaching directly into the internal module (`products/logs/backend/logs_query_runner`), bypassing any intended encapsulation boundary for the logs product.

## Changes

Introduces a `facade/` package under `products/logs/backend/` that acts as the single public import surface for the logs product. `LogsQueryRunner` is re-exported from `facade/queries.py`, keeping the heavy HogQL imports isolated from config-only consumers (e.g. `facade/api.py`) so they don't get pulled onto the `django.setup()` path unnecessarily.

The two external import sites — the core query-runner registry and the `posthog_ai` HogQL example script — are updated to import from `products.logs.backend.facade.queries` instead of the internal module directly.

## How did you test this code?

The change is a pure re-export with no logic changes. The existing test suite covering `LogsQueryRunner` and the query-runner registry dispatch validates correctness.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`skip-inkeep-docs`