### PR TITLE
feat(conversations): add customer_email to message_sent event

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -98,6 +98,24 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["message_content"] == "Hello customer"
         assert call_kwargs["properties"]["author_type"] == "team"
         assert call_kwargs["properties"]["author_id"] == 42
+        assert call_kwargs["properties"]["customer_email"] == "test@example.com"
+
+    @parameterized.expand(
+        [
+            ("capture_ticket_created", capture_ticket_created, []),
+            ("capture_message_received", capture_message_received, ["msg-id", "content"]),
+            ("capture_message_sent", capture_message_sent, ["msg-id", "content", 1]),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_customer_email_falls_back_to_email_from(self, _name, capture_fn, extra_args, mock_capture):
+        self.ticket.anonymous_traits = {}
+        self.ticket.email_from = "customer@example.com"
+
+        capture_fn(self.ticket, *extra_args)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["properties"]["customer_email"] == "customer@example.com"
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_capture_message_received_uses_team_token(self, mock_capture):

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -19,6 +19,12 @@ logger = structlog.get_logger(__name__)
 EVENT_SOURCE = "conversations_events"
 
 
+def _get_customer_email(ticket: Ticket) -> str:
+    """Resolve the customer's email across channels: widget traits, then email-channel From."""
+    traits = ticket.anonymous_traits or {}
+    return traits.get("email") or ticket.email_from or ""
+
+
 def _get_ticket_base_properties(ticket: Ticket) -> dict:
     return {
         "ticket_id": str(ticket.id),
@@ -34,7 +40,7 @@ def capture_ticket_created(ticket: Ticket) -> None:
     properties = _get_ticket_base_properties(ticket)
     traits = ticket.anonymous_traits or {}
     properties["customer_name"] = traits.get("name", "")
-    properties["customer_email"] = traits.get("email", "")
+    properties["customer_email"] = _get_customer_email(ticket)
 
     team = ticket.team
     team_id = team.id
@@ -111,6 +117,7 @@ def capture_message_sent(ticket: Ticket, message_id: str, message_content: str, 
     properties["message_content"] = (message_content or "")[:1000]
     properties["author_type"] = "team"
     properties["author_id"] = author_id
+    properties["customer_email"] = _get_customer_email(ticket)
 
     capture_internal(
         token=ticket.team.api_token,
@@ -130,7 +137,7 @@ def capture_message_received(ticket: Ticket, message_id: str, message_content: s
     properties["author_type"] = "customer"
     traits = ticket.anonymous_traits or {}
     properties["customer_name"] = traits.get("name", "")
-    properties["customer_email"] = traits.get("email", "")
+    properties["customer_email"] = _get_customer_email(ticket)
 
     capture_internal(
         token=ticket.team.api_token,


### PR DESCRIPTION
## Problem

The `$conversation_message_sent` event (fired when a team member replies on a conversations ticket) identified only **who sent the reply** — via `author_id` and `author_type: "team"`. It did not record **who the customer on the ticket is**, unlike its sibling events. That made it harder to use the event for workflow triggers and downstream analytics that need to key off the customer.

## Changes

- Add `customer_email` to `$conversation_message_sent`, so the event now captures both the actor (`author_id`) and the customer on the ticket.
- Introduce a shared `_get_customer_email(ticket)` helper that resolves the customer's email across channels: `anonymous_traits["email"]`, falling back to `email_from` for email-channel tickets, then `""`.
- Route the existing `$conversation_ticket_created` and `$conversation_message_received` events through the same helper, so all three events resolve `customer_email` identically — this also fixes those two events to populate `customer_email` for email-channel customers, which previously only read from `anonymous_traits`.

## How did you test this code?

I'm an agent. I ran the existing automated test suite for these events and added coverage; I did not perform manual testing.

- `products/conversations/backend/api/tests/test_events.py` — 23 tests passing.
- Extended `test_capture_message_sent_uses_team_token` to assert `customer_email` is set.
- Added a parameterized `test_customer_email_falls_back_to_email_from` covering all three capture functions resolving `customer_email` from `email_from` when `anonymous_traits` has no email.

## Publish to changelog?

no

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.8).

- The original request referred to an existing `actor_email` property; that property does not exist in the code — the actor is represented by `author_id` / `author_type`. Confirmed with the author and scoped the change to only adding `customer_email`, leaving the actor representation untouched.
- For customer-email resolution, chose the more complete `anonymous_traits` → `email_from` fallback (over matching the sibling events' `anonymous_traits`-only behavior) so email-channel conversations are covered. The author then opted to apply the same helper to the two sibling events for consistency.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
