### PR TITLE
chore(slack-app): distinguish failure paths in Slack email lookup

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -26,7 +26,6 @@ from posthog.event_usage import groups
 from posthog.helpers.slack_scopes import REQUIRED_SLACK_SCOPES
 from posthog.llm.gateway_client import get_llm_client
 from posthog.models.integration import (
-    ERROR_TOKEN_REFRESH_FAILED,
     SLACK_INTEGRATION_KINDS,
     Integration,
     SlackIntegration,
@@ -1357,27 +1356,11 @@ def _notify_missing_slack_scopes(
 
 
 # Slack ``users.info`` error codes that mean the stored bot token can no longer talk to
-# Slack on this workspace's behalf. We mirror them onto ``Integration.errors`` so the
-# Settings UI surfaces the existing "needs reconnect" banner instead of going silent.
+# Slack on this workspace's behalf. Surfaced as ``token_broken=True`` on the failure log
+# so support can distinguish "needs reconnect" from other API failures at a glance.
 _SLACK_AUTH_FAILURE_CODES = frozenset(
     {"token_revoked", "invalid_auth", "not_authed", "account_inactive", "token_expired"}
 )
-
-
-def _mark_slack_integration_token_broken(integration: Integration, error_code: str) -> None:
-    """Persist a token-broken marker on the integration row so the reconnect banner
-    appears in Settings. Idempotent: skips the write if the row already carries it.
-    """
-    if integration.errors == ERROR_TOKEN_REFRESH_FAILED:
-        return
-    integration.errors = ERROR_TOKEN_REFRESH_FAILED
-    integration.save(update_fields=["errors"])
-    logger.warning(
-        "slack_app_integration_token_marked_broken",
-        integration_id=integration.id,
-        slack_team_id=integration.integration_id,
-        error_code=error_code,
-    )
 
 
 def get_slack_email_for_user(probe_integration: Integration, slack_user_id: str) -> str | None:
@@ -1417,14 +1400,14 @@ def get_slack_email_for_user(probe_integration: Integration, slack_user_id: str)
             return None
         return slack_email
     except SlackApiError as exc:
-        error_code = (exc.response or {}).get("error") if exc.response is not None else None
-        if isinstance(error_code, str) and error_code in _SLACK_AUTH_FAILURE_CODES:
-            _mark_slack_integration_token_broken(probe_integration, error_code)
+        error_code = exc.response.get("error") if exc.response else None
+        token_broken = isinstance(error_code, str) and error_code in _SLACK_AUTH_FAILURE_CODES
         logger.warning(
             "slack_app_resolve_user_email_failed",
             integration_id=probe_integration.id,
             slack_user_id=slack_user_id,
             error_code=error_code,
+            token_broken=token_broken,
             exc_info=True,
         )
         return None
@@ -1434,6 +1417,7 @@ def get_slack_email_for_user(probe_integration: Integration, slack_user_id: str)
             integration_id=probe_integration.id,
             slack_user_id=slack_user_id,
             error_code=None,
+            token_broken=False,
             exc_info=True,
         )
         return None

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -18,6 +18,7 @@ from django.views.decorators.csrf import csrf_exempt
 import requests
 import structlog
 import posthoganalytics
+from slack_sdk.errors import SlackApiError
 from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
@@ -25,6 +26,7 @@ from posthog.event_usage import groups
 from posthog.helpers.slack_scopes import REQUIRED_SLACK_SCOPES
 from posthog.llm.gateway_client import get_llm_client
 from posthog.models.integration import (
+    ERROR_TOKEN_REFRESH_FAILED,
     SLACK_INTEGRATION_KINDS,
     Integration,
     SlackIntegration,
@@ -1354,26 +1356,84 @@ def _notify_missing_slack_scopes(
     _post_slack_user_feedback(slack, channel, slack_user_id, thread_ts, text, prefer_thread_message=True)
 
 
+# Slack ``users.info`` error codes that mean the stored bot token can no longer talk to
+# Slack on this workspace's behalf. We mirror them onto ``Integration.errors`` so the
+# Settings UI surfaces the existing "needs reconnect" banner instead of going silent.
+_SLACK_AUTH_FAILURE_CODES = frozenset(
+    {"token_revoked", "invalid_auth", "not_authed", "account_inactive", "token_expired"}
+)
+
+
+def _mark_slack_integration_token_broken(integration: Integration, error_code: str) -> None:
+    """Persist a token-broken marker on the integration row so the reconnect banner
+    appears in Settings. Idempotent: skips the write if the row already carries it.
+    """
+    if integration.errors == ERROR_TOKEN_REFRESH_FAILED:
+        return
+    integration.errors = ERROR_TOKEN_REFRESH_FAILED
+    integration.save(update_fields=["errors"])
+    logger.warning(
+        "slack_app_integration_token_marked_broken",
+        integration_id=integration.id,
+        slack_team_id=integration.integration_id,
+        error_code=error_code,
+    )
+
+
 def get_slack_email_for_user(probe_integration: Integration, slack_user_id: str) -> str | None:
-    """Best-effort lookup of the Slack user's email via ``users.info``,
-    cache-first then a fresh hit on miss. Returns ``None`` when Slack doesn't
-    expose an email for the user (profile email hidden) or the lookup fails.
+    """Best-effort lookup of the Slack user's email via ``users.info``, cache-first then
+    a fresh hit on miss. Returns ``None`` when Slack doesn't expose an email for the
+    user (profile email hidden) or the lookup fails.
+
+    Every termination path emits a distinct structured log so a silent ``None`` can
+    still be diagnosed from logs alone — historically the failure modes collapsed
+    onto a downstream ``user_not_found`` warning that hid the actual cause.
     """
     slack_client = SlackIntegration(probe_integration)
     try:
         user_info = get_slack_user_info(slack_client, probe_integration, slack_user_id)
         slack_email = user_info.get("user", {}).get("profile", {}).get("email")
+        if slack_email:
+            return slack_email
+
+        fresh = normalize_slack_response(slack_client.client.users_info(user=slack_user_id))
+        if not fresh:
+            logger.warning(
+                "slack_app_resolve_user_email_empty_response",
+                integration_id=probe_integration.id,
+                slack_user_id=slack_user_id,
+            )
+            return None
+
+        persist_slack_user_info(probe_integration, slack_user_id, fresh)
+        slack_email = fresh.get("user", {}).get("profile", {}).get("email")
         if not slack_email:
-            fresh = normalize_slack_response(slack_client.client.users_info(user=slack_user_id))
-            if fresh:
-                persist_slack_user_info(probe_integration, slack_user_id, fresh)
-                slack_email = fresh.get("user", {}).get("profile", {}).get("email")
-        return slack_email or None
+            logger.warning(
+                "slack_app_resolve_user_email_missing_in_profile",
+                integration_id=probe_integration.id,
+                slack_user_id=slack_user_id,
+                ok=fresh.get("ok"),
+            )
+            return None
+        return slack_email
+    except SlackApiError as exc:
+        error_code = (exc.response or {}).get("error") if exc.response is not None else None
+        if isinstance(error_code, str) and error_code in _SLACK_AUTH_FAILURE_CODES:
+            _mark_slack_integration_token_broken(probe_integration, error_code)
+        logger.warning(
+            "slack_app_resolve_user_email_failed",
+            integration_id=probe_integration.id,
+            slack_user_id=slack_user_id,
+            error_code=error_code,
+            exc_info=True,
+        )
+        return None
     except Exception:
         logger.warning(
             "slack_app_resolve_user_email_failed",
             integration_id=probe_integration.id,
             slack_user_id=slack_user_id,
+            error_code=None,
             exc_info=True,
         )
         return None

--- a/products/slack_app/backend/tests/test_get_slack_email_for_user.py
+++ b/products/slack_app/backend/tests/test_get_slack_email_for_user.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from slack_sdk.errors import SlackApiError
+
+from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.slack_app.backend.api import get_slack_email_for_user
+from products.slack_app.backend.models import SlackUserProfileCache
+
+
+@pytest.fixture
+def integration(db):
+    organization = Organization.objects.create(name="Test Org")
+    team = Team.objects.create(organization=organization, name="Test Team")
+    return Integration.objects.create(
+        team=team,
+        kind="slack",
+        integration_id="T12345",
+        sensitive_config={"access_token": "xoxb-test"},
+    )
+
+
+def _make_slack_response(payload):
+    response = MagicMock()
+    response.data = payload
+    return response
+
+
+def _slack_api_error(error_code):
+    err = SlackApiError(message=f"slack returned {error_code}", response={"ok": False, "error": error_code})
+    return err
+
+
+class TestGetSlackEmailForUser:
+    @patch("posthog.models.integration.WebClient")
+    def test_returns_email_when_present_in_fresh_response(self, mock_webclient_class, integration):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.return_value = _make_slack_response(
+            {"ok": True, "user": {"id": "U1", "profile": {"email": "dev@example.com"}}}
+        )
+
+        email = get_slack_email_for_user(integration, "U1")
+
+        assert email == "dev@example.com"
+        assert SlackUserProfileCache.objects.filter(integration=integration, slack_user_id="U1").exists()
+
+    @patch("posthog.models.integration.WebClient")
+    def test_logs_empty_response_when_users_info_returns_blank(self, mock_webclient_class, integration, caplog):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        # Both the cache-miss call inside ``get_slack_user_info`` and the explicit fresh
+        # retry return an unusable response. ``normalize_slack_response`` collapses both
+        # to ``{}``, so we should emit the dedicated empty-response log and bail.
+        mock_client.users_info.return_value = _make_slack_response(None)
+
+        with caplog.at_level("WARNING"):
+            email = get_slack_email_for_user(integration, "U1")
+
+        assert email is None
+        assert any("slack_app_resolve_user_email_empty_response" in record.message for record in caplog.records)
+
+    @patch("posthog.models.integration.WebClient")
+    def test_logs_missing_email_when_profile_has_no_email(self, mock_webclient_class, integration, caplog):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        # Bot token works but lacks ``users:read.email``, or the user's email is hidden:
+        # Slack returns ``ok=true`` with a profile that has no ``email`` field.
+        mock_client.users_info.return_value = _make_slack_response(
+            {"ok": True, "user": {"id": "U1", "profile": {"display_name": "Dev"}}}
+        )
+
+        with caplog.at_level("WARNING"):
+            email = get_slack_email_for_user(integration, "U1")
+
+        assert email is None
+        assert any("slack_app_resolve_user_email_missing_in_profile" in record.message for record in caplog.records)
+
+    @pytest.mark.parametrize(
+        "error_code",
+        [
+            "token_revoked",
+            "invalid_auth",
+            "not_authed",
+            "account_inactive",
+            "token_expired",
+        ],
+    )
+    @patch("posthog.models.integration.WebClient")
+    def test_auth_error_marks_integration_errors(self, mock_webclient_class, integration, error_code, caplog):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.side_effect = _slack_api_error(error_code)
+
+        with caplog.at_level("WARNING"):
+            email = get_slack_email_for_user(integration, "U1")
+
+        assert email is None
+        integration.refresh_from_db()
+        assert integration.errors == ERROR_TOKEN_REFRESH_FAILED
+        assert any("slack_app_resolve_user_email_failed" in record.message for record in caplog.records)
+        assert any("slack_app_integration_token_marked_broken" in record.message for record in caplog.records)
+
+    @patch("posthog.models.integration.WebClient")
+    def test_non_auth_slack_error_does_not_mark_integration_errors(self, mock_webclient_class, integration, caplog):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.side_effect = _slack_api_error("user_not_found")
+
+        with caplog.at_level("WARNING"):
+            email = get_slack_email_for_user(integration, "U1")
+
+        assert email is None
+        integration.refresh_from_db()
+        assert integration.errors == ""
+        assert any("slack_app_resolve_user_email_failed" in record.message for record in caplog.records)
+        assert not any("slack_app_integration_token_marked_broken" in record.message for record in caplog.records)
+
+    @patch("posthog.models.integration.WebClient")
+    def test_auth_error_mark_is_idempotent(self, mock_webclient_class, integration):
+        integration.errors = ERROR_TOKEN_REFRESH_FAILED
+        integration.save(update_fields=["errors"])
+
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.side_effect = _slack_api_error("token_revoked")
+
+        with patch.object(Integration, "save") as save_spy:
+            get_slack_email_for_user(integration, "U1")
+
+        save_spy.assert_not_called()
+
+    @patch("posthog.models.integration.WebClient")
+    def test_generic_exception_logs_without_error_code(self, mock_webclient_class, integration, caplog):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.side_effect = RuntimeError("boom")
+
+        with caplog.at_level("WARNING"):
+            email = get_slack_email_for_user(integration, "U1")
+
+        assert email is None
+        integration.refresh_from_db()
+        assert integration.errors == ""
+        # The structured log records ``error_code=None`` for non-Slack exceptions so a
+        # quick log filter still groups them with the auth-error rows.
+        failed_records = [r for r in caplog.records if "slack_app_resolve_user_email_failed" in r.message]
+        assert failed_records, "expected slack_app_resolve_user_email_failed to be logged"

--- a/products/slack_app/backend/tests/test_get_slack_email_for_user.py
+++ b/products/slack_app/backend/tests/test_get_slack_email_for_user.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from slack_sdk.errors import SlackApiError
 
-from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration
+from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 
@@ -30,8 +30,7 @@ def _make_slack_response(payload):
 
 
 def _slack_api_error(error_code):
-    err = SlackApiError(message=f"slack returned {error_code}", response={"ok": False, "error": error_code})
-    return err
+    return SlackApiError(message=f"slack returned {error_code}", response={"ok": False, "error": error_code})
 
 
 class TestGetSlackEmailForUser:
@@ -90,7 +89,7 @@ class TestGetSlackEmailForUser:
         ],
     )
     @patch("posthog.models.integration.WebClient")
-    def test_auth_error_marks_integration_errors(self, mock_webclient_class, integration, error_code, caplog):
+    def test_auth_error_logs_token_broken_flag(self, mock_webclient_class, integration, error_code, caplog):
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         mock_client.users_info.side_effect = _slack_api_error(error_code)
@@ -99,13 +98,16 @@ class TestGetSlackEmailForUser:
             email = get_slack_email_for_user(integration, "U1")
 
         assert email is None
+        # No DB write — the integration row is untouched. Reconnect signal lives on the log line.
         integration.refresh_from_db()
-        assert integration.errors == ERROR_TOKEN_REFRESH_FAILED
-        assert any("slack_app_resolve_user_email_failed" in record.message for record in caplog.records)
-        assert any("slack_app_integration_token_marked_broken" in record.message for record in caplog.records)
+        assert integration.errors == ""
+        failed = [r for r in caplog.records if "slack_app_resolve_user_email_failed" in r.message]
+        assert failed, "expected slack_app_resolve_user_email_failed to be logged"
+        assert any(f"'error_code': '{error_code}'" in r.message for r in failed)
+        assert any("'token_broken': True" in r.message for r in failed)
 
     @patch("posthog.models.integration.WebClient")
-    def test_non_auth_slack_error_does_not_mark_integration_errors(self, mock_webclient_class, integration, caplog):
+    def test_non_auth_slack_error_does_not_flag_token_broken(self, mock_webclient_class, integration, caplog):
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client
         mock_client.users_info.side_effect = _slack_api_error("user_not_found")
@@ -114,24 +116,10 @@ class TestGetSlackEmailForUser:
             email = get_slack_email_for_user(integration, "U1")
 
         assert email is None
-        integration.refresh_from_db()
-        assert integration.errors == ""
-        assert any("slack_app_resolve_user_email_failed" in record.message for record in caplog.records)
-        assert not any("slack_app_integration_token_marked_broken" in record.message for record in caplog.records)
-
-    @patch("posthog.models.integration.WebClient")
-    def test_auth_error_mark_is_idempotent(self, mock_webclient_class, integration):
-        integration.errors = ERROR_TOKEN_REFRESH_FAILED
-        integration.save(update_fields=["errors"])
-
-        mock_client = MagicMock()
-        mock_webclient_class.return_value = mock_client
-        mock_client.users_info.side_effect = _slack_api_error("token_revoked")
-
-        with patch.object(Integration, "save") as save_spy:
-            get_slack_email_for_user(integration, "U1")
-
-        save_spy.assert_not_called()
+        failed = [r for r in caplog.records if "slack_app_resolve_user_email_failed" in r.message]
+        assert failed
+        assert all("'token_broken': False" in r.message for r in failed)
+        assert any("'error_code': 'user_not_found'" in r.message for r in failed)
 
     @patch("posthog.models.integration.WebClient")
     def test_generic_exception_logs_without_error_code(self, mock_webclient_class, integration, caplog):
@@ -143,9 +131,9 @@ class TestGetSlackEmailForUser:
             email = get_slack_email_for_user(integration, "U1")
 
         assert email is None
-        integration.refresh_from_db()
-        assert integration.errors == ""
-        # The structured log records ``error_code=None`` for non-Slack exceptions so a
-        # quick log filter still groups them with the auth-error rows.
-        failed_records = [r for r in caplog.records if "slack_app_resolve_user_email_failed" in r.message]
-        assert failed_records, "expected slack_app_resolve_user_email_failed to be logged"
+        failed = [r for r in caplog.records if "slack_app_resolve_user_email_failed" in r.message]
+        assert failed
+        # Non-Slack exceptions carry ``error_code=None`` and ``token_broken=False`` so a
+        # log filter for "needs reconnect" cleanly excludes them.
+        assert all("'error_code': None" in r.message for r in failed)
+        assert all("'token_broken': False" in r.message for r in failed)


### PR DESCRIPTION
## Problem

When `@PostHog` is mentioned, `get_slack_email_for_user` is the gate between "we got the event" and "we know who you are." It currently has four termination paths that all collapse onto the same downstream `slack_app_no_integration_found reason=user_not_found` warning:

1. `users.info` raised
2. `users.info` returned a payload that `normalize_slack_response` collapsed to `{}`
3. `ok=true` but `profile.email` is missing (scope or privacy)
4. Email returned but no PostHog user matched it

From logs alone, paths 2 and 3 are silent and path 1 doesn't carry the Slack error code. When a support case hits us (Zendesk [#60619](https://posthoghelp.zendesk.com/agent/tickets/60619)), we can't tell apart "token is dead — reconnect" from "email scope missing — fix Slack profile" from "the user isn't in any of your PostHog orgs."

## Changes

`get_slack_email_for_user` (`products/slack_app/backend/api.py`) now emits a distinct structured event for each terminal path:

| Event | Trigger |
|---|---|
| `slack_app_resolve_user_email_empty_response` | `users.info` returned an empty/unusable payload |
| `slack_app_resolve_user_email_missing_in_profile` | `ok=true` but `profile.email` missing |
| `slack_app_resolve_user_email_failed` | API call raised; carries `error_code` from `SlackApiError.response["error"]` plus a `token_broken` boolean |

`token_broken=True` when the Slack error code is one of `token_revoked`, `invalid_auth`, `not_authed`, `account_inactive`, `token_expired` — i.e. the bot install needs to be re-authorized through PostHog. Logs only; no DB side effects.

## How did you test this code?

10 parameterised tests in `products/slack_app/backend/tests/test_get_slack_email_for_user.py` cover every terminal path: cached-success, empty response, missing email, each of the five token-broken codes, a non-auth `SlackApiError`, and a generic `RuntimeError`. All pass locally via `hogli test products/slack_app/backend/tests/test_get_slack_email_for_user.py`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)