### PR TITLE
chore(ci): drop leftover `ass` branch from agent CI workflows

### DIFF
--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -13,9 +13,6 @@ on:
     push:
         branches:
             - 'master'
-            # Kept while the agent platform integrates on `ass` and deploys from
-            # it for testing. Drop at the master cutover (then deploy is master-only).
-            - 'ass'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -71,7 +68,7 @@ jobs:
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.agent_files == 'true') ||
             github.event_name == 'merge_group' ||
             github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && needs.changes.outputs.agent_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
+            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.agent_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
         timeout-minutes: 30
         permissions:
@@ -251,7 +248,7 @@ jobs:
     deploy:
         name: Deploy ${{ matrix.image }}
         needs: build
-        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ass') && github.event_name == 'push'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master' && github.event_name == 'push'
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         # One dispatch per image, not per Helm release. The charts side keys

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -9,7 +9,6 @@ on:
     push:
         branches:
             - master
-            - ass
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Problem

The agent platform workflows still carried `ass`-branch hooks left over from when the platform integrated and deployed off a temporary `ass` branch. The platform now builds and deploys from `master`, so these references are dead config.

## Changes

- **`ci-agent-container.yml`** (agent image build + deploy): removed `ass` from the push trigger and from both the `build` and `deploy` job `if` conditions. Agent image builds and deploys are now `master`-only.
- **`ci-agents.yml`** (agent services CI): removed `ass` from the push trigger.

A repo-wide sweep of `.github/`, charts, and scripts confirms no other `ass`-branch references remain.

## How did you test this code?

I'm an agent. No automated tests were run — this is a YAML-only config change. Verified by grepping the repo for remaining `ass`-branch references (none found) and confirming the edited conditions retain the `master`/PR/`merge_group`/`workflow_dispatch` paths unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ben asked to check whether the `ass` branch was still wired into the agent image deploy action and remove it if so. Found it in `ci-agent-container.yml` (push trigger + build/deploy conditions) and the adjacent `ci-agents.yml` (push trigger), then removed all of them. No skills were needed — straightforward GitHub Actions config cleanup. Tool used: Claude Code.
