### PR TITLE
feat(data-warehouse): enable more Google Analytics tables by default

### DIFF
--- a/posthog/temporal/data_imports/sources/google_analytics/settings.py
+++ b/posthog/temporal/data_imports/sources/google_analytics/settings.py
@@ -42,21 +42,21 @@ GOOGLE_ANALYTICS_REPORT_SCHEMAS: dict[str, GoogleAnalyticsReportSchema] = {
         "dimensions": ["date"],
         "metrics": ["active1DayUsers"],
         "primary_key": ["date"],
-        "should_sync_default": False,
+        "should_sync_default": True,
         "description": "1-day active users per day (DAU).",
     },
     "weekly_active_users": {
         "dimensions": ["date"],
         "metrics": ["active7DayUsers"],
         "primary_key": ["date"],
-        "should_sync_default": False,
+        "should_sync_default": True,
         "description": "Rolling 7-day active users per day (WAU).",
     },
     "four_weekly_active_users": {
         "dimensions": ["date"],
         "metrics": ["active28DayUsers"],
         "primary_key": ["date"],
-        "should_sync_default": False,
+        "should_sync_default": True,
         "description": "Rolling 28-day active users per day.",
     },
     "devices": {
@@ -118,7 +118,7 @@ GOOGLE_ANALYTICS_REPORT_SCHEMAS: dict[str, GoogleAnalyticsReportSchema] = {
         "dimensions": ["date", "firstUserSource", "firstUserMedium"],
         "metrics": ["totalUsers", "newUsers", "sessions", "engagedSessions"],
         "primary_key": ["date", "firstUserSource", "firstUserMedium"],
-        "should_sync_default": False,
+        "should_sync_default": True,
         "description": "Daily acquisition broken out by the source and medium that first acquired each user.",
     },
     "events": {

--- a/posthog/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/posthog/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -60,7 +60,19 @@ def test_get_schemas_returns_all_schemas_with_date_incremental():
 def test_get_schemas_default_sync_set():
     schemas = GoogleAnalyticsSource().get_schemas(_config(), team_id=1)
     by_default_on = {s.name for s in schemas if s.should_sync_default}
-    assert by_default_on == {"website_overview", "devices", "locations", "pages", "traffic_sources"}
+    # Everything except `events` syncs by default; `events` is keyed on date+eventName,
+    # so its volume scales with distinct event names and stays opt-in.
+    assert by_default_on == {
+        "website_overview",
+        "daily_active_users",
+        "weekly_active_users",
+        "four_weekly_active_users",
+        "devices",
+        "locations",
+        "pages",
+        "traffic_sources",
+        "user_acquisition",
+    }
 
 
 def test_get_schemas_filters_by_names():


### PR DESCRIPTION
## Problem

When connecting a Google Analytics source, only 5 of the 10 available report tables were checked by default (`website_overview`, `devices`, `locations`, `pages`, `traffic_sources`). The active-user reports and user acquisition were left opt-in, so most users would miss useful standard reports unless they noticed and ticked them on the table-selection step.

## Changes

Flipped `should_sync_default` to `True` for four more tables so they sync out of the box:

- `daily_active_users` (DAU)
- `weekly_active_users` (WAU)
- `four_weekly_active_users`
- `user_acquisition`

`events` stays opt-in (`should_sync_default: False`) — it's keyed on `date` + `eventName`, so its row count scales with the number of distinct event names a property emits, making it the highest-volume table and the most likely to chew through the 100M-row free-tier limit.

This only affects the default checkbox state on the table-selection screen; users can still toggle any table on or off before importing.

## How did you test this code?

I'm an agent (Claude Code). Updated the existing `test_get_schemas_default_sync_set` assertion to the new 9-table default set and ran the GA source suite:

```
python -m pytest posthog/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
# 21 passed
```

Ruff clean on the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @owerstom. The choice of which tables to default-on was a judgment call — confirmed with the human to enable everything except `events`, holding that one back on cardinality/row-limit grounds. Change is config-only (the `should_sync_default` flag in `settings.py`) plus the corresponding test update; the flag already flows through `source.py` → the external data source API → the table-selection UI.
