### PR TITLE
fix(snowflake): treat invalid key-pair JWT as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -206,6 +206,12 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # rejects the connection because PostHog's egress IP isn't permitted. Retrying can never
             # succeed until their admin allowlists our IPs, so stop retrying and surface what to do.
             "is not allowed to access Snowflake": "Snowflake rejected the connection because a network policy (IP allowlist) on your account does not permit PostHog's IP address. Ask your Snowflake administrator to add PostHog's egress IP addresses to the network policy allowlist, then resync.",
+            # Snowflake error 250001 (08001): key-pair login was rejected because the JWT we signed with
+            # the configured private key doesn't match the public key registered on the Snowflake user
+            # (rotated/removed key, key assigned to a different user, or the wrong key pasted). Retrying
+            # can never succeed until the customer re-registers the matching public key. The host and
+            # request id in the message are volatile, so we match the stable phrase.
+            "JWT token is invalid": "Snowflake rejected key-pair authentication because the signed token is invalid — the private key you configured doesn't match the public key registered on the Snowflake user. Re-register the matching public key on the user in Snowflake (or paste the correct private key), then resync.",
             # Snowflake error 002003 (SQLSTATE 42S02 for tables / 02000 for schemas): a table or
             # schema the source syncs was dropped or renamed in Snowflake, or the role's grant on it
             # was revoked, after the schema was discovered. The driver raises "<object> does not exist

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -702,6 +702,20 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "JWT token is invalid",
+            # The real shape from production: codes, host, and request id vary, but the substring is stable.
+            "250001 (08001): None: Failed to connect to DB: novjltn-acme.snowflakecomputing.com:443. "
+            "JWT token is invalid. [daf5b833-38d8-4aa9-9971-9d6bd736d978]",
+        ],
+    )
+    def test_invalid_jwt_token_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Invalid-JWT error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Table dropped/renamed or grant revoked (002003 / 42S02). Object name and query id vary.
             "002003 (42S02): 01c511e7-0307-1937-0000-7c994379a9c2: SQL compilation error:\n"
             "Table 'PRODUCTION.DBTNOVA.SCOPE_CATEGORIZATION' does not exist or not authorized.",


### PR DESCRIPTION
## Problem

A Snowflake data-warehouse import was failing on every retry with:

```
DatabaseError: 250001 (08001): None: Failed to connect to DB: <host>.snowflakecomputing.com:443. JWT token is invalid. [<request-id>]
```

This is surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019edb41-f456-7cb0-ad60-f66a55c2bf42)). The failure originates in our Snowflake source at `snowflake.py:233` (`connect` → `snowflake.connector.connect`) during key-pair authentication.

The error means Snowflake rejected the JWT we signed with the configured private key because it doesn't match the public key registered on the Snowflake user — a rotated/removed key, the wrong private key pasted, or a key assigned to a different user. Retrying can never succeed until the customer re-registers the matching public key, but the pipeline kept retrying it (the event shows attempt 5).

## Changes

Added `"JWT token is invalid"` to the Snowflake source's `get_non_retryable_errors()` with an actionable message telling the user to re-register the matching public key (or paste the correct private key) and resync. Matching on the stable phrase only — the host and request id in the message are volatile.

Added a parameterized test covering both the bare phrase and the full production-shaped message.

## How did you test this code?

I'm an agent. I ran the source's non-retryable test class — `TestSnowflakeSourceNonRetryableErrors` (20 tests, including the 2 new JWT cases) — and it passes. Ran `ruff check` and `ruff format --check` on both changed files, clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Snowflake import source. Confirmed via the error-tracking MCP tools that the failure genuinely originates in `posthog/temporal/data_imports/sources/snowflake/snowflake.py` (`connect`), then classified it: this is a customer credential/config error (key-pair public key not registered or mismatched), not a bug in our code and not a transient infra error, so the right fix is to stop retrying. Mirrored the existing Snowflake `get_non_retryable_errors` entries (and the Stripe reference pattern), matching a stable low-false-positive substring rather than the volatile host/request id.