### PR TITLE
feat(admin): register product admin inlines without core importing the product

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -208,7 +208,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     def get_inlines(self, request, obj=None):
         # Inlines other apps registered for Organization, so a product can show a panel on
         # this page without core importing it. See posthog.admin.inline_registry.
-        return [*self.inlines, *extra_inlines_for(Organization)]
+        return [*super().get_inlines(request, obj), *extra_inlines_for(Organization)]
 
     def members_count(self, organization: Organization):
         return organization.members.count()

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -12,6 +12,7 @@ from django.utils.html import format_html
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
 
+from posthog.admin.inline_registry import extra_inlines_for
 from posthog.admin.inlines.organization_domain_inline import OrganizationDomainInline
 from posthog.admin.inlines.organization_invite_inline import OrganizationInviteInline
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
@@ -19,8 +20,6 @@ from posthog.admin.inlines.project_inline import ProjectInline
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
 from posthog.models.organization import Organization
-
-from products.legal_documents.backend.admin import LegalDocumentInline
 
 # Registry of models to count for bulk-delete report.
 # Format: (model_import_path, filter_field, display_name)
@@ -178,7 +177,6 @@ class OrganizationAdmin(admin.ModelAdmin):
         OrganizationMemberInline,
         OrganizationInviteInline,
         OrganizationDomainInline,
-        LegalDocumentInline,
     ]
     readonly_fields = [
         "id",
@@ -206,6 +204,11 @@ class OrganizationAdmin(admin.ModelAdmin):
         "id",
         "name",
     )
+
+    def get_inlines(self, request, obj=None):
+        # Inlines other apps registered for Organization, so a product can show a panel on
+        # this page without core importing it. See posthog.admin.inline_registry.
+        return [*self.inlines, *extra_inlines_for(Organization)]
 
     def members_count(self, organization: Organization):
         return organization.members.count()

