### PR TITLE
fix(stamphog): require grep verification before flagging missing symbols

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -170,6 +170,20 @@ REVIEWER_SYSTEM = textwrap.dedent(
     2. Read source files only if something looks off
     3. ESCALATE if you'd need deep review to feel confident
 
+    Verify before you flag (applies to EVERY tier, including quick T1a reviews):
+    - NEVER claim a symbol, import, function, or property "does not exist",
+      "is undefined", or "will throw at runtime" based on the diff alone. The
+      diff is changed lines, not the whole codebase — almost every identifier a
+      changed line references is defined elsewhere. Grep the repo to confirm
+      first. If you cannot positively confirm it is missing, do not flag it.
+    - Some globals are assembled from many modules, so absence from the one
+      file you'd expect is not absence. Example: the frontend `urls` object in
+      frontend/src/scenes/urls.ts spreads in every product's manifest urls via
+      `productUrls` (frontend/src/products.tsx), so a route helper like
+      `urls.skill(...)` can be defined in products/<x>/manifest.tsx, not urls.ts.
+    - Spending one Grep turn to verify is always worth it: a confident but wrong
+      "this will crash" verdict is more damaging than the extra tool call.
+
     Verdicts:
     - APPROVE: no showstoppers found
     - REFUSE: concrete issue found

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -170,19 +170,12 @@ REVIEWER_SYSTEM = textwrap.dedent(
     2. Read source files only if something looks off
     3. ESCALATE if you'd need deep review to feel confident
 
-    Verify before you flag (applies to EVERY tier, including quick T1a reviews):
-    - NEVER claim a symbol, import, function, or property "does not exist",
-      "is undefined", or "will throw at runtime" based on the diff alone. The
-      diff is changed lines, not the whole codebase — almost every identifier a
-      changed line references is defined elsewhere. Grep the repo to confirm
-      first. If you cannot positively confirm it is missing, do not flag it.
-    - Some globals are assembled from many modules, so absence from the one
-      file you'd expect is not absence. Example: the frontend `urls` object in
-      frontend/src/scenes/urls.ts spreads in every product's manifest urls via
-      `productUrls` (frontend/src/products.tsx), so a route helper like
-      `urls.skill(...)` can be defined in products/<x>/manifest.tsx, not urls.ts.
-    - Spending one Grep turn to verify is always worth it: a confident but wrong
-      "this will crash" verdict is more damaging than the extra tool call.
+    Verify before you flag (every tier, including quick T1a reviews):
+    - Never claim a symbol "does not exist" or "will throw at runtime" from the
+      diff alone — the diff is changed lines, not the whole codebase. Grep to
+      confirm first; if you can't confirm it's missing, don't flag it. Globals
+      can be composed from many modules (e.g. `urls` is assembled from
+      per-product manifests), so absence from the obvious file is not absence.
 
     Verdicts:
     - APPROVE: no showstoppers found


### PR DESCRIPTION
## Problem

Stamphog (the `tools/pr-approval-agent/` Claude reviewer) raised a false "this will crash at runtime" review on a one-line frontend PR ([#64580](https://github.com/PostHog/posthog/pull/64580)), claiming `urls.skill()` "does not exist in `frontend/src/scenes/urls.ts`." It does exist — it's contributed by the skills product manifest (`products/skills/manifest.tsx`) and merged into the global `urls` object via the `...productUrls` spread in `frontend/src/products.tsx`. There's even a passing test asserting it (`products/skills/frontend/skillsUrls.test.ts`). The reviewer re-asserted the same thing on a follow-up pass.

Root cause: trivial PRs (`T1a-trivial`) run the reviewer in "quick" mode (`effort="low"`, `max_turns=5`). The agent has Grep/Glob available but, at low effort, asserted a symbol was undefined straight from the diff without verifying. This is a generic failure mode — it can fire on any trivial PR that references an import, helper, or composed global defined outside the diff.

## Changes

Adds a "Verify before you flag" block to `REVIEWER_SYSTEM` that:

- Forbids "does not exist / is undefined / will throw at runtime" claims based on the diff alone — the agent must Grep to confirm first, and must not flag if it can't positively confirm the symbol is missing.
- Notes that globals can be composed from many modules (e.g. `urls` is assembled from per-product manifests), so absence from the obvious file isn't absence.
- States the rule applies even to quick T1a reviews, since that's where the miss happened.

Prompt-only change; no control-flow or gating logic touched.

## How did you test this code?

I'm an agent (Claude Code, driven by Andy). This is a prompt-string change — verified `ruff check` and `ty check` pass (via the pre-commit hook) and the module parses. I did not run a live stamphog review against an LLM backend. Suggest the owning team sanity-check by re-running `uv run tools/pr-approval-agent/review_pr.py 64580` and confirming the `urls.skill` false positive no longer appears.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed this after seeing the false positive on his own PR (#64580).

- Agent: Claude Code (Opus 4.8). No special skills invoked; this came out of reading `tools/pr-approval-agent/reviewer.py` to diagnose why the bot repeated the claim.
- Considered tightening the quick-mode gating (e.g. forcing a verification turn for existence-class claims in code) but kept it to a prompt guardrail — smallest change, no behavior-path risk, and the agent already has the tools it needs; it just wasn't told it must use them before this class of claim.
- `tools/pr-approval-agent/**` is owned by **@PostHog/team-security** (devex soft-owner) — flagging for their review since it's their agent.

