### PR TITLE
docs(mcp-analytics): canonical $mcp_tool_call event and $session_id key

### DIFF
--- a/products/mcp_analytics/skills/exploring-mcp-intent-clusters/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-intent-clusters/SKILL.md
@@ -16,7 +16,7 @@ clusters. Each cluster carries its tool distribution, call counts, and error
 rates — answering "what are people _trying_ to do, and does it work?" rather
 than "which tool was called".
 
-Unlike tool quality and sessions (which are plain HogQL over `mcp_tool_call`),
+Unlike tool quality and sessions (which are plain HogQL over `$mcp_tool_call`),
 clustering needs embeddings and is **not expressible in SQL**. It is served by
 two typed tools backed by a stored snapshot.
 
@@ -74,7 +74,7 @@ background. Poll `...-retrieve` until `status` returns to `idle` (done) or
 
 - Clusters are only as good as the `$mcp_intent` coverage — if few calls carry
   an intent, clusters will be sparse; cross-check intent coverage with a quick
-  `countIf(toString(properties.$mcp_intent) != '')` over `mcp_tool_call`
+  `countIf(toString(properties.$mcp_intent) != '')` over `$mcp_tool_call`
 - A cluster with high `error_rate_pct` plus high `routing_entropy` is the
   strongest "the tools don't serve this goal well" signal — worth a closer look
   at its `sample_intents` and `tool_distribution`

--- a/products/mcp_analytics/skills/exploring-mcp-sessions/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-sessions/SKILL.md
@@ -10,9 +10,9 @@ description: >
 
 # Exploring MCP sessions
 
-An MCP session is one agent run, identified by `$mcp_session_id` on the
-`mcp_tool_call` event. A session is just the set of `mcp_tool_call` events that
-share a `$mcp_session_id`, ordered by `timestamp`. Listing sessions and reading
+An MCP session is one agent run, identified by `$session_id` on the
+`$mcp_tool_call` event. A session is just the set of `$mcp_tool_call` events that
+share a `$session_id`, ordered by `timestamp`. Listing sessions and reading
 a session's tool calls are both plain HogQL over `events`; the full property
 schema and recipes are in the shared reference:
 [`products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md`](../../../posthog_ai/skills/querying-posthog-data/references/models-mcp.md).
@@ -29,13 +29,13 @@ the typed tool `posthog:mcp-analytics-sessions-generate-intent`.
 
 ## Workflow: list recent sessions
 
-Group `mcp_tool_call` by `$mcp_session_id`, deriving start/end, duration, call
+Group `$mcp_tool_call` by `$session_id`, deriving start/end, duration, call
 count, error count, and the harness:
 
 ```sql
 posthog:execute-sql
 SELECT
-    toString(properties.$mcp_session_id) AS session_id,
+    $session_id AS session_id,
     min(timestamp) AS session_start,
     max(timestamp) AS session_end,
     dateDiff('second', min(timestamp), max(timestamp)) AS duration_seconds,
@@ -43,8 +43,8 @@ SELECT
     countIf(toBool(properties.$mcp_is_error)) AS errors,
     any(properties.$mcp_client_name) AS client
 FROM events
-WHERE event = 'mcp_tool_call'
-    AND toString(properties.$mcp_session_id) != ''
+WHERE event = '$mcp_tool_call'
+    AND $session_id != ''
     AND timestamp >= now() - INTERVAL 7 DAY
 GROUP BY session_id
 ORDER BY session_start DESC
@@ -67,8 +67,8 @@ SELECT
     round(toFloat(properties.$mcp_duration_ms)) AS duration_ms,
     toString(properties.$mcp_intent) AS intent
 FROM events
-WHERE event = 'mcp_tool_call'
-    AND toString(properties.$mcp_session_id) = '<session_id>'
+WHERE event = '$mcp_tool_call'
+    AND $session_id = '<session_id>'
 ORDER BY timestamp ASC
 ```
 

--- a/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
@@ -12,7 +12,7 @@ description: >
 # Exploring MCP tool quality
 
 Any MCP server instrumented with PostHog's MCP analytics SDK emits a
