### PR TITLE
feat(mcp): restore intent capture and tools-list analytics on the hono server

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,7 +363,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -460,7 +460,7 @@ importers:
         version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)
       '@storybook/react-webpack5':
         specifier: ^8.6.14
-        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
       '@storybook/test-runner':
         specifier: ^0.19.1
         version: 0.19.1(storybook@8.6.18(prettier@3.8.2))
@@ -514,7 +514,7 @@ importers:
         version: 2.0.0(webpack@5.105.4)
       webpack:
         specifier: ^5.94.0
-        version: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+        version: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -4064,7 +4064,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -4249,8 +4249,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/mcp-analytics':
-        specifier: npm:@posthog/mcp@0.2.0
-        version: '@posthog/mcp@0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
+        specifier: npm:@posthog/mcp@0.4.0
+        version: '@posthog/mcp@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
@@ -9464,9 +9464,6 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
-  '@posthog/core@1.32.3':
-    resolution: {integrity: sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==}
-
   '@posthog/core@1.35.1':
     resolution: {integrity: sha512-2a9JgJgR+Ow8lrUQHVZYXH9EgXskYDlpbgNW6UvtsVxp8pEEFD8PxjZMnzq73Dx3NhAwNUrnVpb8KeZzHAtoSA==}
 
@@ -9504,8 +9501,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/mcp@0.2.0':
-    resolution: {integrity: sha512-G3+CuVSkm77wpuZlqcbLEaffezsIR4oJrR2ufctHnk1RcqJchU/0FzV5LA02oRuqj2mmB0bzd8F0BXSqBxbLug==}
+  '@posthog/mcp@0.4.0':
+    resolution: {integrity: sha512-5k5q4On86ISHKczYUgHC4KxA3XNIN/6mbgXHEaF1cNo2xI+gxBJxivDVlzcU1h2F++WYJP5AGEj3lxffjLXG7Q==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.29.0
@@ -9523,9 +9520,6 @@ packages:
 
   '@posthog/siphash@1.1.1':
     resolution: {integrity: sha512-JUFk57H89fOnHpF62FDyFGw4uXeHAX20OPfkLL8/iqg/xrVp5Q21LvJUDijmS5wt0avgUwXF2bxYgaZ5iWRmAg==}
-
-  '@posthog/types@1.386.3':
-    resolution: {integrity: sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==}
 
   '@posthog/types@1.390.0':
     resolution: {integrity: sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw==}
@@ -26951,6 +26945,41 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.18.8)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -27072,6 +27101,42 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
       jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-haste-map: 30.0.5
+      jest-message-util: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-resolve-dependencies: 30.0.5
+      jest-runner: 30.0.5
+      jest-runtime: 30.0.5
+      jest-snapshot: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      jest-watcher: 30.0.5
+      micromatch: 4.0.8
+      pretty-format: 30.0.5
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+    dependencies:
+      '@jest/console': 30.0.5
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.0.5
+      '@jest/test-result': 30.0.5
+      '@jest/transform': 30.0.5
+      '@jest/types': 30.0.5
+      '@types/node': 22.18.8
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.0.5
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -29705,10 +29770,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/core@1.32.3':
-    dependencies:
-      '@posthog/types': 1.386.3
-
   '@posthog/core@1.35.1':
     dependencies:
       '@posthog/types': 1.390.0
@@ -29750,10 +29811,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/mcp@0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
+  '@posthog/mcp@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      '@posthog/core': 1.32.3
+      '@posthog/core': 1.35.1
       posthog-node: 5.25.0
 
   '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.390.2)(react@18.3.1)':
@@ -29764,8 +29825,6 @@ snapshots:
       '@types/react': 18.3.27
 
   '@posthog/siphash@1.1.1': {}
-
-  '@posthog/types@1.386.3': {}
 
   '@posthog/types@1.390.0': {}
 
@@ -31262,7 +31321,7 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)
 
-  '@storybook/builder-webpack5@8.6.18(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@8.6.18(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@types/semver': 7.7.1
@@ -31280,12 +31339,12 @@ snapshots:
       semver: 7.8.0
       storybook: 8.6.18(prettier@3.8.2)
       style-loader: 3.3.3(webpack@5.105.4)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack@5.105.4)
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack@5.105.4)
       ts-dedent: 2.2.0
       url: 0.11.1
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.105.4)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.2
@@ -31379,7 +31438,7 @@ snapshots:
     dependencies:
       storybook: 8.6.18(prettier@3.8.2)
 
-  '@storybook/preset-react-webpack@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/preset-react-webpack@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)
@@ -31394,7 +31453,7 @@ snapshots:
       semver: 7.8.0
       storybook: 8.6.18(prettier@3.8.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -31428,7 +31487,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -31466,10 +31525,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react-webpack5@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/react-webpack5@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.18(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
+      '@storybook/builder-webpack5': 8.6.18(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)(webpack-cli@5.1.4)
       '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.8.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@6.0.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -33832,17 +33891,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xmldom/xmldom@0.8.13': {}
@@ -34364,7 +34423,7 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -35270,6 +35329,21 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
+  create-jest@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -35403,7 +35477,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   css-loader@6.8.1(webpack@5.105.4):
     dependencies:
@@ -35415,7 +35489,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.15):
     dependencies:
@@ -36996,7 +37070,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   file-uri-to-path@1.0.0: {}
 
@@ -37115,7 +37189,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -37777,7 +37851,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.105.4))(webpack@5.105.4):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.105.4)
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.105.4):
     dependencies:
