### PR TITLE
fix(postgres): scope statement_timeout for schema discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -951,6 +951,18 @@ def _schemas_from_conn(
 ) -> dict[str, PostgresDiscoveredSchema]:
     """Discover columns for tables on the given pre-opened connection."""
     with connection.cursor() as cursor:
+        # Raise statement_timeout for the catalog scan below. Some hosted/pooled Postgres set a
+        # short role/server default that cancels the `information_schema.columns` query
+        # (QueryCanceled) on large schemas before discovery finishes — the read path guards its own
+        # metadata query the same way in `_get_table`. Best-effort: engines without statement_timeout
+        # (e.g. DuckDB) reject the SET, so clear the aborted transaction and fall back to the default.
+        try:
+            cursor.execute(
+                sql.SQL("SET statement_timeout = {timeout}").format(timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS))
+            )
+        except psycopg.Error:
+            connection.rollback()
+
         discovered_tables, _qualify_with_schema = _get_discovered_tables(cursor, schema, names)
         if not discovered_tables:
             return {}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2111,7 +2111,9 @@ class TestPostgresSchemaDiscovery:
 
         cursor = connection.cursor.return_value.__enter__.return_value
         executed_queries = [
-            call.args[0] for call in cursor.execute.call_args_list if "SELECT version()" not in str(call.args[0])
+            call.args[0]
+            for call in cursor.execute.call_args_list
+            if "SELECT version()" not in str(call.args[0]) and "statement_timeout" not in str(call.args[0])
         ]
         first_query = executed_queries[0]
         second_query = executed_queries[1]
@@ -2205,7 +2207,9 @@ class TestPostgresSchemaDiscovery:
 
         cursor = connection.cursor.return_value.__enter__.return_value
         executed_queries = [
-            call.args[0] for call in cursor.execute.call_args_list if "SELECT version()" not in str(call.args[0])
+            call.args[0]
+            for call in cursor.execute.call_args_list
+            if "SELECT version()" not in str(call.args[0]) and "statement_timeout" not in str(call.args[0])
         ]
         first_query = executed_queries[0]
         second_query = executed_queries[1]
@@ -4062,7 +4066,15 @@ class TestGetTable:
             dj_cursor.execute("CREATE TABLE test_schemas_from_conn_timeout (id INTEGER PRIMARY KEY, name TEXT)")
 
         conn = _RecordingConnection(django_connection)
-        discovered = _schemas_from_conn(cast(Any, conn), "public", ["test_schemas_from_conn_timeout"])
+        try:
+            discovered = _schemas_from_conn(cast(Any, conn), "public", ["test_schemas_from_conn_timeout"])
+        finally:
+            # `_schemas_from_conn` issues a session-level `SET statement_timeout` (production opens and
+            # closes its own connection, so the GUC is discarded with it). Here it runs against the shared
+            # `django_connection`, which Postgres does not reset on transaction rollback — clear it so the
+            # raised timeout can't leak onto subsequent tests reusing the connection.
+            with django_connection.cursor() as dj_cursor:
+                dj_cursor.execute("RESET statement_timeout")
 
         assert "test_schemas_from_conn_timeout" in discovered
         assert {col[0] for col in discovered["test_schemas_from_conn_timeout"].columns} >= {"id", "name"}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -88,6 +88,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _rls_active_from_conn,
     _role_subject_to_rls,
     _safe_close_connection,
+    _schemas_from_conn,
     _statement_timeout_as_non_retryable,
     _xmin_capable_tables_from_conn,
     filter_postgres_incremental_fields,
@@ -3984,9 +3985,9 @@ class TestIsReadReplica:
 class _RecordingCursor:
     """Wraps a real cursor, recording executed SQL as text while delegating everything else."""
 
-    def __init__(self, inner: Any):
+    def __init__(self, inner: Any, sink: list[str] | None = None):
         self._inner = inner
-        self.executed: list[str] = []
+        self.executed: list[str] = sink if sink is not None else []
 
     def execute(self, query: Any, *args: Any, **kwargs: Any) -> Any:
         try:
@@ -3994,6 +3995,27 @@ class _RecordingCursor:
         except Exception:
             self.executed.append(str(query))
         return self._inner.execute(query, *args, **kwargs)
