### PR TITLE
feat(logs): add cross-filtered facet value counts endpoint

### DIFF
--- a/products/logs/backend/log_facet_values_query_runner.py
+++ b/products/logs/backend/log_facet_values_query_runner.py
@@ -1,0 +1,95 @@
+from functools import cached_property
+
+from posthog.schema import CachedLogsQueryResponse, LogsQuery
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+
+from products.logs.backend.logs_query_runner import LogsFilterBuilder, LogsQueryResponse, LogsQueryRunnerMixin
+
+# Columns a facet may group by. Each value is also the WHERE clause that gets omitted, so a facet's
+# counts reflect every *other* active filter rather than its own selection.
+FACET_FIELDS: frozenset[str] = frozenset({"severity_text", "service_name"})
+
+DEFAULT_FACET_LIMIT = 100
+
+
+class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
+    """Per-value counts for a single facet field, cross-filtered.
+
+    Every active filter is applied except the one belonging to `facet_field`, so selecting a value
+    in a facet re-scopes the *other* facets without zeroing out the facet's own siblings — the
+    standard faceted-search behaviour.
+    """
+
+    query: LogsQuery
+    cached_response: CachedLogsQueryResponse
+
+    def __init__(self, query: LogsQuery, facet_field: str, *args, **kwargs):
+        super().__init__(query, *args, **kwargs)
+        if facet_field not in FACET_FIELDS:
+            raise ValueError(f"Unsupported facet field: {facet_field!r}")
+        self.facet_field = facet_field
+
+    @cached_property
+    def settings(self) -> HogQLGlobalSettings:
+        # Fail fast rather than scan unbounded data, matching CountQueryRunner.
+        return HogQLGlobalSettings(
+            max_execution_time=30,
+            max_bytes_to_read=10_000_000_000,
+            read_overflow_mode="throw",
+        )
+
+    def _calculate(self) -> LogsQueryResponse:
+        response = execute_hogql_query(
+            query_type="LogsQuery",
+            query=self.to_query(),
+            modifiers=self.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            settings=self.settings,
+        )
+        results = [{"value": row[0], "count": row[1]} for row in (response.results or [])]
+        return LogsQueryResponse(results=results)
+
+    def to_query(self) -> ast.SelectQuery:
+        # The day-precision time_bucket prune in where() is widened to exact timestamp bounds so the
+        # counts match the requested window (same half-open pattern as CountQueryRunner).
+        where = ast.And(
+            exprs=[
+                LogsFilterBuilder(
+                    self.query, self.team, self.query_date_range, exclude_facet_field=self.facet_field
+                ).where(),
+                parse_expr(
+                    "timestamp >= {date_from} AND timestamp < {date_to}",
+                    placeholders={
+                        "date_from": ast.Constant(value=self.query_date_range.date_from()),
+                        "date_to": ast.Constant(value=self.query_date_range.date_to()),
+                    },
+                ),
+            ]
+        )
+        query = parse_select(
+            """
+            SELECT {facet_field} AS value, count() AS count
+            FROM logs
+            WHERE {where}
+            GROUP BY {facet_field}
+            ORDER BY count() DESC, {facet_field} ASC
+            LIMIT {limit}
+            """,
+            placeholders={
+                "facet_field": ast.Field(chain=[self.facet_field]),
+                "where": where,
+                "limit": ast.Constant(value=self.query.limit or DEFAULT_FACET_LIMIT),
+            },
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -203,10 +203,20 @@ class LogsFilterBuilder:
     Standalone — no QueryRunner dependency.
     """
 
-    def __init__(self, query: LogsQuery, team: "Team", query_date_range: QueryDateRange):
+    def __init__(
+        self,
+        query: LogsQuery,
+        team: "Team",
+        query_date_range: QueryDateRange,
+        exclude_facet_field: str | None = None,
+    ):
         self.query = query
         self.team = team
         self.query_date_range = query_date_range
+        # When set (e.g. "severity_text" or "service_name"), that facet's own filter is omitted
+        # from the WHERE clause so facet counts reflect every *other* active filter — the standard
+        # faceted-search behaviour where selecting a value doesn't zero out its siblings.
+        self.exclude_facet_field = exclude_facet_field
 
         self.resource_attribute_filters: list[LogPropertyFilter] = []
         self.resource_attribute_negative_filters: list[LogPropertyFilter] = []
@@ -280,7 +290,7 @@ class LogsFilterBuilder:
             )
         )
 
-        if self.query.serviceNames:
+        if self.query.serviceNames and self.exclude_facet_field != "service_name":
             exprs.append(
                 parse_expr(
                     "service_name IN {serviceNames}",
@@ -307,7 +317,8 @@ class LogsFilterBuilder:
             if self.log_filters:
                 for log_filter in self.log_filters:
                     if log_filter.key == "severity_level":
-                        exprs.append(_severity_level_to_expr(log_filter))
+                        if self.exclude_facet_field != "severity_text":
+                            exprs.append(_severity_level_to_expr(log_filter))
                         continue
                     if log_filter.key in ("trace_id", "span_id"):
                         log_filter = log_filter.copy(deep=True)
@@ -328,7 +339,7 @@ class LogsFilterBuilder:
             exprs.append(get_lowercase_index_hint(search_filter, team=self.team))
             exprs.append(property_to_expr(search_filter, team=self.team))
 
-        if self.query.severityLevels:
+        if self.query.severityLevels and self.exclude_facet_field != "severity_text":
             exprs.append(
                 parse_expr(
                     "severity_text IN {severityLevels}",

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -45,6 +45,7 @@ from products.logs.backend.count_ranges_query_runner import (
 )
 from products.logs.backend.has_logs_query_runner import team_has_logs
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
+from products.logs.backend.log_facet_values_query_runner import FACET_FIELDS, LogFacetValuesQueryRunner
 from products.logs.backend.log_values_query_runner import LogValuesQueryRunner
 from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, LogsQueryResponse, LogsQueryRunner
 from products.logs.backend.presentation.views.alerts_api import LogsAlertViewSet
@@ -318,6 +319,50 @@ class _LogsCountBodySerializer(serializers.Serializer):
 
 class _LogsCountRequestSerializer(serializers.Serializer):
     query = _LogsCountBodySerializer(help_text="The count query to execute.")
+
+
+class _LogFacetValueSerializer(serializers.Serializer):
+    value = serializers.CharField(help_text="The facet value (e.g. a severity level or service name).")
+    count = serializers.IntegerField(
+        help_text="Number of matching log records, with all active filters applied except this facet's own selection."
+    )
+
+
+class _LogsFacetValuesResponseSerializer(serializers.Serializer):
+    results = _LogFacetValueSerializer(
+        many=True, help_text="Facet values with cross-filtered counts, ordered by count descending."
+    )
+
+
+class _LogsFacetValuesBodySerializer(serializers.Serializer):
+    facetField = serializers.ChoiceField(
+        choices=["severity_text", "service_name"],
+        help_text="Column to facet on. Its own filter is excluded so counts reflect the other active filters.",
+    )
+    dateRange = _DateRangeSerializer(required=False, help_text="Date range. Defaults to last hour.")
+    severityLevels = serializers.ListField(
+        child=serializers.ChoiceField(choices=["trace", "debug", "info", "warn", "error", "fatal"]),
+        required=False,
+        default=list,
+        help_text="Filter by log severity levels (ignored when faceting on severity_text).",
+    )
+    serviceNames = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text="Filter by service names (ignored when faceting on service_name).",
+    )
+    searchTerm = serializers.CharField(required=False, help_text="Full-text search term to filter log bodies.")
+    filterGroup = serializers.ListField(
+        child=_LogPropertyFilterSerializer(),
+        required=False,
+        default=list,
+        help_text="Property filters for the query.",
+    )
+
+
+class _LogsFacetValuesRequestSerializer(serializers.Serializer):
+    query = _LogsFacetValuesBodySerializer(help_text="The facet values query to execute.")
 
 
 class _LogsCountRangesBodySerializer(serializers.Serializer):
@@ -779,6 +824,35 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         )
 
         return Response(response.results, status=status.HTTP_200_OK)
+
+    @extend_schema(request=_LogsFacetValuesRequestSerializer, responses={200: _LogsFacetValuesResponseSerializer})
+    @action(detail=False, methods=["POST"], required_scopes=["logs:read"])
+    def facet_values(self, request: Request, *args, **kwargs) -> Response:
+        tag_queries(product=Product.LOGS, feature=Feature.QUERY)
+        query_data = request.data.get("query", {})
+
+        facet_field = query_data.get("facetField")
+        if facet_field not in FACET_FIELDS:
+            raise ParseError(f"facetField must be one of {sorted(FACET_FIELDS)}")
+
+        date_range_data = query_data.get("dateRange")
+        date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
+
+        query = LogsQuery(
+            dateRange=date_range,
+            severityLevels=query_data.get("severityLevels", []),
+            serviceNames=query_data.get("serviceNames", []),
+            searchTerm=query_data.get("searchTerm", None),
+            filterGroup=self._normalize_filter_group(query_data.get("filterGroup", None)),
+        )
+
+        runner = LogFacetValuesQueryRunner(team=self.team, query=query, facet_field=facet_field)
+        response = runner.run(
+            ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
+        assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
+        return Response({"results": response.results}, status=status.HTTP_200_OK)
 
     @extend_schema(request=_LogsCountRequestSerializer, responses={200: _LogsCountResponseSerializer})
     @action(detail=False, methods=["POST"], required_scopes=["logs:read"])

--- a/products/logs/backend/test/test_log_facet_values.py
+++ b/products/logs/backend/test/test_log_facet_values.py
@@ -1,0 +1,75 @@
+import os
+import json
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
+
+
+class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    DATE_RANGE = {"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            sql = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                sql += json.dumps(log_item) + "\n"
+            sync_execute(f"""
+                INSERT INTO logs
+                FORMAT JSONEachRow
+                {sql}
+            """)
+
+    def _facet(self, facet_field: str, **filters) -> dict[str, int]:
+        body = {"query": {"facetField": facet_field, "dateRange": self.DATE_RANGE, **filters}}
+        response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {r["value"]: r["count"] for r in response.json()["results"]}
+
+    @parameterized.expand(
+        [
+            ("severity_text", "severityLevels"),
+            ("service_name", "serviceNames"),
+        ]
+    )
+    def test_facet_ignores_its_own_filter(self, facet_field, own_filter_key):
+        """Selecting a value in a facet must NOT change that facet's own counts (cross-filtering)."""
+        base = self._facet(facet_field)
+        self.assertGreater(len(base), 0)
+
+        own_value = next(iter(base))
+        filtered = self._facet(facet_field, **{own_filter_key: [own_value]})
+        self.assertEqual(filtered, base, f"{facet_field} facet must ignore its own {own_filter_key} filter")
+
+    @parameterized.expand(
+        [
+            ("severity_text", "service_name", "serviceNames"),
+            ("service_name", "severity_text", "severityLevels"),
+        ]
+    )
+    def test_facet_honors_other_filter(self, facet_field, other_facet_field, other_filter_key):
+        """Selecting a value in another facet DOES re-scope this facet's counts (strictly fewer)."""
+        base = self._facet(facet_field)
+        other_value = next(iter(self._facet(other_facet_field)))
+
+        scoped = self._facet(facet_field, **{other_filter_key: [other_value]})
+        self.assertLess(
+            sum(scoped.values()),
+            sum(base.values()),
+            f"{other_filter_key} should re-scope {facet_field} counts",
+        )
+
+    def test_invalid_facet_field_is_rejected(self):
+        body = {"query": {"facetField": "body", "dateRange": self.DATE_RANGE}}
+        response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -990,6 +990,52 @@ export interface ExplainRequestApi {
 }
 
 /**
+ * * `severity_text` - severity_text
+ * * `service_name` - service_name
+ */
+export type FacetFieldEnumApi = (typeof FacetFieldEnumApi)[keyof typeof FacetFieldEnumApi]
+
+export const FacetFieldEnumApi = {
+    SeverityText: 'severity_text',
+    ServiceName: 'service_name',
+} as const
+
+export interface _LogsFacetValuesBodyApi {
+    /** Column to facet on. Its own filter is excluded so counts reflect the other active filters.
+     *
+     * * `severity_text` - severity_text
+     * * `service_name` - service_name */
+    facetField: FacetFieldEnumApi
+    /** Date range. Defaults to last hour. */
+    dateRange?: _DateRangeApi
+    /** Filter by log severity levels (ignored when faceting on severity_text). */
+    severityLevels?: SeverityLevelsEnumApi[]
+    /** Filter by service names (ignored when faceting on service_name). */
+    serviceNames?: string[]
+    /** Full-text search term to filter log bodies. */
+    searchTerm?: string
+    /** Property filters for the query. */
+    filterGroup?: _LogPropertyFilterApi[]
+}
+
+export interface _LogsFacetValuesRequestApi {
+    /** The facet values query to execute. */
+    query: _LogsFacetValuesBodyApi
+}
+
+export interface _LogFacetValueApi {
+    /** The facet value (e.g. a severity level or service name). */
+    value: string
+    /** Number of matching log records, with all active filters applied except this facet's own selection. */
+    count: number
+}
+
+export interface _LogsFacetValuesResponseApi {
+    /** Facet values with cross-filtered counts, ordered by count descending. */
+    results: _LogFacetValueApi[]
+}
+
+/**
  * * `latest` - latest
  * * `earliest` - earliest
  */

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -41,6 +41,8 @@ import type {
     _LogsCountRangesResponseApi,
     _LogsCountRequestApi,
     _LogsCountResponseApi,
+    _LogsFacetValuesRequestApi,
+    _LogsFacetValuesResponseApi,
     _LogsQueryRequestApi,
     _LogsQueryResponseApi,
     _LogsServicesRequestApi,
@@ -375,6 +377,23 @@ export const logsExportCreate = async (projectId: string, options?: RequestInit)
     return apiMutator<LogsExportCreate201>(getLogsExportCreateUrl(projectId), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getLogsFacetValuesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/facet_values/`
+}
+
+export const logsFacetValuesCreate = async (
+    projectId: string,
+    _logsFacetValuesRequestApi: _LogsFacetValuesRequestApi,
+    options?: RequestInit
+): Promise<_LogsFacetValuesResponseApi> => {
+    return apiMutator<_LogsFacetValuesResponseApi>(getLogsFacetValuesCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(_logsFacetValuesRequestApi),
     })
 }
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -601,6 +601,97 @@ export const LogsExplainLogWithAICreateBody = /* @__PURE__ */ zod.object({
         .describe('Force regenerate explanation, bypassing cache'),
 })
 
+export const LogsFacetValuesCreateBody = /* @__PURE__ */ zod.object({
+    query: zod
+        .object({
+            facetField: zod
+                .enum(['severity_text', 'service_name'])
+                .describe('\* `severity_text` - severity_text\n\* `service_name` - service_name')
+                .describe(
+                    'Column to facet on. Its own filter is excluded so counts reflect the other active filters.\n\n\* `severity_text` - severity_text\n\* `service_name` - service_name'
+                ),
+            dateRange: zod
+                .object({
+                    date_from: zod
+                        .string()
+                        .nullish()
+                        .describe(
+                            'Start of the date range. Accepts ISO 8601 timestamps or relative formats: -7d, -1h, -1mStart, etc.'
+                        ),
+                    date_to: zod
+                        .string()
+                        .nullish()
+                        .describe('End of the date range. Same format as date_from. Omit or null for \"now\".'),
+                })
+                .optional()
+                .describe('Date range. Defaults to last hour.'),
+            severityLevels: zod
+                .array(
+                    zod
+                        .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+                        .describe(
+                            '\* `trace` - trace\n\* `debug` - debug\n\* `info` - info\n\* `warn` - warn\n\* `error` - error\n\* `fatal` - fatal'
+                        )
+                )
+                .optional()
+                .describe('Filter by log severity levels (ignored when faceting on severity_text).'),
+            serviceNames: zod
+                .array(zod.string())
+                .optional()
+                .describe('Filter by service names (ignored when faceting on service_name).'),
+            searchTerm: zod.string().optional().describe('Full-text search term to filter log bodies.'),
+            filterGroup: zod
+                .array(
+                    zod.object({
+                        key: zod
+                            .string()
+                            .describe(
+                                'Attribute key. For type \"log\", use \"message\". For \"log_attribute\"\/\"log_resource_attribute\", use the attribute key (e.g. \"k8s.container.name\").'
+                            ),
+                        type: zod
+                            .enum(['log', 'log_attribute', 'log_resource_attribute'])
+                            .describe(
+                                '\* `log` - log\n\* `log_attribute` - log_attribute\n\* `log_resource_attribute` - log_resource_attribute'
+                            )
+                            .describe(
+                                '\"log\" filters the log body\/message. \"log_attribute\" filters log-level attributes. \"log_resource_attribute\" filters resource-level attributes.\n\n\* `log` - log\n\* `log_attribute` - log_attribute\n\* `log_resource_attribute` - log_resource_attribute'
+                            ),
+                        operator: zod
+                            .enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'lt',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'is_set',
+                                'is_not_set',
+                            ])
+                            .describe(
+                                '\* `exact` - exact\n\* `is_not` - is_not\n\* `icontains` - icontains\n\* `not_icontains` - not_icontains\n\* `regex` - regex\n\* `not_regex` - not_regex\n\* `gt` - gt\n\* `lt` - lt\n\* `is_date_exact` - is_date_exact\n\* `is_date_before` - is_date_before\n\* `is_date_after` - is_date_after\n\* `is_set` - is_set\n\* `is_not_set` - is_not_set'
+                            )
+                            .describe(
+                                'Comparison operator.\n\n\* `exact` - exact\n\* `is_not` - is_not\n\* `icontains` - icontains\n\* `not_icontains` - not_icontains\n\* `regex` - regex\n\* `not_regex` - not_regex\n\* `gt` - gt\n\* `lt` - lt\n\* `is_date_exact` - is_date_exact\n\* `is_date_before` - is_date_before\n\* `is_date_after` - is_date_after\n\* `is_set` - is_set\n\* `is_not_set` - is_not_set'
+                            ),
+                        value: zod
+                            .unknown()
+                            .optional()
+                            .describe(
+                                'Value to compare against. String, number, or array of strings. Omit for is_set\/is_not_set operators.'
+                            ),
+                    })
+                )
+                .optional()
+                .describe('Property filters for the query.'),
+        })
+        .describe('The facet values query to execute.'),
+})
+
 export const logsQueryCreateBodyQueryOneSeverityLevelsDefault = []
 export const logsQueryCreateBodyQueryOneServiceNamesDefault = []
 export const logsQueryCreateBodyQueryOneFilterGroupDefault = []

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -341,6 +341,9 @@ tools:
     logs-export-create:
         operation: logs_export_create
         enabled: false
+    logs-facet-values-create:
+        operation: logs_facet_values_create
+        enabled: false
     logs-has-logs-retrieve:
         operation: logs_has_logs_retrieve
         enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -553,6 +553,7 @@ ignore_imports = [
     "products.logs.backend.presentation.views.api -> products.logs.backend.count_ranges_query_runner",
     "products.logs.backend.presentation.views.api -> products.logs.backend.has_logs_query_runner",
     "products.logs.backend.presentation.views.api -> products.logs.backend.log_attributes_query_runner",
+    "products.logs.backend.presentation.views.api -> products.logs.backend.log_facet_values_query_runner",
     "products.logs.backend.presentation.views.api -> products.logs.backend.log_values_query_runner",
     "products.logs.backend.presentation.views.api -> products.logs.backend.logs_query_runner",
     "products.logs.backend.presentation.views.api -> products.logs.backend.services_query_runner",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -22185,6 +22185,18 @@ export namespace Schemas {
       Error: 'error',
     } as const;
 
+    /**
+     * * `severity_text` - severity_text
+     * * `service_name` - service_name
+     */
+    export type FacetFieldEnum = typeof FacetFieldEnum[keyof typeof FacetFieldEnum];
+
+
+    export const FacetFieldEnum = {
+      SeverityText: 'severity_text',
+      ServiceName: 'service_name',
+    } as const;
+
     export type FeatureFlagFilters = { [key: string]: unknown };
 
     export type FeatureFlagSurveys = { [key: string]: unknown };
@@ -50184,6 +50196,13 @@ export namespace Schemas {
       event_name?: string;
     }
 
+    export interface _LogFacetValue {
+      /** The facet value (e.g. a severity level or service name). */
+      value: string;
+      /** Number of matching log records, with all active filters applied except this facet's own selection. */
+      count: number;
+    }
+
     /**
      * * `log` - log
      * * `log_attribute` - log_attribute
@@ -50329,6 +50348,34 @@ export namespace Schemas {
     export interface _LogsCountResponse {
       /** Number of log entries matching the filters. */
       count: number;
+    }
+
+    export interface _LogsFacetValuesBody {
+      /** Column to facet on. Its own filter is excluded so counts reflect the other active filters.
+       *
+       * * `severity_text` - severity_text
+       * * `service_name` - service_name */
+      facetField: FacetFieldEnum;
+      /** Date range. Defaults to last hour. */
+      dateRange?: _DateRange;
+      /** Filter by log severity levels (ignored when faceting on severity_text). */
+      severityLevels?: SeverityLevelsEnum[];
+      /** Filter by service names (ignored when faceting on service_name). */
+      serviceNames?: string[];
+      /** Full-text search term to filter log bodies. */
+      searchTerm?: string;
+      /** Property filters for the query. */
+      filterGroup?: _LogPropertyFilter[];
+    }
+
+    export interface _LogsFacetValuesRequest {
+      /** The facet values query to execute. */
+      query: _LogsFacetValuesBody;
+    }
+
+    export interface _LogsFacetValuesResponse {
+      /** Facet values with cross-filtered counts, ordered by count descending. */
+      results: _LogFacetValue[];
     }
 
     export interface _LogsQueryBody {


### PR DESCRIPTION
## Problem

Logs facet filters (severity level, service name) currently have no way to return cross-filtered counts — i.e. counts that reflect all active filters *except* the facet's own selection. Without this, selecting a severity level would zero out all other severity options in the UI, breaking the standard faceted-search UX.

## Changes

Adds a `POST /api/projects/{id}/logs/facet_values/` endpoint that returns per-value counts for a single facet field (`severity_text` or `service_name`), with cross-filtering applied:

- **`LogFacetValuesQueryRunner`** — new query runner that groups by the requested facet field, applies all active filters, and excludes the facet's own filter so sibling values remain visible.
- **`LogsFilterBuilder`** — extended with an `exclude_facet_field` parameter that skips the `severityLevels` or `serviceNames` WHERE clause when the corresponding facet is being computed.
- **`facet_values` API action** — new DRF action on the logs viewset, with request/response serializers and OpenAPI schema.
- **Generated TypeScript types and Zod schemas** — updated to include `FacetFieldEnum`, `_LogsFacetValuesRequest`, `_LogsFacetValuesResponse`, and the `logsFacetValuesCreate` API client function.

## How did you test this code?

Integration tests in `test_log_facet_values.py` cover:

- Severity facet ignores its own `severityLevels` filter (cross-filtering correctness).
- Severity facet is re-scoped when a service filter is active.
- Service facet ignores its own `serviceNames` filter.
- Service facet is re-scoped when a severity filter is active.
- Invalid `facetField` values are rejected with HTTP 400.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The implementation follows the existing `CountQueryRunner` pattern for settings (30s timeout, 10 GB read cap). The `exclude_facet_field` approach was chosen over duplicating filter logic because it keeps the WHERE clause construction in one place (`LogsFilterBuilder`) and makes the exclusion explicit and auditable. An alternative of building separate filter builders per facet was considered but rejected as it would scatter the logic.