@@ -37786,7 +37860,7 @@ snapshots:
       lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -38511,14 +38585,14 @@ snapshots:
 
   jest-cli@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      create-jest: 29.7.0
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -38604,6 +38678,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/test-result': 30.0.5
+      '@jest/types': 30.0.5
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   jest-config@27.5.1(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -38637,6 +38730,64 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
+
+  jest-config@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
@@ -38792,6 +38943,74 @@ snapshots:
       '@types/node': 22.18.8
       esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39679,7 +39898,7 @@ snapshots:
 
   jest@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0
@@ -39731,6 +39950,19 @@ snapshots:
       '@jest/types': 30.0.5
       import-local: 3.2.0
       jest-cli: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/types': 30.0.5
+      import-local: 3.2.0
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40042,7 +40274,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -42298,7 +42530,7 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.15):
     dependencies:
@@ -43062,7 +43294,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -44098,7 +44330,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -44758,11 +44990,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   style-loader@3.3.3(webpack@5.105.4):
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -45129,19 +45361,6 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack@5.105.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.15.18
-      cssnano: 7.0.6(postcss@8.5.15)
-      esbuild: 0.25.12
-      postcss: 8.5.15
-
   terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -45153,6 +45372,17 @@ snapshots:
       '@swc/core': 1.15.18
       cssnano: 7.0.6(postcss@8.5.15)
       esbuild: 0.28.0
+      postcss: 8.5.15
+
+  terser-webpack-plugin@5.6.0(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack@5.105.4):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
+    optionalDependencies:
+      cssnano: 7.0.6(postcss@8.5.15)
       postcss: 8.5.15
 
   terser@5.46.0:
@@ -46304,7 +46534,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.3(webpack@5.105.4):
@@ -46315,7 +46545,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -46333,49 +46563,6 @@ snapshots:
   webpack-virtual-modules@0.5.0: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.22.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.25.12)(postcss@8.5.15)(webpack@5.105.4)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack@5.105.4)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
 
   webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15):
     dependencies:
