### PR TITLE
feat(slack): surface missing scopes on the OAuth landing page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -552,6 +552,34 @@ snapshots:
         hash: v1.k794b7964.046c56457e162fe1a6a5402eae7613ec9077fa44b8225006a6cbd841eb8ff0c4.SA_AUQ5ZS85jRhQIEOj-UyEZaWz5VlTlAp9_cQsRFio
     components-hogcharts-boxplot--with-gaps--light:
         hash: v1.k794b7964.086dbebb41332bd7582db67d9bdf55256172bfeb1e686de9cff5b01d1007f206.4Ne6kRBHZUB3TPLMEz9eQX-SgPC6xJoGKrX5pLrJJMU
+    components-hogcharts-combochart--area-and-line--dark:
+        hash: v1.k794b7964.8f605a0262398a127af8486f8366aa7189c5d05b170a60ccf28a2bd1a8cf5fd9.W5EftsAVdPWW-Gb_F6a6xMfF3NvNV0IZ_MmS9NJo8eU
+    components-hogcharts-combochart--area-and-line--light:
+        hash: v1.k794b7964.c44f0d154c370409dae17eea011ec37f07aa4594a43a45b484ef2eeca5474a0a.27wcQkL_HxsPmKbGWSSS-DpSOdRl4e7VlxxLSsKbrbw
+    components-hogcharts-combochart--bar-and-line--dark:
+        hash: v1.k794b7964.b21955429d27c6b8d5c27cfdd68a8ed1ffc75079a86a4ad8316c047a97fd60a3.OS8VXzqaE6vWNA6bFtRbuh_p9D2dqj85IeVef5HxI_E
+    components-hogcharts-combochart--bar-and-line--light:
+        hash: v1.k794b7964.a78617b48bd4437d57cd358b877670756ea8fca8df8113d7e3e748e76d631cfa.w6hla1sm0Gz6G4tpPRJf5Z0CApBEOXDIwsww549N5Zc
+    components-hogcharts-combochart--dual-y-axis-bar-and-line--dark:
+        hash: v1.k794b7964.bb893b324bfa2950c0157bc551b57e76b03df90e6e31c58cac048a6a6de9064f.SaLLI0K0hz-OHDCn0dnX_nr2TRyRdOvLmcbA1Klc2Hg
+    components-hogcharts-combochart--dual-y-axis-bar-and-line--light:
+        hash: v1.k794b7964.6a9f32434af77dc1d31226a9da134cf4acf6755aa1f17d2e1e48128b5196e042.Jv1n1TWojcqnGkdkJgNBxSYE_wrY6qH3sXe4XSqeJk4
+    components-hogcharts-combochart--empty--dark:
+        hash: v1.k794b7964.f4a02c6786a1fc031877e1581c74c93043890f855bfeec936e129b325f49f76b.21F6xAcfwYF6PdHfpIqr3VCoc7Eqv3hTqu8hFJmxGLU
+    components-hogcharts-combochart--empty--light:
+        hash: v1.k794b7964.8003169247a00bdd087cdb86efd11744f27c426f7dcbd0f8fc46ccace7ec5de1.r0Z_eyPmkICfKYBEAZR-I3S-Lof7ljfkGLhHtLjMGVs
+    components-hogcharts-combochart--grouped-bars-and-line--dark:
+        hash: v1.k794b7964.8a550c027166e56da8c962f6bfd2e958e227fcbafde6eff9f3f8fef2d70c4f25.6kjnUQTu2QGNSGd30u0gSrtC8roD4JvbuESkTctefGs
+    components-hogcharts-combochart--grouped-bars-and-line--light:
+        hash: v1.k794b7964.8ef0eba984169f1bf0d9950d347cc45fb89230d78d8f7204d67fe2e359344182.IbP2UuwBNtQZGhnmTDFD5TFbM4zjl4FkWpVa40SM3eI
+    components-hogcharts-combochart--line-before-area--dark:
+        hash: v1.k794b7964.6c582af133b6e0cc8cfaebeed45af068d1768c2c5ed3f6fb679a699bb13f2562.o-bzHuxXKWt0xvfT9JynURDbZX3NcFb5CMQ2egLorHU
+    components-hogcharts-combochart--line-before-area--light:
+        hash: v1.k794b7964.503d8e4ba77dafcc7ae5ab9c32d7b17c0dd137d007b201bf6b23a34104283a3a.wFjmc7u_FZTXGygOMkHDYPE51dYrhBm58m7lBDIePzs
+    components-hogcharts-combochart--stacked-bars-and-line--dark:
+        hash: v1.k794b7964.902c9be7688a67190b37eb789707bf2189b13e6c460cef63e1070dfc17196184.gxj4XB703vlholt4Z8TC2bjHVRiWJMMwT3xap2L1Sfg
+    components-hogcharts-combochart--stacked-bars-and-line--light:
+        hash: v1.k794b7964.da86914291718262e6fc1aa52483bcca08ac08c9c2fad67c5f877d6cf78151f7.qO61mSB67aOC7auAYE6KLt69LLRyWdM_VM-Vf0qrq6Q
     components-hogcharts-legend--horizontal--dark:
         hash: v1.k794b7964.748c8221979ca1984c3ef06b0a2d5016e683810a2530a2b7549ff2994484d32d.WlgOW_onzflesCUfetduXiySjbl4uF8oTLxdKf4xYso
     components-hogcharts-legend--horizontal--light:
