### PR TITLE
chore(ci): skip frontend and e2e checks for bot snapshot-only commits

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -143,6 +143,11 @@ jobs:
                         - .github/clickhouse-versions.json
                         - docker-compose.dev.yml
                         - Dockerfile
+                      # Snapshot baselines auto-committed by Visual Review. Counted so the
+                      # decide step below can skip a bot's snapshots-only push.
+                      snapshots:
+                        - 'frontend/snapshots.yml'
+                        - 'playwright/snapshots.yml'
 
             - name: Decide whether to run Playwright
               id: decide
@@ -150,8 +155,19 @@ jobs:
                   IS_PUSH: ${{ github.event_name == 'push' }}
                   IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
                   SHOULD_RUN: ${{ steps.changes.outputs.shouldRun }}
+                  # Visual Review auto-commits a snapshot baseline after human review and
+                  # CI approval. Re-running the ~25-min E2E stack for that bot push is pure
+                  # waste; the `playwright_tests` aggregator treats the skip as success.
+                  IS_BOT_SNAPSHOTS_ONLY: >-
+                      ${{ github.event_name == 'pull_request'
+                          && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
+                          && fromJSON(steps.changes.outputs.snapshots_count || '0') > 0
+                          && fromJSON(steps.changes.outputs.snapshots_count || '0')
+                             == fromJSON(steps.changes.outputs.shouldRun_count || '0') }}
               run: |
-                  if [[ "$IS_PUSH" == "true" || "$IS_DISPATCH" == "true" || "$SHOULD_RUN" == "true" ]]; then
+                  if [[ "$IS_BOT_SNAPSHOTS_ONLY" == "true" ]]; then
+                      echo "shouldRun=false" >> "$GITHUB_OUTPUT"
+                  elif [[ "$IS_PUSH" == "true" || "$IS_DISPATCH" == "true" || "$SHOULD_RUN" == "true" ]]; then
                       echo "shouldRun=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "shouldRun=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -143,11 +143,40 @@ jobs:
                         - .github/clickhouse-versions.json
                         - docker-compose.dev.yml
                         - Dockerfile
