### PR TITLE
feat(data-warehouse): show dotted HogQL table name in source schema list

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6226,6 +6226,8 @@ export interface ExternalDataJob {
 export interface SimpleDataWarehouseTable {
     id: string
     name: string
+    /** Dotted name the table is queried by in HogQL (e.g. `googleanalytics.devices`). */
+    hogql_name?: string
     columns: DatabaseSchemaField[]
     row_count: number
 }

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -946,10 +946,14 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return context
 
     def safely_get_queryset(self, queryset):
-        queryset = queryset.exclude(deleted=True).prefetch_related("created_by")
+        # `table__external_data_source` is read on every schema serialization (SimpleTableSerializer
+        # derives the dotted HogQL name from it), so join it for all actions to avoid a per-row query.
+        queryset = (
+            queryset.exclude(deleted=True).prefetch_related("created_by").select_related("table__external_data_source")
+        )
         if self.action == "retrieve":
-            # retrieve serializes the source summary + table; pull them in one round-trip.
-            queryset = queryset.select_related("source", "table__credential", "table__external_data_source")
+            # retrieve additionally embeds the source summary + table credential.
+            queryset = queryset.select_related("source", "table__credential")
         return queryset.order_by(self.ordering)
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/products/data_warehouse/backend/api/table.py
+++ b/products/data_warehouse/backend/api/table.py
@@ -11,7 +11,7 @@ from rest_framework import filters, parsers, request, response, serializers, sta
 from posthog.schema import DatabaseSerializedFieldType
 
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database, SerializedField, serialize_fields
+from posthog.hogql.database.database import Database, SerializedField, get_data_warehouse_table_name, serialize_fields
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -192,11 +192,20 @@ class TableSerializer(UserAccessControlSerializerMixin, serializers.ModelSeriali
 
 class SimpleTableSerializer(UserAccessControlSerializerMixin, serializers.ModelSerializer):
     columns = serializers.SerializerMethodField(read_only=True)
+    hogql_name = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Dotted name the table is queried by in HogQL (e.g. `googleanalytics.devices` or "
+        "`postgres.<prefix>.<table>`), as opposed to `name`, which is the underlying storage identifier.",
+    )
 
     class Meta:
         model = DataWarehouseTable
-        fields = ["id", "name", "columns", "row_count", "user_access_level"]
-        read_only_fields = ["id", "name", "columns", "row_count", "user_access_level"]
+        fields = ["id", "name", "hogql_name", "columns", "row_count", "user_access_level"]
+        read_only_fields = ["id", "name", "hogql_name", "columns", "row_count", "user_access_level"]
+
+    @extend_schema_field(serializers.CharField())
+    def get_hogql_name(self, table: DataWarehouseTable) -> str:
+        return get_data_warehouse_table_name(table.external_data_source, table.name)
 
     def get_columns(self, table: DataWarehouseTable) -> list[SerializedField]:
         database = self.context.get("database", None)

--- a/products/data_warehouse/backend/api/test/test_table.py
+++ b/products/data_warehouse/backend/api/test/test_table.py
@@ -11,6 +11,7 @@ import boto3
 from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
 
+from products.data_warehouse.backend.api.table import SimpleTableSerializer
 from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_PATTERN
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
@@ -463,6 +464,62 @@ class TestTable(APIBaseTest):
         table.refresh_from_db()
 
         assert table.deleted is False
+
+    @parameterized.expand(
+        [
+            # (label, prefix, access_method, storage_name, expected_hogql_name)
+            (
+                "warehouse_no_prefix",
+                "",
+                ExternalDataSource.AccessMethod.WAREHOUSE,
+                "googleanalytics_devices",
+                "googleanalytics.devices",
+            ),
+            (
+                "warehouse_multi_word_schema",
+                "",
+                ExternalDataSource.AccessMethod.WAREHOUSE,
+                "googleanalytics_daily_active_users",
+                "googleanalytics.daily_active_users",
+            ),
+            (
+                "warehouse_with_prefix",
+                "myprefix_",
+                ExternalDataSource.AccessMethod.WAREHOUSE,
+                "myprefix_googleanalytics_devices",
+                "googleanalytics.myprefix.devices",
+            ),
+            # Direct-query sources are referenced by their raw storage name, not a dotted form.
+            ("direct_access", "", ExternalDataSource.AccessMethod.DIRECT, "accounts", "accounts"),
+        ]
+    )
+    def test_simple_table_serializer_hogql_name(
+        self, _label: str, prefix: str, access_method: str, storage_name: str, expected: str
+    ):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            team_id=self.team.pk,
+            source_type="GoogleAnalytics",
+            prefix=prefix,
+            access_method=access_method,
+        )
+        table = DataWarehouseTable.objects.create(
+            name=storage_name,
+            format="Parquet",
+            team=self.team,
+            team_id=self.team.pk,
+            columns={},
+            external_data_source_id=source.pk,
+        )
+
+        assert SimpleTableSerializer().get_hogql_name(table) == expected
+
+    def test_simple_table_serializer_hogql_name_without_source(self):
+        table = DataWarehouseTable.objects.create(
+            name="self_managed_table", format="Parquet", team=self.team, team_id=self.team.pk, columns={}
+        )
+
+        assert SimpleTableSerializer().get_hogql_name(table) == "self_managed_table"
 
     def test_refresh_schema_direct_postgres_table_not_exposed_via_warehouse_tables_api(self):
         source = ExternalDataSource.objects.create(

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -388,7 +388,10 @@ function ManagedSchemaTable({
                                         )}
                                     </div>
                                 }
-                                description={schema.table?.name ? <code>{schema.table.name}</code> : undefined}
+                                description={((): JSX.Element | undefined => {
+                                    const tableName = schema.table?.hogql_name ?? schema.table?.name
+                                    return tableName ? <code>{tableName}</code> : undefined
+                                })()}
                             />
                         )
                     },


