### PR TITLE
fix(personhog): split person query relied on version pg 15

### DIFF
--- a/rust/personhog-replica/.sqlx/query-48780a58f81dbb31f71b263d4271cecf1fb67899ed62ee8e5cde7a81412a4d15.json
+++ b/rust/personhog-replica/.sqlx/query-48780a58f81dbb31f71b263d4271cecf1fb67899ed62ee8e5cde7a81412a4d15.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO posthog_person (uuid, team_id, properties, created_at, version, is_identified)\n            SELECT u.uuid, $2, '{}'::jsonb, NOW(), $3, false\n            FROM unnest($1::uuid[]) AS u(uuid)\n            ON CONFLICT (team_id, uuid) DO UPDATE SET version = $3\n            RETURNING id::bigint as \"id!\", uuid as \"uuid!\", created_at as \"created_at!\"\n            ",
+  "query": "\n                INSERT INTO posthog_person (uuid, team_id, properties, created_at, version, is_identified)\n                SELECT u.uuid, $2, '{}'::jsonb, NOW(), $3, false\n                FROM unnest($1::uuid[]) AS u(uuid)\n                RETURNING id::bigint as \"id!\", uuid as \"uuid!\", created_at as \"created_at!\"\n                ",
   "describe": {
     "columns": [
       {
@@ -32,5 +32,5 @@
       false
     ]
   },
-  "hash": "2fa96913eca0fcf773b70e0c7385b1cd0ae5a82d80da976cd49904d9393887a5"
+  "hash": "48780a58f81dbb31f71b263d4271cecf1fb67899ed62ee8e5cde7a81412a4d15"
 }

--- a/rust/personhog-replica/.sqlx/query-49bcc915e71cec48ea8e91fac80f2e4a004a39a064354ea5ef7dd6ae4e5afb78.json
+++ b/rust/personhog-replica/.sqlx/query-49bcc915e71cec48ea8e91fac80f2e4a004a39a064354ea5ef7dd6ae4e5afb78.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id::bigint as \"id!\", uuid as \"uuid!\", created_at as \"created_at!\"\n            FROM posthog_person\n            WHERE team_id = $1 AND uuid = ANY($2)\n            FOR UPDATE\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "uuid!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "49bcc915e71cec48ea8e91fac80f2e4a004a39a064354ea5ef7dd6ae4e5afb78"
+}