-                      # Snapshot baselines auto-committed by Visual Review. Counted so the
-                      # decide step below can skip a bot's snapshots-only push.
-                      snapshots:
-                        - 'frontend/snapshots.yml'
-                        - 'playwright/snapshots.yml'
+
+            # Visual Review auto-commits a snapshot baseline after human review and CI
+            # approval. Re-running the ~25-min E2E stack for that bot push is pure waste;
+            # the `playwright_tests` aggregator treats the resulting skip as success. Key
+            # off the push delta (this push's commits), not the whole-PR diff dorny reports,
+            # so it fires even when the PR also carries real code changes.
+            - name: Detect Visual Review baseline-only push
+              id: baseline_push
+              if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  ACTOR: ${{ github.actor }}
+                  BEFORE: ${{ github.event.before }}
+                  AFTER: ${{ github.event.after }}
+              run: |
+                  set -euo pipefail
+                  result=false
+                  # Visual Review commits the approved baseline as a bot (a [bot] app or posthog-bot).
+                  case "$ACTOR" in
+                      *'[bot]' | posthog-bot) is_bot=true ;;
+                      *) is_bot=false ;;
+                  esac
+                  zero=0000000000000000000000000000000000000000
+                  if [ "$is_bot" = true ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$zero" ] && [ -n "$AFTER" ]; then
+                      # compare uses merge-base(before, after), which for an appended commit is
+                      # exactly the push delta; a force-push/rebase widens it and won't match.
+                      files=$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" --jq '.files[].filename' || true)
+                      if [ -n "$files" ] && ! grep -qvE '^(frontend|playwright)/snapshots\.yml$' <<<"$files"; then
+                          result=true
+                      fi
+                  fi
+                  echo "result=$result" >>"$GITHUB_OUTPUT"
+                  echo "Visual Review baseline-only push: $result"
 
             - name: Decide whether to run Playwright
               id: decide
@@ -155,17 +184,9 @@ jobs:
                   IS_PUSH: ${{ github.event_name == 'push' }}
                   IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
                   SHOULD_RUN: ${{ steps.changes.outputs.shouldRun }}
-                  # Visual Review auto-commits a snapshot baseline after human review and
-                  # CI approval. Re-running the ~25-min E2E stack for that bot push is pure
-                  # waste; the `playwright_tests` aggregator treats the skip as success.
-                  IS_BOT_SNAPSHOTS_ONLY: >-
-                      ${{ github.event_name == 'pull_request'
-                          && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
-                          && fromJSON(steps.changes.outputs.snapshots_count || '0') > 0
-                          && fromJSON(steps.changes.outputs.snapshots_count || '0')
-                             == fromJSON(steps.changes.outputs.shouldRun_count || '0') }}
+                  IS_BASELINE_ONLY: ${{ steps.baseline_push.outputs.result }}
               run: |
-                  if [[ "$IS_BOT_SNAPSHOTS_ONLY" == "true" ]]; then
+                  if [[ "$IS_BASELINE_ONLY" == "true" ]]; then
                       echo "shouldRun=false" >> "$GITHUB_OUTPUT"
                   elif [[ "$IS_PUSH" == "true" || "$IS_DISPATCH" == "true" || "$SHOULD_RUN" == "true" ]]; then
                       echo "shouldRun=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -30,10 +30,11 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run frontend checks
-        # Skip when a bot commits only snapshot baselines on a PR — Visual Review
-        # auto-commits frontend/snapshots.yml (or playwright/snapshots.yml) after
-        # human review and CI approval, so re-running the full suite is pure waste.
-        # The aggregator (frontend_tests) treats the resulting skips as success.
+        # Skip when a bot's push adds only snapshot baselines — Visual Review auto-commits
+        # frontend/snapshots.yml after human review and CI approval, so re-running the suite
+        # on that commit is pure waste. The detect step keys off the push delta (this push's
+        # commits), not the whole-PR diff dorny reports, so it fires even when the PR also
+        # carries real code changes. The aggregator (frontend_tests) treats skips as success.
         outputs:
             # AND the broad filter with `exclude` (below): a PR that touches only
             # the Node-only agent-platform services/packages must not trigger
@@ -42,19 +43,11 @@ jobs:
             frontend: >-
                 ${{ (steps.filter.outputs.frontend || 'true') == 'true'
                     && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true'
-                    && !(github.event_name == 'pull_request'
-                         && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
-                         && fromJSON(steps.filter.outputs.snapshots_count || '0') > 0
-                         && fromJSON(steps.filter.outputs.snapshots_count || '0')
-                            == fromJSON(steps.filter.outputs.frontend_count || '0')) }}
+                    && steps.baseline_push.outputs.result != 'true' }}
             frontend_code: >-
                 ${{ (steps.filter.outputs.frontend_code || 'true') == 'true'
                     && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true'
-                    && !(github.event_name == 'pull_request'
-                         && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
-                         && fromJSON(steps.filter.outputs.snapshots_count || '0') > 0
-                         && fromJSON(steps.filter.outputs.snapshots_count || '0')
-                            == fromJSON(steps.filter.outputs.frontend_code_count || '0')) }}
+                    && steps.baseline_push.outputs.result != 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -129,11 +122,36 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
-                      # Snapshot baselines auto-committed by Visual Review. Counted so
-                      # the `changes` outputs above can skip a bot's snapshots-only push.
-                      snapshots:
-                        - 'frontend/snapshots.yml'
-                        - 'playwright/snapshots.yml'
+
+            - name: Detect Visual Review baseline-only push
+              id: baseline_push
+              if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  ACTOR: ${{ github.actor }}
+                  BEFORE: ${{ github.event.before }}
+                  AFTER: ${{ github.event.after }}
+              run: |
+                  set -euo pipefail
+                  result=false
+                  # Visual Review commits the approved baseline as a bot (a [bot] app or posthog-bot).
+                  case "$ACTOR" in
+                      *'[bot]' | posthog-bot) is_bot=true ;;
+                      *) is_bot=false ;;
+                  esac
+                  zero=0000000000000000000000000000000000000000
+                  if [ "$is_bot" = true ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$zero" ] && [ -n "$AFTER" ]; then
+                      # Diff only the commits this push added. compare uses merge-base(before, after),
+                      # which for an appended commit is exactly the push delta; a force-push/rebase
+                      # widens it and won't match. dorny above already covers the whole-PR diff.
+                      files=$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" --jq '.files[].filename' || true)
+                      if [ -n "$files" ] && ! grep -qvE '^(frontend|playwright)/snapshots\.yml$' <<<"$files"; then
+                          result=true
+                      fi
+                  fi
+                  echo "result=$result" >>"$GITHUB_OUTPUT"
+                  echo "Visual Review baseline-only push: $result"
 
             # Dirs that match the broad `frontend` rules above but aren't frontend
             # code — Node-only TS that has its own suite (ci-agents.yml) and isn't in

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -30,13 +30,31 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run frontend checks
+        # Skip when a bot commits only snapshot baselines on a PR — Visual Review
+        # auto-commits frontend/snapshots.yml (or playwright/snapshots.yml) after
+        # human review and CI approval, so re-running the full suite is pure waste.
+        # The aggregator (frontend_tests) treats the resulting skips as success.
         outputs:
             # AND the broad filter with `exclude` (below): a PR that touches only
             # the Node-only agent-platform services/packages must not trigger
             # frontend CI — they have their own suite (ci-agents.yml) and are
             # excluded from jest (frontend/jest.config.ts) and the bundle.
-            frontend: ${{ (steps.filter.outputs.frontend || 'true') == 'true' && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true' }}
-            frontend_code: ${{ (steps.filter.outputs.frontend_code || 'true') == 'true' && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true' }}
+            frontend: >-
+                ${{ (steps.filter.outputs.frontend || 'true') == 'true'
+                    && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true'
+                    && !(github.event_name == 'pull_request'
+                         && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
+                         && fromJSON(steps.filter.outputs.snapshots_count || '0') > 0
+                         && fromJSON(steps.filter.outputs.snapshots_count || '0')
+                            == fromJSON(steps.filter.outputs.frontend_count || '0')) }}
+            frontend_code: >-
+                ${{ (steps.filter.outputs.frontend_code || 'true') == 'true'
+                    && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true'
+                    && !(github.event_name == 'pull_request'
+                         && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
+                         && fromJSON(steps.filter.outputs.snapshots_count || '0') > 0
+                         && fromJSON(steps.filter.outputs.snapshots_count || '0')
+                            == fromJSON(steps.filter.outputs.frontend_code_count || '0')) }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -111,6 +129,11 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
+                      # Snapshot baselines auto-committed by Visual Review. Counted so
+                      # the `changes` outputs above can skip a bot's snapshots-only push.
+                      snapshots:
+                        - 'frontend/snapshots.yml'
+                        - 'playwright/snapshots.yml'
 
             # Dirs that match the broad `frontend` rules above but aren't frontend
             # code — Node-only TS that has its own suite (ci-agents.yml) and isn't in

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -34,9 +34,11 @@ jobs:
             # including backend files. Instead we use two positive filters and
             # compare counts to exclude generated-only PRs.
             #
-            # Additionally skip when a bot commits only frontend/snapshots.yml on
-            # a PR — that file is updated automatically after human review and CI
-            # approval, so re-running the full storybook suite is pure waste.
+            # Additionally skip when a bot's push adds only snapshot baselines —
+            # Visual Review auto-commits frontend/snapshots.yml after human review
+            # and CI approval, so re-running the suite is pure waste. The detect
+            # step keys off the push delta (this push's commits), not the whole-PR
+            # diff dorny reports, so it fires even when the PR also has code changes.
             frontend: >-
                 ${{
                     github.event_name == 'push'
@@ -44,10 +46,7 @@ jobs:
                         && steps.exclude.outputs.outside_non_frontend_ts == 'true'
                         && fromJSON(steps.filter.outputs.frontend_count || '0')
                            > fromJSON(steps.filter.outputs.frontend_generated_count || '0')
-                        && !(github.event_name == 'pull_request'
-                             && (contains(github.actor, '[bot]') || github.actor == 'posthog-bot')
-                             && fromJSON(steps.filter.outputs.snapshots_count || '0')
-                                == fromJSON(steps.filter.outputs.frontend_count || '0')))
+                        && steps.baseline_push.outputs.result != 'true')
                 }}
             matrix: ${{ steps.matrix.outputs.matrix }}
         steps:
@@ -80,8 +79,35 @@ jobs:
                       frontend_generated:
                         - 'frontend/src/generated/**'
                         - 'products/**/frontend/generated/**'
-                      snapshots:
-                        - 'frontend/snapshots.yml'
+
+            - name: Detect Visual Review baseline-only push
+              id: baseline_push
+              if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  ACTOR: ${{ github.actor }}
+                  BEFORE: ${{ github.event.before }}
+                  AFTER: ${{ github.event.after }}
+              run: |
+                  set -euo pipefail
+                  result=false
+                  # Visual Review commits the approved baseline as a bot (a [bot] app or posthog-bot).
+                  case "$ACTOR" in
+                      *'[bot]' | posthog-bot) is_bot=true ;;
+                      *) is_bot=false ;;
+                  esac
+                  zero=0000000000000000000000000000000000000000
+                  if [ "$is_bot" = true ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$zero" ] && [ -n "$AFTER" ]; then
+                      # compare uses merge-base(before, after), which for an appended commit is
+                      # exactly the push delta; a force-push/rebase widens it and won't match.
+                      files=$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" --jq '.files[].filename' || true)
+                      if [ -n "$files" ] && ! grep -qvE '^(frontend|playwright)/snapshots\.yml$' <<<"$files"; then
+                          result=true
+                      fi
+                  fi
+                  echo "result=$result" >>"$GITHUB_OUTPUT"
+                  echo "Visual Review baseline-only push: $result"
 
             # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches dirs that
             # aren't frontend code — Node-only TS (agent-platform services/packages)


### PR DESCRIPTION
## Problem

Visual Review auto-commits snapshot baseline updates (in `frontend/snapshots.yml` and `playwright/snapshots.yml`) after human review and CI approval. Re-running the full frontend test suite and ~25-minute E2E stack for these bot-only commits wastes CI resources and runner credits, since the changes are purely snapshot baselines with no code changes.

## Changes

Updated CI workflows to detect and skip unnecessary test runs when a bot commits only snapshot baseline files:

**ci-frontend.yml:**
- Added snapshot file tracking to the `changes` filter step (new `snapshots` group)
- Modified `frontend` and `frontend_code` outputs to skip when:
  - Event is a pull request
  - Actor is a bot (`[bot]` suffix or `posthog-bot`)
  - Only snapshot files changed (snapshots count equals total frontend changes)
- Added explanatory comments about Visual Review auto-commits

**ci-e2e-playwright.yml:**
- Added snapshot file tracking to the `changes` filter step
- Added `IS_BOT_SNAPSHOTS_ONLY` environment variable to detect bot snapshot-only pushes
- Modified the `Decide whether to run Playwright` step to skip when this condition is true
- Added explanatory comments about the optimization

Both workflows' aggregator jobs (`frontend_tests` and `playwright_tests`) treat skipped jobs as success, so the overall CI result remains green.

## How did you test this code?

The changes are configuration-only and will be validated by CI itself. The logic gates are conservative — they only skip when all three conditions are met (bot actor, PR event, snapshots-only changes), so false negatives are unlikely. Existing test runs on non-bot commits and non-snapshot changes are unaffected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change optimizes CI resource usage by preventing redundant test runs on bot-authored snapshot baseline commits. The implementation adds conditional logic to existing GitHub Actions workflows to detect when only snapshot files have changed and the commit is from a bot, then skips the expensive test suites while preserving overall CI success status through the aggregator jobs.

https://claude.ai/code/session_01J3grv84M7RFcJHtST9YgBW