### PR TITLE
fix(data-imports): treat WorkOS 422 responses as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/workos/source.py
+++ b/posthog/temporal/data_imports/sources/workos/source.py
@@ -89,6 +89,10 @@ The key starts with `sk_`.
         return {
             "401 Client Error: Unauthorized for url: https://api.workos.com": "Your WorkOS API key is invalid or has been revoked. Please update the key in your WorkOS dashboard and reconnect.",
             "403 Client Error: Forbidden for url: https://api.workos.com": "Your WorkOS API key does not have permission to access this endpoint. Please check the key's scopes in your WorkOS dashboard.",
+            # WorkOS returns 422 for a syntactically valid list request it can't fulfil for this
+            # account — e.g. the Directory Sync endpoints (directory_users/directory_groups) when
+            # Directory Sync isn't provisioned. It's deterministic, so retrying never resolves it.
+            "422 Client Error: Unprocessable Entity for url: https://api.workos.com": "WorkOS could not process the request for one of the endpoints being synced. This usually means the data isn't available for your WorkOS account (for example, Directory Sync isn't configured). Please check your WorkOS configuration and the endpoints you're syncing, then reconnect.",
         }
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/workos/tests/test_workos_source.py
+++ b/posthog/temporal/data_imports/sources/workos/tests/test_workos_source.py
@@ -40,14 +40,21 @@ class TestWorkOSSource:
         [
             "401 Client Error: Unauthorized for url: https://api.workos.com",
             "403 Client Error: Forbidden for url: https://api.workos.com",
+            "422 Client Error: Unprocessable Entity for url: https://api.workos.com",
         ],
     )
     def test_non_retryable_errors_includes_workos_key(self, expected_key):
         errors = self.source.get_non_retryable_errors()
         assert expected_key in errors
 
-    def test_non_retryable_errors_matches_observed_error_message(self):
-        observed_error = "401 Client Error: Unauthorized for url: https://api.workos.com/organizations?limit=100"
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.workos.com/organizations?limit=100",
+            "422 Client Error: Unprocessable Entity for url: https://api.workos.com/directory_users?limit=100&order=desc",
+        ],
+    )
+    def test_non_retryable_errors_matches_observed_error_message(self, observed_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable_errors)
 


### PR DESCRIPTION
## Problem

A data-warehouse import surfaced via error tracking as an unhandled `HTTPError`:

```
422 Client Error: Unprocessable Entity for url: https://api.workos.com/directory_users?limit=100&order=desc
```

Issue: https://us.posthog.com/project/2/error_tracking/019edb47-7931-7a31-bcdf-faec5c0193ac

The stack trace ends in the shared REST client (`rest_source/rest_client.py:_send_request` → `raise_for_status`) on the first page of a WorkOS `directory_users` sync. WorkOS returns 422 for a request that is itself well-formed: per the [WorkOS API reference](https://workos.com/docs/reference/directory-sync/directory-user/list), `directory`/`group` are optional and `order` defaults to `desc`, which is exactly what we send. In practice WorkOS returns 422 when it can't fulfil the list for the account — most commonly when Directory Sync isn't provisioned for that account.

A 422 here is deterministic: the same request will always be rejected, so retrying just burns the retry budget and re-fires the alert.

## Changes

Add the WorkOS 422 to `WorkOSSource.get_non_retryable_errors()`, mirroring the existing host-scoped `401`/`403` entries:

```
"422 Client Error: Unprocessable Entity for url: https://api.workos.com"
```

The match key is the stable status text + host (no per-request path, query, or ids), consistent with the existing WorkOS and Stripe patterns. It surfaces an actionable message pointing the user at their WorkOS configuration instead of retrying a request that can't succeed.

Extended the source unit tests to assert the 422 key is present and that the observed `directory_users` message is classified non-retryable.

## How did you test this code?

I'm an agent. The full Django-backed test runner couldn't boot in this environment (missing project deps), so I verified at two layers:

- `ruff check` + `ruff format --check` pass on both changed files; `py_compile` is clean.
- Reproduced the matcher from `import_data_sync.py` (`any(key in error_msg ...)`) in isolation and asserted: the observed `directory_users` 422 (and the sibling `directory_groups` 422) are recognised non-retryable; other-vendor 422s (Stripe) do **not** match; and transient infra errors (read timeout, 500) stay retryable.

The added cases live in `test_workos_source.py::TestWorkOSSource` (`test_non_retryable_errors_includes_workos_key`, `test_non_retryable_errors_matches_observed_error_message`) and should run in CI.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue end to end: pulled the issue + a raw sample event via the PostHog error-tracking MCP tools to get the full stack trace and confirm the exact failing request, then read the WorkOS source under `posthog/temporal/data_imports/sources/workos/` and the shared `rest_source` client.

Decision — user/upstream vs fixable bug: classified this as upstream/config rather than a code bug. The request we send is valid per the WorkOS reference (checked: `order=desc` is the documented default, `directory`/`group` optional), so there's no param to correct and no graceful-skip that's clearly right. A 422 is deterministic, so leaving it retryable is strictly wrong. Rejected widening the match to the per-endpoint URL path in favour of the host-scoped key already used for 401/403. Scoped strictly to WorkOS — no change to global retry policy.
