### PR TITLE
chore(skills): harden flaky-test skill against trusting ci:insights

### DIFF
--- a/.agents/skills/fixing-flaky-tests/SKILL.md
+++ b/.agents/skills/fixing-flaky-tests/SKILL.md
@@ -16,22 +16,48 @@ Three non-negotiables, in order:
 3. **Validate with an N-run loop.** One green run proves nothing about an intermittent failure.
    Size N to the observed failure rate.
 
+Before any of these: **measure, don't assume.** Flaky-vs-deterministic, and the rate, are facts to establish from verifiable GitHub run data (step 1) — never inherited from a Slack alert, a teammate's guess, or a `ci:insights` label.
+
 For triaging a red CI run (finding and classifying the failure), use the `debugging-ci-failures` skill first — this skill takes over once the failure is classified as a flaky test.
 For writing new Playwright tests that aren't flaky, use the `playwright-test` skill.
 
-## 1. Confirm it is actually flaky
+## 1. Measure the failure rate — from GitHub, not from a digest
 
-Before investing in reproduction:
+The GitHub Actions API (or GitHub MCP) is the source of truth. `hogli ci:insights` is a digest, not an oracle — it can mislabel flaky-vs-deterministic, misstate the rate, and lag the API. Use it to _validate_ a hypothesis or pull historical context, never as the first move or the classification authority.
+
+Establish the timeline yourself from raw run data:
 
 ```bash
-hogli ci:insights search "<test name or error>"   # occurrence history, confidence, existing fix
-git log --oneline -10 -- <test_file_path>          # recently fixed already?
+# Pass/fail history for the workflow on the branch under suspicion (master shown):
+gh run list --repo PostHog/posthog --workflow=ci-backend.yml --branch master \
+  --status completed --limit 60 --json conclusion,headSha,createdAt,databaseId
 ```
 
-- An insight with a **merged fix** means the flake may already be resolved — read the fix, confirm it covers this failure, and report instead of re-fixing.
-- A test failing **consistently** (every run, including on `master`) is a regression, not a flake — go back to `debugging-ci-failures`.
-- Record the observed failure rate (occurrences / total runs from `ci:insights`, or from rerun attempts on the PR).
-  You need it to size the validation loop later.
+The run-level conclusion is not enough — a red run may be failing on a _different_ job/test. Confirm it is the **same test** each time by reading the failing shard's log; and for green runs, confirm the test actually **ran and passed** in that shard (it may have been sharded elsewhere, not fixed):
+
+```bash
+gh api repos/PostHog/posthog/actions/jobs/{job_id}/logs \
+  | grep -E "<exact::test::id>|short test summary"
+```
+
+Read the timeline before you classify:
+
+- **Interleaved pass/fail on adjacent commits** — the same unchanged test verified passing in some runs, failing in others → genuinely **flaky**; continue here.
+- **A long unbroken failure streak** (say 30+ consecutive) is statistically incompatible with a flake — at any per-run rate below ~95%, `p^30 ≈ 0`. That is a **deterministic regression**: go to `debugging-ci-failures` and find the introducing commit (step 4).
+- **Both at once** is common: a latent flake whose rate jumped to ~100%. Find the transition (last green → first red); that boundary, not the digest's one-line guess, is what tells you what tipped it.
+
+If a failure is reported as (or you suspect it is) **consistent**, don't serialize — measure the rate and attempt a repro **in parallel**.
+
+Record the **measured** rate (failures / total runs, from the run data). You need it to size the validation loop in step 6.
+
+Then confirm it is not already handled:
+
+```bash
+git log --oneline -10 -- <test_file_path>          # recently fixed already?
+hogli ci:insights search "<test name or error>"    # historical context / existing fix — corroborate against the run data, do not trust blindly
+```
+
+An insight with a **merged fix** means the flake may already be resolved — read the fix, confirm _against the run data_ that it covers this failure, and report instead of re-fixing.
 
 ## 2. Extract the failure from CI
 
