### PR TITLE
fix(conversations): make workflow ticket-tags input always editable

### DIFF
--- a/products/conversations/frontend/components/TicketTags/CyclotronJobInputTicketTags.test.tsx
+++ b/products/conversations/frontend/components/TicketTags/CyclotronJobInputTicketTags.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import api from 'lib/api'
+
+import { tagsModel } from '~/models/tagsModel'
+import { initKeaTests } from '~/test/init'
+import { CyclotronJobInputSchemaType } from '~/types'
+
+import CyclotronJobInputTicketTags from './CyclotronJobInputTicketTags'
+
+// `schema` is part of the renderer contract but unused by this component.
+const schema = { key: 'tags', type: 'posthog_ticket_tags' } as CyclotronJobInputSchemaType
+
+describe('CyclotronJobInputTicketTags', () => {
+    beforeEach(() => {
+        jest.spyOn(api.tags, 'list').mockResolvedValue(['existing_tag'])
+        initKeaTests()
+        tagsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+        jest.restoreAllMocks()
+    })
+
+    // Regression: the workflow tags input must be an always-on multi-select, not ObjectTags'
+    // click-to-edit toggle. The toggle collapses (unmounting the input) the moment focus leaves,
+    // which made removing/adding a tag impossible inside the ReactFlow node panel.
+    it('renders an always-editable input without a click-to-edit toggle', async () => {
+        render(<CyclotronJobInputTicketTags schema={schema} value={['plan_enterprise']} onChange={jest.fn()} />)
+
+        await waitFor(() => expect(screen.getByText('plan_enterprise')).toBeInTheDocument())
+        // The text input is present immediately — no "Edit tags"/"Add tag" gate to click first.
+        expect(document.querySelector('input[type="text"]')).toBeInTheDocument()
+        expect(screen.queryByText('Edit tags')).not.toBeInTheDocument()
+        expect(screen.queryByText('Add tag')).not.toBeInTheDocument()
+    })
+
+    it('removes a tag via its × and reports the trimmed list through onChange', async () => {
+        const onChange = jest.fn()
+        render(
+            <CyclotronJobInputTicketTags
+                schema={schema}
+                value={['plan_enterprise', 'unknown_slack_default_enterprise']}
+                onChange={onChange}
+            />
+        )
+
+        await waitFor(() => expect(screen.getByText('plan_enterprise')).toBeInTheDocument())
+
+        const closeButtons = document.querySelectorAll<HTMLButtonElement>('.LemonSnack__close button')
+        expect(closeButtons).toHaveLength(2)
+
+        await userEvent.click(closeButtons[0])
+
+        expect(onChange).toHaveBeenCalledWith(['unknown_slack_default_enterprise'])
+    })
+
+    it('handles an undefined value as an empty tag list', async () => {
+        render(<CyclotronJobInputTicketTags schema={schema} value={undefined} onChange={jest.fn()} />)
+
+        await waitFor(() => expect(document.querySelector('input[type="text"]')).toBeInTheDocument())
+        expect(document.querySelectorAll('.LemonSnack__close button')).toHaveLength(0)
+    })
+})

--- a/products/conversations/frontend/components/TicketTags/CyclotronJobInputTicketTags.tsx
+++ b/products/conversations/frontend/components/TicketTags/CyclotronJobInputTicketTags.tsx
@@ -1,7 +1,28 @@
+import { useValues } from 'kea'
+
+import { LemonInputSelect } from '@posthog/lemon-ui'
+
 import type { CustomInputRendererProps } from 'lib/components/CyclotronJob/customInputRenderers'
 
-import { TicketTags } from '.'
+import { tagsModel } from '~/models/tagsModel'
 
 export default function CyclotronJobInputTicketTags({ value, onChange }: CustomInputRendererProps): JSX.Element {
-    return <TicketTags tags={value ?? []} onChange={onChange} className="justify-start" />
+    const { tags: tagsAvailable, tagsLoading } = useValues(tagsModel)
+
+    // Render an always-editable multi-select rather than ObjectTags' click-to-edit toggle.
+    // ObjectTags collapses back to display mode on blur, which unmounts the input mid-click —
+    // inside the ReactFlow node panel that makes removing/adding a tag impossible (the click
+    // lands on nothing and ReactFlow treats it as a pane click, deselecting the step).
+    return (
+        <LemonInputSelect
+            mode="multiple"
+            allowCustomValues
+            value={value ?? []}
+            options={tagsAvailable?.map((t) => ({ key: t, label: t }))}
+            onChange={onChange}
+            loading={tagsLoading}
+            placeholder='try "official"'
+            data-attr="ticket-tags-input"
+        />
+    )
 }


### PR DESCRIPTION
## Problem

The tags input on workflow function steps (e.g. the update-ticket step) was effectively uneditable in the visual builder. Clicking a tag's × did nothing, and clicking into the box just collapsed the step's edit panel back to the build overview.

Root cause is two things stacking:

- The input rendered through `ObjectTags`, a **click-to-edit toggle that exits on blur**. Clicking a tag's × first blurs the input, firing `onBlur` → `setEditingTags(false)`, which unmounts the editable control mid-click — so the remove never registers.
- The node panel is a DOM descendant of ReactFlow's pane. ReactFlow fires `onPaneClick` only when the click target *is* the pane itself. Because the input unmounts mid-click, the orphaned click resolves up to the pane → `handlePaneClick` → `setSelectedNodeId(null)`, snapping the panel back to the build overview.

## Changes

`CyclotronJobInputTicketTags` now renders an always-on `LemonInputSelect` (mirroring the existing pattern in `CyclotronJobInputs.tsx`) instead of the blur-collapsing `ObjectTags`. The input stays mounted across interactions, so adding and removing tags works and the node panel no longer collapses.

Scope is limited to the workflow/destination input renderer. The live ticket UI (`SupportTicketScene`) keeps using `ObjectTags`, where blur-to-commit is the intended behavior.

## How did you test this code?

I'm an agent (Claude Code). I did not manually click through the builder. I added `CyclotronJobInputTicketTags.test.tsx` with three cases and ran them via jest:

- renders an always-editable input with no click-to-edit toggle
- removing a tag via its × reports the trimmed list through `onChange` (the core regression)
- an undefined value renders as an empty tag list

All three pass; lint and format are clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The work started from a report that the `customer_slack_channel` tag couldn't be removed from a workflow in the UI; this PR fixes the underlying input bug. An Explore subagent traced the render chain (`CyclotronJobInputs` → custom renderer → `TicketTags` → `ObjectTags`) and the ReactFlow panel wiring; I then verified the load-bearing claims directly in source, including ReactFlow's `wrapHandler` (`event.target === pane` gate) in the installed `@xyflow/react` build.

An early idea — guarding the panel with `stopPropagation` — was rejected once the source confirmed the pane-click fires *at* the pane (above the panel), so propagation guards can't catch it. The chosen fix removes the mid-click unmount at the source instead, which resolves both symptoms. No repo skills were invoked for the code change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