--- a/posthog/admin/inline_registry.py
+++ b/posthog/admin/inline_registry.py
@@ -1,0 +1,39 @@
+"""Cross-app admin inline registration.
+
+Lets a product surface a Django admin inline on a *core* admin page (e.g. the
+Organization change page) without core importing the product. A Django inline must be
+listed in its parent ModelAdmin, and core admins live in posthog/admin/ — so a product
+that owns an inline would otherwise force a core -> product import, breaking the product's
+isolation boundary.
+
+Instead the product registers its inline against the parent *model* at admin-autodiscover
+time, and the parent admin pulls registered inlines in get_inlines(). Keying by model class
+(not by importing the parent ModelAdmin) keeps the dependency one-way (product -> posthog)
+and avoids the auth.admin circular-import gotcha.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.contrib.admin import InlineModelAdmin
+    from django.db.models import Model
+
+_extra_inlines: dict[type, list[type]] = {}
+
+
+def register_admin_inline(parent_model: type[Model], inline_cls: type[InlineModelAdmin]) -> None:
+    """Attach an admin inline to `parent_model`'s admin page from another app.
+
+    Call at admin-module import time (autodiscover) — e.g. in a product's backend/admin.py.
+    The parent admin must opt in by adding extra_inlines_for() to its get_inlines(). Idempotent.
+    """
+    inlines = _extra_inlines.setdefault(parent_model, [])
+    if inline_cls not in inlines:
+        inlines.append(inline_cls)
+
+
+def extra_inlines_for(parent_model: type[Model]) -> list[type]:
+    """Inlines other apps registered for `parent_model`, in registration order."""
+    return list(_extra_inlines.get(parent_model, []))

--- a/posthog/admin/inline_registry.py
+++ b/posthog/admin/inline_registry.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from django.contrib.admin import InlineModelAdmin
+    from django.contrib.admin.options import InlineModelAdmin
     from django.db.models import Model
 
-_extra_inlines: dict[type, list[type]] = {}
+_extra_inlines: dict[type[Model], list[type[InlineModelAdmin]]] = {}
 
 
 def register_admin_inline(parent_model: type[Model], inline_cls: type[InlineModelAdmin]) -> None:
@@ -34,6 +34,6 @@ def register_admin_inline(parent_model: type[Model], inline_cls: type[InlineMode
         inlines.append(inline_cls)
 
 
-def extra_inlines_for(parent_model: type[Model]) -> list[type]:
+def extra_inlines_for(parent_model: type[Model]) -> list[type[InlineModelAdmin]]:
     """Inlines other apps registered for `parent_model`, in registration order."""
     return list(_extra_inlines.get(parent_model, []))

--- a/posthog/admin/test_inline_registry.py
+++ b/posthog/admin/test_inline_registry.py
@@ -1,0 +1,20 @@
+from posthog.admin.inline_registry import extra_inlines_for, register_admin_inline
+
+
+def test_register_admin_inline_is_idempotent():
+    class _DummyModel:
+        pass
+
+    class _Inline:
+        pass
+
+    register_admin_inline(_DummyModel, _Inline)
+    register_admin_inline(_DummyModel, _Inline)
+    assert extra_inlines_for(_DummyModel) == [_Inline]
+
+
+def test_extra_inlines_for_unregistered_model_is_empty():
+    class _Unregistered:
+        pass
+
+    assert extra_inlines_for(_Unregistered) == []

--- a/posthog/admin/test_inline_registry.py
+++ b/posthog/admin/test_inline_registry.py
@@ -1,4 +1,15 @@
+import pytest
+
+from posthog.admin import inline_registry
 from posthog.admin.inline_registry import extra_inlines_for, register_admin_inline
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    saved = {model: list(inlines) for model, inlines in inline_registry._extra_inlines.items()}
+    yield
+    inline_registry._extra_inlines.clear()
+    inline_registry._extra_inlines.update(saved)
 
 
 def test_register_admin_inline_is_idempotent():

--- a/posthog/admin/test_inline_registry.py
+++ b/posthog/admin/test_inline_registry.py
@@ -1,7 +1,14 @@
 import pytest
 
+from django.contrib import admin
+
 from posthog.admin import inline_registry
 from posthog.admin.inline_registry import extra_inlines_for, register_admin_inline
+from posthog.models import Organization, Team
+
+
+class _DummyInline(admin.TabularInline):
+    model = Organization
 
 
 @pytest.fixture(autouse=True)
@@ -13,19 +20,12 @@ def _restore_registry():
 
 
 def test_register_admin_inline_is_idempotent():
-    class _DummyModel:
-        pass
-
-    class _Inline:
-        pass
-
-    register_admin_inline(_DummyModel, _Inline)
-    register_admin_inline(_DummyModel, _Inline)
-    assert extra_inlines_for(_DummyModel) == [_Inline]
+    register_admin_inline(Organization, _DummyInline)
+    register_admin_inline(Organization, _DummyInline)
+    assert extra_inlines_for(Organization).count(_DummyInline) == 1
 
 
-def test_extra_inlines_for_unregistered_model_is_empty():
-    class _Unregistered:
-        pass
-
-    assert extra_inlines_for(_Unregistered) == []
+def test_inline_is_scoped_to_its_parent_model():
+    register_admin_inline(Organization, _DummyInline)
+    assert _DummyInline in extra_inlines_for(Organization)
+    assert _DummyInline not in extra_inlines_for(Team)

--- a/products/legal_documents/backend/admin.py
+++ b/products/legal_documents/backend/admin.py
@@ -13,7 +13,9 @@ from django.utils.safestring import SafeString
 
 import structlog
 
+from posthog.admin.inline_registry import register_admin_inline
 from posthog.cloud_utils import is_cloud, is_dev_mode
+from posthog.models.organization import Organization
 from posthog.storage import object_storage
 
 from . import logic
@@ -328,3 +330,8 @@ class LegalDocumentInline(admin.TabularInline):
             return "—"
         url = f"/api/organizations/{document.organization_id}/legal_documents/{document.id}/download"
         return format_html('<a href="{}" target="_blank" rel="noopener">Download PDF</a>', url)
+
+
+# Surface this inline on core's Organization admin page without core importing the product.
+# OrganizationAdmin pulls it in via get_inlines() — see posthog.admin.inline_registry.
+register_admin_inline(Organization, LegalDocumentInline)

--- a/products/legal_documents/backend/tests/test_admin.py
+++ b/products/legal_documents/backend/tests/test_admin.py
@@ -12,9 +12,10 @@ from django.utils.datastructures import MultiValueDict
 
 from parameterized import parameterized
 
-from posthog.models.organization import OrganizationMembership
+from posthog.admin.admins.organization_admin import OrganizationAdmin
+from posthog.models.organization import Organization, OrganizationMembership
 
-from products.legal_documents.backend.admin import LegalDocumentAdmin, LegalDocumentAdminForm
+from products.legal_documents.backend.admin import LegalDocumentAdmin, LegalDocumentAdminForm, LegalDocumentInline
 from products.legal_documents.backend.models import LegalDocument
 from products.legal_documents.backend.storage import signed_pdf_storage_key
 
@@ -349,3 +350,14 @@ class TestLegalDocumentAdminPermissions(APIBaseTest):
         request = self._request_for(is_staff=False)
         self.assertFalse(self.admin.has_add_permission(request))
         self.assertFalse(self.admin.has_delete_permission(request))
+
+
+class TestLegalDocumentInlineRegistration(APIBaseTest):
+    def test_inline_attaches_to_organization_admin(self) -> None:
+        # legal_documents registers LegalDocumentInline via posthog.admin.inline_registry, so
+        # core surfaces it on the Organization admin page without importing the product.
+        org_admin = OrganizationAdmin(Organization, AdminSite())
+        inlines = org_admin.get_inlines(RequestFactory().get("/"))
+        self.assertIn(LegalDocumentInline, inlines)
+        # It arrived through the registry, not core's static inlines list.
+        self.assertNotIn(LegalDocumentInline, org_admin.inlines)

--- a/products/legal_documents/package.json
+++ b/products/legal_documents/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-legal-documents",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/legal_documents/turbo.json
+++ b/products/legal_documents/turbo.json
@@ -1,4 +1,10 @@
 {
     "extends": ["//"],
-    "tasks": {}
+    "tasks": {
+        "backend:contract-check": {
+            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "outputs": [],
+            "cache": true
+        }
+    }
 }

--- a/tach.toml
+++ b/tach.toml
@@ -761,23 +761,14 @@ from = [
     "products.mcp_store",
 ]
 
-# legal_documents has a non-standard public surface, so it gets a dedicated block rather than
-# joining the canonical alternation above: posthog/urls registers its pandadoc webhook
-# (presentation.webhook), and core's OrganizationAdmin lists its LegalDocumentInline (admin
-# block below — a Django inline must be named in its parent admin's `inlines`).
+# legal_documents has a non-standard public surface — posthog/urls registers its pandadoc
+# webhook (presentation.webhook), not the canonical presentation.views — so it gets a dedicated
+# block rather than joining the canonical alternation above.
 [[interfaces]]
 expose = [
     "backend\\.facade.*",
     "backend\\.presentation.*",
     "backend\\.routes.*",
-]
-from = [
-    "products.legal_documents",
-]
-
-[[interfaces]]
-expose = [
-    "backend\\.admin.*",
 ]
 from = [
     "products.legal_documents",


### PR DESCRIPTION
> Stacked on #64520 — review/merge that first. This branch targets `chore/devex-isolation-seal-maturity`; the diff against it is just the admin-registry change.

## Problem

Core's `OrganizationAdmin` listed `legal_documents`' `LegalDocumentInline` directly (`from products.legal_documents.backend.admin import LegalDocumentInline`). A Django inline must be named in its parent admin's `inlines`, and the parent lives in core — so a product that owns an inline is forced into a `core → product` import, which breaks the product's isolation boundary. That's exactly why #64520 had to give `legal_documents` a tach admin-leak block and strip its `backend:contract-check` skip as a stopgap. The earlier "permanent" framing was wrong: this coupling is removable.

## Changes

Add a small cross-app inline registry so a product can surface an inline on a core admin page without core importing it:

- `posthog/admin/inline_registry.py` — `register_admin_inline(parent_model, inline_cls)` + `extra_inlines_for(parent_model)`.
- `OrganizationAdmin.get_inlines` returns `[*self.inlines, *extra_inlines_for(Organization)]`; the static `LegalDocumentInline` import is gone.
- `legal_documents/backend/admin.py` registers its own inline at admin-autodiscover time.

Keyed by **model class** (not by importing the parent `ModelAdmin`), so the dependency stays one-way (`product → posthog`, already allowed) and it dodges the `auth.admin` circular-import gotcha. Registration runs at autodiscover import; `get_inlines` resolves lazily at request time, so timing is safe. It's the reusable mechanism for any future product that wants a presence on a core admin page.

With core no longer importing it, `legal_documents` is fully sealed: it drops the tach admin-leak block, keeps a clean dedicated interface (its public surface is the pandadoc webhook — `presentation.webhook`, not the canonical `presentation.views`), and gets its `backend:contract-check` skip back.

## How did you test this code?

Agent-authored. Ran locally:

- `tach check --dependencies --interfaces` → all modules validated (the leak is gone; no new violations)
- new tests: `posthog/admin/test_inline_registry.py` (registry primitive) and a case in `products/legal_documents/backend/tests/test_admin.py` asserting `LegalDocumentInline` still attaches to `OrganizationAdmin.get_inlines` via the registry (not core's static list)
- `hogli product:lint` → `legal_documents` now passes as fully sealed (`product:maturity` shows external + internal sealed, isolated tests ON)
- `ruff check` / `ruff format` clean

The Organization admin page still renders the legal-documents panel — now via the registry rather than a direct import.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @webjunkie, as the follow-up promised in #64520. A fork-investigation confirmed this is the only product→core-admin inline coupling in the repo and that it inverts cleanly via Django's `get_inlines` hook (already used in `products/tasks/backend/admin.py`) — unlike error_tracking's frozen-migration leak, which genuinely can't be rerouted.

Decision: register **by model**, not by importing `OrganizationAdmin`, to keep the dependency one-way and sidestep the `auth.admin` circular-import issue. The registry is deliberately tiny and generic so it serves the next product that needs a core-admin panel, rather than being a one-off shim for this consumer.
