### PR TITLE
fix(cli): make authorize search full width

### DIFF
--- a/frontend/src/scenes/authentication/cli/CLIAuthorize.tsx
+++ b/frontend/src/scenes/authentication/cli/CLIAuthorize.tsx
@@ -157,6 +157,7 @@ export function CLIAuthorize(): JSX.Element {
                                                 onChange={setSearchTerm}
                                                 className="mb-2"
                                                 size="small"
+                                                fullWidth
                                             />
                                             <div className="max-h-64 overflow-y-auto pr-1">
                                                 {filteredScopes.length === 0 ? (


### PR DESCRIPTION
## Problem

The scopes search input on `/cli/authorize` uses LemonInput's default search width, which caps the field at a small fixed size. That leaves unused horizontal space in the authorization form.

## Changes

<img width="526" height="1047" alt="Screenshot 2026-06-18 at 3 53 33 PM" src="https://github.com/user-attachments/assets/baac5ce6-4dd7-4f53-9abe-1ab23f6f8ab4" />

- Set the CLI scopes search `LemonInput` to `fullWidth` so it spans the available form width.

## How did you test this code?

Tested on my local machine

## Docs update

no