### PR TITLE
fix(temporalio): treat unresolvable host DNS error as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -38,6 +38,13 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
             # The Temporal core builds the connection target from the configured host:port. An empty
             # or scheme-only host yields no parseable host — a config problem retrying never fixes.
             "invalid target URL: empty host": "Temporal could not connect because the configured host is empty or invalid. Update the source with the hostname of your Temporal namespace's gRPC endpoint (for example, your-namespace.account.tmprl.cloud) — without a protocol scheme or port.",
+            # tonic's DNS resolver surfaces getaddrinfo's EAI_NONAME as this exact phrase when the
+            # configured host does not resolve at all (a wrong/typo'd hostname, a deleted namespace,
+            # or a scheme/port accidentally pasted into the host field). Retrying never recovers a
+            # name that doesn't exist in DNS. Match the EAI_NONAME phrase specifically — the transient
+            # EAI_AGAIN ("Temporary failure in name resolution") is a different message and stays
+            # retryable.
+            "failed to lookup address information: Name or service not known": "Temporal could not connect because the configured host could not be found in DNS. Check the source's host points at your Temporal namespace's gRPC endpoint (for example, your-namespace.account.tmprl.cloud) — without a protocol scheme or port — and that the namespace still exists.",
             "received fatal alert: UnknownCA": "Temporal rejected this source's client certificate because it is not signed by a certificate authority the namespace trusts. This usually means the namespace's CA certificates were rotated — update the source with a client certificate and key signed by the current CA.",
             "received fatal alert: CertificateExpired": "This source's client certificate has expired. Update the source with a renewed client certificate and key.",
             "received fatal alert: CertificateRevoked": "This source's client certificate has been revoked. Update the source with a new client certificate and key.",

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -54,6 +54,7 @@ class TestTemporalIONonRetryableErrors:
             "Failed client connect: Server connection error: tonic::transport::Error(Transport, CertificateParseError)",
             'RuntimeError: Failed client connect: invalid target URL: empty host: ":7233"',
             "tonic::transport::Error(Transport, InvalidUri(InvalidUri(InvalidFormat))): invalid target URL: empty host",
+            'RuntimeError: Failed client connect: Server connection error: tonic::transport::Error(Transport, ConnectError(ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" })))',
         ],
     )
     def test_config_failures_are_non_retryable(self, error_message):
@@ -81,6 +82,9 @@ class TestTemporalIONonRetryableErrors:
         [
             "activity Heartbeat timeout",
             'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Os { code: 60, kind: TimedOut, message: "Operation timed out" }))) }',
+            # EAI_AGAIN is a transient resolver failure, distinct from the EAI_NONAME phrase we treat
+            # as non-retryable — it must keep retrying.
+            'RuntimeError: Failed client connect: Server connection error: tonic::transport::Error(Transport, ConnectError(ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" })))',
         ],
     )
     def test_transient_failures_stay_retryable(self, error_message):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `RuntimeError` from the Temporal.io data-warehouse import source:

```
Failed client connect: Server connection error: tonic::transport::Error(Transport,
ConnectError(ConnectError("dns error", Custom { kind: Uncategorized,
error: "failed to lookup address information: Name or service not known" })))
```

Issue: https://us.posthog.com/project/2/error_tracking/019edb4c-d898-79b1-b33f-424ec7df6f8f

The stack trace confirms the failure originates in this source — `temporalio.py` → `_get_temporal_client` → `posthog/temporal/common/client.py:connect` — at the point where the Rust Temporal client connects to the configured `host:port`.

`failed to lookup address information: Name or service not known` is getaddrinfo's `EAI_NONAME`: the configured host does not resolve in DNS at all. In practice that means a wrong or typo'd hostname, a deleted namespace, or a scheme/port accidentally pasted into the host field. Today this is retried like a transient error, so a broken source keeps re-running the import and re-raising the same error indefinitely.

## Changes

Treat the `EAI_NONAME` DNS phrase as non-retryable by adding it to the source's `get_non_retryable_errors()`, alongside the existing `invalid target URL: empty host` host-config entry. The user-facing message points them at fixing the source's host.

The match is the specific `EAI_NONAME` phrase, **not** the broader "dns error". That's deliberate: the transient `EAI_AGAIN` variant (`Temporary failure in name resolution`) is a different message and must keep retrying — a regression test asserts it stays retryable.

This is scoped strictly to this one error class; no change to global retry policy.

## How did you test this code?

I'm an agent. I added automated tests at the same layer as the fix (`test_temporalio.py`):

- A new non-retryable case asserting the real production error string matches a non-retryable pattern.
- A new retryable case asserting the transient `EAI_AGAIN` DNS variant does **not** match (stays retryable).

I could not run the suite in this environment (no test runner / dependencies provisioned), but verified the substring-matching logic that the tests exercise produces the expected results. CI will run the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's stack trace and a representative event via the PostHog error-tracking tools, confirmed the failure path runs through `posthog/temporal/data_imports/sources/temporalio/temporalio.py` (not just incidental log context), then read the source and shared `connect` helper.

Decision: user/upstream config error, not a fixable bug or a transient infra error. The configured host doesn't exist in DNS (`EAI_NONAME`), which retrying can never recover — same class as the existing `invalid target URL: empty host` entry. Chose to match the precise `EAI_NONAME` phrase rather than a broad `dns error` substring specifically so the transient `EAI_AGAIN` resolver failure keeps retrying; added a regression test pinning that boundary.