+
+    def __enter__(self) -> "_RecordingCursor":
+        self._inner.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> Any:
+        return self._inner.__exit__(*args)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+class _RecordingConnection:
+    """Wraps a real connection so `_schemas_from_conn` runs against a recording cursor."""
+
+    def __init__(self, inner: Any):
+        self._inner = inner
+        self.executed: list[str] = []
+
+    def cursor(self, *args: Any, **kwargs: Any) -> _RecordingCursor:
+        return _RecordingCursor(self._inner.cursor(*args, **kwargs), self.executed)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
@@ -4029,6 +4051,29 @@ class TestGetTable:
                 i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
             )
             assert info_schema_idx == set_local_idx + 1
+
+    @pytest.mark.django_db
+    def test_schemas_from_conn_runs_under_scoped_statement_timeout(self):
+        """`_schemas_from_conn` (the discovery path `sync_new_schemas_activity` and credential
+        validation use) raises statement_timeout before scanning the catalog, so a short
+        role/server default can't cancel the `information_schema.columns` query with QueryCanceled
+        on large schemas. Pin that the timeout is bumped before the column query runs."""
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_schemas_from_conn_timeout (id INTEGER PRIMARY KEY, name TEXT)")
+
+        conn = _RecordingConnection(django_connection)
+        discovered = _schemas_from_conn(cast(Any, conn), "public", ["test_schemas_from_conn_timeout"])
+
+        assert "test_schemas_from_conn_timeout" in discovered
+        assert {col[0] for col in discovered["test_schemas_from_conn_timeout"].columns} >= {"id", "name"}
+
+        set_timeout_idx = next(
+            i
+            for i, q in enumerate(conn.executed)
+            if "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
+        )
+        column_query_idx = next(i for i, q in enumerate(conn.executed) if "information_schema.columns" in q)
+        assert set_timeout_idx < column_query_idx
 
     @pytest.mark.django_db
     def test_regular_table(self):


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports were failing with `QueryCanceled: canceling statement due to statement timeout` during schema discovery. Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019edbdd-415a-7fc2-ba93-9d772663f8c0

The stack traces into `posthog/temporal/data_imports/sources/postgres/postgres.py` at `_schemas_from_conn` → `cursor.execute(...)` (the `information_schema.columns` catalog query), reached via `sync_new_schemas_activity` → `PostgresSource.get_schemas` → `postgres.get_schemas`.

The read path already learned this lesson: `_get_table` wraps its metadata query in a generous `statement_timeout` because some hosted/pooled Postgres set a short role/server-default `statement_timeout` that cancels the catalog scan on large schemas before it finishes. The discovery path (`_schemas_from_conn`) never got the same guard, so it inherited the customer's short default and got canceled. Because the cancellation is deterministic, Temporal retried the activity forever.

## Changes

`_schemas_from_conn` now raises `statement_timeout` to `METADATA_STATEMENT_TIMEOUT_MS` (10 min) before scanning the catalog, matching the read path's `_get_table`. It's best-effort: engines without `statement_timeout` (e.g. DuckDB/Duckgres) reject the `SET`, so the aborted transaction is rolled back and discovery falls back to the inherited default.

This is a code fix, not a NonRetryableErrors change — the failure was our discovery query inheriting a short timeout we should override, not an unrecoverable user/upstream condition.

## How did you test this code?

I'm an agent. Automated + manual verification I actually ran:

- Added `test_schemas_from_conn_runs_under_scoped_statement_timeout`, which asserts discovery succeeds and the `SET statement_timeout` runs before the `information_schema.columns` query. It mirrors the existing, passing `test_schema_discovery_query_runs_under_scoped_statement_timeout` for `_get_table`.
- Verified end-to-end against a real local Postgres with an aggressive `ALTER ROLE ... SET statement_timeout = '5ms'`:
  - Without the guard, the catalog query reproduces the exact production error: `QueryCanceled: canceling statement due to statement timeout`.
  - With the fix, `_schemas_from_conn` issues `SET statement_timeout = 600000` first and discovery completes successfully.
- `ruff check` and `ruff format --check` pass on both changed files.

The new pytest could not be run inside the standard test harness in my sandbox because the session DB fixture requires a ClickHouse instance I couldn't stand up; the behavior is instead proven by the real-Postgres reproduction above.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Pulled the full stack trace via the PostHog error-tracking MCP tools, confirmed the failing frame is `_schemas_from_conn`, and traced the call path from `sync_new_schemas_activity`. Found the read path (`_get_table`) already guards the identical hazard, so the fix is to apply the same scoped `statement_timeout` to the discovery path rather than widen `NonRetryableErrors`. Checked open PRs (including the maintainer's) for duplicates — none touch the discovery `statement_timeout`. No skills were applicable to this change.
