### PR TITLE
feat(mcp): expose Metric display color params in trends query schema

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4301,7 +4301,7 @@
                 },
                 "display": {
                     "default": "ActionsLineGraph",
-                    "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
+                    "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `Metric` - single large number with a period-over-period change pill and a sparkline. Like `BoldNumber` but trend-aware; configure it with the `metric*` fields below. Single series, no breakdown. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
                     "enum": [
                         "Auto",
                         "ActionsLineGraph",
@@ -4352,7 +4352,7 @@
                 },
                 "metricShowChange": {
                     "default": true,
-                    "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                    "description": "Only applies when `display` is `Metric`. Show the change pill next to the big number — the percentage change from the first to the last point of the series over the selected date range.",
                     "type": "boolean"
                 },
                 "showAlertThresholdLines": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4329,6 +4329,32 @@
                     },
                     "type": "array"
                 },
+                "metricChangeDecreaseColor": {
+                    "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for the change pill when the metric went DOWN. Defaults to red (`#db3707`). For a \"lower is better\" metric (latency, error rate, cost), set this to a green (e.g. `#388600`) so a decrease reads as good.",
+                    "type": "string"
+                },
+                "metricChangeIncreaseColor": {
+                    "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for the change pill when the metric went UP. Defaults to green (`#388600`). For a \"lower is better\" metric (latency, error rate, cost), set this to a red (e.g. `#db3707`) so an increase reads as bad.",
+                    "type": "string"
+                },
+                "metricColorByDirection": {
+                    "default": false,
+                    "description": "Only applies when `display` is `Metric`. Color the sparkline under the big number by whether the metric increased or decreased over the period (using the increase/decrease line colors).",
+                    "type": "boolean"
+                },
+                "metricLineDecreaseColor": {
+                    "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went DOWN. Defaults to red (`#db3707`). Flip to a green for a \"lower is better\" metric.",
+                    "type": "string"
+                },
+                "metricLineIncreaseColor": {
+                    "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went UP. Defaults to green (`#388600`). Flip to a red for a \"lower is better\" metric.",
+                    "type": "string"
+                },
+                "metricShowChange": {
+                    "default": true,
+                    "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                    "type": "boolean"
+                },
                 "showAlertThresholdLines": {
                     "default": false,
                     "description": "Whether to show alert threshold lines on the chart.",

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -476,6 +476,7 @@ export interface AssistantTrendsFilter {
      * `ActionsAreaGraph` - time-series area chart.
      * `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics.
      * `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series.
+     * `Metric` - single large number with a period-over-period change pill and a sparkline. Like `BoldNumber` but trend-aware; configure it with the `metric*` fields below. Single series, no breakdown.
      * `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data.
      * `ActionsPie` - total value pie chart; good for visualizing proportions.
      * `ActionsTable` - total value table; good when using breakdown to list users or other entities.
@@ -561,8 +562,8 @@ export interface AssistantTrendsFilter {
     showMultipleYAxes?: TrendsFilterLegacy['show_multiple_y_axes']
 
     /**
-     * Only applies when `display` is `Metric`. Show the period-over-period change pill next to the
-     * big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.
+     * Only applies when `display` is `Metric`. Show the change pill next to the big number — the
+     * percentage change from the first to the last point of the series over the selected date range.
      * @default true
      */
     metricShowChange?: boolean

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -559,6 +559,48 @@ export interface AssistantTrendsFilter {
      * @default false
      */
     showMultipleYAxes?: TrendsFilterLegacy['show_multiple_y_axes']
+
+    /**
+     * Only applies when `display` is `Metric`. Show the period-over-period change pill next to the
+     * big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.
+     * @default true
+     */
+    metricShowChange?: boolean
+
+    /**
+     * Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for the change pill when
+     * the metric went UP. Defaults to green (`#388600`). For a "lower is better" metric (latency,
+     * error rate, cost), set this to a red (e.g. `#db3707`) so an increase reads as bad.
+     */
+    metricChangeIncreaseColor?: string
+
+    /**
+     * Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for the change pill when
+     * the metric went DOWN. Defaults to red (`#db3707`). For a "lower is better" metric (latency,
+     * error rate, cost), set this to a green (e.g. `#388600`) so a decrease reads as good.
+     */
+    metricChangeDecreaseColor?: string
+
+    /**
+     * Only applies when `display` is `Metric`. Color the sparkline under the big number by whether
+     * the metric increased or decreased over the period (using the increase/decrease line colors).
+     * @default false
+     */
+    metricColorByDirection?: boolean
+
+    /**
+     * Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for
+     * the sparkline when the metric went UP. Defaults to green (`#388600`). Flip to a red for a
+     * "lower is better" metric.
+     */
+    metricLineIncreaseColor?: string
+
+    /**
+     * Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for
+     * the sparkline when the metric went DOWN. Defaults to red (`#db3707`). Flip to a green for a
+     * "lower is better" metric.
+     */
+    metricLineDecreaseColor?: string
 }
 
 export interface AssistantTrendsQuery extends AssistantInsightsQueryBase {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4241,6 +4241,56 @@ class AssistantTrendsFilter(BaseModel):
             " complete` (unique users) and `B` is `$identify` (unique users)."
         ),
     )
