### PR TITLE
feat(data-warehouse): reorder source groups on sources homepage

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourcesScene/SourcesList.tsx
+++ b/products/data_warehouse/frontend/scenes/SourcesScene/SourcesList.tsx
@@ -31,6 +31,14 @@ export function SourcesList({ action }: { action: JSX.Element }): JSX.Element {
                 />
             ) : null}
 
+            <SceneSection
+                title="Managed data warehouse sources"
+                description="PostHog can connect to external sources and automatically import data from them into the PostHog data warehouse"
+            >
+                <ManagedSourcesTable />
+            </SceneSection>
+            <SceneDivider />
+
             <FlaggedFeature flag="cdp-hog-sources">
                 <>
                     <SceneSection
@@ -50,13 +58,6 @@ export function SourcesList({ action }: { action: JSX.Element }): JSX.Element {
                 </>
             </FlaggedFeature>
 
-            <SceneSection
-                title="Managed data warehouse sources"
-                description="PostHog can connect to external sources and automatically import data from them into the PostHog data warehouse"
-            >
-                <ManagedSourcesTable />
-            </SceneSection>
-            <SceneDivider />
             <SceneSection
                 title="Self-managed data warehouse sources"
                 description="Connect to your own data sources, making them queryable in PostHog"


### PR DESCRIPTION
## Problem

On the data management sources homepage, the source groups were ordered with Event sources first, then Managed warehouse sources, then Self-managed. Managed warehouse sources are the primary thing people come to this page for, so they should lead.

## Changes

Reordered the groups to:

1. Managed data warehouse sources
2. Event sources (still behind the `cdp-hog-sources` flag and the "Experimental" tag)
3. Self-managed data warehouse sources

Section dividers stay correct in both flag states — flag off: Managed → divider → Self-managed; flag on: Managed → divider → Event sources → divider → Self-managed.

## How did you test this code?

I'm an agent (Claude Code). This is a presentational reorder of JSX sections in a single file. `oxlint` clean. No logic or data changes; I did not run a manual click-through.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @owerstom. Purely a render-order change in `SourcesList.tsx` — moved the Managed section above the flagged Event sources block and kept the divider placement so the layout is correct whether or not `cdp-hog-sources` is enabled.