@@ -46404,6 +46591,49 @@ snapshots:
       terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack-cli@5.1.4):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.22.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(postcss@8.5.15)(webpack@5.105.4)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack@5.105.4)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -44,7 +44,7 @@
         "@hono/node-server": "^2.0.2",
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.2.0",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
         "@toon-format/toon": "^2.1.0",

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -57,7 +57,7 @@ function buildBaseProperties(
 
 export async function trackInitEvent(state: ResolvedState): Promise<void> {
     try {
-        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const analyticsContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
         const requestContext = state.requestContext
         const initDurationMs = requestContext.requestStartTime
             ? Date.now() - requestContext.requestStartTime
@@ -127,7 +127,7 @@ export async function trackToolCall(
     intentMeta?: ToolCallIntentMeta
 ): Promise<void> {
     try {
-        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const analyticsContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
         const requestContext = state.requestContext
         const sessionUuid = requestContext.sessionId
             ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
@@ -194,7 +194,7 @@ export async function trackToolCall(
 
 export async function trackToolsList(toolNames: string[], state: ResolvedState): Promise<void> {
     try {
-        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const analyticsContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
         const requestContext = state.requestContext
         const sessionUuid = requestContext.sessionId
             ? await state.reqCtx.getSessionUuid(requestContext.sessionId)

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -1,3 +1,5 @@
+import type { MCPAnalyticsIntentSource } from '@posthog/mcp-analytics'
+
 import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { getPostHogClient } from '@/lib/posthog'
 import {
@@ -109,12 +111,20 @@ export async function trackInitEvent(state: ResolvedState): Promise<void> {
     }
 }
 
+export interface ToolCallIntentMeta {
+    /** The agent's stated intent (the injected `context` arg) → `$mcp_intent`. */
+    intent?: string
+    /** Where it came from → `$mcp_intent_source`. */
+    intentSource?: MCPAnalyticsIntentSource
+}
+
 export async function trackToolCall(
     toolName: string,
     durationMs: number,
     isError: boolean,
     state: ResolvedState,
-    extraProperties?: Record<string, unknown>
+    extraProperties?: Record<string, unknown>,
+    intentMeta?: ToolCallIntentMeta
 ): Promise<void> {
     try {
         const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
@@ -136,8 +146,11 @@ export async function trackToolCall(
 
         // Emits `$mcp_tool_call` (+ `$mcp_is_error`). The SDK maps `toolName` →
         // `$mcp_tool_name`, `durationMs` → `$mcp_duration_ms`, `isError` →
-        // `$mcp_is_error`, and `sessionId` → `$session_id`. `$exception` fan-out
-        // is disabled on the client, so an errored call stays a single event.
+        // `$mcp_is_error`, `intent` → `$mcp_intent`, and `sessionId` →
+        // `$session_id`. `$exception` fan-out is disabled on the client, so an
+        // errored call stays a single event. The intent pipeline reads
+        // `$mcp_intent` off this canonical event, so it only needs to land here
+        // (not on the legacy dual-emit below).
         getPostHogClient().captureToolCall({
             toolName,
             durationMs,
@@ -145,6 +158,7 @@ export async function trackToolCall(
             distinctId: state.distinctId,
             groups,
             ...(sessionUuid ? { sessionId: sessionUuid } : {}),
+            ...(intentMeta?.intent ? { intent: intentMeta.intent, intentSource: intentMeta.intentSource } : {}),
             properties: {
                 ...properties,
                 tool_name: toolName,
@@ -170,6 +184,34 @@ export async function trackToolCall(
                 ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
                 ...extraProperties,
+            },
+        })
+    } catch {
+        // never break the request for analytics
+    }
+}
+
+export async function trackToolsList(toolNames: string[], state: ResolvedState): Promise<void> {
+    try {
+        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const requestContext = state.requestContext
+        const sessionUuid = requestContext.sessionId
+            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
+            : undefined
+
+        const { properties, groups } = buildBaseProperties(state, analyticsContext)
+
+        // Emits `$mcp_tools_list`. The SDK maps `toolNames` → `$mcp_listed_tool_names`,
+        // which powers "advertised but never called" analysis. No legacy dual-emit:
+        // `mcp_tools_list` has had no consumers since the cutover.
+        getPostHogClient().captureToolsList({
+            toolNames,
+            distinctId: state.distinctId,
+            groups,
+            ...(sessionUuid ? { sessionId: sessionUuid } : {}),
+            properties: {
+                ...properties,
+                tool_count: toolNames.length,
             },
         })
     } catch {

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -158,7 +158,8 @@ export async function trackToolCall(
             distinctId: state.distinctId,
             groups,
             ...(sessionUuid ? { sessionId: sessionUuid } : {}),
-            ...(intentMeta?.intent ? { intent: intentMeta.intent, intentSource: intentMeta.intentSource } : {}),
+            ...(intentMeta?.intent ? { intent: intentMeta.intent } : {}),
+            ...(intentMeta?.intentSource ? { intentSource: intentMeta.intentSource } : {}),
             properties: {
                 ...properties,
                 tool_name: toolName,

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -153,7 +153,7 @@ export class RequestContext {
             getDistinctId: () => this.getDistinctId(),
         }
         const trackEvent: Context['trackEvent'] = async (event, properties = {}) => {
-            const analyticsContext = await this.getAnalyticsContextSafe(partialContext)
+            const analyticsContext = await this.safelyGetAnalyticsContext(partialContext)
             const distinctId = await this.getDistinctId()
             await this.trackEvent(event, properties, analyticsContext, undefined, distinctId)
         }
@@ -165,7 +165,7 @@ export class RequestContext {
         this.sessionContext = sessionContext
     }
 
-    async getAnalyticsContextSafe(context: Pick<Context, 'stateManager'>): Promise<MCPAnalyticsContext | undefined> {
+    async safelyGetAnalyticsContext(context: Pick<Context, 'stateManager'>): Promise<MCPAnalyticsContext | undefined> {
         try {
             return await context.stateManager.getAnalyticsContext()
         } catch {
@@ -178,7 +178,7 @@ export class RequestContext {
         context: Context,
         previousContext: MCPAnalyticsContext | undefined
     ): Promise<void> {
-        const resolvedContext = await this.getAnalyticsContextSafe(context)
+        const resolvedContext = await this.safelyGetAnalyticsContext(context)
         if (!resolvedContext) {
             return
         }

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -115,7 +115,7 @@ export class RequestStateResolver {
         // the rendering prompt section on it (like `mcp-feedback-tool`).
         const allFlagKeys = [...toolFlagKeys, RENDER_UI_FEATURE_FLAG]
 
-        const flagAnalyticsContext = await reqCtx.getAnalyticsContextSafe(context)
+        const flagAnalyticsContext = await reqCtx.safelyGetAnalyticsContext(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
 
         const [allFlags, _apiKey, distinctId] = await Promise.all([

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -17,13 +17,14 @@ import {
     findRecoverableApiError,
 } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
+import { getPostHogClient } from '@/lib/posthog'
 import { AnalyticsEvent } from '@/lib/posthog/analytics'
 import { createExecTool, formatInputValidationError, type ExecInnerCallTracker } from '@/tools/exec'
 import { createRenderUiTool } from '@/tools/render-ui'
 import { getToolCategory } from '@/tools/toolDefinitions'
 import type { Context, ZodObjectAny } from '@/tools/types'
 
-import { trackToolCall } from './analytics'
+import { trackToolCall, trackToolsList, type ToolCallIntentMeta } from './analytics'
 import type { InstructionsBuilder } from './instructions'
 import { getEffectiveMCPClientContext } from './mcp-context'
 import { toolCallDurationSeconds, toolCallsTotal, toolErrorsTotal } from './metrics'
@@ -51,24 +52,44 @@ export class ToolExecutor {
     }
 
     async handleToolsList(state: ResolvedState): Promise<ListToolsResult> {
+        const baseTools = this.buildAdvertisedTools(state)
+
+        // Inject the `context` argument into every advertised tool so agents can
+        // state what they're trying to do. `handleToolCall` strips it via
+        // `prepareToolCall` before validation and surfaces it as `$mcp_intent`.
+        // This is the same injection `instrument()` does for SDK-wrapped servers.
+        // Guarded: analytics must never break `tools/list`, so any failure falls
+        // back to the un-augmented tool list.
+        let tools = baseTools
+        try {
+            tools = getPostHogClient().prepareToolList(baseTools)
+        } catch {
+            // fall back to un-augmented tools
+        }
+
+        void trackToolsList(
+            tools.map((t) => t.name),
+            state
+        )
+
+        return { tools }
+    }
+
+    private buildAdvertisedTools(state: ResolvedState): ListToolsResult['tools'] {
         if (state.useSingleExec) {
             const renderUiEntry = state.renderUiEnabled ? this.instructionsBuilder.buildRenderUiToolEntry(state) : null
-            return {
-                tools: [this.instructionsBuilder.buildExecToolEntry(state), ...(renderUiEntry ? [renderUiEntry] : [])],
-            }
+            return [this.instructionsBuilder.buildExecToolEntry(state), ...(renderUiEntry ? [renderUiEntry] : [])]
         }
 
         const nameSet = new Set(state.allTools.map((t) => t.name))
         const filteredTools = this.catalog.getPreBuiltEntries().filter((e) => nameSet.has(e.name))
 
-        const withSqlDescription = filteredTools.map((entry) => {
+        return filteredTools.map((entry) => {
             if (entry.name === 'execute-sql') {
                 return { ...entry, description: this.instructionsBuilder.formatExecuteSqlDescription() }
             }
             return entry
         })
-
-        return { tools: withSqlDescription }
     }
 
     async handleToolCall(params: Record<string, unknown> | undefined, state: ResolvedState): Promise<unknown> {
@@ -77,8 +98,26 @@ export class ToolExecutor {
             return { content: [{ type: 'text', text: 'Missing tool name' }], isError: true }
         }
 
+        // Pull the agent's stated intent off the injected `context` arg and strip it
+        // so tool schemas/handlers never see it (validation here is `.strict()` in
+        // places). The intent rides through to `$mcp_intent` on the captured event.
+        // Guarded: analytics must never break `tools/call`. On failure we fall back
+        // to the raw args — safe because `context` is only ever present when the
+        // matching `prepareToolList` injection succeeded.
+        const rawArgs = (params?.arguments ?? {}) as Record<string, unknown>
+        let intentMeta: ToolCallIntentMeta = {}
+        let callArgs = rawArgs
+        try {
+            const prepared = getPostHogClient().prepareToolCall(toolName, rawArgs)
+            intentMeta = { intent: prepared.intent, intentSource: prepared.intentSource }
+            callArgs = prepared.args ?? rawArgs
+        } catch {
+            // fall back to raw args; intent simply won't be captured for this call
+        }
+        const callParams = { ...params, arguments: callArgs }
+
         if (toolName === 'exec') {
-            return this.callExecTool(params, state)
+            return this.callExecTool(callParams, state, intentMeta)
         }
 
         if (toolName === 'render-ui') {
@@ -87,7 +126,7 @@ export class ToolExecutor {
                 toolCallsTotal.inc({ tool: toolName, status: 'error' })
                 return { content: [{ type: 'text', text: `Tool ${toolName} not found` }], isError: true }
             }
-            return this.callRenderUiTool(params, state)
+            return this.callRenderUiTool(callParams, state, intentMeta)
         }
 
         if (!state.allTools.some((t) => t.name === toolName)) {
@@ -108,15 +147,17 @@ export class ToolExecutor {
                 handler: (ctx, args) => preBuilt.base.handler(ctx, args),
                 _meta: preBuilt.base._meta,
             },
-            params,
-            state
+            callParams,
+            state,
+            intentMeta
         )
     }
 
     private async callTool(
         tool: ResolvedTool,
         params: Record<string, unknown> | undefined,
-        state: ResolvedState
+        state: ResolvedState,
+        intentMeta?: ToolCallIntentMeta
     ): Promise<unknown> {
         const toolArgs = (params?.arguments ?? {}) as Record<string, unknown>
         const validation = tool.schema.safeParse(toolArgs, { reportInput: true })
@@ -166,10 +207,17 @@ export class ToolExecutor {
                 })
             }
 
-            void trackToolCall(tool.name, duration, false, state, {
-                input_tokens: estimateTokens(validation.data),
-                output_tokens: estimateResponseTokens(response),
-            })
+            void trackToolCall(
+                tool.name,
+                duration,
+                false,
+                state,
+                {
+                    input_tokens: estimateTokens(validation.data),
+                    output_tokens: estimateResponseTokens(response),
+                },
+                intentMeta
+            )
 
             return response
         } catch (error: unknown) {
@@ -177,14 +225,18 @@ export class ToolExecutor {
             stop({ status: 'error' })
             classifyToolError(error, tool.name)
 
-            void trackToolCall(tool.name, Date.now() - startMs, true, state)
+            void trackToolCall(tool.name, Date.now() - startMs, true, state, undefined, intentMeta)
 
             const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             return handleToolError(error, tool.name, state.distinctId, sessionUuid)
         }
     }
 
-    private async callExecTool(params: Record<string, unknown> | undefined, state: ResolvedState): Promise<unknown> {
+    private async callExecTool(
+        params: Record<string, unknown> | undefined,
+        state: ResolvedState,
+        intentMeta?: ToolCallIntentMeta
+    ): Promise<unknown> {
         const execMetrics: ExecMetricState = { innerToolName: undefined }
         const resolved = this.resolveExecTool(state, execMetrics)
 
@@ -215,10 +267,17 @@ export class ToolExecutor {
                       distinctId: undefined,
                   })
 
-            void trackToolCall('exec', duration, false, state, {
-                input_tokens: estimateTokens(validation.data),
-                output_tokens: estimateResponseTokens(response),
-            })
+            void trackToolCall(
+                'exec',
+                duration,
+                false,
+                state,
+                {
+                    input_tokens: estimateTokens(validation.data),
+                    output_tokens: estimateResponseTokens(response),
+                },
+                intentMeta
+            )
 
             return response
         } catch (error: unknown) {
@@ -228,7 +287,7 @@ export class ToolExecutor {
             }
             classifyToolError(error, metricTool)
 
-            void trackToolCall('exec', Date.now() - startMs, true, state)
+            void trackToolCall('exec', Date.now() - startMs, true, state, undefined, intentMeta)
 
             const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             // Attribute the failure to the inner tool that actually ran (e.g. `query-logs`),
@@ -294,7 +353,8 @@ export class ToolExecutor {
 
     private async callRenderUiTool(
         params: Record<string, unknown> | undefined,
-        state: ResolvedState
+        state: ResolvedState,
+        intentMeta?: ToolCallIntentMeta
     ): Promise<unknown> {
         const renderUiTool = createRenderUiTool(state.allTools, state.context)
         if (!renderUiTool) {
@@ -317,14 +377,14 @@ export class ToolExecutor {
             const handlerResult = await renderUiTool.handler(state.context, validation.data)
             toolCallsTotal.inc({ tool: 'render-ui', status: 'success' })
             stop({ status: 'success' })
-            void trackToolCall('render-ui', Date.now() - startMs, false, state)
+            void trackToolCall('render-ui', Date.now() - startMs, false, state, undefined, intentMeta)
             // The handler always returns an exec-built payload (UI resourceUri + structuredContent).
             return handlerResult
         } catch (error: unknown) {
             toolCallsTotal.inc({ tool: 'render-ui', status: 'error' })
             stop({ status: 'error' })
             classifyToolError(error, 'render-ui')
-            void trackToolCall('render-ui', Date.now() - startMs, true, state)
+            void trackToolCall('render-ui', Date.now() - startMs, true, state, undefined, intentMeta)
             const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             return handleToolError(error, 'render-ui', state.distinctId, sessionUuid)
         }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -180,7 +180,7 @@ export class ToolExecutor {
         try {
             const isContextSwitch = tool.name === 'switch-project' || tool.name === 'switch-organization'
             const previousContext = isContextSwitch
-                ? await state.reqCtx.getAnalyticsContextSafe(state.context)
+                ? await state.reqCtx.safelyGetAnalyticsContext(state.context)
                 : undefined
 
             const handlerResult = await tool.handler(state.context, validation.data)
@@ -322,7 +322,7 @@ export class ToolExecutor {
             const toolCategory = getToolCategory(toolName)
 
             void (async () => {
-                const freshContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+                const freshContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
                 await state.reqCtx.trackEvent(
                     AnalyticsEvent.MCP_TOOL_CALL,
                     {

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -52,20 +52,7 @@ export class ToolExecutor {
     }
 
     async handleToolsList(state: ResolvedState): Promise<ListToolsResult> {
-        const baseTools = this.buildAdvertisedTools(state)
-
-        // Inject the `context` argument into every advertised tool so agents can
-        // state what they're trying to do. `handleToolCall` strips it via
-        // `prepareToolCall` before validation and surfaces it as `$mcp_intent`.
-        // This is the same injection `instrument()` does for SDK-wrapped servers.
-        // Guarded: analytics must never break `tools/list`, so any failure falls
-        // back to the un-augmented tool list.
-        let tools = baseTools
-        try {
-            tools = getPostHogClient().prepareToolList(baseTools)
-        } catch {
-            // fall back to un-augmented tools
-        }
+        const tools = this.injectContext(this.buildAdvertisedTools(state))
 
         void trackToolsList(
             tools.map((t) => t.name),
@@ -73,6 +60,19 @@ export class ToolExecutor {
         )
 
         return { tools }
+    }
+
+    // Inject the `context` argument into every advertised tool so agents can state
+    // what they're trying to do (`handleToolCall` strips it before validation and
+    // surfaces it as `$mcp_intent` — the same injection `instrument()` does for
+    // SDK-wrapped servers). Guarded: analytics must never break `tools/list`, so
+    // any failure falls back to the un-augmented tools.
+    private injectContext(tools: ListToolsResult['tools']): ListToolsResult['tools'] {
+        try {
+            return getPostHogClient().prepareToolList(tools)
+        } catch {
+            return tools
+        }
     }
 
     private buildAdvertisedTools(state: ResolvedState): ListToolsResult['tools'] {
@@ -98,23 +98,8 @@ export class ToolExecutor {
             return { content: [{ type: 'text', text: 'Missing tool name' }], isError: true }
         }
 
-        // Pull the agent's stated intent off the injected `context` arg and strip it
-        // so tool schemas/handlers never see it (validation here is `.strict()` in
-        // places). The intent rides through to `$mcp_intent` on the captured event.
-        // Guarded: analytics must never break `tools/call`. On failure we fall back
-        // to the raw args — safe because `context` is only ever present when the
-        // matching `prepareToolList` injection succeeded.
-        const rawArgs = (params?.arguments ?? {}) as Record<string, unknown>
-        let intentMeta: ToolCallIntentMeta = {}
-        let callArgs = rawArgs
-        try {
-            const prepared = getPostHogClient().prepareToolCall(toolName, rawArgs)
-            intentMeta = { intent: prepared.intent, intentSource: prepared.intentSource }
-            callArgs = prepared.args ?? rawArgs
-        } catch {
-            // fall back to raw args; intent simply won't be captured for this call
-        }
-        const callParams = { ...params, arguments: callArgs }
+        const { intentMeta, args } = this.extractIntent(toolName, (params?.arguments ?? {}) as Record<string, unknown>)
+        const callParams = { ...params, arguments: args }
 
         if (toolName === 'exec') {
             return this.callExecTool(callParams, state, intentMeta)
@@ -151,6 +136,26 @@ export class ToolExecutor {
             state,
             intentMeta
         )
+    }
+
+    // Pull the agent's stated intent off the injected `context` arg and strip it so
+    // tool schemas/handlers never see it (validation is `.strict()` in places). The
+    // intent rides through to `$mcp_intent` on the captured event. Guarded: analytics
+    // must never break `tools/call`, so on failure we fall back to the raw args —
+    // safe because `context` is only present when the matching injection succeeded.
+    private extractIntent(
+        toolName: string,
+        rawArgs: Record<string, unknown>
+    ): { intentMeta: ToolCallIntentMeta; args: Record<string, unknown> } {
+        try {
+            const prepared = getPostHogClient().prepareToolCall(toolName, rawArgs)
+            return {
+                intentMeta: { intent: prepared.intent, intentSource: prepared.intentSource },
+                args: prepared.args ?? rawArgs,
+            }
+        } catch {
+            return { intentMeta: {}, args: rawArgs }
+        }
     }
 
     private async callTool(

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -21,7 +21,7 @@ import type { ResolvedState } from '@/hono/request-state-resolver'
 function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
     return {
         reqCtx: {
-            getAnalyticsContextSafe: vi.fn(async () => undefined),
+            safelyGetAnalyticsContext: vi.fn(async () => undefined),
             getSessionUuid: vi.fn(async () => 'session-uuid'),
         } as any,
         context: {

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -57,7 +57,7 @@ vi.mock('@/hono/request-context', () => {
                         getAiConsentGiven: vi.fn(async () => undefined),
                     },
                 })),
-                getAnalyticsContextSafe: vi.fn(async () => undefined),
+                safelyGetAnalyticsContext: vi.fn(async () => undefined),
                 getDistinctId: vi.fn(async () => 'distinct-id'),
                 setMcpContexts: vi.fn(),
             }

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -31,7 +31,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
     return {
         reqCtx: {
             cache: { get: vi.fn(), set: vi.fn() },
-            getAnalyticsContextSafe: vi.fn().mockResolvedValue(undefined),
+            safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -91,7 +91,20 @@ describe('ToolExecutor intent capture', () => {
         expect(execEntry.inputSchema.required).toContain('context')
     })
 
-    it('forwards the agent intent to captureToolCall and strips context before the handler', async () => {
+    it.each([
+        {
+            label: 'forwards the agent intent and strips context before the handler',
+            args: { command: 'tools', context: 'investigating signup drop' },
+            expectedIntent: 'investigating signup drop',
+            expectedSource: 'context_parameter',
+        },
+        {
+            label: 'captures no intent when the agent omits context',
+            args: { command: 'tools' },
+            expectedIntent: undefined,
+            expectedSource: undefined,
+        },
+    ])('exec call $label', async ({ args, expectedIntent, expectedSource }) => {
         const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
 
         const filteredTools = catalog
@@ -99,36 +112,18 @@ describe('ToolExecutor intent capture', () => {
             .filter((tool) => tool.name === 'execute-sql' || tool.name === 'organization-get')
 
         const result = (await executor.handleToolCall(
-            { name: 'exec', arguments: { command: 'tools', context: 'investigating signup drop' } },
+            { name: 'exec', arguments: args },
             makeState(filteredTools, { useSingleExec: false })
         )) as any
 
-        // context must not break exec validation — proves it was stripped before the handler.
+        // context (when present) must not break exec validation — proves it was stripped.
         expect(result.isError).toBeFalsy()
 
         expect(captureSpy).toHaveBeenCalledTimes(1)
         const arg = captureSpy.mock.calls[0]![0]
         expect(arg.toolName).toBe('exec')
-        expect(arg.intent).toBe('investigating signup drop')
-        expect(arg.intentSource).toBe('context_parameter')
-
-        captureSpy.mockRestore()
-    })
-
-    it('captures no intent when the agent omits context', async () => {
-        const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
-
-        const filteredTools = catalog
-            .getFilteredTools({ scopes: ['*'] })
-            .filter((tool) => tool.name === 'organization-get')
-
-        await executor.handleToolCall(
-            { name: 'exec', arguments: { command: 'tools' } },
-            makeState(filteredTools, { useSingleExec: false })
-        )
-
-        expect(captureSpy).toHaveBeenCalledTimes(1)
-        expect(captureSpy.mock.calls[0]![0].intent).toBeUndefined()
+        expect(arg.intent).toBe(expectedIntent)
+        expect(arg.intentSource).toBe(expectedSource)
 
         captureSpy.mockRestore()
     })

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -1,0 +1,135 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/resources/internals', () => ({
+    fetchContextMillResources: vi.fn().mockRejectedValue(new Error('mocked')),
+    filterValidEntries: vi.fn().mockReturnValue([]),
+    loadManifestFromArchive: vi.fn().mockReturnValue({ resources: [] }),
+    clearResourceCache: vi.fn(),
+}))
+
+vi.mock('@/resources', () => ({
+    getPromptsFromManifest: vi.fn().mockResolvedValue([]),
+}))
+
+// Replace the project's PostHog client with a real (but disabled, no-network)
+// PostHogMCP so `prepareToolList` / `prepareToolCall` run the actual SDK injection
+// and extraction logic — this proves dotcom's wiring against real SDK behavior,
+// not a stub.
+vi.mock('@/lib/posthog', async () => {
+    const { PostHogMCP } = await import('@posthog/mcp-analytics')
+    const client = new PostHogMCP('phc_test', { disabled: true })
+    return { getPostHogClient: () => client }
+})
+
+import { InstructionsBuilder } from '@/hono/instructions'
+import type { ResolvedState } from '@/hono/request-state-resolver'
+import { ToolCatalog } from '@/hono/tool-catalog'
+import { ToolExecutor } from '@/hono/tool-executor'
+import { getPostHogClient } from '@/lib/posthog'
+
+function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> = {}): ResolvedState {
+    return {
+        reqCtx: {
+            cache: { get: vi.fn(), set: vi.fn() },
+            getAnalyticsContextSafe: vi.fn().mockResolvedValue(undefined),
+            trackEvent: vi.fn(),
+            getSessionUuid: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        context: {
+            api: {},
+            cache: {},
+            env: {},
+            stateManager: {},
+            sessionManager: {},
+            getDistinctId: vi.fn(),
+            trackEvent: vi.fn(),
+        } as any,
+        useSingleExec: false,
+        toolFeatureFlags: undefined,
+        apiKeyScopes: [],
+        clientProfile: {
+            capabilities: { supportsInstructions: true },
+            isCliModeEnabled: vi.fn(() => false),
+        } as any,
+        requestContext: {
+            sessionId: 'sess-1',
+            mcpClientName: 'test',
+            mcpClientVersion: '1.0',
+            mcpProtocolVersion: '2025-03-26',
+            transport: 'streamable-http',
+        },
+        sessionContext: null,
+        allTools: tools as any,
+        scopeGatedTools: [],
+        distinctId: 'test-distinct-id',
+        renderUiEnabled: false,
+        ...overrides,
+    }
+}
+
+describe('ToolExecutor intent capture', () => {
+    let catalog: ToolCatalog
+    let executor: ToolExecutor
+
+    beforeAll(async () => {
+        catalog = new ToolCatalog()
+        await catalog.warmup()
+        executor = new ToolExecutor(catalog, new InstructionsBuilder(''))
+    })
+
+    it('injects the context argument into advertised tools', async () => {
+        const state = makeState([], { useSingleExec: true })
+
+        const result = await executor.handleToolsList(state)
+
+        const execEntry = result.tools.find((t) => t.name === 'exec')!
+        const properties = execEntry.inputSchema.properties as Record<string, unknown>
+        // The SDK injects `context` (required, to nudge the agent to state intent)
+        // while leaving the existing `command` arg untouched.
+        expect(properties).toHaveProperty('context')
+        expect(properties).toHaveProperty('command')
+        expect(execEntry.inputSchema.required).toContain('context')
+    })
+
+    it('forwards the agent intent to captureToolCall and strips context before the handler', async () => {
+        const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
+
+        const filteredTools = catalog
+            .getFilteredTools({ scopes: ['*'] })
+            .filter((tool) => tool.name === 'execute-sql' || tool.name === 'organization-get')
+
+        const result = (await executor.handleToolCall(
+            { name: 'exec', arguments: { command: 'tools', context: 'investigating signup drop' } },
+            makeState(filteredTools, { useSingleExec: false })
+        )) as any
+
+        // context must not break exec validation — proves it was stripped before the handler.
+        expect(result.isError).toBeFalsy()
+
+        expect(captureSpy).toHaveBeenCalledTimes(1)
+        const arg = captureSpy.mock.calls[0]![0]
+        expect(arg.toolName).toBe('exec')
+        expect(arg.intent).toBe('investigating signup drop')
+        expect(arg.intentSource).toBe('context_parameter')
+
+        captureSpy.mockRestore()
+    })
+
+    it('captures no intent when the agent omits context', async () => {
+        const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
+
+        const filteredTools = catalog
+            .getFilteredTools({ scopes: ['*'] })
+            .filter((tool) => tool.name === 'organization-get')
+
+        await executor.handleToolCall(
+            { name: 'exec', arguments: { command: 'tools' } },
+            makeState(filteredTools, { useSingleExec: false })
+        )
+
+        expect(captureSpy).toHaveBeenCalledTimes(1)
+        expect(captureSpy.mock.calls[0]![0].intent).toBeUndefined()
+
+        captureSpy.mockRestore()
+    })
+})

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -132,4 +132,44 @@ describe('ToolExecutor intent capture', () => {
 
         captureSpy.mockRestore()
     })
+
+    // A native (non-exec) tool call with context: proves the native callTool path
+    // strips context and forwards intent. captureToolCall only fires *after*
+    // validation passes (the validation-error path returns before tracking), so its
+    // being called with the intent proves context was stripped before validation.
+    // (projects-get hits the API, which the harness can't fulfill, so we assert on
+    // the captured analytics, not the tool's own result.)
+    it('strips context before a native tool validates and still forwards intent', async () => {
+        const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
+
+        await executor.handleToolCall(
+            { name: 'projects-get', arguments: { context: 'looking up the current user' } },
+            makeState([{ name: 'projects-get' }])
+        )
+
+        expect(captureSpy).toHaveBeenCalledTimes(1)
+        expect(captureSpy.mock.calls[0]![0].toolName).toBe('projects-get')
+        expect(captureSpy.mock.calls[0]![0].intent).toBe('looking up the current user')
+
+        captureSpy.mockRestore()
+    })
+
+    // Old-schema / old-client compatibility: an agent that doesn't know about the
+    // injected context arg calls with just the tool's own args. The call is handled
+    // exactly as before (a graceful result, never a thrown error) and no intent is
+    // captured.
+    it('handles a native call with no context (old-schema clients) gracefully', async () => {
+        const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
+
+        const result = (await executor.handleToolCall(
+            { name: 'projects-get', arguments: {} },
+            makeState([{ name: 'projects-get' }])
+        )) as any
+
+        expect(result.content).toBeTruthy()
+        expect(captureSpy).toHaveBeenCalledTimes(1)
+        expect(captureSpy.mock.calls[0]![0].intent).toBeUndefined()
+
+        captureSpy.mockRestore()
+    })
 })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -45,7 +45,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
     return {
         reqCtx: {
             cache: { get: vi.fn(), set: vi.fn() },
-            getAnalyticsContextSafe: vi.fn().mockResolvedValue(undefined),
+            safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             trackContextSwitchEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -29,7 +29,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
     return {
         reqCtx: {
             cache: { get: vi.fn(), set: vi.fn() },
-            getAnalyticsContextSafe: vi.fn().mockResolvedValue(undefined),
+            safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             trackContextSwitchEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -28,7 +28,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
     return {
         reqCtx: {
             cache: { get: vi.fn(), set: vi.fn() },
-            getAnalyticsContextSafe: vi.fn().mockResolvedValue(undefined),
+            safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,


### PR DESCRIPTION
## What & why

Our MCP server stopped recording two analytics signals when traffic moved from the old durable-object server (wrapped with `@posthog/mcp`'s `instrument()`) to the hono dispatcher, which hand-rolls capture:

- **`$mcp_intent`** — dead since **~May 27**. The hono path never injected the `context` argument that carries the agent's stated goal, so there was nothing to capture. The entire intent pipeline (session summaries, intent clusters) has been running on empty since.
- **`$mcp_tools_list`** — dead since **~Jun 5**. Never emitted by the hono path.

This PR wires the hono dispatcher into the SDK's server-agnostic helpers (`@posthog/mcp` `0.2.0` → `0.4.0`) to restore both, with no change to tool behavior.

## How it works

| Where | Change |
|---|---|
| `handleToolsList` | `injectContext()` adds the `context` arg to every advertised tool (via `prepareToolList`); emits `$mcp_tools_list`. |
| `handleToolCall` | `extractIntent()` reads the agent's `context`, **strips it before validation**, and forwards `intent`/`intentSource` into `captureToolCall` → `$mcp_intent`. |

Intent lands on the canonical `$mcp_tool_call` event, which is what the pipeline reads (`MCP_TOOL_CALL_EVENT = "$mcp_tool_call"`).

## How we make sure this doesn't break the server

Analytics must never affect a tool call. Three layers guarantee that:

1. **Guarded SDK calls** — `injectContext` / `extractIntent` wrap the SDK in `try/catch`; any failure falls back to the un-augmented tools / raw args. If analytics breaks, the tool call proceeds untouched.
2. **`context` is stripped before validation** — so the injected arg can never trip a tool's (often `.strict()`) zod schema. Tested on both the exec and native paths.
3. **Fire-and-forget is safe here** — the `track*` functions swallow all errors internally (never reject), and the server is a long-lived Node process with the client set to `flushAt: 1` (events flush immediately, nothing buffered to lose). `void` adds zero latency to tool responses; awaiting would only slow them down.

### Backward compatibility
`context` is injected as a *required* arg in the advertised schema (this is what drove the historical ~37–62% capture rate). Because it's stripped before our own validation, an agent that ignores it — or an old client on the pre-injection schema — still works and is never rejected. Explicitly tested ("old-schema clients" case).

### Tests
`tool-executor-intent.test.ts` drives the **real** (disabled) `PostHogMCP` and proves: context injected, intent forwarded, context stripped before validation, and no-intent / old-schema calls handled gracefully. Full hono suite green (271), `MCP Tests Pass` ✅ green in CI.

## Deferred: `get_more_tools`
Not included — dotcom already has a richer missing-capability mechanism (the `mcp-missing-capability-report` tool → structured Postgres submission, surfaced in the product). The SDK's `get_more_tools` would duplicate it and emit an event nothing reads. It's the right primitive for external customers without a backend, not for our own server.

## Lockfile note
The `pnpm-lock.yaml` diff is larger than the dep bump — `pnpm install` re-deduped stale frontend dev-deps (`@jest/core`, `@storybook/*`). It passes `--frozen-lockfile` and `ci-mcp` doesn't install the frontend workspace, so it's safe; flagging in case you want it trimmed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
