### PR TITLE
feat(metrics): add Prometheus remote-write ingestion endpoint

### DIFF
--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -7,6 +7,7 @@ use capture_logs::config::Config;
 use capture_logs::endpoints::datadog;
 use capture_logs::kafka::KafkaSink;
 use capture_logs::middleware::translate_compression_query_param;
+use capture_logs::prometheus_remote_write::export_prometheus_remote_write_http;
 use capture_logs::service::Service;
 use capture_logs::service::{
     export_logs_http, export_metrics_http, export_traces_http, options_handler,
@@ -178,12 +179,30 @@ async fn main() {
             "/i/v1/logs/datadog/:token/api/v2/logs",
             post(datadog::export_datadog_logs_http).options(options_handler),
         )
-        .with_state(logs_service)
+        .with_state(logs_service.clone())
         .layer(DefaultBodyLimit::max(config.max_request_body_size_bytes))
         .layer(axum::middleware::from_fn(track_metrics))
         .layer(RequestDecompressionLayer::new())
-        .layer(axum::middleware::from_fn(translate_compression_query_param))
-        .layer(cors);
+        .layer(axum::middleware::from_fn(translate_compression_query_param));
+
+    // Prometheus remote-write sends `Content-Encoding: snappy`, which
+    // RequestDecompressionLayer rejects with 415 before the handler runs. This
+    // route is deliberately kept off that layer (and the gzip query-param
+    // shim); the handler snappy-decodes the body itself.
+    let prometheus_router = Router::new()
+        .route(
+            "/i/v1/prometheus/write",
+            post(export_prometheus_remote_write_http).options(options_handler),
+        )
+        .route(
+            "/i/v1/prometheus/write/:token",
+            post(export_prometheus_remote_write_http).options(options_handler),
+        )
+        .with_state(logs_service)
+        .layer(DefaultBodyLimit::max(config.max_request_body_size_bytes))
+        .layer(axum::middleware::from_fn(track_metrics));
+
+    let http_router = http_router.merge(prometheus_router).layer(cors);
 
     let http_server = tokio::spawn(async move {
         if let Err(e) = axum::serve(

--- a/rust/capture-logs/src/prometheus_remote_write.rs
+++ b/rust/capture-logs/src/prometheus_remote_write.rs
@@ -1,13 +1,20 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use prometheus_rw_proto::prometheus::v1::{metric_metadata::MetricType, WriteRequest};
 use prost::Message;
+use serde::Deserialize;
 use serde_json::json;
+use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::metric_record::{override_timestamp, KafkaMetricRow};
+use crate::service::Service;
 
 const METRIC_NAME_LABEL: &str = "__name__";
 const JOB_LABEL: &str = "job";
@@ -172,4 +179,102 @@ fn classify(name: &str, declared: Option<MetricType>) -> (&'static str, bool, &'
     } else {
         ("gauge", false, "")
     }
+}
+
+#[derive(Deserialize)]
+pub struct RemoteWriteQueryParams {
+    token: Option<String>,
+}
+
+/// Resolve the project token from (in order) the URL path, the Authorization
+/// header (Bearer or bare), or the `token` query param.
+fn extract_token(
+    path_token: Option<String>,
+    headers: &HeaderMap,
+    query_token: Option<&str>,
+) -> Option<String> {
+    if let Some(token) = path_token {
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
+    if let Some(auth) = headers.get("authorization").and_then(|v| v.to_str().ok()) {
+        let token = auth
+            .strip_prefix("Bearer ")
+            .or_else(|| auth.strip_prefix("bearer "))
+            .unwrap_or(auth)
+            .trim();
+        if !token.is_empty() {
+            return Some(token.to_string());
+        }
+    }
+    query_token.filter(|t| !t.is_empty()).map(str::to_string)
+}
+
+/// Prometheus remote-write v1 ingestion endpoint.
+///
+/// Snappy-decodes the protobuf body, maps it to `KafkaMetricRow` records, and
+/// produces them through the shared `KafkaSink` so the rest of the pipeline is
+/// identical to OTLP ingestion. Response codes follow remote-write semantics:
+/// 204 on success, 400 on a permanent decode failure (sender drops the batch),
+/// 5xx on a transient produce failure (sender retries).
+#[tracing::instrument(skip_all, fields(token))]
+pub async fn export_prometheus_remote_write_http(
+    State(service): State<Service>,
+    path_token: Option<Path<String>>,
+    Query(query_params): Query<RemoteWriteQueryParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> std::result::Result<StatusCode, (StatusCode, Json<serde_json::Value>)> {
+    let token = match extract_token(
+        path_token.map(|Path(t)| t),
+        &headers,
+        query_params.token.as_deref(),
+    ) {
+        Some(token) => token,
+        None => {
+            error!("No token provided");
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "No token provided"})),
+            ));
+        }
+    };
+
+    if service.token_dropper.should_drop(&token, "") {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid token"})),
+        ));
+    }
+    tracing::Span::current().record("token", &token);
+
+    let write_request = match decode_write_request(&body) {
+        Ok(request) => request,
+        Err(e) => {
+            error!("Failed to decode remote-write request: {e}");
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("{e}") })),
+            ));
+        }
+    };
+
+    let (rows, timestamps_overridden) = write_request_to_kafka_rows(write_request);
+    let row_count = rows.len();
+
+    if let Err(e) = service
+        .sink
+        .write_metrics(&token, rows, body.len() as u64, timestamps_overridden)
+        .await
+    {
+        error!("Failed to send remote-write metrics to Kafka: {e}");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "Internal server error"})),
+        ));
+    }
+
+    debug!("Sent {row_count} remote-write data points to Kafka");
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/rust/capture-logs/tests/prometheus_remote_write_test.rs
+++ b/rust/capture-logs/tests/prometheus_remote_write_test.rs
@@ -243,3 +243,67 @@ fn snappy_round_trip_decodes_and_maps() {
 fn rejects_non_snappy_garbage() {
     assert!(decode_write_request(b"not snappy at all").is_err());
 }
+
+/// The prometheus route is deliberately kept off `RequestDecompressionLayer`, so
+/// a `Content-Encoding: snappy` request reaches the handler with the raw body to
+/// decode itself — proving the 415 problem is avoided.
+#[tokio::test]
+async fn snappy_body_reaches_handler_without_decompression_layer() {
+    use axum::{body::Body, http::Request, routing::post, Router};
+    use bytes::Bytes;
+    use tower::ServiceExt;
+
+    async fn echo(body: Bytes) -> Bytes {
+        body
+    }
+
+    let app = Router::new().route("/i/v1/prometheus/write", post(echo));
+
+    let compressed = snap::raw::Encoder::new().compress_vec(b"hello").unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/i/v1/prometheus/write")
+        .header("content-encoding", "snappy")
+        .body(Body::from(compressed.clone()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "expected 2xx, got {}",
+        resp.status()
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    assert_eq!(&bytes[..], compressed.as_slice());
+}
+
+/// Regression guard: the layer the OTLP/logs routes use rejects snappy with 415,
+/// which is exactly why the prometheus route must not pass through it.
+#[tokio::test]
+async fn request_decompression_layer_rejects_snappy_with_415() {
+    use axum::{body::Body, http::Request, http::StatusCode, routing::post, Router};
+    use bytes::Bytes;
+    use tower::ServiceExt;
+    use tower_http::decompression::RequestDecompressionLayer;
+
+    async fn echo(body: Bytes) -> Bytes {
+        body
+    }
+
+    let app = Router::new()
+        .route("/i/v1/metrics", post(echo))
+        .layer(RequestDecompressionLayer::new());
+
+    let compressed = snap::raw::Encoder::new().compress_vec(b"hello").unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/i/v1/metrics")
+        .header("content-encoding", "snappy")
+        .body(Body::from(compressed))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}


### PR DESCRIPTION
## Problem

With the decode + mapping layer in place (stacked PR below), capture-logs needs an HTTP endpoint so Prometheus / vmagent clients can push remote-write v1. The catch: Prometheus sends `Content-Encoding: snappy`, and capture-logs' shared `RequestDecompressionLayer` rejects snappy with **415** before any handler runs — the exact wall the earlier bridge attempt hit.

## Changes

- New route `/i/v1/prometheus/write` (and `/i/v1/prometheus/write/:token`) wired in `main.rs`.
- `export_prometheus_remote_write_http` handler: resolves the project token (path → `Authorization` header → query param), applies the existing `token_dropper` check, snappy-decodes + maps the body (via the layer from the stacked PR), and produces rows through the shared `KafkaSink` — identical to OTLP from Kafka onward. Response codes follow remote-write semantics: **204** success, **400** permanent decode failure (sender drops the batch), **5xx** transient produce failure (sender retries).
- **The 415 fix:** the Prometheus route is mounted on a separate sub-router kept *off* `RequestDecompressionLayer` and the gzip query-param shim, so the snappy body reaches the handler intact (the handler decodes snappy itself). CORS is still applied to the merged router.

## How did you test this code?

I'm an agent (PostHog Code). Automated only — no manual testing claimed:

- 2 integration tests: one proves a `Content-Encoding: snappy` request reaches a handler on a router without the decompression layer; a regression guard proves the OTLP-style layer still 415s snappy (documenting *why* this route is split out).
- Full crate compiles (`main.rs` included), `cargo clippy` clean, `cargo fmt --check` clean. The decode/mapping layer's 9 tests (stacked PR) also pass.

Not yet covered (follow-ups, tracked in the stack/docs): exposing the route on the capture-logs ingress, server-side dedup for HA Prometheus pairs (RF=2 → 2× samples), and histogram type inference so product-layer `histogram_quantile` sees remote-write histograms (they're queryable via snuffle/PromQL in the meantime).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Customer onboarding docs ("point any Prometheus/vmagent `remote_write` at `/i/v1/prometheus/write` with your project token") will land with the ingress work.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Opus) at Daniel's direction. PR 2 of 2, stacked on the decode/mapping PR. No repo skills required.

The central decision was isolating this route from `RequestDecompressionLayer`: Prometheus' `Content-Encoding: snappy` is non-negotiable, and that layer 415s it pre-handler — so the handler owns snappy decode and the route is mounted on a decompression-free (but CORS-shared) sub-router. Token resolution mirrors the existing Datadog endpoint (path / header / query). Reused the shared `KafkaSink.write_metrics` so the produce path, quota, and downstream consumer are identical to OTLP.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
