### PR TITLE
feat(logs): isolate via facade contracts + tach interface

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -94,14 +94,14 @@ from products.feature_flags.backend.models.evaluation_context import (
     TeamDefaultEvaluationContext,
     normalize_context_name,
 )
-from products.logs.backend.models import TeamLogsConfig
+from products.logs.backend.facade import api as logs_facade
 from products.signals.backend.models import SignalSourceConfig
 from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
 
 tracer = trace.get_tracer(__name__)
 
 
-class TeamLogsConfigSerializer(serializers.ModelSerializer):
+class TeamLogsConfigSerializer(serializers.Serializer):
     logs_distinct_id_attribute_key = serializers.CharField(
         max_length=200,
         help_text=(
@@ -114,24 +114,24 @@ class TeamLogsConfigSerializer(serializers.ModelSerializer):
         ),
     )
 
-    class Meta:
-        model = TeamLogsConfig
-        fields = ["logs_distinct_id_attribute_key"]
-
 
 def handle_logs_config(request: request.Request, team: Team) -> response.Response:
     """Shared handler for the logs_config action — exposed under both the team/environment
     and project routers so the canonical /api/projects/ URL resolves alongside the legacy
-    /api/environments/ alias. Both endpoints operate on the env-scoped TeamLogsConfig
+    /api/environments/ alias. Both endpoints operate on the env-scoped logs config
     keyed by team_id."""
-    config = get_or_create_team_extension(team, TeamLogsConfig)
-
     if request.method == "PATCH":
-        serializer = TeamLogsConfigSerializer(config, data=request.data, partial=True)
+        serializer = TeamLogsConfigSerializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
-        return response.Response(serializer.data)
+        if "logs_distinct_id_attribute_key" in serializer.validated_data:
+            config = logs_facade.update_team_logs_config(
+                team, serializer.validated_data["logs_distinct_id_attribute_key"]
+            )
+        else:
+            config = logs_facade.get_team_logs_config(team)
+        return response.Response(TeamLogsConfigSerializer(config).data)
 
+    config = logs_facade.get_team_logs_config(team)
     return response.Response(TeamLogsConfigSerializer(config).data)
 
 

--- a/posthog/api/test/test_team_logs_config.py
+++ b/posthog/api/test/test_team_logs_config.py
@@ -4,9 +4,8 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import OrganizationMembership, Team
-from posthog.models.team.extensions import get_or_create_team_extension
 
-from products.logs.backend.models import TeamLogsConfig
+from products.logs.backend.facade import api as logs_facade
 
 # Both routes resolve to the same handler — /api/projects/ is canonical, /api/environments/
 # remains as the back-compat alias. See `handle_logs_config` in posthog/api/team.py.
@@ -40,7 +39,7 @@ class TestTeamLogsConfig(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"logs_distinct_id_attribute_key": "user.id"})
 
-        config = get_or_create_team_extension(self.team, TeamLogsConfig)
+        config = logs_facade.get_team_logs_config(self.team)
         self.assertEqual(config.logs_distinct_id_attribute_key, "user.id")
 
     @parameterized.expand(URL_PREFIXES)

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -1,6 +1,9 @@
 import uuid
+from typing import TYPE_CHECKING
 
 from posthog.test.base import BaseTest, NonAtomicBaseTest
+
+from django.apps import apps
 
 from parameterized import parameterized
 
@@ -40,7 +43,6 @@ from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrac
 from products.experiments.backend.models.experiment import Experiment
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
-from products.logs.backend.models import LogsAlertConfiguration, LogsView
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 from products.product_analytics.backend.models.insight import Insight
 from products.product_analytics.backend.models.insight_variable import InsightVariable
@@ -50,6 +52,9 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable as DataWarehouseTableModel
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+
+if TYPE_CHECKING:
+    from products.logs.backend.models import LogsAlertConfiguration, LogsView
 
 ALL_SYSTEM_TABLE_NAMES = sorted(SystemTables().children.keys())
 
@@ -368,11 +373,13 @@ def _create_integration_repository_cache_entry(team: Team, label: str):
     )
 
 
-def _create_logs_view(team: Team, label: str) -> LogsView:
+def _create_logs_view(team: Team, label: str) -> "LogsView":
+    LogsView = apps.get_model("logs", "LogsView")
     return LogsView.objects.create(team=team, name=f"logs_view_{label}")
 
 
