### PR TITLE
feat(logs): expose alert cleanup task via facade

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -81,7 +81,7 @@ from products.feature_flags.backend.tasks import (
     refresh_expiring_flag_definitions_cache_entries,
     refresh_expiring_flags_cache_entries,
 )
-from products.logs.backend.tasks import logs_alert_events_cleanup_task
+from products.logs.backend.facade.tasks import logs_alert_events_cleanup_task
 from products.reminders.backend.tasks import process_due_reminders
 from products.streamlit_apps.backend.facade.api import (
     auto_restart_crashed_streamlit_sandboxes,

--- a/products/logs/backend/facade/tasks.py
+++ b/products/logs/backend/facade/tasks.py
@@ -1,0 +1,11 @@
+"""Facade re-export for the logs Celery task.
+
+Core's beat schedule (``posthog/tasks/scheduled.py``) imports the task object and calls
+``.s()`` on it, so the wiring crosses the boundary as an object, not data. Re-exporting
+the task keeps that coupling at the facade boundary. Its ``name=`` is pinned in
+``tasks/tasks.py``, so the registered task identity is independent of the import path.
+"""
+
+from products.logs.backend.tasks.tasks import logs_alert_events_cleanup_task
+
+__all__ = ["logs_alert_events_cleanup_task"]


### PR DESCRIPTION
## Problem

The `logs_alert_events_cleanup_task` was imported directly from `products/logs/backend/tasks`, bypassing the facade layer. Core's beat schedule should only cross product boundaries through facade interfaces.

## Changes

Introduces `products/logs/backend/facade/tasks.py` as a re-export shim, and updates the import in `posthog/tasks/scheduled.py` to use it. The registered Celery task identity (`name=`) is unaffected since it's pinned in `tasks/tasks.py`.

## How did you test this code?

The change is a pure import path redirect with no logic changes. The Celery task's registered `name=` is unchanged, so no workers need redeployment and no beat schedule entries break.

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`skip-inkeep-docs`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Moved the import to respect the facade boundary pattern already established elsewhere in the codebase (e.g. `streamlit_apps`). The re-export file includes a docstring explaining why the task object itself crosses the boundary rather than data — necessary because core's beat schedule calls `.s()` on the imported object directly.