### PR TITLE
fix(cohorts): dedupe realtime cohort event count by uuid

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -1151,7 +1151,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
                 AND condition = {{condition_hash}}
                 AND {date_filter}
             GROUP BY person_id
-            HAVING count() {sql_operator} {{min_matches}}
+            HAVING count(DISTINCT uuid) {sql_operator} {{min_matches}}
         """
 
         query_params: dict[str, ast.Expr] = {

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -632,8 +632,8 @@ class TestHogQLRealtimeCohortQuery(ClickhouseTestMixin, APIBaseTest):
 
         # Should query precalculated_events
         self.assertIn("precalculated_events", query_str)
-        # Should have count aggregation
-        self.assertIn("count()", query_str)
+        # Should dedupe re-ingested rows by uuid before counting (precalculated_events is a ReplacingMergeTree)
+        self.assertIn("count(DISTINCT uuid)", query_str)
         # Should have HAVING clause for count filtering
         self.assertIn("HAVING", query_str)
         # Should use person_id directly from precalculated_events
@@ -707,7 +707,7 @@ class TestHogQLRealtimeCohortQuery(ClickhouseTestMixin, APIBaseTest):
         query_str = HogQLRealtimeCohortQuery(cohort=cohort).query_str("clickhouse")
 
         self.assertIn("precalculated_events", query_str)
-        self.assertIn("count()", query_str)
+        self.assertIn("count(DISTINCT uuid)", query_str)
         self.assertIn("HAVING", query_str)
         self.assertEqual(query_str.count("toDate("), 2)
 


### PR DESCRIPTION
## Problem

Realtime behavioral cohorts that use a "performed event N times" filter (`performed_event_multiple`) read from `precalculated_events`, a `ReplacingMergeTree` keyed by `(team_id, condition, date, distinct_id, uuid)`. A re-ingested event (same `uuid`) lives as a duplicate row until a background part merge collapses it. The matcher's `HAVING count() {op} {min_matches}` counts those un-merged duplicates, so a person can transiently satisfy "performed event ≥ N times" on duplicate rows alone and land in a cohort they shouldn't.

## Changes

`HogQLRealtimeCohortQuery.get_performed_event_multiple` now uses `count(DISTINCT uuid)` instead of `count()` in the `HAVING` clause. This dedupes by event identity regardless of merge state, matching the deduplication the sibling `get_performed_event_condition` already does with `SELECT DISTINCT person_id`. No performance regression expected — the query already filters on the sort-key prefix `(team_id, condition, date)` and prunes by partition.

This is a semantic change to cohort membership (correctness), not a raw perf change.

## How did you test this code?

I'm an agent (Claude Code). I updated the two unit tests in `test_hogql_cohort_query.py` that asserted the printed SQL, changing the `count()` assertion to `count(DISTINCT uuid)`.

I could **not** run the DB-backed tests in this environment — there's no Postgres or ClickHouse available (the tests create a `Cohort` row and resolve the print path against the warehouse DB). I verified the change is sound at the layers that matter instead:
- `uuid` is a real column on both the table (`models/precalculated_events/sql.py`) and the HogQL virtual table (`hogql/database/schema/precalculated_events.py`).
- `count(DISTINCT …)` is established, printer-safe HogQL used elsewhere (e.g. `aggregation_operations.py`, `lifecycle_query_runner.py`); the printer emits `DISTINCT` from `node.distinct`.

A reviewer should run the `TestHogQLRealtimeCohortQuery` suite (and ideally confirm against prod `system.query_log` which cohorts use `performed_event_multiple`) before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by Gustavo Strassburger. Invoked the `/optimizing-clickhouse-and-hogql-queries` skill to review the realtime cohorts Temporal workflow (`realtime_cohort_calculation_workflow.py`) end to end.

The review found the inner query builders already free of the usual smells — no `FINAL` (they dedupe `ReplacingMergeTree` reads via `argMax`/`GROUP BY`), no `JSONExtract`, and correct sort-key/partition coverage on every query. The one substantive issue was this un-deduplicated `count()`. Other candidates were considered and rejected: converting the outer single-team raw-SQL diff query was deemed low-value (the team guard is already explicit and there's nothing to recover), and the unbounded time scan on `precalculated_person_properties` is inherent to point-in-time person properties, not a query bug.
