### PR TITLE
feat(dashboards): add hover refresh button to dashboard tiles

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -580,6 +580,10 @@ snapshots:
         hash: v1.k794b7964.902c9be7688a67190b37eb789707bf2189b13e6c460cef63e1070dfc17196184.gxj4XB703vlholt4Z8TC2bjHVRiWJMMwT3xap2L1Sfg
     components-hogcharts-combochart--stacked-bars-and-line--light:
         hash: v1.k794b7964.da86914291718262e6fc1aa52483bcca08ac08c9c2fad67c5f877d6cf78151f7.qO61mSB67aOC7auAYE6KLt69LLRyWdM_VM-Vf0qrq6Q
+    components-hogcharts-legend--built-in-toggle--dark:
+        hash: v1.k794b7964.a44913b0e0cdf88b5d0d8960560fa4ce5a663f0b187cdcc5a723d1bb9b653fc6.pxcAORXTtyj4dK4h_9PUe9keV7tagKmaBvwS56KoeXI
+    components-hogcharts-legend--built-in-toggle--light:
+        hash: v1.k794b7964.dc8065b867dd309ca1c05935745e283b13d2fd7ebb7ddde80c9b5e8c24ee6cec.BzRyo-huuWL4HvNyXrykyXbCBuFTjeQKpECqODhn7AE
     components-hogcharts-legend--horizontal--dark:
         hash: v1.k794b7964.748c8221979ca1984c3ef06b0a2d5016e683810a2530a2b7549ff2994484d32d.WlgOW_onzflesCUfetduXiySjbl4uF8oTLxdKf4xYso
     components-hogcharts-legend--horizontal--light:

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -104,6 +104,8 @@
             position: absolute;
             top: 0.5rem;
             right: 0.75rem;
+            // Opaque strip so the hover-revealed refresh icon sits over (not garbles) the title tail.
+            background: var(--color-bg-surface-primary);
         }
 
         .CardMeta__divider {

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -104,6 +104,7 @@
             position: absolute;
             top: 0.5rem;
             right: 0.75rem;
+
             // Opaque strip so the hover-revealed refresh icon sits over (not garbles) the title tail.
             background: var(--color-bg-surface-primary);
         }

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -198,15 +198,15 @@
     align-items: center;
 }
 
-// Refresh control is hidden at rest and revealed on tile hover (or keyboard focus)
-// so it doesn't crowd the tile.
+// Refresh control is hidden at rest and revealed when hovering the tile header (or on
+// keyboard focus) so it doesn't crowd the tile or trigger from hovering the chart.
 .CardMeta__refresh {
     opacity: 0;
     pointer-events: none;
     transition: opacity 150ms ease;
 }
 
-.DashboardTileCard:hover .CardMeta__refresh,
+.CardMeta:hover .CardMeta__refresh,
 .CardMeta__refresh:focus-visible,
 .CardMeta__refresh:focus-within {
     opacity: 1;

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -198,17 +198,14 @@
     align-items: center;
 }
 
-// Refresh control is hidden at rest and revealed when hovering the tile header (or on
-// keyboard focus) so it doesn't crowd the tile or trigger from hovering the chart.
+// Refresh control is hidden at rest and revealed only when hovering the tile header.
+// Use `visibility` (not `opacity`) so a disabled LemonButton's own opacity override
+// — which kicks in once a refreshed tile is rate-limited — can't keep it visible.
+// Keyboard/touch users reach refresh via the always-present "⋯" menu.
 .CardMeta__refresh {
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 150ms ease;
+    visibility: hidden;
 }
 
-// Strictly hover — no focus reveal, so clicking the icon doesn't pin it visible after the
-// pointer leaves. Keyboard users still reach refresh via the always-present "⋯" menu.
 .CardMeta:hover .CardMeta__refresh {
-    opacity: 1;
-    pointer-events: auto;
+    visibility: visible;
 }

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -206,9 +206,10 @@
     transition: opacity 150ms ease;
 }
 
+// :focus-visible (not :focus-within) so a mouse click doesn't keep the icon pinned visible
+// after the pointer leaves — keyboard focus still reveals it.
 .CardMeta:hover .CardMeta__refresh,
