### PR TITLE
feat(logs): hide severity/service filters from bar when facet rail on

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -48,6 +48,8 @@ const taxonomicGroupTypes = [
 
 export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
+    // When the facet rail is on, Level + Service live in the rail instead of this bar.
+    const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
     const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
     const { zoomDateRange, setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
@@ -60,8 +62,16 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
             <div className="flex flex-col gap-2 w-full bg-primary">
                 <div className="flex gap-2 flex-wrap w-full justify-between">
                     <div className="flex shrink-0 flex-1 gap-1.5">
-                        <SeverityLevelsFilter value={severityLevels} onChange={setSeverityLevels} />
-                        <ServiceFilter value={serviceNames} onChange={setServiceNames} dateRange={utcDateRange} />
+                        {!showFacetRail && (
+                            <>
+                                <SeverityLevelsFilter value={severityLevels} onChange={setSeverityLevels} />
+                                <ServiceFilter
+                                    value={serviceNames}
+                                    onChange={setServiceNames}
+                                    dateRange={utcDateRange}
+                                />
+                            </>
+                        )}
                         <div className="min-w-[300px] max-w-[350px] w-full">
                             <LogsFilterSearch />
                         </div>


### PR DESCRIPTION
## Problem

Level and service filters in the logs viewer lived only in the top filter bar, making them easy to miss and disconnected from the visual language of the log rows. The facet rail existed as a shell with no real content.

## Changes

**`Facet` component** — a new reusable collapsible facet that supports multi-select (OR semantics), an optional search box, optional color swatches (used for severity), and virtualized rendering via `react-window` when `maxHeight` is set.

**`facetRailLogic`** — a keyed Kea logic that acts as a thin lens over `logsViewerFiltersLogic`. Toggling a severity level or service name writes directly back to the shared filter reducers, keeping URL sync, saved views, and the chips bar in step. Collapsed-facet state is persisted locally per rail instance.

**`FacetRail`** — now renders a Level facet (with severity bar colors matching the log rows) and a Service facet (with search and virtualized list). The `ServiceFacet` inner component binds `serviceFilterLogic` so it can fetch and search service names independently.

**`LogsFilterBar`** — Level and Service filter controls are hidden when the `LOGS_FACET_RAIL` feature flag is on, so they don't appear in both places simultaneously.

**`SEVERITY_BAR_COLORS`** — exported from `columnDefinitions` so the rail can reuse the exact same Tailwind classes as the severity bar in log rows.

## How did you test this code?

Unit tests in `facetRailLogic.test.ts` cover:
- Adding, accumulating (OR), and removing severity levels
- Adding and removing a service name
- Toggling relative to selections already present on the shared filters logic