### PR TITLE
chore(cdp): stop deleting shared kafka topics in e2e tests

### DIFF
--- a/nodejs/src/cdp/cdp-e2e.test.ts
+++ b/nodejs/src/cdp/cdp-e2e.test.ts
@@ -5,7 +5,7 @@ import { KafkaProducerObserver } from '~/tests/helpers/mocks/producer.spy'
 
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { waitForExpect } from '~/tests/helpers/expectations'
-import { resetKafka } from '~/tests/helpers/kafka'
+import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
@@ -57,7 +57,7 @@ describe('CDP Consumer loop', () => {
                 return ActualKafkaProducerWrapper.create(...args)
             })
 
-            await resetKafka()
+            await ensureKafkaTopics(TEST_KAFKA_TOPICS)
 
             await resetTestDatabase()
             hub = await createHub()

--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -13,7 +13,7 @@ import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
 
-import { KAFKA_HOG_INVOCATION_RESULTS, KAFKA_INGESTION_WARNINGS } from '../../config/kafka-topics'
+import { KAFKA_HOG_INVOCATION_RESULTS } from '../../config/kafka-topics'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -151,7 +151,7 @@ describe('CDP hog invocation rerun e2e', () => {
         // Ensure all topics exist (idempotently, without deleting) so the ClickHouse
         // Kafka engine consumers keep their connections. Includes KAFKA_HOG_INVOCATION_RESULTS,
         // which this test's MV needs but the shared set does not cover.
-        await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS, KAFKA_INGESTION_WARNINGS])
+        await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS])
         await clickhouse.truncate('hog_invocation_results_data')
         await waitForHogInvocationResultsMvReady(clickhouse)
         await resetTestDatabase()

--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -9,7 +9,7 @@ import { Pool } from 'pg'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
 import { waitForExpect } from '~/tests/helpers/expectations'
-import { ensureKafkaTopics, resetKafka } from '~/tests/helpers/kafka'
+import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { PersonReadRepository } from '~/worker/ingestion/persons/repositories/person-repository'
 
@@ -45,11 +45,10 @@ interface PersistedRow {
 }
 
 /**
- * Probe the ClickHouse Kafka MV for our topic in particular. resetKafka()
- * deletes and recreates the topic, which forces the MV's internal consumer to
- * reconnect; with auto.offset.reset=latest, anything produced before the
- * reconnect is silently dropped. Send probe rows until one lands in CH so we
- * know the MV is live.
+ * Probe the ClickHouse Kafka MV for our topic in particular. With
+ * auto.offset.reset=latest, anything produced before the MV's internal consumer
+ * has attached is silently dropped. Send probe rows until one lands in CH so we
+ * know the MV is live before the test produces real rows.
  */
 const waitForHogInvocationResultsMvReady = async (clickhouse: Clickhouse): Promise<void> => {
     const producer = await ActualKafkaProducerWrapper.create(undefined)
@@ -149,10 +148,10 @@ describe('CDP hog invocation rerun e2e', () => {
         // real producer to observe via KafkaProducerObserver.
         MockKafkaProducerWrapper.create = jest.fn((...args: any[]) => ActualKafkaProducerWrapper.create(...args))
 
-        await resetKafka()
-        // resetKafka does not include KAFKA_HOG_INVOCATION_RESULTS — add it so the
-        // ClickHouse Kafka engine consumer can attach.
-        await ensureKafkaTopics([KAFKA_HOG_INVOCATION_RESULTS, KAFKA_INGESTION_WARNINGS])
+        // Ensure all topics exist (idempotently, without deleting) so the ClickHouse
+        // Kafka engine consumers keep their connections. Includes KAFKA_HOG_INVOCATION_RESULTS,
+        // which this test's MV needs but the shared set does not cover.
+        await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS, KAFKA_INGESTION_WARNINGS])
         await clickhouse.truncate('hog_invocation_results_data')
         await waitForHogInvocationResultsMvReady(clickhouse)
         await resetTestDatabase()

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -21,7 +21,7 @@ import { register } from 'prom-client'
 
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { waitForExpect } from '~/tests/helpers/expectations'
-import { resetKafka } from '~/tests/helpers/kafka'
+import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
 import { KAFKA_APP_METRICS_2, KAFKA_LOG_ENTRIES } from '../../src/config/kafka-topics'
@@ -95,7 +95,7 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
             return ActualKafkaProducerWrapper.create(...args)
         })
 
-        await resetKafka()
+        await ensureKafkaTopics(TEST_KAFKA_TOPICS)
         await resetTestDatabase()
         await cyclotronPool.query('DELETE FROM cyclotron_jobs')
 
@@ -1361,7 +1361,7 @@ describe('Workflows E2E (email queue)', () => {
             return ActualKafkaProducerWrapper.create(...args)
         })
 
-        await resetKafka()
+        await ensureKafkaTopics(TEST_KAFKA_TOPICS)
         await resetTestDatabase()
         await cyclotronPool.query('DELETE FROM cyclotron_jobs')
 


### PR DESCRIPTION
## Problem

The session-replay e2e test (`nodejs/src/session-recording/consumer.e2e.test.ts`) is still flaky despite #64357, which set out to stop deleting/recreating Kafka topics per test (topic churn forces the ClickHouse Kafka-engine consumers to reconnect, and the session test's ClickHouse poll then times out).

#64357 converted the ingestion and session-recording e2e tests from the destructive `resetKafka()` to the idempotent `ensureKafkaTopics()`, but left the CDP e2e tests still calling `resetKafka()`:

- `nodejs/src/cdp/cdp-e2e.test.ts`
- `nodejs/src/cdp/rerun/rerun-e2e.test.ts`
- `nodejs/src/cdp/workflows-e2e.test.ts`

`resetKafka()` runs `deleteAllTopics()` — which deletes **every** non-internal topic, including the session-replay topics and the others the ClickHouse Kafka-engine tables consume — then recreates them. CI runs `jest --runInBand --shard=N/3`; each shard is one process against one shared Kafka + ClickHouse. When jest's shard split lands a CDP e2e file in the same shard as the session-recording test, the CDP `resetKafka()` tears down the topics ClickHouse is mid-consume on, and the session test flakes. So the fix landed for the victims but not the culprits.

## Changes

Replace `resetKafka()` with `ensureKafkaTopics()` in the three CDP e2e tests — the same swap #64357 made elsewhere. `ensureKafkaTopics()` creates topics idempotently without deleting, so no test tears down topics another test (or ClickHouse) depends on.

`rerun-e2e.test.ts` already had a `waitForHogInvocationResultsMvReady()` probe to work around the very deletion-reconnect issue this removes; the probe stays as harmless insurance and its comment is updated to no longer reference `resetKafka`.

## How did you test this code?

Automated checks run locally (no manual testing performed): prettier and ESLint pass on the three changed files. These are infra-dependent e2e tests (Kafka + ClickHouse + S3 + Postgres) that run in CI; the change is a like-for-like helper swap with no production-code impact. The real signal is the session-replay e2e flake rate on CI going forward.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
