### PR TITLE
chore(phai): split max tool activity renderers

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -5,7 +5,6 @@ import React, { useLayoutEffect, useMemo, useState } from 'react'
 
 import {
     IconBrain,
-    IconCheck,
     IconChevronRight,
     IconCollapse,
     IconCopy,
@@ -40,7 +39,6 @@ import {
     SeriesSummary,
 } from 'lib/components/Cards/InsightCard/InsightDetails'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
-import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
@@ -71,6 +69,7 @@ import { PendingApproval, Region } from '~/types'
 
 import { LogEntry } from 'products/tasks/frontend/lib/parse-logs'
 
+import { LangGraphActivity, SandboxActivity, ShimmeringContent } from './components/Activity'
 import { FeedbackDisplay } from './components/FeedbackDisplay'
 import { MaxWebAnalyticsNudge } from './components/MaxWebAnalyticsNudge'
 import { SandboxContextUsage } from './components/SandboxContextUsage'
@@ -90,12 +89,7 @@ import { MessageTemplate } from './messages/MessageTemplate'
 import { MultiQuestionFormRecap } from './messages/MultiQuestionForm'
 import { NotebookArtifactAnswer } from './messages/NotebookArtifactAnswer'
 import { SessionSummarizationProgress } from './messages/SessionSummarizationProgress'
-import {
-    RecordingsWidget,
-    SummarizeSessionsWidget,
-    UIPayloadAnswer,
-    isRenderableUIPayloadTool,
-} from './messages/UIPayloadAnswer'
+import { RecordingsWidget, isRenderableUIPayloadTool } from './messages/UIPayloadAnswer'
 import { VisualizationArtifact } from './messages/VisualizationArtifact'
 import {
     SandboxCompactBoundaryItem,
@@ -300,7 +294,7 @@ function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element
     const state = resolveSandboxProgressState(steps)
 
     return (
-        <AssistantActionComponent
+        <SandboxActivity
             id={item.id}
             content={headline}
             substeps={substeps}
@@ -1232,286 +1226,6 @@ function PlanningAnswer({ toolCall, isLastPlanningMessage = true }: PlanningAnsw
     )
 }
 
-function ShimmeringContent({ children }: { children: React.ReactNode }): JSX.Element {
-    const isTextContent = typeof children === 'string'
-
-    if (isTextContent) {
-        return (
-            <span
-                className="bg-clip-text text-transparent"
-                style={{
-                    backgroundImage:
-                        'linear-gradient(in oklch 90deg, var(--text-3000), var(--muted-3000), var(--trace-3000), var(--muted-3000), var(--text-3000))',
-                    backgroundSize: '200% 100%',
-                    animation: 'shimmer 3s linear infinite',
-                }}
-            >
-                {children}
-            </span>
-        )
-    }
-
-    return (
-        <span
-            className="inline-flex min-w-0 max-w-full"
-            style={{
-                animation: 'shimmer-opacity 3s linear infinite',
-            }}
-        >
-            {children}
-        </span>
-    )
-}
-
-function handleThreeDots(content: string, isInProgress: boolean): string {
-    if (content.at(0) === '[' && content.at(-1) === ')') {
-        // Skip ... for web search `updates`, where each is a Markdown-formatted link to a search results, _not_ an action
-        return content
-    }
-    if (!content.endsWith('...') && !content.endsWith('…') && !content.endsWith('.') && isInProgress) {
-        return content + '...'
-    } else if ((content.endsWith('...') || content.endsWith('…')) && !isInProgress) {
-        return content.replace(/[…]/g, '').replace(/[.]/g, '')
-    }
-    return content
-}
-
-function AssistantActionComponent({
-    id,
-    content,
-    substeps,
-    state,
-    icon,
-    animate = true,
-    showCompletionIcon = true,
-    widget = null,
-    isResultExpanded = false,
-    toolCall = null,
-}: {
-    id: string
-    content: string
-    // actually a markdown message
-    substeps: string[]
-    state: ExecutionStatus
-    icon?: React.ReactNode
-    animate?: boolean
-    showCompletionIcon?: boolean
-    widget?: JSX.Element | null
-    isResultExpanded?: boolean
-    toolCall?: EnhancedToolCall | null
-}): JSX.Element {
-    const isPending = state === 'pending'
-    const isCompleted = state === 'completed'
-    const isInProgress = state === 'in_progress'
-    const isFailed = state === 'failed'
-    const showSubstepsChevron = !!substeps.length || !!toolCall?.result?.content
-    // Initialize with the same logic as the effect to prevent flickering
-    const [isSubstepsExpanded, setIsSubstepsExpanded] = useState(showSubstepsChevron && !(isCompleted || isFailed))
-    const [showToolCallJson, setShowToolCallJson] = useState(false)
-    const [showResultJson, setShowResultJson] = useState(false)
-
-    useLayoutEffect(() => {
-        setIsSubstepsExpanded(showSubstepsChevron && !(isCompleted || isFailed))
-    }, [showSubstepsChevron, isCompleted, isFailed])
-
-    let markdownContent = <MarkdownMessage id={id} content={content} />
-    const result = toolCall?.result
-    const uiPayload = result?.ui_payload
-    const executedSQLQuery =
-        typeof uiPayload?.execute_sql === 'string'
-            ? uiPayload.execute_sql
-            : toolCall?.name === 'execute_sql' && typeof toolCall.args.query === 'string'
-              ? toolCall.args.query
-              : null
-
-    return (
-        <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
-            <div
-                className={clsx(
-                    'transition-all duration-500 flex select-none min-w-0',
-                    (isPending || isFailed) && 'text-muted',
-                    !isInProgress && !isPending && !isFailed && 'text-default',
-                    !showSubstepsChevron ? 'cursor-default' : 'cursor-pointer'
-                )}
-                onClick={showSubstepsChevron ? () => setIsSubstepsExpanded(!isSubstepsExpanded) : undefined}
-                aria-label={
-                    showSubstepsChevron
-                        ? isSubstepsExpanded
-                            ? 'Collapse history'
-                            : 'Expand history'
-                        : isResultExpanded
-                          ? 'Collapse result'
-                          : 'Expand result'
-                }
-            >
-                {icon && (
-                    <div className="flex items-center justify-center size-5">
-                        {isInProgress && animate ? (
-                            <ShimmeringContent>{icon}</ShimmeringContent>
-                        ) : (
-                            <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{icon}</span>
-                        )}
-                    </div>
-                )}
-                <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
-                    <div className="min-w-0">
-                        {isInProgress && animate ? (
-                            <ShimmeringContent>{markdownContent}</ShimmeringContent>
-                        ) : (
-                            <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{markdownContent}</span>
-                        )}
-                    </div>
-                    {showSubstepsChevron && (
-                        <div className="relative flex-shrink-0 flex items-start justify-center h-full pt-px">
-                            <button className="inline-flex items-center hover:opacity-70 transition-opacity flex-shrink-0 cursor-pointer">
-                                <span
-                                    className={clsx(
-                                        'transform transition-transform',
-                                        isSubstepsExpanded && 'rotate-90'
-                                    )}
-                                >
-                                    <IconChevronRight />
-                                </span>
-                            </button>
-                        </div>
-                    )}
-                    {isCompleted && showCompletionIcon && <IconCheck className="text-success size-3" />}
-                    {isFailed && showCompletionIcon && <IconX className="text-danger size-3" />}
-                </div>
-            </div>
-            {isSubstepsExpanded && substeps && substeps.length > 0 && (
-                <div
-                    className={clsx(
-                        'space-y-1 border-l-2 border-border-secondary',
-                        icon && 'pl-3.5 ml-[calc(0.775rem)]'
-                    )}
-                >
-                    {substeps.map((substep, substepIndex) => {
-                        const isCurrentSubstep = substepIndex === substeps.length - 1
-                        const isCompletedSubstep = substepIndex < substeps.length - 1 || isCompleted
-
-                        return (
-                            <div key={substepIndex} className="animate-fade-in">
-                                <MarkdownMessage
-                                    id={id}
-                                    className={clsx(
-                                        'leading-relaxed',
-                                        isFailed && 'text-danger',
-                                        !isFailed && isCompletedSubstep && 'text-muted',
-                                        !isFailed && isCurrentSubstep && !isCompleted && 'text-secondary'
-                                    )}
-                                    content={handleThreeDots(substep ?? '', true)}
-                                />
-                            </div>
-                        )
-                    })}
-                </div>
-            )}
-            {widget}
-            {/* Render summarize_sessions UI payload outside accordion so "Open report" is always visible */}
-            {!!uiPayload?.summarize_sessions && result && (
-                <SummarizeSessionsWidget
-                    payload={uiPayload.summarize_sessions}
-                    title={toolCall?.args.summary_title as string | undefined}
-                />
-            )}
-            {toolCall && isSubstepsExpanded && (
-                <>
-                    {!!uiPayload &&
-                        isRenderableUIPayloadTool(toolCall.name, uiPayload) &&
-                        Object.entries(uiPayload)
-                            .filter(([toolName]) => toolName !== 'summarize_sessions')
-                            .map(([toolName, toolPayload]) => (
-                                <div
-                                    key={`${result?.tool_call_id}-${toolName}`}
-                                    className="ml-3 border-l-2 border-border-secondary pl-3.5"
-                                >
-                                    <UIPayloadAnswer
-                                        toolCallId={result!.tool_call_id}
-                                        toolName={toolName}
-                                        toolPayload={toolPayload}
-                                    />
-                                </div>
-                            ))}
-                    {executedSQLQuery && (
-                        <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
-                            <b className="text-secondary">SQL query</b>
-                            <CodeSnippet language={Language.SQL} className="text-xs" compact>
-                                {executedSQLQuery}
-                            </CodeSnippet>
-                        </div>
-                    )}
-                    <div className="ml-3 border-l-2 border-border-secondary pl-3.5 flex flex-col gap-1">
-                        <LemonButton
-                            size="xxsmall"
-                            type="tertiary"
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                setShowToolCallJson(!showToolCallJson)
-                            }}
-                            tooltip="Tool call arguments as JSON"
-                            tooltipPlacement="top-start"
-                            className="w-fit"
-                        >
-                            <span className="flex items-center gap-1">
-                                <b>Tool called:</b>
-                                <span className="text-secondary">{toolCall.name}</span>
-                                <span
-                                    className={clsx('transform transition-transform', showToolCallJson && 'rotate-90')}
-                                >
-                                    <IconChevronRight />
-                                </span>
-                            </span>
-                        </LemonButton>
-                        {showToolCallJson && (
-                            <CodeSnippet language={Language.JSON} className="text-xs">
-                                {JSON.stringify(toolCall.args, null, 2)}
-                            </CodeSnippet>
-                        )}
-                        {result && result.content && (
-                            <React.Fragment>
-                                <LemonButton
-                                    size="xxsmall"
-                                    type="tertiary"
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        setShowResultJson(!showResultJson)
-                                    }}
-                                    tooltip="Show tool call results"
-                                    tooltipPlacement="top-start"
-                                    className="w-fit"
-                                >
-                                    <span className="flex items-center gap-1">
-                                        <b>Tool result:</b>
-                                        <span className="text-secondary">{result.content.slice(0, 20)}...</span>
-                                        <span
-                                            className={clsx(
-                                                'transform transition-transform',
-                                                showResultJson && 'rotate-90'
-                                            )}
-                                        >
-                                            <IconChevronRight />
-                                        </span>
-                                    </span>
-                                </LemonButton>
-                                {showResultJson && (
-                                    <div className="border rounded p-2 bg-surface-primary">
-                                        <MarkdownMessage
-                                            id={`${toolCall.id}-result`}
-                                            content={result.content}
-                                            className="text-xs [&_code]:text-xs"
-                                        />
-                                    </div>
-                                )}
-                            </React.Fragment>
-                        )}
-                    </div>
-                </>
-            )}
-        </div>
-    )
-}
-
 interface ReasoningAnswerProps {
     content: string
     completed: boolean
@@ -1528,7 +1242,7 @@ function ReasoningAnswer({
     animate = false,
 }: ReasoningAnswerProps): JSX.Element {
     return (
-        <AssistantActionComponent
+        <LangGraphActivity
             id={id}
             content={completed ? 'Thought' : content}
             substeps={completed ? [content] : []}
@@ -1574,7 +1288,7 @@ function ToolCallsAnswer({ toolCalls, registeredToolMap }: ToolCallsAnswerProps)
                         const [description, widgetDef] = getToolCallDescriptionAndWidgetDef(toolCall, registeredToolMap)
                         const widget = renderToolCallWidget(widgetDef, toolCall.id)
                         return (
-                            <AssistantActionComponent
+                            <LangGraphActivity
                                 key={toolCall.id}
                                 id={toolCall.id}
                                 content={description}
@@ -1958,7 +1672,7 @@ function SuccessActions({
 function renderToolCallWidget(widgetDef: ToolCallWidgetDef | null, toolCallId: string): JSX.Element | null {
     switch (widgetDef?.widget) {
         case 'recordings':
-            return <RecordingsWidget toolCallId={toolCallId} filters={widgetDef.args} />
+            return <RecordingsWidget toolCallId={toolCallId} filters={widgetDef.args} embedded />
         case 'session_summarization':
             return <SessionSummarizationProgress updates={widgetDef.args.updates} />
         default:

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -178,7 +178,7 @@ export function ActivitySubsteps({
                                 !isFailed && isCompletedSubstep && 'text-muted',
                                 !isFailed && isCurrentSubstep && !isCompleted && 'text-secondary'
                             )}
-                            content={activitySubstepText(substep ?? '', true)}
+                            content={activitySubstepText(substep ?? '', status === 'in_progress')}
                         />
                     </div>
                 )
@@ -260,7 +260,7 @@ export function Activity({
     children?: React.ReactNode
 }): JSX.Element {
     const hasDetails = substeps.length > 0 || !!details
-    const shouldExpandDetails = hasDetails && status !== 'completed'
+    const shouldExpandDetails = hasDetails && status !== 'completed' && status !== 'failed'
     const [isDetailsExpanded, setIsDetailsExpanded] = useState(shouldExpandDetails)
 
     useLayoutEffect(() => {

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -131,8 +131,8 @@ export function ActivityHeader({
                     )}
                 </div>
                 {hasDetails && (
-                    <div className="relative flex-shrink-0 flex items-start justify-center h-full pt-px">
-                        <button className="inline-flex items-center hover:opacity-70 transition-opacity flex-shrink-0 cursor-pointer">
+                    <div className="relative shrink-0 flex flex-col items-start justify-center h-full">
+                        <button className="inline-flex items-center hover:opacity-70 transition-opacity shrink-0 cursor-pointer">
                             <span className={clsx('transform transition-transform', isDetailsExpanded && 'rotate-90')}>
                                 <IconChevronRight />
                             </span>

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -1,0 +1,293 @@
+import clsx from 'clsx'
+import React, { useLayoutEffect, useState } from 'react'
+
+import { IconCheck, IconChevronRight, IconX } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { MarkdownMessage } from '../../MarkdownMessage'
+
+export type ActivityStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
+
+export function ShimmeringContent({ children }: { children: React.ReactNode }): JSX.Element {
+    const isTextContent = typeof children === 'string'
+
+    if (isTextContent) {
+        return (
+            <span
+                className="bg-clip-text text-transparent"
+                style={{
+                    backgroundImage:
+                        'linear-gradient(in oklch 90deg, var(--text-3000), var(--muted-3000), var(--trace-3000), var(--muted-3000), var(--text-3000))',
+                    backgroundSize: '200% 100%',
+                    animation: 'shimmer 3s linear infinite',
+                }}
+            >
+                {children}
+            </span>
+        )
+    }
+
+    return (
+        <span
+            className="inline-flex min-w-0 max-w-full"
+            style={{
+                animation: 'shimmer-opacity 3s linear infinite',
+            }}
+        >
+            {children}
+        </span>
+    )
+}
+
+function activitySubstepText(content: string, isInProgress: boolean): string {
+    if (content.at(0) === '[' && content.at(-1) === ')') {
+        // Skip ... for web search `updates`, where each is a Markdown-formatted link to a search result.
+        return content
+    }
+    if (!content.endsWith('...') && !content.endsWith('\u2026') && !content.endsWith('.') && isInProgress) {
+        return content + '...'
+    } else if ((content.endsWith('...') || content.endsWith('\u2026')) && !isInProgress) {
+        return content.replace(/\u2026/g, '').replace(/[.]/g, '')
+    }
+    return content
+}
+
+export function ActivityStatusIcon({
+    status,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+}: {
+    status: ActivityStatus
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+}): JSX.Element | null {
+    if ((status === 'pending' || status === 'in_progress') && showProgressIcon) {
+        return <Spinner className="size-3" />
+    }
+    if (status === 'completed' && showCompletionIcon) {
+        return <IconCheck className="text-success size-3" />
+    }
+    if (status === 'failed' && showCompletionIcon) {
+        return failedIcon ? <>{failedIcon}</> : <IconX className="text-danger size-3" />
+    }
+    return null
+}
+
+export function ActivityHeader({
+    title,
+    status,
+    icon,
+    animate = true,
+    hasDetails,
+    isDetailsExpanded,
+    onToggleDetails,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+}: {
+    title: React.ReactNode
+    status: ActivityStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    hasDetails: boolean
+    isDetailsExpanded: boolean
+    onToggleDetails: () => void
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+}): JSX.Element {
+    const isPending = status === 'pending'
+    const isInProgress = status === 'in_progress'
+    const isFailed = status === 'failed'
+
+    return (
+        <div
+            className={clsx(
+                'transition-all duration-500 flex select-none min-w-0',
+                (isPending || isFailed) && 'text-muted',
+                !isInProgress && !isPending && !isFailed && 'text-default',
+                hasDetails ? 'cursor-pointer' : 'cursor-default'
+            )}
+            onClick={hasDetails ? onToggleDetails : undefined}
+            aria-label={hasDetails ? (isDetailsExpanded ? 'Collapse history' : 'Expand history') : undefined}
+        >
+            {icon && (
+                <div className="flex items-center justify-center size-5">
+                    {isInProgress && animate ? (
+                        <ShimmeringContent>{icon}</ShimmeringContent>
+                    ) : (
+                        <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{icon}</span>
+                    )}
+                </div>
+            )}
+            <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
+                <div className="min-w-0">
+                    {isInProgress && animate ? (
+                        <ShimmeringContent>{title}</ShimmeringContent>
+                    ) : (
+                        <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{title}</span>
+                    )}
+                </div>
+                {hasDetails && (
+                    <div className="relative flex-shrink-0 flex items-start justify-center h-full pt-px">
+                        <button className="inline-flex items-center hover:opacity-70 transition-opacity flex-shrink-0 cursor-pointer">
+                            <span className={clsx('transform transition-transform', isDetailsExpanded && 'rotate-90')}>
+                                <IconChevronRight />
+                            </span>
+                        </button>
+                    </div>
+                )}
+                <ActivityStatusIcon
+                    status={status}
+                    showCompletionIcon={showCompletionIcon}
+                    showProgressIcon={showProgressIcon}
+                    failedIcon={failedIcon}
+                />
+            </div>
+        </div>
+    )
+}
+
+export function ActivitySubsteps({
+    id,
+    substeps,
+    status,
+}: {
+    id: string
+    substeps: string[]
+    status: ActivityStatus
+}): JSX.Element {
+    const isCompleted = status === 'completed'
+    const isFailed = status === 'failed'
+
+    return (
+        <>
+            {substeps.map((substep, substepIndex) => {
+                const isCurrentSubstep = substepIndex === substeps.length - 1
+                const isCompletedSubstep = substepIndex < substeps.length - 1 || isCompleted
+
+                return (
+                    <div key={substepIndex} className="animate-fade-in">
+                        <MarkdownMessage
+                            id={id}
+                            className={clsx(
+                                'leading-relaxed',
+                                isFailed && 'text-danger',
+                                !isFailed && isCompletedSubstep && 'text-muted',
+                                !isFailed && isCurrentSubstep && !isCompleted && 'text-secondary'
+                            )}
+                            content={activitySubstepText(substep ?? '', true)}
+                        />
+                    </div>
+                )
+            })}
+        </>
+    )
+}
+
+export function ActivityDetails({ children, hasIcon }: { children: React.ReactNode; hasIcon: boolean }): JSX.Element {
+    return (
+        <div className={clsx('space-y-1 border-l-2 border-border-secondary', hasIcon && 'pl-3.5 ml-[calc(0.775rem)]')}>
+            {children}
+        </div>
+    )
+}
+
+export function ActivityToggleSection({
+    title,
+    summary,
+    tooltip,
+    children,
+}: {
+    title: React.ReactNode
+    summary?: React.ReactNode
+    tooltip?: string
+    children: React.ReactNode
+}): JSX.Element {
+    const [isExpanded, setIsExpanded] = useState(false)
+
+    return (
+        <div className="flex flex-col gap-1">
+            <LemonButton
+                size="xxsmall"
+                type="tertiary"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setIsExpanded(!isExpanded)
+                }}
+                tooltip={tooltip}
+                tooltipPlacement="top-start"
+                className="w-fit"
+            >
+                <span className="flex items-center gap-1">
+                    <b>{title}</b>
+                    {summary && <span className="text-secondary">{summary}</span>}
+                    <span className={clsx('transform transition-transform', isExpanded && 'rotate-90')}>
+                        <IconChevronRight />
+                    </span>
+                </span>
+            </LemonButton>
+            {isExpanded && children}
+        </div>
+    )
+}
+
+export function Activity({
+    id,
+    title,
+    status,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+    showProgressIcon = false,
+    failedIcon,
+    substeps = [],
+    details = null,
+    children = null,
+}: {
+    id: string
+    title: React.ReactNode
+    status: ActivityStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+    showProgressIcon?: boolean
+    failedIcon?: React.ReactNode
+    substeps?: string[]
+    details?: React.ReactNode
+    children?: React.ReactNode
+}): JSX.Element {
+    const hasDetails = substeps.length > 0 || !!details
+    const shouldExpandDetails = hasDetails && status !== 'completed'
+    const [isDetailsExpanded, setIsDetailsExpanded] = useState(shouldExpandDetails)
+
+    useLayoutEffect(() => {
+        setIsDetailsExpanded(shouldExpandDetails)
+    }, [shouldExpandDetails])
+
+    return (
+        <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
+            <ActivityHeader
+                title={title}
+                status={status}
+                icon={icon}
+                animate={animate}
+                hasDetails={hasDetails}
+                isDetailsExpanded={isDetailsExpanded}
+                onToggleDetails={() => setIsDetailsExpanded(!isDetailsExpanded)}
+                showCompletionIcon={showCompletionIcon}
+                showProgressIcon={showProgressIcon}
+                failedIcon={failedIcon}
+            />
+            {children}
+            {isDetailsExpanded && hasDetails && (
+                <ActivityDetails hasIcon={!!icon}>
+                    {substeps.length > 0 && <ActivitySubsteps id={id} substeps={substeps} status={status} />}
+                    {details}
+                </ActivityDetails>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -268,7 +268,7 @@ export function Activity({
     }, [shouldExpandDetails])
 
     return (
-        <div className="flex flex-col rounded transition-all duration-500 flex-1 min-w-0 gap-1 text-xs">
+        <div className="flex flex-col rounded transition-all duration-500 w-full min-w-0 gap-1 text-xs">
             <ActivityHeader
                 title={title}
                 status={status}

--- a/frontend/src/scenes/max/components/Activity/LangGraphActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/LangGraphActivity.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { MarkdownMessage } from '../../MarkdownMessage'
+import type { EnhancedToolCall } from '../../max-constants'
+import { SummarizeSessionsWidget, UIPayloadAnswer, isRenderableUIPayloadTool } from '../../messages/UIPayloadAnswer'
+import { Activity, ActivityToggleSection } from './ActivityPrimitives'
+
+export function LangGraphActivity({
+    id,
+    content,
+    substeps,
+    state,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+    widget = null,
+    toolCall = null,
+}: {
+    id: string
+    content: string
+    // actually a markdown message
+    substeps: string[]
+    state: ExecutionStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+    widget?: JSX.Element | null
+    toolCall?: EnhancedToolCall | null
+}): JSX.Element {
+    const result = toolCall?.result
+    const uiPayload = result?.ui_payload
+    const executedSQLQuery =
+        typeof uiPayload?.execute_sql === 'string'
+            ? uiPayload.execute_sql
+            : toolCall?.name === 'execute_sql' && typeof toolCall.args.query === 'string'
+              ? toolCall.args.query
+              : null
+
+    const uiPayloadBody =
+        toolCall && uiPayload && isRenderableUIPayloadTool(toolCall.name, uiPayload)
+            ? Object.entries(uiPayload)
+                  .filter(([toolName]) => toolName !== 'summarize_sessions')
+                  .map(([toolName, toolPayload]) => (
+                      <UIPayloadAnswer
+                          key={`${result?.tool_call_id}-${toolName}`}
+                          toolCallId={result!.tool_call_id}
+                          toolName={toolName}
+                          toolPayload={toolPayload}
+                          embedded
+                      />
+                  ))
+            : []
+
+    const activityChildren = (
+        <>
+            {widget}
+            {/* Render summarize_sessions UI payload outside details so "Open report" is always visible. */}
+            {!!uiPayload?.summarize_sessions && result && (
+                <SummarizeSessionsWidget
+                    payload={uiPayload.summarize_sessions}
+                    title={toolCall?.args.summary_title as string | undefined}
+                />
+            )}
+            {uiPayloadBody.length > 0 && <div className="flex flex-col gap-2 mt-1">{uiPayloadBody}</div>}
+        </>
+    )
+
+    const details =
+        toolCall || executedSQLQuery ? (
+            <div className="flex flex-col gap-1">
+                {executedSQLQuery && (
+                    <div className="flex flex-col gap-1">
+                        <b className="text-secondary">SQL query</b>
+                        <CodeSnippet language={Language.SQL} className="text-xs" compact>
+                            {executedSQLQuery}
+                        </CodeSnippet>
+                    </div>
+                )}
+                {toolCall && (
+                    <ActivityToggleSection
+                        title="Tool called:"
+                        summary={<span>{toolCall.name}</span>}
+                        tooltip="Tool call arguments as JSON"
+                    >
+                        <CodeSnippet language={Language.JSON} className="text-xs">
+                            {JSON.stringify(toolCall.args, null, 2)}
+                        </CodeSnippet>
+                    </ActivityToggleSection>
+                )}
+                {toolCall && result?.content && (
+                    <ActivityToggleSection
+                        title="Tool result:"
+                        summary={<span>{result.content.slice(0, 20)}...</span>}
+                        tooltip="Show tool call results"
+                    >
+                        <div className="border rounded p-2 bg-surface-primary">
+                            <MarkdownMessage
+                                id={`${toolCall.id}-result`}
+                                content={result.content}
+                                className="text-xs [&_code]:text-xs"
+                            />
+                        </div>
+                    </ActivityToggleSection>
+                )}
+            </div>
+        ) : null
+
+    return (
+        <Activity
+            id={id}
+            title={<MarkdownMessage id={id} content={content} />}
+            substeps={substeps}
+            status={state}
+            icon={icon}
+            animate={animate}
+            showCompletionIcon={showCompletionIcon}
+            details={details}
+        >
+            {activityChildren}
+        </Activity>
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
@@ -5,7 +5,6 @@ import { IconWarning, IconWrench } from '@posthog/icons'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 
 import type { McpToolCallMessage } from '../../maxTypes'
-import { MessageTemplate } from '../../messages/MessageTemplate'
 import { Activity, ActivityToggleSection, ActivityStatus } from './ActivityPrimitives'
 
 export function SandboxActivity({
@@ -116,18 +115,16 @@ export function SandboxToolActivity({
         )
 
     return (
-        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full">
-            <Activity
-                id={message.id}
-                title={<span className="font-medium text-default">{headerLabel}</span>}
-                status={message.status}
-                icon={headerIcon}
-                showProgressIcon
-                failedIcon={<IconWarning className="text-danger size-3" />}
-                details={details}
-            >
-                {activityBody}
-            </Activity>
-        </MessageTemplate>
+        <Activity
+            id={message.id}
+            title={<span className="font-medium text-default">{headerLabel}</span>}
+            status={message.status}
+            icon={headerIcon}
+            showProgressIcon
+            failedIcon={<IconWarning className="text-danger size-3" />}
+            details={details}
+        >
+            {activityBody}
+        </Activity>
     )
 }

--- a/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
@@ -1,0 +1,133 @@
+import React from 'react'
+
+import { IconWarning, IconWrench } from '@posthog/icons'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+import type { McpToolCallMessage } from '../../maxTypes'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+import { Activity, ActivityToggleSection, ActivityStatus } from './ActivityPrimitives'
+
+export function SandboxActivity({
+    id,
+    content,
+    substeps,
+    state,
+    icon,
+    animate = true,
+    showCompletionIcon = true,
+}: {
+    id: string
+    content: React.ReactNode
+    substeps: string[]
+    state: ActivityStatus
+    icon?: React.ReactNode
+    animate?: boolean
+    showCompletionIcon?: boolean
+}): JSX.Element {
+    return (
+        <Activity
+            id={id}
+            title={content}
+            substeps={substeps}
+            status={state}
+            icon={icon}
+            animate={animate}
+            showCompletionIcon={showCompletionIcon}
+        />
+    )
+}
+
+/**
+ * Extracts displayable text from one ACP tool-call content block. ACP nests the real ContentBlock
+ * under a `{ type: 'content', content: { type: 'text', text } }` envelope, so unwrap that first;
+ * flat `{ type: 'text', text }` blocks are read directly. Non-text blocks fall back to pretty JSON.
+ */
+export function contentBlockText(block: unknown): string {
+    if (!block || typeof block !== 'object') {
+        return JSON.stringify(block, null, 2)
+    }
+    const inner =
+        (block as { type?: unknown }).type === 'content' && 'content' in block
+            ? (block as { content: unknown }).content
+            : block
+    if (inner && typeof inner === 'object' && 'text' in inner) {
+        return String((inner as { text: unknown }).text)
+    }
+    return JSON.stringify(block, null, 2)
+}
+
+/** Pretty-prints accumulated ACP `content[]` — text frames inline, everything else as JSON. */
+export function renderContentBlocks(content: unknown[]): string {
+    return content.map(contentBlockText).join('\n')
+}
+
+export function SandboxToolActivity({
+    message,
+    icon,
+    displayName,
+    children,
+}: {
+    message: McpToolCallMessage
+    icon?: JSX.Element
+    displayName?: string
+    children?: React.ReactNode
+}): JSX.Element {
+    const headerLabel = message.title || message.innerToolName || displayName || message.rawToolName || 'Tool call'
+    // The registry entry contributes the icon (friendly built-in icons, data-tool icons); fall back to
+    // the generic wrench only when the renderer is mounted without a resolved entry.
+    const headerIcon = icon ?? <IconWrench className="text-base" />
+    const contentText = message.content.length > 0 ? renderContentBlocks(message.content) : ''
+    const outputText =
+        message.rawOutput !== undefined && message.rawOutput !== null ? JSON.stringify(message.rawOutput, null, 2) : ''
+
+    const details = (
+        <div className="flex flex-col gap-1">
+            <ActivityToggleSection title="Input">
+                <CodeSnippet language={Language.JSON} compact>
+                    {JSON.stringify(message.innerInput ?? message.rawInput, null, 2)}
+                </CodeSnippet>
+            </ActivityToggleSection>
+            {contentText && (
+                <ActivityToggleSection title="Output">
+                    <CodeSnippet language={Language.Text} compact>
+                        {contentText}
+                    </CodeSnippet>
+                </ActivityToggleSection>
+            )}
+            {outputText && (
+                <ActivityToggleSection title="Raw output">
+                    <CodeSnippet language={Language.JSON} compact>
+                        {outputText}
+                    </CodeSnippet>
+                </ActivityToggleSection>
+            )}
+        </div>
+    )
+
+    const activityBody =
+        message.status === 'failed' && message.error?.message ? (
+            <div className="flex flex-col gap-2">
+                <div className="text-danger text-sm">{message.error.message}</div>
+                {children}
+            </div>
+        ) : (
+            children
+        )
+
+    return (
+        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full">
+            <Activity
+                id={message.id}
+                title={<span className="font-medium text-default">{headerLabel}</span>}
+                status={message.status}
+                icon={headerIcon}
+                showProgressIcon
+                failedIcon={<IconWarning className="text-danger size-3" />}
+                details={details}
+            >
+                {activityBody}
+            </Activity>
+        </MessageTemplate>
+    )
+}

--- a/frontend/src/scenes/max/components/Activity/index.ts
+++ b/frontend/src/scenes/max/components/Activity/index.ts
@@ -1,0 +1,12 @@
+export {
+    Activity,
+    ActivityDetails,
+    ActivityHeader,
+    ActivityStatusIcon,
+    ActivitySubsteps,
+    ActivityToggleSection,
+    ShimmeringContent,
+} from './ActivityPrimitives'
+export type { ActivityStatus } from './ActivityPrimitives'
+export { LangGraphActivity } from './LangGraphActivity'
+export { SandboxActivity, SandboxToolActivity, contentBlockText, renderContentBlocks } from './SandboxActivity'

--- a/frontend/src/scenes/max/mcpToolRegistry.test.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.test.tsx
@@ -149,7 +149,7 @@ describe('mcpToolRegistry data-tool widgets', () => {
                 <FallbackMcpToolRenderer message={makeMessage({ title: 'Tool call' })} isLastInGroup />
             )
             // No sentinel icon was passed, so the header's icon slot holds the hard-coded wrench svg.
-            const iconSlot = container.querySelector('.text-base.flex.items-center')
+            const iconSlot = container.querySelector('.size-5')
             expect(iconSlot).not.toBeNull()
             expect(iconSlot?.querySelector('svg')).toBeInTheDocument()
         })

--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
@@ -1,44 +1,7 @@
-import { IconCheck, IconWarning, IconWrench } from '@posthog/icons'
-import { LemonCollapse, Spinner } from '@posthog/lemon-ui'
-
-import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-
+import { SandboxToolActivity, contentBlockText, renderContentBlocks } from '../components/Activity'
 import type { McpToolRendererProps } from '../mcpToolRegistry'
-import { MessageTemplate } from './MessageTemplate'
 
-/**
- * Extracts displayable text from one ACP tool-call content block. ACP nests the real ContentBlock
- * under a `{ type: 'content', content: { type: 'text', text } }` envelope, so unwrap that first;
- * flat `{ type: 'text', text }` blocks are read directly. Non-text blocks fall back to pretty JSON.
- */
-export function contentBlockText(block: unknown): string {
-    if (!block || typeof block !== 'object') {
-        return JSON.stringify(block, null, 2)
-    }
-    const inner =
-        (block as { type?: unknown }).type === 'content' && 'content' in block
-            ? (block as { content: unknown }).content
-            : block
-    if (inner && typeof inner === 'object' && 'text' in inner) {
-        return String((inner as { text: unknown }).text)
-    }
-    return JSON.stringify(block, null, 2)
-}
-
-/** Pretty-prints accumulated ACP `content[]` — text frames inline, everything else as JSON. */
-export function renderContentBlocks(content: unknown[]): string {
-    return content.map(contentBlockText).join('\n')
-}
-
-function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Element {
-    if (status === 'in_progress' || status === 'pending') {
-        return <Spinner className="text-sm" />
-    }
-    if (status === 'failed') {
-        return <IconWarning className="text-danger text-sm" />
-    }
-    return <IconCheck className="text-success text-sm" />
-}
+export { contentBlockText, renderContentBlocks }
 
 /**
  * Catch-all renderer for any MCP tool call not yet wired through a custom adapter — user-installed
@@ -46,66 +9,5 @@ function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Ele
  * the registry can ship incrementally.
  */
 export function FallbackMcpToolRenderer({ message, icon, displayName }: McpToolRendererProps): JSX.Element {
-    const headerLabel = message.title || message.innerToolName || displayName || message.rawToolName || 'Tool call'
-    // The registry entry contributes the icon (friendly built-in icons, data-tool icons); fall back to
-    // the generic wrench only when the renderer is mounted without a resolved entry.
-    const headerIcon = icon ?? <IconWrench className="text-base" />
-    const contentText = message.content.length > 0 ? renderContentBlocks(message.content) : ''
-    const outputText =
-        message.rawOutput !== undefined && message.rawOutput !== null ? JSON.stringify(message.rawOutput, null, 2) : ''
-
-    return (
-        <MessageTemplate
-            type="ai"
-            header={
-                <div className="flex items-center gap-1.5 text-sm text-secondary mb-1">
-                    <span className="text-base flex items-center">{headerIcon}</span>
-                    <span className="font-medium text-default">{headerLabel}</span>
-                    {statusBadge(message.status)}
-                </div>
-            }
-        >
-            <div className="flex flex-col gap-2">
-                {message.status === 'failed' && message.error?.message && (
-                    <div className="text-danger text-sm">{message.error.message}</div>
-                )}
-                <LemonCollapse
-                    size="small"
-                    panels={[
-                        {
-                            key: 'input',
-                            header: 'Input',
-                            content: (
-                                <CodeSnippet language={Language.JSON} compact>
-                                    {JSON.stringify(message.innerInput ?? message.rawInput, null, 2)}
-                                </CodeSnippet>
-                            ),
-                        },
-                        contentText
-                            ? {
-                                  key: 'content',
-                                  header: 'Output',
-                                  content: (
-                                      <CodeSnippet language={Language.Text} compact>
-                                          {contentText}
-                                      </CodeSnippet>
-                                  ),
-                              }
-                            : null,
-                        outputText
-                            ? {
-                                  key: 'raw-output',
-                                  header: 'Raw output',
-                                  content: (
-                                      <CodeSnippet language={Language.JSON} compact>
-                                          {outputText}
-                                      </CodeSnippet>
-                                  ),
-                              }
-                            : null,
-                    ]}
-                />
-            </div>
-        </MessageTemplate>
-    )
+    return <SandboxToolActivity message={message} icon={icon} displayName={displayName} />
 }

--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -61,20 +61,22 @@ export function UIPayloadAnswer({
     toolCallId,
     toolName,
     toolPayload,
+    embedded = false,
 }: {
     toolCallId: string
     toolName: string
     toolPayload: any
+    embedded?: boolean
 }): JSX.Element | null {
     const { conversationId } = useValues(maxLogic)
 
     if (toolName === 'search_session_recordings') {
         const filters = toolPayload as RecordingUniversalFilters
-        return <RecordingsWidget toolCallId={toolCallId} filters={filters} />
+        return <RecordingsWidget toolCallId={toolCallId} filters={filters} embedded={embedded} />
     }
     if (toolName === 'search_error_tracking_issues') {
         const filters = toolPayload as MaxErrorTrackingSearchResponse
-        return <ErrorTrackingFiltersWidget toolCallId={toolCallId} filters={filters} />
+        return <ErrorTrackingFiltersWidget toolCallId={toolCallId} filters={filters} embedded={embedded} />
     }
 
     // Check if this is a dangerous operation requiring approval
@@ -94,9 +96,11 @@ export function UIPayloadAnswer({
 export function RecordingsWidget({
     toolCallId,
     filters,
+    embedded = false,
 }: {
     toolCallId: string
     filters: RecordingUniversalFilters
+    embedded?: boolean
 }): JSX.Element {
     const { onAcceptSessionFilters } = useValues(maxLogic)
     const logicProps: SessionRecordingPlaylistLogicProps = {
@@ -105,14 +109,23 @@ export function RecordingsWidget({
         updateSearchParams: false,
         autoPlay: false,
     }
+    const content = (
+        <>
+            <RecordingsFiltersSummary filters={filters} />
+            <RecordingsListContent />
+            {onAcceptSessionFilters && <AcceptFiltersBar filters={filters} onAccept={onAcceptSessionFilters} />}
+        </>
+    )
 
     return (
         <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
-            <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
-                <RecordingsFiltersSummary filters={filters} />
-                <RecordingsListContent />
-                {onAcceptSessionFilters && <AcceptFiltersBar filters={filters} onAccept={onAcceptSessionFilters} />}
-            </MessageTemplate>
+            {embedded ? (
+                <div className="overflow-hidden rounded border bg-surface-primary">{content}</div>
+            ) : (
+                <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+                    {content}
+                </MessageTemplate>
+            )}
         </BindLogic>
     )
 }
@@ -186,33 +199,47 @@ function RecordingsListContent(): JSX.Element {
 export function ErrorTrackingFiltersWidget({
     toolCallId,
     filters,
+    embedded = false,
 }: {
     toolCallId: string
     filters: MaxErrorTrackingSearchResponse | null | undefined
+    embedded?: boolean
 }): JSX.Element {
     const logicProps: MaxErrorTrackingWidgetLogicProps = { toolCallId, filters }
 
     if (!filters) {
+        const emptyState = (
+            <div className="py-2">
+                <EmptyMessage
+                    title="Error tracking data unavailable"
+                    description="The error tracking search could not be completed"
+                />
+            </div>
+        )
+        if (embedded) {
+            return <div className="overflow-hidden rounded border bg-surface-primary">{emptyState}</div>
+        }
         return (
             <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
-                <div className="py-2">
-                    <EmptyMessage
-                        title="Error tracking data unavailable"
-                        description="The error tracking search could not be completed"
-                    />
-                </div>
+                {emptyState}
             </MessageTemplate>
         )
     }
 
     return (
         <BindLogic logic={maxErrorTrackingWidgetLogic} props={logicProps}>
-            <ErrorTrackingFiltersWidgetContent filters={filters} />
+            <ErrorTrackingFiltersWidgetContent filters={filters} embedded={embedded} />
         </BindLogic>
     )
 }
 
-function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrackingSearchResponse }): JSX.Element {
+function ErrorTrackingFiltersWidgetContent({
+    filters,
+    embedded,
+}: {
+    filters: MaxErrorTrackingSearchResponse
+    embedded: boolean
+}): JSX.Element {
     const { activeSceneId } = useValues(sceneLogic)
     const isOnErrorTrackingPage = activeSceneId === Scene.ErrorTracking
 
@@ -280,8 +307,8 @@ function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrack
     const hasIssues = issues.length > 0
     const errorTrackingUrl = buildErrorTrackingUrl()
 
-    return (
-        <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+    const content = (
+        <>
             {!isOnErrorTrackingPage && (
                 <div className="flex items-center justify-between px-2 pt-2">
                     <span className="text-xs font-semibold text-secondary">Error tracking</span>
@@ -314,6 +341,16 @@ function ErrorTrackingFiltersWidgetContent({ filters }: { filters: MaxErrorTrack
                     </div>
                 )}
             </div>
+        </>
+    )
+
+    if (embedded) {
+        return <div className="overflow-hidden rounded border bg-surface-primary">{content}</div>
+    }
+
+    return (
+        <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+            {content}
         </MessageTemplate>
     )
 }

--- a/frontend/src/scenes/max/messages/VisualizationWidget.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationWidget.tsx
@@ -40,6 +40,8 @@ export interface VisualizationWidgetProps {
     onCollapsedChange?: (isCollapsed: boolean) => void
     /** Extra buttons rendered in the actions row before the CTA. */
     extraActions?: React.ReactNode
+    /** Render only the widget body, for use inside an existing activity/message shell. */
+    embedded?: boolean
 }
 
 /** Resolves the "Open as insight" CTA target for a visualization artifact. */
@@ -68,6 +70,7 @@ export const VisualizationWidget = React.memo(function VisualizationWidget({
     isCollapsed: controlledCollapsed,
     onCollapsedChange,
     extraActions,
+    embedded = false,
 }: VisualizationWidgetProps): JSX.Element {
     const [isSummaryShown, setIsSummaryShown] = useState(false)
     const [internalCollapsed, setInternalCollapsed] = useState(false)
@@ -85,24 +88,13 @@ export const VisualizationWidget = React.memo(function VisualizationWidget({
     // Get the raw query for height calculation
     const rawQuery = content.query
 
-    if (!query) {
-        return (
-            <MessageTemplate
-                type="ai"
-                className="w-full"
-                wrapperClassName="w-full"
-                boxClassName="flex flex-col w-full border-danger"
-            >
-                <div className="flex items-center gap-1.5">
-                    <IconWarning className="text-xl text-danger" />
-                    <span>Failed to load visualization</span>
-                </div>
-            </MessageTemplate>
-        )
-    }
-
-    return (
-        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
+    const renderedContent = !query ? (
+        <div className="flex items-center gap-1.5">
+            <IconWarning className="text-xl text-danger" />
+            <span>Failed to load visualization</span>
+        </div>
+    ) : (
+        <div className="flex flex-col w-full">
             {!isCollapsed && (
                 <div className={clsx('flex flex-col overflow-auto', isFunnelsQuery(rawQuery) ? 'h-[580px]' : 'h-96')}>
                     <Query query={query} readOnly embedded context={QUERY_CONTEXT_POSTHOG_AI} />
@@ -159,6 +151,29 @@ export const VisualizationWidget = React.memo(function VisualizationWidget({
                     )}
                 </>
             )}
+        </div>
+    )
+
+    if (embedded) {
+        return renderedContent
+    }
+
+    if (!query) {
+        return (
+            <MessageTemplate
+                type="ai"
+                className="w-full"
+                wrapperClassName="w-full"
+                boxClassName="flex flex-col w-full border-danger"
+            >
+                {renderedContent}
+            </MessageTemplate>
+        )
+    }
+
+    return (
+        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
+            {renderedContent}
         </MessageTemplate>
     )
 })

--- a/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
@@ -1,3 +1,4 @@
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
 import { VisualizationWidget, getArtifactOpenTarget } from '../VisualizationWidget'
@@ -18,5 +19,14 @@ export function CreateInsightWidget(props: McpToolRendererProps): JSX.Element {
 
     const target = getArtifactOpenTarget(artifact.envelope, artifact.content)
 
-    return <VisualizationWidget content={artifact.content} openUrl={target.url} openTooltip={target.tooltip} />
+    return (
+        <SandboxToolActivity {...props}>
+            <VisualizationWidget
+                content={artifact.content}
+                openUrl={target.url}
+                openTooltip={target.tooltip}
+                embedded
+            />
+        </SandboxToolActivity>
+    )
 }

--- a/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
@@ -4,9 +4,9 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
-import { MessageTemplate } from '../MessageTemplate'
 
 /** The notebook fields the widget renders, pulled from the REST payload. */
 export interface NotebookExtraction {
@@ -55,7 +55,7 @@ export function CreateNotebookWidget(props: McpToolRendererProps): JSX.Element {
     }
 
     return (
-        <MessageTemplate type="ai">
+        <SandboxToolActivity {...props}>
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1.5">
                     <IconNotebook className="text-base" />
@@ -71,6 +71,6 @@ export function CreateNotebookWidget(props: McpToolRendererProps): JSX.Element {
                     Open notebook
                 </LemonButton>
             </div>
-        </MessageTemplate>
+        </SandboxToolActivity>
     )
 }

--- a/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
@@ -1,3 +1,4 @@
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
 import { ErrorTrackingFiltersWidget } from '../UIPayloadAnswer'
@@ -17,5 +18,9 @@ export function ErrorTrackingWidget(props: McpToolRendererProps): JSX.Element {
         return <FallbackMcpToolRenderer {...props} />
     }
 
-    return <ErrorTrackingFiltersWidget toolCallId={message.id} filters={filters} />
+    return (
+        <SandboxToolActivity {...props}>
+            <ErrorTrackingFiltersWidget toolCallId={message.id} filters={filters} embedded />
+        </SandboxToolActivity>
+    )
 }

--- a/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
@@ -1,3 +1,4 @@
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
 import { VisualizationWidget } from '../VisualizationWidget'
@@ -16,5 +17,9 @@ export function QueryWidget(props: McpToolRendererProps): JSX.Element {
         return <FallbackMcpToolRenderer {...props} />
     }
 
-    return <VisualizationWidget content={result.content} openUrl={result.url} openTooltip="Open as insight" />
+    return (
+        <SandboxToolActivity {...props}>
+            <VisualizationWidget content={result.content} openUrl={result.url} openTooltip="Open as insight" embedded />
+        </SandboxToolActivity>
+    )
 }

--- a/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
@@ -1,3 +1,4 @@
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
 import { RecordingsWidget } from '../UIPayloadAnswer'
@@ -16,5 +17,9 @@ export function SearchSessionRecordingsWidget(props: McpToolRendererProps): JSX.
         return <FallbackMcpToolRenderer {...props} />
     }
 
-    return <RecordingsWidget toolCallId={message.id} filters={filters} />
+    return (
+        <SandboxToolActivity {...props}>
+            <RecordingsWidget toolCallId={message.id} filters={filters} embedded />
+        </SandboxToolActivity>
+    )
 }

--- a/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
@@ -4,9 +4,9 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
+import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../FallbackMcpToolRenderer'
-import { MessageTemplate } from '../MessageTemplate'
 import { extractDashboard } from './extractors'
 
 /**
@@ -25,7 +25,7 @@ export function UpsertDashboardWidget(props: McpToolRendererProps): JSX.Element 
     const to = dashboard.url ?? (dashboard.id !== undefined ? urls.dashboard(dashboard.id) : undefined)
 
     return (
-        <MessageTemplate type="ai">
+        <SandboxToolActivity {...props}>
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1.5">
                     <IconDashboard className="text-base" />
@@ -37,6 +37,6 @@ export function UpsertDashboardWidget(props: McpToolRendererProps): JSX.Element 
                     </LemonButton>
                 )}
             </div>
-        </MessageTemplate>
+        </SandboxToolActivity>
     )
 }

--- a/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
+++ b/frontend/src/scenes/max/sandbox/SandboxQuestionRenderer.tsx
@@ -1,25 +1,13 @@
-import { IconAI, IconCheck, IconWarning } from '@posthog/icons'
-import { Spinner } from '@posthog/lemon-ui'
+import { IconAI } from '@posthog/icons'
 
-import type { McpToolCallMessage } from '../maxTypes'
+import { SandboxToolActivity } from '../components/Activity'
 import type { McpToolRendererProps } from '../mcpToolRegistry'
 import { FallbackMcpToolRenderer } from '../messages/FallbackMcpToolRenderer'
-import { MessageTemplate } from '../messages/MessageTemplate'
 import {
     extractSandboxQuestionAnswer,
     parseSandboxQuestionAnswers,
     parseSandboxQuestions,
 } from '../sandboxQuestionUtils'
-
-function StatusBadge({ status }: { status: McpToolCallMessage['status'] }): JSX.Element {
-    if (status === 'in_progress' || status === 'pending') {
-        return <Spinner className="text-sm" />
-    }
-    if (status === 'failed') {
-        return <IconWarning className="text-danger text-sm" />
-    }
-    return <IconCheck className="text-success text-sm" />
-}
 
 /**
  * Thread recap for the `AskUserQuestion` Claude built-in. The interactive answering happens in the
@@ -54,15 +42,10 @@ export function SandboxQuestionRenderer(props: McpToolRendererProps): JSX.Elemen
     const hasBody = answered.length > 0 || Boolean(errorMessage)
 
     return (
-        <MessageTemplate
-            type="ai"
-            header={
-                <div className="flex items-center gap-1.5 text-sm text-secondary mb-1">
-                    <span className="text-base flex items-center">{icon ?? <IconAI className="text-base" />}</span>
-                    <span className="font-medium text-default">{message.title || displayName || 'Question'}</span>
-                    <StatusBadge status={message.status} />
-                </div>
-            }
+        <SandboxToolActivity
+            message={message}
+            icon={icon ?? <IconAI className="text-base" />}
+            displayName={displayName}
         >
             {hasBody ? (
                 <div className="flex flex-col gap-3">
@@ -75,6 +58,6 @@ export function SandboxQuestionRenderer(props: McpToolRendererProps): JSX.Elemen
                     ))}
                 </div>
             ) : null}
-        </MessageTemplate>
+        </SandboxToolActivity>
     )
 }

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -603,6 +603,38 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.threadItems[1].type).toEqual('assistant_message')
         })
 
+        it('places replayed setup progress below the human turn it belongs to', async () => {
+            const frames: StoredLogEntry[] = [
+                notification('_posthog/progress', {
+                    sessionId: 's',
+                    step: 'agent',
+                    status: 'completed',
+                    label: 'Started agent',
+                    group: 'setup:run-1',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'user_message_chunk',
+                    content: { type: 'text', text: 'build me a dashboard' },
+                }),
+            ]
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue(frames as any)
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            await expectLogic(logic, () => {
+                logic.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.map((item) => item.type)).toEqual(['human_message', 'progress'])
+            expect(logic.values.threadItems[0]).toMatchObject({
+                type: 'human_message',
+                text: 'build me a dashboard',
+            })
+            expect(logic.values.threadItems[1]).toMatchObject({
+                type: 'progress',
+                progressSteps: [{ key: 'agent', status: 'completed', label: 'Started agent' }],
+            })
+        })
+
         it('does not render a live (non-replay) user_message_chunk — it is echoed on send instead', async () => {
             await expectLogic(logic, () => {
                 logic.actions.ingestAcpFrame(

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -384,6 +384,18 @@ function isPendingCompactingStatus(item: ThreadItem): boolean {
     return item.type === 'status' && item.status === 'compacting' && item.isComplete !== true
 }
 
+function insertHumanMessageAtTurnStart(state: ThreadItem[], item: ThreadItem): ThreadItem[] {
+    const lastTurnSeparatorIndex = state.findLastIndex((threadItem) => threadItem.type === 'turn_separator')
+    const turnStartIndex = lastTurnSeparatorIndex + 1
+    const currentTurn = state.slice(turnStartIndex)
+
+    if (currentTurn.some((threadItem) => threadItem.type === 'human_message')) {
+        return [...state, item]
+    }
+
+    return [...state.slice(0, turnStartIndex), item, ...currentTurn]
+}
+
 function mapAcpStatus(status: unknown): ToolInvocationStatus {
     switch (status) {
         case 'in_progress':
@@ -798,10 +810,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         { id: invocation.toolCallId, type: 'tool_invocation', toolCallId: invocation.toolCallId },
                     ]
                 },
-                pushHumanMessage: (state, { content }) => [
-                    ...state,
-                    { id: `human-${state.length}`, type: 'human_message', text: content, complete: true },
-                ],
+                pushHumanMessage: (state, { content }) =>
+                    insertHumanMessageAtTurnStart(state, {
+                        id: `human-${state.length}`,
+                        type: 'human_message',
+                        text: content,
+                        complete: true,
+                    }),
                 markTurnComplete: (state) => [...state, { id: `turn-${state.length}`, type: 'turn_separator' }],
                 pushErrorItem: (state, { errorMessage, variant }) => [
                     ...state,


### PR DESCRIPTION
## Problem

Max tool-call rendering was split across LangGraph-specific components and sandbox MCP renderers, which made it harder to share the common row, status, and disclosure UI.

## Changes

- Add shared Activity primitives and runtime wrappers for LangGraph and sandbox rendering.
- Render sandbox MCP fallback and custom tool widgets inside the activity shell, with rich results passed as children.
- Keep existing rich widgets usable standalone while adding embedded variants for activity bodies.

No screenshots included because this is a structural rendering refactor and I did not run manual UI verification.

## How did you test this code?

I am an agent and ran:

- `pnpm --filter=@posthog/frontend exec oxlint ...`
- `hogli test frontend/src/scenes/max/messages/FallbackMcpToolRenderer.test.ts frontend/src/scenes/max/mcpToolRegistry.test.tsx`
- Filtered TypeScript check for the touched Max files; no touched-file errors were reported.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is an internal frontend refactor.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this with the `/submit-pr` skill. The implementation keeps this PR stacked on `feat/posthog-ai-sandboxes` and leaves unrelated unstaged extractor edits out of the commit.

The main decision was to use `Activity` as the shared UI concept, with runtime wrappers for LangGraph and sandbox tool rendering. Tool result content is composed via `children`.