### PR TITLE
refactor(customer-analytics): add single account write path via the manager

### DIFF
--- a/.semgrep/devex-rules/customer-analytics-no-raw-account-properties-write.yaml
+++ b/.semgrep/devex-rules/customer-analytics-no-raw-account-properties-write.yaml
@@ -1,0 +1,36 @@
+rules:
+    - id: customer-analytics-no-raw-account-properties-write
+      message: |
+          Don't write Account `_properties` directly. Every account write must go through the
+          AccountManager chokepoint — `Account.objects.create_account(...)` or
+          `Account.objects.update_account(...)` — which validates and coerces properties via
+          `AccountProperties.from_input`.
+
+          Passing `_properties=` to `.create(...)` or assigning `account._properties = ...`
+          bypasses that validation and can persist malformed properties.
+
+          Pass `properties=<dict>` to the manager instead. Tags and the surrounding transaction
+          are the caller's responsibility (see `api/serializers.py` and `max_tools/upsert_account.py`
+          for the pattern).
+
+          Test setup may build fixtures directly, so this rule excludes tests. For a genuine
+          non-test exception, add
+          `# nosemgrep: customer-analytics-no-raw-account-properties-write` with a short reason.
+      severity: ERROR
+      languages: [python]
+      paths:
+          include:
+              - '/products/customer_analytics/backend/**'
+          exclude:
+              - '/products/customer_analytics/backend/models/account.py'
+              - '**/test_*.py'
+              - '**/*_test.py'
+              - '**/test/**'
+              - '**/migrations/**'
+      pattern-either:
+          - pattern: $X.create(..., _properties=$V, ...)
+          - pattern: $OBJ._properties = $V
+      metadata:
+          category: best-practice
+          subcategory:
+              - audit

--- a/products/customer_analytics/backend/api/serializers.py
+++ b/products/customer_analytics/backend/api/serializers.py
@@ -1,15 +1,17 @@
 import json
 
+from django.db import IntegrityError, transaction
+
 from drf_spectacular.utils import extend_schema_field
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers
 
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
+from posthog.exceptions import Conflict
 from posthog.models import OrganizationMembership
 
 from products.customer_analytics.backend.models import Account, CustomerJourney, CustomerProfileConfig