-def _create_logs_alert(team: Team, label: str) -> LogsAlertConfiguration:
+def _create_logs_alert(team: Team, label: str) -> "LogsAlertConfiguration":
+    LogsAlertConfiguration = apps.get_model("logs", "LogsAlertConfiguration")
     return LogsAlertConfiguration.objects.create(
         team=team,
         name=f"logs_alert_{label}",

--- a/posthog/hogql/test/test_get_lowercase_index_hint.py
+++ b/posthog/hogql/test/test_get_lowercase_index_hint.py
@@ -26,7 +26,7 @@ from posthog.hogql.visitor import clear_locations
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 
-from products.logs.backend.logs_query_runner import LogsQueryRunner
+from products.logs.backend.facade.queries import LogsQueryRunner
 
 
 class TestGetLowercaseIndexHint(BaseTest):

--- a/products/logs/backend/facade/api.py
+++ b/products/logs/backend/facade/api.py
@@ -1,0 +1,37 @@
+"""Facade API for logs.
+
+The data-capability surface other apps import from. Accepts and returns contracts,
+never ORM instances or querysets.
+
+Keep heavy imports (HogQL, temporalio) out of this module — those live in
+``facade/queries.py`` and ``facade/temporal.py`` so config-only consumers don't drag
+them onto the ``django.setup()`` import path.
+"""
+
+from typing import TYPE_CHECKING
+
+from posthog.models.team.extensions import get_or_create_team_extension
+
+from products.logs.backend.facade import contracts
+from products.logs.backend.models import TeamLogsConfig
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+
+def _to_team_logs_config(config: TeamLogsConfig) -> contracts.TeamLogsConfig:
+    return contracts.TeamLogsConfig(logs_distinct_id_attribute_key=config.logs_distinct_id_attribute_key)
+
+
+def get_team_logs_config(team: "Team") -> contracts.TeamLogsConfig:
+    """Read a team's logs config, creating it with defaults if it doesn't exist yet."""
+    config = get_or_create_team_extension(team, TeamLogsConfig)
+    return _to_team_logs_config(config)
+
+
+def update_team_logs_config(team: "Team", logs_distinct_id_attribute_key: str) -> contracts.TeamLogsConfig:
+    """Set the distinct-id attribute key for a team's logs config."""
+    config = get_or_create_team_extension(team, TeamLogsConfig)
+    config.logs_distinct_id_attribute_key = logs_distinct_id_attribute_key
+    config.save(update_fields=["logs_distinct_id_attribute_key"])
+    return _to_team_logs_config(config)

--- a/products/logs/backend/facade/contracts.py
+++ b/products/logs/backend/facade/contracts.py
@@ -1,0 +1,19 @@
+"""Contract types for logs.
+
+Stable, framework-free frozen dataclasses that define what this product exposes to the
+rest of the codebase. No Django imports.
+
+These use ``pydantic.dataclasses.dataclass`` rather than the stdlib variant — same
+shape and ``is_dataclass()`` compatibility, but with runtime validation on
+construction, so a malformed mapper or caller surfaces at the facade boundary instead
+of producing a bad payload downstream.
+"""
+
+from pydantic.dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TeamLogsConfig:
+    """A team's logs configuration (env-scoped, keyed by team_id)."""
+
+    logs_distinct_id_attribute_key: str

--- a/tach.toml
+++ b/tach.toml
@@ -690,7 +690,7 @@ expose = [
     "backend\\.routes.*",
 ]
 from = [
-    "products\\.(error_tracking|experiments|mcp_analytics|mcp_store|metrics|notifications|tracing|user_interviews|visual_review)",
+    "products\\.(error_tracking|experiments|logs|mcp_analytics|mcp_store|metrics|notifications|tracing|user_interviews|visual_review)",
 ]
 
 # TODO: Experiments-specific temporary interface


### PR DESCRIPTION
## Problem

The logs product was exposing its ORM models (`TeamLogsConfig`, `LogsView`, `LogsAlertConfiguration`) directly to the rest of the codebase. This creates tight coupling between products and makes it harder to evolve the logs data layer independently.

## Changes

Introduces a facade layer for the logs product (`products/logs/backend/facade/`) with two modules:

- **`contracts.py`** — frozen Pydantic dataclasses that define the stable public interface. No Django imports, so config-only consumers don't pull in heavy dependencies.
- **`api.py`** — `get_team_logs_config` and `update_team_logs_config` functions that accept/return contracts rather than ORM instances.

The `TeamLogsConfigSerializer` in `posthog/api/team.py` is converted from a `ModelSerializer` to a plain `Serializer`, with read/write operations now routed through the facade. The `handle_logs_config` view handler is updated accordingly.

Lazy model loading via `apps.get_model()` replaces direct imports of `LogsView` and `LogsAlertConfiguration` in the system tables test, using `TYPE_CHECKING` guards for the type annotations.

The `tach.toml` module boundary config is updated to include `logs` in the set of products permitted to depend on the shared facade pattern.

## How did you test this code?

Existing tests in `posthog/api/test/test_team_logs_config.py` cover the PATCH and GET paths for both the `/api/projects/` and `/api/environments/` routes. The test helper is updated to use `logs_facade.get_team_logs_config` to verify persistence after a PATCH.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Introduced a facade pattern for the logs product to decouple ORM models from cross-product consumers. The key decisions were: using Pydantic frozen dataclasses for contracts (runtime validation at the boundary, no Django dependency), keeping `api.py` free of heavy imports (HogQL, Temporal) so it stays cheap to import, and converting the DRF serializer to a plain `Serializer` since persistence is now handled explicitly through the facade rather than via `.save()`.