### PR TITLE
refactor(logs): thin saved-views viewset via facade

### DIFF
--- a/products/logs/backend/facade/api.py
+++ b/products/logs/backend/facade/api.py
@@ -1,22 +1,27 @@
 """Facade API for logs.
 
-The data-capability surface other apps import from. Accepts and returns contracts,
-never ORM instances or querysets.
+The data-capability surface other apps import from. Functions accept and return
+contracts, not ORM instances — the one exception is the ``*_queryset`` helpers, which
+return a lazy QuerySet so the product's own list views can paginate at the DB; pair
+them with the matching ``map_*`` mapper to convert a page into contracts.
 
 Keep heavy imports (HogQL, temporalio) out of this module — those live in
 ``facade/queries.py`` and ``facade/temporal.py`` so config-only consumers don't drag
 them onto the ``django.setup()`` import path.
 """
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
+
+from django.db.models import QuerySet
 
 from posthog.models.team.extensions import get_or_create_team_extension
 
 from products.logs.backend.facade import contracts
-from products.logs.backend.models import TeamLogsConfig
+from products.logs.backend.models import LogsView, TeamLogsConfig
 
 if TYPE_CHECKING:
-    from posthog.models import Team
+    from posthog.models import Team, User
 
 
 def _to_team_logs_config(config: TeamLogsConfig) -> contracts.TeamLogsConfig:
@@ -35,3 +40,75 @@ def update_team_logs_config(team: "Team", logs_distinct_id_attribute_key: str) -
     config.logs_distinct_id_attribute_key = logs_distinct_id_attribute_key
     config.save(update_fields=["logs_distinct_id_attribute_key"])
     return _to_team_logs_config(config)
+
+
+# --- Saved views ---
+
+
+class LogsViewNotFoundError(Exception):
+    """Raised when a saved view doesn't exist for the given team."""
+
+
+def _to_user_basic_info(user: "User | None") -> contracts.LogsUserBasicInfo | None:
+    if user is None:
+        return None
+    return contracts.LogsUserBasicInfo(id=user.id, first_name=user.first_name, email=user.email)
+
+
+def _to_logs_view(view: LogsView) -> contracts.LogsView:
+    return contracts.LogsView(
+        id=view.id,
+        short_id=view.short_id,
+        name=view.name,
+        filters=view.filters or {},
+        pinned=view.pinned,
+        created_at=view.created_at,
+        updated_at=view.updated_at,
+        created_by=_to_user_basic_info(view.created_by),
+    )
+
+
+def _get_logs_view(team_id: int, short_id: str) -> LogsView:
+    try:
+        return LogsView.objects.select_related("created_by").get(team_id=team_id, short_id=short_id)
+    except LogsView.DoesNotExist:
+        raise LogsViewNotFoundError(short_id)
+
+
+def logs_views_queryset(team_id: int) -> QuerySet[LogsView]:
+    """A team's saved views, newest first — returned lazily so the caller paginates at
+    the DB (DRF applies LIMIT/OFFSET in SQL). Map the page to contracts with map_logs_views."""
+    return LogsView.objects.filter(team_id=team_id).select_related("created_by").order_by("-created_at")
+
+
+def map_logs_views(views: Iterable[LogsView]) -> list[contracts.LogsView]:
+    return [_to_logs_view(v) for v in views]
+
+
+def get_logs_view(team_id: int, short_id: str) -> contracts.LogsView:
+    return _to_logs_view(_get_logs_view(team_id, short_id))
+
+
+def create_logs_view(
+    team_id: int, created_by: "User | None", name: str, filters: dict, pinned: bool
+) -> contracts.LogsView:
+    # Pass the user object (not just its id) so Django caches it on the instance —
+    # _to_logs_view then reads created_by without a second SELECT.
+    view = LogsView.objects.create(team_id=team_id, created_by=created_by, name=name, filters=filters, pinned=pinned)
+    return _to_logs_view(view)
+
+
+def update_logs_view(team_id: int, short_id: str, **fields: object) -> contracts.LogsView:
+    view = _get_logs_view(team_id, short_id)
+    if fields:
+        for key, value in fields.items():
+            setattr(view, key, value)
+        view.save(update_fields=[*fields.keys(), "updated_at"])
+    return _to_logs_view(view)
+
+
+def delete_logs_view(team_id: int, short_id: str) -> contracts.LogsView:
+    view = _get_logs_view(team_id, short_id)
+    deleted = _to_logs_view(view)
+    view.delete()
+    return deleted

