### PR TITLE
feat(logs): add collapsible left filter rail behind feature flag

### DIFF
--- a/frontend/src/lib/components/Resizer/resizerLogic.ts
+++ b/frontend/src/lib/components/Resizer/resizerLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, beforeUnmount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import posthog from 'posthog-js'
 
 import type { resizerLogicType } from './resizerLogicType'
@@ -162,4 +162,8 @@ export const resizerLogic = kea<resizerLogicType>([
             document.body.classList.remove('is-resizing')
         },
     })),
+    // Clear the body resizing state if we unmount mid-drag (before mouseup fires endResize).
+    beforeUnmount(() => {
+        document.body.classList.remove('is-resizing')
+    }),
 ])

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -351,6 +351,7 @@ export const FEATURE_FLAGS = {
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-ai-observability
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
+    LOGS_FACET_RAIL: 'logs-facet-rail', // owner: #team-logs
     LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs
     LOGS_SERVICES_VIEW: 'logs-services-view', // owner: #team-logs
     LOGS_SETTINGS: 'logs-settings', // owner: #team-logs

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -1,0 +1,56 @@
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef } from 'react'
+
+import { Resizer } from 'lib/components/Resizer/Resizer'
+import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
+
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+
+const DEFAULT_WIDTH_PX = 240
+const COLLAPSE_THRESHOLD_PX = 120
+
+export interface FacetRailProps {
+    id: string
+}
+
+/** Resizable left-hand facet rail. Shell only — facets and filtering land in follow-up work. */
+export function FacetRail({ id }: FacetRailProps): JSX.Element {
+    const railRef = useRef<HTMLDivElement>(null)
+    const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
+
+    const onToggleClosed = useCallback(
+        (shouldBeClosed: boolean) => setFacetRailCollapsed(shouldBeClosed),
+        [setFacetRailCollapsed]
+    )
+    const resizerLogicProps: ResizerLogicProps = useMemo(
+        () => ({
+            logicKey: `logs-facet-rail-${id}`,
+            containerRef: railRef,
+            persistent: true,
+            persistPrefix: '2026-06-18',
+            placement: 'right',
+            closeThreshold: COLLAPSE_THRESHOLD_PX,
+            onToggleClosed,
+        }),
+        [id, onToggleClosed]
+    )
+    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
+
+    return (
+        <div
+            ref={railRef}
+            className="relative flex flex-col shrink-0 border rounded bg-surface-primary overflow-hidden"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ width: desiredSize ?? DEFAULT_WIDTH_PX, minWidth: 'min-content', maxWidth: '40%' }}
+            data-attr="logs-facet-rail"
+        >
+            <div className="px-2 py-1 border-b">
+                <span className="text-xs font-semibold text-secondary uppercase tracking-wide">Filters</span>
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto p-2">
+                <p className="text-xs text-muted m-0">Facets will appear here.</p>
+            </div>
+            <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -1,7 +1,11 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useCallback, useEffect, useRef } from 'react'
 
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
 import { TZLabelProps } from 'lib/components/TZLabel'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