### PR DESCRIPTION
## Problem

On a managed source's page, the schema list shows each table's underlying storage identifier (e.g. `googleanalytics_devices`) as the subtitle. That's not the name you actually query the table by in HogQL — the queryable name is the dotted form (`googleanalytics.devices`, or `<source_type>.<prefix>.<table>` when a prefix is set). Showing the storage name is misleading: copy it into the SQL editor and the query won't resolve.

## Changes

The schema list now displays the dotted HogQL name instead of the raw storage name.

- Added a read-only `hogql_name` field to `SimpleTableSerializer`, computed via the existing canonical `get_data_warehouse_table_name(source, table_name)` — the same function HogQL uses to expose warehouse tables. This keeps the displayed name in lockstep with what the query engine actually resolves (prefix stripping, direct-query passthrough, and all).
- `SchemasTab` renders `hogql_name`, falling back to `name` if it's ever absent.
- No N+1: the source-detail and schema querysets already `select_related("table__external_data_source")`.

Direct-query sources are unaffected — `get_data_warehouse_table_name` returns the raw name for them, which is correct.

## How did you test this code?

I'm an agent (Claude Code). Added a parameterized backend test (`test_simple_table_serializer_hogql_name`) covering no-prefix, multi-word schema, prefixed, direct-access, and no-source cases.

The local venv is Python 3.12 while the repo targets 3.13, so the ClickHouse-touching `APIBaseTest` suite can't boot locally (pre-existing, affects all backend tests). To verify the logic I ran `get_data_warehouse_table_name` directly against the same five cases — all produced the expected dotted names. The pytest cases will run in CI on 3.13.

Frontend: `oxlint` clean and `tsgo` typecheck clean on the changed files (`SchemasTab.tsx`, `types.ts`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @owerstom. Invoked the `/improving-drf-endpoints` skill before the serializer change (added `help_text`, typed the `SerializerMethodField` with `@extend_schema_field`). Chose to surface the canonical backend-computed name via the serializer rather than reconstruct the dotted form on the frontend — the prefix-stripping logic (`_strip_external_source_prefix`) handles several prefix shapes including the source PK hex, so replicating it client-side would be fragile and drift-prone. `SimpleTableSerializer` is only consumed through a `SerializerMethodField` returning a plain dict (no `@extend_schema_field`), so the new field doesn't enter the OpenAPI spec and there's no generated-type drift; the frontend's handwritten `SimpleDataWarehouseTable` type was updated by hand.