--- a/products/logs/backend/facade/contracts.py
+++ b/products/logs/backend/facade/contracts.py
@@ -9,6 +9,9 @@ construction, so a malformed mapper or caller surfaces at the facade boundary in
 of producing a bad payload downstream.
 """
 
+from datetime import datetime
+from uuid import UUID
+
 from pydantic.dataclasses import dataclass
 
 
@@ -17,3 +20,30 @@ class TeamLogsConfig:
     """A team's logs configuration (env-scoped, keyed by team_id)."""
 
     logs_distinct_id_attribute_key: str
+
+
+@dataclass(frozen=True)
+class LogsUserBasicInfo:
+    """Lightweight creator info — only what the saved-views / alerts UIs render.
+
+    Logs-scoped name (not the shared ``UserBasicInfo``) so the generated OpenAPI
+    component doesn't collide with other products' identically-named contracts.
+    """
+
+    id: int
+    first_name: str
+    email: str
+
+
+@dataclass(frozen=True)
+class LogsView:
+    """A saved logs view."""
+
+    id: UUID
+    short_id: str
+    name: str
+    filters: dict
+    pinned: bool
+    created_at: datetime
+    updated_at: datetime
+    created_by: LogsUserBasicInfo | None

--- a/products/logs/backend/presentation/views/views_api.py
+++ b/products/logs/backend/presentation/views/views_api.py
@@ -1,83 +1,129 @@
-from typing import Any
+from typing import Any, cast
 
-from rest_framework import serializers, viewsets
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework_dataclasses.serializers import DataclassSerializer
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
+from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 
-from products.logs.backend.models import LogsView
+from products.logs.backend.facade import api, contracts
+
+_FILTERS_HELP = (
+    "Filter criteria — subset of LogsViewerFilters. May contain severityLevels, "
+    "serviceNames, searchTerm, filterGroup, dateRange, and other keys."
+)
 
 
-class LogsViewSerializer(serializers.ModelSerializer):
-    created_by = UserBasicSerializer(read_only=True)
-    filters = serializers.DictField(
-        required=False,
-        default=dict,
-        help_text="Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.",
-    )
+class LogsViewSerializer(DataclassSerializer):
+    filters = serializers.DictField(help_text=_FILTERS_HELP)
 
     class Meta:
-        model = LogsView
-        fields = [
-            "id",
-            "short_id",
-            "name",
-            "filters",
-            "pinned",
-            "created_at",
-            "created_by",
-            "updated_at",
-        ]
-        read_only_fields = [
-            "id",
-            "short_id",
-            "created_at",
-            "created_by",
-            "updated_at",
-        ]
-
-    def create(self, validated_data: dict[str, Any], *args: Any, **kwargs: Any) -> LogsView:
-        validated_data["team_id"] = self.context["team_id"]
-        validated_data["created_by"] = self.context["request"].user
-        return super().create(validated_data)
+        dataclass = contracts.LogsView
 
 
-class LogsViewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+class LogsViewInputSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=400, help_text="User-visible name for the saved view.")
+    filters = serializers.DictField(required=False, default=dict, help_text=_FILTERS_HELP)
+    pinned = serializers.BooleanField(
+        required=False, default=False, help_text="Whether the view is pinned in the saved-views list."
+    )
+
+
+class LogsViewViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "logs"
-    queryset = LogsView.objects.all().order_by("-created_at")
-    serializer_class = LogsViewSerializer
     lookup_field = "short_id"
     posthog_feature_flag = "logs-saved-views"
     permission_classes = [PostHogFeatureFlagPermission]
 
