### PR TITLE
fix(signals): skip unknown inbox ordering clauses instead of dropping all

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -368,10 +368,10 @@ class TestSignalReportListAPI(APIBaseTest):
     def test_ordering_skips_unknown_clause_keeps_valid_ones(self):
         """An unrecognized clause (e.g. a stale persisted field) is skipped, not fatal:
         the valid clauses still apply instead of silently reverting to the default order."""
-        r_p3 = self._create_report(title="P3 report", summary="s", signal_count=1, total_weight=1.0)
         r_p1 = self._create_report(title="P1 report", summary="s", signal_count=1, total_weight=1.0)
-        self._priority_artefact(r_p3, priority="P3")
+        r_p3 = self._create_report(title="P3 report", summary="s", signal_count=1, total_weight=1.0)
         self._priority_artefact(r_p1, priority="P1")
+        self._priority_artefact(r_p3, priority="P3")
 
         response = self.client.get(self._list_url(status="ready", ordering="bogus_field,priority"))
         assert response.status_code == status.HTTP_200_OK

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -365,6 +365,19 @@ class TestSignalReportListAPI(APIBaseTest):
         assert ids.index(str(r_p3.id)) < ids.index(str(r_p4.id))
         assert ids.index(str(r_p4.id)) < ids.index(str(r_none.id))
 
+    def test_ordering_skips_unknown_clause_keeps_valid_ones(self):
+        """An unrecognized clause (e.g. a stale persisted field) is skipped, not fatal:
+        the valid clauses still apply instead of silently reverting to the default order."""
+        r_p3 = self._create_report(title="P3 report", summary="s", signal_count=1, total_weight=1.0)
+        r_p1 = self._create_report(title="P1 report", summary="s", signal_count=1, total_weight=1.0)
+        self._priority_artefact(r_p3, priority="P3")
+        self._priority_artefact(r_p1, priority="P1")
+
+        response = self.client.get(self._list_url(status="ready", ordering="bogus_field,priority"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(r_p1.id)) < ids.index(str(r_p3.id))
+
     def test_ordering_by_total_weight_only_crosses_status_rank(self):
         """Without `status`, `ordering=-total_weight` is a global sort by weight."""
         low_ready = self._create_report(

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -743,10 +743,6 @@ class SignalReportViewSet(
         return self._apply_signal_report_ordering(queryset)
 
     def _parse_ordering_string(self, raw: str) -> list[str]:
-        # Skip an unrecognized clause rather than discarding the whole ordering. A stale
-        # sort field persisted by an older client should at worst lose that one tiebreak,
-        # not silently revert every sort back to the default (which reads as random order).
-        # An entirely-unrecognized string yields an empty list; callers fall back to the default.
         parts = [p.strip() for p in raw.split(",") if p.strip()]
         clauses: list[str] = []
         for part in parts:

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -743,6 +743,10 @@ class SignalReportViewSet(
         return self._apply_signal_report_ordering(queryset)
 
     def _parse_ordering_string(self, raw: str) -> list[str]:
+        # Skip an unrecognized clause rather than discarding the whole ordering. A stale
+        # sort field persisted by an older client should at worst lose that one tiebreak,
+        # not silently revert every sort back to the default (which reads as random order).
+        # An entirely-unrecognized string yields an empty list; callers fall back to the default.
         parts = [p.strip() for p in raw.split(",") if p.strip()]
         clauses: list[str] = []
         for part in parts:
@@ -750,7 +754,7 @@ class SignalReportViewSet(
             name = part[1:] if descending else part
             db_field = self._SIGNAL_REPORT_ORDERING_FIELDS.get(name)
             if db_field is None:
-                return self._default_signal_report_ordering_clauses
+                continue
             clause = f"-{db_field}" if descending else db_field
             clauses.append(clause)
         return clauses


### PR DESCRIPTION
## Problem

The inbox (signals reports) sort felt random — picking "Priority first" or "Newest first" often didn't visibly change the order. The backend's `_parse_ordering_string` reverted the **entire** ordering to the default the moment a single clause was unrecognized, with no error and no log. Because the frontend persists the sort field/direction in localStorage with no validation or version key, a value left over from an earlier client build strands there and silently disables the chosen sort.

## Changes

`_parse_ordering_string` now skips an unrecognized clause instead of discarding the whole ordering. A stale field loses at most that one tiebreak; the remaining valid clauses still apply. An entirely-unrecognized string yields an empty list, and the existing caller fallback to the default ordering still holds.

Added a test asserting an unknown clause is skipped while valid clauses still order the results.

## How did you test this code?

I'm an agent (PostHog Slack app). I added `test_ordering_skips_unknown_clause_keeps_valid_ones` and ran `ruff check` / `ruff format --check` (both clean). I could **not** execute the DB-backed test suite in my environment — Postgres was unreachable, so all `test_signal_report_api.py` tests error at connection setup, not on logic. CI should run them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread where the inbox sort appeared random. Initial hypothesis was the `status`-prefixed ordering tier, but the product owner pointed out the tabs already constrain status, and identified the silent ordering fallback as the likely culprit — confirmed in the code. Scope was deliberately kept to the backend fix only (per the owner); a frontend change to clamp/version the persisted sort state was discussed and left out.

Skills invoked: `/improving-drf-endpoints` (the change is internal control-flow in an existing viewset helper — no serializer/schema surface changes, so no annotation work was required).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781789746634789?thread_ts=1781789746.634789&cid=C09SK2PAGKF)*
