### PR TITLE
feat(data-warehouse): promote RevenueCat source to beta

### DIFF
--- a/posthog/temporal/data_imports/sources/revenuecat/source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/source.py
@@ -152,7 +152,7 @@ class RevenueCatSource(
                     ),
                 ],
             ),
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             featureFlag="dwh-revenuecat",
             webhookSetupCaption=(
                 "PostHog tries to register a webhook integration in RevenueCat using your "


### PR DESCRIPTION
## Problem

The RevenueCat data-warehouse source has been shipping in alpha. It now clears the bar for beta:

- **Teams using it:** 53 (need ≥ 30), last 7d
- **Import error rate:** 2.5% (need < 5.0%), last 7d

## Changes

Flip `releaseStatus` on the RevenueCat `SourceConfig` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in `posthog/temporal/data_imports/sources/revenuecat/source.py`. This is the field that `/api/public_source_configs/` surfaces for the connector.

Status-only change: no connector behavior, schemas, or sync logic touched.

I left the `featureFlag="dwh-revenuecat"` gating in place. Per the `implementing-warehouse-sources` conventions, `releaseStatus` is a soft label on a visible source while `featureFlag` is an independent controlled-rollout gate — promoting the stage doesn't imply removing the flag, so I left gating untouched.

## How did you test this code?

I'm an agent (Claude Code). This is a one-line enum value change with no behavioral impact. There are no tests asserting the prior `ALPHA` value for this source, so nothing required updating. No automated tests were run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Invoked the `/implementing-warehouse-sources` skill to confirm where source release status lives and the conventions around `releaseStatus` vs `featureFlag`. Located the RevenueCat source config, confirmed the single `releaseStatus` assignment, and flipped it to beta. Before opening this PR I searched open PRs (by RevenueCat, "releaseStatus", "promote beta", and the maintainer's own open PRs) for an existing promotion — the only RevenueCat PR open (#64444) is about webhook price decimals, unrelated — so this is not a duplicate.