-from products.customer_analytics.backend.models.account import AccountProperties
 from products.notebooks.backend.models import Notebook
 
 _ACCOUNT_ASSIGNMENT_SCHEMA = {
@@ -194,33 +196,51 @@ class AccountSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
     def validate_properties(self, value):
         if value is None:
             return {}
-
         if not isinstance(value, dict):
             raise serializers.ValidationError("properties must be a JSON object.")
-
         try:
             json.dumps(value)
         except (TypeError, ValueError):
             raise serializers.ValidationError("properties must be JSON-serializable.")
-
-        try:
-            AccountProperties.model_validate(value)
-        except PydanticValidationError as exc:
-            raise serializers.ValidationError(_format_pydantic_errors(exc))
-
         return value
 
     def create(self, validated_data):
-        from django.db import IntegrityError
-
-        from posthog.exceptions import Conflict
-
-        validated_data["created_by"] = self.context["request"].user
-        validated_data["team_id"] = self.context["team_id"]
+        properties = validated_data.pop("_properties", {})
+        validated_data.pop("tags", None)
         try:
-            return super().create(validated_data)
+            with transaction.atomic():
+                account = Account.objects.create_account(
+                    team=self.context["get_team"](),
+                    created_by=self.context["request"].user,
+                    name=validated_data["name"],
+                    external_id=validated_data.get("external_id"),
+                    properties=properties,
+                )
+                self._attempt_set_tags(self.initial_data.get("tags"), account)
+        except PydanticValidationError as exc:
+            raise serializers.ValidationError({"properties": _format_pydantic_errors(exc)})
         except IntegrityError:
             raise Conflict("An account with this external_id already exists for this team.")
+        return account
+
+    def update(self, instance, validated_data):
+        update_kwargs: dict = {}
+        if "name" in validated_data:
+            update_kwargs["name"] = validated_data["name"]
+        if "external_id" in validated_data:
+            update_kwargs["external_id"] = validated_data["external_id"]
+        if "_properties" in validated_data:
+            update_kwargs["properties"] = validated_data["_properties"]
+
+        try:
+            with transaction.atomic():
+                account = Account.objects.update_account(instance, **update_kwargs)
+                self._attempt_set_tags(self.initial_data.get("tags"), account)
+        except PydanticValidationError as exc:
+            raise serializers.ValidationError({"properties": _format_pydantic_errors(exc)})
+        except IntegrityError:
+            raise Conflict("An account with this external_id already exists for this team.")
+        return account
 
 
 def _format_pydantic_errors(exc: PydanticValidationError) -> list[str]:

--- a/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
@@ -164,12 +164,12 @@ class Command(BaseCommand):
             for index, (group_key, props) in enumerate(groups):
                 account = existing.get(group_key)
                 if account is None:
-                    account = Account.objects.create(
+                    account = Account.objects.create_account(
                         team=team,
                         name=props.get("name") or group_key,
                         external_id=group_key,
                         created_by=creator,
-                        _properties=self._account_roles(assignments, index, group_key).model_dump(mode="json"),
+                        properties=self._account_roles(assignments, index, group_key),
                     )
                     created += 1
                 accounts.append(account)

--- a/products/customer_analytics/backend/max_tools/upsert_account.py
+++ b/products/customer_analytics/backend/max_tools/upsert_account.py
@@ -183,12 +183,12 @@ class UpsertAccountTool(MaxTool):
     @sync_to_async
     def _create_account(self, action: CreateAccountAction, properties: dict[str, Any]) -> Account:
         with transaction.atomic():
-            account = Account.objects.unscoped().create(
+            account = Account.objects.create_account(
                 team=self._team,
                 created_by=self._user,
-                name=action.name[:400],
-                external_id=(action.external_id[:400] if action.external_id else None),
-                _properties=properties,
+                name=action.name,
+                external_id=(action.external_id or None),
+                properties=properties,
             )
             if action.tags is not None:
                 set_tags_on_object(action.tags, account)
@@ -196,20 +196,17 @@ class UpsertAccountTool(MaxTool):
 
     @sync_to_async
     def _update_account(self, account: Account, action: UpdateAccountAction) -> Account:
+        update_kwargs: dict[str, Any] = {}
+        if action.name is not None:
+            update_kwargs["name"] = action.name
+        if action.external_id is not None:
+            update_kwargs["external_id"] = action.external_id or None
+        if action.properties is not None:
+            properties = account.properties.model_dump(mode="json")
+            properties.update(action.properties.model_dump(exclude_unset=True))
+            update_kwargs["properties"] = properties
         with transaction.atomic():
-            update_fields: list[str] = []
-            if action.name is not None:
-                account.name = action.name[:400]
-                update_fields.append("name")
-            if action.external_id is not None:
-                account.external_id = action.external_id[:400] or None
-                update_fields.append("external_id")
-            if action.properties is not None:
-                merged = {**(account._properties or {}), **action.properties.model_dump(exclude_unset=True)}
-                account._properties = merged
-                update_fields.append("_properties")
-            if update_fields:
-                account.save(update_fields=update_fields)
+            account = Account.objects.update_account(account, **update_kwargs)
             if action.tags is not None:
                 set_tags_on_object(action.tags, account)
         return account

--- a/products/customer_analytics/backend/models/account.py
+++ b/products/customer_analytics/backend/models/account.py
@@ -1,4 +1,5 @@
-from typing import Any
+from enum import Enum
+from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
 from django.core.exceptions import ValidationError
@@ -12,6 +13,9 @@ from pydantic import BaseModel, ConfigDict
 from posthog.models.scoping.manager import TeamScopedManager
 from posthog.models.scoping.root_mixin import TeamScopedRootMixin
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
+
+if TYPE_CHECKING:
+    from posthog.models import Team, User
 
 
 class AccountAssignment(BaseModel):
@@ -36,22 +40,66 @@ class AccountProperties(BaseModel):
     slack_channel_id: str | None = None
     usage_dashboard_link: str | None = None
 
+    @classmethod
+    def from_input(cls, data: "dict | AccountProperties") -> "AccountProperties":
+        if isinstance(data, AccountProperties):
+            data = data.model_dump(mode="json", exclude_unset=True)
+        return cls.model_validate(data)
+
+
+class _Unset(Enum):
+    UNSET = "unset"
+
+
+_UNSET = _Unset.UNSET
+
 
 class AccountManager(TeamScopedManager["Account"]):
-    def create(
+    def create_account(
         self,
         *,
+        team: "Team",
+        name: str,
+        created_by: "User | None" = None,
+        external_id: str | None = None,
         properties: "dict | AccountProperties | None" = None,
-        **kwargs: Any,
     ) -> "Account":
-        if properties is not None:
-            validated = (
-                properties
-                if isinstance(properties, AccountProperties)
-                else AccountProperties.model_validate(properties)
+        validated = AccountProperties.from_input(properties or {})
+        return self.unscoped().create(
+            team=team,
+            created_by=created_by,
+            name=self._cap_to_field_length("name", name),
+            external_id=self._cap_to_field_length("external_id", external_id) if external_id is not None else None,
+            _properties=validated.model_dump(mode="json", exclude_unset=True),
+        )
+
+    def update_account(
+        self,
+        account: "Account",
+        *,
+        name: str | _Unset = _UNSET,
+        external_id: str | None | _Unset = _UNSET,
+        properties: "dict | AccountProperties | _Unset" = _UNSET,
+    ) -> "Account":
+        update_fields: list[str] = []
+        if name is not _UNSET:
+            account.name = self._cap_to_field_length("name", name)
+            update_fields.append("name")
+        if external_id is not _UNSET:
+            account.external_id = (
+                self._cap_to_field_length("external_id", external_id) if external_id is not None else None
             )
-            kwargs["_properties"] = validated.model_dump(mode="json")
-        return super().create(**kwargs)
+            update_fields.append("external_id")
+        if properties is not _UNSET:
+            account._properties = AccountProperties.from_input(properties).model_dump(mode="json", exclude_unset=True)
+            update_fields.append("_properties")
+        if update_fields:
+            account.save(update_fields=update_fields)
+        return account
+
+    def _cap_to_field_length(self, field_name: str, value: str) -> str:
+        max_length = cast(models.CharField, self.model._meta.get_field(field_name)).max_length
+        return value[:max_length]
 
 
 class Account(TeamScopedRootMixin, UUIDModel, CreatedMetaFields, UpdatedMetaFields):

--- a/products/customer_analytics/backend/models/account_test.py
+++ b/products/customer_analytics/backend/models/account_test.py
@@ -1,10 +1,12 @@
 from contextlib import AbstractContextManager
+from typing import cast
 
 import pytest
 from posthog.test.base import BaseTest
 
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, models, transaction
+from django.test import SimpleTestCase
 
 from parameterized import parameterized
 from pydantic import ValidationError as PydanticValidationError
@@ -124,3 +126,56 @@ class TeamCustomerAnalyticsConfigDriftPolicyTest(_AccountTeamScopedTestMixin, Ba
             self.config.save()
             self.config.refresh_from_db()
             assert self.config.account_group_type_index == new_index
+
+
+class AccountManagerWriteTest(_AccountTeamScopedTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(
+            email="mgr@example.com", password=None, first_name="Mgr", is_email_verified=True
+        )
+
+    def test_update_account_replaces_properties_wholesale(self):
+        account = Account.objects.create_account(
+            team=self.team,
+            created_by=self.user,
+            name="Acme",
+            properties={"csm": {"id": self.user.id, "email": self.user.email}},
+        )
+        Account.objects.update_account(account, properties={"stripe_customer_id": "cus_123"})
+        account.refresh_from_db()
+        assert account.properties.csm is None
+        assert account.properties.stripe_customer_id == "cus_123"
+
+    def test_update_account_leaves_properties_untouched_when_not_passed(self):
+        account = Account.objects.create_account(
+            team=self.team,
+            created_by=self.user,
+            name="Acme",
+            properties={"stripe_customer_id": "cus_123"},
+        )
+
+        Account.objects.update_account(account, name="Renamed")
+
+        account.refresh_from_db()
+        assert account.name == "Renamed"
+        assert account.properties.stripe_customer_id == "cus_123"
+
+    def test_update_account_updates_name_and_external_id(self):
+        account = Account.objects.create_account(team=self.team, created_by=self.user, name="Old")
+        Account.objects.update_account(account, name="New", external_id="acme-1")
+        account.refresh_from_db()
+        assert account.name == "New"
+        assert account.external_id == "acme-1"
+
+
+class AccountManagerCapToFieldLengthTest(SimpleTestCase):
+    @parameterized.expand([("name",), ("external_id",)])
+    def test_caps_value_to_field_max_length(self, field_name):
+        max_length = cast(models.CharField, Account._meta.get_field(field_name)).max_length
+        assert max_length is not None
+        result = Account.objects._cap_to_field_length(field_name, "x" * (max_length + 50))
+        assert result == "x" * max_length
+
+    def test_leaves_value_within_limit_unchanged(self):
+        assert Account.objects._cap_to_field_length("name", "Acme") == "Acme"


### PR DESCRIPTION
## Problem

Account `_properties` are written from several call sites (serializer, max_tools, seed) with no shared validation path.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Part of https://github.com/PostHog/posthog/issues/60300

## Changes

- Add `AccountManager.create_account` / `update_account` as the single account write path
- Validate properties through `AccountProperties.from_input`; cap `name` / `external_id` to field length in the manager
- Route the serializer, max_tools, and seed command through the manager (replace semantics — callers read-modify-write the full object)
- Add a semgrep guard banning raw `_properties=` writes outside the manager
- Custom property definitions are split into a follow-up PR

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-authored. Unit tests — account model/manager (15) and serializer/API, max_tools, seed callers (140) — all passing. `ruff` and `ty` clean; `makemigrations` reports no migration drift. No manual UI testing.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code, directed by Arthur. Skills invoked: `/improving-drf-endpoints` (serializer), `/django-migrations` (migration split), `/pr-description`.

Split out of a larger branch that also introduced `CustomPropertyDefinition`. That model and all custom-property validation were removed here and deferred to a follow-up PR, so this is purely the write-path centralization. Properties use **replace** semantics (callers read-modify-write the full object), so deleting a field is just omission.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->