@@ -952,14 +980,26 @@ snapshots:
         hash: v1.k794b7964.923047d63ec1ae864e60b7b86cfac17b0d5f6219a30d49cd5136f01ff0484e29.NuIevRcOCohA9RKgPAqDQ4LePOvXKSWlle-moHjrNMQ
     components-insighttooltip--math-tags-single-series--light:
         hash: v1.k794b7964.d24656089329001d29308a16f3e6a1c3e462bc441399753a7d34cbbbcbea7b52.5lWzjuoDbPhC3rdjisXnHNn7RfsfgBdtjtl89icOwlc
+    components-integrations-slack--slack-full-page-connect--dark:
+        hash: v1.k794b7964.51583f338ebbc9431907cf88e2a9203eac9d935bf9b1239c4719ec2b0d8fde60.QaekG_L27F8dbaTbN7cZhq55VHrO7eZoZzasZQJ8zcQ
+    components-integrations-slack--slack-full-page-connect--light:
+        hash: v1.k794b7964.887985c176c1acc4a271e7035ff0df683b21db6df6a4b2e5ee5b9d57ea450892.Fu27S76ove9JpMONVMPLJKnrFC6tKRtcWQJ_x4zEAWA
+    components-integrations-slack--slack-full-page-connected-all-scopes--dark:
+        hash: v1.k794b7964.a98f3a60ecef683efb4fdf3cbc58286ebc98f570b44fe24c97ed0668c51064eb.DPIIxII9L49YGcc_NOiAjR8p2cJ_5JDuw5c2hwVcYac
+    components-integrations-slack--slack-full-page-connected-all-scopes--light:
+        hash: v1.k794b7964.b23d81fff71cd1d4cee2efa42ba7a4db827ad2a0ec09138716f01f3605b99322.KMT66t2fhW4MExoWKAe6__v5CL8l4L5qBLjHOI029MY
+    components-integrations-slack--slack-full-page-connected-missing-scopes--dark:
+        hash: v1.k794b7964.13446a4ebca85a6c734614405d1e52e58c8b4526650761a81c7c9dea1487e108.kYq2Z2ogm7O6RInvJ5UGxBuxHzaR_Vp2-18KmOlp27A
+    components-integrations-slack--slack-full-page-connected-missing-scopes--light:
+        hash: v1.k794b7964.d6899b66373d28d2340c90fad643cc13a62301ca1454c084ba1036a8d2c1d5b4.jLOVtJQun2Ow8TsRSoRB0-BpkgDTNeVT_1GVriGXMQ4
     components-integrations-slack--slack-integration--dark:
         hash: v1.k794b7964.b9ee8adc2251177b325e3775fe7fd391540c3dba77c06d9da9db33ec80eddf81.0Jsmo2XKYiKkfSVMN4GzeK-ePRjh4q_l60Ez2M90L58
     components-integrations-slack--slack-integration--light:
         hash: v1.k794b7964.5e31191fe884081eaecccc0ca410571bfea114969731061b25274559c377e9c2.48o8xuoIkdsSSYnrrvbAKMwn9XvAGobjR0zC3-wD7bc
     components-integrations-slack--slack-integration-added--dark:
-        hash: v1.k794b7964.b9ee8adc2251177b325e3775fe7fd391540c3dba77c06d9da9db33ec80eddf81.bsnv2iCt7wmYW7NkkBCcYY4qe9uGkjk1co5S1VY-12A
+        hash: v1.k794b7964.a1ad42b0f0f975569b93110a669febd3e486f6b90ee785b80979ae83dcbff1db.hV7aqt2bShW5KttL4NDjY3p-mcL2bXJKtEJJvQhn8ao
     components-integrations-slack--slack-integration-added--light:
-        hash: v1.k794b7964.5e31191fe884081eaecccc0ca410571bfea114969731061b25274559c377e9c2.Tz-VqjD9I4B2AkjAU8Z5Aje26LxOJs2i3LfzLBbLoPU
+        hash: v1.k794b7964.ed6cb6ffb8918525982aca7a4eed6c21a239d5cacfe49c0c81898e842fd012ac.c_YqaIbzzzNXueagP2l8S4VMtTe870p7kVDnC6P-27A
     components-integrations-slack--slack-integration-instance-not-configured--dark:
         hash: v1.k794b7964.b9ee8adc2251177b325e3775fe7fd391540c3dba77c06d9da9db33ec80eddf81.VkdQOtlSqpDDliAWoEWxISdK8UUYqJyt7gFvAGeB7HE
     components-integrations-slack--slack-integration-instance-not-configured--light:
