### PR TITLE
feat(metrics): decode Prometheus remote_write v1 into metric rows

### DIFF
--- a/proto/prometheus/v1/remote_write.proto
+++ b/proto/prometheus/v1/remote_write.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package prometheus.v1;
+
+// Minimal subset of the Prometheus remote-write v1 protocol
+// (github.com/prometheus/prometheus/prompb) sufficient to decode a write
+// request. Field numbers MUST match upstream for wire compatibility.
+//
+// TimeSeries fields 3 (exemplars) and 4 (native histograms) are intentionally
+// omitted: proto3 skips unknown fields during decoding, so a v1 sender that
+// includes them is decoded without error and those payloads are dropped. Native
+// histogram and exemplar support is deferred (and would require RW v2 for
+// per-series type metadata anyway).
+
+message WriteRequest {
+  repeated TimeSeries timeseries = 1;
+  // Field 2 is reserved upstream.
+  repeated MetricMetadata metadata = 3;
+}
+
+message TimeSeries {
+  repeated Label labels = 1;
+  repeated Sample samples = 2;
+}
+
+message Label {
+  string name = 1;
+  string value = 2;
+}
+
+message Sample {
+  double value = 1;
+  // Milliseconds since the Unix epoch.
+  int64 timestamp = 2;
+}
+
+message MetricMetadata {
+  enum MetricType {
+    UNKNOWN = 0;
+    COUNTER = 1;
+    GAUGE = 2;
+    HISTOGRAM = 3;
+    GAUGEHISTOGRAM = 4;
+    SUMMARY = 5;
+    INFO = 6;
+    STATESET = 7;
+  }
+
+  MetricType type = 1;
+  string metric_family_name = 2;
+  string help = 4;
+  string unit = 5;
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1834,11 +1834,13 @@ dependencies = [
  "limiters",
  "metrics",
  "opentelemetry-proto 0.29.0",
+ "prometheus-rw-proto",
  "prost 0.13.5",
  "rdkafka",
  "serde",
  "serde_derive",
  "serde_json",
+ "snap",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",
@@ -7809,6 +7811,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-rw-proto"
+version = "0.1.0"
+dependencies = [
+ "prost 0.13.5",
+ "tonic-build 0.12.3",
+]
+
+[[package]]
 name = "property-defs-rs"
 version = "0.1.0"
 dependencies = [
@@ -9761,6 +9771,12 @@ dependencies = [
  "static_assertions",
  "version_check",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,6 +51,7 @@ members = [
   "personhog-leader",
   "personhog-writer",
   "personhog-proto",
+  "prometheus-rw-proto",
   "personhog-replica",
   "personhog-router",
   "affected-services",
@@ -142,6 +143,7 @@ serde_derive = { version = "1.0" }
 serde_json = { version = "1.0" }
 serde_urlencoded = "0.7.1"
 siphasher = "1.0.1"
+snap = "1"
 sqlx = { version = "0.8.6", features = [
   "chrono",
   "json",

--- a/rust/capture-logs/Cargo.toml
+++ b/rust/capture-logs/Cargo.toml
@@ -35,6 +35,8 @@ prost = { workspace = true }
 bytes = { workspace = true }
 tower-http = { workspace = true }
 hex = "0.4"
+snap = { workspace = true }
+prometheus-rw-proto = { path = "../prometheus-rw-proto" }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/rust/capture-logs/src/lib.rs
+++ b/rust/capture-logs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod log_record;
 pub mod metric_record;
 pub mod metrics_avro_schema;
 pub mod middleware;
+pub mod prometheus_remote_write;
 pub mod service;
 pub mod trace_record;
 pub mod traces_avro_schema;

--- a/rust/capture-logs/src/prometheus_remote_write.rs
+++ b/rust/capture-logs/src/prometheus_remote_write.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use chrono::{TimeZone, Utc};
+use prometheus_rw_proto::prometheus::v1::{metric_metadata::MetricType, WriteRequest};
+use prost::Message;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::metric_record::{override_timestamp, KafkaMetricRow};
+
+const METRIC_NAME_LABEL: &str = "__name__";
+const JOB_LABEL: &str = "job";
+const INSTANCE_LABEL: &str = "instance";
+
+/// Decode a snappy-compressed Prometheus remote-write v1 payload.
+///
+/// Prometheus sends `Content-Encoding: snappy` using the snappy *block* format
+/// (not the framed format), so we decode the raw body ourselves — the global
+/// `RequestDecompressionLayer` does not understand snappy.
+pub fn decode_write_request(body: &[u8]) -> Result<WriteRequest> {
+    let decompressed = snap::raw::Decoder::new()
+        .decompress_vec(body)
+        .map_err(|e| anyhow!("snappy decode failed: {e}"))?;
+    WriteRequest::decode(decompressed.as_slice())
+        .map_err(|e| anyhow!("remote-write protobuf decode failed: {e}"))
+}
+
+/// Translate a decoded remote-write request into `KafkaMetricRow` records — the
+/// same Avro shape the OTLP path produces, so the rest of the pipeline
+/// (`ingestion-metrics` → consumer → `clickhouse_metrics` → `metrics1`) is
+/// unchanged. One row is emitted per sample. Returns the rows and the number of
+/// samples whose timestamp was clamped by `override_timestamp`.
+pub fn write_request_to_kafka_rows(req: WriteRequest) -> (Vec<KafkaMetricRow>, u64) {
+    // Metric-family name -> declared type. Only populated when the sender
+    // includes the optional metadata block (vmagent and many agents omit it,
+    // so the name-suffix heuristic in `classify` is the primary path).
+    let metadata: HashMap<String, MetricType> = req
+        .metadata
+        .iter()
+        .filter_map(|m| {
+            MetricType::try_from(m.r#type)
+                .ok()
+                .map(|t| (m.metric_family_name.clone(), t))
+        })
+        .collect();
+
+    let mut rows = Vec::new();
+    let mut timestamps_overridden = 0u64;
+
+    for series in req.timeseries {
+        let mut metric_name = String::new();
+        let mut service_name = String::new();
+        let mut resource_attributes: HashMap<String, String> = HashMap::new();
+        let mut attributes: HashMap<String, String> = HashMap::new();
+
+        for label in series.labels {
+            match label.name.as_str() {
+                METRIC_NAME_LABEL => metric_name = label.value,
+                // Map Prometheus topology labels onto OTel resource semantics so
+                // `service_name` populates the same way it does for OTLP. Map
+                // values are JSON-encoded to match the OTLP/Datadog paths — the
+                // ClickHouse MV applies JSONExtractString to them.
+                JOB_LABEL => {
+                    service_name = label.value.clone();
+                    resource_attributes
+                        .insert("service.name".to_string(), json!(label.value).to_string());
+                }
+                INSTANCE_LABEL => {
+                    resource_attributes.insert(
+                        "service.instance.id".to_string(),
+                        json!(label.value).to_string(),
+                    );
+                }
+                _ => {
+                    attributes.insert(label.name, json!(label.value).to_string());
+                }
+            }
+        }
+
+        // A series with no metric name is unusable; skip it.
+        if metric_name.is_empty() {
+            continue;
+        }
+
+        let (metric_type, is_monotonic, temporality) =
+            classify(&metric_name, lookup_type(&metadata, &metric_name));
+
+        for sample in series.samples {
+            // Remote-write sample timestamps are milliseconds since the epoch.
+            let raw_timestamp = Utc
+                .timestamp_millis_opt(sample.timestamp)
+                .single()
+                .unwrap_or_else(Utc::now);
+            let (timestamp, original_timestamp) = override_timestamp(raw_timestamp);
+
+            let mut sample_attributes = attributes.clone();
+            if let Some(original) = original_timestamp {
+                timestamps_overridden += 1;
+                sample_attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
+            }
+
+            rows.push(KafkaMetricRow {
+                uuid: Uuid::now_v7().to_string(),
+                trace_id: String::new(),
+                span_id: String::new(),
+                trace_flags: 0,
+                timestamp,
+                observed_timestamp: Utc::now(),
+                service_name: service_name.clone(),
+                metric_name: metric_name.clone(),
+                metric_type: metric_type.to_string(),
+                value: sample.value,
+                count: 1,
+                histogram_bounds: Vec::new(),
+                histogram_counts: Vec::new(),
+                unit: String::new(),
+                aggregation_temporality: temporality.to_string(),
+                is_monotonic,
+                resource_attributes: resource_attributes.clone(),
+                instrumentation_scope: String::new(),
+                attributes: sample_attributes,
+            });
+        }
+    }
+
+    (rows, timestamps_overridden)
+}
+
+/// Look up a declared metric type, falling back to the base family name —
+/// histogram/summary/counter families register under a base name while the
+/// exposed series append `_bucket`/`_sum`/`_count`/`_total`.
+fn lookup_type(metadata: &HashMap<String, MetricType>, name: &str) -> Option<MetricType> {
+    if let Some(t) = metadata.get(name) {
+        return Some(*t);
+    }
+    for suffix in ["_bucket", "_sum", "_count", "_total"] {
+        if let Some(base) = name.strip_suffix(suffix) {
+            if let Some(t) = metadata.get(base) {
+                return Some(*t);
+            }
+        }
+    }
+    None
+}
+
+/// Infer (metric_type, is_monotonic, aggregation_temporality) for a series.
+///
+/// Prometheus counters, histograms and summaries are cumulative. RW v1 carries
+/// no per-sample type, so declared metadata (when present) takes precedence and
+/// the `_total`/`_bucket`/`_sum`/`_count` suffix heuristic is the fallback.
+/// Classic histograms/summaries are stored as their decomposed scalar component
+/// series (queryable via PromQL); native-histogram array reconstruction is
+/// deferred.
+fn classify(name: &str, declared: Option<MetricType>) -> (&'static str, bool, &'static str) {
+    if let Some(t) = declared {
+        match t {
+            MetricType::Counter => return ("sum", true, "cumulative"),
+            MetricType::Gauge => return ("gauge", false, ""),
+            // Histogram/Summary expose decomposed cumulative component series;
+            // type each component via the suffix heuristic below.
+            _ => {}
+        }
+    }
+
+    if name.ends_with("_total")
+        || name.ends_with("_bucket")
+        || name.ends_with("_count")
+        || name.ends_with("_sum")
+    {
+        ("sum", true, "cumulative")
+    } else {
+        ("gauge", false, "")
+    }
+}

--- a/rust/capture-logs/tests/prometheus_remote_write_test.rs
+++ b/rust/capture-logs/tests/prometheus_remote_write_test.rs
@@ -1,0 +1,245 @@
+use capture_logs::prometheus_remote_write::{decode_write_request, write_request_to_kafka_rows};
+use chrono::{Duration, Utc};
+use prometheus_rw_proto::prometheus::v1::{
+    metric_metadata::MetricType, Label, MetricMetadata, Sample, TimeSeries, WriteRequest,
+};
+use prost::Message;
+
+fn label(name: &str, value: &str) -> Label {
+    Label {
+        name: name.to_string(),
+        value: value.to_string(),
+    }
+}
+
+fn series(labels: Vec<Label>, samples: Vec<Sample>) -> TimeSeries {
+    TimeSeries { labels, samples }
+}
+
+/// A timestamp comfortably within the ±24h window so it is not clamped.
+fn now_ms() -> i64 {
+    Utc::now().timestamp_millis()
+}
+
+#[test]
+fn maps_labels_to_name_service_and_attributes() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![
+                label("__name__", "node_cpu_seconds"),
+                label("job", "node-exporter"),
+                label("instance", "10.0.0.1:9100"),
+                label("mode", "idle"),
+            ],
+            vec![Sample {
+                value: 12.5,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, overridden) = write_request_to_kafka_rows(req);
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(overridden, 0);
+    let row = &rows[0];
+    assert_eq!(row.metric_name, "node_cpu_seconds");
+    assert_eq!(row.service_name, "node-exporter");
+    assert_eq!(row.metric_type, "gauge");
+    assert!(!row.is_monotonic);
+    assert_eq!(row.value, 12.5);
+    assert_eq!(row.count, 1);
+    // Map values are JSON-encoded to match the OTLP/Datadog paths, since the
+    // ClickHouse MV applies JSONExtractString to them.
+    assert_eq!(
+        row.resource_attributes.get("service.name").unwrap(),
+        "\"node-exporter\""
+    );
+    assert_eq!(
+        row.resource_attributes.get("service.instance.id").unwrap(),
+        "\"10.0.0.1:9100\""
+    );
+    assert_eq!(row.attributes.get("mode").unwrap(), "\"idle\"");
+    // __name__/job/instance are not duplicated into the attributes map.
+    assert!(!row.attributes.contains_key("__name__"));
+    assert!(!row.attributes.contains_key("job"));
+}
+
+#[test]
+fn infers_counter_from_total_suffix() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![
+                label("__name__", "http_requests_total"),
+                label("job", "api"),
+            ],
+            vec![Sample {
+                value: 99.0,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, _) = write_request_to_kafka_rows(req);
+
+    assert_eq!(rows[0].metric_type, "sum");
+    assert!(rows[0].is_monotonic);
+    assert_eq!(rows[0].aggregation_temporality, "cumulative");
+}
+
+#[test]
+fn types_histogram_bucket_as_cumulative_sum() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![
+                label("__name__", "http_req_duration_bucket"),
+                label("job", "api"),
+                label("le", "0.5"),
+            ],
+            vec![Sample {
+                value: 10.0,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, _) = write_request_to_kafka_rows(req);
+
+    assert_eq!(rows[0].metric_type, "sum");
+    assert!(rows[0].is_monotonic);
+    assert_eq!(rows[0].aggregation_temporality, "cumulative");
+    // The bucket boundary label is preserved so PromQL can reconstruct quantiles.
+    assert_eq!(rows[0].attributes.get("le").unwrap(), "\"0.5\"");
+}
+
+#[test]
+fn metadata_counter_overrides_default_gauge() {
+    // A bare name (no _total suffix) would default to gauge, but declared
+    // metadata says COUNTER and must win.
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("__name__", "requests"), label("job", "api")],
+            vec![Sample {
+                value: 1.0,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![MetricMetadata {
+            r#type: MetricType::Counter as i32,
+            metric_family_name: "requests".to_string(),
+            help: String::new(),
+            unit: String::new(),
+        }],
+    };
+
+    let (rows, _) = write_request_to_kafka_rows(req);
+
+    assert_eq!(rows[0].metric_type, "sum");
+    assert!(rows[0].is_monotonic);
+    assert_eq!(rows[0].aggregation_temporality, "cumulative");
+}
+
+#[test]
+fn emits_one_row_per_sample() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("__name__", "g"), label("job", "j")],
+            vec![
+                Sample {
+                    value: 1.0,
+                    timestamp: now_ms(),
+                },
+                Sample {
+                    value: 2.0,
+                    timestamp: now_ms(),
+                },
+                Sample {
+                    value: 3.0,
+                    timestamp: now_ms(),
+                },
+            ],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, _) = write_request_to_kafka_rows(req);
+
+    assert_eq!(rows.len(), 3);
+    assert_eq!(
+        rows.iter().map(|r| r.value).collect::<Vec<_>>(),
+        vec![1.0, 2.0, 3.0]
+    );
+}
+
+#[test]
+fn clamps_far_past_timestamp_and_counts_override() {
+    let two_days_ago = (Utc::now() - Duration::hours(48)).timestamp_millis();
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("__name__", "g"), label("job", "j")],
+            vec![Sample {
+                value: 1.0,
+                timestamp: two_days_ago,
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, overridden) = write_request_to_kafka_rows(req);
+
+    assert_eq!(overridden, 1);
+    assert!(rows[0].attributes.contains_key("$originalTimestamp"));
+    // Clamped forward to ~now.
+    assert!((Utc::now() - rows[0].timestamp).num_seconds().abs() < 5);
+}
+
+#[test]
+fn skips_series_without_metric_name() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("job", "j")],
+            vec![Sample {
+                value: 1.0,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let (rows, _) = write_request_to_kafka_rows(req);
+
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn snappy_round_trip_decodes_and_maps() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("__name__", "up"), label("job", "prometheus")],
+            vec![Sample {
+                value: 1.0,
+                timestamp: now_ms(),
+            }],
+        )],
+        metadata: vec![],
+    };
+
+    let mut encoded = Vec::new();
+    req.encode(&mut encoded).unwrap();
+    let compressed = snap::raw::Encoder::new().compress_vec(&encoded).unwrap();
+
+    let decoded = decode_write_request(&compressed).expect("snappy+protobuf decode");
+    let (rows, _) = write_request_to_kafka_rows(decoded);
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].metric_name, "up");
+    assert_eq!(rows[0].service_name, "prometheus");
+}
+
+#[test]
+fn rejects_non_snappy_garbage() {
+    assert!(decode_write_request(b"not snappy at all").is_err());
+}