+    metricChangeDecreaseColor: str | None = Field(
+        default=None,
+        description=(
+            "Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for"
+            " the change pill when the metric went DOWN. Defaults to red (`#db3707`)."
+            ' For a "lower is better" metric (latency, error rate, cost), set this to a'
+            " green (e.g. `#388600`) so a decrease reads as good."
+        ),
+    )
+    metricChangeIncreaseColor: str | None = Field(
+        default=None,
+        description=(
+            "Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for"
+            " the change pill when the metric went UP. Defaults to green (`#388600`)."
+            ' For a "lower is better" metric (latency, error rate, cost), set this to a'
+            " red (e.g. `#db3707`) so an increase reads as bad."
+        ),
+    )
+    metricColorByDirection: bool | None = Field(
+        default=False,
+        description=(
+            "Only applies when `display` is `Metric`. Color the sparkline under the big"
+            " number by whether the metric increased or decreased over the period"
+            " (using the increase/decrease line colors)."
+        ),
+    )
+    metricLineDecreaseColor: str | None = Field(
+        default=None,
+        description=(
+            "Only applies when `display` is `Metric` and `metricColorByDirection` is"
+            " `true`. Hex color for the sparkline when the metric went DOWN. Defaults"
+            ' to red (`#db3707`). Flip to a green for a "lower is better" metric.'
+        ),
+    )
+    metricLineIncreaseColor: str | None = Field(
+        default=None,
+        description=(
+            "Only applies when `display` is `Metric` and `metricColorByDirection` is"
+            " `true`. Hex color for the sparkline when the metric went UP. Defaults to"
+            ' green (`#388600`). Flip to a red for a "lower is better" metric.'
+        ),
+    )
+    metricShowChange: bool | None = Field(
+        default=True,
+        description=(
+            "Only applies when `display` is `Metric`. Show the period-over-period"
+            " change pill next to the big number. The pill needs a comparison period,"
+            " so also set `compareFilter.compare` to `true`."
+        ),
+    )
     showAlertThresholdLines: bool | None = Field(
         default=False, description="Whether to show alert threshold lines on the chart."
     )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4215,8 +4215,11 @@ class AssistantTrendsFilter(BaseModel):
             " chart; good for cumulative metrics. `BoldNumber` - total value single"
             " large number. Use when user explicitly asks for a single output number."
             " You CANNOT use this with breakdown or if the insight has more than one"
-            " series. `ActionsBarValue` - total value (NOT time-series) bar chart; good"
-            " for categorical data. `ActionsPie` - total value pie chart; good for"
+            " series. `Metric` - single large number with a period-over-period change"
+            " pill and a sparkline. Like `BoldNumber` but trend-aware; configure it"
+            " with the `metric*` fields below. Single series, no breakdown."
+            " `ActionsBarValue` - total value (NOT time-series) bar chart; good for"
+            " categorical data. `ActionsPie` - total value pie chart; good for"
             " visualizing proportions. `ActionsTable` - total value table; good when"
             " using breakdown to list users or other entities. `WorldMap` - total value"
             " world map; use when breaking down by country name using property"
