### PR TITLE
chore(notebooks): change owner to data tools team

### DIFF
--- a/products/notebooks/product.yaml
+++ b/products/notebooks/product.yaml
@@ -1,3 +1,3 @@
 name: Notebooks
 owners:
-    - team-platform-features
+    - team-data-tools


### PR DESCRIPTION
Move Notebooks ownership from Platform Features to Data Tools.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
