### PR TITLE
fix(mysql): treat out-of-sort-memory (1038) as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -242,6 +242,15 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # locale-independent error code (the user, host, and table are volatile and the message text
             # is translated on non-English servers), consistent with the other code-prefixed entries.
             "(1142,": "PostHog's database user doesn't have SELECT permission on a table this sync reads (MySQL error 1142). Ask your database admin to grant SELECT on it, or remove that table from the sync, then resync.",
+            # MySQL/MariaDB error 1038 (ER_OUT_OF_SORTMEMORY): the server's `sort_buffer_size` is too
+            # small to filesort the `ORDER BY <incremental_field>` the incremental query requires. We
+            # already try to dodge the sort with the in-activity FORCE INDEX fallback (see
+            # `_is_bad_plan_error`); this only escapes once that fallback can't apply — no usable index
+            # on the incremental field. Both `sort_buffer_size` and the missing index are static
+            # server-side state, so every retry filesorts the same rows and fails identically. Match the
+            # locale-independent error code (the trailing message text is translated on non-English
+            # servers) so it catches both the raw pymysql string and the wrapped `(1038, ...)` form.
+            "(1038,": "Your MySQL/MariaDB server ran out of sort buffer memory while ordering this table by its incremental field (error 1038). We try to avoid the sort by forcing the incremental field's index, but this table has no usable index on that field. Add an index on the incremental field, raise the server's 'sort_buffer_size', or switch this table to a full re-sync, then resync.",
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1452,6 +1452,20 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form (single-quoted tuple repr).
+            str(pymysql.err.OperationalError(1038, "Out of sort memory, consider increasing server sort buffer size")),
+            # Temporal-wrapped form (double-quoted).
+            'OperationalError: (1038, "Out of sort memory, consider increasing server sort buffer size")',
+        ],
+    )
+    def test_out_of_sort_memory_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Out-of-sort-memory error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

The MySQL data-warehouse import source surfaces a recurring `OperationalError` in error tracking:

> `(1038, 'Out of sort memory, consider increasing server sort buffer size')`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019edb68-5fa7-74d2-9f96-b08a479416ea

The failure originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` — the streaming `fetchmany` inside `_stream_with_optional_force_index`. The incremental sync query carries `ORDER BY <incremental_field>`, and MySQL filesorts it because no index is used; the server's `sort_buffer_size` is too small to hold the sort, so it aborts before streaming any rows.

We already have an in-activity FORCE INDEX fallback for this (`_is_bad_plan_error` matches 1038 and retries with the incremental field's index, which lets MySQL read in index order and skip the filesort). But that fallback only applies when the table actually has a usable index on the incremental field. When it doesn't, 1038 escapes the activity — and since both `sort_buffer_size` and the missing index are static server-side state, every Temporal retry filesorts the same rows and fails identically.

## Changes

Add error 1038 to the MySQL source's `get_non_retryable_errors()`, matching on the locale-independent error-code token `(1038,` (the trailing message text is translated on non-English servers) so it catches both the raw pymysql string and the wrapped form.

This only takes effect once the FORCE INDEX recovery has already failed — that recovery is internal to the activity and runs before any exception escapes, so the non-retryable classification (which only applies to escaping exceptions) doesn't interfere with it. The result: instead of retrying to the activity maximum, the job stops after a few attempts with an actionable message (add an index on the incremental field, raise `sort_buffer_size`, or switch the table to a full re-sync).

This is a deterministic, customer-side resource/config limit — not a transient infrastructure error — so it belongs with the other non-retryable server-side errors (1129 host-blocked, 1054 unknown column, SSL version mismatch) rather than staying retryable like 2013/1135.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_out_of_sort_memory_is_non_retryable`) covering the raw pymysql `str(error)` form and the Temporal-wrapped form, mirroring the existing non-retryable tests. Automated tests run:

- `TestMySQLSourceNonRetryableErrors` and `TestIsBadPlanError` — pass
- Full `test_mysql.py` (123 tests) — pass
- `ruff check` + `ruff format --check` — clean

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue's top in-app frame is genuinely in this source (`mysql.py:1032`), then traced the call path and read the FORCE INDEX fallback logic.

Decision: this is a user/upstream error in its non-recoverable case, not a code bug. The FORCE INDEX fallback is already the code-level fix for 1038; when it can't apply (no index on the incremental field), the only resolutions are customer-side. Rather than widen retry behavior or touch the filesort logic, the scoped fix is to stop the pointless retries via `NonRetryableErrors`, following the established Stripe/MySQL pattern. Matched on the error code rather than the translatable message text, consistent with the existing 1054/1129 entries.