### PR TITLE
feat(oauth): capture insufficient-scope denials for OAuth tokens

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -610,6 +610,18 @@ class APIScopePermission(ScopeBasePermission):
 
             if not any(scope in key_scopes for scope in valid_scopes):
                 self.message = f"API key missing required scope '{required_scope}'"
+                # Track OAuth scope-insufficiency so we can see whether clients re-authorize
+                # after an app widens its required scopes, or get stranded on the old set.
+                if isinstance(authenticator, OAuthAccessTokenAuthentication):
+                    posthoganalytics.capture(
+                        distinct_id=str(getattr(request.user, "distinct_id", "") or request.user.pk),
+                        event="oauth token insufficient scope",
+                        properties={
+                            "application_id": str(authenticator.access_token.application_id),
+                            "required_scope": required_scope,
+                            "scope_object": scope_object,
+                        },
+                    )
                 return False
 
         return True


### PR DESCRIPTION
## Problem

When an OAuth app widens its required scopes, existing users' tokens don't automatically gain them — by design (a refresh can't escalate scope; the client must re-authorize via `/authorize`). The standard model is the client detecting a `403` for a missing scope and re-authorizing, which PostHog already supports. What we lack is visibility into whether that's actually happening — i.e. whether any clients get stranded on the old scope set after an app expands, rather than re-authorizing.

## Changes

Capture a `oauth token insufficient scope` analytics event when an OAuth access token is denied for a missing scope (in `APIScopePermission`), tagged with `application_id`, `required_scope`, and `scope_object`. This lets us watch, per app, whether insufficient-scope denials spike-then-taper (clients re-authorizing, healthy) or recur for the same app/users (clients stranded). That's the signal that would justify revisiting a server-side scope-widening mechanism.

PAK / project-secret / ID-JAG denials are unaffected — the event only fires for OAuth tokens. No change to the `403` response itself; the capture is best-effort telemetry.

## How did you test this code?

I'm an agent (Claude Code). `ruff` passes. The change is a single telemetry capture inside the existing scope-denial branch with no behavior change to the response. No automated test added — a small unit test asserting the event fires for an OAuth denial (and not for a PAK denial) would be a reasonable add; flagging for the reviewer.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is the monitoring fallback from a decision to **not** build server-side per-user scope widening. Survey of GitHub/Google/Microsoft/Atlassian/Slack showed the standard model is client re-auth on insufficient scope (only GitHub does auto-pickup, and via re-derived installation tokens, not by mutating OAuth tokens). Rather than treat issued tokens as mutable, we rely on the existing client-re-auth path and add this event to detect — with real data — whether any client actually fails to re-auth and strands users. Revisit server-side widening only if this shows real stranding.