@@ -6585,9 +6625,9 @@ snapshots:
     scenes-other-billing-product--billing-product-without-addons--light:
         hash: v1.k794b7964.3455fe6bd5eb074408ff091675444e597f9c7a34d232faa0f392a3fcb4f6e021.2FmYvUHcc47NK-z0ntILzg44Any6Y947VSerITyrL6k
     scenes-other-integration-landing-page--connected--dark:
-        hash: v1.k794b7964.c3f38cb69619148711f73cbd2358e9879a628dedce0133ddf4a55c909eb74023.TKSLIKWkZhyP9yVqCUNnOWE-phlM8jkN2hg7yhVk-x8
+        hash: v1.k794b7964.7012e3f23570ed0bdf0af3b947fa8b09bb1a40edd59928bea76c9472eef444a1.yWbx-kU4Sx_plVguU1neQn8eHFiPseBMjmr8tCiy6O0
     scenes-other-integration-landing-page--connected--light:
-        hash: v1.k794b7964.75ccf59d3aeba8ec4f6036dacc9812fad6ac24ebcc8988f74c0de3b4d0ae2ffb.NXnkDcwqc_lAqnRMFjZA4hgi6DiLOx_pL6TfEKmzK7s
+        hash: v1.k794b7964.ecea4a3cebed2c5fba619695c4ca576cfa0ce3a9a818af498791c1080be2675e.nkq28LhIVvheqMxYLdV5Od1eeCXKI1AFgIKfcbUOAEw
     scenes-other-integration-landing-page--not-connected--dark:
         hash: v1.k794b7964.cbc1efc83f9f31ee7ed22a7da2be3ec19e7e6f6568a5b43ade5f75ee4aaccbc5.u1nKAJkTALr_RPPMm4EA68pFFF4JE03AJBqWleTvbJk
     scenes-other-integration-landing-page--not-connected--light:

