### PR TITLE
feat(signals): add signals section to web inbox scout detail

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -7,8 +7,10 @@ import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 import { pluralize } from 'lib/utils/strings'
 
 import { inboxSceneLogic } from '../../../inboxSceneLogic'
+import { scoutDetailLogic } from '../../../logics/scoutDetailLogic'
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { SCOUT_RUNS_WINDOW_SPAN, scoutRunsWindowLabel } from '../../../utils/scoutRunsWindow'
+import { ScoutEmissionCard } from './ScoutEmissionCard'
 import { ScoutRowCard } from './ScoutRowCard'
 
 /**
@@ -74,10 +76,38 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
                         </span>
                     </div>
 
+                    <ScoutSignalsSection skillName={skillName} />
+
                     <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
-                        Signals and run history are coming to this view soon.
+                        Run history is coming to this view soon.
                     </div>
                 </>
+            )}
+        </div>
+    )
+}
+
+/**
+ * The Signals section: every finding this scout emitted in the recent window, newest first.
+ * Emissions are fetched per emitted run by `scoutDetailLogic` (keyed by skill) off the fleet's
+ * already-polled runs window. Most runs are quiet, so an empty list is the healthy default.
+ */
+function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element {
+    const { emissionRows, emissionsLoading } = useValues(scoutDetailLogic({ skillName }))
+
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-default uppercase tracking-wide">Signals</span>
+            {emissionsLoading && emissionRows.length === 0 ? (
+                <LemonSkeleton className="h-12 w-full rounded" />
+            ) : emissionRows.length === 0 ? (
+                <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
+                    No signals emitted in the last {SCOUT_RUNS_WINDOW_SPAN}.
+                </div>
+            ) : (
+                emissionRows.map(({ emission, run }) => (
+                    <ScoutEmissionCard key={emission.id} emission={emission} run={run} />
+                ))
             )}
         </div>
     )

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -93,12 +93,18 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
  * already-polled runs window. Most runs are quiet, so an empty list is the healthy default.
  */
 function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element {
-    const { emissionRows, emissionsLoading } = useValues(scoutDetailLogic({ skillName }))
+    const { emissionRows, emissionsLoading, runsWindowLoadedOnce } = useValues(scoutDetailLogic({ skillName }))
+
+    // "Loading" until the fleet's runs window has settled once AND this scout's emissions have
+    // resolved — otherwise a fresh deep-link would flash the empty state before we know the
+    // emitted runs. Gating on the fleet's first-load flag (not its per-poll loading) keeps the
+    // quiet-scout empty state from flickering to a skeleton every 60s poll.
+    const loading = !runsWindowLoadedOnce || emissionsLoading
 
     return (
         <div className="flex flex-col gap-2">
             <span className="text-xs font-medium text-default uppercase tracking-wide">Signals</span>
-            {emissionsLoading && emissionRows.length === 0 ? (
+            {loading && emissionRows.length === 0 ? (
                 <LemonSkeleton className="h-12 w-full rounded" />
             ) : emissionRows.length === 0 ? (
                 <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -56,7 +56,10 @@ export function ScoutEmissionCard({
             </button>
 
             <div className="px-3 pb-2 pl-9">
-                <LemonMarkdown className={expanded ? 'text-sm text-primary' : 'text-sm text-primary line-clamp-2'}>
+                <LemonMarkdown
+                    disableImages
+                    className={expanded ? 'text-sm text-primary' : 'text-sm text-primary line-clamp-2'}
+                >
                     {emission.description || '_No description._'}
                 </LemonMarkdown>
 

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+
+import { IconChevronDown, IconExternal } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+
+import { SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
+import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
+
+/** Truncated mono identifier rendering for the footer finding id. */
+function MonoId({ label, value }: { label: string; value: string }): JSX.Element {
+    return (
+        <span className="inline-flex items-center gap-1">
+            <span>{label}</span>
+            <span className="font-mono">{value.length > 12 ? `${value.slice(0, 12)}…` : value}</span>
+        </span>
+    )
+}
+
+/**
+ * One emitted finding in the scout detail Signals section. Shares the collapse/expand grammar of
+ * the run rows: a header (chevron · severity · confidence · timestamp) that stays visible, a 2-line
+ * markdown preview when collapsed, and the full markdown plus an id/task-run footer when expanded.
+ */
+export function ScoutEmissionCard({
+    emission,
+    run,
+}: {
+    emission: SignalScoutEmission
+    run: SignalScoutRunSummary
+}): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
+
+    return (
+        <div className="flex flex-col rounded border border-primary bg-bg-light">
+            <button
+                type="button"
+                onClick={() => setExpanded((value) => !value)}
+                className="flex items-center gap-2 px-3 py-2 text-left"
+                aria-expanded={expanded}
+            >
+                <IconChevronDown
+                    className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
+                />
+                <SignalReportPriorityBadge priority={emission.severity} />
+                <span className="whitespace-nowrap text-[11px] text-muted tabular-nums">
+                    {confidencePercent}% confidence
+                </span>
+                <span className="flex-1" />
+                <span className="whitespace-nowrap text-[11px] text-muted">
+                    {humanFriendlyDetailedTime(emission.emitted_at)}
+                </span>
+            </button>
+
+            <div className="px-3 pb-2 pl-9">
+                <LemonMarkdown className={expanded ? 'text-sm text-primary' : 'text-sm text-primary line-clamp-2'}>
+                    {emission.description || '_No description._'}
+                </LemonMarkdown>
+
+                {expanded && (
+                    <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
+                        <MonoId label="Finding" value={emission.finding_id} />
+                        {run.task_url && (
+                            <>
+                                <span className="flex-1" />
+                                <Link to={run.task_url} className="flex items-center gap-1 font-medium shrink-0">
+                                    Open task run <IconExternal className="size-3" />
+                                </Link>
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -12,6 +12,12 @@ export interface ScoutDetailLogicProps {
     skillName: string
 }
 
+// A noisy scout on the 10-minute floor can rack up hundreds of emitted runs across the window;
+// fetching emissions for all of them at once would fan out hundreds of concurrent requests and
+// render hundreds of markdown cards. Bound both to the most recent N emitted runs — older
+// findings live on in the inbox reports they produced.
+const MAX_EMITTED_RUNS = 50
+
 /** An emitted finding paired with the run that produced it (for the run-level task link). */
 export interface ScoutEmissionRow {
     emission: SignalScoutEmission
@@ -31,7 +37,7 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
     key((props) => props.skillName),
 
     connect(() => ({
-        values: [scoutFleetLogic, ['rollups']],
+        values: [scoutFleetLogic, ['rollups', 'runsWindowLoadedOnce']],
     })),
 
     loaders(({ values }) => ({
@@ -43,29 +49,42 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                     if (runs.length === 0) {
                         return []
                     }
-                    const perRun = await Promise.all(runs.map((run) => api.signalScout.runs.emissions(run.run_id)))
-                    return perRun.flat()
+                    // allSettled, not all: one failed run's fetch (transient 500, deleted run)
+                    // shouldn't discard every other run's findings — surface the partial set.
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissions(run.run_id))
+                    )
+                    return settled
+                        .filter(
+                            (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
+                                result.status === 'fulfilled'
+                        )
+                        .flatMap((result) => result.value)
                 },
             },
         ],
     })),
 
     selectors({
-        // This scout's runs that emitted at least one finding, newest first.
+        // This scout's runs that emitted at least one finding, newest first, capped to the most
+        // recent MAX_EMITTED_RUNS. `.filter()` returns a fresh array, so the in-place `.sort()`
+        // never touches the shared rollup `runs` the header timeline reads (oldest-first).
         emittedRuns: [
             (s) => [s.rollups, (_, props) => props.skillName],
             (rollups, skillName): SignalScoutRunSummary[] =>
                 (rollups.get(skillName)?.runs ?? [])
                     .filter((run) => (run.emitted_count ?? 0) > 0)
-                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? '')),
+                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+                    .slice(0, MAX_EMITTED_RUNS),
         ],
-        // Stable string key over the emitted run ids — refetch emissions only when the set
-        // actually changes, not on every 60s runs-window poll that returns the same runs.
+        // Stable string key over the emitted runs — refetch emissions only when the set actually
+        // changes, not on every 60s runs-window poll that returns the same runs. Includes
+        // `emitted_count` so a run that emits more findings while still in progress retriggers.
         emittedRunsKey: [
             (s) => [s.emittedRuns],
             (emittedRuns): string =>
                 emittedRuns
-                    .map((run) => run.run_id)
+                    .map((run) => `${run.run_id}:${run.emitted_count ?? 0}`)
                     .sort()
                     .join(','),
         ],

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -1,0 +1,95 @@
+import { connect, kea, key, path, props, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
+
+import api from 'lib/api'
+
+import { SignalScoutEmission, SignalScoutRunSummary } from '../types'
+import type { scoutDetailLogicType } from './scoutDetailLogicType'
+import { scoutFleetLogic } from './scoutFleetLogic'
+
+export interface ScoutDetailLogicProps {
+    skillName: string
+}
+
+/** An emitted finding paired with the run that produced it (for the run-level task link). */
+export interface ScoutEmissionRow {
+    emission: SignalScoutEmission
+    run: SignalScoutRunSummary
+}
+
+/**
+ * Per-scout detail logic, keyed by skill_name. Reuses the singleton `scoutFleetLogic`'s
+ * runs window (already polled while the detail page is open) to find this scout's emitted
+ * runs, then fetches each run's emissions and flattens them into one newest-first list — the
+ * Signals section. The runs endpoint has no per-finding listing, so emissions are fetched
+ * per emitted run; quiet runs (the vast majority) are never hit.
+ */
+export const scoutDetailLogic = kea<scoutDetailLogicType>([
+    path((key) => ['scenes', 'inbox', 'logics', 'scoutDetailLogic', key]),
+    props({} as ScoutDetailLogicProps),
+    key((props) => props.skillName),
+
+    connect(() => ({
+        values: [scoutFleetLogic, ['rollups']],
+    })),
+
+    loaders(({ values }) => ({
+        emissions: [
+            [] as SignalScoutEmission[],
+            {
+                loadEmissions: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    const perRun = await Promise.all(runs.map((run) => api.signalScout.runs.emissions(run.run_id)))
+                    return perRun.flat()
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        // This scout's runs that emitted at least one finding, newest first.
+        emittedRuns: [
+            (s) => [s.rollups, (_, props) => props.skillName],
+            (rollups, skillName): SignalScoutRunSummary[] =>
+                (rollups.get(skillName)?.runs ?? [])
+                    .filter((run) => (run.emitted_count ?? 0) > 0)
+                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? '')),
+        ],
+        // Stable string key over the emitted run ids — refetch emissions only when the set
+        // actually changes, not on every 60s runs-window poll that returns the same runs.
+        emittedRunsKey: [
+            (s) => [s.emittedRuns],
+            (emittedRuns): string =>
+                emittedRuns
+                    .map((run) => run.run_id)
+                    .sort()
+                    .join(','),
+        ],
+        // Join fetched emissions back to their run (for the per-row task-run link), newest first.
+        emissionRows: [
+            (s) => [s.emissions, s.emittedRuns],
+            (emissions, emittedRuns): ScoutEmissionRow[] => {
+                const runsById = new Map(emittedRuns.map((run) => [run.run_id, run]))
+                return emissions
+                    .map((emission) => {
+                        const run = runsById.get(emission.run_id)
+                        return run ? { emission, run } : null
+                    })
+                    .filter((row): row is ScoutEmissionRow => row !== null)
+                    .sort((a, b) => (b.emission.emitted_at ?? '').localeCompare(a.emission.emitted_at ?? ''))
+            },
+        ],
+    }),
+
+    subscriptions(({ actions }) => ({
+        // Fires on mount (empty → real ids once the runs window loads) and whenever the set of
+        // emitted runs changes; the string key holds equal across no-op polls so we don't refetch.
+        emittedRunsKey: () => {
+            actions.loadEmissions()
+        },
+    })),
+])

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -153,6 +153,16 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                     state?.map((config) => (config.id === configId ? { ...config, ...updates } : config)) ?? state,
             },
         ],
+        // Flips true the first time the runs window settles (success or failure) and stays true
+        // across the 60s polls. Consumers (e.g. the scout detail Signals section) use it to tell
+        // "not loaded yet" from "loaded, genuinely empty" without flickering a skeleton on polls.
+        runsWindowLoadedOnce: [
+            false,
+            {
+                loadRunsWindowSuccess: () => true,
+                loadRunsWindowFailure: () => true,
+            },
+        ],
     }),
 
     selectors({


### PR DESCRIPTION
## Problem

PR #64642 added the web inbox scout **detail** page (header + recent-window rollup) but left the body as a placeholder. The scout's actual product — the findings it emitted — wasn't visible anywhere on the page. This is **W2** in the web-parity backlog: the signals-first core of the detail surface, matching the desktop app.

## Changes

Replaces the placeholder with a **Signals section**: every finding the scout emitted in the recent window, newest first, one card each.

- **`ScoutEmissionCard`** — markdown description, severity badge (P0–P4), confidence %, and an expand/collapse grammar matching the desktop cards. Collapsed shows a preview; expanded reveals the finding id + an "Open task run ↗" link (from the run's `task_url`).
- **`scoutDetailLogic`** — a keyed (per-skill) kea logic that reads this scout's emitted runs off `scoutFleetLogic`'s already-polled runs window, fetches each emitted run's emissions via `api.signalScout.runs.emissions`, and flattens them into one newest-first list. Quiet runs (the vast majority) are never fetched. A stable string key over the emitted-run ids gates refetches so the 60s fleet poll doesn't re-hit the endpoint when nothing changed.
- Empty state: "No signals emitted in the last 3 days." — the healthy default for a quiet scout.

Run history (W3) is still a placeholder.

### Screenshots

| Populated | Empty |
|---|---|
| P2 badge · 82% confidence · markdown body; expands to finding id + task-run link | "No signals emitted in the last 3 days." |

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- `kea-typegen write` (generated types resolve), `typescript:check` (clean — only the pre-existing unrelated `DebugCHQueriesType.ts` error remains), and `oxlint` + `oxfmt` on the three files (0 warnings/errors).

Manual verification on the local dev stack (project 1) via Playwright: I seeded one temporary emission on a recent in-window run, confirmed the card rendered (severity, confidence, markdown bold + inline code), confirmed expand revealed the footer + task-run link, confirmed the empty state on a scout with no emissions, then deleted the seeded row and restored the run. No automated component tests were added (matches the currently untested `scoutFleetLogic`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed this as the next step (W2) in the scouts-ui workstream after #64642 merged.

Built with Claude Code. No repo skills were required for this change (frontend-only, no DRF/migration/API-type surface). Followed the existing inbox conventions: business logic in a kea logic (not React hooks), reused `SignalReportPriorityBadge` and `LemonMarkdown`. One bug caught during live testing — the kea selector referenced the loader-provided `emissions` value before `loaders` was declared, which threw an "incorrect input" build error; fixed by ordering `loaders` before `selectors`.