-`mcp_tool_call` event on the shared `events` table every time an agent invokes a
+`$mcp_tool_call` event on the shared `events` table every time an agent invokes a
 tool. There is **no dedicated ClickHouse table** — every field lives as a
 `$mcp_*` property on `events`, and every tool-quality metric (error rate, latency
 percentiles, reach) is an aggregation over this one event. This is the data
@@ -56,7 +56,7 @@ SELECT
     countIf(toBool(properties.$mcp_is_error)) AS errors,
     round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct
 FROM events
-WHERE event = 'mcp_tool_call'
+WHERE event = '$mcp_tool_call'
     AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) != ''
     AND timestamp >= now() - INTERVAL 30 DAY
 GROUP BY tool
@@ -80,13 +80,13 @@ under "Tool-quality matrix".
 
 Pull the most common error messages for a tool, then correlate to richer
 exception detail (`$exception` events carry `$exception_message`, joined by
-`$mcp_session_id` / `$session_id` and timestamp):
+`$session_id` and timestamp):
 
 ```sql
 posthog:execute-sql
 SELECT toString(properties.$mcp_error_message) AS error, count() AS n
 FROM events
-WHERE event = 'mcp_tool_call'
+WHERE event = '$mcp_tool_call'
     AND toBool(properties.$mcp_is_error)
     AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) = '<tool>'
     AND timestamp >= now() - INTERVAL 30 DAY

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
@@ -1,6 +1,6 @@
-# MCP analytics (`mcp_tool_call` events)
+# MCP analytics (`$mcp_tool_call` events)
 
-PostHog's own MCP server emits a `mcp_tool_call` event on the shared `events` table every time an agent invokes a tool. There is **no dedicated ClickHouse table** — all fields live as `$mcp_*` properties on `events`, queried directly with `posthog:execute-sql`. This is the data behind the MCP analytics dashboard, tool-quality, and tool-detail screens; every metric on those screens is reproducible as HogQL over this event.
+Any MCP server instrumented with the `@posthog/mcp` SDK — and PostHog's own MCP server — emits a `$mcp_tool_call` event on the shared `events` table every time an agent invokes a tool. There is **no dedicated ClickHouse table** — all fields live as `$mcp_*` properties on `events`, queried directly with `posthog:execute-sql`. This is the data behind the MCP analytics dashboard, tool-quality, and tool-detail screens; every metric on those screens is reproducible as HogQL over this event.
 
 **HogQL is the primary path here.** Session listing, per-session tool calls, tool-level metrics (error rate, latency, adoption), harness breakdowns, time series, and co-occurrence are all just aggregations over this event — query them with `execute-sql`. The only typed tools are for things SQL can't express: `posthog:mcp-analytics-intent-clusters-retrieve` / `...-recompute` (embedding-based intent clustering) and `posthog:mcp-analytics-sessions-generate-intent` (LLM session summary).
 
@@ -13,7 +13,7 @@ PostHog's own MCP server emits a `mcp_tool_call` event on the shared `events` ta
 | `$mcp_is_error`            | Whether the call failed. Always read via `toBool(properties.$mcp_is_error)`.                                                             |
 | `$mcp_error_message`       | Error text when `$mcp_is_error` is true.                                                                                                 |
 | `$mcp_duration_ms`         | Wall-clock duration; cast with `toFloat(...)`.                                                                                           |
-| `$mcp_session_id`          | Session/conversation id — the grouping key for a single agent run.                                                                       |
+| `$session_id`              | Session/conversation id — the grouping key for a single agent run. Use the bare `$session_id` field, not `properties.$session_id`.       |
 | `$mcp_intent`              | The agent's stated intent for the call, when supplied.                                                                                   |
 | `$mcp_client_name`         | Raw client string (e.g. `claude-code/1.2.3`). The dashboard buckets these into harnesses in the frontend; there is no `category` column. |
 | `$mcp_tool_category`       | Tool category, when tagged.                                                                                                              |
@@ -25,7 +25,7 @@ PostHog's own MCP server emits a `mcp_tool_call` event on the shared `events` ta
 coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))
 ```
 
-**Failures with detail.** `mcp_tool_call` carries `$mcp_is_error` + `$mcp_error_message`; richer stack/exception data is on `$exception` events (`$exception_message`), correlated by `$mcp_session_id` / `$session_id` and timestamp.
+**Failures with detail.** `$mcp_tool_call` carries `$mcp_is_error` + `$mcp_error_message`; richer stack/exception data is on `$exception` events (`$exception_message`), correlated by `$session_id` and timestamp.
 
 ## Example queries
 
