### PR TITLE
chore(ci): emit per-test traces on all in-repo PRs with branch attribute

### DIFF
--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -350,6 +350,9 @@ def workflow_resource_attributes() -> dict[str, str | int]:
     attrs["ci.event_name"] = os.environ.get("GITHUB_EVENT_NAME", "")
     attrs["ci.head_ref"] = os.environ.get("GITHUB_HEAD_REF", "")
     attrs["ci.base_ref"] = os.environ.get("GITHUB_BASE_REF", "")
+    attrs["ci.ref_name"] = os.environ.get("GITHUB_REF_NAME", "")
+    # Branch name regardless of event: PR source branch, else the pushed branch.
+    attrs["ci.branch"] = os.environ.get("GITHUB_HEAD_REF") or os.environ.get("GITHUB_REF_NAME", "")
     pr_number = get_pull_request_number()
     if pr_number is not None:
         attrs["ci.pr_number"] = pr_number

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -384,8 +384,20 @@ def test_workflow_resource_attributes_includes_query_and_drilldown_fields(
     assert attrs["ci.event_name"] == "pull_request"
     assert attrs["ci.head_ref"] == "worktree-per-test-telemetry-junit"
     assert attrs["ci.base_ref"] == "master"
+    assert attrs["ci.branch"] == "worktree-per-test-telemetry-junit"
     assert attrs["ci.pr_number"] == 57216
     assert attrs["ci.run_url"] == "https://github.com/PostHog/posthog/actions/runs/25218527467"
+
+
+def test_workflow_resource_attributes_branch_on_push(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_REF_NAME", "master")
+
+    attrs = report_test_timings.workflow_resource_attributes()
+
+    assert attrs["ci.ref_name"] == "master"
+    assert attrs["ci.branch"] == "master"
 
 
 # ---------- trace id ----------

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -389,7 +389,7 @@ def test_workflow_resource_attributes_includes_query_and_drilldown_fields(
     assert attrs["ci.run_url"] == "https://github.com/PostHog/posthog/actions/runs/25218527467"
 
 
-def test_workflow_resource_attributes_branch_on_push(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_workflow_resource_attributes_branch_on_push(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
     monkeypatch.setenv("GITHUB_REF_NAME", "master")

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3020,15 +3020,14 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: true
         timeout-minutes: 10
-        # Master pushes always; PRs only when labelled `capture-test-timings`. Skip forks (no secrets access).
+        # Master pushes and all in-repo PRs. Skip forks (no secrets access).
         if: >-
             always() &&
             github.repository == 'PostHog/posthog' &&
             (
             (github.event_name != 'pull_request' && github.ref == 'refs/heads/master') ||
             (github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == 'PostHog/posthog' &&
-            contains(github.event.pull_request.labels.*.name, 'capture-test-timings'))
+            github.event.pull_request.head.repo.full_name == 'PostHog/posthog')
             )
         steps:
             # Labelled PRs run the trusted base parser, so the same PR can't swap the script that receives secrets.


### PR DESCRIPTION
## Problem

Per-test traces (the OTEL spans emitted from JUnit shard results by `report_test_timings.py`) only shipped on `master` pushes and on PRs that were manually tagged with the `capture-test-timings` label. That meant the vast majority of PR runs produced no trace data, so we couldn't compare a branch's test timing/setup behavior against master without remembering to label the PR first.

## Changes

- **`report-test-timings` job (`ci-backend.yml`):** dropped the `capture-test-timings` label requirement. Traces now emit on master pushes (as before) and on every PR opened from a `PostHog/posthog` branch. Forks are still excluded — they have no access to the project token secret. The existing trust model is unchanged: the job still checks out the **base** SHA on PRs and verifies the trusted reporter script exists before handing it the secret, so a PR can't swap the script that receives the token.
- **Branch attribute on the trace (`report_test_timings.py`):** added two resource attributes, attached to every span:
  - `ci.ref_name` — the raw `GITHUB_REF_NAME`
  - `ci.branch` — resolves to the PR source branch (`GITHUB_HEAD_REF`) on PRs, falling back to `GITHUB_REF_NAME` on master pushes, giving one consistent branch field to group/filter on regardless of event type. (`ci.ref` is `refs/pull/N/merge` on PRs and `ci.head_ref` is empty on pushes, hence the dedicated field.)

One tradeoff worth calling out: this adds one extra short job per in-repo backend PR run.

## How did you test this code?

I'm an agent (PostHog Code). I ran the affected unit tests — `test_report_test_timings.py` — and extended them: the existing PR-event test now asserts `ci.branch`, and I added a push-event test asserting `ci.branch`/`ci.ref_name` fall back to `GITHUB_REF_NAME`. Both pass locally. No manual CI run was performed; the workflow `if:` change is validated by inspection.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). The request was to ship test traces on PRs as well as master and ensure a branch attribute is present. On investigation the job already supported PRs but was gated behind a label, so the fix was to relax the `if:` condition (keeping the fork exclusion and base-SHA checkout intact) rather than build anything new. No special repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
