### PR TITLE
fix(ci): run storybook visual regression on quill changes

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -67,6 +67,9 @@ jobs:
                         - 'products/**/*.{ts,tsx}'
                         - 'products/**/frontend/**'
                         - 'common/{esbuilder,mosaic,storybook,tailwind}/**'
+                        # quill is consumed app-wide via `workspace:*`, so a change here
+                        # alters rendering across the main-app stories — run the suite.
+                        - 'packages/quill/**'
                         - 'ee/frontend/**'
                         - 'services/mcp/src/ui-apps/**'
                         - '.storybook/**'


### PR DESCRIPTION
## Problem

The storybook visual-regression suite is gated by a paths-filter in `ci-storybook.yml` that did **not** include `packages/quill/**`. But the main app consumes `@posthog/quill-charts` (and `@posthog/quill`) as `workspace:*` — built from source, used app-wide.

So a PR that only touches quill changes rendering across many main-app chart stories, yet is classified as non-frontend: the suite skips entirely and the required "Visual regression tests pass" check goes green without rendering anything. The render change merges to master, and the diffs only surface — as "needs approval" against now-stale baselines — on the next unrelated frontend-touching PR. This is what happened with #64467 (interactive chart legends): visual regression was skipped on it, and the legend diffs landed on other contributors' PRs.

This isn't snapshot flakiness or non-determinism — it's a CI coverage gap.

## Changes

Add `packages/quill/**` to the `frontend` paths-filter so quill-only PRs run the full visual-regression matrix and capture/approve their affected baselines before merge.

## How did you test this code?

I'm an agent (PostHog Slack app). No automated tests were run — this is a CI workflow paths-filter change. Verified by inspection that `frontend/package.json` declares `@posthog/quill-charts: workspace:*`, that #64467 touched only `packages/quill/**`, and that its Storybook checks ("Build Storybook", "Create/Complete Visual Review run", "Visual regression tests") all reported `skipping` while "Visual regression tests pass" reported `pass`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread about "unrelated" visual-snapshot approvals appearing on a contributor's PR. Traced the path-filter gate in `.github/workflows/ci-storybook.yml` and `bin/find-affected-stories`, confirmed quill is a `workspace:*` source dependency, and verified via the GitHub checks API that the suite skipped on the quill-only PR that introduced the change. Chose the minimal fix — add `packages/quill/**` to the existing frontend filter — rather than touching the affected-story selector, since the root cause is the suite never running at all on quill PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1781628342870569?thread_ts=1781628342.870569&cid=C09G8QA6740)*
