### PR TITLE
feat(tracing): return all five per-metric deltas from symbol-stats

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -41990,6 +41990,10 @@
                     "$ref": "#/definitions/integer",
                     "description": "Spans whose OTel status is Error (`status_code = 2`)."
                 },
+                "error_rate_pct_change": {
+                    "description": "Percentage change in error rate (`error_count / count` per window) vs the previous period. Null when the previous error rate is 0 — i.e. the previous window had no errors or no traffic. This includes a 0→N new-error spike, which surfaces as null rather than a delta.",
+                    "type": ["number", "null"]
+                },
                 "line": {
                     "$ref": "#/definitions/integer",
                     "description": "The bucket's anchor line: the source line in line mode, or the symbol's `startLine` in symbol mode."
@@ -42005,6 +42009,10 @@
                 "p50_duration_nano": {
                     "description": "Median wall-clock span duration, in nanoseconds.",
                     "type": "number"
+                },
+                "p50_duration_pct_change": {
+                    "description": "Percentage change in p50 duration vs the previous period (180 = +180%). Null when the previous p50 is 0 (no comparable baseline), which can happen even when previous.count > 0 — do not read null as \"new\".",
+                    "type": ["number", "null"]
                 },
                 "p95_busy_nano": {
                     "description": "95th-percentile active (busy) time, in nanoseconds.",
@@ -42025,6 +42033,10 @@
                 "p99_duration_nano": {
                     "description": "99th-percentile wall-clock span duration, in nanoseconds.",
                     "type": "number"
+                },
+                "p99_duration_pct_change": {
+                    "description": "Percentage change in p99 duration vs the previous period (180 = +180%). Null when the previous p99 is 0 (no comparable baseline), which can happen even when previous.count > 0 — do not read null as \"new\".",
+                    "type": ["number", "null"]
                 },
                 "previous": {
                     "$ref": "#/definitions/SymbolStatsPeriod",
@@ -42049,7 +42061,10 @@
                 "p99_busy_nano",
                 "previous",
                 "count_pct_change",
-                "p95_duration_pct_change"
+                "p50_duration_pct_change",
+                "p95_duration_pct_change",
+                "p99_duration_pct_change",
+                "error_rate_pct_change"
             ],
             "type": "object"
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3460,10 +3460,26 @@ export interface SymbolStatsRow {
      */
     count_pct_change: number | null
     /**
+     * Percentage change in p50 duration vs the previous period (180 = +180%). Null when the previous p50
+     * is 0 (no comparable baseline), which can happen even when previous.count > 0 — do not read null as "new".
+     */
+    p50_duration_pct_change: number | null
+    /**
      * Percentage change in p95 duration vs the previous period (180 = +180%). Null when the previous p95
      * is 0 (no comparable baseline), which can happen even when previous.count > 0 — do not read null as "new".
      */
     p95_duration_pct_change: number | null
+    /**
+     * Percentage change in p99 duration vs the previous period (180 = +180%). Null when the previous p99
+     * is 0 (no comparable baseline), which can happen even when previous.count > 0 — do not read null as "new".
+     */
+    p99_duration_pct_change: number | null
+    /**
+     * Percentage change in error rate (`error_count / count` per window) vs the previous period. Null when
+     * the previous error rate is 0 — i.e. the previous window had no errors or no traffic. This includes a
+     * 0→N new-error spike, which surfaces as null rather than a delta.
+     */
+    error_rate_pct_change: number | null
 }
 
 export interface TraceSpansSymbolStatsQuery extends DataNode<TraceSpansSymbolStatsQueryResponse> {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7074,6 +7074,15 @@ class SymbolStatsRow(BaseModel):
         description="`endLine` of the matched symbol's range. Symbol mode only.",
     )
     error_count: int = Field(..., description="Spans whose OTel status is Error (`status_code = 2`).")
+    error_rate_pct_change: float | None = Field(
+        ...,
+        description=(
+            "Percentage change in error rate (`error_count / count` per window) vs the"
+            " previous period. Null when the previous error rate is 0 — i.e. the"
+            " previous window had no errors or no traffic. This includes a 0→N"
+            " new-error spike, which surfaces as null rather than a delta."
+        ),
+    )
     line: int = Field(
         ...,
         description=(
@@ -7089,6 +7098,14 @@ class SymbolStatsRow(BaseModel):
         description=("Median active (busy) time, in nanoseconds. Excludes time awaiting children."),
     )
     p50_duration_nano: float = Field(..., description="Median wall-clock span duration, in nanoseconds.")
+    p50_duration_pct_change: float | None = Field(
+        ...,
+        description=(
+            "Percentage change in p50 duration vs the previous period (180 = +180%)."
+            " Null when the previous p50 is 0 (no comparable baseline), which can"
+            ' happen even when previous.count > 0 — do not read null as "new".'
+        ),
+    )
     p95_busy_nano: float = Field(..., description="95th-percentile active (busy) time, in nanoseconds.")
     p95_duration_nano: float = Field(..., description="95th-percentile wall-clock span duration, in nanoseconds.")
     p95_duration_pct_change: float | None = Field(
@@ -7101,6 +7118,14 @@ class SymbolStatsRow(BaseModel):
     )
     p99_busy_nano: float = Field(..., description="99th-percentile active (busy) time, in nanoseconds.")
     p99_duration_nano: float = Field(..., description="99th-percentile wall-clock span duration, in nanoseconds.")
+    p99_duration_pct_change: float | None = Field(
+        ...,
+        description=(
+            "Percentage change in p99 duration vs the previous period (180 = +180%)."
+            " Null when the previous p99 is 0 (no comparable baseline), which can"
+            ' happen even when previous.count > 0 — do not read null as "new".'
+        ),
+    )
     previous: SymbolStatsPeriod = Field(
         ...,
         description=("The same metrics over the immediately-preceding equal-length period."),

--- a/products/tracing/backend/symbol_stats_query_runner.py
+++ b/products/tracing/backend/symbol_stats_query_runner.py
@@ -382,7 +382,10 @@ class TraceSpansSymbolStatsQueryRunner(AnalyticsQueryRunner[TraceSpansSymbolStat
         symbol = symbols_by_start.get(line)
         symbol_name, symbol_end_line = (symbol.name, symbol.endLine) if symbol else (None, None)
         current_count = count or 0
+        current_error_count = error_count or 0
+        current_p50 = _num(p50_duration_nano)
         current_p95 = _num(p95_duration_nano)
+        current_p99 = _num(p99_duration_nano)
         previous = SymbolStatsPeriod(
             count=prev_count or 0,
             error_count=prev_error_count or 0,
@@ -395,23 +398,30 @@ class TraceSpansSymbolStatsQueryRunner(AnalyticsQueryRunner[TraceSpansSymbolStat
             p95_busy_nano=_num(prev_p95_busy_nano),
             p99_busy_nano=_num(prev_p99_busy_nano),
         )
+        # Error rate per window (0 when the window had no traffic); the delta is null when the previous
+        # window's rate is 0 — no errors or no traffic — so a 0→N spike reads as "no baseline", not +inf.
+        current_error_rate = current_error_count / current_count if current_count else 0.0
+        previous_error_rate = previous.error_count / previous.count if previous.count else 0.0
         return SymbolStatsRow(
             line=line,
             name=symbol_name,
             end_line=symbol_end_line,
             count=current_count,
-            error_count=error_count or 0,
+            error_count=current_error_count,
             sum_duration_nano=_num(sum_duration_nano),
-            p50_duration_nano=_num(p50_duration_nano),
+            p50_duration_nano=current_p50,
             p95_duration_nano=current_p95,
-            p99_duration_nano=_num(p99_duration_nano),
+            p99_duration_nano=current_p99,
             busy_count=busy_count or 0,
             p50_busy_nano=_num(p50_busy_nano),
             p95_busy_nano=_num(p95_busy_nano),
             p99_busy_nano=_num(p99_busy_nano),
             previous=previous,
             count_pct_change=_pct_change(current_count, previous.count),
+            p50_duration_pct_change=_pct_change(current_p50, previous.p50_duration_nano),
             p95_duration_pct_change=_pct_change(current_p95, previous.p95_duration_nano),
+            p99_duration_pct_change=_pct_change(current_p99, previous.p99_duration_nano),
+            error_rate_pct_change=_pct_change(current_error_rate, previous_error_rate),
         )
 
     def run(self, *args, **kwargs) -> TraceSpansSymbolStatsQueryResponse | CachedTraceSpansSymbolStatsQueryResponse:

--- a/products/tracing/backend/tests/test_symbol_stats.py
+++ b/products/tracing/backend/tests/test_symbol_stats.py
@@ -67,12 +67,60 @@ SPANS = [
     ("window/src/file.rs", 5, "current", 0, 10, None, "current"),
     ("window/src/file.rs", 6, "current", 0, 10, None, "previous"),
     ("window/src/file.rs", 7, "current", 0, 10, None, "outside"),
+    # Period-over-period delta fixtures. Each "function" lives on a SINGLE line so the bucket and the five
+    # *_pct_change values are identical in line mode (bucket = the line) and in symbol mode (a [L, L] range
+    # anchored on L) — letting one parametrized test assert mode parity.
+    #   line 10: traffic + errors in BOTH windows → real deltas (count/p50/p95/p99 +100, error_rate -50).
+    ("pct/src/deltas.rs", 10, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 10, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 10, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 10, "current", 2, 100, None, "current"),  # 4 current, 1 error → rate 1/4
+    ("pct/src/deltas.rs", 10, "current", 0, 50, None, "previous"),
+    ("pct/src/deltas.rs", 10, "current", 2, 50, None, "previous"),  # 2 previous, 1 error → rate 1/2
+    #   line 20: previous only → every metric (count, p50/p95/p99, error_rate) drops -100%.
+    ("pct/src/deltas.rs", 20, "current", 2, 50, None, "previous"),
+    ("pct/src/deltas.rs", 20, "current", 0, 50, None, "previous"),
+    ("pct/src/deltas.rs", 20, "current", 0, 50, None, "previous"),  # 3 previous, 1 error → rate 1/3
+    #   line 30: current only → no baseline for any metric → all five pct_change null.
+    ("pct/src/deltas.rs", 30, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 30, "current", 0, 100, None, "current"),
+    #   line 40: errors present previous, none current but traffic continues → error_rate -100.
+    ("pct/src/deltas.rs", 40, "current", 2, 50, None, "previous"),
+    ("pct/src/deltas.rs", 40, "current", 0, 50, None, "previous"),  # 2 previous, 1 error → rate 1/2
+    ("pct/src/deltas.rs", 40, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 40, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 40, "current", 0, 100, None, "current"),  # 3 current, 0 errors → rate 0
+    #   line 50: no errors previous, errors appear current → error_rate null (0→N spike, prev rate 0).
+    ("pct/src/deltas.rs", 50, "current", 0, 50, None, "previous"),
+    ("pct/src/deltas.rs", 50, "current", 0, 50, None, "previous"),  # 2 previous, 0 errors → rate 0
+    ("pct/src/deltas.rs", 50, "current", 2, 100, None, "current"),
+    ("pct/src/deltas.rs", 50, "current", 0, 100, None, "current"),
+    ("pct/src/deltas.rs", 50, "current", 0, 100, None, "current"),  # 3 current, 1 error → rate 1/3
 ]
 
 FM_SYMBOLS = [
     {"name": "match_flags", "startLine": 459, "endLine": 826},
     {"name": "closure", "startLine": 500, "endLine": 520},
     {"name": "evaluate_flags_in_level", "startLine": 900, "endLine": 980},
+]
+
+# Single-line ranges over the pct/src/deltas.rs fixture: each anchors on its own line, so symbol mode
+# buckets exactly as line mode does.
+DELTA_SYMBOLS = [
+    {"name": "ten", "startLine": 10, "endLine": 10},
+    {"name": "twenty", "startLine": 20, "endLine": 20},
+    {"name": "thirty", "startLine": 30, "endLine": 30},
+    {"name": "forty", "startLine": 40, "endLine": 40},
+    {"name": "fifty", "startLine": 50, "endLine": 50},
+]
+
+# The five server-computed deltas every row carries, in both line and symbol mode.
+PCT_CHANGE_FIELDS = [
+    "count_pct_change",
+    "p50_duration_pct_change",
+    "p95_duration_pct_change",
+    "p99_duration_pct_change",
+    "error_rate_pct_change",
 ]
 
 
@@ -176,6 +224,45 @@ class TestTraceSpansSymbolStats(_TraceSpansTestBase):
         self.assertEqual(by_line[900]["previous"]["count"], 5)
         self.assertEqual(by_line[900]["count_pct_change"], -100.0)
         self.assertEqual(by_line[900]["p95_duration_pct_change"], -100.0)
+
+    @parameterized.expand([("line_mode", None), ("symbol_mode", DELTA_SYMBOLS)])
+    def test_all_five_pct_changes(self, _name, symbols):
+        # Single-line buckets make every delta identical across granularities, so the same assertions hold
+        # whether we bucket by line (no symbols) or by a [L, L] symbol range.
+        by_line = {r["line"]: r for r in self._post("pct/src/deltas.rs", symbols)["results"]}
+        self.assertEqual(sorted(by_line), [10, 20, 30, 40, 50])
+
+        # Mode parity: line and symbol mode return the same five server-computed deltas on every row.
+        for row in by_line.values():
+            for field in PCT_CHANGE_FIELDS:
+                self.assertIn(field, row)
+
+        # line 10 — traffic in both windows: positive count/duration delta, real (negative) error-rate delta.
+        # count 2→4 = +100; p50/p95/p99 50ms→100ms = +100; error_rate 1/2→1/4 = -50.
+        ten = by_line[10]
+        self.assertEqual(ten["count_pct_change"], 100.0)
+        self.assertEqual(ten["p50_duration_pct_change"], 100.0)
+        self.assertEqual(ten["p95_duration_pct_change"], 100.0)
+        self.assertEqual(ten["p99_duration_pct_change"], 100.0)
+        self.assertEqual(ten["error_rate_pct_change"], -50.0)
+
+        # line 20 — previous only: every metric drops -100% (incl. error_rate, errors present previously).
+        twenty = by_line[20]
+        self.assertEqual(twenty["count_pct_change"], -100.0)
+        self.assertEqual(twenty["p50_duration_pct_change"], -100.0)
+        self.assertEqual(twenty["p95_duration_pct_change"], -100.0)
+        self.assertEqual(twenty["p99_duration_pct_change"], -100.0)
+        self.assertEqual(twenty["error_rate_pct_change"], -100.0)
+
+        # line 30 — current only: no baseline → null for each of the five.
+        for field in PCT_CHANGE_FIELDS:
+            self.assertIsNone(by_line[30][field])
+
+        # line 40 — errors vanish (present previous, none current though traffic continues) → error_rate -100.
+        self.assertEqual(by_line[40]["error_rate_pct_change"], -100.0)
+
+        # line 50 — new errors (none previous, appear current) → null, preserving 0→N-spike semantics.
+        self.assertIsNone(by_line[50]["error_rate_pct_change"])
 
     def test_busy_absent_yields_zero_count_and_no_name(self):
         rows = self._symbol_stats("svc/src/legacy.rs", [{"startLine": 10, "endLine": 50}])


### PR DESCRIPTION
## Problem

`POST /api/projects/:id/tracing/spans/symbol-stats/` returns one row per source line (line mode) or per symbol range (symbol mode), each with current-window metrics, a full `previous` block, and two pre-computed deltas: `count_pct_change` and `p95_duration_pct_change`.

The desktop client ignores those two and recomputes **all five** deltas itself (count, p50, p95, p99, error-rate) from `previous`. That's split ownership — the server half-computes the comparison, the client redoes it. We want the server to own the full comparison so every consumer (editor popover, agent inline comments, MCP tool) gets identical deltas and the client can later delete its delta math.

## Changes

Adds three fields to each result row so all five surfaced metrics have a server-computed delta:

| field | metric | status |
|---|---|---|
| `count_pct_change` | count | exists |
| `p50_duration_pct_change` | p50 duration | **new** |
| `p95_duration_pct_change` | p95 duration | exists |
| `p99_duration_pct_change` | p99 duration | exists |
| `error_rate_pct_change` | error rate | **new** |

All five share the existing `_pct_change` formula and null rule:

```
pct_change(current, previous) = ((current - previous) / previous) * 100   if previous > 0
                              = null                                        otherwise
```

- **Durations** compute on raw nano values (ratio is unit-invariant); null when the previous metric is 0.
- **Error rate** is `error_count / count` per window (0 when no traffic); `error_rate_pct_change` is null when the previous rate is 0 — i.e. the previous window had no errors or no traffic. A 0→N new-error spike therefore reads as "no baseline" (null), preserving today's client behavior for a clean swap.

This is **purely additive** — the `previous` block stays — so it deploys independently of the (unmerged) desktop stack. Dropping `previous` and deleting the client's delta math are explicit follow-ups, not this PR.

No SQL change was needed: p50/p99 and error counts were already selected; only the response-row construction changed. The MCP `tools.yaml` entry for this tool is disabled with no inline row schema (the shape derives from the OpenAPI/schema pipeline), so it needs no change.

## How did you test this code?

I'm an agent (Claude Code). Here's what I actually ran:

- `ruff check` + `ruff format --check` on the runner and tests — clean.
- Both Python files byte-compile.
- Regenerated `posthog/schema.py` / `schema.json` from the TypeScript schema source; verified the generated diff is only the three new required-nullable fields.
- Validated the runner↔schema contract by constructing the generated `SymbolStatsRow` Pydantic model with the runner's exact field set (accepted) and with the new fields omitted (correctly rejected).
- Reproduced the runner's delta arithmetic standalone against the new fixtures — every asserted value matches.

I added `test_all_five_pct_changes`, parametrized over **line and symbol mode**, covering: positive delta, −100% drop, no-baseline→null for all five, and the four error-rate cases (real delta, errors→0, 0→errors, no-traffic-previous), plus field-presence parity across granularities. **I could not run the ClickHouse-backed integration test in my environment** (no Docker/ClickHouse/Postgres) — it needs to run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a detailed brief. The work was scoped to a behavior-preserving, additive server-side change so the client can later swap its local delta math for the server values without a behavior change.

Key decisions:
- Reused the existing `_pct_change` helper rather than introducing a new formula — its `previous <= 0` guard is equivalent to the spec's `previous > 0` rule for non-negative inputs, so the existing two deltas already match.
- Error-rate null semantics deliberately preserve the current client behavior (0→N spike → null) for a clean swap, rather than reporting new spikes.
- Test fixtures use single-line "functions" so each bucket and its five deltas are identical in line mode and symbol mode, letting one parametrized test assert mode parity.

No repo skills were strictly required (no migration, no new DRF endpoint/serializer — the response schema flows from the existing TypeScript schema source through `datamodel-codegen`).
