### PR TITLE
feat(logs): expose temporal wiring via facade

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -195,7 +195,7 @@ from products.exports.backend.temporal.subscriptions import (
     ACTIVITIES as SUBSCRIPTION_ACTIVITIES,
     WORKFLOWS as SUBSCRIPTION_WORKFLOWS,
 )
-from products.logs.backend.temporal import (
+from products.logs.backend.facade.temporal import (
     ACTIVITIES as LOGS_ALERTING_ACTIVITIES,
     WORKFLOWS as LOGS_ALERTING_WORKFLOWS,
 )

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -65,7 +65,7 @@ from products.experiments.backend.temporal.recalculation_metrics import (
     EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_METRICS,
     ExperimentsRecalculationMetricsInterceptor,
 )
-from products.logs.backend.temporal.metrics import (
+from products.logs.backend.facade.temporal import (
     LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS,
     LOGS_ALERTING_COUNT_HISTOGRAM_METRICS,
     LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS,

--- a/posthog/temporal/logs_alerting/schedule.py
+++ b/posthog/temporal/logs_alerting/schedule.py
@@ -15,8 +15,7 @@ from temporalio.client import (
 
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 
-from products.logs.backend.temporal.activities import CheckAlertsInput
-from products.logs.backend.temporal.constants import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME
+from products.logs.backend.facade.temporal import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME, CheckAlertsInput
 
 
 async def create_logs_alert_check_schedule(client: Client) -> None:

--- a/products/logs/backend/facade/temporal.py
+++ b/products/logs/backend/facade/temporal.py
@@ -1,0 +1,34 @@
+"""Facade re-exports for the logs alerting Temporal wiring.
+
+Core registers this product's workflow + activities with the Temporal worker
+(``posthog/management/commands/start_temporal_worker.py``), wires its metrics
+interceptor (``posthog/temporal/common/worker.py``), and registers its schedule
+(``posthog/temporal/logs_alerting/schedule.py``). That wiring crosses the boundary as
+objects and constants, not data, so re-export exactly what core touches and keep the
+temporalio-heavy imports here, off the ``facade/api.py`` path.
+"""
+
+from products.logs.backend.temporal import ACTIVITIES, WORKFLOWS
+from products.logs.backend.temporal.activities import CheckAlertsInput
+from products.logs.backend.temporal.constants import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME
+from products.logs.backend.temporal.metrics import (
+    LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_COUNT_HISTOGRAM_METRICS,
+    LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
+    LogsAlertingMetricsInterceptor,
+)
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "CheckAlertsInput",
+    "SCHEDULE_CRON",
+    "SCHEDULE_ID",
+    "WORKFLOW_NAME",
+    "LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS",
+    "LOGS_ALERTING_COUNT_HISTOGRAM_METRICS",
+    "LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS",
+    "LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS",
+    "LogsAlertingMetricsInterceptor",
+]


### PR DESCRIPTION
## Problem

Core infrastructure (`start_temporal_worker`, `worker.py`, `schedule.py`) needs to import Temporal wiring from the logs product, but those imports were scattered across multiple internal submodules (`temporal/`, `temporal/activities.py`, `temporal/constants.py`, `temporal/metrics.py`). This creates a leaky boundary where core reaches deep into product internals.

## Changes

Introduces `products/logs/backend/facade/temporal.py` as a single re-export facade for all Temporal-related symbols that core touches. Core now imports exclusively from this facade rather than from scattered internal paths.

The facade module intentionally keeps `temporalio`-heavy imports isolated from the `facade/api.py` path, since the Temporal wiring crosses the boundary as objects and constants rather than data.

## How did you test this code?

This is a pure import reorganization with no behavioral changes. The existing test suite covering logs alerting workflows and activities validates correctness.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Consolidated scattered cross-boundary imports into a single facade module. The key decision was to keep this facade separate from `facade/api.py` to avoid pulling `temporalio` dependencies into the API path, which could affect import performance or cause issues in contexts where Temporal isn't available.