### PR TITLE
fix(bigquery): treat CDC max_staleness read failure as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -116,6 +116,17 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # from transient rate-limit quota errors ("Quota exceeded: ..." / reason
             # `rateLimitExceeded`) that must stay retryable.
             "Custom quota exceeded": "Your BigQuery project hit a custom usage quota set by your administrator (for example QueryUsagePerDay). Raise the custom cost-control quota in Google Cloud, or reduce how much data you're syncing, then re-enable the source.",
+            # Raised from the Storage Read API's `create_read_session` (see `get_rows` in
+            # `bigquery.py`) when the source table uses change data capture with a `max_staleness`
+            # window and has pending upserts older than that window. The Storage Read API can't
+            # apply CDC changes on the fly — only GoogleSQL queries and BigQuery's background apply
+            # jobs do — so it rejects the read as a google.api_core InvalidArgument whose str() is
+            # "400 request failed: The table has un-applied upsert data that is not fresh enough to
+            # meet table's max_staleness.". Retrying within the sync's window can't recover it: the
+            # pending changes are applied on BigQuery's own schedule, not ours, so it just hammers
+            # the Read API and spams error tracking until a later sync finds the table caught up.
+            # Matched on the stable freshness phrasing rather than the volatile table id.
+            "un-applied upsert data that is not fresh enough": "BigQuery couldn't read this table through the Storage Read API because it uses change data capture and has pending upserts that haven't been applied within the table's max_staleness window. This usually clears once BigQuery applies the pending changes, so a later sync should recover. If it persists, lower the table's max_staleness or run a query against the table in BigQuery to apply the changes.",
         }
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from unittest import mock
 
 from dateutil import parser
-from google.api_core.exceptions import BadRequest, Forbidden, NotFound, PermissionDenied
+from google.api_core.exceptions import BadRequest, Forbidden, InvalidArgument, NotFound, PermissionDenied
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery import bigquery as bq_module
@@ -822,3 +822,37 @@ def test_bigquery_billing_not_enabled_is_non_retryable():
     assert billing_key in non_retryable_errors, "expected billing key to be non-retryable"
     # Mirror the substring match used by `update_external_data_job_model`.
     assert billing_key in internal_error
+
+
+def test_bigquery_cdc_staleness_is_non_retryable():
+    """A CDC table whose pending upserts are staler than its max_staleness can't be read via the
+    Storage Read API (it never applies CDC changes), so the read fails as an InvalidArgument.
+    Retrying within the sync's window can't recover it — the apply happens on BigQuery's schedule —
+    so it must be recognised as non-retryable instead of hammering the Read API every attempt."""
+    error_msg = str(
+        InvalidArgument(
+            "request failed: The table has un-applied upsert data that is not fresh enough to meet "
+            "table's max_staleness."
+        )
+    )
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in error_msg]
+
+    assert matching, "CDC max_staleness read failure should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
+    "other_error",
+    [
+        # A genuine config error about max_staleness must not be swallowed by the freshness key.
+        "400 Invalid value for max_staleness: must be a valid INTERVAL",
+        # Transient server errors must stay retryable.
+        "503 Service unavailable, please retry",
+    ],
+)
+def test_bigquery_cdc_staleness_key_does_not_match_unrelated_errors(other_error):
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert "un-applied upsert data that is not fresh enough" not in other_error
+    assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

BigQuery imports are failing for tables that use change data capture (CDC) with a `max_staleness` window. When such a table has pending upserts older than its `max_staleness`, the Storage Read API's `create_read_session` (in `get_rows`, `bigquery.py`) rejects the read with a `google.api_core` `InvalidArgument` (HTTP 400):

> request failed: The table has un-applied upsert data that is not fresh enough to meet table's max_staleness.

The Storage Read API can't apply CDC changes on the fly — only GoogleSQL queries and BigQuery's background apply jobs do. So retrying the read within the sync's retry window can't recover it: the pending changes get applied on BigQuery's own schedule, not ours. The import currently treats this as retryable, so it burns its attempts hammering the Read API and spams error tracking each run.

Observed via error tracking: [InvalidArgument — un-applied upsert data not fresh enough](https://us.posthog.com/project/2/error_tracking/019edb3a-ff9e-76e1-bdd9-7bb2ddeeddf1). The stack confirms the failure originates in this source — `bigquery.py:get_rows` → `create_read_session`.

## Changes

Added the stable freshness phrase to `BigQuerySource.get_non_retryable_errors`, mirroring the existing entries (and directly analogous to `"Custom quota exceeded"`, another condition that resets on Google's own schedule rather than within our retry window). The non-retryable handler still allows a few attempts over 24h before giving up, so a sync that genuinely self-heals once BigQuery applies the pending changes still recovers on a later scheduled run — we just stop the tight retry loop and the error-tracking noise in between.

Matched on `un-applied upsert data that is not fresh enough` — a low-false-positive substring that excludes volatile parts (table id, timestamps). The user-facing message explains the CDC/`max_staleness` cause and the recovery options (wait for the next sync, lower `max_staleness`, or run a query against the table to apply changes).

## How did you test this code?

I'm an agent. Automated tests only — no manual testing.

- Added `test_bigquery_cdc_staleness_is_non_retryable` (asserts the real `InvalidArgument` message is recognised, with a non-null user message).
- Added `test_bigquery_cdc_staleness_key_does_not_match_unrelated_errors` (guards against false positives — a genuine `max_staleness` config error and a transient 503 must stay retryable).
- Ran the full `test_source.py` suite: 74 passed. `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the failure originates in `posthog/temporal/data_imports/sources/bigquery/bigquery.py` (`get_rows` → Storage Read API `create_read_session`), read the import error-handling path (`_handle_import_error` → `get_non_retryable_errors` → `handle_non_retryable_error`) and the activity retry policy to confirm behaviour.

Decision: this is an upstream/config condition (the customer's CDC table is in a state the Storage Read API can't read), not a fixable bug in our request shape and not transient infrastructure. A code-level fix would mean falling back to the temp-table-copy path (a query applies CDC changes before the Read API reads it) — the same trick already used for views/external tables — but that's a larger, riskier change with real query-cost implications and no cheap way to test against a real CDC table, so it was out of scope here. Extending `NonRetryableErrors` is the minimal, safe action and matches the established pattern in this source. Verified the exact `str(InvalidArgument(...))` format (`400 request failed: ...`) so the substring match is reliable.