--- a/rust/personhog-replica/.sqlx/query-c09aa87a6a34fd6cd5023fac1d854b8270eb8927213e601b3c09d83acffe5ec9.json
+++ b/rust/personhog-replica/.sqlx/query-c09aa87a6a34fd6cd5023fac1d854b8270eb8927213e601b3c09d83acffe5ec9.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE posthog_person SET version = $3\n                WHERE team_id = $1 AND uuid = ANY($2)\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "UuidArray",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c09aa87a6a34fd6cd5023fac1d854b8270eb8927213e601b3c09d83acffe5ec9"
+}

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -727,33 +727,77 @@ impl PersonLookup for PostgresStorage {
             .map(|did| pdi_version_by_did[did.as_str()] + SPLIT_VERSION_OFFSET)
             .collect();
 
-        // Upsert all new persons in one statement (deterministic UUIDs, idempotent).
-        // RETURNING covers both freshly inserted and conflict-updated rows; for
-        // conflicts, created_at is the pre-existing row's original value.
-        let new_persons = sqlx::query!(
+        // Find persons that already exist for these UUIDs (idempotent re-split).
+        // No ON CONFLICT — the partitioned table has a unique index, not a
+        // unique constraint, so ON CONFLICT inference doesn't work.
+        let existing_persons = sqlx::query!(
             r#"
-            INSERT INTO posthog_person (uuid, team_id, properties, created_at, version, is_identified)
-            SELECT u.uuid, $2, '{}'::jsonb, NOW(), $3, false
-            FROM unnest($1::uuid[]) AS u(uuid)
-            ON CONFLICT (team_id, uuid) DO UPDATE SET version = $3
-            RETURNING id::bigint as "id!", uuid as "uuid!", created_at as "created_at!"
+            SELECT id::bigint as "id!", uuid as "uuid!", created_at as "created_at!"
+            FROM posthog_person
+            WHERE team_id = $1 AND uuid = ANY($2)
+            FOR UPDATE
             "#,
-            &new_uuids,
             team_id as i32,
-            new_person_version
+            &new_uuids
         )
         .fetch_all(&mut *tx)
         .await?;
 
-        let person_by_uuid: HashMap<Uuid, (i64, DateTime<Utc>)> = new_persons
+        let mut person_by_uuid: HashMap<Uuid, (i64, DateTime<Utc>)> = existing_persons
             .into_iter()
             .map(|r| (r.uuid, (r.id, r.created_at)))
             .collect();
+
+        let uuids_to_insert: Vec<Uuid> = new_uuids
+            .iter()
+            .filter(|u| !person_by_uuid.contains_key(u))
+            .copied()
+            .collect();
+
+        if !uuids_to_insert.is_empty() {
+            let inserted = sqlx::query!(
+                r#"
+                INSERT INTO posthog_person (uuid, team_id, properties, created_at, version, is_identified)
+                SELECT u.uuid, $2, '{}'::jsonb, NOW(), $3, false
+                FROM unnest($1::uuid[]) AS u(uuid)
+                RETURNING id::bigint as "id!", uuid as "uuid!", created_at as "created_at!"
+                "#,
+                &uuids_to_insert,
+                team_id as i32,
+                new_person_version
+            )
+            .fetch_all(&mut *tx)
+            .await?;
+            for r in inserted {
+                person_by_uuid.insert(r.uuid, (r.id, r.created_at));
+            }
+        }
+
+        let uuids_to_update: Vec<Uuid> = new_uuids
+            .iter()
+            .filter(|u| !uuids_to_insert.contains(u))
+            .copied()
+            .collect();
+
+        if !uuids_to_update.is_empty() {
+            sqlx::query!(
+                r#"
+                UPDATE posthog_person SET version = $3
+                WHERE team_id = $1 AND uuid = ANY($2)
+                "#,
+                team_id as i32,
+                &uuids_to_update,
+                new_person_version
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
+
         let new_person_rows: Vec<(i64, DateTime<Utc>)> = new_uuids
             .iter()
             .map(|u| {
                 person_by_uuid.get(u).copied().ok_or_else(|| {
-                    StorageError::Query(format!("person upsert did not return a row for uuid {u}"))
+                    StorageError::Query(format!("person insert did not return a row for uuid {u}"))
                 })
             })
             .collect::<StorageResult<_>>()?;

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -748,9 +748,11 @@ impl PersonLookup for PostgresStorage {
             .map(|r| (r.uuid, (r.id, r.created_at)))
             .collect();
 
+        let existing_uuids: HashSet<Uuid> = person_by_uuid.keys().copied().collect();
+
         let uuids_to_insert: Vec<Uuid> = new_uuids
             .iter()
-            .filter(|u| !person_by_uuid.contains_key(u))
+            .filter(|u| !existing_uuids.contains(u))
             .copied()
             .collect();
 
@@ -773,11 +775,7 @@ impl PersonLookup for PostgresStorage {
             }
         }
 
-        let uuids_to_update: Vec<Uuid> = new_uuids
-            .iter()
-            .filter(|u| !uuids_to_insert.contains(u))
-            .copied()
-            .collect();
+        let uuids_to_update: Vec<Uuid> = existing_uuids.into_iter().collect();
 
         if !uuids_to_update.is_empty() {
             sqlx::query!(


### PR DESCRIPTION
## Problem

The split person RPC relied on a unique index (team_id, uuid) that does not exist on deployed databases. The index exists but it is not UNIQUE

## Changes

Original query was a single statement handling both "person exists" and "person does not exist" gases. Relied on a ON CONFLICT (team_id, uuid) which needed a unique constraint or unique index to do the ON CONFLICT match.

New query does the repalcement in 3 steps in same transaction:

1. SELECT FOR UPDATE the existing persons that match the target UUIDs
2. INSERT only the UUIDs that weren't found
3. UPDATE the version on the ones that did exist

This is how the previous django functionality executed the split

## How did you test this code?

Ran the previously existing tests that exercised this functionality against it and they passed.