### PR TITLE
chore(codeowners): rename team-signals to team-self-driving

### DIFF
--- a/.agents/skills/establishing-code-ownership/SKILL.md
+++ b/.agents/skills/establishing-code-ownership/SKILL.md
@@ -7,7 +7,7 @@ description: Determine which PostHog team owns a file, directory, or code path, 
 
 Two sources, checked in order:
 
-1. **`products/*/product.yaml`: source of truth under `products/`.** Lists owning team(s) under `owners:` as bare slugs (the CODEOWNERS handle minus `@PostHog/`: `conversations`, `logs`, `team-signals`, …) and owns **all** of `products/<name>/**`. Lives in the dir it owns, so never stale.
+1. **`products/*/product.yaml`: source of truth under `products/`.** Lists owning team(s) under `owners:` as bare slugs (the CODEOWNERS handle minus `@PostHog/`: `conversations`, `logs`, `team-self-driving`, …) and owns **all** of `products/<name>/**`. Lives in the dir it owns, so never stale.
 2. **`.github/CODEOWNERS` + [`CODEOWNERS-soft`](../../../.github/CODEOWNERS-soft): backup for paths outside `products/`.** [`CODEOWNERS`](../../../.github/CODEOWNERS) is hard/blocking (mostly infra); `CODEOWNERS-soft` carries most product mappings for shared code (backend, frontend scenes, generated artifacts, overrides).
 
 ## Fast path: `ownership.js`
@@ -63,4 +63,4 @@ If even the handbook fails and the Slack MCP is available, search Slack. It's th
 
 - **Handle** (CODEOWNERS): `@PostHog/<slug>`, e.g. `@PostHog/team-replay`.
 - **Slug** (`product.yaml`): handle minus `@PostHog/`, e.g. `team-replay`.
-- **Not uniform**: some carry `team-` (`team-signals`), some don't (`conversations`, `logs`). If a name doesn't resolve, try both forms.
+- **Not uniform**: some carry `team-` (`team-self-driving`), some don't (`conversations`, `logs`). If a name doesn't resolve, try both forms.

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -283,13 +283,13 @@ ee/clickhouse/queries/experiments/ @PostHog/team-experiments
 frontend/src/scenes/data-model/ @PostHog/team-data-modeling
 posthog/hogql_queries/endpoints/ @PostHog/team-data-modeling
 
-# Signals / PostHog AI - owned by @PostHog/team-signals
-frontend/src/scenes/max/ @PostHog/team-signals
-frontend/src/scenes/inbox/ @PostHog/team-signals
-ee/hogai/ @PostHog/team-signals
-ee/support_sidebar_max/ @PostHog/team-signals
-posthog/models/ai/** @PostHog/team-signals
-posthog/hogql_queries/document_embeddings_query_runner.py @PostHog/team-signals
+# Signals / PostHog AI - owned by @PostHog/team-self-driving
+frontend/src/scenes/max/ @PostHog/team-self-driving
+frontend/src/scenes/inbox/ @PostHog/team-self-driving
+ee/hogai/ @PostHog/team-self-driving
+ee/support_sidebar_max/ @PostHog/team-self-driving
+posthog/models/ai/** @PostHog/team-self-driving
+posthog/hogql_queries/document_embeddings_query_runner.py @PostHog/team-self-driving
 
 # Billing - owned by @PostHog/team-billing
 frontend/src/scenes/billing/ @PostHog/team-billing

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -427,7 +427,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_QUILL_SQL_CHARTS: 'product-analytics-quill-sql-charts', // owner: #team-data-tools, gates rendering DataVisualization line/area charts via @posthog/quill-charts
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_DWH: 'retention-dwh', // owner: @thmsobrmlr #team-product-analytics
-    PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-signals
+    PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-self-driving
     PRODUCT_BUSINESS_KNOWLEDGE: 'product-business-knowledge', // owner: @veryayskiy #team-conversations
     PRODUCT_SELECTION_SCREEN_VARIANT: 'product-selection-screen-variant', // owner: @fercgomes #team-growth multivariate=control,spotlight,multiproduct
     PRODUCT_SUPPORT_AI_SUGGESTION: 'product-support-ai-suggestion', // owner: @veryayskiy #team-conversations

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -414,7 +414,7 @@ class Team(UUIDTClassicModel):
     conversations_enabled = field_access_control(models.BooleanField(null=True, blank=True), "project", "admin")
     conversations_settings = field_access_control(models.JSONField(null=True, blank=True), "project", "admin")
 
-    # Proactive tasks (#team-signals)
+    # Proactive tasks (#team-self-driving)
     proactive_tasks_enabled = models.BooleanField(null=True, blank=True)
 
     # Surveys

--- a/products/mcp_store/product.yaml
+++ b/products/mcp_store/product.yaml
@@ -1,3 +1,3 @@
 name: MCP servers
 owners:
-    - team-signals
+    - team-self-driving

--- a/products/posthog_ai/product.yaml
+++ b/products/posthog_ai/product.yaml
@@ -1,3 +1,3 @@
 name: PostHog AI
 owners:
-    - team-signals
+    - team-self-driving

--- a/products/signals/product.yaml
+++ b/products/signals/product.yaml
@@ -1,3 +1,3 @@
 name: Signals
 owners:
-    - team-signals
+    - team-self-driving

--- a/products/slack_app/product.yaml
+++ b/products/slack_app/product.yaml
@@ -1,3 +1,3 @@
 name: Slack app
 owners:
-    - team-signals
+    - team-self-driving

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - team-signals
+    - team-self-driving


### PR DESCRIPTION
## Problem

The `team-signals` GitHub team no longer exists — it was replaced by `team-self-driving`. Several CODEOWNERS rules and product ownership entries still point at the dead `team-signals` handle, so ownership routing and reviewer assignment for those paths resolve to a team that isn't there.

## Changes

Renamed every remaining `team-signals` reference to `team-self-driving`:

- `.github/CODEOWNERS-soft` — the Signals / PostHog AI soft-ownership block (header comment + 6 path rules)
- `products/*/product.yaml` — `owners:` slug for `signals`, `mcp_store`, `posthog_ai`, `tracing`, `slack_app`
- `frontend/src/lib/constants.tsx` and `posthog/models/team/team.py` — owner reference in code comments
- `.agents/skills/establishing-code-ownership/SKILL.md` — two illustrative slug examples

No behavioral code changes — this is ownership/metadata only.

## How did you test this code?

I'm an agent. Verification was a repo-wide `grep` confirming zero remaining `team-signals` references after the rename. Pre-commit hooks (ruff, prettier/oxfmt, ty check, yaml/markdown format) ran clean on commit. No automated test suite applies to CODEOWNERS/metadata edits.

One thing for the reviewer to confirm: that `@PostHog/team-self-driving` is the canonical GitHub team slug, so CODEOWNERS resolves correctly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to find CODEOWNERS references to `team-signals`, then clarified the team was renamed to `team-self-driving` and asked for a cleanup PR. I swept the repo for all `team-signals` occurrences (not just CODEOWNERS — also caught two code comments and two doc examples) and did a straight rename. No skills were required for this change.
