### PR TITLE
fix(data-deletion): pre-warm hogvm import for dagster predicate compile

### DIFF
--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -9,6 +9,18 @@ import dagster
 import pydantic
 from clickhouse_driver import Client
 
+# Pre-warm the HogQL → HogVM bytecode import chain at code-location load time. Compiling a
+# predicate (process_property_removal_per_shard → compile_hogql_predicate) builds the HogQL
+# database, whose virtual-field placeholder replacement lazily does
+# ``from common.hogvm.python.execute import …`` (posthog/hogql/placeholders.py). That import
+# first runs during op execution, when the Dagster run worker can no longer resolve the
+# top-level ``common`` namespace package off sys.path — yielding "No module named 'common'".
+# Importing it here, while the worker is still loading op modules with the repo root resolvable,
+# caches the chain in sys.modules so the op-time lazy import is a cache hit. Regular posthog.*
+# packages already get cached this way; common.hogvm is the only fresh import on the predicate
+# path, so it is the one that breaks without this.
+import posthog.hogql.compiler.bytecode  # noqa: F401
+
 from posthog.clickhouse.adhoc_events_deletion import ADHOC_EVENTS_DELETION_TABLE
 from posthog.clickhouse.cluster import AlterTableMutationRunner, ClickhouseCluster, LightweightDeleteMutationRunner
 from posthog.dags.common import JobOwners

--- a/posthog/models/data_deletion_request.py
+++ b/posthog/models/data_deletion_request.py
@@ -94,6 +94,11 @@ def compile_hogql_predicate(obj) -> tuple[str, dict]:
     )
     try:
         sql = translate_hogql(predicate, context, dialect="clickhouse")
+    except ImportError:
+        # A failed import means the runtime environment is broken (e.g. a Dagster worker that
+        # can't resolve ``common.hogvm`` during compilation), not that the predicate is invalid.
+        # Let it propagate as-is rather than masquerading as a predicate validation error.
+        raise
     except Exception as exc:
         raise ValidationError({"hogql_predicate": f"Could not compile HogQL: {exc}"}) from exc
 


### PR DESCRIPTION
## Problem

Running a data deletion request (property or event removal) that carries a `hogql_predicate` failed in Dagster, every time, with:

```
django.core.exceptions.ValidationError: {'hogql_predicate': ["Could not compile HogQL: No module named 'common'"]}
```

The Dagster run worker imports op modules at code-location load (when the repo root is resolvable on `sys.path`) and caches them, which is why `posthog.*` imports keep working. But HogQL compilation pulls in `common.hogvm` **lazily** — only when a predicate is actually compiled, during op execution — by which point the worker can no longer resolve the top-level `common` namespace package off `sys.path`. So the first-ever `common` import happens at op time and fails, while every already-cached `posthog.*` module is fine.

This is not specific to the recent modifiers change: `translate_hogql` was already on the compile path. Data-deletion-with-predicate is simply the first Dagster job to compile HogQL, so it's the first to surface the gap.

## Changes

- **Pre-warm the import at module load.** `posthog/dags/data_deletion_requests.py` now imports `posthog.hogql.compiler.bytecode` at module scope, while the repo root is still resolvable. That caches the whole `common.hogvm` chain in `sys.modules`, so the op-time lazy import (`placeholders.py` → `bytecode.py` → `common.hogvm`) becomes a cache hit that never touches `sys.path` again. Covers all predicate-compiling ops in the module (property removal, event removal, queued-request verification).
- **Stop masking infrastructure faults.** `compile_hogql_predicate` no longer wraps `ImportError`/`ModuleNotFoundError` as a "Could not compile HogQL" `ValidationError` — those propagate untouched, so a broken runtime reads as an infra error instead of a misleading "your predicate is invalid".
- Added the implementation plan for the earlier predicate-modifiers work under `docs/plans/`.

## How did you test this code?

Automated checks run locally:

- Reproduced the exact failure and verified the fix by simulating the run-worker condition (pre-warm at load, then strip `/code` from `sys.path` and `chdir` away before exercising the placeholder/bytecode path): **without** the pre-warm the simulation raises `ModuleNotFoundError("No module named 'common'")`; **with** it the path returns normally.
- Added a regression test (`test_dag_module_prewarms_hogvm_bytecode_import`) that asserts, in a clean interpreter, that importing the dag module caches `common.hogvm` (confirmed `django.setup()` alone does not), so deleting the pre-warm import is caught.
- `ruff check` / `ruff format` clean on all changed files.

The durable root-cause fix (making `/code` explicitly part of the Dagster pods' `PYTHONPATH` so any future lazy import is unaffected) is a separate change in the charts repo.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
