### PR TITLE
fix(dashboards): address PR review on add-widget nudge

### DIFF
--- a/.agents/skills/manage-dashboard-widgets/references/checklist-new-widget-type.md
+++ b/.agents/skills/manage-dashboard-widgets/references/checklist-new-widget-type.md
@@ -99,7 +99,7 @@ Use when introducing a new **`groupId`**, not just another variant in an existin
 - [ ] RBAC: extend `DashboardWidgetProductAccess`, `WIDGET_PRODUCT_ACCESS_CHECKS`, BE `WidgetSpec.required_product_access` (+ optional `product_access_denied_message`)
 - [ ] Availability: new `WidgetAvailabilityRequirementId` in `widgetAvailability.ts` + BE `WidgetSpec.availability_requirements` when catalog uses `availability`; optional branch in `WidgetAvailabilitySetupPrompt`
 - [ ] Optional **`titleHref`** on catalog — product scene route for header "View" link (`urls.*` or scene path)
-- [ ] Optional **`DASHBOARD_WIDGET_GROUP_PRODUCT_INTRO`** entry in `catalog.ts` (`{ productKey, valueProp, ctaLabel, docsHref }`) — surfaces a group-level nudge in the Add widget picker (value-prop one-liner + explore CTA). Only shown when the group also has an unmet **`availability`** setup requirement, so it's only meaningful for products that gate on a project setting (skip for areas with no requirement, e.g. `experiments`, `activity`)
+- [ ] Optional **`DASHBOARD_WIDGET_GROUP_PRODUCT_INTRO`** entry in `catalog.ts` (`{ productKey, requirement, valueProp, ctaLabel, docsHref }`) — surfaces a group-level nudge in the Add widget picker (value-prop one-liner + explore CTA). The `requirement` (a `WidgetAvailabilityRequirementId`) gates it directly: shown only while that requirement is unmet, so it's only meaningful for products that gate on a project setting (skip for areas with no requirement, e.g. `experiments`, `activity`)
 - [ ] Net-new product: see [`products/README.md`](../../../products/README.md) for product bootstrap before wiring the widget
 
 ## 5. Frontend widget component

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1356,6 +1356,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         addWidgetCollapsedGroups: [
             [] as string[],
             {
+                setAddWidgetModalOpen: (state, { open }) => (open ? [] : state),
                 toggleAddWidgetCollapsedGroup: (state, { groupId }) => {
                     const collapsed = new Set(state)
                     if (collapsed.has(groupId)) {

--- a/products/dashboards/frontend/widget_types/catalog.ts
+++ b/products/dashboards/frontend/widget_types/catalog.ts
@@ -22,7 +22,7 @@ import {
     ExperimentsListWidgetPreview,
 } from '../widgets/previews/ExperimentsWidgetPreviews'
 import { SessionReplayWidgetPreview } from '../widgets/previews/SessionReplayWidgetPreview'
-import type { WidgetAvailabilityConfig } from './widgetAvailability'
+import type { WidgetAvailabilityConfig, WidgetAvailabilityRequirementId } from './widgetAvailability'
 
 export const DASHBOARD_WIDGET_HEADER_LAYOUTS = ['simple', 'dashboard_tile'] as const
 
@@ -99,6 +99,8 @@ export function getDashboardWidgetGroupIcon(groupId: string): ComponentType<{ cl
 
 type DashboardWidgetGroupProductIntroConfig = {
     productKey: ProductKey
+    /** Setup requirement that gates the nudge — shown only while this requirement is unmet. */
+    requirement: WidgetAvailabilityRequirementId
     /** One-liner pitching why the product is worth a look — shown up front in the picker nudge. */
     valueProp: string
     /** Label for the CTA link (e.g. "Explore error tracking"). */
@@ -114,12 +116,14 @@ type DashboardWidgetGroupProductIntroConfig = {
 export const DASHBOARD_WIDGET_GROUP_PRODUCT_INTRO = {
     error_tracking: {
         productKey: ProductKey.ERROR_TRACKING,
+        requirement: 'exception_autocapture',
         valueProp: 'Catch and resolve the errors hurting your users.',
         ctaLabel: 'Explore error tracking',
         docsHref: 'https://posthog.com/docs/error-tracking',
     },
     session_replay: {
         productKey: ProductKey.SESSION_REPLAY,
+        requirement: 'session_replay_enabled',
         valueProp: 'Watch real sessions to see exactly where users get stuck.',
         ctaLabel: 'Explore session replay',
         docsHref: 'https://posthog.com/docs/session-replay',

--- a/products/dashboards/frontend/widgets/AddWidgetModal.test.tsx
+++ b/products/dashboards/frontend/widgets/AddWidgetModal.test.tsx
@@ -147,4 +147,14 @@ describe('AddWidgetModal', () => {
         await userEvent.click(screen.getByRole('button', { name: /Error tracking/i }))
         expect(screen.getByRole('checkbox', { name: 'Top issues' })).toBeInTheDocument()
     })
+
+    it('resets collapsed sections when the modal is reopened', async () => {
+        const logic = renderAddWidgetModal()
+
+        await userEvent.click(screen.getByRole('button', { name: /Error tracking/i }))
+        expect(logic.values.addWidgetCollapsedGroups).toContain('error_tracking')
+
+        logic.actions.setAddWidgetModalOpen(true)
+        expect(logic.values.addWidgetCollapsedGroups).toEqual([])
+    })
 })

--- a/products/dashboards/frontend/widgets/AddWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/AddWidgetModal.tsx
@@ -22,7 +22,7 @@ import {
     getDashboardWidgetGroupIcon,
     getDashboardWidgetGroupProductIntro,
 } from '../widget_types/catalog'
-import { getWidgetAvailabilityStatus, type WidgetAvailabilityConfig } from '../widget_types/widgetAvailability'
+import { isWidgetAvailabilityRequirementMet } from '../widget_types/widgetAvailability'
 import {
     type AddWidgetPayload,
     getAddButtonLabel,
@@ -136,13 +136,8 @@ export function AddWidgetModal({ isOpen, onClose, loading, onAdd }: AddWidgetMod
                     {DASHBOARD_WIDGET_CATALOG_GROUPS.map((group, groupIndex) => {
                         const productIntro = getDashboardWidgetGroupProductIntro(group.groupId)
                         // Nudge only when the product's setup requirement (a project setting) is unmet.
-                        const availabilityConfig = group.widgets
-                            .map(({ entry }) => entry.availability)
-                            .find((availability): availability is WidgetAvailabilityConfig => !!availability)
                         const showProductIntro =
-                            !!productIntro &&
-                            !!availabilityConfig &&
-                            !getWidgetAvailabilityStatus(availabilityConfig, currentTeam).isAvailable
+                            !!productIntro && !isWidgetAvailabilityRequirementMet(productIntro.requirement, currentTeam)
                         const GroupIcon = getDashboardWidgetGroupIcon(group.groupId)
                         const isCollapsed = collapsedGroups.has(group.groupId)
 


### PR DESCRIPTION
## Problem

Follow-up to review comments on #64390. Two valid issues plus one stale note.

## Changes

- **Nudge gating no longer order-dependent** — the group product nudge gated on whichever widget's `availability` config happened to be listed first (`.find()`). It now keys off an explicit `requirement` field on the `DASHBOARD_WIDGET_GROUP_PRODUCT_INTRO` entry, evaluated via `isWidgetAvailabilityRequirementMet`, so groups with mixed availability requirements stay correct.
- **Collapsed sections reset on reopen** — `addWidgetCollapsedGroups` persisted across modal open/close. It now resets on `setAddWidgetModalOpen(true)`, so reopening the Add widget modal always starts fully expanded.
- Added a test for the reopen-reset behavior; updated the widget-type checklist for the new `requirement` field.

The third comment (parameterize two adoption-state tests) was stale — it referenced the old "New" badge / "Learn more" tests removed when the nudge was reworked to gate on the availability setting.

## How did you test this code?

I'm an agent. Added a Jest test asserting collapsed groups reset when the modal reopens, alongside the existing collapse/expand and nudge-gating tests. I couldn't run Jest in this environment (no `node_modules`); oxfmt passes on all changed files. CI is the source of truth.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked onto the #64390 branch to address inline review feedback from automated reviewers and a human reviewer. Key decision: rather than tightening the `.find()` heuristic, I made the nudge's setup requirement explicit in the catalog config so it's decoupled from widget ordering. The collapsed-state reset mirrors the existing `clearAddWidgetSelectedTypes`-on-open pattern, implemented as a reducer reaction on `setAddWidgetModalOpen` to avoid a new action.
