### PR TITLE
fix(mysql): treat host-not-privileged (1130) as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -192,6 +192,12 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # text is translated on non-English servers) so it catches both the raw pymysql string and
             # the Temporal-wrapped `OperationalError: (1054, ...)` form.
             '(1054, "Unknown column': "A column referenced during sync no longer exists in your source table (MySQL error 1054). This usually means a column was renamed or dropped — if it's the table's incremental field, update it to a column that exists (or switch to a full re-sync), then resync.",
+            # MySQL/MariaDB error 1130 (ER_HOST_NOT_PRIVILEGED): the server has no grant permitting
+            # PostHog's connecting host, so the handshake is rejected before any credentials are
+            # checked. Only a DB admin can fix this server-side (GRANT for the host, or allow our
+            # egress / SSH-tunnel host) — retrying connects from the same host fails identically.
+            # Match the stable tail phrase, not the volatile host in the message prefix.
+            "is not allowed to connect to this MySQL server": "Your MySQL/MariaDB server isn't allowing connections from PostHog's host (error 1130). Ask your database admin to grant access for the connecting host (or allow our IP / SSH-tunnel host), then retry the sync.",
         }
 
     def reconcile_schema_metadata(

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1217,6 +1217,25 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form.
+            str(
+                pymysql.err.OperationalError(
+                    1130,
+                    "Host 'ec2-52-4-194-122.compute-1.amazonaws.com' is not allowed to connect to this MySQL server",
+                )
+            ),
+            # Temporal-wrapped str(e.cause) form — different host, same stable phrase.
+            "OperationalError: (1130, \"Host '10.0.1.5' is not allowed to connect to this MySQL server\")",
+        ],
+    )
+    def test_host_not_privileged_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Host-not-privileged error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OperationalError` from the MySQL data-warehouse import source:

```
(1130, "Host '<host>' is not allowed to connect to this MySQL server")
```

This is MySQL/MariaDB error **1130 (ER_HOST_NOT_PRIVILEGED)**. The server has no grant permitting PostHog's connecting host, so it rejects the handshake before any credentials are even checked. The failure originates in our source's connection path — `build_pipeline` → `connect` → `pymysql.connect(...)` in `posthog/temporal/data_imports/sources/mysql/mysql.py` — and the import activity retried it five times before giving up.

There is nothing we can do on our side: only the customer's DB admin can fix it server-side by adding a grant for the connecting host (or allowing our egress / SSH-tunnel host). Every retry connects from the same host and fails identically, so retrying just burns activity attempts.

## Changes

Added error 1130 to the MySQL source's `get_non_retryable_errors`, with a user-facing message that explains the host isn't granted access and what the DB admin needs to do. The match is on the stable tail phrase `is not allowed to connect to this MySQL server` rather than the volatile host in the message prefix, so it catches both the raw pymysql string and the Temporal-wrapped `OperationalError: (1130, ...)` form.

This mirrors the existing treatment of the neighbouring host-state errors (1129 host-blocked, 1045 access-denied, 1054 unknown-column).

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_host_not_privileged_is_non_retryable`) covering both the raw pymysql and Temporal-wrapped message forms, and ran the source's non-retryable / retryable test suite:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py -k "host_not_privileged or host_blocked or unknown_column or transient or ssl_wrong or decimal or widened"
# 19 passed
```

The transient-error tests (lost connection 2013, thread exhaustion 1135) still assert those stay retryable, confirming the new entry didn't widen matching into transient infrastructure errors.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's full stack trace and confirmed the failure raises inside the MySQL source's `connect` (not just serialized log context). Classified 1130 as a user/upstream config error rather than a fixable bug or a transient infra error — the server-side grant is outside our control and retrying is futile — so the fix is to stop retrying and surface actionable guidance. Scoped strictly to this one error; no retry-policy or pipeline-wide changes.
