### PR TITLE
test(data-warehouse): speed up non-retryable short-circuit e2e test

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -69,6 +69,12 @@ from products.warehouse_sources.backend.models.external_data_source import Exter
 
 LOGGER = get_logger(__name__)
 
+# Cap retries at 3 in local dev so failing syncs don't loop for tens of minutes while developers
+# iterate; prod cadence is unchanged. Defined at module level so tests can patch them to keep the
+# expensive retry-exhaustion paths fast.
+MAX_RESUMABLE_SOURCE_RETRIES = 3 if settings.DEBUG else 15
+MAX_INCREMENTAL_SOURCE_RETRIES = 3 if settings.DEBUG else 9
+
 Any_Source_Errors: dict[str, str | None] = {
     "Could not establish session to SSH gateway": None,
     # Raised by `SSHTunnel.get_tunnel` when `is_auth_valid()` fails — the SSH tunnel private key
@@ -393,11 +399,8 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
                 source = SourceRegistry.get_source(ExternalDataSourceType(source_type))
                 is_resumable_source = isinstance(source, ResumableSource)
 
-            # Cap retries at 3 in local dev so failing syncs don't loop for
-            # tens of minutes while developers iterate. Prod cadence is
-            # unchanged.
-            max_resumable_attempts = 3 if settings.DEBUG else 15
-            max_incremental_attempts = 3 if settings.DEBUG else 9
+            max_resumable_attempts = MAX_RESUMABLE_SOURCE_RETRIES
+            max_incremental_attempts = MAX_INCREMENTAL_SOURCE_RETRIES
 
             if is_resumable_source:
                 timeout_params = {

--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -53,6 +53,11 @@ def build_non_retryable_errors_redis_key(team_id: int, source_id: str, run_id: s
     return f"posthog:data_warehouse:non_retryable_errors:{team_id}:{source_id}:{run_id}"
 
 
+# A source-classified non-retryable error still gets a small retry budget before we give up, in
+# case the failure was transient despite matching a known pattern.
+NON_RETRYABLE_ERROR_RETRY_LIMIT = 3
+
+
 async def trim_source_job_inputs(source: "ExternalDataSource") -> None:
     if not source.job_inputs:
         return
@@ -169,9 +174,11 @@ async def handle_non_retryable_error(
         )
         attempts = await redis_client.incr(retry_key)
 
-        if attempts <= 3:
+        if attempts <= NON_RETRYABLE_ERROR_RETRY_LIMIT:
             await redis_client.expire(retry_key, 86400)  # Expire after 24 hours
-            await logger.adebug(f"Non-retryable error attempt {attempts}/3, retrying. error={error_msg}")
+            await logger.adebug(
+                f"Non-retryable error attempt {attempts}/{NON_RETRYABLE_ERROR_RETRY_LIMIT}, retrying. error={error_msg}"
+            )
             raise error
 
     await logger.adebug(f"Non-retryable error after {attempts} runs, giving up. error={error_msg}")

--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -53,8 +53,6 @@ def build_non_retryable_errors_redis_key(team_id: int, source_id: str, run_id: s
     return f"posthog:data_warehouse:non_retryable_errors:{team_id}:{source_id}:{run_id}"
 
 
-# A source-classified non-retryable error still gets a small retry budget before we give up, in
-# case the failure was transient despite matching a known pattern.
 NON_RETRYABLE_ERROR_RETRY_LIMIT = 3
 
 

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -3361,50 +3361,71 @@ async def test_v3_delta_commit_metadata_and_idempotency_fallback(team, stripe_cu
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_non_retryable_error_short_circuiting(team, stripe_customer, mock_stripe_client):
-    with mock.patch("posthog.temporal.data_imports.sources.stripe.stripe.get_rows") as mock_get_rows:
-        mock_get_rows.side_effect = Exception("Some error that doesn't retry")
+@pytest.mark.parametrize("pipeline_mode", ["non_dlt"], indirect=True)
+async def test_non_retryable_error_short_circuiting(team, stripe_customer, mock_stripe_client, pipeline_mode):
+    # The retry/short-circuit behaviour lives in the workflow + activity layer, upstream of the
+    # v3/non_dlt split, so running a single pipeline mode is enough — running both just doubles the
+    # cost. Each attempt re-executes the whole import activity, so we also shrink the retry budgets
+    # to keep the test fast: cap resumable retries at 3 and make the non-retryable path give up after
+    # 2 attempts. The contrast (3 retryable attempts vs 2 non-retryable attempts) is what proves the
+    # short-circuit; the prod caps (15 / 3) are just larger values of the same mechanism.
+    resumable_retry_cap = 3
+    non_retryable_attempts = 2
 
-        with pytest.raises(Exception):
-            await _run(
-                team=team,
-                schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,
-                table_name="stripe_customer",
-                source_type="Stripe",
-                job_inputs={
-                    "auth_method": {"selection": "api_key", "stripe_secret_key": "test-key"},
-                    "stripe_account_id": "acct_id",
-                },
-                mock_data_response=stripe_customer["data"],
-                ignore_assertions=True,
-            )
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.external_data_job.MAX_RESUMABLE_SOURCE_RETRIES",
+            resumable_retry_cap,
+        ),
+        mock.patch(
+            "posthog.temporal.data_imports.pipelines.common.extract.NON_RETRYABLE_ERROR_RETRY_LIMIT",
+            non_retryable_attempts - 1,
+        ),
+    ):
+        with mock.patch("posthog.temporal.data_imports.sources.stripe.stripe.get_rows") as mock_get_rows:
+            mock_get_rows.side_effect = Exception("Some error that doesn't retry")
 
-    # Resumable source syncs retry up to 15 times
-    assert mock_get_rows.call_count == 15
+            with pytest.raises(Exception):
+                await _run(
+                    team=team,
+                    schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,
+                    table_name="stripe_customer",
+                    source_type="Stripe",
+                    job_inputs={
+                        "auth_method": {"selection": "api_key", "stripe_secret_key": "test-key"},
+                        "stripe_account_id": "acct_id",
+                    },
+                    mock_data_response=stripe_customer["data"],
+                    ignore_assertions=True,
+                )
 
-    source_cls = SourceRegistry.get_source(ExternalDataSourceType.STRIPE)
-    non_retryable_errors = source_cls.get_non_retryable_errors()
-    non_retryable_error = next(iter(non_retryable_errors.keys()))
+        # Resumable source syncs retry up to the configured cap
+        assert mock_get_rows.call_count == resumable_retry_cap
 
-    with mock.patch("posthog.temporal.data_imports.sources.stripe.stripe.get_rows") as mock_get_rows:
-        mock_get_rows.side_effect = Exception(non_retryable_error)
+        source_cls = SourceRegistry.get_source(ExternalDataSourceType.STRIPE)
+        non_retryable_errors = source_cls.get_non_retryable_errors()
+        non_retryable_error = next(iter(non_retryable_errors.keys()))
 
-        with pytest.raises(Exception):
-            await _run(
-                team=team,
-                schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,
-                table_name="stripe_customer",
-                source_type="Stripe",
-                job_inputs={
-                    "auth_method": {"selection": "api_key", "stripe_secret_key": "test-key"},
-                    "stripe_account_id": "acct_id",
-                },
-                mock_data_response=stripe_customer["data"],
-                ignore_assertions=True,
-            )
+        with mock.patch("posthog.temporal.data_imports.sources.stripe.stripe.get_rows") as mock_get_rows:
+            mock_get_rows.side_effect = Exception(non_retryable_error)
 
-    # Non-retryable errors are retried up to 3 times before giving up (4 total attempts)
-    assert mock_get_rows.call_count == 4
+            with pytest.raises(Exception):
+                await _run(
+                    team=team,
+                    schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,
+                    table_name="stripe_customer",
+                    source_type="Stripe",
+                    job_inputs={
+                        "auth_method": {"selection": "api_key", "stripe_secret_key": "test-key"},
+                        "stripe_account_id": "acct_id",
+                    },
+                    mock_data_response=stripe_customer["data"],
+                    ignore_assertions=True,
+                )
+
+        # Non-retryable errors short-circuit before reaching the resumable cap
+        assert mock_get_rows.call_count == non_retryable_attempts
+        assert non_retryable_attempts < resumable_retry_cap
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

`test_non_retryable_error_short_circuiting` is very slow. It re-runs the entire failing import pipeline **38 times**: once per retry attempt, under *both* the `non_dlt` and `v3` pipeline modes (the module's `autouse` `pipeline_mode` parametrize), exhausting the resumable retry cap (15) and the non-retryable retry budget (4). Each failing attempt costs a couple of minutes (dominated by exception-traceback rendering in test mode), so the test ran for tens of minutes.

## Changes

The retry/short-circuit behaviour lives in the workflow + activity layer, **upstream** of the `v3`/`non_dlt` split, so exercising one pipeline mode is sufficient — running both just doubled the cost for no added coverage. And the exact prod caps (15 / 3) aren't what the test verifies; the test verifies the *contrast* — that a source-classified non-retryable error short-circuits with a smaller retry budget than a generic retryable error.

- Pin the test to a single pipeline mode (`non_dlt`) via indirect parametrize.
- Patch the retry budgets down to 3 (resumable) and 2 (non-retryable), keeping the short-circuit contrast (3 retryable attempts vs 2 non-retryable) intact.
- Hoist the two magic numbers to named module constants so they're patchable from tests:
  - `MAX_RESUMABLE_SOURCE_RETRIES` / `MAX_INCREMENTAL_SOURCE_RETRIES` in `external_data_job.py`
  - `NON_RETRYABLE_ERROR_RETRY_LIMIT` in `pipelines/common/extract.py`

Production behaviour is unchanged (constants still resolve to the same `3 if DEBUG else 15/9/3` values). Net: **38 → 5** full pipeline executions.

The remaining per-attempt cost is rich exception-traceback rendering under the test-mode `ConsoleRenderer` (the production logger path uses `show_locals=False` to avoid it). That's a file-wide concern affecting every data-imports failure-path e2e test and is left as a potential follow-up.

## How did you test this code?

I'm an agent. I ran the optimized test locally against the dev stack and it passed (`1 passed`), with `get_rows.call_count` asserting 3 (retryable) and 2 (non-retryable). `ruff check` passes on all three files. I confirmed the test now collects a single `[non_dlt]` parametrization. No manual UI testing — this is a test-only + internal-constant change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code at the request of @frankhamand to optimize a slow Temporal e2e test.

Approach: profiled the test to attribute the runtime. Found two multipliers (redundant `v3`/`non_dlt` parametrization; full prod retry caps under `DEBUG=False` in the temporal test tree) plus a heavy per-attempt cost. First tried reducing the cap via `override_settings(DEBUG=True)`, but that didn't reach the workflow at runtime, so switched to hoisting the caps into patchable module constants and patching them directly. Kept the non-retryable budget at 2 (one retry then give up) rather than 1 to preserve the "retries a little before giving up" semantics of the original test. The per-attempt traceback-rendering cost was identified but deliberately left out of scope since fixing it touches shared logger config used by the whole temporal test suite.

No repo skills were applicable to this change.
