### PR TITLE
feat(logs): show per-value counts in the facet rail

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
@@ -5,6 +5,7 @@ import { IconChevronDown, IconChevronRight } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
+import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 
 const ROW_HEIGHT = 33
 
@@ -13,6 +14,8 @@ export interface FacetOption {
     label: string
     /** Tailwind bg class for a leading color swatch (e.g. severity colors). */
     color?: string
+    /** Number of matching log records; rendered right-aligned. Omitted when unavailable. */
+    count?: number
 }
 
 interface FacetProps {
@@ -169,9 +172,12 @@ function FacetValueButton({
             onClick={() => onToggle(option.value)}
             data-attr={`logs-facet-${slug}-${option.value}`}
         >
-            <span className="flex items-center gap-2 min-w-0">
+            <span className="flex items-center gap-2 min-w-0 w-full">
                 {option.color && <span className={cn('w-1 h-3.5 rounded-full shrink-0', option.color)} />}
-                <span className="truncate">{option.label}</span>
+                <span className="truncate flex-1">{option.label}</span>
+                {option.count != null && (
+                    <span className="shrink-0 text-muted tabular-nums">{humanFriendlyLargeNumber(option.count)}</span>
+                )}
             </span>
         </LemonButton>
     )

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -7,6 +7,7 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 import { LogSeverityLevel } from '~/queries/schema/schema-general'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { serviceFilterLogic } from 'products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic'
 import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
@@ -38,8 +39,11 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
     const { severityLevels, serviceNames, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { severityTotals } = useValues(logsViewerDataLogic)
     const { collapsedFacets } = useValues(facetRailLogic({ id }))
     const { toggleSeverityLevel, toggleServiceName, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
+
+    const levelOptions = SEVERITY_OPTIONS.map((option) => ({ ...option, count: severityTotals?.[option.value] }))
 
     const onToggleClosed = useCallback(
         (shouldBeClosed: boolean) => setFacetRailCollapsed(shouldBeClosed),
@@ -76,7 +80,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 </div>
                 <Facet
                     title="Level"
-                    options={SEVERITY_OPTIONS}
+                    options={levelOptions}
                     selected={severityLevels ?? []}
                     onToggle={(value) => toggleSeverityLevel(value as LogSeverityLevel)}
                     collapsed={collapsedFacets.includes('level')}
@@ -107,10 +111,10 @@ function ServiceFacet({
     collapsed: boolean
     onToggleCollapsed: () => void
 }): JSX.Element {
-    const { serviceNames, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
+    const { serviceValues, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
     const { setSearch } = useActions(serviceFilterLogic)
 
-    const options: FacetOption[] = serviceNames.map((name) => ({ value: name, label: name }))
+    const options: FacetOption[] = serviceValues.map((s) => ({ value: s.name, label: s.name, count: s.count }))
 
     return (
         <Facet

--- a/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
@@ -13,6 +13,11 @@ export interface ServiceFilterLogicProps {
     dateRange?: DateRange
 }
 
+export interface ServiceValue {
+    name: string
+    count?: number
+}
+
 export const serviceFilterLogic = kea<serviceFilterLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'Filters', 'serviceFilterLogic']),
     props({} as ServiceFilterLogicProps),
@@ -32,7 +37,7 @@ export const serviceFilterLogic = kea<serviceFilterLogicType>([
 
     loaders(({ values, props: logicProps }) => ({
         allServiceNames: [
-            [] as string[],
+            [] as ServiceValue[],
             {
                 loadServiceNames: async () => {
                     const url = combineUrl(`api/environments/${values.currentTeamId}/logs/values`, {
@@ -44,14 +49,17 @@ export const serviceFilterLogic = kea<serviceFilterLogicType>([
                     }).url
                     // nosemgrep: prefer-codegen-api
                     const response = await api.get(url)
-                    return ((response.results ?? []) as { name: string }[]).map((r) => r.name)
+                    return (response.results ?? []) as ServiceValue[]
                 },
             },
         ],
     })),
 
     selectors({
-        serviceNames: [(s) => [s.allServiceNames], (allServiceNames): string[] => allServiceNames],
+        // Names only — kept for the legacy ServiceFilter dropdown (flag off).
+        serviceNames: [(s) => [s.allServiceNames], (allServiceNames): string[] => allServiceNames.map((r) => r.name)],
+        // Name + count — used by the facet rail to show per-value counts.
+        serviceValues: [(s) => [s.allServiceNames], (allServiceNames): ServiceValue[] => allServiceNames],
     }),
 
     listeners(({ actions }) => ({

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -481,6 +481,26 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             (s) => [s.sparkline],
             (sparkline): number => sparkline?.reduce((sum: number, item: any) => sum + item.count, 0) ?? 0,
         ],
+        // Per-severity totals for the facet rail's Level counts, summed from the already-loaded
+        // sparkline. Only available when the sparkline is broken down by severity (the default);
+        // returns null otherwise so the Level facet just omits counts rather than showing wrong ones.
+        severityTotals: [
+            (s) => [s.sparkline, s.sparklineBreakdownBy],
+            (
+                sparkline: any[] | null,
+                sparklineBreakdownBy: LogsSparklineBreakdownBy
+            ): Record<string, number> | null => {
+                if (!sparkline || sparklineBreakdownBy !== 'severity') {
+                    return null
+                }
+                return sparkline.reduce((acc: Record<string, number>, row: any) => {
+                    if (row.severity) {
+                        acc[row.severity] = (acc[row.severity] ?? 0) + row.count
+                    }
+                    return acc
+                }, {})
+            },
+        ],
         logsRemainingToLoad: [
             (s) => [s.totalLogsMatchingFilters, s.logs],
             (totalLogsMatchingFilters, logs): number => totalLogsMatchingFilters - logs.length,


### PR DESCRIPTION
## Problem

Users browsing the logs facet rail had no way to see how many log records matched each severity level or service name. This made it harder to quickly gauge the distribution of logs across levels and services without applying filters first.

## Changes

**Severity counts in the Level facet**

`logsViewerDataLogic` now exposes a `severityTotals` selector that aggregates per-severity counts from the already-loaded sparkline data (only when the sparkline is broken down by severity — the default). These totals are passed into the Level facet options so counts appear right-aligned next to each level label.

**Service counts in the Service facet**

`serviceFilterLogic` now returns the full `{ name, count }` objects from the `/logs/values` API response instead of just the name strings. A new `serviceValues` selector exposes these enriched objects to the facet rail, while the existing `serviceNames` selector is preserved for backward compatibility with the legacy service filter dropdown.

**Facet UI**

`FacetOption` gains an optional `count` field. When present, it renders right-aligned in muted, tabular-numeral text using `humanFriendlyLargeNumber` for readability at large values. The label now uses `flex-1` so it pushes the count to the far right.

![image.png](https://app.graphite.com/user-attachments/assets/f73fc6b5-1465-457e-b7bb-8eaaefc2ea31.png)



## How did you test this code?

This PR was agent-assisted. Automated type-checking and existing unit tests were relied upon for validation. No manual testing was performed by the agent.

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude with code editing tools.
- The `severityTotals` selector reuses the existing sparkline data to avoid an extra network request; it returns `null` when the breakdown isn't by severity so the facet gracefully omits counts rather than showing stale or incorrect data.
- The `serviceValues` / `serviceNames` split was chosen to avoid breaking the legacy dropdown while giving the facet rail access to counts.