### PR TITLE
fix(google_ads): treat API quota exhaustion as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -63,6 +63,14 @@ class GoogleAdsSource(
             # recover — the user must reconnect their Google Ads account. Model-specific so we don't
             # swallow unrelated `DoesNotExist` errors from other models, which may be real bugs.
             "Integration matching query does not exist": "Your Google Ads connection is no longer available — it may have been disconnected. Please reconnect your Google Ads account.",
+            # gRPC RESOURCE_EXHAUSTED quota rejection from the Google Ads API: the account's API
+            # quota (operations/day for the developer token's access level) is used up. Retrying
+            # within the activity's window can't recover — Google's quota resets on its own schedule,
+            # not within our backoff — and each retry burns more of the limited quota. Match the
+            # stable quota phrase, NOT the bare status: the client-side "Received message larger than
+            # max" RESOURCE_EXHAUSTED is a different failure handled by raising the receive limit (see
+            # google_ads.py), and must stay out of this list.
+            "Resource has been exhausted (e.g. check quota)": "PostHog hit your Google Ads API quota and paused this sync. The quota typically resets within 24 hours — re-enable the sync once it recovers. If this keeps happening, request a higher Google Ads API access level or sync fewer resources.",
         }
 
     # TODO: clean up google ads source to not have two auth config options

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -176,6 +176,27 @@ class TestGoogleAdsNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Observed in production: gRPC RESOURCE_EXHAUSTED quota rejection surfaced as both
+            # `_InactiveRpcError` and `google.api_core.exceptions.ResourceExhausted`.
+            (
+                "<_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.RESOURCE_EXHAUSTED\n\t"
+                'details = "Resource has been exhausted (e.g. check quota)."\n>'
+            ),
+            "Resource has been exhausted (e.g. check quota).",
+        ],
+    )
+    def test_quota_exhausted_is_non_retryable(self, error_msg):
+        is_non_retryable = any(pattern in error_msg for pattern in self.non_retryable.keys())
+        assert is_non_retryable, f"Expected error to be non-retryable: {error_msg}"
+
+    def test_quota_exhausted_has_friendly_message(self):
+        friendly = self.non_retryable["Resource has been exhausted (e.g. check quota)"]
+        assert friendly is not None
+        assert "quota" in friendly.lower()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Transient network/infrastructure errors should still be retried.
             "DeadlineExceeded: 504 Deadline Exceeded",
             "UNAVAILABLE: The service is currently unavailable",
@@ -184,6 +205,12 @@ class TestGoogleAdsNonRetryableErrors:
             # A RefreshError wrapping a transient 502 from Google's token endpoint shares the
             # same error-tracking group as access_not_configured but must remain retryable.
             "('<!DOCTYPE html><title>Error 502 (Server Error)!!1</title>', None)",
+            # The client-side "message too large" RESOURCE_EXHAUSTED is a distinct failure handled
+            # by raising the gRPC receive limit — it must NOT be swept up by the quota pattern.
+            (
+                "<_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.RESOURCE_EXHAUSTED\n\t"
+                'details = "Received message larger than max (104857600 vs. 67108864)"\n>'
+            ),
         ],
     )
     def test_transient_errors_are_retryable(self, error_msg):


### PR DESCRIPTION
## Problem

Google Ads imports surfaced a recurring error in error tracking: a gRPC `RESOURCE_EXHAUSTED` from the Google Ads API with the message `"Resource has been exhausted (e.g. check quota)."`, raised inside `_search_as_arrow_tables` (`posthog/temporal/data_imports/sources/google_ads/google_ads.py`) while paginating `GoogleAdsService.search`.

This is the Google Ads API rejecting requests because the account's API quota (operations/day, tied to the developer token's access level) is exhausted — a Google-side limit, not our infrastructure. It was being treated as retryable, so the import activity retried it up to 9 times across a week-long window. Every retry just burns more of the customer's already-exhausted quota and can't recover within our backoff: Google's quota resets on its own schedule, not within retry intervals.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019edb43-b382-76a1-ba35-e9e29161d7d9

## Changes

Added the stable quota phrase `"Resource has been exhausted (e.g. check quota)"` to `GoogleAdsSource.get_non_retryable_errors()` with a user-facing message explaining that the sync paused on the API quota, the quota typically resets within 24 hours, and what to do if it persists (request higher API access or sync fewer resources).

The match is deliberately scoped to the **quota** phrase rather than the bare `RESOURCE_EXHAUSTED` status. The source already handles a *different* `RESOURCE_EXHAUSTED` — the client-side `"Received message larger than max"` — by raising the gRPC receive limit (`google_ads.py`). That one is a fixable transport concern, not a user error, and must stay retryable. The two have distinct message strings, so matching the quota phrase keeps them apart.

## How did you test this code?

I'm an agent. I added regression tests to `TestGoogleAdsNonRetryableErrors` and ran them:

- New `test_quota_exhausted_is_non_retryable` asserts the quota message (both the raw `_InactiveRpcError` repr and the `ResourceExhausted` string form) is classified non-retryable.
- New `test_quota_exhausted_has_friendly_message` asserts a user-facing message is present.
- Extended `test_transient_errors_are_retryable` with the client-side `"Received message larger than max"` `RESOURCE_EXHAUSTED` to prove it is **not** swept up by the new pattern.

Ran the full source test file: `pytest posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py` — 63 passed. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's stack trace and a representative event via the PostHog error-tracking tools and confirmed the failure genuinely originates in the google_ads source's `get_rows` / `_search_as_arrow_tables` frames (not just serialized log context).

Decision: classified this as an upstream/third-party limit rather than a transient infra error or a code bug. Considered leaving it retryable (it does eventually recover when quota resets), but rejected that because the retries actively harm the customer by consuming more of the exhausted quota and never recover inside the activity's backoff window. The non-retryable path still allows a few attempts before pausing the schema, which covers momentary throttling. Scoped the match string to avoid colliding with the already-handled client-side "message too large" `RESOURCE_EXHAUSTED`.

No skills were applicable to this change (no migrations, DRF endpoints, or generated API types touched).