@@ -4286,9 +4289,9 @@ class AssistantTrendsFilter(BaseModel):
     metricShowChange: bool | None = Field(
         default=True,
         description=(
-            "Only applies when `display` is `Metric`. Show the period-over-period"
-            " change pill next to the big number. The pill needs a comparison period,"
-            " so also set `compareFilter.compare` to `true`."
+            "Only applies when `display` is `Metric`. Show the change pill next to the"
+            " big number — the percentage change from the first to the last point of"
+            " the series over the selected date range."
         ),
     )
     showAlertThresholdLines: bool | None = Field(

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -513,7 +513,7 @@ const AssistantTrendsFilter = z.object({
             'SlopeGraph',
         ])
         .describe(
-            'Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.'
+            'Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `Metric` - single large number with a period-over-period change pill and a sparkline. Like `BoldNumber` but trend-aware; configure it with the `metric*` fields below. Single series, no breakdown. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.'
         )
         .default('ActionsLineGraph')
         .optional(),
@@ -557,7 +557,7 @@ const AssistantTrendsFilter = z.object({
     metricShowChange: z.coerce
         .boolean()
         .describe(
-            'Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.'
+            'Only applies when `display` is `Metric`. Show the change pill next to the big number — the percentage change from the first to the last point of the series over the selected date range.'
         )
         .default(true)
         .optional(),

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -523,6 +523,44 @@ const AssistantTrendsFilter = z.object({
             'Use custom formulas to perform mathematical operations like calculating percentages or metrics. Use the following syntax: `A/B`, where `A` and `B` are the names of the series. You can combine math aggregations and formulas. When using a formula, you must:\n- Identify and specify **all** events and actions needed to solve the formula.\n- Carefully review the list of available events and actions to find appropriate entities for each part of the formula.\n- Ensure that you find events and actions corresponding to both the numerator and denominator in ratio calculations. Examples of using math formulas:\n- If you want to calculate the percentage of users who have completed onboarding, you need to find and use events or actions similar to `$identify` and `onboarding complete`, so the formula will be `A / B`, where `A` is `onboarding complete` (unique users) and `B` is `$identify` (unique users).'
         )
         .optional(),
+    metricChangeDecreaseColor: z
+        .string()
+        .describe(
+            'Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for the change pill when the metric went DOWN. Defaults to red (`#db3707`). For a "lower is better" metric (latency, error rate, cost), set this to a green (e.g. `#388600`) so a decrease reads as good.'
+        )
+        .optional(),
+    metricChangeIncreaseColor: z
+        .string()
+        .describe(
+            'Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for the change pill when the metric went UP. Defaults to green (`#388600`). For a "lower is better" metric (latency, error rate, cost), set this to a red (e.g. `#db3707`) so an increase reads as bad.'
+        )
+        .optional(),
+    metricColorByDirection: z.coerce
+        .boolean()
+        .describe(
+            'Only applies when `display` is `Metric`. Color the sparkline under the big number by whether the metric increased or decreased over the period (using the increase/decrease line colors).'
+        )
+        .default(false)
+        .optional(),
+    metricLineDecreaseColor: z
+        .string()
+        .describe(
+            'Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went DOWN. Defaults to red (`#db3707`). Flip to a green for a "lower is better" metric.'
+        )
+        .optional(),
+    metricLineIncreaseColor: z
+        .string()
+        .describe(
+            'Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went UP. Defaults to green (`#388600`). Flip to a red for a "lower is better" metric.'
+        )
+        .optional(),
+    metricShowChange: z.coerce
+        .boolean()
+        .describe(
+            'Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.'
+        )
+        .default(true)
+        .optional(),
     showAlertThresholdLines: z.coerce
         .boolean()
         .describe('Whether to show alert threshold lines on the chart.')

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
@@ -3795,7 +3795,7 @@
                         },
                         "display": {
                             "default": "ActionsLineGraph",
-                            "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
+                            "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `Metric` - single large number with a period-over-period change pill and a sparkline. Like `BoldNumber` but trend-aware; configure it with the `metric*` fields below. Single series, no breakdown. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
                             "enum": [
                                 "Auto",
                                 "ActionsLineGraph",
@@ -3856,7 +3856,7 @@
                         },
                         "metricShowChange": {
                             "default": true,
-                            "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                            "description": "Only applies when `display` is `Metric`. Show the change pill next to the big number — the percentage change from the first to the last point of the series over the selected date range.",
                             "type": "boolean"
                         },
                         "showAlertThresholdLines": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
@@ -3833,6 +3833,32 @@
                             },
                             "type": "array"
                         },
+                        "metricChangeDecreaseColor": {
+                            "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for the change pill when the metric went DOWN. Defaults to red (`#db3707`). For a \"lower is better\" metric (latency, error rate, cost), set this to a green (e.g. `#388600`) so a decrease reads as good.",
+                            "type": "string"
+                        },
+                        "metricChangeIncreaseColor": {
+                            "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for the change pill when the metric went UP. Defaults to green (`#388600`). For a \"lower is better\" metric (latency, error rate, cost), set this to a red (e.g. `#db3707`) so an increase reads as bad.",
+                            "type": "string"
+                        },
+                        "metricColorByDirection": {
+                            "default": false,
+                            "description": "Only applies when `display` is `Metric`. Color the sparkline under the big number by whether the metric increased or decreased over the period (using the increase/decrease line colors).",
+                            "type": "boolean"
+                        },
+                        "metricLineDecreaseColor": {
+                            "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went DOWN. Defaults to red (`#db3707`). Flip to a green for a \"lower is better\" metric.",
+                            "type": "string"
+                        },
+                        "metricLineIncreaseColor": {
+                            "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went UP. Defaults to green (`#388600`). Flip to a red for a \"lower is better\" metric.",
+                            "type": "string"
+                        },
+                        "metricShowChange": {
+                            "default": true,
+                            "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                            "type": "boolean"
+                        },
                         "showAlertThresholdLines": {
                             "default": false,
                             "description": "Whether to show alert threshold lines on the chart.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
@@ -3645,6 +3645,32 @@
                     },
                     "type": "array"
                 },
+                "metricChangeDecreaseColor": {
+                    "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#db3707`) for the change pill when the metric went DOWN. Defaults to red (`#db3707`). For a \"lower is better\" metric (latency, error rate, cost), set this to a green (e.g. `#388600`) so a decrease reads as good.",
+                    "type": "string"
+                },
+                "metricChangeIncreaseColor": {
+                    "description": "Only applies when `display` is `Metric`. Hex color (e.g. `#388600`) for the change pill when the metric went UP. Defaults to green (`#388600`). For a \"lower is better\" metric (latency, error rate, cost), set this to a red (e.g. `#db3707`) so an increase reads as bad.",
+                    "type": "string"
+                },
+                "metricColorByDirection": {
+                    "default": false,
+                    "description": "Only applies when `display` is `Metric`. Color the sparkline under the big number by whether the metric increased or decreased over the period (using the increase/decrease line colors).",
+                    "type": "boolean"
+                },
+                "metricLineDecreaseColor": {
+                    "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went DOWN. Defaults to red (`#db3707`). Flip to a green for a \"lower is better\" metric.",
+                    "type": "string"
+                },
+                "metricLineIncreaseColor": {
+                    "description": "Only applies when `display` is `Metric` and `metricColorByDirection` is `true`. Hex color for the sparkline when the metric went UP. Defaults to green (`#388600`). Flip to a red for a \"lower is better\" metric.",
+                    "type": "string"
+                },
+                "metricShowChange": {
+                    "default": true,
+                    "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                    "type": "boolean"
+                },
                 "showAlertThresholdLines": {
                     "default": false,
                     "description": "Whether to show alert threshold lines on the chart.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
@@ -3607,7 +3607,7 @@
                 },
                 "display": {
                     "default": "ActionsLineGraph",
-                    "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
+                    "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `Metric` - single large number with a period-over-period change pill and a sparkline. Like `BoldNumber` but trend-aware; configure it with the `metric*` fields below. Single series, no breakdown. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
                     "enum": [
                         "Auto",
                         "ActionsLineGraph",
@@ -3668,7 +3668,7 @@
                 },
                 "metricShowChange": {
                     "default": true,
-                    "description": "Only applies when `display` is `Metric`. Show the period-over-period change pill next to the big number. The pill needs a comparison period, so also set `compareFilter.compare` to `true`.",
+                    "description": "Only applies when `display` is `Metric`. Show the change pill next to the big number — the percentage change from the first to the last point of the series over the selected date range.",
                     "type": "boolean"
                 },
                 "showAlertThresholdLines": {


### PR DESCRIPTION
## Problem

The `query-trends` MCP tool couldn't set any of the **Metric** display's color/change options ("Show change", "Color by trend", and their increase/decrease colors). Its `trendsFilter` schema is a curated allowlist, and those six fields weren't on it — so an agent asked to, say, make a latency metric show a **decrease as green** had no way to do it through the typed tool. The backend already supports these fields (they round-trip through a freeform `insight-update` source), but that escape hatch isn't discoverable, so an agent doesn't know it's possible.

## Changes

Added the six Metric-display fields to `AssistantTrendsFilter` (the SSOT for the MCP trends query schema):

- `metricShowChange`
- `metricChangeIncreaseColor` / `metricChangeDecreaseColor`
- `metricColorByDirection`
- `metricLineIncreaseColor` / `metricLineDecreaseColor`

Each description spells out the "lower is better → flip the colors" case (latency, error rate, cost) and references the real defaults (green `#388600` / red `#db3707`), so an agent can invert the coloring on the first try instead of guessing.

Regenerated the downstream artifacts from the source edit:

| File | How |
| --- | --- |
| `frontend/src/queries/schema.json` | `schema:build:json` |
| `posthog/schema.py` | `build-schema-python.sh` |
| `services/mcp/src/tools/generated/query-wrappers.ts` | query-wrapper codegen (+38 lines, purely additive) |
| `services/mcp/tests/.../query-trends*.json` | snapshot update |

## How did you test this code?

I'm an agent. Automated tests I actually ran:

- `services/mcp` `tool-schema-snapshots.test.ts` (`vitest -u`) — passes; the two `query-trends*` snapshots now include the six fields, which also confirms the regenerated `query-wrappers.ts` imports and builds at runtime.
- Verified the fields are present in `schema.json`, `posthog/schema.py`, and `query-wrappers.ts`.

I could not run the full `hogli build:openapi` here — it needs Django + Postgres to emit `frontend/tmp/openapi.json`, which isn't available in this environment. I regenerated `query-wrappers.ts` by driving the pipeline's own `generateQueryWrapperFile` against the updated `schema.json` + YAML, then formatted with `hogli format:js`. A normal `hogli build:openapi` run in CI will reproduce the same output.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (PostHog MCP for live insight/dashboard ops, repo tools for the code change). Skill invoked: `/implementing-mcp-tools` (to confirm the schema → codegen pipeline and regeneration commands).

The work started as a request to color three dashboard metric cards so a decrease reads as good (green) for cache-hit latency. We found `query-trends` couldn't express it (curated `trendsFilter` allowlist), while `insight-update` could (freeform `source` that the backend already honors). The live cards were fixed via `insight-update`; this PR closes the discoverability gap by adding the fields to the typed `query-trends` schema with usage guidance, so future agents reach for the right path immediately.

`AssistantTrendsFilter` was the right layer to edit (vs. the full `TrendsFilter`) because it's what the MCP query wrappers generate from; the full `TrendsFilter` already had these fields.