-.CardMeta__refresh:focus-visible,
-.CardMeta__refresh:focus-within {
+.CardMeta__refresh:focus-visible {
     opacity: 1;
     pointer-events: auto;
 }

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -198,21 +198,24 @@
     align-items: center;
 }
 
-// Refresh control is revealed on tile hover so it doesn't crowd the tile at rest.
-// On touch devices (no hover) it stays visible so it remains reachable.
+// Refresh control is hidden at rest and revealed on tile hover (or keyboard focus)
+// so it doesn't crowd the tile.
 .CardMeta__refresh {
+    opacity: 0;
+    pointer-events: none;
     transition: opacity 150ms ease;
 }
 
-@media (hover: hover) {
-    .CardMeta__refresh {
-        opacity: 0;
-        pointer-events: none;
-    }
+.DashboardTileCard:hover .CardMeta__refresh,
+.CardMeta__refresh:focus-visible,
+.CardMeta__refresh:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+}
 
-    .DashboardTileCard:hover .CardMeta__refresh,
-    .CardMeta__refresh:focus-visible,
-    .CardMeta__refresh:focus-within {
+// Touch devices have no hover, so keep the control reachable.
+@media (hover: none) {
+    .CardMeta__refresh {
         opacity: 1;
         pointer-events: auto;
     }

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -211,3 +211,12 @@
 .CardMeta:hover .CardMeta__refresh {
     visibility: visible;
 }
+
+// On compact tiles too narrow to fit the icon without overlapping the title, keep it hidden
+// even on hover — refresh stays available in the "⋯" menu. The container is only established in
+// compact mode, so this never applies to the non-compact (saved insights) layout.
+@container (max-width: 22rem) {
+    .CardMeta:hover .CardMeta__refresh {
+        visibility: hidden;
+    }
+}

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -206,10 +206,9 @@
     transition: opacity 150ms ease;
 }
 
-// :focus-visible (not :focus-within) so a mouse click doesn't keep the icon pinned visible
-// after the pointer leaves — keyboard focus still reveals it.
-.CardMeta:hover .CardMeta__refresh,
-.CardMeta__refresh:focus-visible {
+// Strictly hover — no focus reveal, so clicking the icon doesn't pin it visible after the
+// pointer leaves. Keyboard users still reach refresh via the always-present "⋯" menu.
+.CardMeta:hover .CardMeta__refresh {
     opacity: 1;
     pointer-events: auto;
 }

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -197,3 +197,23 @@
     gap: 0.25rem;
     align-items: center;
 }
+
+// Refresh control is revealed on tile hover so it doesn't crowd the tile at rest.
+// On touch devices (no hover) it stays visible so it remains reachable.
+.CardMeta__refresh {
+    transition: opacity 150ms ease;
+}
+
+@media (hover: hover) {
+    .CardMeta__refresh {
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    .DashboardTileCard:hover .CardMeta__refresh,
+    .CardMeta__refresh:focus-visible,
+    .CardMeta__refresh:focus-within {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -212,11 +212,3 @@
     opacity: 1;
     pointer-events: auto;
 }
-
-// Touch devices have no hover, so keep the control reachable.
-@media (hover: none) {
-    .CardMeta__refresh {
-        opacity: 1;
-        pointer-events: auto;
-    }
-}

--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -39,6 +39,8 @@ export interface CardMetaProps extends Pick<React.HTMLAttributes<HTMLDivElement>
     samplingFactor?: number | null
     /** Additional controls to show in the top controls area */
     extraControls?: JSX.Element | null
+    /** Refresh control revealed on card hover, shown in the top controls area. */
+    refreshControl?: JSX.Element | null
     /** Description shown in the compact popover. */
     metaDescription?: JSX.Element | null
     /** Heading always shown in the popover (e.g. insight type + date range). Falls back to topHeading. */
@@ -68,6 +70,7 @@ export function CardMeta({
     onMouseDown,
     samplingFactor,
     extraControls,
+    refreshControl,
 }: CardMetaProps): JSX.Element {
     const { ref: primaryRef, width: primaryWidth } = useResizeObserver()
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
@@ -125,6 +128,7 @@ export function CardMeta({
                             <div className="CardMeta__top">
                                 <div className="CardMeta__heading">{topHeading}</div>
                                 <div className="CardMeta__controls">
+                                    {refreshControl}
                                     {showEditingControls &&
                                         (moreTooltip ? (
                                             <Tooltip title={moreTooltip}>
@@ -155,6 +159,7 @@ export function CardMeta({
                                     )}
                                 </h5>
                                 <div className="CardMeta__controls">
+                                    {refreshControl}
                                     {extraControls &&
                                         React.cloneElement(extraControls, {
                                             ...extraControls.props,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -76,7 +76,6 @@ export interface InsightCardProps extends Resizeable {
     removeFromDashboard?: () => void
     deleteWithUndo?: () => Promise<void>
     refresh?: () => void
-    refreshEnabled?: boolean
     rename?: () => void
     duplicate?: () => void
     setOverride?: () => void
@@ -131,7 +130,6 @@ function InsightCardInternal(
         removeFromDashboard,
         deleteWithUndo,
         refresh,
-        refreshEnabled,
         rename,
         duplicate,
         setOverride,
@@ -265,7 +263,6 @@ function InsightCardInternal(
                         removeFromDashboard={removeFromDashboard}
                         deleteWithUndo={deleteWithUndo}
                         refresh={refresh}
-                        refreshEnabled={refreshEnabled}
                         loadingQueued={loadingQueued}
                         loading={loading}
                         rename={rename}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconInfo, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconInfo, IconRefresh, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
@@ -12,7 +12,6 @@ import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -279,12 +278,35 @@ export function InsightMeta({
         )
     }
 
-    const refreshDisabledReason =
+    const nextRefreshFromNow =
         nextAllowedClientRefresh && dayjs(nextAllowedClientRefresh).isAfter(dayjs())
-            ? 'You are viewing the most recent calculated results.'
-            : loading || loadingQueued || !refreshEnabled
-              ? 'Refreshing...'
-              : undefined
+            ? dayjs(nextAllowedClientRefresh).fromNow()
+            : null
+    const refreshDisabledReason = nextRefreshFromNow
+        ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
+        : loading || loadingQueued
+          ? 'Refreshing…'
+          : !refreshEnabled
+            ? 'Another tile is refreshing — please wait…'
+            : undefined
+
+    const refreshControl = refresh ? (
+        <LemonButton
+            className="CardMeta__refresh"
+            icon={<IconRefresh />}
+            size="small"
+            onClick={() => refresh()}
+            disabledReason={refreshDisabledReason}
+            tooltip={
+                refreshDisabledReason
+                    ? undefined
+                    : insight.last_refresh
+                      ? `Refresh data (last computed ${dayjs(insight.last_refresh).fromNow()})`
+                      : 'Refresh data'
+            }
+            data-attr="insight-card-refresh"
+        />
+    ) : null
 
     const topHeadingEl = showCompactHeading ? (
         <TopHeading {...topHeadingProps} showInsightType={!showCompactTile} />
@@ -563,34 +585,6 @@ export function InsightMeta({
                                 />
                             </>
                         ) : null}
-                        <>
-                            {refresh && (
-                                <LemonButton
-                                    onClick={() => {
-                                        refresh()
-                                    }}
-                                    disabledReason={refreshDisabledReason}
-                                    fullWidth
-                                >
-                                    {insight.last_refresh ? (
-                                        <div className="block my-1">
-                                            Refresh data
-                                            <p className="text-xs text-muted mt-0.5">
-                                                Last computed{' '}
-                                                <TZLabel
-                                                    time={insight.last_refresh}
-                                                    noStyles
-                                                    className="whitespace-nowrap border-dotted border-b"
-                                                />
-                                            </p>
-                                        </div>
-                                    ) : (
-                                        <>Refresh data</>
-                                    )}
-                                </LemonButton>
-                            )}
-                        </>
-
                         {/* More */}
                         {moreButtons && (
                             <>
@@ -602,10 +596,11 @@ export function InsightMeta({
                 }
                 moreTooltip={
                     canEditInsight
-                        ? 'Rename, duplicate, export, refresh and more…'
-                        : 'Duplicate, export, refresh and more…'
+                        ? 'Rename, duplicate, export and more…'
+                        : 'Duplicate, export and more…'
                 }
                 extraControls={surveyOpportunityButton ?? feedbackButtons}
+                refreshControl={refreshControl}
             />
             {showDashboardAlertsMenuItem && insight.id ? (
                 <ManageAlertsModal

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -289,15 +289,19 @@ export function InsightMeta({
             : null
     const refreshDisabledReason = nextRefreshFromNow
         ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
-        : !refreshEnabled
-          ? 'Another tile is refreshing — please wait…'
+        : // `refreshEnabled` is false both while another tile refreshes and during the initial
+          // dashboard load, so keep the message accurate for both rather than naming a tile.
+          !refreshEnabled
+          ? 'The dashboard is busy — please wait…'
           : undefined
     // The always-visible "⋯" menu keeps refresh reachable on touch/keyboard. Unlike the hover
     // icon (which hides while this tile refreshes) the menu item stays but disables.
     const refreshMenuDisabledReason = tileRefreshing ? 'Refreshing…' : refreshDisabledReason
 
+    // Gate the hover icon on `showEditingControls` so it doesn't appear on public/export
+    // dashboards, matching the "⋯" menu (which is already gated there).
     const refreshControl =
-        refresh && !tileRefreshing ? (
+        refresh && showEditingControls && !tileRefreshing ? (
             <LemonButton
                 className="CardMeta__refresh"
                 icon={<IconRefresh />}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -8,6 +8,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
 import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { CardMeta } from 'lib/components/Cards/CardMeta'
+import { DashboardTileRefreshDataButton } from 'lib/components/Cards/InsightCard/DashboardTileRefreshDataButton'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
@@ -288,6 +289,9 @@ export function InsightMeta({
     const refreshDisabledReason = nextRefreshFromNow
         ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
         : undefined
+    // The hover icon is desktop-only, so the always-visible "⋯" menu keeps refresh reachable on
+    // touch. Unlike the hover icon (which hides while refreshing) the menu item stays but disables.
+    const refreshMenuDisabledReason = refreshDisabledReason ?? (refreshInProgress ? 'Refreshing…' : undefined)
 
     const refreshControl =
         refresh && !refreshInProgress ? (
@@ -585,6 +589,13 @@ export function InsightMeta({
                                 />
                             </>
                         ) : null}
+                        {refresh && (
+                            <DashboardTileRefreshDataButton
+                                onRefresh={refresh}
+                                disabledReason={refreshMenuDisabledReason}
+                                lastRefresh={insight.last_refresh}
+                            />
+                        )}
                         {/* More */}
                         {moreButtons && (
                             <>
@@ -594,7 +605,11 @@ export function InsightMeta({
                         )}
                     </>
                 }
-                moreTooltip={canEditInsight ? 'Rename, duplicate, export and more…' : 'Duplicate, export and more…'}
+                moreTooltip={
+                    canEditInsight
+                        ? 'Rename, duplicate, export, refresh and more…'
+                        : 'Duplicate, export, refresh and more…'
+                }
                 extraControls={surveyOpportunityButton ?? feedbackButtons}
                 refreshControl={refreshControl}
             />

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -68,7 +68,6 @@ interface InsightMetaProps extends Pick<
     | 'removeFromDashboard'
     | 'deleteWithUndo'
     | 'refresh'
-    | 'refreshEnabled'
     | 'loading'
     | 'loadingQueued'
     | 'rename'
@@ -105,7 +104,6 @@ export function InsightMeta({
     removeFromDashboard,
     deleteWithUndo,
     refresh,
-    refreshEnabled,
     loading,
     loadingQueued,
     rename,
@@ -279,9 +277,9 @@ export function InsightMeta({
         )
     }
 
-    // Only suppress this tile's icon while this tile itself is refreshing (a full-dashboard
-    // refresh marks every tile as loading, so it still hides them all). Other tiles keep their
-    // icon — disabled with a reason — while a different tile refreshes.
+    // Suppress this tile's icon only while this tile itself is refreshing (a full-dashboard
+    // refresh marks every tile as loading, so it still hides them all). Other tiles stay
+    // refreshable — the batched refresh already caps concurrency, so there's no need to block.
     const tileRefreshing = !!(loading || loadingQueued)
     const nextRefreshFromNow =
         nextAllowedClientRefresh && dayjs(nextAllowedClientRefresh).isAfter(dayjs())
@@ -289,11 +287,7 @@ export function InsightMeta({
             : null
     const refreshDisabledReason = nextRefreshFromNow
         ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
-        : // `refreshEnabled` is false both while another tile refreshes and during the initial
-          // dashboard load, so keep the message accurate for both rather than naming a tile.
-          !refreshEnabled
-          ? 'The dashboard is busy — please wait…'
-          : undefined
+        : undefined
     // The always-visible "⋯" menu keeps refresh reachable on touch/keyboard. Unlike the hover
     // icon (which hides while this tile refreshes) the menu item stays but disables.
     const refreshMenuDisabledReason = tileRefreshing ? 'Refreshing…' : refreshDisabledReason

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -279,22 +279,25 @@ export function InsightMeta({
         )
     }
 
-    // Hide the per-tile refresh control while anything is refreshing (e.g. a full-dashboard
-    // refresh marks every tile as loading) so the icons don't flash across all tiles at once.
-    const refreshInProgress = loading || loadingQueued || !refreshEnabled
+    // Only suppress this tile's icon while this tile itself is refreshing (a full-dashboard
+    // refresh marks every tile as loading, so it still hides them all). Other tiles keep their
+    // icon — disabled with a reason — while a different tile refreshes.
+    const tileRefreshing = !!(loading || loadingQueued)
     const nextRefreshFromNow =
         nextAllowedClientRefresh && dayjs(nextAllowedClientRefresh).isAfter(dayjs())
             ? dayjs(nextAllowedClientRefresh).fromNow()
             : null
     const refreshDisabledReason = nextRefreshFromNow
         ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
-        : undefined
-    // The hover icon is desktop-only, so the always-visible "⋯" menu keeps refresh reachable on
-    // touch. Unlike the hover icon (which hides while refreshing) the menu item stays but disables.
-    const refreshMenuDisabledReason = refreshDisabledReason ?? (refreshInProgress ? 'Refreshing…' : undefined)
+        : !refreshEnabled
+          ? 'Another tile is refreshing — please wait…'
+          : undefined
+    // The always-visible "⋯" menu keeps refresh reachable on touch/keyboard. Unlike the hover
+    // icon (which hides while this tile refreshes) the menu item stays but disables.
+    const refreshMenuDisabledReason = tileRefreshing ? 'Refreshing…' : refreshDisabledReason
 
     const refreshControl =
-        refresh && !refreshInProgress ? (
+        refresh && !tileRefreshing ? (
             <LemonButton
                 className="CardMeta__refresh"
                 icon={<IconRefresh />}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -594,11 +594,7 @@ export function InsightMeta({
                         )}
                     </>
                 }
-                moreTooltip={
-                    canEditInsight
-                        ? 'Rename, duplicate, export and more…'
-                        : 'Duplicate, export and more…'
-                }
+                moreTooltip={canEditInsight ? 'Rename, duplicate, export and more…' : 'Duplicate, export and more…'}
                 extraControls={surveyOpportunityButton ?? feedbackButtons}
                 refreshControl={refreshControl}
             />

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -278,35 +278,35 @@ export function InsightMeta({
         )
     }
 
+    // Hide the per-tile refresh control while anything is refreshing (e.g. a full-dashboard
+    // refresh marks every tile as loading) so the icons don't flash across all tiles at once.
+    const refreshInProgress = loading || loadingQueued || !refreshEnabled
     const nextRefreshFromNow =
         nextAllowedClientRefresh && dayjs(nextAllowedClientRefresh).isAfter(dayjs())
             ? dayjs(nextAllowedClientRefresh).fromNow()
             : null
     const refreshDisabledReason = nextRefreshFromNow
         ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
-        : loading || loadingQueued
-          ? 'Refreshing…'
-          : !refreshEnabled
-            ? 'Another tile is refreshing — please wait…'
-            : undefined
+        : undefined
 
-    const refreshControl = refresh ? (
-        <LemonButton
-            className="CardMeta__refresh"
-            icon={<IconRefresh />}
-            size="small"
-            onClick={() => refresh()}
-            disabledReason={refreshDisabledReason}
-            tooltip={
-                refreshDisabledReason
-                    ? undefined
-                    : insight.last_refresh
-                      ? `Refresh data (last computed ${dayjs(insight.last_refresh).fromNow()})`
-                      : 'Refresh data'
-            }
-            data-attr="insight-card-refresh"
-        />
-    ) : null
+    const refreshControl =
+        refresh && !refreshInProgress ? (
+            <LemonButton
+                className="CardMeta__refresh"
+                icon={<IconRefresh />}
+                size="small"
+                onClick={() => refresh()}
+                disabledReason={refreshDisabledReason}
+                tooltip={
+                    refreshDisabledReason
+                        ? undefined
+                        : insight.last_refresh
+                          ? `Refresh data (last computed ${dayjs(insight.last_refresh).fromNow()})`
+                          : 'Refresh data'
+                }
+                data-attr="insight-card-refresh"
+            />
+        ) : null
 
     const topHeadingEl = showCompactHeading ? (
         <TopHeading {...topHeadingProps} showInsightType={!showCompactTile} />

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -47,7 +47,6 @@ export function DashboardItems(): JSX.Element {
         isRefreshing,
         highlightedInsightId,
         refreshStatus,
-        itemsLoading,
         dashboardStreaming,
         effectiveEditBarFilters,
         effectiveDashboardVariableOverrides,
@@ -445,7 +444,6 @@ export function DashboardItems(): JSX.Element {
                                         toggleShowDescription={() => toggleTileDescription(tile.id)}
                                         ribbonColor={tile.color}
                                         refresh={() => refreshDashboardItem({ tile })}
-                                        refreshEnabled={!itemsLoading}
                                         rename={() => renameInsight(insight)}
                                         duplicate={() => duplicateTile(tile)}
                                         setOverride={() => setTileOverride(tile)}

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2305,6 +2305,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return
             }
 
+            // Shared/public/export viewers must not be able to trigger server-side refreshes.
+            if (isSharedView()) {
+                return
+            }
+
             // Cache values before the long-running await — the logic may unmount
             const { currentTeamId, effectiveRefreshFilters, urlFilters, urlVariables } = values
 


### PR DESCRIPTION
## Problem

- Refreshing a single dashboard tile required opening the "⋯" menu — slow when you just want to recompute one tile.
- No at-a-glance signal for *why* a tile can't be refreshed yet.

## Changes

https://github.com/user-attachments/assets/7742a434-6ae6-4543-9900-047baeb02860


- Adds a refresh icon to each tile, revealed **only on hover of the tile header**.
- Respects existing refresh rules; when rate-limited, the button disables and the tooltip explains why (e.g. "next refresh available in N minutes").
- When enabled, tooltip shows when data was last computed.
- A tile's icon hides only while **that tile itself** is refreshing; other tiles stay refreshable (the batched refresh already caps concurrency).
- Hidden on public/export dashboards, and `refreshDashboardItem` is guarded with `isSharedView()` so shared viewers can't trigger server-side refreshes.
- Keeps "Refresh data" in the "⋯" menu so refresh stays reachable on touch/keyboard.

## How did you test this code?

- I'm an agent. Verified formatting (oxfmt) and TypeScript locally; relied on CI for the full suite.
- Ran an automated multi-angle code review over the diff and fixed the confirmed findings (public-dashboard exposure, compact-mode title overlap).
- No existing tests assert on the changed UI; `products/dashboards/.../WidgetCard` refresh tests target a separate component and are unaffected.
- Note: visible UI change — `InsightCard` Storybook snapshots will need regenerating.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code at a contributor's direction.
- Added a generic `refreshControl` slot to `CardMeta` (rendered in compact + non-compact layouts); `InsightMeta` supplies the icon button.
- Reveal gated with `visibility` (not `opacity`) on `.CardMeta:hover` — a disabled `LemonButton`'s own opacity override was otherwise keeping rate-limited tiles' icons pinned visible. Compact controls strip has a surface background so the icon overlays the title cleanly.
- Security: icon gated on `showEditingControls` and the refresh action guarded with `isSharedView()`.
- Dropped the original `refreshEnabled` gate (and its prop threading) so tiles can refresh concurrently — the batched refresh already caps concurrency at 4, so blocking other tiles was needless friction.
- No skills were applicable.