### PR TITLE
fix(llma): stop flooding error tracking with Hog evaluator user errors

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_hog.py
+++ b/posthog/temporal/ai_observability/evaluation_hog.py
@@ -22,6 +22,8 @@ def run_hog_eval(bytecode: list, event_data: dict[str, Any], allows_na: bool = F
     Used by both the Temporal activity and the test endpoint.
     Returns {"verdict": bool | None, "reasoning": str, "error": str | None}.
     When allows_na=True, a `return null` is treated as N/A (not an error).
+    Sets "unexpected": True only when the bytecode raised something other than a
+    HogVM error — i.e. a bug in our code rather than in the user's Hog source.
     """
     properties = event_data["properties"]
     if isinstance(properties, str):
@@ -57,9 +59,14 @@ def run_hog_eval(bytecode: list, event_data: dict[str, Any], allows_na: bool = F
         return {"verdict": None, "reasoning": "", "error": "Memory limit exceeded"}
     except HogVMException as e:
         return {"verdict": None, "reasoning": "", "error": f"Runtime error: {e}"}
-    except Exception:
+    except Exception as e:
         logger.exception("Unexpected error executing Hog eval bytecode")
-        return {"verdict": None, "reasoning": "", "error": "Unexpected error during evaluation"}
+        return {
+            "verdict": None,
+            "reasoning": "",
+            "error": f"Unexpected error during evaluation: {type(e).__name__}: {e}",
+            "unexpected": True,
+        }
 
     reasoning = "\n".join(response.stdout) if response.stdout else ""
 
@@ -103,10 +110,29 @@ async def execute_hog_eval_activity(evaluation: dict[str, Any], event_data: dict
     result = await database_sync_to_async(_execute, thread_sensitive=False)()
 
     if result["error"]:
-        raise ApplicationError(
-            f"Hog evaluation error: {result['error']}",
-            non_retryable=True,
-        )
+        if result.get("unexpected"):
+            # A genuine bug in our evaluation code (not the user's Hog). Raise so the Temporal
+            # interceptor reports it to error tracking and we get paged to investigate.
+            raise ApplicationError(
+                f"Hog evaluation error: {result['error']}",
+                non_retryable=True,
+            )
+
+        # The user's Hog source itself errored (invalid code, execution timeout, or a
+        # non-boolean result). That's an expected outcome of running customer-authored code,
+        # not a system fault — record it as a skipped evaluation the user can see, rather than
+        # raising (which would flood error tracking with one event per matching generation).
+        errored_result: EvaluationActivityResult = {
+            "result_type": "boolean",
+            "verdict": None if allows_na else False,
+            "reasoning": result["error"],
+            "allows_na": allows_na,
+            "skipped": True,
+            "skip_reason": "hog_error",
+        }
+        if allows_na:
+            errored_result["applicable"] = False
+        return errored_result
 
     activity_result: EvaluationActivityResult = {
         "result_type": "boolean",

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -877,7 +877,7 @@ class TestExecuteHogEvalActivity:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
-    async def test_hog_eval_non_bool_raises_error(self, setup_data):
+    async def test_hog_eval_non_bool_returns_skipped(self, setup_data):
         team = setup_data["team"]
 
         from posthog.cdp.validation import compile_hog
@@ -896,8 +896,12 @@ class TestExecuteHogEvalActivity:
 
         event_data = create_mock_event_data(team.id)
 
-        with pytest.raises(ApplicationError, match="Must return boolean"):
-            await execute_hog_eval_activity(evaluation, event_data)
+        # A non-boolean result is a user-authored Hog error: recorded as skipped, not raised.
+        result = await execute_hog_eval_activity(evaluation, event_data)
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "hog_error"
+        assert "Must return boolean" in result["reasoning"]
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
@@ -991,6 +995,75 @@ class TestExecuteHogEvalActivity:
         result = await execute_hog_eval_activity(evaluation, event_data)
 
         assert result["verdict"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_hog_eval_runtime_error_returns_skipped(self, setup_data):
+        team = setup_data["team"]
+
+        from posthog.cdp.validation import compile_hog
+
+        bytecode = compile_hog("return true", "destination")
+
+        evaluation = {
+            "id": str(setup_data["evaluation"].id),
+            "name": "Hog Eval",
+            "evaluation_type": "hog",
+            "evaluation_config": {"source": "return true", "bytecode": bytecode},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(team.id)
+
+        # A HogVM runtime error in user-authored Hog (e.g. unsupported function, unknown global)
+        # is recorded as skipped, not raised — so it never reaches error tracking.
+        user_error = {"verdict": None, "reasoning": "", "error": "Runtime error: Global variable not found: continue"}
+        with patch(
+            "posthog.temporal.ai_observability.evaluation_hog.run_hog_eval",
+            return_value=user_error,
+        ):
+            result = await execute_hog_eval_activity(evaluation, event_data)
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "hog_error"
+        assert "Global variable not found" in result["reasoning"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_hog_eval_unexpected_error_raises(self, setup_data):
+        team = setup_data["team"]
+
+        from posthog.cdp.validation import compile_hog
+
+        bytecode = compile_hog("return true", "destination")
+
+        evaluation = {
+            "id": str(setup_data["evaluation"].id),
+            "name": "Hog Eval",
+            "evaluation_type": "hog",
+            "evaluation_config": {"source": "return true", "bytecode": bytecode},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+
+        event_data = create_mock_event_data(team.id)
+
+        # An unexpected error is a bug in our code, so it must still surface to error tracking.
+        unexpected_error = {
+            "verdict": None,
+            "reasoning": "",
+            "error": "Unexpected error during evaluation: KeyError: 'foo'",
+            "unexpected": True,
+        }
+        with patch(
+            "posthog.temporal.ai_observability.evaluation_hog.run_hog_eval",
+            return_value=unexpected_error,
+        ):
+            with pytest.raises(ApplicationError, match="Unexpected error during evaluation"):
+                await execute_hog_eval_activity(evaluation, event_data)
 
 
 class TestExecuteSentimentEvalActivity:
@@ -1196,7 +1269,7 @@ class TestExecuteHogEvalActivityAllowsNA:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
-    async def test_hog_eval_null_return_without_allows_na_raises(self, setup_data):
+    async def test_hog_eval_null_return_without_allows_na_returns_skipped(self, setup_data):
         team = setup_data["team"]
 
         from posthog.cdp.validation import compile_hog
@@ -1215,8 +1288,12 @@ class TestExecuteHogEvalActivityAllowsNA:
 
         event_data = create_mock_event_data(team.id)
 
-        with pytest.raises(ApplicationError, match="Must return boolean"):
-            await execute_hog_eval_activity(evaluation, event_data)
+        result = await execute_hog_eval_activity(evaluation, event_data)
+
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "hog_error"
+        assert result["verdict"] is False
+        assert "Must return boolean" in result["reasoning"]
 
 
 class TestIncrementTrialEvalCountActivity:


### PR DESCRIPTION
## Problem

A new error-tracking issue spiked from zero — `ApplicationError: Hog evaluation error: …` from `execute_hog_eval_activity` — firing continuously across multiple teams. The activity caught every Hog failure into a structured result and then **re-raised** it as a non-retryable `ApplicationError`. The Temporal interceptor (`posthog_client.py`) reports any activity exception to error tracking, so each invalid **customer-authored** evaluator produced one exception per matching `$ai_generation`, paging `#alerts-ai-observability`.

The bulk of these are user-content errors — the customer's own Hog source is invalid (uses unsupported constructs, calls unavailable functions, returns a non-boolean, or times out). Those are expected outcomes of running customer code, not faults in our system, and shouldn't be captured as server exceptions.

## Changes

- **Don't raise for user-authored Hog errors** (HogVM runtime errors, execution timeout, memory, non-boolean results). They're now recorded as a *skipped* evaluation (`skip_reason: "hog_error"`) with the error surfaced in `reasoning`, so the user sees what went wrong on the evaluation — reusing the existing skip/emit path, mirroring the LLM-judge errored-result pattern.
- **Keep alerting only on genuine bugs in our code.** The bare `except Exception` path still raises (and reaches error tracking), and now includes the exception type and message instead of the opaque "Unexpected error during evaluation", so those remaining cases are actually diagnosable.

Out of scope (noted in the investigation, not addressed here): catching broken evaluators at save time, and the underlying Hog gaps (`continue`/`break` compiling to a global lookup, `hogql()` unavailable in the eval sandbox).

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the test suite in my environment (no project Python env / flox available), so the tests below were **not executed** — they were authored and the changed modules pass `python -m py_compile` and `ruff check`:

- Updated two tests that previously asserted a raise on user errors (`return 42`, `return null` without N/A) to assert a skipped result instead.
- Added `test_hog_eval_runtime_error_returns_skipped` (user runtime error → skipped) and `test_hog_eval_unexpected_error_raises` (our-bug error → still raises).

A reviewer should run `hogli test posthog/temporal/ai_observability/test_run_evaluation.py` to confirm.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread off an error-tracking alert. Traced the spike to `execute_hog_eval_activity` re-raising structured eval errors, confirmed via the Temporal activity interceptor that any raised activity exception is captured to error tracking, and confirmed the emit path already supports `skipped`/`skip_reason`. Chose to reuse that skip mechanism rather than add a new result field, to keep the change minimal and consistent with the LLM-judge `_build_errored_trace_result` pattern. No repo skills applied beyond reading `posthog/temporal/` guidance.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1781807451345219?thread_ts=1781807451.345219&cid=C0A006STKHR)*
