### PR TITLE
fix(inbox): show only ready PRs in the pull requests tab

### DIFF
--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -28,9 +28,6 @@ export interface ReportListLogicProps {
  * bodies, the count chips, and the scene. Mirrors the backend filters confirmed in the plan.
  */
 export const INBOX_FLAT_TAB_LIST_PARAMS: Record<InboxFlatListTabKey, ReportListParams> = {
-    // Only `ready` PRs (a draft awaiting review). Without a status filter the backend
-    // returns every non-suppressed status, so merged/closed (`resolved`) PRs piled up in
-    // the list and inflated the count chip with work that was already done.
     pulls: { has_implementation_pr: 'true', status: 'ready' },
     reports: {
         has_implementation_pr: 'false',

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -28,7 +28,10 @@ export interface ReportListLogicProps {
  * bodies, the count chips, and the scene. Mirrors the backend filters confirmed in the plan.
  */
 export const INBOX_FLAT_TAB_LIST_PARAMS: Record<InboxFlatListTabKey, ReportListParams> = {
-    pulls: { has_implementation_pr: 'true' },
+    // Only `ready` PRs (a draft awaiting review). Without a status filter the backend
+    // returns every non-suppressed status, so merged/closed (`resolved`) PRs piled up in
+    // the list and inflated the count chip with work that was already done.
+    pulls: { has_implementation_pr: 'true', status: 'ready' },
     reports: {
         has_implementation_pr: 'false',
         status: 'ready,pending_input',


### PR DESCRIPTION
## Problem

The inbox Pull requests tab sent only `has_implementation_pr=true`, so the backend returned PRs of every non-suppressed status. Merged/closed (`resolved`) PRs piled up in the list and inflated the tab's count chip with work that's already done — a user saw 4 PRs when only 1 was actually awaiting review.

## Changes

Add `status: 'ready'` to the pulls tab's fixed params (`INBOX_FLAT_TAB_LIST_PARAMS.pulls`). The list and its count chip share these params, so both now show only `ready` PRs (a draft awaiting review). Resolved/merged PRs drop off.

## How did you test this code?

I'm an agent (PostHog Code). This is a one-line change to a fixed filter param; no Cloud tests reference `INBOX_FLAT_TAB_LIST_PARAMS`. The matching change in the PostHog Code desktop app (PostHog/code#2758) carries unit tests for the equivalent `ready`-only PR membership rule, which pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed from a PostHog Slack thread where the inbox PR count differed between Cloud and the Code desktop app. Investigation found the difference was `resolved` PRs: the Code app hid them, Cloud showed them. The agreed direction was that neither should surface done work — the Pull requests tab should show and count only `ready` PRs. This PR makes that change in Cloud; PostHog/code#2758 makes the matching change in the desktop app (superseding an earlier PR that had aligned the wrong way).

Built with PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781789565853999?thread_ts=1781789565.853999&cid=C09SK2PAGKF)*