@@ -10,6 +14,7 @@ import { UniversalFiltersGroup } from '~/types'
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
+import { FacetRail } from 'products/logs/frontend/components/LogsViewer/FacetRail/FacetRail'
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
 import { logsFilterHistoryLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterHistoryLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
@@ -103,13 +108,15 @@ function LogsViewerContent({
         clearSelection,
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
-    const { orderBy, sparklineBreakdownBy, sparklineCollapsed } = useValues(logsViewerConfigLogic)
-    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
+    const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed } = useValues(logsViewerConfigLogic)
+    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed, setFacetRailCollapsed } =
+        useActions(logsViewerConfigLogic)
     const { logsLoading, parsedLogs, sparklineData, sparklineLoading, hasMoreLogsToLoad, totalLogsMatchingFilters } =
         useValues(logsViewerDataLogic)
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
     const { openLogsViewerModal } = useActions(logsViewerModalLogic)
+    const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
     const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
@@ -277,8 +284,8 @@ function LogsViewerContent({
         ]
     )
 
-    return (
-        <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
+    const sparklineSection = (
+        <>
             <LogsSparkline
                 sparklineData={sparklineData}
                 sparklineLoading={sparklineLoading}
@@ -290,7 +297,13 @@ function LogsViewerContent({
                 onToggleCollapse={toggleSparklineCollapsed}
             />
             <SceneDivider />
-            {showFilterBar && <LogsFilterBar showSavedViewsButton={showSavedViewsButton} />}
+        </>
+    )
+
+    const filterBar = showFilterBar ? <LogsFilterBar showSavedViewsButton={showSavedViewsButton} /> : null
+
+    const logBody = (
+        <>
             <LogsViewerToolbar
                 totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
                 orderBy={orderBy}
@@ -325,7 +338,43 @@ function LogsViewerContent({
                 orderBy={orderBy}
                 onChangeOrderBy={(newOrderBy) => setOrderBy(newOrderBy, 'header')}
             />
+        </>
+    )
 
+    const railToggle = (
+        <LemonButton
+            size="small"
+            icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
+            onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
+        >
+            {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
+        </LemonButton>
+    )
+
+    if (showFacetRail) {
+        return (
+            <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
+                {sparklineSection}
+                <div className="flex flex-row gap-2 flex-1 min-h-0">
+                    {!facetRailCollapsed && <FacetRail id={id} />}
+                    <div className="flex flex-col gap-2 flex-1 min-w-0">
+                        <div className="flex items-start gap-2">
+                            {railToggle}
+                            {filterBar && <div className="flex-1 min-w-0">{filterBar}</div>}
+                        </div>
+                        {logBody}
+                    </div>
+                </div>
+                <LogDetailsModal timezone={timezone} />
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
+            {sparklineSection}
+            {filterBar}
+            {logBody}
             <LogDetailsModal timezone={timezone} />
         </div>
     )

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -40,6 +40,7 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
         setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => ({ sparklineBreakdownBy }),
         setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
         toggleSparklineCollapsed: true,
+        setFacetRailCollapsed: (facetRailCollapsed: boolean) => ({ facetRailCollapsed }),
     }),
 
     reducers({
@@ -65,6 +66,13 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
             { persist: true },
             {
                 toggleSparklineCollapsed: (state) => !state,
+            },
+        ],
+        facetRailCollapsed: [
+            false,
+            { persist: true },
+            {
+                setFacetRailCollapsed: (_, { facetRailCollapsed }) => facetRailCollapsed,
             },
         ],
         orderBy: [


### PR DESCRIPTION
## Problem

The logs viewer lacks a faceted filter rail — a left-hand panel that lets users quickly filter by log attributes. This PR lays the structural groundwork: a resizable, collapsible rail with persistent width, gated behind a feature flag (`LOGS_FACET_RAIL`). Actual facets, counts, and filtering logic follow in subsequent work.

There was also a latent bug in the resizer: if the component unmounted mid-drag (e.g. dragging the rail past its collapse threshold removes it from the DOM before `mouseup` fires), the `is-resizing` class would get stuck on `document.body`, leaving the grabbing cursor and disabled pointer events everywhere until a page reload.

## Changes

- **Resizer bug fix:** Added a `beforeUnmount` hook to `resizerLogic` that removes `is-resizing` from `document.body`, preventing the stuck-cursor state when a resizable panel is unmounted during a drag.
- **`FacetRail` component:** A resizable, collapsible left-hand panel. Dragging it below 120 px collapses it; width persists across reloads via the `persistent` resizer option. The structural shell is in place; facet content is a placeholder.
- **`LogsViewer` layout:** When the `LOGS_FACET_RAIL` flag is enabled, the viewer renders a two-column layout with the rail on the left and a toggle button to expand/collapse it. The collapsed state persists via `logsViewerConfigLogic`.
- **`logsViewerConfigLogic`:** Added `facetRailCollapsed` state (persisted) and a `setFacetRailCollapsed` action.
- **Feature flag:** Added `LOGS_FACET_RAIL` to the constants.

![Facet rail placeholder — actual facets TBD]

## How did you test this code?

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`skip-inkeep-docs`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The resizer `beforeUnmount` fix was identified as a prerequisite: without it, collapsing the rail mid-drag leaves the UI in a broken state. The `FacetRail` was built as a structural shell only, intentionally deferring facet data and filtering to keep this PR reviewable and mergeable independently. The feature flag gates the entire new layout path so existing logs users are unaffected.