### PR TITLE
test: deflake poll_query_performance StopIteration

### DIFF
--- a/posthog/tasks/test/test_poll_query_performance.py
+++ b/posthog/tasks/test/test_poll_query_performance.py
@@ -89,6 +89,10 @@ class TestPollQueryPerformanceTask(SimpleTestCase):
 
     @patch("posthog.tasks.tasks.logger.error")
     @patch("posthog.tasks.tasks.poll_query_performance.delay")
+    # Stub the inner query worker the task delegates to (a different module that happens to share
+    # the name — not the task under test): the real worker makes extra time.time_ns() calls that
+    # would exhaust the 2-value mock below and flake with StopIteration.
+    @patch("posthog.tasks.poll_query_performance.poll_query_performance", MagicMock())
     @patch("time.time_ns", MagicMock(side_effect=[int(1e9), int(4e9)]))
     def test_poll_query_performance_runs_and_restarts_itself_with_no_delay_if_it_takes_too_long(
         self, mock_delay: MagicMock, mock_logger_error: MagicMock


### PR DESCRIPTION
## Problem

`test_poll_query_performance_..._if_it_takes_too_long` is failing master's `ci-backend` Core shard with `StopIteration`. The test patches global `time.time_ns` with 2 values but lets the real inner query worker run, which makes extra `time.time_ns()` calls that exhaust the mock.

Latent flake that has tipped to effectively deterministic: interleaved 15 pass / 8 fail before ~13:09 UTC today (same test verified passing in the Core shard), then 37 consecutive failures since — which is why master is stuck red. The fix removes the dependency on the real query path either way.

## Changes

Stub the inner query worker (a different module that shares the name `poll_query_performance`, not the task under test) so the test covers only the task's scheduling logic. The two production `time.time_ns()` calls then match the 2 mock values.

## How did you test this code?

Agent-authored, automated only: 6/6 class pass, 20/20 repetition loop, plus a throwaway deterministic test confirming the mechanism (removed).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed via `hogli ci:insights` + `gh` logs (measured the pass/fail timeline across 60 master runs). Skills: `/fixing-flaky-tests`, `/simplify`. Chose to mock the inner worker (proper unit isolation; the query has its own `sync_execute`-mocking tests) over making the time mock non-exhaustible. The organic CI race didn't reproduce locally, so the mechanism was proven analytically with the throwaway test.
