### PR TITLE
fix(insights): auto-dismiss export toast after download

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.test.ts
@@ -127,7 +127,7 @@ describe('exportsLogic', () => {
                 label: 'blocking export with content is downloaded and confirmed',
                 response: asset({ id: 12, export_format: ExporterFormat.CSV, has_content: true }),
                 format: ExporterFormat.CSV,
-                toast: { fn: 'success', args: ['Export complete!'] },
+                toast: { fn: 'success', args: ['Export complete!', { pauseOnFocusLoss: false }] },
                 expectsDownload: true,
                 freshIds: [],
             },

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -104,7 +104,9 @@ export const exportsLogic = kea<exportsLogicType>([
                         type: exportData.export_context.mediaType,
                     })
                     downloadBlob(blob, exportData.export_context.filename)
-                    lemonToast.success('Export complete!')
+                    // Triggering a download blurs the window, which would otherwise pause
+                    // react-toastify's auto-dismiss timer (pauseOnFocusLoss) indefinitely.
+                    lemonToast.success('Export complete!', { pauseOnFocusLoss: false })
                 } catch (e: any) {
                     lemonToast.error(`Export failed with error: ${e.message}`)
                 }
@@ -224,13 +226,18 @@ export const exportsLogic = kea<exportsLogicType>([
                             if (response && response.has_content) {
                                 // Blocking export already finished in the request — download and confirm.
                                 await downloadExportedAsset(response)
-                                lemonToast.success('Export complete!')
+                                // The download blurs the window; disable pauseOnFocusLoss so the
+                                // toast's auto-dismiss timer isn't frozen indefinitely.
+                                lemonToast.success('Export complete!', { pauseOnFocusLoss: false })
                             } else if (response && response.exception) {
                                 lemonToast.error('Export failed: ' + response.exception)
                             } else if (response) {
                                 // Async export (e.g. video render) is a background job: acknowledge the
                                 // kickoff right away. It surfaces in the Exports panel once the render finishes.
                                 lemonToast.success('Export started', {
+                                    // A later download (e.g. from the Exports panel) blurs the window,
+                                    // which would otherwise freeze this toast's auto-dismiss timer.
+                                    pauseOnFocusLoss: false,
                                     button: {
                                         label: 'View exports',
                                         action: () => newInternalTab(urls.exports()),


### PR DESCRIPTION
## Problem

Exporting an insight/table (e.g. a screengrab/PNG or CSV) downloads the file fine, but the "Export complete!" / "Export started" toast never auto-dismisses — it lingers until you close it manually.

The cause is a react-toastify gotcha. Its `pauseOnFocusLoss` option is on by default and freezes a toast's auto-dismiss timer whenever the window loses focus. Triggering a browser download blurs the window, so the export toast's timer gets paused and — if focus doesn't cleanly return — never resumes. This is specific to export toasts because they're the ones paired with a download; ordinary toasts (e.g. "Saved") don't blur the window.

## Changes

Disable `pauseOnFocusLoss` on the export-success toasts in `exportsLogic` (local export complete, blocking export complete, and async export started) so the download-triggered blur can't freeze their auto-dismiss timer.

## How did you test this code?

I'm an agent (PostHog Slack app). I updated the existing `exportsLogic.test.ts` case to assert the new toast option. I could not run the jest suite in this environment because frontend dependencies aren't installed here — the change is a one-option addition mirrored in the test.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged a Slack bug report ("exported a screengrab and it downloaded but the toast never goes away on its own"). Traced the export toast flow through `exportsLogic` and the shared `LemonToast` wrapper, confirmed all export-success toasts rely on the global `ToastContainer`'s 6s `autoClose`, and identified `pauseOnFocusLoss` (react-toastify default `true`) as the culprit: the download blurs the window and pauses the dismiss timer. Fixed by opting these specific toasts out of `pauseOnFocusLoss` rather than changing the behavior globally, to avoid affecting unrelated toasts. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781194134804879?thread_ts=1781194134.804879&cid=C0ACRAMJUAG)*
