### PR TITLE
fix(django): wrong db choice for gtm eventual consistency

### DIFF
--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -20,7 +20,7 @@ import structlog
 from prometheus_client import Counter
 
 from posthog.models.utils import RootTeamMixin
-from posthog.person_db_router import PERSONS_DB_FOR_WRITE
+from posthog.person_db_router import PERSONS_DB_FOR_READ, PERSONS_DB_FOR_WRITE
 from posthog.personhog_client import ReadConsistency, consistency_to_read_options
 from posthog.personhog_client.caller_tag import personhog_caller_tag
 from posthog.personhog_client.metrics import PERSONHOG_ROUTING_ERRORS_TOTAL, PERSONHOG_ROUTING_TOTAL, get_client_name
@@ -529,7 +529,7 @@ def _fetch_group_types_for_project_direct(
     from posthog.personhog_client.converters import proto_group_type_mapping_to_dict
     from posthog.personhog_client.proto import GetGroupTypeMappingsByProjectIdRequest
 
-    db_alias = PERSONS_DB_FOR_WRITE if consistency == "strong" else "default"
+    db_alias = PERSONS_DB_FOR_WRITE if consistency == "strong" else PERSONS_DB_FOR_READ
 
     return _personhog_routed(
         "get_group_types_for_project_direct",


### PR DESCRIPTION
## Problem

There was a bug in `_fetch_group_types_for_project_direct` in `group_type_mapping.py`. The ORM fallback path uses the `default` database for eventual consistency option instead of the persons read replica.

No callers currently pass eventual and this is a fallback path, but to protect against future callers of this function trying to read from teh wrong database.

## Changes

Replace the `default` with `PERSONS_DB_FOR_READ` so the eventual consistency fallback targets person read replica

## How did you test this code?

Current CI should pass