### PR TITLE
feat(inbox): add Rapid review swipe mode with GitHub PR merge

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,6 +244,10 @@ import type {
     SessionGroupSummaryType,
     SessionSummariesConfig,
 } from 'products/session_summaries/frontend/types'
+import type {
+    SignalReportMergePrRequestApi,
+    SignalReportMergePrResponseApi,
+} from 'products/signals/frontend/generated/api.schemas'
 import type { Task, TaskListParams, TaskRun, TaskUpsertProps } from 'products/tasks/frontend/types'
 import type { BlastRadiusApi } from 'products/workflows/frontend/generated/api.schemas'
 import type { OptOutEntry } from 'products/workflows/frontend/OptOuts/types'
@@ -5140,6 +5144,15 @@ const api = {
         // State transitions: suppress (dismiss) or snooze back to potential. Backend: `state` action.
         async setState(id: SignalReport['id'], data: SignalReportStateRequest): Promise<SignalReport> {
             return await new ApiRequest().signalReport(id).withAction('state').create({ data })
+        },
+        async mergePr(
+            id: SignalReport['id'],
+            data?: SignalReportMergePrRequestApi
+        ): Promise<SignalReportMergePrResponseApi> {
+            return await new ApiRequest()
+                .signalReport(id)
+                .withAction('merge_pr')
+                .create({ data: data ?? {} })
         },
         // Backend returns a flat `{ [user_uuid]: { name, email } }` map (not paginated).
         async availableReviewers(query?: string): Promise<{ user_uuid: string; name: string; email: string }[]> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,10 +244,6 @@ import type {
     SessionGroupSummaryType,
     SessionSummariesConfig,
 } from 'products/session_summaries/frontend/types'
-import type {
-    SignalReportMergePrRequestApi,
-    SignalReportMergePrResponseApi,
-} from 'products/signals/frontend/generated/api.schemas'
 import type { Task, TaskListParams, TaskRun, TaskUpsertProps } from 'products/tasks/frontend/types'
 import type { BlastRadiusApi } from 'products/workflows/frontend/generated/api.schemas'
 import type { OptOutEntry } from 'products/workflows/frontend/OptOuts/types'
@@ -5144,15 +5140,6 @@ const api = {
         // State transitions: suppress (dismiss) or snooze back to potential. Backend: `state` action.
         async setState(id: SignalReport['id'], data: SignalReportStateRequest): Promise<SignalReport> {
             return await new ApiRequest().signalReport(id).withAction('state').create({ data })
-        },
-        async mergePr(
-            id: SignalReport['id'],
-            data?: SignalReportMergePrRequestApi
-        ): Promise<SignalReportMergePrResponseApi> {
-            return await new ApiRequest()
-                .signalReport(id)
-                .withAction('merge_pr')
-                .create({ data: data ?? {} })
         },
         // Backend returns a flat `{ [user_uuid]: { name, email } }` map (not paginated).
         async availableReviewers(query?: string): Promise<{ user_uuid: string; name: string; email: string }[]> {

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -19,6 +19,8 @@ export interface InboxReportCardProps {
 interface InboxReportListProps extends ReportListLogicProps {
     Card: ComponentType<InboxReportCardProps>
     emptyState: { icon: JSX.Element; title: string; description: string }
+    /** Extra controls rendered next to the refresh button in the filter bar. */
+    headerActions?: React.ReactNode
 }
 
 /**
@@ -36,7 +38,7 @@ export function InboxReportList(props: InboxReportListProps): JSX.Element {
     )
 }
 
-function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps): JSX.Element {
+function InboxReportListInner({ tabKey, Card, emptyState, headerActions }: InboxReportListProps): JSX.Element {
     const { reports, count, hasMore, reportsResponseLoading, isLoaded } = useValues(reportListLogic)
     const { ensureLoaded, loadMore, archiveReport, refresh } = useActions(reportListLogic)
     const sentinelRef = useRef<HTMLDivElement>(null)
@@ -75,7 +77,11 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
 
     return (
         <div className="@container mx-auto max-w-4xl flex flex-col gap-4 px-6 py-4">
-            <InboxSearchFilterBar onRefresh={() => refresh()} refreshing={reportsResponseLoading} />
+            <InboxSearchFilterBar
+                onRefresh={() => refresh()}
+                refreshing={reportsResponseLoading}
+                actions={headerActions}
+            />
             <InboxBulkSelectionBar />
 
             {showSkeleton ? (

--- a/frontend/src/scenes/inbox/components/RapidReview.tsx
+++ b/frontend/src/scenes/inbox/components/RapidReview.tsx
@@ -1,0 +1,180 @@
+import { useActions, useValues } from 'kea'
+import { animate, motion, useMotionValue, useTransform } from 'motion/react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+
+import { IconArchive, IconArrowLeft, IconCheckCircle } from '@posthog/icons'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { rapidReviewLogic } from '../logics/rapidReviewLogic'
+import { SignalReport } from '../types'
+import { ReportDetail } from './detail/ReportDetail'
+
+/** Drag distance / velocity past which a release commits the swipe. */
+const SWIPE_DISTANCE_THRESHOLD = 140
+const SWIPE_VELOCITY_THRESHOLD = 600
+
+type SwipeDirection = 'left' | 'right'
+
+interface SwipeSheetHandle {
+    swipe: (direction: SwipeDirection) => void
+}
+
+/** A draggable, internally-scrollable sheet rendering the full report detail. */
+const SwipeSheet = forwardRef<SwipeSheetHandle, { report: SignalReport; onResolved: (d: SwipeDirection) => void }>(
+    function SwipeSheet({ report, onResolved }, ref): JSX.Element {
+        const x = useMotionValue(0)
+        const rotate = useTransform(x, [-400, 0, 400], [-6, 0, 6])
+        const archiveOpacity = useTransform(x, [-SWIPE_DISTANCE_THRESHOLD, -40], [1, 0])
+        const mergeOpacity = useTransform(x, [40, SWIPE_DISTANCE_THRESHOLD], [0, 1])
+
+        const fling = (direction: SwipeDirection): void => {
+            animate(x, direction === 'right' ? 1200 : -1200, {
+                duration: 0.35,
+                ease: 'easeIn',
+                onComplete: () => onResolved(direction),
+            })
+        }
+
+        useImperativeHandle(ref, () => ({ swipe: fling }))
+
+        return (
+            <motion.div
+                className="absolute inset-0 flex justify-center"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{ x, rotate }}
+                drag="x"
+                dragDirectionLock
+                dragSnapToOrigin
+                dragElastic={0.5}
+                onDragEnd={(_, info) => {
+                    if (info.offset.x > SWIPE_DISTANCE_THRESHOLD || info.velocity.x > SWIPE_VELOCITY_THRESHOLD) {
+                        fling('right')
+                    } else if (
+                        info.offset.x < -SWIPE_DISTANCE_THRESHOLD ||
+                        info.velocity.x < -SWIPE_VELOCITY_THRESHOLD
+                    ) {
+                        fling('left')
+                    }
+                }}
+            >
+                <div className="relative w-full max-w-3xl h-full rounded-lg border border-primary bg-surface-primary shadow-sm overflow-hidden">
+                    {/* Swipe-intent stamps, pinned over the scroll area. */}
+                    <motion.div
+                        className="absolute top-6 left-6 z-10 flex items-center gap-1 rounded-md border-2 border-danger px-3 py-1.5 text-base font-bold uppercase text-danger -rotate-12 pointer-events-none"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ opacity: archiveOpacity }}
+                    >
+                        <IconArchive className="size-5" /> Archive
+                    </motion.div>
+                    <motion.div
+                        className="absolute top-6 right-6 z-10 flex items-center gap-1 rounded-md border-2 border-success px-3 py-1.5 text-base font-bold uppercase text-success rotate-12 pointer-events-none"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ opacity: mergeOpacity }}
+                    >
+                        <IconCheckCircle className="size-5" /> Merge
+                    </motion.div>
+                    <div className="size-full overflow-y-auto overscroll-contain">
+                        <ReportDetail report={report} tab="pulls" />
+                    </div>
+                </div>
+            </motion.div>
+        )
+    }
+)
+
+export function RapidReview({ onExit }: { onExit: () => void }): JSX.Element {
+    const { currentReport, remainingCount, isLoaded, reportsResponseLoading } = useValues(rapidReviewLogic)
+    const { archiveCurrent, mergeCurrent } = useActions(rapidReviewLogic)
+    const sheetRef = useRef<SwipeSheetHandle>(null)
+
+    const onResolved = (direction: SwipeDirection): void => {
+        if (direction === 'right') {
+            mergeCurrent()
+        } else {
+            archiveCurrent()
+        }
+    }
+
+    // Keyboard shortcuts: ←  archive, →  merge. Active only while a sheet is present.
+    useEffect(() => {
+        if (!currentReport) {
+            return
+        }
+        const onKeyDown = (event: KeyboardEvent): void => {
+            if (event.key === 'ArrowLeft') {
+                sheetRef.current?.swipe('left')
+            } else if (event.key === 'ArrowRight') {
+                sheetRef.current?.swipe('right')
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [currentReport])
+
+    return (
+        <div className="flex flex-col h-full min-h-0">
+            <div className="flex items-center justify-between gap-2 px-6 pt-4 pb-3 shrink-0">
+                <LemonButton type="secondary" size="small" icon={<IconArrowLeft />} onClick={onExit}>
+                    Back to list
+                </LemonButton>
+                {currentReport && (
+                    <span className="text-xs text-tertiary tabular-nums">
+                        {remainingCount} to review · ← archive · → merge
+                    </span>
+                )}
+            </div>
+
+            {!isLoaded && reportsResponseLoading ? (
+                <div className="flex flex-1 items-center justify-center px-4 pb-4 min-h-0">
+                    <LemonSkeleton className="w-full max-w-3xl h-full rounded-lg" />
+                </div>
+            ) : !currentReport ? (
+                <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center px-6">
+                    <IconCheckCircle className="text-4xl text-success" />
+                    <h3 className="m-0 text-base font-semibold">All caught up</h3>
+                    <p className="text-sm text-secondary max-w-sm">
+                        No more pull requests to review. New PR drafts will appear here as agents ship changes.
+                    </p>
+                </div>
+            ) : (
+                <>
+                    {/* Deck fills the remaining height; the sheet scrolls internally. */}
+                    <div className="relative flex-1 min-h-0 px-4">
+                        {/* A faint backing sheet suggests the stack. */}
+                        <div className="absolute inset-x-4 inset-y-0 flex justify-center pointer-events-none">
+                            <div className="w-full max-w-3xl h-full scale-[0.97] translate-y-2 rounded-lg border border-primary bg-surface-primary opacity-50" />
+                        </div>
+                        <SwipeSheet
+                            key={currentReport.id}
+                            ref={sheetRef}
+                            report={currentReport}
+                            onResolved={onResolved}
+                        />
+                    </div>
+
+                    <div className="flex items-center justify-center gap-6 py-4 shrink-0">
+                        <LemonButton
+                            type="secondary"
+                            status="danger"
+                            icon={<IconArchive />}
+                            tooltip="Archive (←)"
+                            onClick={() => sheetRef.current?.swipe('left')}
+                            aria-label="Archive"
+                        >
+                            Archive
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            icon={<IconCheckCircle />}
+                            tooltip="Merge into GitHub (→)"
+                            onClick={() => sheetRef.current?.swipe('right')}
+                            aria-label="Merge"
+                        >
+                            Merge
+                        </LemonButton>
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
@@ -86,6 +86,8 @@ interface InboxSearchFilterBarProps {
     /** Triggers a reload of the report list (lives on `inboxSceneLogic`). */
     onRefresh?: () => void
     refreshing?: boolean
+    /** Extra controls rendered next to the refresh button (e.g. the Rapid review entry). */
+    actions?: React.ReactNode
 }
 
 /**
@@ -98,6 +100,7 @@ export function InboxSearchFilterBar({
     searchPlaceholder = 'Search by title or description…',
     onRefresh,
     refreshing,
+    actions,
 }: InboxSearchFilterBarProps): JSX.Element {
     const { searchQuery, sortField, sortDirection, sourceProductFilter, priorityFilter } = useValues(inboxFiltersLogic)
     const { setSearchQuery, setSort, toggleSourceProduct, togglePriority } = useActions(inboxFiltersLogic)
@@ -174,17 +177,22 @@ export function InboxSearchFilterBar({
                 ))}
             </FilterPopover>
 
-            {onRefresh && (
-                <LemonButton
-                    type="secondary"
-                    size="xsmall"
-                    icon={<IconRefresh />}
-                    loading={refreshing}
-                    tooltip="Refresh"
-                    aria-label="Refresh"
-                    onClick={onRefresh}
-                    className="bg-surface-primary ml-auto"
-                />
+            {(onRefresh || actions) && (
+                <div className="ml-auto flex items-center gap-2">
+                    {actions}
+                    {onRefresh && (
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconRefresh />}
+                            loading={refreshing}
+                            tooltip="Refresh"
+                            aria-label="Refresh"
+                            onClick={onRefresh}
+                            className="bg-surface-primary"
+                        />
+                    )}
+                </div>
             )}
         </div>
     )

--- a/frontend/src/scenes/inbox/components/tabs/PullRequestsTab.tsx
+++ b/frontend/src/scenes/inbox/components/tabs/PullRequestsTab.tsx
@@ -1,15 +1,36 @@
-import { IconPullRequest } from '@posthog/icons'
+import { useState } from 'react'
+
+import { IconBolt, IconPullRequest } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { INBOX_FLAT_TAB_LIST_PARAMS } from '../../logics/reportListLogic'
 import { ReportCard } from '../cards/ReportCard'
 import { InboxReportList } from '../InboxReportList'
+import { RapidReview } from '../RapidReview'
 
 export function PullRequestsTab(): JSX.Element {
+    const [rapidReview, setRapidReview] = useState(false)
+
+    if (rapidReview) {
+        return <RapidReview onExit={() => setRapidReview(false)} />
+    }
+
     return (
         <InboxReportList
             tabKey="pulls"
             listParams={INBOX_FLAT_TAB_LIST_PARAMS.pulls}
             Card={ReportCard}
+            headerActions={
+                <LemonButton
+                    type="secondary"
+                    size="xsmall"
+                    icon={<IconBolt />}
+                    tooltip="Rapid review"
+                    aria-label="Rapid review"
+                    onClick={() => setRapidReview(true)}
+                    className="bg-surface-primary"
+                />
+            }
             emptyState={{
                 icon: <IconPullRequest className="text-2xl" />,
                 title: 'No pull requests right now',

--- a/frontend/src/scenes/inbox/logics/rapidReviewLogic.ts
+++ b/frontend/src/scenes/inbox/logics/rapidReviewLogic.ts
@@ -1,0 +1,124 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
+import { SignalReport } from '../types'
+import type { rapidReviewLogicType } from './rapidReviewLogicType'
+import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from './reportListLogic'
+
+/** Grace period before a swiped-right merge actually fires, during which it can be undone. */
+const MERGE_UNDO_MS = 5000
+
+const PULLS_LIST_PROPS = { tabKey: 'pulls' as const, listParams: INBOX_FLAT_TAB_LIST_PARAMS.pulls }
+
+function prLabel(report: SignalReport): string {
+    const number = report.implementation_pr_url?.split('/').pop()
+    return number ? `PR #${number}` : 'this PR'
+}
+
+function mergeToastId(reportId: string): string {
+    return `rapid-merge-${reportId}`
+}
+
+/**
+ * Drives "Rapid review" — the swipe deck over the Pull requests tab. Reuses the pulls
+ * `reportListLogic` as the source of truth (so the list and deck stay in sync) and layers a
+ * `processedIds` set on top: a card leaves the deck the moment it is swiped, and a merge is only
+ * committed to GitHub after a short undo window. Archive = suppress; merge = merge the PR.
+ */
+export const rapidReviewLogic = kea<rapidReviewLogicType>([
+    path(['scenes', 'inbox', 'logics', 'rapidReviewLogic']),
+    connect(() => ({
+        values: [reportListLogic(PULLS_LIST_PROPS), ['reports', 'reportsResponseLoading', 'isLoaded']],
+        actions: [reportListLogic(PULLS_LIST_PROPS), ['loadReports', 'removeReport']],
+    })),
+    actions({
+        markProcessed: (reportId: string) => ({ reportId }),
+        unmarkProcessed: (reportId: string) => ({ reportId }),
+        archiveCurrent: true,
+        mergeCurrent: true,
+        scheduleMerge: (report: SignalReport) => ({ report }),
+        undoMerge: (reportId: string) => ({ reportId }),
+        performMerge: (reportId: string) => ({ reportId }),
+        resetDeck: true,
+    }),
+    reducers({
+        // Reports swiped out of the deck. Archive stays here permanently (then drops from `reports`);
+        // a pending merge stays until it commits, and is removed again on undo so the card returns.
+        processedIds: [
+            [] as string[],
+            {
+                markProcessed: (state, { reportId }) => (state.includes(reportId) ? state : [...state, reportId]),
+                unmarkProcessed: (state, { reportId }) => state.filter((id) => id !== reportId),
+                resetDeck: () => [],
+            },
+        ],
+    }),
+    selectors({
+        deck: [
+            (s) => [s.reports, s.processedIds],
+            (reports: SignalReport[], processedIds: string[]): SignalReport[] =>
+                reports.filter((report) => !processedIds.includes(report.id)),
+        ],
+        currentReport: [(s) => [s.deck], (deck: SignalReport[]): SignalReport | null => deck[0] ?? null],
+        nextReport: [(s) => [s.deck], (deck: SignalReport[]): SignalReport | null => deck[1] ?? null],
+        remainingCount: [(s) => [s.deck], (deck: SignalReport[]): number => deck.length],
+    }),
+    listeners(({ actions, values, cache }) => ({
+        archiveCurrent: async () => {
+            const report = values.currentReport
+            if (!report) {
+                return
+            }
+            // Optimistically drop the card; restore it if the suppress call fails.
+            actions.markProcessed(report.id)
+            try {
+                await api.signalReports.setState(report.id, { state: 'suppressed' })
+                actions.removeReport(report.id)
+            } catch {
+                actions.unmarkProcessed(report.id)
+                lemonToast.error('Could not archive this report. Please try again.')
+            }
+        },
+        mergeCurrent: () => {
+            const report = values.currentReport
+            if (!report) {
+                return
+            }
+            actions.markProcessed(report.id)
+            actions.scheduleMerge(report)
+        },
+        scheduleMerge: ({ report }) => {
+            lemonToast.info(`Merging ${prLabel(report)} into GitHub…`, {
+                toastId: mergeToastId(report.id),
+                autoClose: MERGE_UNDO_MS,
+                button: { label: 'Undo', action: () => actions.undoMerge(report.id) },
+            })
+            // Fire the merge once the undo window lapses; cancellable via the disposable key.
+            cache.disposables.add(() => {
+                const timer = setTimeout(() => actions.performMerge(report.id), MERGE_UNDO_MS)
+                return () => clearTimeout(timer)
+            }, report.id)
+        },
+        undoMerge: ({ reportId }) => {
+            cache.disposables.dispose(reportId)
+            actions.unmarkProcessed(reportId)
+            lemonToast.dismiss(mergeToastId(reportId))
+        },
+        performMerge: async ({ reportId }) => {
+            cache.disposables.dispose(reportId)
+            try {
+                const result = await api.signalReports.mergePr(reportId)
+                actions.removeReport(reportId)
+                const suffix = result.merge_method === 'squash' ? ' (squash)' : ''
+                lemonToast.success(`Merged${suffix} into GitHub`)
+            } catch (error: any) {
+                // "Attempt anyway": surface GitHub's rejection and return the card to the deck.
+                actions.unmarkProcessed(reportId)
+                const message = error?.data?.error ?? error?.detail ?? 'GitHub could not merge this pull request.'
+                lemonToast.error(message)
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/inbox/logics/rapidReviewLogic.ts
+++ b/frontend/src/scenes/inbox/logics/rapidReviewLogic.ts
@@ -2,6 +2,9 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
+
+import { signalsReportsMergePrCreate } from 'products/signals/frontend/generated/api'
 
 import { SignalReport } from '../types'
 import type { rapidReviewLogicType } from './rapidReviewLogicType'
@@ -109,7 +112,7 @@ export const rapidReviewLogic = kea<rapidReviewLogicType>([
         performMerge: async ({ reportId }) => {
             cache.disposables.dispose(reportId)
             try {
-                const result = await api.signalReports.mergePr(reportId)
+                const result = await signalsReportsMergePrCreate(String(getCurrentTeamId()), reportId)
                 actions.removeReport(reportId)
                 const suffix = result.merge_method === 'squash' ? ' (squash)' : ''
                 lemonToast.success(`Merged${suffix} into GitHub`)

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2662,6 +2662,50 @@ class GitHubIntegration(GitHubIntegrationBase):
                 "status_code": response.status_code,
             }
 
+    def merge_pull_request(self, repository: str, pr_number: int, merge_method: str = "merge") -> dict[str, Any]:
+        """Merge a pull request via the GitHub API.
+
+        `merge_method` is one of "merge" (a merge commit), "squash", or "rebase". Returns a
+        structured result; on failure it carries GitHub's status code and message so the caller
+        can decide whether to retry with a different method.
+        """
+        org = self.organization()
+        access_token = self.integration.sensitive_config["access_token"]
+
+        response = self._github_api_put(
+            f"https://api.github.com/repos/{org}/{repository}/pulls/{pr_number}/merge",
+            endpoint="/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+            json_body={"merge_method": merge_method},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {access_token}",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            },
+        )
+
+        if response.status_code == 200:
+            merge_data = response.json()
+            return {
+                "success": True,
+                "merged": merge_data.get("merged", True),
+                "sha": merge_data.get("sha"),
+                "merge_method": merge_method,
+                "message": merge_data.get("message", ""),
+            }
+
+        message = response.text
+        try:
+            message = response.json().get("message", message)
+        except ValueError:
+            pass
+        return {
+            "success": False,
+            "merged": False,
+            "merge_method": merge_method,
+            "error": message,
+            "status_code": response.status_code,
+        }
+
     def get_branch_info(self, repository: str, branch_name: str) -> dict[str, Any]:
         """Get information about a specific branch."""
         org = self.organization()

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -11,6 +11,7 @@ from parameterized import parameterized
 from rest_framework import status
 from social_django.models import UserSocialAuth
 
+from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.team.team import Team
 
 from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
@@ -78,6 +79,133 @@ class TestSignalReportDeleteAPI(APIBaseTest):
     def test_delete_already_deleted_report_returns_404(self):
         report = self._create_report(report_status=SignalReport.Status.DELETED)
         response = self.client.delete(self._url(str(report.id)))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestSignalReportMergePrAPI(APIBaseTest):
+    PR_URL = "https://github.com/PostHog/posthog/pull/123"
+
+    def _url(self, report_id: str) -> str:
+        return f"/api/projects/{self.team.id}/signals/reports/{report_id}/merge_pr/"
+
+    def _create_report(self, team=None, report_status=SignalReport.Status.READY) -> SignalReport:
+        return SignalReport.objects.create(
+            team=team or self.team,
+            status=report_status,
+            title="Test report",
+            summary="Test summary",
+            signal_count=3,
+            total_weight=1.5,
+        )
+
+    def _create_github_integration(self, team=None) -> None:
+        Integration.objects.create(
+            team=team or self.team,
+            kind="github",
+            integration_id="install-123",
+            config={"account": {"type": "Organization", "name": "PostHog"}},
+            sensitive_config={"access_token": "ghs_token"},
+        )
+
+    @patch.object(GitHubIntegration, "merge_pull_request")
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_success_resolves_report(self, mock_fetch, mock_merge):
+        report = self._create_report()
+        self._create_github_integration()
+        mock_fetch.return_value = {str(report.id): self.PR_URL}
+        mock_merge.return_value = {"success": True, "merged": True, "sha": "abc123", "merge_method": "merge"}
+
+        response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["merged"] is True
+        assert body["sha"] == "abc123"
+        assert body["pr_url"] == self.PR_URL
+        assert body["report"]["status"] == SignalReport.Status.RESOLVED
+        mock_merge.assert_called_once_with("posthog", 123, merge_method="merge")
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.RESOLVED
+
+    @patch.object(GitHubIntegration, "merge_pull_request")
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_falls_back_to_squash(self, mock_fetch, mock_merge):
+        report = self._create_report()
+        self._create_github_integration()
+        mock_fetch.return_value = {str(report.id): self.PR_URL}
+        mock_merge.side_effect = [
+            {"success": False, "merged": False, "merge_method": "merge", "error": "not allowed", "status_code": 405},
+            {"success": True, "merged": True, "sha": "def456", "merge_method": "squash"},
+        ]
+
+        response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["merge_method"] == "squash"
+        assert mock_merge.call_count == 2
+        assert mock_merge.call_args_list[1].kwargs["merge_method"] == "squash"
+
+    @patch.object(GitHubIntegration, "merge_pull_request")
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_honors_explicit_method_without_fallback(self, mock_fetch, mock_merge):
+        report = self._create_report()
+        self._create_github_integration()
+        mock_fetch.return_value = {str(report.id): self.PR_URL}
+        mock_merge.return_value = {"success": True, "merged": True, "sha": "x", "merge_method": "rebase"}
+
+        response = self.client.post(self._url(str(report.id)), {"merge_method": "rebase"})
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_merge.assert_called_once_with("posthog", 123, merge_method="rebase")
+
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_without_linked_pr_returns_400(self, mock_fetch):
+        report = self._create_report()
+        self._create_github_integration()
+        mock_fetch.return_value = {}
+
+        response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.READY
+
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_without_integration_returns_400(self, mock_fetch):
+        report = self._create_report()
+        mock_fetch.return_value = {str(report.id): self.PR_URL}
+
+        response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch.object(GitHubIntegration, "merge_pull_request")
+    @patch("products.signals.backend.views.fetch_implementation_pr_urls_for_reports")
+    def test_merge_pr_github_failure_returns_422(self, mock_fetch, mock_merge):
+        report = self._create_report()
+        self._create_github_integration()
+        mock_fetch.return_value = {str(report.id): self.PR_URL}
+        mock_merge.return_value = {
+            "success": False,
+            "merged": False,
+            "merge_method": "merge",
+            "error": "Pull Request is not mergeable",
+            "status_code": 405,
+        }
+
+        response = self.client.post(self._url(str(report.id)))
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "mergeable" in response.json()["error"]
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.READY
+
+    def test_merge_pr_other_teams_report_returns_404(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        report = self._create_report(team=other_team)
+
+        response = self.client.post(self._url(str(report.id)))
+
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1,3 +1,4 @@
+import re
 import json
 import uuid
 from datetime import timedelta
@@ -29,7 +30,7 @@ import structlog
 from asgiref.sync import async_to_sync
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import exceptions, mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -44,7 +45,7 @@ from temporalio.exceptions import WorkflowAlreadyStartedError
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import InternalAPIAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.models import Team, User
-from posthog.models.integration import Integration
+from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.permissions import APIScopePermission
 from posthog.temporal.common.client import sync_connect
@@ -357,6 +358,28 @@ class SignalReportStateRequestSerializer(serializers.Serializer):
             "Omit to let the report re-enter the pipeline on the next matching signal."
         ),
     )
+
+
+class SignalReportMergePrRequestSerializer(serializers.Serializer):
+    merge_method = serializers.ChoiceField(
+        choices=[("merge", "merge"), ("squash", "squash"), ("rebase", "rebase")],
+        required=False,
+        allow_null=True,
+        help_text=(
+            "GitHub merge method for the report's implementation pull request. Omit to use the default "
+            "('merge', a merge commit), which falls back to 'squash' if the repository disallows merge commits."
+        ),
+    )
+
+
+class SignalReportMergePrResponseSerializer(serializers.Serializer):
+    merged = serializers.BooleanField(help_text="Whether GitHub merged the pull request.")
+    sha = serializers.CharField(
+        allow_null=True, help_text="SHA of the resulting merge commit, when GitHub returns one."
+    )
+    merge_method = serializers.CharField(help_text="The merge method GitHub ultimately used.")
+    pr_url = serializers.CharField(help_text="URL of the pull request that was merged.")
+    report = SignalReportSerializer(help_text="The report after the merge, transitioned to resolved on success.")
 
 
 @extend_schema_view(
@@ -1060,6 +1083,96 @@ class SignalReportViewSet(
                     del report.prefetched_dismissal_artefacts
 
         return Response(SignalReportSerializer(report, context=self._enriched_report_context(report)).data)
+
+    @extend_schema(
+        request=SignalReportMergePrRequestSerializer,
+        responses={
+            200: SignalReportMergePrResponseSerializer,
+            400: OpenApiResponse(description="The report has no linked pull request or GitHub integration."),
+            422: OpenApiResponse(description="GitHub could not merge the pull request."),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="merge_pr", required_scopes=["task:write"])
+    def merge_pr(self, request, pk=None, **kwargs):
+        """
+        Merge the report's implementation pull request into GitHub.
+
+        Resolves the latest implementation PR URL for the report and the team's GitHub integration,
+        then merges via the GitHub API. Defaults to a merge commit, falling back to squash when the
+        repository disallows merge commits. On a successful merge the report is transitioned to
+        resolved (tolerating an already-resolved state, since a GitHub webhook resolves it too).
+        """
+        report = cast(SignalReport, self.get_object())
+
+        serializer = SignalReportMergePrRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        requested_method = serializer.validated_data.get("merge_method")
+
+        pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
+        if not pr_url:
+            return Response(
+                {"error": "This report has no linked pull request."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        match = re.match(r"https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)", pr_url)
+        if not match:
+            return Response(
+                {"error": "The linked pull request URL is not a recognized GitHub PR."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        repository = match.group("repo")
+        pr_number = int(match.group("number"))
+
+        # Resolve the team-level GitHub app integration directly. User integrations can't open PRs in
+        # the first place, so a report with a linked PR always has a team-level integration to merge with.
+        integration = (
+            Integration.objects.filter(team_id=self.team.id, kind="github")
+            .exclude(repository_cache=[], repository_cache_updated_at__isnull=False)
+            .order_by("config__account__type", "created_at", "id")
+            .first()
+        )
+        if integration is None:
+            return Response(
+                {"error": "No GitHub app integration is connected for this team."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        github = GitHubIntegration(integration)
+
+        # Default to a merge commit, falling back to squash when the repository disallows merge commits
+        # (GitHub returns 405 "Merge commits are not allowed on this repository"). An explicit request
+        # method is honored verbatim with no fallback.
+        methods_to_try = [requested_method] if requested_method else ["merge", "squash"]
+        result: dict | None = None
+        for method in methods_to_try:
+            result = github.merge_pull_request(repository, pr_number, merge_method=method)
+            if result.get("success") or result.get("status_code") != 405:
+                break
+
+        if result is None or not result.get("success"):
+            message = (result or {}).get("error") or "GitHub could not merge the pull request."
+            return Response({"error": message}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+        # The merge already happened on GitHub (an irreversible side effect), so it must not sit inside a
+        # transaction that could roll back. Transition to resolved for immediate UX; a parallel GitHub
+        # webhook resolves it too, so tolerate an invalid transition (e.g. already resolved).
+        try:
+            updated_fields = report.transition_to(SignalReport.Status.RESOLVED)
+            report.save(update_fields=updated_fields)
+        except InvalidStatusTransition:
+            logger.info("SignalReport %s was already past a resolvable state when its PR merged", report.id)
+
+        response_payload = {
+            "merged": result.get("merged", True),
+            "sha": result.get("sha"),
+            "merge_method": result.get("merge_method", methods_to_try[0]),
+            "pr_url": pr_url,
+            "report": report,
+        }
+        response_serializer = SignalReportMergePrResponseSerializer(
+            response_payload, context=self._enriched_report_context(report)
+        )
+        return Response(response_serializer.data)
 
     @extend_schema(exclude=True)
     @action(detail=True, methods=["post"], url_path="reingest", required_scopes=["task:write"])

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -119,6 +119,44 @@ export interface PaginatedSignalReportListApi {
 }
 
 /**
+ * * `merge` - merge
+ * * `squash` - squash
+ * * `rebase` - rebase
+ */
+export type MergeMethodEnumApi = (typeof MergeMethodEnumApi)[keyof typeof MergeMethodEnumApi]
+
+export const MergeMethodEnumApi = {
+    Merge: 'merge',
+    Squash: 'squash',
+    Rebase: 'rebase',
+} as const
+
+export interface SignalReportMergePrRequestApi {
+    /** GitHub merge method for the report's implementation pull request. Omit to use the default ('merge', a merge commit), which falls back to 'squash' if the repository disallows merge commits.
+     *
+     * * `merge` - merge
+     * * `squash` - squash
+     * * `rebase` - rebase */
+    merge_method?: MergeMethodEnumApi | null
+}
+
+export interface SignalReportMergePrResponseApi {
+    /** Whether GitHub merged the pull request. */
+    merged: boolean
+    /**
+     * SHA of the resulting merge commit, when GitHub returns one.
+     * @nullable
+     */
+    sha: string | null
+    /** The merge method GitHub ultimately used. */
+    merge_method: string
+    /** URL of the pull request that was merged. */
+    pr_url: string
+    /** The report after the merge, transitioned to resolved on success. */
+    report: SignalReportApi
+}
+
+/**
  * * `suppressed` - suppressed
  * * `potential` - potential
  */

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -25,6 +25,8 @@ import type {
     ScoutEmissionReportLinkApi,
     ScratchpadEntryApi,
     SignalReportApi,
+    SignalReportMergePrRequestApi,
+    SignalReportMergePrResponseApi,
     SignalReportStateRequestApi,
     SignalScoutConfigApi,
     SignalScoutConfigCreateApi,
@@ -164,6 +166,32 @@ export const signalsReportsRetrieve = async (
     return apiMutator<SignalReportApi>(getSignalsReportsRetrieveUrl(projectId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getSignalsReportsMergePrCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/signals/reports/${id}/merge_pr/`
+}
+
+/**
+ * Merge the report's implementation pull request into GitHub.
+ *
+ * Resolves the latest implementation PR URL for the report and the team's GitHub integration,
+ * then merges via the GitHub API. Defaults to a merge commit, falling back to squash when the
+ * repository disallows merge commits. On a successful merge the report is transitioned to
+ * resolved (tolerating an already-resolved state, since a GitHub webhook resolves it too).
+ */
+export const signalsReportsMergePrCreate = async (
+    projectId: string,
+    id: string,
+    signalReportMergePrRequestApi?: SignalReportMergePrRequestApi,
+    options?: RequestInit
+): Promise<SignalReportMergePrResponseApi> => {
+    return apiMutator<SignalReportMergePrResponseApi>(getSignalsReportsMergePrCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(signalReportMergePrRequestApi),
     })
 }
 

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -19,6 +19,28 @@ export const SignalsProcessingPauseUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Merge the report's implementation pull request into GitHub.
+ *
+ * Resolves the latest implementation PR URL for the report and the team's GitHub integration,
+ * then merges via the GitHub API. Defaults to a merge commit, falling back to squash when the
+ * repository disallows merge commits. On a successful merge the report is transitioned to
+ * resolved (tolerating an already-resolved state, since a GitHub webhook resolves it too).
+ */
+export const SignalsReportsMergePrCreateBody = /* @__PURE__ */ zod.object({
+    merge_method: zod
+        .union([
+            zod
+                .enum(['merge', 'squash', 'rebase'])
+                .describe('\* `merge` - merge\n\* `squash` - squash\n\* `rebase` - rebase'),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            "GitHub merge method for the report's implementation pull request. Omit to use the default ('merge', a merge commit), which falls back to 'squash' if the repository disallows merge commits.\n\n\* `merge` - merge\n\* `squash` - squash\n\* `rebase` - rebase"
+        ),
+})
+
+/**
  * Transition a report to a new state. The model validates allowed transitions.
  *
  * The request body is validated by SignalReportStateRequestSerializer — only the

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -181,6 +181,9 @@ tools:
             required; `enabled` and `config` are optional and keep their current values if omitted). Prefer
             `inbox-source-configs-partial-update` when you only need to flip `enabled` or tweak `config`. Enabling the
             session_analysis_cluster source requires the organization to have approved AI data processing.
+    signals-reports-merge-pr-create:
+        operation: signals_reports_merge_pr_create
+        enabled: false
     signals-scout-config-create:
         operation: signals_scout_config_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27681,6 +27681,20 @@ export namespace Schemas {
       scraping_status?: ScrapingStatusEnum | BlankEnum | null;
     }
 
+    /**
+     * * `merge` - merge
+     * * `squash` - squash
+     * * `rebase` - rebase
+     */
+    export type MergeMethodEnum = typeof MergeMethodEnum[keyof typeof MergeMethodEnum];
+
+
+    export const MergeMethodEnum = {
+      Merge: 'merge',
+      Squash: 'squash',
+      Rebase: 'rebase',
+    } as const;
+
     export type MessageContextualTools = { [key: string]: unknown };
 
     /**
@@ -45119,6 +45133,31 @@ export namespace Schemas {
       variant_key: string;
       /** If true, prepend a release condition to the feature flag that rolls the variant out to 100% of users, overriding any existing release conditions on the flag. If false (default), only update the variant distribution — existing release conditions are preserved and the variant is served only to users who already match them. */
       release_to_everyone?: boolean;
+    }
+
+    export interface SignalReportMergePrRequest {
+      /** GitHub merge method for the report's implementation pull request. Omit to use the default ('merge', a merge commit), which falls back to 'squash' if the repository disallows merge commits.
+       *
+       * * `merge` - merge
+       * * `squash` - squash
+       * * `rebase` - rebase */
+      merge_method?: MergeMethodEnum | null;
+    }
+
+    export interface SignalReportMergePrResponse {
+      /** Whether GitHub merged the pull request. */
+      merged: boolean;
+      /**
+         * SHA of the resulting merge commit, when GitHub returns one.
+         * @nullable
+         */
+      sha: string | null;
+      /** The merge method GitHub ultimately used. */
+      merge_method: string;
+      /** URL of the pull request that was merged. */
+      pr_url: string;
+      /** The report after the merge, transitioned to resolved on success. */
+      report: SignalReport;
     }
 
     /**


### PR DESCRIPTION
## Problem

The Pull requests inbox is a clean list, but triaging a backlog of agent-shipped PRs one click at a time is slow. Reviewers want a fast, focused way to make the call on each PR – is it substantial, does it matter, can I just merge it – and act on it without leaving the flow.

## Changes

- Adds a **Rapid review** mode to the Pull requests tab, entered from a small, low-key icon button next to Refresh (it's not the default view).
- Each PR is a full-bleed, internally-scrollable one-pager that renders the existing `ReportDetail` verbatim: summary, priority/actionability judgments, the full evidence signal cards, suggested reviewers, and linked tasks. Everything you need to judge it at a glance.
- Swipe left (or `←`, or the Archive button) to suppress the report. Swipe right (or `→`, or Merge) to merge the PR into GitHub.
- Merge is the real thing: a new `GitHubIntegration.merge_pull_request` plus a `POST signals/reports/{id}/merge_pr/` action that resolves the report's implementation PR and the team's GitHub app integration, merges it, and transitions the report to resolved. It defaults to a merge commit and falls back to squash when the repo disallows merge commits.
- Right-swipe fires after a 5-second undo-countdown toast, so a mis-swipe can be reverted before it reaches GitHub. Non-mergeable PRs surface GitHub's error and bounce the card back into the deck.

Frontend screenshots: _not captured (agent-authored)._

## How did you test this code?

I'm an agent, so no manual browser testing. I added and ran backend tests (`TestSignalReportMergePrAPI`): merge success and report resolution, squash fallback, explicit `merge_method` with no fallback, missing-PR and missing-integration 400s, GitHub-failure 422, and cross-team 404. All passing. Frontend `typescript:check`, oxlint, and oxfmt are clean; OpenAPI and generated types were regenerated via `hogli build:openapi`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: `/improving-drf-endpoints` (the new viewset action and its request/response serializers) and `/using-kea-disposables` (the undo-countdown timer).

Decisions worth a reviewer's eye:

- The one-pager renders `ReportDetail` as-is rather than a bespoke layout, so Rapid review never drifts from the canonical detail view.
- `merge_pull_request` lives on `GitHubIntegration`; the action resolves the team integration with a small inline query instead of importing the tasks repo-selection helper, which would drag the Docker-sandbox import chain onto the web and test paths.
- Merge prefers a merge commit and only falls back to squash when GitHub rejects the method (405); an explicit `merge_method` is honored with no fallback.
- The deck reuses the pulls `reportListLogic` as its source of truth, so the list and the deck stay in sync as cards are archived or merged.