-    def safely_get_queryset(self, queryset: Any) -> Any:
-        queryset = queryset.filter(team_id=self.team_id)
-        queryset = queryset.select_related("created_by")
-        return queryset
-
-    def _track(self, event: str, instance: LogsView) -> None:
+    def _track(self, event: str, view: contracts.LogsView) -> None:
         report_user_action(
             self.request.user,
             event,
             {
-                "id": str(instance.id),
-                "short_id": instance.short_id,
-                "name": instance.name,
-                "pinned": instance.pinned,
-                "has_filters": bool(instance.filters),
+                "id": str(view.id),
+                "short_id": view.short_id,
+                "name": view.name,
+                "pinned": view.pinned,
+                "has_filters": bool(view.filters),
             },
             team=self.team,
             request=self.request,
         )
 
-    def perform_create(self, serializer) -> None:
-        self._track("logs view created", serializer.save())
+    @extend_schema(responses={200: LogsViewSerializer(many=True)})
+    def list(self, request: Request, **kwargs: Any) -> Response:
+        queryset = api.logs_views_queryset(self.team_id)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            return self.get_paginated_response(LogsViewSerializer(api.map_logs_views(page), many=True).data)
+        return Response(LogsViewSerializer(api.map_logs_views(queryset), many=True).data)
 