--- a/rust/prometheus-rw-proto/Cargo.toml
+++ b/rust/prometheus-rw-proto/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "prometheus-rw-proto"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }
+
+[package.metadata.cargo-shear]
+ignored = ["prost"]
+
+[lints]
+workspace = true

--- a/rust/prometheus-rw-proto/build.rs
+++ b/rust/prometheus-rw-proto/build.rs
@@ -1,0 +1,13 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_root = std::env::var("PROTO_ROOT").unwrap_or_else(|_| "../../proto".to_string());
+
+    // Messages only — no gRPC service in this proto, so skip server/client codegen.
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(false)
+        .compile_protos(
+            &[format!("{proto_root}/prometheus/v1/remote_write.proto")],
+            &[proto_root],
+        )?;
+    Ok(())
+}

--- a/rust/prometheus-rw-proto/src/lib.rs
+++ b/rust/prometheus-rw-proto/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod prometheus {
+    pub mod v1 {
+        // No gRPC service in this proto, so the generated file is pure prost
+        // message types with no tonic dependency — include it directly rather
+        // than via tonic::include_proto!.
+        include!(concat!(env!("OUT_DIR"), "/prometheus.v1.rs"));
+    }
+}


### PR DESCRIPTION
## Problem

PostHog metrics ingestion only accepts OTLP today. The Prometheus ecosystem (Prometheus, vmagent, Grafana Agent) — the dominant metrics install base — speaks Prometheus remote-write v1. An earlier attempt to bridge it through an OTel `prometheusremotewrite` receiver hit a hard protocol wall: that receiver is remote-write **v2 only**, vmagent emits **v1**, and v2 is not on vmagent's roadmap. To accept the Prometheus install base as a first-class ingestion path, capture-logs needs to speak remote-write v1 natively.

