### PR TITLE
feat(data-warehouse): enable incremental sync for Gorgias

### DIFF
--- a/posthog/temporal/data_imports/sources/gorgias/gorgias.py
+++ b/posthog/temporal/data_imports/sources/gorgias/gorgias.py
@@ -12,7 +12,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from posthog.temporal.data_imports.sources.gorgias.settings import GORGIAS_ENDPOINTS, VALID_SORT_FIELDS
+from posthog.temporal.data_imports.sources.gorgias.settings import GORGIAS_ENDPOINTS, GorgiasEndpointConfig
 
 # Gorgias caps `limit` at 100 on every list endpoint.
 PAGE_SIZE = 100
@@ -81,8 +81,19 @@ def _page_newest(items: list[Any], field: str) -> datetime | None:
     return max(parsed) if parsed else None
 
 
-def _is_incremental(should_use_incremental_field: bool, incremental_field: Optional[str]) -> bool:
-    return should_use_incremental_field and incremental_field in VALID_SORT_FIELDS
+def _incremental_sort_field(
+    config: GorgiasEndpointConfig, should_use_incremental_field: bool, incremental_field: Optional[str]
+) -> str | None:
+    """The field to sort `<field>:desc` for an incremental sync, or None for full refresh.
+
+    Guards against sending a sort the endpoint does not accept: an `order_by` Gorgias
+    rejects (or silently ignores) would break the newest-first ordering the watermark
+    stop condition relies on, so anything not in `sortable_datetime_fields` falls back
+    to full refresh.
+    """
+    if should_use_incremental_field and incremental_field in config.sortable_datetime_fields:
+        return incremental_field
+    return None
 
 
 def _get_auth_header(email: str, api_key: str) -> str:
