### PR TITLE
fix(postgres): treat invalid SSL negotiation response as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -308,6 +308,24 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "speaking TLS (for example an HTTP, proxy, or edge endpoint, or the wrong port). "
                 "Check your host and port, then re-enable the sync."
             ),
+            # libpq raises "received invalid response to SSL negotiation: <byte>" when, after sending
+            # the SSLRequest packet, it reads back a byte that isn't a valid response ('S'/'N'/'E').
+            # A byte was received, so the host/port is reachable and responding — but with something
+            # that isn't the PostgreSQL protocol. In practice the configured host/port points at a
+            # non-Postgres service (an HTTP/proxy/edge endpoint, or the wrong port), or a middlebox is
+            # mangling the connection, so retrying re-runs into the same invalid response. With
+            # require_ssl=True the same condition is surfaced as SSLRequiredError below (str(e)
+            # contains "SSL"); this key catches the require_ssl=False (sslmode=prefer) path where the
+            # raw OperationalError propagates unwrapped. Match the stable phrase and exclude the
+            # volatile trailing byte/host/port. Placed before the generic SSL entries so its accurate
+            # message wins if both happen to match.
+            "received invalid response to SSL negotiation": (
+                "PostHog couldn't negotiate a connection with the host and port you configured — the "
+                'server sent an invalid response during SSL negotiation ("received invalid response '
+                "to SSL negotiation\"). This usually means the host and port don't point at a "
+                "PostgreSQL server (for example an HTTP, proxy, or edge endpoint, or the wrong port). "
+                "Check your host and port, then re-enable the sync."
+            ),
             "SSLRequiredError": None,
             "SSL/TLS connection is required": None,
             "Could not establish session to SSH gateway": None,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -315,6 +315,32 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)) when require_ssl=False
+            # leaves the OperationalError unwrapped. The host/port and trailing byte are volatile.
+            'connection failed: connection to server at "66.33.22.254", port 41667 failed: received invalid response to SSL negotiation: I',
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: received invalid response to SSL negotiation: H',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'OperationalError: connection failed: connection to server at "66.33.22.254", port 41667 failed: received invalid response to SSL negotiation: I',
+        ],
+    )
+    def test_invalid_ssl_negotiation_response_errors_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Invalid SSL negotiation response error should be non-retryable: {error_msg}"
+
+    def test_invalid_ssl_negotiation_response_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "66.33.22.254", port 41667 failed: '
+            "received invalid response to SSL negotiation: I"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Invalid SSL negotiation response error should surface an actionable message"
+        assert "host and port" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Neon suspends compute when the plan's compute-time quota is exhausted; the handshake
             # fails with this provider message. The host/IP and port are volatile and excluded.
             'connection failed: connection to server at "44.198.216.75", port 5432 failed: ERROR:  Your account or project has exceeded the compute time quota. Upgrade your plan to increase limits.',


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError` from the Postgres warehouse import source:

```
connection failed: connection to server at "<host>", port <port> failed: received invalid response to SSL negotiation: I
```

The failure genuinely originates in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`_open_setup_connection` → `_connect_with_options_fallback`), raised by libpq when, after sending the SSLRequest packet, it reads back a byte that isn't a valid negotiation response (`'S'`/`'N'`/`'E'`).

A byte *was* received, so the host/port is reachable and responding — but with something that isn't the PostgreSQL wire protocol. In practice this means the configured host/port points at a non-Postgres service (an HTTP/proxy/edge endpoint, or simply the wrong port), or a middlebox is mangling the connection. It is deterministic: every retry re-runs into the same invalid response.

When `require_ssl=True` the same condition is already caught — the message contains `"SSL"`, so it's wrapped as `SSLRequiredError`, which is non-retryable. But on the `require_ssl=False` (`sslmode=prefer`) path the raw `OperationalError` propagates unwrapped, matched no non-retryable key, and Temporal retried the activity to exhaustion before capturing it as error-tracking noise.

## Changes

Add `"received invalid response to SSL negotiation"` to `PostgresSource.get_non_retryable_errors()` with an actionable message, placed before the generic SSL entries so its accurate message wins. This is the SSL-negotiation sibling of the existing `"no application protocol"` (TLS ALPN) entry and mirrors its rationale. The match is a stable phrase that excludes the volatile trailing byte/host/port.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Added `test_invalid_ssl_negotiation_response_errors_are_non_retryable` (raw + Temporal-wrapped messages) and `test_invalid_ssl_negotiation_response_returns_friendly_message` in `test_postgres.py`.
- Ran the postgres source non-retryable/retryable suite: `pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py -k "ssl_negotiation or non_retryable or retryable or no_application_protocol"` → 69 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

The existing `test_transient_connection_errors_are_retryable` still passes, confirming the new key doesn't accidentally catch transient mid-stream drops.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Postgres import source. Pulled the full stack trace and a representative event via the PostHog error-tracking tools, confirmed the failure originates in the source's connection-setup code, and traced the call path (`postgres_source` → `_connect_with_dropped_retry` → `_open_setup_connection`).

Decision — **user/upstream error, not a code bug or transient infra**: a byte was received and was invalid, which means the endpoint isn't speaking the Postgres protocol (wrong host/port or an interfering proxy). That's a customer config condition and deterministic across retries, so the right fix is to stop retrying via `get_non_retryable_errors` rather than change connection code or retry policy. Considered whether it could be a transient blip and rejected that: a network blip surfaces as a reset/timeout, not a well-formed-but-invalid negotiation response. Scoped strictly to this one substring; no retry-policy or connection-logic changes.

Tooling: Claude Code with the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`). No repo skills were required for this change.