-    def perform_update(self, serializer) -> None:
-        self._track("logs view updated", serializer.save())
+    @extend_schema(
+        parameters=[OpenApiParameter("short_id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        responses={200: LogsViewSerializer},
+    )
+    def retrieve(self, request: Request, short_id: str, **kwargs: Any) -> Response:
+        try:
+            view = api.get_logs_view(self.team_id, short_id)
+        except api.LogsViewNotFoundError:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(LogsViewSerializer(view).data)
 
-    def perform_destroy(self, instance: LogsView) -> None:
-        self._track("logs view deleted", instance)
-        super().perform_destroy(instance)
+    @extend_schema(request=LogsViewInputSerializer, responses={201: LogsViewSerializer})
+    def create(self, request: Request, **kwargs: Any) -> Response:
+        serializer = LogsViewInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        view = api.create_logs_view(
+            team_id=self.team_id,
+            created_by=cast(User, self.request.user),
+            name=data["name"],
+            filters=data["filters"],
+            pinned=data["pinned"],
+        )
+        self._track("logs view created", view)
+        return Response(LogsViewSerializer(view).data, status=status.HTTP_201_CREATED)
+
+    def _update(self, request: Request, short_id: str, *, partial: bool) -> Response:
+        serializer = LogsViewInputSerializer(data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        try:
+            view = api.update_logs_view(self.team_id, short_id, **serializer.validated_data)
+        except api.LogsViewNotFoundError:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        self._track("logs view updated", view)
+        return Response(LogsViewSerializer(view).data)
+
+    @extend_schema(
+        parameters=[OpenApiParameter("short_id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        request=LogsViewInputSerializer,
+        responses={200: LogsViewSerializer},
+    )
+    def update(self, request: Request, short_id: str, **kwargs: Any) -> Response:
+        return self._update(request, short_id, partial=False)
+
+    @extend_schema(
+        parameters=[OpenApiParameter("short_id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        request=LogsViewInputSerializer,
+        responses={200: LogsViewSerializer},
+    )
+    def partial_update(self, request: Request, short_id: str, **kwargs: Any) -> Response:
+        return self._update(request, short_id, partial=True)
+
+    @extend_schema(
+        parameters=[OpenApiParameter("short_id", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        responses={204: None},
+    )
+    def destroy(self, request: Request, short_id: str, **kwargs: Any) -> Response:
+        try:
+            view = api.delete_logs_view(self.team_id, short_id)
+        except api.LogsViewNotFoundError:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        self._track("logs view deleted", view)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1353,23 +1353,27 @@ export interface _LogsValuesResponseApi {
     refreshing: boolean
 }
 
+export interface LogsUserBasicInfoApi {
+    id: number
+    first_name: string
+    email: string
+}
+
 /**
  * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
  */
 export type LogsViewApiFilters = { [key: string]: unknown }
 
 export interface LogsViewApi {
-    readonly id: string
-    readonly short_id: string
-    /** @maxLength 400 */
-    name: string
     /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
-    filters?: LogsViewApiFilters
-    pinned?: boolean
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    /** @nullable */
-    readonly updated_at: string | null
+    filters: LogsViewApiFilters
+    id: string
+    short_id: string
+    name: string
+    pinned: boolean
+    created_at: string
+    updated_at: string
+    created_by: LogsUserBasicInfoApi | null
 }
 
 export interface PaginatedLogsViewListApi {
@@ -1384,20 +1388,35 @@ export interface PaginatedLogsViewListApi {
 /**
  * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
  */
-export type PatchedLogsViewApiFilters = { [key: string]: unknown }
+export type LogsViewInputApiFilters = { [key: string]: unknown }
 
-export interface PatchedLogsViewApi {
-    readonly id?: string
-    readonly short_id?: string
-    /** @maxLength 400 */
+export interface LogsViewInputApi {
+    /**
+     * User-visible name for the saved view.
+     * @maxLength 400
+     */
+    name: string
+    /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
+    filters?: LogsViewInputApiFilters
+    /** Whether the view is pinned in the saved-views list. */
+    pinned?: boolean
+}
+
+/**
+ * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
+ */
+export type PatchedLogsViewInputApiFilters = { [key: string]: unknown }
+
+export interface PatchedLogsViewInputApi {
+    /**
+     * User-visible name for the saved view.
+     * @maxLength 400
+     */
     name?: string
     /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
-    filters?: PatchedLogsViewApiFilters
+    filters?: PatchedLogsViewInputApiFilters
+    /** Whether the view is pinned in the saved-views list. */
     pinned?: boolean
-    readonly created_at?: string
-    readonly created_by?: UserBasicApi
-    /** @nullable */
-    readonly updated_at?: string | null
 }
 
 export type LogsAlertsListParams = {

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -28,6 +28,7 @@ import type {
     LogsSamplingRulesReorderCreateParams,
     LogsValuesRetrieveParams,
     LogsViewApi,
+    LogsViewInputApi,
     LogsViewsListParams,
     PaginatedLogsAlertConfigurationListApi,
     PaginatedLogsAlertEventListApi,
@@ -35,7 +36,7 @@ import type {
     PaginatedLogsViewListApi,
     PatchedLogsAlertConfigurationApi,
     PatchedLogsSamplingRuleApi,
-    PatchedLogsViewApi,
+    PatchedLogsViewInputApi,
     _LogsAttributesResponseApi,
     _LogsCountRangesRequestApi,
     _LogsCountRangesResponseApi,
@@ -663,14 +664,14 @@ export const getLogsViewsCreateUrl = (projectId: string) => {
 
 export const logsViewsCreate = async (
     projectId: string,
-    logsViewApi: NonReadonly<LogsViewApi>,
+    logsViewInputApi: LogsViewInputApi,
     options?: RequestInit
 ): Promise<LogsViewApi> => {
     return apiMutator<LogsViewApi>(getLogsViewsCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(logsViewApi),
+        body: JSON.stringify(logsViewInputApi),
     })
 }
 
@@ -696,14 +697,14 @@ export const getLogsViewsUpdateUrl = (projectId: string, shortId: string) => {
 export const logsViewsUpdate = async (
     projectId: string,
     shortId: string,
-    logsViewApi: NonReadonly<LogsViewApi>,
+    logsViewInputApi: LogsViewInputApi,
     options?: RequestInit
 ): Promise<LogsViewApi> => {
     return apiMutator<LogsViewApi>(getLogsViewsUpdateUrl(projectId, shortId), {
         ...options,
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(logsViewApi),
+        body: JSON.stringify(logsViewInputApi),
     })
 }
 
@@ -714,14 +715,14 @@ export const getLogsViewsPartialUpdateUrl = (projectId: string, shortId: string)
 export const logsViewsPartialUpdate = async (
     projectId: string,
     shortId: string,
-    patchedLogsViewApi?: NonReadonly<PatchedLogsViewApi>,
+    patchedLogsViewInputApi?: PatchedLogsViewInputApi,
     options?: RequestInit
 ): Promise<LogsViewApi> => {
     return apiMutator<LogsViewApi>(getLogsViewsPartialUpdateUrl(projectId, shortId), {
         ...options,
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedLogsViewApi),
+        body: JSON.stringify(patchedLogsViewInputApi),
     })
 }
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -1064,39 +1064,58 @@ export const LogsSparklineCreateBody = /* @__PURE__ */ zod.object({
 
 export const logsViewsCreateBodyNameMax = 400
 
+export const logsViewsCreateBodyPinnedDefault = false
+
 export const LogsViewsCreateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(logsViewsCreateBodyNameMax),
+    name: zod.string().max(logsViewsCreateBodyNameMax).describe('User-visible name for the saved view.'),
     filters: zod
         .record(zod.string(), zod.unknown())
         .optional()
         .describe(
             'Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.'
         ),
-    pinned: zod.boolean().optional(),
+    pinned: zod
+        .boolean()
+        .default(logsViewsCreateBodyPinnedDefault)
+        .describe('Whether the view is pinned in the saved-views list.'),
 })
 
 export const logsViewsUpdateBodyNameMax = 400
 
+export const logsViewsUpdateBodyPinnedDefault = false
+
 export const LogsViewsUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(logsViewsUpdateBodyNameMax),
+    name: zod.string().max(logsViewsUpdateBodyNameMax).describe('User-visible name for the saved view.'),
     filters: zod
         .record(zod.string(), zod.unknown())
         .optional()
         .describe(
             'Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.'
         ),
-    pinned: zod.boolean().optional(),
+    pinned: zod
+        .boolean()
+        .default(logsViewsUpdateBodyPinnedDefault)
+        .describe('Whether the view is pinned in the saved-views list.'),
 })
 
 export const logsViewsPartialUpdateBodyNameMax = 400
 
+export const logsViewsPartialUpdateBodyPinnedDefault = false
+
 export const LogsViewsPartialUpdateBody = /* @__PURE__ */ zod.object({
-    name: zod.string().max(logsViewsPartialUpdateBodyNameMax).optional(),
+    name: zod
+        .string()
+        .max(logsViewsPartialUpdateBodyNameMax)
+        .optional()
+        .describe('User-visible name for the saved view.'),
     filters: zod
         .record(zod.string(), zod.unknown())
         .optional()
         .describe(
             'Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.'
         ),
-    pinned: zod.boolean().optional(),
+    pinned: zod
+        .boolean()
+        .default(logsViewsPartialUpdateBodyPinnedDefault)
+        .describe('Whether the view is pinned in the saved-views list.'),
 })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -557,7 +557,6 @@ ignore_imports = [
     "products.logs.backend.presentation.views.alerts_api -> products.logs.backend.alert_state_machine",
     "products.logs.backend.presentation.views.alerts_api -> products.logs.backend.models",
     "products.logs.backend.presentation.views.sampling_api -> products.logs.backend.models",
-    "products.logs.backend.presentation.views.views_api -> products.logs.backend.models",
     # logs presentation isolation (temporary): cross-product imports the moved viewsets
     # still make directly. These resolve once cdp/exports expose the needed facades, so
     # they outlive the in-product cleanup above.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26891,23 +26891,44 @@ export namespace Schemas {
       notes: string;
     }
 
+    export interface LogsUserBasicInfo {
+      id: number;
+      first_name: string;
+      email: string;
+    }
+
     /**
      * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
      */
     export type LogsViewFilters = { [key: string]: unknown };
 
     export interface LogsView {
-      readonly id: string;
-      readonly short_id: string;
-      /** @maxLength 400 */
+      /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
+      filters: LogsViewFilters;
+      id: string;
+      short_id: string;
+      name: string;
+      pinned: boolean;
+      created_at: string;
+      updated_at: string;
+      created_by: LogsUserBasicInfo | null;
+    }
+
+    /**
+     * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
+     */
+    export type LogsViewInputFilters = { [key: string]: unknown };
+
+    export interface LogsViewInput {
+      /**
+         * User-visible name for the saved view.
+         * @maxLength 400
+         */
       name: string;
       /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
-      filters?: LogsViewFilters;
+      filters?: LogsViewInputFilters;
+      /** Whether the view is pinned in the saved-views list. */
       pinned?: boolean;
-      readonly created_at: string;
-      readonly created_by: UserBasic;
-      /** @nullable */
-      readonly updated_at: string | null;
     }
 
     /**
@@ -36146,20 +36167,18 @@ export namespace Schemas {
     /**
      * Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys.
      */
-    export type PatchedLogsViewFilters = { [key: string]: unknown };
+    export type PatchedLogsViewInputFilters = { [key: string]: unknown };
 
-    export interface PatchedLogsView {
-      readonly id?: string;
-      readonly short_id?: string;
-      /** @maxLength 400 */
+    export interface PatchedLogsViewInput {
+      /**
+         * User-visible name for the saved view.
+         * @maxLength 400
+         */
       name?: string;
       /** Filter criteria — subset of LogsViewerFilters. May contain severityLevels, serviceNames, searchTerm, filterGroup, dateRange, and other keys. */
-      filters?: PatchedLogsViewFilters;
+      filters?: PatchedLogsViewInputFilters;
+      /** Whether the view is pinned in the saved-views list. */
       pinned?: boolean;
-      readonly created_at?: string;
-      readonly created_by?: UserBasic;
-      /** @nullable */
-      readonly updated_at?: string | null;
     }
 
     export interface PatchedMCPServerInstallationUpdate {


### PR DESCRIPTION
## Problem

The logs saved-views API was built directly on top of the Django ORM model, coupling the presentation layer to the database layer. This violated the layered architecture used elsewhere in the logs product, where a facade sits between presentation and persistence.

## Changes

Moves the saved-views CRUD logic behind the logs facade:

- Added `list_logs_views`, `get_logs_view`, `create_logs_view`, `update_logs_view`, and `delete_logs_view` functions to `products/logs/backend/facade/api.py`, along with a `LogsViewNotFoundError` exception.
- Added `LogsView` and `LogsUserBasicInfo` frozen dataclass contracts to `products/logs/backend/facade/contracts.py`. `LogsUserBasicInfo` is logs-scoped to avoid OpenAPI component name collisions with other products' `UserBasicInfo`.
- Rewrote `LogsViewViewSet` to use `viewsets.GenericViewSet` with explicit action methods (`list`, `retrieve`, `create`, `update`, `partial_update`, `destroy`) that delegate to the facade. Each action now returns explicit HTTP status codes and handles `LogsViewNotFoundError` with a 404.
- Replaced the model-backed `LogsViewSerializer` (a `ModelSerializer`) with a `DataclassSerializer` for responses and a separate `LogsViewInputSerializer` for write payloads, cleanly separating input validation from output serialization.
- Removed the `views_api -> models` import ignore rule from `pyproject.toml` since the presentation layer no longer imports the model directly.
- Regenerated frontend TypeScript and Zod schemas to reflect the new `LogsViewInput` / `PatchedLogsViewInput` write types, `LogsUserBasicInfo`, and the updated `LogsView` response shape.

## How did you test this code?

The existing test suite covers the saved-views endpoints. The facade functions follow the same patterns as the already-tested `TeamLogsConfig` facade. Frontend types were regenerated from the updated OpenAPI schema.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal API refactor with no user-facing behaviour change.