### PR TITLE
feat(logs): return per-value counts from the values endpoint

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -25951,6 +25951,10 @@
         "LogValueResult": {
             "additionalProperties": false,
             "properties": {
+                "count": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Number of log records with this attribute value, over the current date range, service, and resource filters."
+                },
                 "id": {
                     "type": "string"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3182,6 +3182,8 @@ export interface LogAttributesQueryResponse extends AnalyticsQueryResponseBase {
 export interface LogValueResult {
     id: string
     name: string
+    /** Number of log records with this attribute value, over the current date range, service, and resource filters. */
+    count?: integer
 }
 
 export interface LogValuesQueryResponse extends AnalyticsQueryResponseBase {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1633,14 +1633,6 @@ class LogAttributeResult(BaseModel):
     propertyFilterType: str = Field(..., description="Either 'log_attribute' or 'log_resource_attribute'.")
 
 
-class LogValueResult(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    id: str
-    name: str
-
-
 class LogsAlertStateChangeSignalExtra(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5613,6 +5605,21 @@ class LogPropertyFilter(BaseModel):
     operator: PropertyOperator
     type: LogPropertyFilterType
     value: list[str | float | bool] | str | float | bool | None = None
+
+
+class LogValueResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    count: int | None = Field(
+        default=None,
+        description=(
+            "Number of log records with this attribute value, over the current date"
+            " range, service, and resource filters."
+        ),
+    )
+    id: str
+    name: str
 
 
 class LogsAlertStateChangeSignalInput(BaseModel):

--- a/products/logs/backend/log_values_query_runner.py
+++ b/products/logs/backend/log_values_query_runner.py
@@ -44,12 +44,12 @@ class LogValuesQueryRunner(AnalyticsQueryRunner[LogValuesQueryResponse], LogsQue
         query = parse_select(
             """
             SELECT
-                groupArray({limit})(attribute_value) as values,
+                groupArray({limit})((attribute_value, value_count)) as values,
                 count() as total_count
             FROM (
                 SELECT
                     attribute_value,
-                    sum(attribute_count)
+                    sum(attribute_count) AS value_count
                 FROM log_attributes
                 WHERE time_bucket >= {date_from_start_of_interval}
                 AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
@@ -107,8 +107,8 @@ class LogValuesQueryRunner(AnalyticsQueryRunner[LogValuesQueryResponse], LogsQue
 
         formatted_results: list[LogValueResult] = []
         if isinstance(response.results, list) and len(response.results) > 0 and len(response.results[0]) > 0:
-            for result in response.results[0][0]:
-                entry = LogValueResult(id=result, name=result)
+            for value, count in response.results[0][0]:
+                entry = LogValueResult(id=value, name=value, count=count)
                 formatted_results.append(entry)
 
         return LogValuesQueryResponse(results=formatted_results)

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -592,6 +592,10 @@ class _LogsAttributesResponseSerializer(serializers.Serializer):
 class _LogAttributeValueSerializer(serializers.Serializer):
     id = serializers.CharField(help_text="Attribute value (used as the identifier).")
     name = serializers.CharField(help_text="Display name — currently identical to `id`.")
+    count = serializers.IntegerField(
+        required=False,
+        help_text="Number of log records with this attribute value, scoped to the current date range, service, and resource filters.",
+    )
 
 
 class _LogsValuesResponseSerializer(serializers.Serializer):

--- a/products/logs/backend/test/test_log_values_attributes.py
+++ b/products/logs/backend/test/test_log_values_attributes.py
@@ -3,6 +3,7 @@ import json
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.clickhouse.client import sync_execute
@@ -158,6 +159,34 @@ class TestLogValuesAttributesTimezones(ClickhouseTestMixin, APIBaseTest):
         empty_names = {r["name"] for r in empty_results}
         self.assertEqual(all_names, empty_names, "Empty value filter should return same values as no filter")
         self.assertEqual(set(all_names), {"info", "DEBUG", "PING", "more", "error"})
+
+    @parameterized.expand(
+        [
+            ("level", "log"),
+            ("service.name", "resource"),
+        ]
+    )
+    def test_log_values_query_returns_counts(self, key, attribute_type):
+        """Each value carries a positive integer count, and results are ordered most-observed first."""
+
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "key": key,
+            "attribute_type": attribute_type,
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/values", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        self.assertGreater(len(results), 0, f"Expected at least one {key} value")
+
+        for result in results:
+            self.assertIsInstance(result["count"], int, f"count missing/non-int for {result['name']}")
+            self.assertGreater(result["count"], 0, f"count should be positive for {result['name']}")
+
+        counts = [r["count"] for r in results]
+        self.assertEqual(counts, sorted(counts, reverse=True), "Values should be ordered by count descending")
 
     def test_log_attributes_search_values_off_by_default(self):
         """Searching with `search_values` unset should match attribute keys only."""

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1344,6 +1344,8 @@ export interface _LogAttributeValueApi {
     id: string
     /** Display name — currently identical to `id`. */
     name: string
+    /** Number of log records with this attribute value, scoped to the current date range, service, and resource filters. */
+    count?: number
 }
 
 export interface _LogsValuesResponseApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -25037,6 +25037,8 @@ export namespace Schemas {
     }
 
     export interface LogValueResult {
+      /** Number of log records with this attribute value, over the current date range, service, and resource filters. */
+      count?: number | null;
       id: string;
       name: string;
     }
@@ -49815,6 +49817,8 @@ export namespace Schemas {
       id: string;
       /** Display name — currently identical to `id`. */
       name: string;
+      /** Number of log records with this attribute value, scoped to the current date range, service, and resource filters. */
+      count?: number;
     }
 
     /**

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

When users browse log attribute values (e.g. filtering by `level`), there's no signal about how common each value is. Adding a `count` field lets the UI surface frequency information and order results by relevance.

## Changes

The `LogValueResult` schema gains an optional `count` field representing the number of log records matching that attribute value within the current date range, service, and resource filters.

On the backend, the ClickHouse query now fetches `(attribute_value, value_count)` tuples instead of bare values, so the count is available without an extra query. The query runner unpacks these tuples and populates `count` on each `LogValueResult`. Results are returned ordered by count descending (most-observed first).

The `count` field is propagated through:
- Python schema (`posthog/schema.py`)
- TypeScript query schema (`schema-general.ts` / `schema.json`)
- DRF serializer for the REST API
- Generated API types for the frontend and MCP service

## How did you test this code?

A new integration test (`test_log_values_query_returns_counts`) verifies that:
- Every returned value carries a positive integer `count`
- Results are ordered by `count` descending

Existing tests for the values endpoint continue to pass unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent extended the `log_values_query_runner` to return counts alongside values, updated all schema layers consistently, and added a targeted test. No alternative approaches were considered — the tuple-based groupArray approach was the straightforward extension of the existing query pattern.