### PR TITLE
feat(navigation): force-filter project tree by object type

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
@@ -1,13 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useActions } from 'kea'
+import { delay, HttpResponse } from 'msw'
 import { useEffect } from 'react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
-import { setFeatureFlags } from '~/mocks/browser'
+import { setFeatureFlags, useStorybookMocks } from '~/mocks/browser'
+import { toPaginatedResponse } from '~/mocks/handlers'
 
 import { ProjectTree, ProjectTreeProps } from './ProjectTree'
+
+// A mix of object types living at the root of the project file tree, used to show how the
+// `type` prop force-filters the tree down to a single product's objects.
+const MOCK_PROJECT_FILES = [
+    { id: 'f-1', path: 'Marketing', type: 'folder' },
+    { id: 'f-2', path: 'Product', type: 'folder' },
+    { id: 'd-1', path: 'Revenue overview', type: 'dashboard', ref: '1', href: '/dashboard/1' },
+    { id: 'd-2', path: 'Growth metrics', type: 'dashboard', ref: '2', href: '/dashboard/2' },
+    { id: 'i-1', path: 'Weekly active users', type: 'insight/trends', ref: '3', href: '/insights/3' },
+    { id: 'i-2', path: 'Signup funnel', type: 'insight/funnels', ref: '4', href: '/insights/4' },
+    { id: 'ff-1', path: 'new-onboarding', type: 'feature_flag', ref: '5', href: '/feature_flags/5' },
+]
 
 interface StoryProps extends ProjectTreeProps {
     enableCustomProductsFlag?: boolean
@@ -78,5 +92,58 @@ export const AllProducts: Story = {
                 </div>
             </div>
         )
+    },
+}
+
+// Renders the project file tree with the given `type` filter, mocking the file system API.
+const TypeFilteredTree = ({ label, type }: { label: string; type?: string }): JSX.Element => {
+    useStorybookMocks({
+        get: {
+            '/api/environments/:team_id/file_system/': async () => {
+                await delay(10)
+                return HttpResponse.json(toPaginatedResponse(MOCK_PROJECT_FILES))
+            },
+        },
+    })
+
+    return (
+        <div className="w-[280px] h-[600px] border rounded bg-surface-primary overflow-hidden">
+            <div className="p-2 border-b text-sm font-semibold text-secondary">{label}</div>
+            <div className="h-[calc(100%-40px)] overflow-auto group/colorful-product-icons colorful-product-icons-true">
+                <ProjectTree root="project://" type={type} onlyTree logicKey={`type-filtered-${type ?? 'all'}`} />
+            </div>
+        </div>
+    )
+}
+
+// Unfiltered project tree — every object type shows alongside folders.
+export const ProjectTreeAllTypes: Story = {
+    render: () => <TypeFilteredTree label="Project tree — all objects" />,
+    parameters: {
+        docs: { description: { story: 'The full project tree with no `type` filter: folders plus all objects.' } },
+    },
+}
+
+// Force-filtered to dashboards only — leaf objects of other types are hidden, folders stay.
+export const ProjectTreeDashboardsOnly: Story = {
+    render: () => <TypeFilteredTree label="Project tree — dashboards only" type="dashboard" />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `type="dashboard"`, only dashboard objects render. Folders are kept so the tree stays navigable.',
+            },
+        },
+    },
+}
+
+// Force-filtered to insights only — matches the `insight/*` subtypes via type-prefix matching.
+export const ProjectTreeInsightsOnly: Story = {
+    render: () => <TypeFilteredTree label="Project tree — insights only" type="insight" />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `type="insight"`, objects whose type is `insight` or any `insight/*` subtype render; other types are hidden.',
+            },
+        },
     },
 }

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -56,6 +56,8 @@ import { calculateMovePath } from './utils'
 export interface ProjectTreeProps {
     logicKey?: string // key override?
     root?: string
+    /** Force-filter the tree to only show objects of this file system type (e.g. `dashboard`, `insight`). */
+    type?: string
     onlyTree?: boolean
     showRecents?: boolean // whether to show recents in the tree
     searchPlaceholder?: string
@@ -119,6 +121,7 @@ const isItemActive = (item: TreeDataItem): boolean => {
 export function ProjectTree({
     logicKey,
     root,
+    type,
     onlyTree = false,
     searchPlaceholder,
     treeSize = 'default',
@@ -130,7 +133,7 @@ export function ProjectTree({
     const [uniqueKey] = useState(() => `project-tree-${counter++}`)
     const { viableItems, shortcutEntryIdMap } = useValues(projectTreeDataLogic)
     const { reorderShortcutByDrag } = useActions(projectTreeDataLogic)
-    const projectTreeLogicProps = { key: logicKey ?? uniqueKey, root }
+    const projectTreeLogicProps = { key: logicKey ?? uniqueKey, root, type }
     const {
         fullFileSystemFiltered,
         lastViewedId,

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -49,6 +49,8 @@ export interface ProjectTreeLogicProps {
     root?: string
     includeRoot?: boolean
     hideFolders?: string[]
+    /** Force-filter the tree to only show objects of this file system type (e.g. `dashboard`, `insight`). */
+    type?: string
 }
 
 const FOLDER_LOADING = [
@@ -627,8 +629,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 (_, props) => props.root,
                 (_, props) => props.includeRoot,
                 (_, props) => props.hideFolders,
+                (_, props) => props.type,
             ],
-            (fullFileSystem, searchTerm, root, includeRoot, hideFolders): TreeDataItem[] => {
+            (fullFileSystem, searchTerm, root, includeRoot, hideFolders, type): TreeDataItem[] => {
                 let firstFolders = fullFileSystem
 
                 // Filter out folders specified in hideFolders prop
@@ -656,6 +659,25 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     } else {
                         firstFolders = []
                     }
+                }
+
+                // When a `type` is provided, force-filter the tree to only show objects of that type.
+                // Folders and structural nodes (loading indicators, load-more rows, etc.) are always kept
+                // so the hierarchy stays navigable as folders lazy-load their children. Object types can
+                // carry a subtype (e.g. `insight/trends`), so we match on the type prefix too.
+                if (type) {
+                    const matchesType = (recordType: string): boolean =>
+                        recordType === type || recordType.startsWith(`${type}/`)
+                    const filterByType = (nodes: TreeDataItem[]): TreeDataItem[] =>
+                        nodes.reduce<TreeDataItem[]>((acc, node) => {
+                            const recordType = typeof node.record?.type === 'string' ? node.record.type : undefined
+                            if (recordType && recordType !== 'folder' && !matchesType(recordType)) {
+                                return acc
+                            }
+                            acc.push(node.children ? { ...node, children: filterByType(node.children) } : node)
+                            return acc
+                        }, [])
+                    firstFolders = filterByType(firstFolders)
                 }
 
                 function addRoot(tree: TreeDataItem[]): TreeDataItem[] {


### PR DESCRIPTION
## Problem

Products want to embed a partial view of the project tree to browse and sort just *their* objects (e.g. only dashboards inside the Dashboards product), rather than showing the entire mixed file tree. There was no way to scope `ProjectTree` to a single object type.

## Changes

- Added a `type` prop to `ProjectTree`, threaded through `projectTreeLogic` (`ProjectTreeLogicProps.type`).
- When `type` is set, `fullFileSystemFiltered` force-filters the tree to only show objects of that file system type. Folders and structural nodes (loading indicators, load-more rows) are always kept so the hierarchy stays navigable as folders lazy-load their children.
- Object types can carry a subtype, so matching is prefix-based: `type="insight"` covers `insight`, `insight/trends`, `insight/funnels`, etc.; `type="dashboard"` matches exactly.
- Added Storybook entries (unfiltered, dashboards-only, insights-only) that mock the file system API to demonstrate the filtering.

## How did you test this code?

I'm an agent (PostHog Slack app). Automated checks I actually ran on the changed files:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the changed files (after regenerating kea types via `typegen:write`).
- `oxlint` — 0 warnings, 0 errors.
- `oxfmt` — no formatting changes.

Added Storybook stories for visual/snapshot coverage; did not run the full Storybook/Playwright suite locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Marius Andra via a Slack thread: add a `type` prop to `ProjectTree` that force-filters the tree to a single object type, so a partial tree can be embedded within a product to sort that product's objects, plus Storybook entries.

Key decisions:
- Filter in the logic selector (`fullFileSystemFiltered`) rather than the component, so search and the `project://` early-return path both inherit the filter.
- Keep folders/structural nodes unconditionally — with lazy-loaded children, pruning empty folders would be unreliable, and keeping them preserves navigability.
- Prefix matching on `type` to handle `insight/*` subtypes (mirrors the existing `type__startswith` query pattern).

No skills were required for these files (no DRF/migration/taxonomic-filter/generated-API changes).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1781789283966789?thread_ts=1781789283.966789&cid=C09BDQLM8KA)*