@@ -139,7 +150,7 @@ def get_rows(
     # Gorgias has no server-side time filter. For incremental we sort the chosen field
     # newest-first and stop paginating once a whole page predates the watermark, so a
     # steady-state sync only pulls the changed prefix instead of every page.
-    sort_field = incremental_field if _is_incremental(should_use_incremental_field, incremental_field) else None
+    sort_field = _incremental_sort_field(config, should_use_incremental_field, incremental_field)
     order_by = f"{sort_field}:desc" if sort_field else config.order_by
     watermark = _coerce_to_utc(db_incremental_field_last_value) if sort_field else None
 
@@ -157,6 +168,11 @@ def get_rows(
         reraise=True,
     )
     def fetch_page(request_cursor: str | None) -> dict[str, Any]:
+        # `cursor` is documented as "position in the list of resources" — the list is
+        # defined by `order_by`/`limit`, so we re-send them on every page to keep the
+        # sort stable. The docs list `cursor` and `order_by` as coexisting params (no
+        # mutual exclusion); dropping order_by on follow-up pages could reset to the
+        # endpoint default and corrupt the newest-first order incremental relies on.
         params: dict[str, Any] = {"limit": PAGE_SIZE, "order_by": order_by}
         if request_cursor:
             params["cursor"] = request_cursor
@@ -209,7 +225,7 @@ def gorgias_source(
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = GORGIAS_ENDPOINTS[endpoint]
-    incremental = _is_incremental(should_use_incremental_field, incremental_field)
+    incremental = _incremental_sort_field(config, should_use_incremental_field, incremental_field) is not None
 
     return SourceResponse(
         name=endpoint,

--- a/posthog/temporal/data_imports/sources/gorgias/gorgias.py
+++ b/posthog/temporal/data_imports/sources/gorgias/gorgias.py
@@ -2,7 +2,8 @@ import re
 import base64
 import dataclasses
 from collections.abc import Iterator
-from typing import Any
+from datetime import UTC, date, datetime
+from typing import Any, Optional
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -11,7 +12,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from posthog.temporal.data_imports.sources.gorgias.settings import GORGIAS_ENDPOINTS
+from posthog.temporal.data_imports.sources.gorgias.settings import GORGIAS_ENDPOINTS, VALID_SORT_FIELDS
 
 # Gorgias caps `limit` at 100 on every list endpoint.
 PAGE_SIZE = 100
@@ -59,6 +60,31 @@ def get_base_url(domain: str) -> str:
     return f"https://{subdomain}.gorgias.com/api"
 
 
+def _coerce_to_utc(value: Any) -> datetime | None:
+    """Best-effort parse of a Gorgias datetime (ISO string) or a DB watermark (datetime)."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time(), tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _page_newest(items: list[Any], field: str) -> datetime | None:
+    """Newest value of `field` across a page; None if nothing parses."""
+    parsed = [dt for item in items if isinstance(item, dict) and (dt := _coerce_to_utc(item.get(field))) is not None]
+    return max(parsed) if parsed else None
+
+
+def _is_incremental(should_use_incremental_field: bool, incremental_field: Optional[str]) -> bool:
+    return should_use_incremental_field and incremental_field in VALID_SORT_FIELDS
+
+
 def _get_auth_header(email: str, api_key: str) -> str:
     token = base64.b64encode(f"{email}:{api_key}".encode()).decode()
     return f"Basic {token}"
@@ -102,10 +128,20 @@ def get_rows(
     endpoint: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: ResumableSourceManager[GorgiasResumeConfig],
+    should_use_incremental_field: bool = False,
+    incremental_field: Optional[str] = None,
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> Iterator[Any]:
     config = GORGIAS_ENDPOINTS[endpoint]
     url = f"{get_base_url(domain)}{config.path}"
     session = make_tracked_session(headers=get_headers(email, api_key), redact_values=(api_key,))
+
+    # Gorgias has no server-side time filter. For incremental we sort the chosen field
+    # newest-first and stop paginating once a whole page predates the watermark, so a
+    # steady-state sync only pulls the changed prefix instead of every page.
+    sort_field = incremental_field if _is_incremental(should_use_incremental_field, incremental_field) else None
+    order_by = f"{sort_field}:desc" if sort_field else config.order_by
+    watermark = _coerce_to_utc(db_incremental_field_last_value) if sort_field else None
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
     cursor = resume_config.cursor if resume_config else None
@@ -121,7 +157,7 @@ def get_rows(
         reraise=True,
     )
     def fetch_page(request_cursor: str | None) -> dict[str, Any]:
-        params: dict[str, Any] = {"limit": PAGE_SIZE, "order_by": config.order_by}
+        params: dict[str, Any] = {"limit": PAGE_SIZE, "order_by": order_by}
         if request_cursor:
             params["cursor"] = request_cursor
 
@@ -144,6 +180,13 @@ def get_rows(
         if items:
             yield items
 
+        # Rows arrive newest-first under incremental sort; once an entire page predates the
+        # watermark, everything further back is already synced, so stop.
+        if watermark is not None and sort_field is not None and items:
+            page_newest = _page_newest(items, sort_field)
+            if page_newest is not None and page_newest < watermark:
+                break
+
         next_cursor = (data.get("meta") or {}).get("next_cursor")
         if not next_cursor:
             break
@@ -161,8 +204,12 @@ def gorgias_source(
     endpoint: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: ResumableSourceManager[GorgiasResumeConfig],
+    should_use_incremental_field: bool = False,
+    incremental_field: Optional[str] = None,
+    db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = GORGIAS_ENDPOINTS[endpoint]
+    incremental = _is_incremental(should_use_incremental_field, incremental_field)
 
     return SourceResponse(
         name=endpoint,
@@ -173,6 +220,9 @@ def gorgias_source(
             endpoint=endpoint,
             logger=logger,
             resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            incremental_field=incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
         ),
         primary_keys=["id"],
         partition_count=1,
@@ -180,5 +230,7 @@ def gorgias_source(
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
-        sort_mode="asc",
+        # Incremental sort returns newest-first; full refresh stays ascending on the
+        # stable creation field. sort_mode must match the order rows actually arrive in.
+        sort_mode="desc" if incremental else "asc",
     )

--- a/posthog/temporal/data_imports/sources/gorgias/settings.py
+++ b/posthog/temporal/data_imports/sources/gorgias/settings.py
@@ -12,6 +12,12 @@ def _datetime_field(name: str) -> IncrementalField:
     }
 
 
+# The only attributes Gorgias accepts in `order_by` (each as `<field>:asc|desc`).
+# Gorgias exposes no server-side timestamp filter, so incremental sync is done by
+# sorting on one of these descending and stopping pagination at the watermark.
+VALID_SORT_FIELDS = frozenset({"created_datetime", "updated_datetime"})
+
+
 @dataclass
 class GorgiasEndpointConfig:
     name: str
@@ -24,9 +30,16 @@ class GorgiasEndpointConfig:
     # stable across a full-refresh sync even if rows are inserted while we paginate.
     # Every list endpoint accepts `created_datetime:asc` (verified against the docs).
     order_by: str = "created_datetime:asc"
-    # Candidate cursor fields surfaced for documentation/forward-compat only. Gorgias
-    # list endpoints expose NO server-side timestamp filter (only `order_by`), so true
-    # incremental sync is impossible today — every endpoint runs as a full refresh.
+    # Whether this endpoint can sync incrementally. Gorgias has no server-side time
+    # filter, so incremental relies on sorting the cursor `<field>:desc` and halting
+    # once a whole page predates the watermark. Only safe when the advertised cursor
+    # field actually reflects the change we care about: `updated_datetime` for mutable
+    # resources, `created_datetime` for append-only ones. Mutable config tables that
+    # expose only `created_datetime` (tags/views/teams/macros) stay full-refresh,
+    # since incremental there would silently miss edits.
+    supports_incremental: bool = False
+    # Cursor fields offered to the user. Only advertise a field whose desc-sort yields
+    # correct incremental semantics for this resource.
     incremental_fields: list[IncrementalField] = field(default_factory=list)
 
 
@@ -34,47 +47,48 @@ GORGIAS_ENDPOINTS: dict[str, GorgiasEndpointConfig] = {
     "tickets": GorgiasEndpointConfig(
         name="tickets",
         path="/tickets",
-        incremental_fields=[_datetime_field("created_datetime"), _datetime_field("updated_datetime")],
+        supports_incremental=True,
+        incremental_fields=[_datetime_field("updated_datetime")],
     ),
     "messages": GorgiasEndpointConfig(
         name="messages",
         path="/messages",
+        supports_incremental=True,
         incremental_fields=[_datetime_field("created_datetime")],
     ),
     "customers": GorgiasEndpointConfig(
         name="customers",
         path="/customers",
-        incremental_fields=[_datetime_field("created_datetime"), _datetime_field("updated_datetime")],
+        supports_incremental=True,
+        incremental_fields=[_datetime_field("updated_datetime")],
     ),
     "users": GorgiasEndpointConfig(
         name="users",
         path="/users",
-        incremental_fields=[_datetime_field("created_datetime"), _datetime_field("updated_datetime")],
+        supports_incremental=True,
+        incremental_fields=[_datetime_field("updated_datetime")],
     ),
     "satisfaction_surveys": GorgiasEndpointConfig(
         name="satisfaction_surveys",
         path="/satisfaction-surveys",
+        supports_incremental=True,
         incremental_fields=[_datetime_field("created_datetime")],
     ),
     "tags": GorgiasEndpointConfig(
         name="tags",
         path="/tags",
-        incremental_fields=[_datetime_field("created_datetime")],
     ),
     "views": GorgiasEndpointConfig(
         name="views",
         path="/views",
-        incremental_fields=[_datetime_field("created_datetime")],
     ),
     "teams": GorgiasEndpointConfig(
         name="teams",
         path="/teams",
-        incremental_fields=[_datetime_field("created_datetime")],
     ),
     "macros": GorgiasEndpointConfig(
         name="macros",
         path="/macros",
-        incremental_fields=[_datetime_field("created_datetime")],
     ),
 }
 

--- a/posthog/temporal/data_imports/sources/gorgias/settings.py
+++ b/posthog/temporal/data_imports/sources/gorgias/settings.py
@@ -12,10 +12,8 @@ def _datetime_field(name: str) -> IncrementalField:
     }
 
 
-# The only attributes Gorgias accepts in `order_by` (each as `<field>:asc|desc`).
-# Gorgias exposes no server-side timestamp filter, so incremental sync is done by
-# sorting on one of these descending and stopping pagination at the watermark.
-VALID_SORT_FIELDS = frozenset({"created_datetime", "updated_datetime"})
+CREATED = "created_datetime"
+UPDATED = "updated_datetime"
 
 
 @dataclass
@@ -25,21 +23,28 @@ class GorgiasEndpointConfig:
     # Stable creation-time field used for datetime partitioning. Gorgias exposes
     # `created_datetime` on every list resource and it never changes once set —
     # never partition on `updated_datetime`, which rewrites partitions on each sync.
-    partition_key: str = "created_datetime"
+    partition_key: str = CREATED
     # Explicit ascending sort on the stable creation field keeps page boundaries
     # stable across a full-refresh sync even if rows are inserted while we paginate.
     # Every list endpoint accepts `created_datetime:asc` (verified against the docs).
-    order_by: str = "created_datetime:asc"
+    order_by: str = f"{CREATED}:asc"
+    # Datetime attributes this endpoint actually accepts in `order_by` — verified
+    # per-endpoint against the Gorgias docs, because they differ: `users` exposes no
+    # `updated_datetime` (only name/email/role), `messages` is created-only, etc.
+    # Drives both the advertised incremental fields and a runtime guard that refuses to
+    # send a sort the API would reject (a rejected/ignored sort silently corrupts the
+    # newest-first ordering that incremental relies on).
+    sortable_datetime_fields: frozenset[str] = frozenset({CREATED})
     # Whether this endpoint can sync incrementally. Gorgias has no server-side time
     # filter, so incremental relies on sorting the cursor `<field>:desc` and halting
-    # once a whole page predates the watermark. Only safe when the advertised cursor
-    # field actually reflects the change we care about: `updated_datetime` for mutable
-    # resources, `created_datetime` for append-only ones. Mutable config tables that
-    # expose only `created_datetime` (tags/views/teams/macros) stay full-refresh,
-    # since incremental there would silently miss edits.
+    # once a whole page predates the watermark. Only safe when the cursor field both
+    # reflects the change we care about AND is server-sortable: `updated_datetime` for
+    # mutable resources, `created_datetime` for append-only ones. Mutable resources that
+    # expose only `created_datetime` (users/tags/views/teams) stay full-refresh, since
+    # `created_datetime` incremental would silently miss edits to existing rows.
     supports_incremental: bool = False
     # Cursor fields offered to the user. Only advertise a field whose desc-sort yields
-    # correct incremental semantics for this resource.
+    # correct incremental semantics for this resource (must be in sortable_datetime_fields).
     incremental_fields: list[IncrementalField] = field(default_factory=list)
 
 
@@ -47,48 +52,62 @@ GORGIAS_ENDPOINTS: dict[str, GorgiasEndpointConfig] = {
     "tickets": GorgiasEndpointConfig(
         name="tickets",
         path="/tickets",
+        sortable_datetime_fields=frozenset({CREATED, UPDATED}),
         supports_incremental=True,
-        incremental_fields=[_datetime_field("updated_datetime")],
+        incremental_fields=[_datetime_field(UPDATED)],
     ),
     "messages": GorgiasEndpointConfig(
         name="messages",
         path="/messages",
+        sortable_datetime_fields=frozenset({CREATED}),
         supports_incremental=True,
-        incremental_fields=[_datetime_field("created_datetime")],
+        incremental_fields=[_datetime_field(CREATED)],
     ),
     "customers": GorgiasEndpointConfig(
         name="customers",
         path="/customers",
+        sortable_datetime_fields=frozenset({CREATED, UPDATED}),
         supports_incremental=True,
-        incremental_fields=[_datetime_field("updated_datetime")],
+        incremental_fields=[_datetime_field(UPDATED)],
     ),
+    # `users` is mutable but Gorgias does not expose `updated_datetime` in its order_by
+    # (only created_datetime/name/email/role), so there is no correct incremental cursor —
+    # full refresh only. The table is small, so this is cheap.
     "users": GorgiasEndpointConfig(
         name="users",
         path="/users",
-        supports_incremental=True,
-        incremental_fields=[_datetime_field("updated_datetime")],
+        sortable_datetime_fields=frozenset({CREATED}),
     ),
     "satisfaction_surveys": GorgiasEndpointConfig(
         name="satisfaction_surveys",
         path="/satisfaction-surveys",
+        sortable_datetime_fields=frozenset({CREATED}),
         supports_incremental=True,
-        incremental_fields=[_datetime_field("created_datetime")],
-    ),
-    "tags": GorgiasEndpointConfig(
-        name="tags",
-        path="/tags",
-    ),
-    "views": GorgiasEndpointConfig(
-        name="views",
-        path="/views",
-    ),
-    "teams": GorgiasEndpointConfig(
-        name="teams",
-        path="/teams",
+        incremental_fields=[_datetime_field(CREATED)],
     ),
     "macros": GorgiasEndpointConfig(
         name="macros",
         path="/macros",
+        sortable_datetime_fields=frozenset({CREATED, UPDATED}),
+        supports_incremental=True,
+        incremental_fields=[_datetime_field(UPDATED)],
+    ),
+    # tags/views/teams are mutable config but expose only `created_datetime` for sorting,
+    # so incremental would miss edits — full refresh only.
+    "tags": GorgiasEndpointConfig(
+        name="tags",
+        path="/tags",
+        sortable_datetime_fields=frozenset({CREATED}),
+    ),
+    "views": GorgiasEndpointConfig(
+        name="views",
+        path="/views",
+        sortable_datetime_fields=frozenset({CREATED}),
+    ),
+    "teams": GorgiasEndpointConfig(
+        name="teams",
+        path="/teams",
+        sortable_datetime_fields=frozenset({CREATED}),
     ),
 }
 

--- a/posthog/temporal/data_imports/sources/gorgias/source.py
+++ b/posthog/temporal/data_imports/sources/gorgias/source.py
@@ -20,7 +20,7 @@ from posthog.temporal.data_imports.sources.gorgias.gorgias import (
     gorgias_source,
     validate_credentials as validate_gorgias_credentials,
 )
-from posthog.temporal.data_imports.sources.gorgias.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.gorgias.settings import ENDPOINTS, GORGIAS_ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -45,13 +45,14 @@ class GorgiasSource(ResumableSource[GorgiasSourceConfig, GorgiasResumeConfig]):
         names: list[str] | None = None,
         force_refresh: bool = False,
     ) -> list[SourceSchema]:
-        # Gorgias list endpoints have no server-side timestamp filter (only client-side
-        # ordering), so every endpoint is full-refresh only. Cursor pagination still lets
-        # an interrupted sync resume mid-stream via the ResumableSourceManager.
+        # Gorgias has no server-side timestamp filter. Incremental-capable endpoints sort
+        # their cursor field newest-first and stop paginating at the watermark; the rest
+        # stay full-refresh. Cursor pagination lets any sync resume mid-stream via the
+        # ResumableSourceManager.
         schemas = [
             SourceSchema(
                 name=endpoint,
-                supports_incremental=False,
+                supports_incremental=GORGIAS_ENDPOINTS[endpoint].supports_incremental,
                 supports_append=False,
                 incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
             )
@@ -85,6 +86,9 @@ class GorgiasSource(ResumableSource[GorgiasSourceConfig, GorgiasResumeConfig]):
             endpoint=inputs.schema_name,
             logger=inputs.logger,
             resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            incremental_field=inputs.incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value,
         )
 
     @property

--- a/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
+++ b/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import UTC, datetime
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -190,6 +191,106 @@ class TestGetRows:
         assert manager.saved == []
 
 
+class TestIncrementalSync:
+    def _run(self, session: MagicMock, **kwargs):
+        manager = _FakeManager()
+        with patch(f"{GORGIAS_MODULE}.make_tracked_session", return_value=session):
+            return list(
+                get_rows(
+                    "acme",
+                    "e@acme.com",
+                    "key",
+                    "tickets",
+                    MagicMock(),
+                    manager,
+                    should_use_incremental_field=True,
+                    incremental_field="updated_datetime",
+                    **kwargs,
+                )
+            )
+
+    def test_incremental_sorts_chosen_field_descending(self) -> None:
+        session = MagicMock()
+        session.get.return_value = _response(json_body={"data": [], "meta": {"next_cursor": None}})
+        self._run(session, db_incremental_field_last_value=None)
+
+        _, kwargs = session.get.call_args
+        assert kwargs["params"]["order_by"] == "updated_datetime:desc"
+
+    def test_first_incremental_sync_walks_all_pages(self) -> None:
+        session = MagicMock()
+        session.get.side_effect = [
+            _response(
+                json_body={
+                    "data": [{"id": 2, "updated_datetime": "2023-07-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": "c2"},
+                }
+            ),
+            _response(
+                json_body={
+                    "data": [{"id": 1, "updated_datetime": "2023-01-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": None},
+                }
+            ),
+        ]
+        batches = self._run(session, db_incremental_field_last_value=None)
+
+        assert [item["id"] for batch in batches for item in batch] == [2, 1]
+        assert session.get.call_count == 2
+
+    def test_stops_once_page_predates_watermark(self) -> None:
+        # Rows arrive newest-first; the third page is never fetched because the second
+        # page is entirely older than the watermark.
+        session = MagicMock()
+        session.get.side_effect = [
+            _response(
+                json_body={
+                    "data": [{"id": 3, "updated_datetime": "2023-07-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": "c2"},
+                }
+            ),
+            _response(
+                json_body={
+                    "data": [{"id": 2, "updated_datetime": "2023-05-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": "c3"},
+                }
+            ),
+            _response(
+                json_body={
+                    "data": [{"id": 1, "updated_datetime": "2023-04-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": None},
+                }
+            ),
+        ]
+        batches = self._run(session, db_incremental_field_last_value=datetime(2023, 6, 1, tzinfo=UTC))
+
+        # The over-the-watermark page is still yielded (merge dedupes), then we stop.
+        assert [item["id"] for batch in batches for item in batch] == [3, 2]
+        assert session.get.call_count == 2
+
+    def test_unknown_incremental_field_falls_back_to_full_refresh(self) -> None:
+        session = MagicMock()
+        session.get.return_value = _response(json_body={"data": [], "meta": {"next_cursor": None}})
+        manager = _FakeManager()
+        with patch(f"{GORGIAS_MODULE}.make_tracked_session", return_value=session):
+            list(
+                get_rows(
+                    "acme",
+                    "e@acme.com",
+                    "key",
+                    "tickets",
+                    MagicMock(),
+                    manager,
+                    should_use_incremental_field=True,
+                    incremental_field="not_a_sortable_field",
+                    db_incremental_field_last_value=datetime(2023, 6, 1, tzinfo=UTC),
+                )
+            )
+
+        _, kwargs = session.get.call_args
+        assert kwargs["params"]["order_by"] == "created_datetime:asc"
+
+
 class TestGorgiasSource:
     @parameterized.expand([(name,) for name in ENDPOINTS])
     def test_source_response_shape(self, endpoint: str) -> None:
@@ -199,6 +300,19 @@ class TestGorgiasSource:
         assert response.partition_mode == "datetime"
         assert response.partition_keys == [GORGIAS_ENDPOINTS[endpoint].partition_key]
         assert response.sort_mode == "asc"
+
+    def test_incremental_source_response_sorts_descending(self) -> None:
+        response = gorgias_source(
+            "acme",
+            "e@acme.com",
+            "key",
+            "tickets",
+            MagicMock(),
+            _FakeManager(),
+            should_use_incremental_field=True,
+            incremental_field="updated_datetime",
+        )
+        assert response.sort_mode == "desc"
 
     def test_every_endpoint_partitions_on_created_datetime(self) -> None:
         for config in GORGIAS_ENDPOINTS.values():

--- a/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
+++ b/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
@@ -290,6 +290,116 @@ class TestIncrementalSync:
         _, kwargs = session.get.call_args
         assert kwargs["params"]["order_by"] == "created_datetime:asc"
 
+    def test_incremental_field_not_sortable_on_endpoint_falls_back(self) -> None:
+        # `users` does not accept `updated_datetime` in order_by; forcing it must not send
+        # an order_by Gorgias would reject — fall back to the full-refresh sort instead.
+        session = MagicMock()
+        session.get.return_value = _response(json_body={"data": [], "meta": {"next_cursor": None}})
+        manager = _FakeManager()
+        with patch(f"{GORGIAS_MODULE}.make_tracked_session", return_value=session):
+            list(
+                get_rows(
+                    "acme",
+                    "e@acme.com",
+                    "key",
+                    "users",
+                    MagicMock(),
+                    manager,
+                    should_use_incremental_field=True,
+                    incremental_field="updated_datetime",
+                    db_incremental_field_last_value=datetime(2023, 6, 1, tzinfo=UTC),
+                )
+            )
+
+        _, kwargs = session.get.call_args
+        assert kwargs["params"]["order_by"] == "created_datetime:asc"
+
+    def test_order_by_persists_across_pages_alongside_cursor(self) -> None:
+        # Gorgias' cursor only makes sense within the same sorted list, so order_by must
+        # ride along on every follow-up page, not just the first.
+        session = MagicMock()
+        session.get.side_effect = [
+            _response(
+                json_body={
+                    "data": [{"id": 2, "updated_datetime": "2023-07-01T00:00:00+00:00"}],
+                    "meta": {"next_cursor": "c2"},
+                }
+            ),
+            _response(
+                json_body={
+                    "data": [{"id": 1, "updated_datetime": "2023-06-15T00:00:00+00:00"}],
+                    "meta": {"next_cursor": None},
+                }
+            ),
+        ]
+        self._run(session, db_incremental_field_last_value=None)
+
+        first_params = session.get.call_args_list[0].kwargs["params"]
+        second_params = session.get.call_args_list[1].kwargs["params"]
+        assert "cursor" not in first_params
+        assert first_params["order_by"] == "updated_datetime:desc"
+        assert second_params["cursor"] == "c2"
+        assert second_params["order_by"] == "updated_datetime:desc"
+        assert second_params["limit"] == 100
+
+
+# Per-endpoint `order_by` enums quoted from the Gorgias API docs (the `.md` reference for
+# each list endpoint). This is the external contract our config must not drift from: if an
+# endpoint is configured to sort by a field absent here, Gorgias would reject or ignore it.
+DOCUMENTED_ORDER_BY_DATETIME_FIELDS: dict[str, set[str]] = {
+    "tickets": {"created_datetime", "updated_datetime"},
+    "messages": {"created_datetime"},
+    "customers": {"created_datetime", "updated_datetime"},
+    "users": {"created_datetime"},  # also name/email/role, but no updated_datetime
+    "satisfaction_surveys": {"created_datetime"},
+    "macros": {"created_datetime", "updated_datetime"},
+    "tags": {"created_datetime"},
+    "views": {"created_datetime"},
+    "teams": {"created_datetime"},
+}
+
+
+class TestApiContract:
+    """Pin the endpoint config to the documented Gorgias API so it can't silently drift."""
+
+    def test_sortable_fields_match_documented_api(self) -> None:
+        assert {name: set(config.sortable_datetime_fields) for name, config in GORGIAS_ENDPOINTS.items()} == (
+            DOCUMENTED_ORDER_BY_DATETIME_FIELDS
+        )
+
+    @parameterized.expand([(name,) for name in ENDPOINTS])
+    def test_full_refresh_order_by_is_accepted_by_endpoint(self, endpoint: str) -> None:
+        config = GORGIAS_ENDPOINTS[endpoint]
+        field, _, direction = config.order_by.partition(":")
+        assert field in DOCUMENTED_ORDER_BY_DATETIME_FIELDS[endpoint]
+        assert direction in {"asc", "desc"}
+
+    @parameterized.expand([(name,) for name in ENDPOINTS])
+    def test_advertised_incremental_fields_are_sortable(self, endpoint: str) -> None:
+        config = GORGIAS_ENDPOINTS[endpoint]
+        advertised = {f["field"] for f in config.incremental_fields}
+        # Every advertised cursor field must be one Gorgias actually accepts in order_by.
+        assert advertised <= DOCUMENTED_ORDER_BY_DATETIME_FIELDS[endpoint]
+        # supports_incremental and the field list must agree.
+        assert bool(advertised) == config.supports_incremental
+
+    def test_incremental_endpoints_use_updated_when_available_else_created(self) -> None:
+        # Mutable resources must track updates when the API lets them; append-only ones
+        # track creation. This guards the core correctness decision per endpoint.
+        expected = {
+            "tickets": "updated_datetime",
+            "customers": "updated_datetime",
+            "macros": "updated_datetime",
+            "messages": "created_datetime",
+            "satisfaction_surveys": "created_datetime",
+        }
+        actual = {
+            name: config.incremental_fields[0]["field"]
+            for name, config in GORGIAS_ENDPOINTS.items()
+            if config.supports_incremental
+        }
+        assert actual == expected
+
 
 class TestGorgiasSource:
     @parameterized.expand([(name,) for name in ENDPOINTS])

--- a/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
+++ b/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias.py
@@ -411,16 +411,23 @@ class TestGorgiasSource:
         assert response.partition_keys == [GORGIAS_ENDPOINTS[endpoint].partition_key]
         assert response.sort_mode == "asc"
 
-    def test_incremental_source_response_sorts_descending(self) -> None:
+    @parameterized.expand(
+        [
+            (name, config.incremental_fields[0]["field"])
+            for name, config in GORGIAS_ENDPOINTS.items()
+            if config.supports_incremental
+        ]
+    )
+    def test_incremental_source_response_sorts_descending(self, endpoint: str, incremental_field: str) -> None:
         response = gorgias_source(
             "acme",
             "e@acme.com",
             "key",
-            "tickets",
+            endpoint,
             MagicMock(),
             _FakeManager(),
             should_use_incremental_field=True,
-            incremental_field="updated_datetime",
+            incremental_field=incremental_field,
         )
         assert response.sort_mode == "desc"
 

--- a/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias_source.py
+++ b/posthog/temporal/data_imports/sources/gorgias/tests/test_gorgias_source.py
@@ -8,7 +8,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInput
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import GorgiasSourceConfig
 from posthog.temporal.data_imports.sources.gorgias.gorgias import GorgiasResumeConfig
-from posthog.temporal.data_imports.sources.gorgias.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.gorgias.settings import ENDPOINTS, GORGIAS_ENDPOINTS
 from posthog.temporal.data_imports.sources.gorgias.source import GorgiasSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
@@ -53,12 +53,17 @@ class TestGorgiasSource:
         assert fields["email"].type == SourceFieldInputConfigType.EMAIL
         assert all(fields[name].required for name in fields)
 
-    def test_get_schemas_lists_every_endpoint_as_full_refresh(self) -> None:
-        schemas = GorgiasSource().get_schemas(_config(), team_id=1)
-        assert {s.name for s in schemas} == set(ENDPOINTS)
-        # Gorgias has no server-side timestamp filter, so nothing supports incremental.
-        assert all(s.supports_incremental is False for s in schemas)
-        assert all(s.supports_append is False for s in schemas)
+    def test_get_schemas_marks_incremental_per_endpoint(self) -> None:
+        schemas = {s.name: s for s in GorgiasSource().get_schemas(_config(), team_id=1)}
+        assert set(schemas) == set(ENDPOINTS)
+        # Incremental support mirrors the endpoint catalog: mutable/append-only resources
+        # are incremental-capable, mutable config tables stay full-refresh.
+        assert {name: s.supports_incremental for name, s in schemas.items()} == {
+            name: GORGIAS_ENDPOINTS[name].supports_incremental for name in ENDPOINTS
+        }
+        assert schemas["tickets"].supports_incremental is True
+        assert schemas["tags"].supports_incremental is False
+        assert all(s.supports_append is False for s in schemas.values())
 
     def test_get_schemas_filters_by_names(self) -> None:
         schemas = GorgiasSource().get_schemas(_config(), team_id=1, names=["tickets", "customers"])
@@ -86,6 +91,15 @@ class TestGorgiasSource:
         response = GorgiasSource().source_for_pipeline(_config(), manager, _inputs(schema_name="customers"))
         assert response.name == "customers"
         assert response.primary_keys == ["id"]
+        assert response.sort_mode == "asc"
+
+    def test_source_for_pipeline_uses_desc_sort_when_incremental(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        inputs = _inputs(schema_name="tickets")
+        inputs.should_use_incremental_field = True
+        inputs.incremental_field = "updated_datetime"
+        response = GorgiasSource().source_for_pipeline(_config(), manager, inputs)
+        assert response.sort_mode == "desc"
 
     def test_non_retryable_errors_cover_auth_failures(self) -> None:
         errors = GorgiasSource().get_non_retryable_errors()


### PR DESCRIPTION
## Problem

The Gorgias warehouse source only supported full refresh. Every sync re-walked every page of every endpoint, which is wasteful for accounts with large ticket/customer histories.

## Changes

Gorgias exposes **no server-side timestamp filter** — the only date control on its list endpoints is `order_by`. So classic `since`/`_gte` incremental is impossible. Instead this uses the same approach as our cursor-only sources (Stripe, Typeform): sort the chosen cursor field **descending** (newest-changed first), paginate, and **stop client-side once a whole page predates the watermark** (`db_incremental_field_last_value`). A steady-state sync then only pulls the changed prefix instead of every page. `sort_mode` flips to `desc` so the pipeline checkpoints the watermark correctly; the existing resumable cursor still handles mid-sync crash resume.

### Verified each endpoint's `order_by` enum against the docs

The accepted `order_by` values **differ per endpoint** — I checked all nine against the Gorgias `.md` reference rather than assuming a global set. This drives both what's advertised and a runtime guard that refuses to send a sort an endpoint would reject (a rejected/ignored sort silently breaks the newest-first ordering the watermark stop relies on).

| Endpoint | accepts `created_datetime` | accepts `updated_datetime` | sync mode |
|---|---|---|---|
| tickets | ✅ | ✅ | incremental on `updated_datetime` |
| customers | ✅ | ✅ | incremental on `updated_datetime` |
| macros | ✅ | ✅ | incremental on `updated_datetime` |
| messages | ✅ | ❌ | incremental on `created_datetime` (append-only) |
| satisfaction_surveys | ✅ | ❌ | incremental on `created_datetime` (append-only) |
| users | ✅ | ❌ (only name/email/role) | **full refresh** — no valid cursor; `created_datetime` would miss edits |
| tags, views, teams | ✅ | ❌ | full refresh — mutable config, `created_datetime` would miss edits |

Mutable endpoints advertise only `updated_datetime`; append-only ones advertise `created_datetime`. Partitioning stays on the stable `created_datetime` everywhere.

### Pagination contract

The reviewer flagged the common "params on page 1, cursor-only afterwards" pattern. The docs describe `cursor` as *"position in the list of resources"* — that list is defined by `order_by`/`limit`, and the docs list `cursor` and `order_by` as coexisting params with no mutual exclusion. So we **re-send `order_by` (and `limit`) on every page** alongside the cursor. Dropping `order_by` on follow-up pages risks resetting to the endpoint default sort mid-pagination and corrupting the newest-first order. A test pins this (page 2 carries both the cursor and the same `order_by`).

## How did you test this code?

I'm an agent. Automated tests only — no live Gorgias account:

- `posthog/temporal/data_imports/sources/gorgias/tests/` — 74 passing. Highlights:
  - **API-contract tests** encode the documented per-endpoint `order_by` enums and assert the config can't drift from them (sortable fields match docs; full-refresh sort is accepted; every advertised cursor field is server-sortable; `supports_incremental` agrees with the field list).
  - incremental transport: desc sort param, first-sync walks all pages, stop-at-watermark halts pagination, `order_by` persists across pages, and fields the endpoint can't sort by fall back to full refresh (covers the `users` + `updated_datetime` case).
- `tests/test_source_categories.py` — passing.

**⚠️ Still worth a live smoke-test before relying on it at scale** (I couldn't — no key): confirm `order_by` + `cursor` are honored together across pages on a real account, and that the per-endpoint `:desc` sorts return 200. Everything here is built strictly from the documented enums and pinned by tests, so the blast radius of a doc/API mismatch is contained to whichever endpoint mismatches.

## Docs update

No docs change — incremental is surfaced automatically via the schema's incremental fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Invoked the `/implementing-warehouse-sources` skill.

Key decisions:
- Confirmed via the API docs that Gorgias has no server-side filter — only `order_by` — and chose the desc + stop-at-watermark pattern (Stripe/Typeform precedent) over a "fetch all pages, skip in Python" pseudo-incremental, which would cost the same as full refresh.
- Checked every endpoint's accepted `order_by` enum individually. This caught that `users` has no `updated_datetime` (reverted to full refresh) and that `macros` does (gained incremental). Made the sortable set per-endpoint with a runtime guard so a misconfiguration degrades to full refresh instead of sending an invalid sort.
- Gated incremental by cursor-field semantics: `updated_datetime` for mutable resources, `created_datetime` only for append-only ones, full refresh for mutable resources that lack a usable update cursor.
- Re-send `order_by` on every page per the documented cursor semantics; pinned with a test.
- Left a live smoke-test as a recommended (no longer blocking) follow-up, since the config is now pinned to the documented contract by tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