@@ -107,6 +133,20 @@ Match the symptom to a cause class; never patch the symptom.
 | Query can't see just-written data                      | Eventual consistency (ClickHouse), missing flush/commit      |
 | Only fails under `--maxWorkers=2` / contention         | Race condition surfaced by scheduling, too-tight timeout     |
 
+### When the cause isn't obvious, bisect
+
+If the symptom table doesn't point at a clear cause and the test file itself is unchanged (`git log -- <test_file>` is stale), the trigger is elsewhere — a neighbor test, a dependency bump, or a product change. Find _when_ it started instead of guessing:
+
+- **Bisect the CI run history first** (cheap, no local builds): from the step-1 timeline, take the last-green → first-red boundary and diff the commits in that window (`git log <good>..<bad>`). That short list often names the culprit outright.
+- **`git bisect` the code** when you can reproduce locally and the failure is (near-)deterministic:
+
+  ```bash
+  git bisect start <bad-sha> <good-sha>
+  git bisect run bash -c '<repro command>'   # exit 0 = good, non-zero = bad
+  ```
+
+  Caveat: for an intermittent flake, a _lucky pass_ at a step sends `git bisect` down the wrong path. Trust code-bisect only when the failure is deterministic; otherwise run the repro N times per step (fail if **any** iteration fails), or just use the CI run-history boundary.
+
 PostHog-specific patterns:
 
 ### Frontend (Jest + kea)
@@ -159,7 +199,7 @@ Finish with one normal run of the surrounding file/suite to confirm the fix didn
 
 ```text
 Test:            <file path>::<test name>
-Observed in CI:  <rate, e.g. ~1 in 8 runs over 2 weeks (ci:insights)>
+Observed in CI:  <measured rate from run data, e.g. 8/45 runs over 3h (gh run list); ci:insights corroborates>
 Local repro:     <command + conditions, e.g. 3/20 failures with neighbor X, maxWorkers=2 | not reproducible locally>
 Root cause:      <one or two sentences>
 Fix:             <what changed and why it removes the cause>


### PR DESCRIPTION
## Problem

The `fixing-flaky-tests` skill reached for `hogli ci:insights` *first* and treated its "flaky" label as the classification authority. In practice the digest can mislabel a deterministic failure as flaky (and vice versa), misstate the rate, and lag the API — leading to a wrong "it's just flaky" call when the truth is measurable from GitHub run data.

## Changes

Learnings baked into the skill:

- **New principle — "measure, don't assume":** flaky-vs-deterministic and the rate are facts to establish from verifiable GitHub run data, never inherited from a Slack alert or a digest label.
- **Rewrote step 1** ("Confirm it is actually flaky" → "Measure the failure rate — from GitHub, not from a digest"): the GitHub Actions API/MCP is the source of truth; `ci:insights` is demoted to hypothesis-validation / historical context. Added the `gh run list` timeline command, the rule to confirm the *same test* per run from shard logs (run-level conclusion isn't enough; verify green runs actually ran+passed it), and the statistical tell — a 30+ consecutive-failure streak is incompatible with a flake, while interleaved pass/fail proves one. Calls out the "latent flake tipped to ~100%" case and to find the last-green → first-red transition.
- **Validate-in-parallel:** if a failure is reported as / suspected consistent, run rate-measurement and reproduction concurrently rather than serializing.
- **New "When the cause isn't obvious, bisect" subsection (step 4):** bisect the CI run-history boundary first (cheap), then `git bisect run` for local deterministic repros — with the lucky-pass caveat for intermittent flakes (run N per step or stick to the CI-history boundary).

## How did you test this code?

Docs-only (a skill markdown file). No code paths changed; frontmatter and section structure verified intact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Distilled from a live session where I trusted a `ci:insights` "flaky 80%" label, called a failure flaky on thin evidence, and only measured the real rate (15 pass / 8 fail interleaved, then 37 consecutive failures) from the GitHub API after the user pushed back twice. The edits encode that correction. Skill touched: `fixing-flaky-tests`.
