### PR TITLE
feat(max): copy AI answers as markdown

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -1336,13 +1336,24 @@ function SuccessActions({
         <>
             <div className="flex items-center ml-1">
                 {content && (
-                    <LemonButton
-                        icon={<IconCopy />}
-                        type="tertiary"
-                        size="xsmall"
-                        tooltip="Copy answer"
-                        onClick={() => copyToClipboard(stripMarkdown(content))}
-                    />
+                    <>
+                        <LemonButton
+                            icon={<IconCopy />}
+                            type="tertiary"
+                            size="xsmall"
+                            tooltip="Copy answer"
+                            onClick={() => copyToClipboard(stripMarkdown(content), 'answer')}
+                        />
+                        <LemonButton
+                            icon={<IconCopy />}
+                            type="tertiary"
+                            size="xsmall"
+                            tooltip="Copy answer as Markdown"
+                            onClick={() => copyToClipboard(content, 'answer as Markdown')}
+                        >
+                            Markdown
+                        </LemonButton>
+                    </>
                 )}
                 {!hideRatingAndRetry && rating !== 'bad' && (
                     <LemonButton


### PR DESCRIPTION
## Problem

Closes #57823

PostHog AI answers can include tables, links, bullets, and code blocks, but the current answer copy action strips Markdown before writing to the clipboard. That makes AI-generated answers harder to paste into Slack, comments, or other Markdown-friendly destinations without losing structure.

## Changes

- Keep the existing plain-text Copy answer action.
- Add a second Copy answer as Markdown action for completed AI answers.
- Use the existing clipboard utility so users get the same success/error toast behavior.

No screenshot attached: this is an icon-only action added to the existing message action row, and I could not run the full PostHog app locally in this Windows environment.

## How did you test this code?

- `node_modules\.bin\oxfmt.CMD --check frontend\src\scenes\max\Thread.tsx`
- `node_modules\.bin\oxlint.CMD frontend\src\scenes\max\Thread.tsx --quiet`
- `git diff --check`
- `node_modules\.bin\jest.CMD src/scenes/max/max.test.ts --runInBand` from `frontend/`

Notes: the full `pnpm install --frozen-lockfile` initially failed on native backend dependencies (`cpu-features` / `node-rdkafka`) because this Windows machine lacks the expected Visual Studio C++ build tools. I completed dependency linking with `--ignore-scripts`, built `@posthog/quill...`, then ran the targeted frontend test. The Jest run passed but emitted existing duplicate mock warnings and a Kea selector console warning.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex helped research live issue/PR overlap, inspect the Max answer UI, and draft this small frontend patch. I rejected broader/staler AI/comment ideas and chose #57823 because it is open, unassigned, has no comments, and no overlapping PRs by issue number or exact feature text. No repo-provided skills were invoked.