@@ -37,7 +37,7 @@ SELECT
     countIf(toBool(properties.$mcp_is_error)) AS errors,
     round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct
 FROM events
-WHERE event = 'mcp_tool_call'
+WHERE event = '$mcp_tool_call'
     -- effective tool name: new-SDK events put the real tool in $mcp_exec_tool_call_name
     AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) = '<tool-name>'
     AND timestamp >= now() - INTERVAL 7 DAY
@@ -55,9 +55,9 @@ SELECT
     round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50_ms,
     round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_ms,
     uniq(distinct_id) AS users,
-    countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions
+    countDistinctIf($session_id, $session_id != '') AS sessions
 FROM events
-WHERE event = 'mcp_tool_call'
+WHERE event = '$mcp_tool_call'
     AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) != ''
     AND timestamp >= now() - INTERVAL 30 DAY
 GROUP BY tool
@@ -71,7 +71,7 @@ SELECT toDate(timestamp) AS day,
     countIf(NOT toBool(properties.$mcp_is_error)) AS successes,
     countIf(toBool(properties.$mcp_is_error)) AS errors
 FROM events
-WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+WHERE event = '$mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
 GROUP BY day ORDER BY day
 ```
 
@@ -87,7 +87,7 @@ SELECT
     uniq(distinct_id) AS users,
     round(uniq(distinct_id) * 100.0 / (
         SELECT uniq(distinct_id) FROM events
-        WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+        WHERE event = '$mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
     ), 1) AS pct_of_users
 FROM (
     SELECT
@@ -116,7 +116,7 @@ FROM (
             distinct_id,
             lower(trim(replaceRegexpOne(toString(properties.$mcp_client_name), '\\s*\\(via mcp-remote[^)]*\\)\\s*', ''))) AS h
         FROM events
-        WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
+        WHERE event = '$mcp_tool_call' AND timestamp >= now() - INTERVAL 30 DAY
     )
 )
 GROUP BY harness
@@ -130,13 +130,13 @@ The `multiIf` above is the canonical bucket list. The denominator is total disti
 ```sql
 SELECT prev_tool AS tool, count() AS co_occurrences
 FROM (
-    SELECT properties.$mcp_session_id AS conv_id,
+    SELECT $session_id AS conv_id,
         coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) AS tool,
         lagInFrame(coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)))
-            OVER (PARTITION BY properties.$mcp_session_id ORDER BY timestamp
+            OVER (PARTITION BY $session_id ORDER BY timestamp
                   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_tool
     FROM events
-    WHERE event = 'mcp_tool_call' AND timestamp >= now() - INTERVAL 7 DAY
+    WHERE event = '$mcp_tool_call' AND timestamp >= now() - INTERVAL 7 DAY
 )
 WHERE tool = '<tool-name>' AND prev_tool != '' AND prev_tool != tool
 GROUP BY prev_tool ORDER BY co_occurrences DESC LIMIT 5


### PR DESCRIPTION
## Problem

The MCP analytics skills and the shared `models-mcp` data reference documented the legacy `mcp_tool_call` event and `$mcp_session_id` key. The `@posthog/mcp` SDK emits only `$mcp_tool_call` / `$session_id`, so those example queries return nothing for SDK-instrumented servers.

## Changes

- Switch all skill and reference query examples to the canonical `$mcp_tool_call` event and the `$session_id` grouping key (bare materialized field).
- The `posthog_ai` shared reference now documents only the `$`-prefixed model — no unprefixed/legacy mentions.

Touches: the three `exploring-mcp-*` skills and `querying-posthog-data/references/models-mcp.md`.

## How did you test this code?

I'm an agent (Claude Code). Docs-only — no code paths changed. Confirmed against local data that `$mcp_tool_call` / `$session_id` return the expected rows; markdown formatting ran via lint-staged. No manual UI testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Split out from the `$session_id` code change (#64524) into its own docs branch at the author's request, so the skill updates ship independently of the product code. Dropped the dual-emit/legacy notes from the `posthog_ai` reference per request, leaving a single canonical model.
