### PR TITLE
feat(data-warehouse): redirect to new source after onboarding wizard

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -825,6 +825,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 s.hasWebhookSchemas,
                 (_, props) => props.onComplete,
                 s.returnConfig,
+                s.sourceId,
             ],
             (
                 currentStep,
@@ -832,7 +833,8 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 isDirectQueryMode,
                 hasWebhookSchemas,
                 onComplete,
-                returnConfig
+                returnConfig,
+                sourceId
             ): string => {
                 if (currentStep === 3 && isManualLinkingSelected) {
                     return 'Link'
@@ -860,6 +862,9 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     }
                     if (returnConfig) {
                         return `Return to ${returnConfig.returnLabel}`
+                    }
+                    if (sourceId) {
+                        return 'Go to source'
                     }
                     return 'Return to sources'
                 }
@@ -1255,8 +1260,11 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         },
         closeWizard: () => {
             const returnUrl = values.returnConfig?.returnUrl
+            const sourceUrl = values.sourceId ? urls.dataWarehouseSource(values.sourceId, 'schemas') : undefined
             actions.cancelWizard()
-            router.actions.push(returnUrl ?? urls.sources())
+            // Prefer an explicit caller-provided return URL, then drop the user on the
+            // source they just created, falling back to the sources list.
+            router.actions.push(returnUrl ?? sourceUrl ?? urls.sources())
         },
         cancelWizard: () => {
             actions.onClear()


### PR DESCRIPTION
## Problem

At the end of the data warehouse source onboarding wizard, the final button ("Return to sources") dropped the user back on the sources list page. After going through the trouble of connecting a source, the natural next step is to look at the source you just created — its schemas, sync status, settings — not to hunt for it in the list.

## Changes

On the final step of the wizard, the user is now taken to the source they just created (`/data-management/sources/:id/schemas`) instead of the sources list.

- `closeWizard` now navigates to the new source's page when a `sourceId` is set.
- Navigation priority: an explicit caller-provided `returnUrl` (used by flows that deep-link into the wizard, e.g. signals setup) wins, then the new source page, then the sources list as a fallback.
- The final button label reads **"Go to source"** in the default case instead of the now-inaccurate "Return to sources". The custom `returnConfig` case keeps its existing `Return to {label}` text.

## How did you test this code?

I'm an agent (Claude Code). This is a small frontend routing change in a kea logic. Verified the changed file is lint-clean (`oxlint`). No existing tests asserted the old label or navigation target, and the selector's return type is unchanged so no kea type regeneration was needed. I did not run a manual click-through.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @owerstom. `closeWizard` is only reachable from the wizard's final sync-progress step, which is only reached for managed sources that always have a `sourceId` — so the new source page is the right target. Kept the existing `returnConfig` override path intact so flows that open the wizard with their own return target are unaffected, and left the sources-list fallback for safety.
