### PR TITLE
fix(agent-runner): auth gateway dispatch via Authorization: Bearer

### DIFF
--- a/products/agent_platform/services/agent-runner/src/index.ts
+++ b/products/agent_platform/services/agent-runner/src/index.ts
@@ -305,6 +305,8 @@ async function main(): Promise<void> {
                   posthogAiGatewayModel({
                       specModel,
                       baseUrl: config.aiGatewayUrl,
+                      // Non-null: boot guard above throws when useAiGateway && !posthogAiGatewayKey.
+                      apiKey: config.posthogAiGatewayKey!,
                   })
             : undefined,
         // Per-session bearer for pi-ai's `streamSimple` (no client-level default).

--- a/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.test.ts
+++ b/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.test.ts
@@ -26,18 +26,17 @@ describe('posthogAiGatewayModel', () => {
         expect(model.provider).toBe('posthog-ai-gateway')
     })
 
-    it('strips /v1 for the anthropic-messages shape and keeps it for openai', () => {
-        const anthropic = posthogAiGatewayModel({
-            specModel: 'anthropic/claude-sonnet-4-6',
+    // anthropic-messages: the SDK appends `/v1/messages`, so the trailing `/v1`
+    // is stripped. openai shapes append their own suffix, so `/v1` is kept.
+    it.each([
+        ['anthropic/claude-sonnet-4-6', 'https://ai-gateway.example.com'],
+        ['openai/gpt-4o', 'https://ai-gateway.example.com/v1'],
+    ])('resolves baseUrl for %s', (specModel, expectedBaseUrl) => {
+        const model = posthogAiGatewayModel({
+            specModel,
             baseUrl: 'https://ai-gateway.example.com/v1',
             apiKey: 'phs_test-key',
         })
-        const openai = posthogAiGatewayModel({
-            specModel: 'openai/gpt-4o',
-            baseUrl: 'https://ai-gateway.example.com/v1',
-            apiKey: 'phs_test-key',
-        })
-        expect(anthropic.baseUrl).toBe('https://ai-gateway.example.com')
-        expect(openai.baseUrl).toBe('https://ai-gateway.example.com/v1')
+        expect(model.baseUrl).toBe(expectedBaseUrl)
     })
 })

--- a/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.test.ts
+++ b/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { aiGatewaySkuFor, posthogAiGatewayModel } from './ai-gateway-model'
+
+describe('aiGatewaySkuFor', () => {
+    it.each([
+        ['openai/gpt-4o', 'gpt-4o'],
+        ['anthropic/claude-sonnet-4-6', 'claude-sonnet-4-6'],
+        ['gpt-4o', 'gpt-4o'],
+    ])('maps %s -> %s', (specModel, sku) => {
+        expect(aiGatewaySkuFor(specModel)).toBe(sku)
+    })
+})
+
+describe('posthogAiGatewayModel', () => {
+    // The gateway reads only `Authorization: Bearer`. pi-ai's anthropic-messages
+    // shape would otherwise send the key as `x-api-key` and 401 at the gateway —
+    // so the Bearer header must be pinned regardless of provider shape.
+    it.each(['anthropic/claude-sonnet-4-6', 'openai/gpt-4o'])('pins Authorization: Bearer for %s', (specModel) => {
+        const model = posthogAiGatewayModel({
+            specModel,
+            baseUrl: 'https://ai-gateway.example.com/v1',
+            apiKey: 'phs_test-key',
+        })
+        expect(model.headers?.Authorization).toBe('Bearer phs_test-key')
+        expect(model.provider).toBe('posthog-ai-gateway')
+    })
+
+    it('strips /v1 for the anthropic-messages shape and keeps it for openai', () => {
+        const anthropic = posthogAiGatewayModel({
+            specModel: 'anthropic/claude-sonnet-4-6',
+            baseUrl: 'https://ai-gateway.example.com/v1',
+            apiKey: 'phs_test-key',
+        })
+        const openai = posthogAiGatewayModel({
+            specModel: 'openai/gpt-4o',
+            baseUrl: 'https://ai-gateway.example.com/v1',
+            apiKey: 'phs_test-key',
+        })
+        expect(anthropic.baseUrl).toBe('https://ai-gateway.example.com')
+        expect(openai.baseUrl).toBe('https://ai-gateway.example.com/v1')
+    })
+})

--- a/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.ts
+++ b/products/agent_platform/services/agent-runner/src/models/ai-gateway-model.ts
@@ -15,6 +15,15 @@
  *     or `/responses` to baseUrl, so we keep the `/v1` suffix on baseUrl.
  *   - anthropic-messages → Anthropic SDK appends `/v1/messages` itself, so
  *     we strip the trailing `/v1` from baseUrl.
+ *
+ * Auth: the gateway authenticates the customer with `Authorization: Bearer
+ * <phs_…>` (it reads only that header). pi-ai's openai shapes already send the
+ * apiKey as `Authorization: Bearer`, but its anthropic-messages shape sends it
+ * as `x-api-key` with no `Authorization` — so a Claude model would 401 at the
+ * gateway's auth tier. We pin `Authorization: Bearer <key>` on the model so
+ * every shape authenticates the way the gateway expects. pi-ai still sends the
+ * key as the provider credential too (x-api-key for Anthropic), which the
+ * gateway overrides when it forwards to the upstream provider.
  */
 
 import type { Model } from '@earendil-works/pi-ai'
@@ -26,6 +35,13 @@ export interface AiGatewayModelOpts {
     specModel: string
     /** Gateway root with `/v1` suffix, e.g. `http://localhost:8080/v1`. */
     baseUrl: string
+    /**
+     * The gateway bearer — a `phs_` project secret key with `llm_gateway:read`.
+     * Pinned as `Authorization: Bearer <key>` on the model so the
+     * anthropic-messages shape (which otherwise sends only `x-api-key`)
+     * authenticates against the gateway. See the auth note above.
+     */
+    apiKey: string
 }
 
 /**
@@ -46,6 +62,10 @@ export function posthogAiGatewayModel(opts: AiGatewayModelOpts): Model<string> {
         id: aiGatewaySkuFor(opts.specModel),
         provider: 'posthog-ai-gateway',
         baseUrl: gatewayBaseUrlForApi(native.api, opts.baseUrl),
+        headers: {
+            ...native.headers,
+            Authorization: `Bearer ${opts.apiKey}`,
+        },
     }
 }
 

--- a/products/agent_platform/services/agent-tests/src/cases/real-inference.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/real-inference.test.ts
@@ -101,6 +101,7 @@ function discoverProviders(): ProviderSpec[] {
             model: posthogAiGatewayModel({
                 specModel: process.env.REAL_INFERENCE_MODEL_ID ?? 'openai/gpt-4.1-mini',
                 baseUrl: process.env.POSTHOG_AI_GATEWAY_URL,
+                apiKey: process.env.POSTHOG_AI_GATEWAY_KEY,
             }),
             apiKey: process.env.POSTHOG_AI_GATEWAY_KEY,
         })

--- a/products/agent_platform/services/agent-tests/src/cases/real-inference.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/real-inference.test.ts
@@ -96,15 +96,23 @@ function discoverProviders(): ProviderSpec[] {
     const pin = process.env.REAL_INFERENCE_PROVIDER?.toLowerCase()
     const out: ProviderSpec[] = []
     if ((!pin || pin === 'gateway') && process.env.POSTHOG_AI_GATEWAY_KEY && process.env.POSTHOG_AI_GATEWAY_URL) {
-        out.push({
-            label: 'ai-gateway',
-            model: posthogAiGatewayModel({
-                specModel: process.env.REAL_INFERENCE_MODEL_ID ?? 'openai/gpt-4.1-mini',
-                baseUrl: process.env.POSTHOG_AI_GATEWAY_URL,
-                apiKey: process.env.POSTHOG_AI_GATEWAY_KEY,
-            }),
-            apiKey: process.env.POSTHOG_AI_GATEWAY_KEY,
-        })
+        const gatewayKey = process.env.POSTHOG_AI_GATEWAY_KEY
+        const gatewayUrl = process.env.POSTHOG_AI_GATEWAY_URL
+        // Exercise BOTH provider shapes through the gateway. openai authenticates
+        // with `Authorization: Bearer` natively; anthropic-messages relies on
+        // posthogAiGatewayModel pinning that header (the regression this guards —
+        // pi-ai's anthropic shape otherwise sends only `x-api-key`, which the
+        // gateway rejects). An explicit REAL_INFERENCE_MODEL_ID pins one model.
+        const gatewayModels = process.env.REAL_INFERENCE_MODEL_ID
+            ? [process.env.REAL_INFERENCE_MODEL_ID]
+            : ['openai/gpt-4.1-mini', 'anthropic/claude-haiku-4-5']
+        for (const specModel of gatewayModels) {
+            out.push({
+                label: `ai-gateway (${specModel})`,
+                model: posthogAiGatewayModel({ specModel, baseUrl: gatewayUrl, apiKey: gatewayKey }),
+                apiKey: gatewayKey,
+            })
+        }
     }
     if ((!pin || pin === 'anthropic') && process.env.ANTHROPIC_API_KEY) {
         out.push({


### PR DESCRIPTION
## Summary

Agent sessions running through the **ai-gateway** fail every Claude turn with:

```
[error] failed {"reason":"401 authentication failed","source":"ai_gateway","model":"claude-sonnet-4-6","provider":"posthog-ai-gateway","api":"anthropic-messages"}
```

**Root cause — runner side, Claude-shape only.** The gateway authenticates the caller from the `Authorization: Bearer <phs_…>` header *only* (`internal/auth/resolver.go` — it reads `Authorization`, rejects anything that isn't a `phs_`/`pha_` bearer before any cache read). pi-ai's **openai** shapes already send the apiKey as `Authorization: Bearer`, but its **anthropic-messages** shape sends it as `x-api-key` with no `Authorization` header (`@earendil-works/pi-ai` `providers/anthropic.js` default branch). So the runner's `posthogAiGatewayModel` path 401'd at the gateway's auth tier for every Claude model, while the runner's usage/wallet reads (`HttpGatewayClient`, which sends Bearer) kept working.

This matches the prod-us fingerprint exactly — same pod, same token, same instant:
- `GET /v1/usage/agent:…` → **404** (auth OK, no ledger row)
- `POST /v1/messages` → **401** `auth_failed` (latency 0)

The deployed credential is **fine** — a valid `phs_` project secret key with `llm_gateway:read`, projected and funded. No infra/credential change needed.

## Fix

Pin `Authorization: Bearer <key>` on the gateway `Model` in `posthogAiGatewayModel`, so every provider shape authenticates the way the gateway expects. pi-ai still sends the key as the provider credential (x-api-key for Anthropic); the gateway overrides that when forwarding upstream, so sending both is harmless.

## Why it wasn't caught

The gateway integration test (`real-inference.test.ts`) defaults to `openai/gpt-4.1-mini` — an OpenAI shape, which uses Bearer and works. The Anthropic shape was never exercised through the gateway. Added a unit test asserting the Bearer header is pinned for both shapes.

## Testing

- `vitest` unit test for `posthogAiGatewayModel` (6/6 pass); `tsc --noEmit` clean; `oxlint` clean.
- **Verified against prod-us** (`https://ai-gateway.us.posthog.com`) with the agents team's `phs_` token:
  - `POST /v1/messages` + `x-api-key` → **401** `auth_failed`
  - `POST /v1/messages` + `Authorization: Bearer` → **200** (real `claude-sonnet-4-6` completion)
  - `Authorization: Bearer` **+** `x-api-key` together (the exact wire shape this fix produces) → **200**

## Agent context

Diagnosed and authored from a Claude Code session (driven by @benwhite). Prod logs read via Grafana/Loki (prod-us); gateway behavior confirmed by direct `curl` with the agents team `phs_` credential (token via `op`, never logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
