### PR TITLE
fix(storybook): raise node heap limit for dev server

### DIFF
--- a/common/storybook/package.json
+++ b/common/storybook/package.json
@@ -3,7 +3,7 @@
     "scripts": {
         "build:products": "pnpm --filter=@posthog/frontend build:products",
         "build": "pnpm build:products && DEBUG=0 NODE_OPTIONS=--max-old-space-size=6144 storybook build -o dist",
-        "start": "pnpm build:products && DEBUG=0 storybook dev -p 6006",
+        "start": "pnpm build:products && DEBUG=0 NODE_OPTIONS=--max-old-space-size=8192 storybook dev -p 6006",
         "test:visual:ci:update": "test-storybook -u --junit --no-index-json --maxWorkers=1",
         "test:visual:ci:verify": "test-storybook --ci --junit --no-index-json --maxWorkers=1",
         "test:visual:debug": "pnpm build:products && PWDEBUG=1 NODE_OPTIONS=--max-old-space-size=16384 test-storybook --browsers chromium webkit --no-index-json",


### PR DESCRIPTION
## Problem

Storybook crashes locally on `start` with `FATAL ERROR: ... JavaScript heap out of memory` (exit 134). It dies during the webpack preview build (`82% sealing chunk`), right around node's default ~4GB heap cap.

The root cause is a mismatch between the two scripts in `common/storybook/package.json`: `build` already sets `NODE_OPTIONS=--max-old-space-size=6144`, but `start` (`storybook dev`) runs at node's default heap limit. The PostHog preview bundle — all of `frontend/` plus every product's stories — exceeds that while webpack seals chunks, so dev OOMs while build survives.

## Changes

Add `NODE_OPTIONS=--max-old-space-size=8192` to the `start` script. Bumped to 8192 rather than matching build's 6144 because dev mode also holds HMR state across rebuilds, so it needs more headroom than a one-shot build.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests cover this — it's a one-line change to a build script's node flags. Diagnosis came directly from the crash log: heap climbed past 4GB and aborted during webpack sealing, and `start` was the only Storybook script missing the heap flag that `build` already has. Not independently verified on the reporter's machine.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a pasted Storybook crash log. The OOM signature (heap maxing ~4GB, abort during webpack `sealing chunk`) plus a read of `common/storybook/package.json` pointed at the `start`/`build` inconsistency — `build` raises the node heap, `start` doesn't. Fix mirrors the existing `build` approach. Considered just matching 6144 but chose 8192 since the dev server retains more state than a one-shot build.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