--- a/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
+++ b/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
@@ -55,7 +55,7 @@ export function IntegrationScopesWarning({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
-    const grantedScopes = useMemo(() => getGrantedScopes(integration), [integration.config])
+    const grantedScopes = useMemo(() => getGrantedScopes(integration), [integration.config, integration])
     const requiredScopes = schema?.requiredScopes?.split(' ') || []
     const missingScopes = requiredScopes.filter((scope) => !grantedScopes.includes(scope))
 

--- a/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
+++ b/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
@@ -8,6 +8,40 @@ import { Link } from 'lib/lemon-ui/Link'
 
 import { IntegrationType } from '~/types'
 
+/**
+ * Extract the granted OAuth scopes from an integration's stored config. Tolerates the
+ * various shapes different providers persist: ``config.scope`` vs ``config.scopes``,
+ * space- or comma-separated strings, or a pre-split array. Returns an empty array when
+ * no recognizable scope list is present (e.g. legacy rows predating the field).
+ *
+ * Exported so any caller that needs to decide "is this install missing a scope" (the
+ * banner below, the OAuth landing-page status hook, etc.) reaches the same verdict.
+ */
+export function getGrantedScopes(integration: IntegrationType): string[] {
+    const scopes: any[] = []
+    const possibleScopeLocation = [integration.config.scope, integration.config.scopes]
+
+    possibleScopeLocation.map((scope) => {
+        if (typeof scope === 'string') {
+            scopes.push(scope.split(' '))
+            scopes.push(scope.split(','))
+        }
+        if (typeof scope === 'object') {
+            scopes.push(scope)
+        }
+    })
+    return scopes.filter((scope: any) => typeof scope === 'object').reduce((a, b) => (a.length > b.length ? a : b), [])
+}
+
+/** Scopes from ``schema.requiredScopes`` that the integration hasn't granted. */
+export function getMissingScopes(integration: IntegrationType, requiredScopes: string[]): string[] {
+    const granted = getGrantedScopes(integration)
+    if (granted.length === 0) {
+        return []
+    }
+    return requiredScopes.filter((scope) => !granted.includes(scope))
+}
+
 export function IntegrationScopesWarning({
     integration,
     schema,
@@ -19,28 +53,11 @@ export function IntegrationScopesWarning({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
-    const getScopes = useMemo((): string[] => {
-        const scopes: any[] = []
-        const possibleScopeLocation = [integration.config.scope, integration.config.scopes]
-
-        possibleScopeLocation.map((scope) => {
-            if (typeof scope === 'string') {
-                scopes.push(scope.split(' '))
-                scopes.push(scope.split(','))
-            }
-            if (typeof scope === 'object') {
-                scopes.push(scope)
-            }
-        })
-        return scopes
-            .filter((scope: any) => typeof scope === 'object')
-            .reduce((a, b) => (a.length > b.length ? a : b), [])
-    }, [integration.config])
-
+    const grantedScopes = useMemo(() => getGrantedScopes(integration), [integration.config])
     const requiredScopes = schema?.requiredScopes?.split(' ') || []
-    const missingScopes = requiredScopes.filter((scope: string) => !getScopes.includes(scope))
+    const missingScopes = requiredScopes.filter((scope) => !grantedScopes.includes(scope))
 
-    if (missingScopes.length === 0 || getScopes.length === 0) {
+    if (missingScopes.length === 0 || grantedScopes.length === 0) {
         return <></>
     }
     return (

--- a/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
+++ b/frontend/src/lib/integrations/IntegrationScopesWarning.tsx
@@ -18,19 +18,21 @@ import { IntegrationType } from '~/types'
  * banner below, the OAuth landing-page status hook, etc.) reaches the same verdict.
  */
 export function getGrantedScopes(integration: IntegrationType): string[] {
-    const scopes: any[] = []
-    const possibleScopeLocation = [integration.config.scope, integration.config.scopes]
+    const candidates: string[][] = []
 
-    possibleScopeLocation.map((scope) => {
-        if (typeof scope === 'string') {
-            scopes.push(scope.split(' '))
-            scopes.push(scope.split(','))
+    for (const raw of [integration.config.scope, integration.config.scopes]) {
+        if (typeof raw === 'string') {
+            // Pick the delimiter explicitly. Pushing both comma- and space-split results and
+            // letting "longest array wins" decide was a heuristic that silently mangled mixed
+            // delimiters like ``"read write,admin"`` into one of several wrong shapes.
+            const split = raw.includes(',') ? raw.split(',') : raw.split(' ')
+            candidates.push(split.map((scope) => scope.trim()).filter(Boolean))
+        } else if (Array.isArray(raw)) {
+            candidates.push(raw)
         }
-        if (typeof scope === 'object') {
-            scopes.push(scope)
-        }
-    })
-    return scopes.filter((scope: any) => typeof scope === 'object').reduce((a, b) => (a.length > b.length ? a : b), [])
+    }
+
+    return candidates.reduce((a, b) => (a.length > b.length ? a : b), [] as string[])
 }
 
 /** Scopes from ``schema.requiredScopes`` that the integration hasn't granted. */

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -119,7 +119,11 @@ function ConnectedView({
                     {ok ? `You're connected to ${definition.name}` : `${definition.name} is connected, with caveats`}
                 </h1>
                 <p className="text-secondary m-0">
-                    {ok ? 'Everything is set up and ready to go.' : 'Review the items below before using it.'}
+                    {ok
+                        ? 'Everything is set up and ready to go.'
+                        : PostConnect
+                          ? 'Review the items below before using it.'
+                          : 'Some settings may need your attention.'}
                 </p>
             </div>
 

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -1,13 +1,15 @@
 import { useActions, useValues } from 'kea'
 
-import { IconArrowLeft, IconCheckCircle } from '@posthog/icons'
+import { IconArrowLeft, IconCheckCircle, IconWarning } from '@posthog/icons'
 import { LemonButton, Link, Spinner } from '@posthog/lemon-ui'
 
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
 
-import { IntegrationDefinition, SettingsSectionComponent } from './integrationTypes'
+import { IntegrationType } from '~/types'
+
+import { IntegrationDefinition, IntegrationStatus, SettingsSectionComponent } from './integrationTypes'
 
 export function IntegrationFullPage({
     definition,
@@ -18,7 +20,8 @@ export function IntegrationFullPage({
 }): JSX.Element {
     const { getIntegrationsByKind, integrationsLoading } = useValues(integrationsLogic)
 
-    const connected = getIntegrationsByKind([definition.kind]).length > 0
+    const integrations = getIntegrationsByKind([definition.kind])
+    const connected = integrations.length > 0
 
     return (
         <div className="flex flex-col items-center justify-center min-h-full w-full p-4">
@@ -39,7 +42,7 @@ export function IntegrationFullPage({
                     {integrationsLoading ? (
                         <Spinner className="text-2xl" />
                     ) : connected ? (
-                        <ConnectedView definition={definition} />
+                        <ConnectedView definition={definition} integrations={integrations} />
                     ) : (
                         <ConnectView definition={definition} SettingsSection={SettingsSection} />
                     )}
@@ -90,15 +93,43 @@ function ConnectView({
     )
 }
 
-function ConnectedView({ definition }: { definition: IntegrationDefinition }): JSX.Element {
+function ConnectedView({
+    definition,
+    integrations,
+}: {
+    definition: IntegrationDefinition
+    integrations: IntegrationType[]
+}): JSX.Element {
+    const PostConnect = definition.PostConnect
+    // Default to ``ok`` when no status hook is provided so today's integrations keep their
+    // current "Everything is set up" copy without each having to opt in.
+    const status: IntegrationStatus = definition.useStatus?.(integrations) ?? 'ok'
+    const ok = status === 'ok'
+
     return (
         <>
-            <IconCheckCircle className="text-success text-4xl" />
+            {ok ? (
+                <IconCheckCircle className="text-success text-4xl" />
+            ) : (
+                <IconWarning className="text-warning text-4xl" />
+            )}
 
             <div className="flex flex-col items-center gap-1 text-center">
-                <h1 className="text-2xl font-bold m-0">You're connected to {definition.name}</h1>
-                <p className="text-secondary m-0">Everything is set up and ready to go.</p>
+                <h1 className="text-2xl font-bold m-0">
+                    {ok ? `You're connected to ${definition.name}` : `${definition.name} is connected, with caveats`}
+                </h1>
+                <p className="text-secondary m-0">
+                    {ok ? 'Everything is set up and ready to go.' : 'Review the items below before using it.'}
+                </p>
             </div>
+
+            {PostConnect ? (
+                <div className="w-full flex flex-col gap-2">
+                    {integrations.map((integration) => (
+                        <PostConnect key={integration.id} integration={integration} />
+                    ))}
+                </div>
+            ) : null}
 
             {definition.capabilities.length > 0 ? (
                 <div className="w-full">

--- a/frontend/src/scenes/integrations/components/SlackIntegration.stories.tsx
+++ b/frontend/src/scenes/integrations/components/SlackIntegration.stories.tsx
@@ -3,11 +3,22 @@ import { Meta, StoryObj } from '@storybook/react'
 import { useStorybookMocks } from '~/mocks/browser'
 import { useAvailableFeatures } from '~/mocks/features'
 import { mockIntegration } from '~/test/mocks'
-import { AvailableFeature } from '~/types'
+import {
+    AvailableFeature,
+    IntegrationType,
+    SLACK_INTEGRATION_SCOPES,
+    SLACK_INTEGRATION_SCOPES_IN_REVIEW,
+} from '~/types'
 
+import { Slack } from '../definitions/slack'
 import { SlackIntegration } from './SlackIntegration'
 
 type StoryArgs = { instanceConfigured?: boolean; integrated?: boolean }
+
+const SLACK_INSTANCE_SETTINGS = [
+    { key: 'SLACK_APP_CLIENT_ID', value: '910200304849.3676478528614' },
+    { key: 'SLACK_APP_CLIENT_SECRET', value: '*****' },
+]
 
 const meta: Meta<StoryArgs> = {
     title: 'Components/Integrations/Slack',
@@ -18,20 +29,9 @@ const meta: Meta<StoryArgs> = {
 
         useStorybookMocks({
             get: {
-                '/api/projects/:id/integrations': { results: integrated ? [mockIntegration] : [] },
+                '/api/environments/:id/integrations': { results: integrated ? [mockIntegration] : [] },
                 '/api/instance_settings': {
-                    results: instanceConfigured
-                        ? [
-                              {
-                                  key: 'SLACK_APP_CLIENT_ID',
-                                  value: '910200304849.3676478528614',
-                              },
-                              {
-                                  key: 'SLACK_APP_CLIENT_SECRET',
-                                  value: '*****',
-                              },
-                          ]
-                        : [],
+                    results: instanceConfigured ? SLACK_INSTANCE_SETTINGS : [],
                 },
             },
         })
@@ -51,4 +51,57 @@ export const SlackIntegrationInstanceNotConfigured: Story = {
 
 export const SlackIntegrationAdded: Story = {
     args: { integrated: true },
+}
+
+// ---- OAuth landing page (``/project/:id/integrations/slack``) ----------------------------
+//
+// The settings-side ``SlackIntegration`` component above does not exercise the full-page
+// success / warning surface that the OAuth callback lands users on. These stories render
+// ``Slack.FullPage`` against a mocked integrations endpoint so the green-success and
+// missing-scope warning states appear in snapshot diffs.
+
+const renderFullPage = ({ integrations }: { integrations: IntegrationType[] }): JSX.Element => {
+    useAvailableFeatures([AvailableFeature.SUBSCRIPTIONS])
+    useStorybookMocks({
+        get: {
+            '/api/environments/:id/integrations': { results: integrations },
+            '/api/instance_settings': { results: SLACK_INSTANCE_SETTINGS },
+        },
+    })
+    return <Slack.FullPage />
+}
+
+const mockSlackIntegrationWithScopes = (scopes: string[]): IntegrationType => ({
+    ...mockIntegration,
+    config: { ...mockIntegration.config, scope: scopes.join(',') },
+})
+
+export const SlackFullPageConnect: StoryObj = {
+    name: 'Full Page — Connect',
+    render: () => renderFullPage({ integrations: [] }),
+}
+
+export const SlackFullPageConnectedAllScopes: StoryObj = {
+    name: 'Full Page — Connected (all scopes)',
+    // Storybook runs with ``isDev === true``, so ``useSlackRequiredScopes`` returns the union
+    // of the always-on and in-review sets. Mirror that here so the green-success state isn't
+    // immediately undone by missing in-review scopes.
+    render: () =>
+        renderFullPage({
+            integrations: [
+                mockSlackIntegrationWithScopes([...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]),
+            ],
+        }),
+}
+
+export const SlackFullPageConnectedMissingScopes: StoryObj = {
+    name: 'Full Page — Connected (missing scopes)',
+    render: () =>
+        renderFullPage({
+            // A legacy notifications-only scope set: enough to send messages, but missing
+            // app_mentions:read / users:read* etc., so the page should flip into "needs attention".
+            integrations: [
+                mockSlackIntegrationWithScopes(['channels:read', 'groups:read', 'chat:write', 'chat:write.customize']),
+            ],
+        }),
 }

--- a/frontend/src/scenes/integrations/components/SlackIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/SlackIntegration.tsx
@@ -9,11 +9,12 @@ import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedAr
 import { TeamMembershipLevel } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { Region, SLACK_INTEGRATION_SCOPES, SLACK_INTEGRATION_SCOPES_IN_REVIEW } from '~/types'
+import { SLACK_INTEGRATION_SCOPES } from '~/types'
+
+import { useSlackRequiredScopes } from './slackScopes'
 
 // Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance.
 const getSlackAppManifest = (): any => ({
@@ -53,7 +54,6 @@ const getSlackAppManifest = (): any => ({
 
 export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element {
     const { slackIntegrations, slackAvailable } = useValues(integrationsLogic)
-    const { preflight, isDev } = useValues(preflightLogic)
     const [showSlackInstructions, setShowSlackInstructions] = useState(false)
     const { user } = useValues(userLogic)
     const restrictedReason = useRestrictedArea({
@@ -61,17 +61,8 @@ export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element 
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
-    // On the DEV instance and local dev (DEBUG=True) the PostHog Slack app manifest lists the
-    // in-review scopes, so we both request them at install and compare against them in the
-    // scope-mismatch banner. On US/EU/self-hosted they'd be rejected by Slack as invalid_scope,
-    // so we stay on the always-on list.
-    const requiredScopes = useMemo(() => {
-        const scopes =
-            isDev || preflight?.region === Region.DEV
-                ? [...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]
-                : SLACK_INTEGRATION_SCOPES
-        return scopes.join(' ')
-    }, [isDev, preflight?.region])
+    const requiredScopesArr = useSlackRequiredScopes()
+    const requiredScopes = useMemo(() => requiredScopesArr.join(' '), [requiredScopesArr])
 
     if (restrictedReason) {
         return <p>{restrictedReason}</p>

--- a/frontend/src/scenes/integrations/components/slackScopes.ts
+++ b/frontend/src/scenes/integrations/components/slackScopes.ts
@@ -1,0 +1,29 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { Region, SLACK_INTEGRATION_SCOPES, SLACK_INTEGRATION_SCOPES_IN_REVIEW } from '~/types'
+
+/**
+ * Required Slack OAuth scopes for the current PostHog instance.
+ *
+ * On the DEV instance and local dev the PostHog Slack app manifest lists the in-review
+ * scopes, so we both request them at install and compare against them here. Anywhere
+ * else (US / EU / self-hosted) Slack rejects them as ``invalid_scope`` so we stay on
+ * the always-on list.
+ *
+ * Used by both the settings-side ``SlackIntegration`` connect/manage UI and the OAuth
+ * landing page's status hook so the two surfaces always agree on what "fully scoped"
+ * means.
+ */
+export function useSlackRequiredScopes(): string[] {
+    const { preflight, isDev } = useValues(preflightLogic)
+    return useMemo(
+        () =>
+            isDev || preflight?.region === Region.DEV
+                ? [...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]
+                : [...SLACK_INTEGRATION_SCOPES],
+        [isDev, preflight?.region]
+    )
+}

--- a/frontend/src/scenes/integrations/definitions/slack.tsx
+++ b/frontend/src/scenes/integrations/definitions/slack.tsx
@@ -1,7 +1,68 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
 import { ICONS } from 'lib/integrations/utils'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { IntegrationType, Region, SLACK_INTEGRATION_SCOPES, SLACK_INTEGRATION_SCOPES_IN_REVIEW } from '~/types'
 
 import { SlackIntegration } from '../components/SlackIntegration'
 import { defineIntegration } from '../integrationDefinition'
+import { IntegrationStatus } from '../integrationTypes'
+
+// Required-scope construction mirrors ``SlackIntegration``'s settings-side computation: on the
+// DEV instance and local dev the PostHog Slack app manifest lists extra in-review scopes, so
+// we both request them at install and compare against them. Anywhere else they'd be rejected
+// by Slack as ``invalid_scope`` and would falsely flag the install as broken.
+function useSlackRequiredScopes(): string[] {
+    const { preflight, isDev } = useValues(preflightLogic)
+    return useMemo(
+        () =>
+            isDev || preflight?.region === Region.DEV
+                ? [...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]
+                : [...SLACK_INTEGRATION_SCOPES],
+        [isDev, preflight?.region]
+    )
+}
+
+function parseGrantedScopes(integration: IntegrationType): string[] {
+    // Slack returns the scopes as a comma-separated string under ``config.scope``. The
+    // settings-side ``IntegrationScopesWarning`` is more permissive (also checks ``scopes``
+    // and accepts arrays) for cross-integration reuse; here we match Slack's actual shape.
+    const raw = integration.config?.scope
+    if (typeof raw !== 'string') {
+        return []
+    }
+    return raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+}
+
+// Render the scopes-mismatch banner directly under the OAuth success card so an install with
+// the wrong scope set surfaces it while the user is still in the install flow, instead of
+// hiding it behind a separate trip to Settings → Integrations that they have no reason to take.
+function SlackPostConnect({ integration }: { integration: IntegrationType }): JSX.Element {
+    const requiredScopes = useSlackRequiredScopes()
+    return <IntegrationScopesWarning integration={integration} schema={{ requiredScopes: requiredScopes.join(' ') }} />
+}
+
+// Aggregate status feeding the landing page headline: any install missing required scopes
+// drops the whole page into the "needs attention" state. We don't flag an install with no
+// scopes recorded at all — that's typically a legacy row predating the scope field, and
+// ``IntegrationScopesWarning`` already declines to render in that case.
+function useSlackStatus(integrations: IntegrationType[]): IntegrationStatus {
+    const requiredScopes = useSlackRequiredScopes()
+    const anyNeedsAttention = integrations.some((integration) => {
+        const granted = parseGrantedScopes(integration)
+        if (granted.length === 0) {
+            return false
+        }
+        return requiredScopes.some((scope) => !granted.includes(scope))
+    })
+    return anyNeedsAttention ? 'needs_attention' : 'ok'
+}
 
 export const Slack = defineIntegration(
     {
@@ -21,6 +82,8 @@ export const Slack = defineIntegration(
             'Manage feature flags, experiments, and surveys from Slack',
         ],
         docsUrl: 'https://posthog.com/docs/webhooks/slack',
+        PostConnect: SlackPostConnect,
+        useStatus: useSlackStatus,
     },
     SlackIntegration
 )

--- a/frontend/src/scenes/integrations/definitions/slack.tsx
+++ b/frontend/src/scenes/integrations/definitions/slack.tsx
@@ -1,44 +1,12 @@
-import { useValues } from 'kea'
-import { useMemo } from 'react'
-
-import { IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
+import { getMissingScopes, IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
 import { ICONS } from 'lib/integrations/utils'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-import { IntegrationType, Region, SLACK_INTEGRATION_SCOPES, SLACK_INTEGRATION_SCOPES_IN_REVIEW } from '~/types'
+import { IntegrationType } from '~/types'
 
 import { SlackIntegration } from '../components/SlackIntegration'
+import { useSlackRequiredScopes } from '../components/slackScopes'
 import { defineIntegration } from '../integrationDefinition'
 import { IntegrationStatus } from '../integrationTypes'
-
-// Required-scope construction mirrors ``SlackIntegration``'s settings-side computation: on the
-// DEV instance and local dev the PostHog Slack app manifest lists extra in-review scopes, so
-// we both request them at install and compare against them. Anywhere else they'd be rejected
-// by Slack as ``invalid_scope`` and would falsely flag the install as broken.
-function useSlackRequiredScopes(): string[] {
-    const { preflight, isDev } = useValues(preflightLogic)
-    return useMemo(
-        () =>
-            isDev || preflight?.region === Region.DEV
-                ? [...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]
-                : [...SLACK_INTEGRATION_SCOPES],
-        [isDev, preflight?.region]
-    )
-}
-
-function parseGrantedScopes(integration: IntegrationType): string[] {
-    // Slack returns the scopes as a comma-separated string under ``config.scope``. The
-    // settings-side ``IntegrationScopesWarning`` is more permissive (also checks ``scopes``
-    // and accepts arrays) for cross-integration reuse; here we match Slack's actual shape.
-    const raw = integration.config?.scope
-    if (typeof raw !== 'string') {
-        return []
-    }
-    return raw
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-}
 
 // Render the scopes-mismatch banner directly under the OAuth success card so an install with
 // the wrong scope set surfaces it while the user is still in the install flow, instead of
@@ -49,18 +17,13 @@ function SlackPostConnect({ integration }: { integration: IntegrationType }): JS
 }
 
 // Aggregate status feeding the landing page headline: any install missing required scopes
-// drops the whole page into the "needs attention" state. We don't flag an install with no
-// scopes recorded at all — that's typically a legacy row predating the scope field, and
-// ``IntegrationScopesWarning`` already declines to render in that case.
+// drops the whole page into the "needs attention" state. ``getMissingScopes`` returns []
+// for legacy rows that have no scopes recorded — same fail-open behavior as the banner.
 function useSlackStatus(integrations: IntegrationType[]): IntegrationStatus {
     const requiredScopes = useSlackRequiredScopes()
-    const anyNeedsAttention = integrations.some((integration) => {
-        const granted = parseGrantedScopes(integration)
-        if (granted.length === 0) {
-            return false
-        }
-        return requiredScopes.some((scope) => !granted.includes(scope))
-    })
+    const anyNeedsAttention = integrations.some(
+        (integration) => getMissingScopes(integration, requiredScopes).length > 0
+    )
     return anyNeedsAttention ? 'needs_attention' : 'ok'
 }
 

--- a/frontend/src/scenes/integrations/integrationTypes.ts
+++ b/frontend/src/scenes/integrations/integrationTypes.ts
@@ -1,7 +1,29 @@
-import { IntegrationKind } from '~/types'
+import { IntegrationKind, IntegrationType } from '~/types'
 
 /** The actionable connect section, reused in both settings and the full page. */
 export type SettingsSectionComponent = (props: { next?: string }) => JSX.Element
+
+/**
+ * Optional slot rendered on the OAuth landing page directly below the success card,
+ * for each connected integration of this kind. Use it to surface follow-up state
+ * the user must act on while they're still in the install flow — missing scopes,
+ * incomplete configuration, channel selection, etc. — rather than relegating it to
+ * the integrations management screen they may never revisit.
+ */
+export type PostConnectComponent = (props: { integration: IntegrationType }) => JSX.Element
+
+/** Aggregate state used by the OAuth landing page to pick its headline + icon. */
+export type IntegrationStatus = 'ok' | 'needs_attention'
+
+/**
+ * Optional hook called once with every connected integration of this kind so the
+ * landing page can switch from "Everything is set up" to a warning state when any
+ * install needs follow-up action (e.g. missing scopes).
+ *
+ * Must follow the Rules of Hooks — call inner hooks unconditionally — because the
+ * page invokes it exactly once on every render.
+ */
+export type IntegrationStatusHook = (integrations: IntegrationType[]) => IntegrationStatus
 
 /**
  * Pure metadata describing an integration. Deliberately holds no components so each
@@ -26,6 +48,17 @@ export interface IntegrationDefinition {
     capabilities: string[]
     /** Optional documentation link. */
     docsUrl?: string
+    /**
+     * Optional component rendered per connected integration on the OAuth landing page,
+     * below the success card. See {@link PostConnectComponent}.
+     */
+    PostConnect?: PostConnectComponent
+    /**
+     * Optional aggregate-status hook. When provided and it returns ``needs_attention``,
+     * the landing page swaps the green checkmark + "Everything is set up and ready to go"
+     * copy for a warning icon and follow-up copy that points at {@link PostConnect}.
+     */
+    useStatus?: IntegrationStatusHook
 }
 
 /** A definition bundled with its renderable components. */


### PR DESCRIPTION
## Problem

If a Slack install is missing the scopes the agent flow needs, the OAuth landing page still shows a green checkmark and "Everything is set up and ready to go." It should tell the user instead.


## Changes

Two optional slots on `IntegrationDefinition`:

| Slot | Role |
|---|---|
| `useStatus` | Aggregate `'ok' \| 'needs_attention'` hook. When any install needs attention, the page swaps the checkmark + success copy for a warning icon and follow-up copy. |
| `PostConnect` | Component rendered per connected integration below the success card. Slack wires it to the existing `IntegrationScopesWarning`. |

`getGrantedScopes` / `getMissingScopes` lifted out of `IntegrationScopesWarning` and a shared `useSlackRequiredScopes` hook added, so the settings view and landing page derive their verdict from the same code and can't drift.

Integrations without `useStatus` / `PostConnect` are unchanged.

## How did you test this code?

End-to-end tested locally in the running PostHog dev app.

## Showcase

<img width="692" height="851" alt="Screenshot 2026-06-18 at 16 57 33" src="https://github.com/user-attachments/assets/76472c2f-13f2-49f2-b9ff-ebfff07e9336" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Claude Opus 4.7. End-to-end tested locally.