## Changes

This is the **decode + mapping layer only** — the pure, side-effect-free half of the feature. The HTTP route lands in the stacked follow-up.

- New `prometheus-rw-proto` crate vendoring a minimal remote-write v1 protobuf (`WriteRequest` / `TimeSeries` / `Label` / `Sample` / `MetricMetadata`), generated via `tonic-build` with services disabled — matching the sibling `*-proto` crates.
- New `prometheus_remote_write.rs` in capture-logs:
  - `decode_write_request` — snappy block-decode + protobuf parse.
  - `write_request_to_kafka_rows` — maps each sample to the existing `KafkaMetricRow` Avro shape. `__name__` / `job` / `instance` route onto OTel metric-name/resource semantics; remaining labels become JSON-encoded attribute-map values (matching the OTLP path); counter/gauge type is inferred from `MetricMetadata` or a `_total` / `_count` / `_bucket` name suffix; the timestamp reuses the existing `override_timestamp` clamp.

Because the output is the **same Avro rows as OTLP**, everything downstream (ingestion-metrics → consumer → clickhouse_metrics → metrics1) is unchanged.

## How did you test this code?

I'm an agent (PostHog Code). Automated only — no manual testing claimed:

- 9 unit tests in `prometheus_remote_write_test.rs`: label → name/service/attribute mapping, counter inference (metadata override + `_total` suffix), histogram `_bucket` → cumulative sum, one-row-per-sample, far-past timestamp clamp + override count, skipping series without `__name__`, snappy round-trip decode, and garbage rejection.
- `cargo build -p capture-logs --all-targets`, `cargo clippy` (clean), `cargo fmt --check` (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Customer onboarding docs ("point any Prometheus/vmagent `remote_write` at this URL") will land with the route + ingress work, not this decode layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Opus) at Daniel's direction. PR 1 of a 2-PR stack splitting the feature into a pure decode/mapping layer (this PR) and the HTTP route + 415 fix (stacked PR). No repo skills were required for Rust ingestion code.

Key decisions: vendored a minimal RW v1 proto into a dedicated crate (rather than inlining a `build.rs` in the hot-path crate) to match existing `*-proto` conventions; mapped onto the existing `KafkaMetricRow` / OTLP Avro shape so the entire downstream pipeline is untouched; chose native remote-write decode over the previously-attempted OTel `prometheusremotewrite` receiver, which is v2-only and incompatible with vmagent's v1 output.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
