### PR TITLE
fix(phai): resolve sandbox tools at render time

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -84,6 +84,7 @@ import { maxGlobalLogic } from './maxGlobalLogic'
 import { ThreadMessage, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
 import type { McpToolCallMessage } from './maxTypes'
+import { resolveToolCall } from './mcpToolMessageResolver'
 import { lookupMcpToolRenderer } from './mcpToolRegistry'
 import { AssistantFailureMessage } from './messages/AssistantFailureMessage'
 import { MessageTemplate } from './messages/MessageTemplate'
@@ -124,22 +125,23 @@ function isErrorMessage(message: ThreadMessage): boolean {
     return message.type !== 'human' && (message.status === 'error' || message.type === 'ai/failure')
 }
 
-/** Maps a merged `ToolInvocation` into the flat `McpToolCallMessage` the registry renderers read. */
+/** Maps a raw merged `ToolInvocation` into the flat `McpToolCallMessage` the registry renderers read. */
 function toolInvocationToMessage(
     invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
 ): McpToolCallMessage | null {
     if (!invocation) {
         return null
     }
+    const resolved = resolveToolCall(invocation)
     return {
         id: invocation.toolCallId,
-        resolvedKey: invocation.resolvedKey,
+        resolvedKey: resolved.resolvedKey,
         rawServerName: invocation.rawServerName,
         rawToolName: invocation.rawToolName,
-        innerToolName: invocation.innerToolName,
-        claudeToolName: invocation.claudeToolName,
+        innerToolName: resolved.innerToolName,
+        claudeToolName: resolved.claudeToolName,
         rawInput: invocation.input,
-        innerInput: invocation.innerInput,
+        innerInput: resolved.innerInput,
         rawOutput: invocation.output,
         content: invocation.contentBlocks,
         status: invocation.status,

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.test.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.test.tsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { Activity } from './ActivityPrimitives'
+
+function expectBefore(first: HTMLElement, second: HTMLElement): void {
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+}
+
+describe('Activity', () => {
+    it('renders details before the widget body', () => {
+        render(
+            <Activity
+                id="tool-call"
+                title={<span data-attr="header">Query trends</span>}
+                status="in_progress"
+                details={<div data-attr="details">Input</div>}
+            >
+                <div data-attr="widget">Visualization</div>
+            </Activity>
+        )
+
+        const header = screen.getByTestId('header')
+        const details = screen.getByTestId('details')
+        const widget = screen.getByTestId('widget')
+
+        expectBefore(header, details)
+        expectBefore(details, widget)
+    })
+})

--- a/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
+++ b/frontend/src/scenes/max/components/Activity/ActivityPrimitives.tsx
@@ -281,13 +281,13 @@ export function Activity({
                 showProgressIcon={showProgressIcon}
                 failedIcon={failedIcon}
             />
-            {children}
             {isDetailsExpanded && hasDetails && (
                 <ActivityDetails hasIcon={!!icon}>
                     {substeps.length > 0 && <ActivitySubsteps id={id} substeps={substeps} status={status} />}
                     {details}
                 </ActivityDetails>
             )}
+            {children}
         </div>
     )
 }

--- a/frontend/src/scenes/max/components/Activity/SandboxActivity.test.tsx
+++ b/frontend/src/scenes/max/components/Activity/SandboxActivity.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import type { McpToolCallMessage } from '../../maxTypes'
+import { SandboxToolActivity } from './SandboxActivity'
+
+function expectBefore(first: HTMLElement, second: HTMLElement): void {
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+}
+
+function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'query-trends',
+        rawServerName: 'posthog',
+        rawToolName: 'exec',
+        rawInput: { command: 'call query-trends {"kind":"TrendsQuery","series":[]}' },
+        innerToolName: 'query-trends',
+        innerInput: { kind: 'TrendsQuery', series: [] },
+        content: [],
+        status: 'in_progress',
+        title: 'Query trends',
+        ...overrides,
+    }
+}
+
+describe('SandboxToolActivity', () => {
+    it('renders details before widget children wrapped in a message bubble', () => {
+        render(
+            <SandboxToolActivity message={makeMessage()}>
+                <div data-attr="widget">Visualization</div>
+            </SandboxToolActivity>
+        )
+
+        const header = screen.getByText('Query trends')
+        const input = screen.getByText('Input')
+        const widget = screen.getByTestId('widget')
+        const bubble = widget.closest('[data-message-type="ai"]')
+
+        expect(bubble).toBeInTheDocument()
+        expectBefore(header, input)
+        expectBefore(input, bubble as HTMLElement)
+    })
+})

--- a/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
+++ b/frontend/src/scenes/max/components/Activity/SandboxActivity.tsx
@@ -5,6 +5,7 @@ import { IconWarning, IconWrench } from '@posthog/icons'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 
 import type { McpToolCallMessage } from '../../maxTypes'
+import { MessageTemplate } from '../../messages/MessageTemplate'
 import { Activity, ActivityToggleSection, ActivityStatus } from './ActivityPrimitives'
 
 export function SandboxActivity({
@@ -61,6 +62,18 @@ export function renderContentBlocks(content: unknown[]): string {
     return content.map(contentBlockText).join('\n')
 }
 
+function SandboxToolMessageBubble({ children }: { children: React.ReactNode }): JSX.Element | null {
+    if (!children) {
+        return null
+    }
+
+    return (
+        <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
+            {children}
+        </MessageTemplate>
+    )
+}
+
 export function SandboxToolActivity({
     message,
     icon,
@@ -104,15 +117,14 @@ export function SandboxToolActivity({
         </div>
     )
 
+    const hasFailureMessage = message.status === 'failed' && !!message.error?.message
     const activityBody =
-        message.status === 'failed' && message.error?.message ? (
+        hasFailureMessage || children ? (
             <div className="flex flex-col gap-2">
-                <div className="text-danger text-sm">{message.error.message}</div>
+                {hasFailureMessage && <div className="text-danger text-sm">{message.error?.message}</div>}
                 {children}
             </div>
-        ) : (
-            children
-        )
+        ) : null
 
     return (
         <Activity
@@ -124,7 +136,7 @@ export function SandboxToolActivity({
             failedIcon={<IconWarning className="text-danger size-3" />}
             details={details}
         >
-            {activityBody}
+            <SandboxToolMessageBubble>{activityBody}</SandboxToolMessageBubble>
         </Activity>
     )
 }

--- a/frontend/src/scenes/max/components/SandboxApproval.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxApproval.test.tsx
@@ -35,8 +35,7 @@ const rawToolCall: ToolInvocation = {
     toolCallId: 'tc-1',
     rawServerName: 'posthog',
     rawToolName: 'exec',
-    resolvedKey: 'insight-create',
-    input: {},
+    input: { command: 'call insight-create {"name":"Signups"}' },
     status: 'pending',
     contentBlocks: [],
 }

--- a/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx
@@ -19,12 +19,12 @@ jest.mock('../sandboxStreamLogic', () => ({
 
 const rawToolCall: ToolInvocation = {
     toolCallId: 'tc-1',
-    rawServerName: '',
-    rawToolName: 'AskUserQuestion',
-    resolvedKey: 'AskUserQuestion',
+    rawServerName: 'claude',
+    rawToolName: '',
     input: {},
     status: 'pending',
     contentBlocks: [],
+    meta: { claudeCode: { toolName: 'AskUserQuestion' } },
 }
 
 function makeRequest(questions: SandboxQuestion[]): PermissionRequestRecord {

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -242,8 +242,8 @@ export function isAgentMode(mode: unknown): mode is AgentMode {
 }
 
 /**
- * The shape `mcpToolRegistry` renderers receive — a merged `ToolInvocation` flattened with the
- * fields the renderer adapters read. Built by `sandboxStreamLogic` from ACP frames.
+ * The shape `mcpToolRegistry` renderers receive — raw `ToolInvocation` stream state plus
+ * renderer-facing fields resolved at render time.
  */
 export interface McpToolCallMessage {
     /** Stable id — the tool call id. */

--- a/frontend/src/scenes/max/mcpToolMessageResolver.test.ts
+++ b/frontend/src/scenes/max/mcpToolMessageResolver.test.ts
@@ -1,0 +1,102 @@
+import { resolveToolCall, resolveToolKey } from './mcpToolMessageResolver'
+
+describe('mcpToolMessageResolver', () => {
+    describe('resolveToolKey', () => {
+        it('parses the inner tool name out of a single-exec call command', () => {
+            const resolved = resolveToolKey('posthog', 'exec', { command: 'call insight-create {"name":"Signups"}' })
+            expect(resolved.resolvedKey).toEqual('insight-create')
+            expect(resolved.innerToolName).toEqual('insight-create')
+            expect(resolved.innerInput).toEqual({ name: 'Signups' })
+        })
+
+        it('parses --json single-exec call commands', () => {
+            const resolved = resolveToolKey('posthog', 'exec', {
+                command: 'call --json query-trends {"kind":"TrendsQuery"}',
+            })
+            expect(resolved.resolvedKey).toEqual('query-trends')
+            expect(resolved.innerInput).toEqual({ kind: 'TrendsQuery' })
+        })
+
+        it('maps discovery verbs to sentinels', () => {
+            expect(resolveToolKey('posthog', 'exec', { command: 'tools' }).resolvedKey).toEqual(
+                '__posthog_exec_tools__'
+            )
+            expect(resolveToolKey('posthog', 'exec', { command: 'search recordings' }).resolvedKey).toEqual(
+                '__posthog_exec_search__'
+            )
+        })
+
+        it('falls back to unknown sentinel for malformed commands', () => {
+            expect(resolveToolKey('posthog', 'exec', { command: '!!!' }).resolvedKey).toEqual(
+                '__posthog_exec_unknown__'
+            )
+        })
+
+        it('returns the wire name for non-exec MCP tools that carry one', () => {
+            expect(resolveToolKey('user-mcp', 'do_thing', {}).resolvedKey).toEqual('do_thing')
+        })
+
+        it.each(['Edit', 'TodoWrite', 'Grep', 'Task'])(
+            'falls back to the SDK %s name when the wire toolName is empty (every Claude built-in)',
+            (sdkName) => {
+                // Built-ins carry no top-level toolName on the wire — only `_meta.claudeCode.toolName`.
+                expect(resolveToolKey('claude', '', {}, sdkName).resolvedKey).toEqual(sdkName)
+            }
+        )
+
+        it('prefers the explicit wire toolName over the SDK name when both are present', () => {
+            expect(resolveToolKey('user-mcp', 'do_thing', {}, 'Edit').resolvedKey).toEqual('do_thing')
+        })
+
+        it('resolves to empty string when neither a wire toolName nor an SDK name is present', () => {
+            expect(resolveToolKey('claude', '', {}).resolvedKey).toEqual('')
+        })
+    })
+
+    describe('resolveToolCall', () => {
+        it('resolves a raw streamed exec invocation at render time', () => {
+            expect(
+                resolveToolCall({
+                    rawServerName: 'posthog',
+                    rawToolName: 'exec',
+                    input: { command: 'call query-trends {"kind":"TrendsQuery"}' },
+                })
+            ).toEqual({
+                resolvedKey: 'query-trends',
+                innerToolName: 'query-trends',
+                innerInput: { kind: 'TrendsQuery' },
+                claudeToolName: undefined,
+            })
+        })
+
+        it('resolves exec invocations when the canonical tool name only arrives in metadata', () => {
+            expect(
+                resolveToolCall({
+                    rawServerName: 'posthog',
+                    rawToolName: '',
+                    input: { command: 'call query-trends {"kind":"TrendsQuery","series":[]}' },
+                    meta: { claudeCode: { toolName: 'mcp__posthog__exec' } },
+                })
+            ).toEqual({
+                resolvedKey: 'query-trends',
+                innerToolName: 'query-trends',
+                innerInput: { kind: 'TrendsQuery', series: [] },
+                claudeToolName: 'mcp__posthog__exec',
+            })
+        })
+
+        it('resolves a raw built-in invocation from metadata at render time', () => {
+            expect(
+                resolveToolCall({
+                    rawServerName: 'claude',
+                    rawToolName: '',
+                    input: { file_path: 'app.ts' },
+                    meta: { claudeCode: { toolName: 'Edit' } },
+                })
+            ).toEqual({
+                resolvedKey: 'Edit',
+                claudeToolName: 'Edit',
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/max/mcpToolMessageResolver.ts
+++ b/frontend/src/scenes/max/mcpToolMessageResolver.ts
@@ -1,0 +1,94 @@
+const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
+
+export interface ResolvedToolKey {
+    resolvedKey: string
+    innerToolName?: string
+    innerInput?: Record<string, unknown>
+}
+
+export interface ResolvableToolCall {
+    rawServerName: string
+    rawToolName: string
+    input: Record<string, unknown>
+    meta?: unknown
+}
+
+export interface ResolvedToolCall extends ResolvedToolKey {
+    claudeToolName?: string
+}
+
+/** Reads `_meta.claudeCode` off a tool frame's `_meta` without trusting its shape. */
+export function getClaudeCodeMeta(meta: unknown): Record<string, unknown> | undefined {
+    if (typeof meta !== 'object' || meta === null) {
+        return undefined
+    }
+    const claudeCode = (meta as { claudeCode?: unknown }).claudeCode
+    return typeof claudeCode === 'object' && claudeCode !== null ? (claudeCode as Record<string, unknown>) : undefined
+}
+
+/** Stable SDK tool name (`"Edit"`, `"TodoWrite"`) from `_meta.claudeCode.toolName`; undefined when absent. */
+export function extractClaudeToolName(meta: unknown): string | undefined {
+    const claudeCode = getClaudeCodeMeta(meta)
+    return typeof claudeCode?.toolName === 'string' && claudeCode.toolName ? claudeCode.toolName : undefined
+}
+
+/**
+ * Resolves the registry key for a tool call. The single-exec `posthog` MCP server exposes one
+ * outer `exec` tool; the inner tool name is parsed out of `rawInput.command`. Non-exec MCP tools
+ * and Claude built-ins look up by their wire name directly. Claude built-ins carry no wire
+ * `toolName`, so `claudeToolName` (from `_meta.claudeCode.toolName`) is preferred as the fallback.
+ */
+export function resolveToolKey(
+    serverName: string,
+    toolName: string,
+    input: Record<string, unknown>,
+    claudeToolName?: string
+): ResolvedToolKey {
+    const fullName = `mcp__${serverName}__${toolName}`
+    const isPostHogExecTool =
+        POSTHOG_EXEC_TOOL_RE.test(fullName) ||
+        POSTHOG_EXEC_TOOL_RE.test(toolName) ||
+        (claudeToolName ? POSTHOG_EXEC_TOOL_RE.test(claudeToolName) : false)
+
+    if (isPostHogExecTool && typeof input.command === 'string') {
+        const verbMatch = input.command.match(/^\s*(tools|search|info|schema|call)(?:\s+([\s\S]*))?\s*$/)
+        if (!verbMatch) {
+            return { resolvedKey: '__posthog_exec_unknown__' }
+        }
+
+        const verb = verbMatch[1] as 'tools' | 'search' | 'info' | 'schema' | 'call'
+        const rest = (verbMatch[2] ?? '').trim()
+
+        if (verb !== 'call') {
+            return { resolvedKey: `__posthog_exec_${verb}__` }
+        }
+
+        const callMatch = rest.match(/^(?:--json\s+)?([a-zA-Z0-9_-]+)\s*([\s\S]*)$/)
+        if (!callMatch) {
+            return { resolvedKey: '__posthog_exec_unknown__' }
+        }
+
+        const innerToolName = callMatch[1]
+        const jsonBody = (callMatch[2] ?? '').trim()
+        let innerInput: Record<string, unknown> = {}
+        if (jsonBody) {
+            try {
+                innerInput = JSON.parse(jsonBody)
+            } catch {
+                // Leave malformed payloads renderable as generic tool calls.
+            }
+        }
+        return { resolvedKey: innerToolName, innerToolName, innerInput }
+    }
+
+    return { resolvedKey: toolName || claudeToolName || '' }
+}
+
+/** Resolves renderer-facing fields from a raw streamed tool invocation. */
+export function resolveToolCall(toolCall: ResolvableToolCall): ResolvedToolCall {
+    const claudeToolName = extractClaudeToolName(toolCall.meta)
+    return {
+        ...resolveToolKey(toolCall.rawServerName, toolCall.rawToolName, toolCall.input, claudeToolName),
+        claudeToolName,
+    }
+}

--- a/frontend/src/scenes/max/messages/adapters/extractors.test.ts
+++ b/frontend/src/scenes/max/messages/adapters/extractors.test.ts
@@ -9,10 +9,14 @@ import {
     extractVisualizationArtifact,
 } from './extractors'
 
-function toolMessage(rawOutput: unknown, innerInput?: Record<string, unknown>): McpToolCallMessage {
+function toolMessage(
+    rawOutput: unknown,
+    innerInput?: Record<string, unknown>,
+    resolvedKey = 'test-tool'
+): McpToolCallMessage {
     return {
         id: 'call-1',
-        resolvedKey: 'test-tool',
+        resolvedKey,
         rawServerName: 'posthog',
         rawToolName: 'mcp__posthog__exec',
         rawInput: {},
@@ -138,6 +142,19 @@ describe('mcp tool adapter extractors', () => {
             const result = extractQueryResult(toolMessage({ query: { kind: 'TracesQuery' }, results: [] }))
             expect(result?.content.query).toEqual({ kind: 'DataTableNode', source: { kind: 'TracesQuery' } })
             expect(result?.url).toBeNull()
+        })
+
+        it('uses the tool input when optimized streamed results omit structured raw output', () => {
+            const result = extractQueryResult(
+                toolMessage(undefined, { kind: 'TrendsQuery', series: [], output_format: 'optimized' }, 'query-trends')
+            )
+            expect(result?.content.query).toEqual({ kind: 'TrendsQuery', series: [] })
+            expect(result?.url).toBeNull()
+        })
+
+        it('infers the query kind from the wrapper tool key when the input omits kind', () => {
+            const result = extractQueryResult(toolMessage(undefined, { series: [] }, 'query-trends'))
+            expect(result?.content.query).toEqual({ kind: 'TrendsQuery', series: [] })
         })
 
         it('wraps the actors wrapper output (ActorsQuery envelope) untouched in a DataTableNode', () => {

--- a/frontend/src/scenes/max/messages/adapters/extractors.ts
+++ b/frontend/src/scenes/max/messages/adapters/extractors.ts
@@ -28,6 +28,37 @@ function asString(value: unknown): string | undefined {
     return typeof value === 'string' ? value : undefined
 }
 
+const QUERY_WRAPPER_KIND_BY_TOOL_KEY: Record<string, NodeKind> = {
+    'query-trends': NodeKind.TrendsQuery,
+    'query-funnel': NodeKind.FunnelsQuery,
+    'query-retention': NodeKind.RetentionQuery,
+    'query-stickiness': NodeKind.StickinessQuery,
+    'query-paths': NodeKind.PathsQuery,
+    'query-lifecycle': NodeKind.LifecycleQuery,
+    'query-llm-traces-list': NodeKind.TracesQuery,
+    'query-trends-actors': NodeKind.InsightActorsQuery,
+    'query-lifecycle-actors': NodeKind.InsightActorsQuery,
+    'query-paths-actors': NodeKind.InsightActorsQuery,
+    'query-retention-actors': NodeKind.InsightActorsQuery,
+}
+
+function queryFromToolInput(message: McpToolCallMessage): Record<string, unknown> | null {
+    const input = asRecord(message.innerInput)
+    if (!input) {
+        return null
+    }
+
+    const query = { ...input }
+    delete query.output_format
+
+    if (typeof query.kind === 'string') {
+        return query
+    }
+
+    const inferredKind = QUERY_WRAPPER_KIND_BY_TOOL_KEY[message.resolvedKey]
+    return inferredKind ? { ...query, kind: inferredKind } : null
+}
+
 /** The artifact envelope + content the visualization widget proxies consume. */
 export interface VisualizationArtifactExtraction {
     envelope: ArtifactMessage
@@ -88,8 +119,8 @@ export interface QueryResultExtraction {
  */
 export function extractQueryResult(message: McpToolCallMessage): QueryResultExtraction | null {
     const output = asRecord(message.rawOutput)
-    const query = output ? asRecord(output.query) : null
-    if (!output || !query || typeof query.kind !== 'string') {
+    const query = (output ? asRecord(output.query) : null) ?? queryFromToolInput(message)
+    if (!query || typeof query.kind !== 'string') {
         return null
     }
 
@@ -118,7 +149,7 @@ export function extractQueryResult(message: McpToolCallMessage): QueryResultExtr
             name: null,
             description: null,
         },
-        url: asString(output._posthogUrl) ?? null,
+        url: asString(output?._posthogUrl) ?? null,
     }
 }
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -17,7 +17,6 @@ import {
     mergeResourceProducts,
     parsePermissionRequestFrame,
     reconnectDelayMs,
-    resolveToolKey,
     sandboxStreamLogic,
     SSE_HEALTHY_CONNECTION_MS,
     SSE_RECONNECT_BASE_DELAY_MS,
@@ -110,50 +109,6 @@ describe('sandboxStreamLogic', () => {
         jest.restoreAllMocks()
     })
 
-    describe('resolveToolKey', () => {
-        it('parses the inner tool name out of a single-exec call command', () => {
-            const resolved = resolveToolKey('posthog', 'exec', { command: 'call insight-create {"name":"Signups"}' })
-            expect(resolved.resolvedKey).toEqual('insight-create')
-            expect(resolved.innerToolName).toEqual('insight-create')
-            expect(resolved.innerInput).toEqual({ name: 'Signups' })
-        })
-
-        it('maps discovery verbs to sentinels', () => {
-            expect(resolveToolKey('posthog', 'exec', { command: 'tools' }).resolvedKey).toEqual(
-                '__posthog_exec_tools__'
-            )
-            expect(resolveToolKey('posthog', 'exec', { command: 'search recordings' }).resolvedKey).toEqual(
-                '__posthog_exec_search__'
-            )
-        })
-
-        it('falls back to unknown sentinel for malformed commands', () => {
-            expect(resolveToolKey('posthog', 'exec', { command: '!!!' }).resolvedKey).toEqual(
-                '__posthog_exec_unknown__'
-            )
-        })
-
-        it('returns the wire name for non-exec MCP tools that carry one', () => {
-            expect(resolveToolKey('user-mcp', 'do_thing', {}).resolvedKey).toEqual('do_thing')
-        })
-
-        it.each(['Edit', 'TodoWrite', 'Grep', 'Task'])(
-            'falls back to the SDK %s name when the wire toolName is empty (every Claude built-in)',
-            (sdkName) => {
-                // Built-ins carry no top-level toolName on the wire — only `_meta.claudeCode.toolName`.
-                expect(resolveToolKey('claude', '', {}, sdkName).resolvedKey).toEqual(sdkName)
-            }
-        )
-
-        it('prefers the explicit wire toolName over the SDK name when both are present', () => {
-            expect(resolveToolKey('user-mcp', 'do_thing', {}, 'Edit').resolvedKey).toEqual('do_thing')
-        })
-
-        it('resolves to empty string when neither a wire toolName nor an SDK name is present', () => {
-            expect(resolveToolKey('claude', '', {}).resolvedKey).toEqual('')
-        })
-    })
-
     describe('ingestAcpFrame replay', () => {
         it('folds a stream of StoredLogEntry frames into thread items', async () => {
             const frames: StoredLogEntry[] = [
@@ -194,7 +149,9 @@ describe('sandboxStreamLogic', () => {
             expect(toolItem?.toolCallId).toEqual('t1')
 
             const invocation = logic.values.toolInvocations.get('t1')
-            expect(invocation?.resolvedKey).toEqual('execute-sql')
+            expect(invocation?.rawServerName).toEqual('posthog')
+            expect(invocation?.rawToolName).toEqual('exec')
+            expect(invocation?.input).toEqual({ command: 'call execute-sql {"query":"select 1"}' })
             expect(invocation?.status).toEqual('completed')
             expect(invocation?.output).toEqual({ rows: 1 })
             expect(invocation?.contentBlocks).toEqual([{ type: 'text', text: 'done' }])
@@ -379,7 +336,7 @@ describe('sandboxStreamLogic', () => {
     })
 
     describe('streamed tool input', () => {
-        it('folds rawInput arriving on a later update into a built-in tool call keyed off _meta', async () => {
+        it('folds rawInput arriving on a later update into a built-in tool call and keeps _meta raw', async () => {
             // Built-ins carry no top-level toolName — the SDK name arrives only on `_meta.claudeCode`.
             const frames: StoredLogEntry[] = [
                 sessionUpdate({
@@ -404,11 +361,11 @@ describe('sandboxStreamLogic', () => {
 
             const invocation = logic.values.toolInvocations.get('t1')
             expect(invocation?.input).toEqual({ query: 'find recordings', max_results: 10 })
-            expect(invocation?.resolvedKey).toEqual('ToolSearch')
-            expect(invocation?.claudeToolName).toEqual('ToolSearch')
+            expect(invocation?.rawToolName).toEqual('')
+            expect(invocation?.meta).toEqual({ claudeCode: { toolName: 'ToolSearch' } })
         })
 
-        it('re-resolves the registry key when an exec command streams in after an empty tool_call', async () => {
+        it('folds an exec command that streams in after an empty tool_call without resolving it', async () => {
             const frames: StoredLogEntry[] = [
                 sessionUpdate({
                     sessionUpdate: 'tool_call',
@@ -431,13 +388,13 @@ describe('sandboxStreamLogic', () => {
             }).toFinishAllListeners()
 
             const invocation = logic.values.toolInvocations.get('t2')
-            expect(invocation?.resolvedKey).toEqual('insight-create')
-            expect(invocation?.innerToolName).toEqual('insight-create')
-            expect(invocation?.innerInput).toEqual({ name: 'Signups' })
+            expect(invocation?.rawServerName).toEqual('posthog')
+            expect(invocation?.rawToolName).toEqual('exec')
+            expect(invocation?.input).toEqual({ command: 'call insight-create {"name":"Signups"}' })
         })
 
         it.each(['Edit', 'TodoWrite', 'Grep', 'Task'])(
-            'keys a built-in %s tool_call off _meta.claudeCode.toolName despite an empty wire toolName',
+            'keeps a built-in %s tool_call raw despite an empty wire toolName',
             async (sdkName) => {
                 const frames: StoredLogEntry[] = [
                     sessionUpdate({
@@ -455,12 +412,12 @@ describe('sandboxStreamLogic', () => {
                 }).toFinishAllListeners()
 
                 const invocation = logic.values.toolInvocations.get('tb')
-                expect(invocation?.resolvedKey).toEqual(sdkName)
-                expect(invocation?.claudeToolName).toEqual(sdkName)
+                expect(invocation?.rawToolName).toEqual('')
+                expect(invocation?.meta).toEqual({ claudeCode: { toolName: sdkName } })
             }
         )
 
-        it('keeps the resolved input when a later update carries none', async () => {
+        it('keeps the raw input when a later update carries none', async () => {
             const frames: StoredLogEntry[] = [
                 sessionUpdate({
                     sessionUpdate: 'tool_call',
@@ -483,8 +440,8 @@ describe('sandboxStreamLogic', () => {
             }).toFinishAllListeners()
 
             const invocation = logic.values.toolInvocations.get('t3')
-            expect(invocation?.resolvedKey).toEqual('execute-sql')
-            expect(invocation?.innerInput).toEqual({ query: 'select 1' })
+            expect(invocation?.rawToolName).toEqual('exec')
+            expect(invocation?.input).toEqual({ command: 'call execute-sql {"query":"select 1"}' })
         })
     })
 
@@ -2003,7 +1960,10 @@ describe('sandboxStreamLogic', () => {
             expect(record?.toolCallId).toEqual('t1')
             expect(record?.toolName).toEqual('mcp__posthog__exec')
             expect(record?.options.map((o) => o.kind)).toEqual(['allow_once', 'reject'])
-            expect(record?.rawToolCall.resolvedKey).toEqual('insight-update')
+            expect(record?.rawToolCall.rawServerName).toEqual('posthog')
+            expect(record?.rawToolCall.rawToolName).toEqual('exec')
+            expect(record?.rawToolCall.input).toEqual({ command: 'call insight-update {"id":"abc"}' })
+            expect(record?.rawToolCall.meta).toEqual({ claudeCode: { toolName: 'mcp__posthog__exec' } })
         })
 
         it('returns null for a frame with no usable options', () => {
@@ -2034,7 +1994,7 @@ describe('sandboxStreamLogic', () => {
             expect(record?.options.find((o) => o.kind === 'reject_once')?.customInput).toEqual(true)
         })
 
-        it('names the inner tool when the toolCall carries _meta.claudeCode.toolName', () => {
+        it('keeps Claude tool metadata on the raw tool call', () => {
             const record = parsePermissionRequestFrame({
                 type: 'permission_request',
                 requestId: 'req-2',
@@ -2047,8 +2007,9 @@ describe('sandboxStreamLogic', () => {
                 options: [{ optionId: 'allow_once', name: 'Approve', kind: 'allow_once' }],
             })
             expect(record).not.toBeNull()
-            expect(record?.rawToolCall.resolvedKey).toEqual('Edit')
-            expect(record?.rawToolCall.claudeToolName).toEqual('Edit')
+            expect(record?.toolName).toEqual('Edit')
+            expect(record?.rawToolCall.rawToolName).toEqual('')
+            expect(record?.rawToolCall.meta).toEqual({ claudeCode: { toolName: 'Edit' } })
         })
 
         it('populates pendingPermissionRequest off a permission_request SSE frame', async () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -8,6 +8,7 @@ import { projectLogic } from 'scenes/projectLogic'
 import { tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
 import type { TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
+import { getClaudeCodeMeta, resolveToolCall } from './mcpToolMessageResolver'
 import { parseSandboxQuestions } from './sandboxQuestionUtils'
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
 import { defaultPermissionDecision, findAllowOptionId } from './sandboxToolPolicy'
@@ -267,30 +268,6 @@ async function fetchRunStatus(
     }
 }
 
-/** Matches `mcp__posthog__exec` (and plugin/regional variants). Ported from Twig posthog-exec-display.ts. */
-const POSTHOG_EXEC_TOOL_RE = /^mcp__(?:plugin_)?posthog(?:_[^_]+)*__exec$/
-
-interface ResolvedToolKey {
-    resolvedKey: string
-    innerToolName?: string
-    innerInput?: Record<string, unknown>
-}
-
-/** Reads `_meta.claudeCode` off a tool frame's `_meta` without trusting its shape. */
-function getClaudeCodeMeta(meta: unknown): Record<string, unknown> | undefined {
-    if (typeof meta !== 'object' || meta === null) {
-        return undefined
-    }
-    const claudeCode = (meta as { claudeCode?: unknown }).claudeCode
-    return typeof claudeCode === 'object' && claudeCode !== null ? (claudeCode as Record<string, unknown>) : undefined
-}
-
-/** Stable SDK tool name (`"Edit"`, `"TodoWrite"`) from `_meta.claudeCode.toolName`; undefined when absent. */
-export function extractClaudeToolName(meta: unknown): string | undefined {
-    const claudeCode = getClaudeCodeMeta(meta)
-    return typeof claudeCode?.toolName === 'string' && claudeCode.toolName ? claudeCode.toolName : undefined
-}
-
 /**
  * Permission-denial reason from `_meta.claudeCode.toolResponse`, preferring `decisionReason` over
  * the generic `message`. Returns undefined when no `_meta` is present (the inline `canUseTool` path),
@@ -310,54 +287,6 @@ export function extractDenialReason(meta: unknown): string | undefined {
         return r.message
     }
     return undefined
-}
-
-/**
- * Resolves the registry key for a tool call. The single-exec `posthog` MCP server exposes one
- * outer `exec` tool; the inner tool name is parsed out of `rawInput.command`. Non-exec MCP tools
- * and Claude built-ins look up by their wire name directly. Claude built-ins carry no wire
- * `toolName`, so `claudeToolName` (from `_meta.claudeCode.toolName`) is preferred as the fallback.
- */
-export function resolveToolKey(
-    serverName: string,
-    toolName: string,
-    input: Record<string, unknown>,
-    claudeToolName?: string
-): ResolvedToolKey {
-    const fullName = `mcp__${serverName}__${toolName}`
-
-    if (POSTHOG_EXEC_TOOL_RE.test(fullName) && typeof input.command === 'string') {
-        const verbMatch = input.command.match(/^\s*(tools|search|info|schema|call)(?:\s+([\s\S]*))?\s*$/)
-        if (!verbMatch) {
-            return { resolvedKey: '__posthog_exec_unknown__' }
-        }
-
-        const verb = verbMatch[1] as 'tools' | 'search' | 'info' | 'schema' | 'call'
-        const rest = (verbMatch[2] ?? '').trim()
-
-        if (verb !== 'call') {
-            return { resolvedKey: `__posthog_exec_${verb}__` }
-        }
-
-        const callMatch = rest.match(/^(?:--json\s+)?([a-zA-Z0-9_-]+)\s*([\s\S]*)$/)
-        if (!callMatch) {
-            return { resolvedKey: '__posthog_exec_unknown__' }
-        }
-
-        const innerToolName = callMatch[1]
-        const jsonBody = (callMatch[2] ?? '').trim()
-        let innerInput: Record<string, unknown> = {}
-        if (jsonBody) {
-            try {
-                innerInput = JSON.parse(jsonBody)
-            } catch {
-                // leave empty
-            }
-        }
-        return { resolvedKey: innerToolName, innerToolName, innerInput }
-    }
-
-    return { resolvedKey: toolName || claudeToolName || '' }
 }
 
 /**
@@ -457,10 +386,9 @@ function parsePermissionOption(raw: unknown): PermissionOption | null {
  * Parses a permission request into a `PermissionRequestRecord` — either the live
  * `data.type === 'permission_request'` SSE envelope or the `_posthog/permission_request`
  * notification params the agent-server persists to the run log (both carry the same fields).
- * The toolCall payload mirrors the ACP `tool_call` shape; reusing `resolveToolKey` keys the
- * request onto the same `toolCallId` as the rendered tool card. Returns null when the frame
- * is malformed or carries no usable options. The wire payload is typed, not validated, so
- * every field read keeps its runtime check.
+ * The toolCall payload mirrors the ACP `tool_call` shape. Returns null when the frame is malformed
+ * or carries no usable options. The wire payload is typed, not validated, so every field read keeps
+ * its runtime check.
  */
 export function parsePermissionRequestFrame(
     frame: PermissionRequestFrame | PosthogPermissionRequestParams
@@ -482,30 +410,21 @@ export function parsePermissionRequestFrame(
     }
 
     const rawServerName = String(toolCall.serverName ?? 'posthog')
-    // MCP-tool approval frames stamp the inner SDK tool name under `_meta.claudeCode.toolName`; pass
-    // it through so the card names the inner tool. No-op when absent (the field may not be present yet).
-    const claudeToolName = extractClaudeToolName(toolCall._meta)
-    const wireToolName = String(toolCall.toolName ?? '')
-    const rawToolName = wireToolName || (claudeToolName ? '' : String(toolCall.title ?? ''))
+    const rawToolName = String(toolCall.toolName ?? '')
     const input = (toolCall.rawInput ?? toolCall.input ?? {}) as Record<string, unknown>
-    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(
-        rawServerName,
-        wireToolName,
-        input,
-        claudeToolName
-    )
 
     // Canonical ACP tool name (e.g. `mcp__posthog__exec`, or a built-in like `Bash`). The wire puts
     // it on `_meta.claudeCode.toolName`; the bare fields are the fallback. The default permission
     // policy classifies off this — `mcp__`-prefixed vs built-in, plus the exec sub-tool.
-    const meta = (toolCall._meta ?? {}) as Record<string, unknown>
-    const claudeCode = (meta.claudeCode ?? {}) as Record<string, unknown>
+    const meta = toolCall._meta
+    const metaRecord = typeof meta === 'object' && meta !== null ? (meta as Record<string, unknown>) : {}
+    const claudeCode = getClaudeCodeMeta(meta) ?? {}
     const toolName = String(claudeCode.toolName ?? toolCall.toolName ?? rawToolName)
 
     // `AskUserQuestion` is routed through the permission framework by the agent (Twig): the question
     // payload rides `_meta.codeToolKind === 'question'` + `_meta.questions`. When present, this renders
     // the interactive question overlay (not the approve/decline card) and is never auto-approved.
-    const questions = meta.codeToolKind === 'question' ? parseSandboxQuestions(meta) : []
+    const questions = metaRecord.codeToolKind === 'question' ? parseSandboxQuestions(metaRecord) : []
 
     return {
         requestId,
@@ -519,16 +438,13 @@ export function parsePermissionRequestFrame(
             toolCallId,
             rawServerName,
             rawToolName,
-            innerToolName,
-            resolvedKey,
-            claudeToolName,
             input,
-            innerInput,
             status: mapAcpStatus(toolCall.status),
             title: toolCall.title as string | undefined,
             kind: toolCall.kind as string | undefined,
             locations: toolCall.locations as { path: string; line?: number }[] | undefined,
             contentBlocks: Array.isArray(toolCall.content) ? toolCall.content : [],
+            meta,
         },
     }
 }
@@ -1299,11 +1215,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // Pin it seen up front so a reconnect replay can't re-process the same request mid-POST.
             actions.markPermissionRequestSeen(record.requestId)
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            const resolvedToolCall = resolveToolCall(record.rawToolCall)
             posthog.capture('permission_auto_approved', {
                 conversation_id: props.conversationId,
                 trace_id: values.traceId,
                 request_id: record.requestId,
-                tool_call_name: record.rawToolCall.resolvedKey,
+                tool_call_name: resolvedToolCall.resolvedKey,
                 tool_call_id: record.toolCallId,
                 run_id: activeRun?.runId,
                 task_id: activeRun?.taskId,
@@ -1335,11 +1252,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             // conversation_id / trace_id are correlated by the caller (the SSE bypasses Django);
             // emit what this logic knows.
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            const resolvedToolCall = resolveToolCall(record.rawToolCall)
             posthog.capture('permission_requested', {
                 conversation_id: props.conversationId,
                 trace_id: values.traceId,
                 request_id: record.requestId,
-                tool_call_name: record.rawToolCall.resolvedKey,
+                tool_call_name: resolvedToolCall.resolvedKey,
                 tool_call_id: record.toolCallId,
                 run_id: activeRun?.runId,
                 task_id: activeRun?.taskId,
@@ -1699,32 +1617,19 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         break
                     }
                     const rawServerName = String(update.serverName ?? 'posthog')
-                    const claudeToolName = extractClaudeToolName(update._meta)
-                    const wireToolName = String(update.toolName ?? '')
-                    // `rawToolName` is the displayed name (wire name, or the human title for built-ins
-                    // that carry no name); the resolver keys off the wire name + SDK name instead.
-                    const rawToolName = wireToolName || (claudeToolName ? '' : String(update.title ?? ''))
+                    const rawToolName = String(update.toolName ?? '')
                     const input = update.rawInput ?? update.input ?? {}
-                    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(
-                        rawServerName,
-                        wireToolName,
-                        input,
-                        claudeToolName
-                    )
                     actions.upsertToolInvocation({
                         toolCallId,
                         rawServerName,
                         rawToolName,
-                        innerToolName,
-                        resolvedKey,
-                        claudeToolName,
                         input,
-                        innerInput,
                         status: mapAcpStatus(update.status),
                         title: update.title,
                         kind: update.kind,
                         locations: update.locations,
                         contentBlocks: Array.isArray(update.content) ? update.content : [],
+                        meta: update._meta,
                     })
                     break
                 }
@@ -1759,40 +1664,29 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         // tool card still renders instead of silently vanishing. No completion telemetry
                         // here — without the creation frame there's no reliable start time or tool name.
                         const rawServerName = 'posthog'
-                        const rawToolName = String(update.title ?? '')
-                        const { resolvedKey, innerToolName, innerInput } = resolveToolKey(
-                            rawServerName,
-                            rawToolName,
-                            rawInput ?? {}
-                        )
+                        const rawToolName = ''
                         actions.upsertToolInvocation({
                             toolCallId,
                             rawServerName,
                             rawToolName,
-                            innerToolName,
-                            resolvedKey,
                             input: rawInput ?? {},
-                            innerInput,
                             status,
                             title: update.title,
                             locations: update.locations,
                             contentBlocks: updateContent,
+                            meta: update._meta,
                             ...(errorMessage !== undefined ? { error: { message: errorMessage } } : {}),
                         })
                         break
                     }
 
-                    // The tool's args stream in across updates (e.g. an `exec` command or a tool's
-                    // input building up), so fold the latest rawInput in and re-resolve the registry
-                    // key from it rather than freezing the empty input the initial tool_call carried.
-                    const reResolved = rawInput
-                        ? resolveToolKey(
-                              existing.rawServerName,
-                              existing.rawToolName,
-                              rawInput,
-                              existing.claudeToolName
-                          )
-                        : undefined
+                    const nextInput = rawInput ?? existing.input
+                    const nextMeta = update._meta ?? existing.meta
+                    const resolvedForTelemetry = resolveToolCall({
+                        ...existing,
+                        input: nextInput,
+                        meta: nextMeta,
+                    })
                     actions.updateToolInvocation(toolCallId, {
                         status,
                         title: update.title ?? existing.title,
@@ -1802,20 +1696,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         contentBlocks: [...existing.contentBlocks, ...updateContent],
                         error: errorMessage !== undefined ? { message: errorMessage } : existing.error,
                         ...(rawInput ? { input: rawInput } : {}),
-                        ...(reResolved
-                            ? {
-                                  resolvedKey: reResolved.resolvedKey,
-                                  innerToolName: reResolved.innerToolName,
-                                  innerInput: reResolved.innerInput,
-                              }
-                            : {}),
+                        ...(update._meta ? { meta: update._meta } : {}),
                     })
                     // TOOL_CALL_COMPLETED telemetry (optional) — emit once when a tool call first
                     // transitions to a terminal status. `duration_ms` is measured from the turn start
                     // since per-tool start timing isn't carried on the wire. Suppressed while replaying
                     // history so a reopen doesn't re-count prior-session tool calls; the missing-creation
-                    // case is handled above and never reaches here. Report the freshly re-resolved key
-                    // (e.g. an `exec`-wrapped inner tool) rather than the stale initial one.
+                    // case is handled above and never reaches here. Report the key resolved from the
+                    // latest raw input/meta without storing it in stream state.
                     if (
                         cache.bootstrapReplay !== true &&
                         (status === 'completed' || status === 'failed') &&
@@ -1827,7 +1715,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                             conversation_id: props.conversationId,
                             trace_id: values.traceId,
                             tool_call_id: toolCallId,
-                            tool_qualified_name: reResolved?.resolvedKey ?? existing.resolvedKey,
+                            tool_qualified_name: resolvedForTelemetry.resolvedKey,
                             status,
                             duration_ms: startedAt !== undefined ? Date.now() - startedAt : undefined,
                             execution_type: 'sandbox',

--- a/frontend/src/scenes/max/sandboxToolPolicy.test.ts
+++ b/frontend/src/scenes/max/sandboxToolPolicy.test.ts
@@ -12,21 +12,22 @@ import type { PermissionOption } from './types/sandboxWireTypes'
 function makeRecord(
     overrides: {
         toolName?: string
-        resolvedKey?: string
-        innerToolName?: string
+        rawServerName?: string
+        rawToolName?: string
+        input?: Record<string, unknown>
+        meta?: unknown
         options?: PermissionOption[]
         questions?: SandboxQuestion[]
     } = {}
 ): PermissionRequestRecord {
     const rawToolCall: ToolInvocation = {
         toolCallId: 'tc',
-        rawServerName: 'posthog',
-        rawToolName: 'exec',
-        resolvedKey: overrides.resolvedKey ?? 'exec',
-        innerToolName: overrides.innerToolName,
-        input: {},
+        rawServerName: overrides.rawServerName ?? 'posthog',
+        rawToolName: overrides.rawToolName ?? 'exec',
+        input: overrides.input ?? {},
         status: 'pending',
         contentBlocks: [],
+        meta: overrides.meta,
     }
     return {
         requestId: 'r',
@@ -68,27 +69,34 @@ describe('sandboxToolPolicy', () => {
 
     describe('defaultPermissionDecision', () => {
         it.each<[string, PermissionRequestRecord, PermissionDecision]>([
-            ['built-in tool', makeRecord({ toolName: 'Bash', resolvedKey: 'Bash' }), 'auto_allow'],
-            ['exec discovery verb', makeRecord({ resolvedKey: '__posthog_exec_tools__' }), 'auto_allow'],
             [
-                'exec create',
-                makeRecord({ resolvedKey: 'insight-create', innerToolName: 'insight-create' }),
+                'built-in tool',
+                makeRecord({
+                    toolName: 'Bash',
+                    rawServerName: 'claude',
+                    rawToolName: '',
+                    meta: { claudeCode: { toolName: 'Bash' } },
+                }),
                 'auto_allow',
             ],
-            ['exec update', makeRecord({ resolvedKey: 'insight-update', innerToolName: 'insight-update' }), 'prompt'],
+            ['exec discovery verb', makeRecord({ input: { command: 'tools' } }), 'auto_allow'],
+            ['exec create', makeRecord({ input: { command: 'call insight-create {"name":"Signups"}' } }), 'auto_allow'],
+            ['exec update', makeRecord({ input: { command: 'call insight-update {"id":"abc"}' } }), 'prompt'],
+            ['exec delete', makeRecord({ input: { command: 'call feature-flag-delete {"key":"new-nav"}' } }), 'prompt'],
             [
-                'exec delete',
-                makeRecord({ resolvedKey: 'feature-flag-delete', innerToolName: 'feature-flag-delete' }),
+                'other mcp tool',
+                makeRecord({ toolName: 'mcp__other__foo', rawServerName: 'other', rawToolName: 'foo' }),
                 'prompt',
             ],
-            ['other mcp tool', makeRecord({ toolName: 'mcp__other__foo', resolvedKey: 'foo' }), 'prompt'],
             // AskUserQuestion rides the permission framework with allow_once options, but must never
             // auto-approve — picking option_0 with no answers gets rejected by the agent.
             [
                 'question request',
                 makeRecord({
                     toolName: 'AskUserQuestion',
-                    resolvedKey: 'AskUserQuestion',
+                    rawServerName: 'claude',
+                    rawToolName: '',
+                    meta: { claudeCode: { toolName: 'AskUserQuestion' } },
                     questions: [{ question: 'Pick one', multiSelect: false, options: [{ label: 'A' }] }],
                 }),
                 'prompt',

--- a/frontend/src/scenes/max/sandboxToolPolicy.ts
+++ b/frontend/src/scenes/max/sandboxToolPolicy.ts
@@ -1,3 +1,4 @@
+import { resolveToolCall } from './mcpToolMessageResolver'
 import type { PermissionRequestRecord } from './types/sandboxStreamTypes'
 
 /**
@@ -41,7 +42,7 @@ export function defaultPermissionDecision(record: PermissionRequestRecord): Perm
     }
 
     const { toolName } = record
-    const { resolvedKey, innerToolName } = record.rawToolCall
+    const { resolvedKey, innerToolName } = resolveToolCall(record.rawToolCall)
 
     const isExec = isPostHogExecTool(toolName) || innerToolName != null || resolvedKey.startsWith('__posthog_exec_')
     if (isExec) {

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -2,8 +2,8 @@
  * Thread shapes for the sandbox agent runtime (`agent_runtime === 'sandbox'`).
  *
  * The sandbox path consumes the products/tasks SSE endpoint directly (the same endpoint
- * PostHog Code uses). `sandboxStreamLogic` parses the raw wire frames (typed in
- * `./sandboxWireTypes`) into the `ToolInvocation` / `ThreadItem` state the renderer consumes.
+ * PostHog Code uses). `sandboxStreamLogic` folds the raw wire frames (typed in
+ * `./sandboxWireTypes`) into `ToolInvocation` / `ThreadItem` stream state.
  */
 
 import type { SandboxQuestion } from '../sandboxQuestionUtils'
@@ -21,8 +21,8 @@ export interface SandboxProgressStep {
 
 /**
  * One merged tool call: a `tool_call` creation plus N × `tool_call_update`s folded into a
- * single record keyed on `toolCallId`. The single-exec `posthog` MCP server runs one outer
- * `exec` tool; the inner tool name is what the renderer keys on (`resolvedKey`).
+ * single raw stream record keyed on `toolCallId`. Renderer-specific parsing, such as resolving
+ * the inner tool name for PostHog's single-exec MCP server, happens outside this stream state.
  */
 export interface ToolInvocation {
     toolCallId: string
@@ -30,19 +30,8 @@ export interface ToolInvocation {
     rawServerName: string
     /** ACP-reported tool, e.g. 'exec', 'TodoWrite', '<user-tool>'. */
     rawToolName: string
-    /** Parsed inner tool name when `rawToolName === 'exec'` — e.g. 'insight-create'. */
-    innerToolName?: string
-    /**
-     * Registry lookup key — the inner tool name for single-exec `call` commands, a
-     * `__posthog_exec_*__` sentinel for discovery verbs, or the wire tool name otherwise.
-     */
-    resolvedKey: string
-    /** Stable SDK tool name from `_meta.claudeCode.toolName` — set for Claude built-ins, which carry no wire `toolName`. */
-    claudeToolName?: string
     /** rawInput at `tool_call` time (for `exec`, includes the wrapper `{ command }`). */
     input: Record<string, unknown>
-    /** JSON-parsed inner args when `innerToolName` is set. */
-    innerInput?: Record<string, unknown>
     /** rawOutput on the final `tool_call_update`. */
     output?: unknown
     /** Error carried by a failed `tool_call_update` (from the update or its notification envelope). */
@@ -56,6 +45,8 @@ export interface ToolInvocation {
     locations?: { path: string; line?: number }[]
     /** Accumulated ACP `content[]` from updates. */
     contentBlocks: unknown[]
+    /** Raw ACP `_meta` from the latest tool frame. */
+    meta?: unknown
 }
 
 export type ThreadItemType =


### PR DESCRIPTION
## Problem

Sandbox tool stream state was doing renderer-specific parsing while tool input was still streaming. That made visualization brittle for PostHog exec-wrapped tools, especially optimized query tools where the rendered query may need to come from the tool input rather than the final output.

## Changes

- Keep sandbox `ToolInvocation` state raw in `sandboxStreamLogic`.
- Add a renderer-facing resolver for PostHog exec commands, discovery sentinels, and Claude built-in metadata.
- Resolve tool calls in the thread renderer, permission policy, and telemetry instead of storing parsed fields in stream state.
- Let query-wrapper adapters render from resolved tool input when optimized output omits structured query output.

No screenshots; this is a stream/rendering behavior fix covered by focused tests.

## How did you test this code?

- `hogli test frontend/src/scenes/max/mcpToolMessageResolver.test.ts frontend/src/scenes/max/sandboxStreamLogic.test.ts frontend/src/scenes/max/sandboxToolPolicy.test.ts frontend/src/scenes/max/components/SandboxApproval.test.tsx frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx frontend/src/scenes/max/mcpToolRegistry.test.tsx frontend/src/scenes/max/messages/adapters/extractors.test.ts`
- `pnpm exec oxfmt frontend/src/scenes/max/mcpToolMessageResolver.ts frontend/src/scenes/max/mcpToolMessageResolver.test.ts frontend/src/scenes/max/types/sandboxStreamTypes.ts frontend/src/scenes/max/maxTypes.ts frontend/src/scenes/max/Thread.tsx frontend/src/scenes/max/sandboxStreamLogic.ts frontend/src/scenes/max/sandboxStreamLogic.test.ts frontend/src/scenes/max/sandboxToolPolicy.ts frontend/src/scenes/max/sandboxToolPolicy.test.ts frontend/src/scenes/max/components/SandboxApproval.test.tsx frontend/src/scenes/max/components/SandboxQuestionInput.test.tsx frontend/src/scenes/max/messages/adapters/extractors.ts`
- `git diff --check`
- `pnpm --filter=@posthog/frontend typescript:check` still fails on existing unrelated repo-wide generated type drift and dependency typing issues; filtering the output found no `src/scenes/max` errors.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this changes internal sandbox tool rendering behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change from a human-directed request to move sandbox tool parsing out of stream state and into the renderer/policy layer. Skills invoked: `/adopting-generated-api-types` and `/submit-pr`.

This PR is stacked on `chore/phai-activity-renderers` because it depends on the updated activity renderer structure already present there.