### PR TITLE
fix(signals): distinguish loading/error/truncated states in scout signals

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -93,27 +93,45 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
  * already-polled runs window. Most runs are quiet, so an empty list is the healthy default.
  */
 function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element {
-    const { emissionRows, emissionsLoading, runsWindowLoadedOnce } = useValues(scoutDetailLogic({ skillName }))
+    const { emissionRows, emissionsLoading, emissionsLoadFailed, runsWindowLoadedOnce, runsWindowComplete } = useValues(
+        scoutDetailLogic({ skillName })
+    )
 
     // "Loading" until the fleet's runs window has settled once AND this scout's emissions have
     // resolved — otherwise a fresh deep-link would flash the empty state before we know the
     // emitted runs. Gating on the fleet's first-load flag (not its per-poll loading) keeps the
     // quiet-scout empty state from flickering to a skeleton every 60s poll.
     const loading = !runsWindowLoadedOnce || emissionsLoading
+    const hasRows = emissionRows.length > 0
 
     return (
         <div className="flex flex-col gap-2">
             <span className="text-xs font-medium text-default uppercase tracking-wide">Signals</span>
-            {loading && emissionRows.length === 0 ? (
+            {loading && !hasRows ? (
                 <LemonSkeleton className="h-12 w-full rounded" />
-            ) : emissionRows.length === 0 ? (
+            ) : emissionsLoadFailed && !hasRows ? (
+                // Every per-run emissions fetch failed while the rollup says these runs emitted —
+                // don't claim "no signals". The 60s poll keeps retrying.
                 <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
-                    No signals emitted in the last {SCOUT_RUNS_WINDOW_SPAN}.
+                    Couldn’t load signals for this scout. Retrying…
+                </div>
+            ) : !hasRows ? (
+                <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
+                    {runsWindowComplete
+                        ? `No signals emitted in the last ${SCOUT_RUNS_WINDOW_SPAN}.`
+                        : `No signals emitted in the recent runs we could load (the last ${SCOUT_RUNS_WINDOW_SPAN} is truncated).`}
                 </div>
             ) : (
-                emissionRows.map(({ emission, run }) => (
-                    <ScoutEmissionCard key={emission.id} emission={emission} run={run} />
-                ))
+                <>
+                    {emissionRows.map(({ emission, run }) => (
+                        <ScoutEmissionCard key={emission.id} emission={emission} run={run} />
+                    ))}
+                    {!runsWindowComplete && (
+                        <span className="text-xs text-muted">
+                            Older signals beyond the loaded {SCOUT_RUNS_WINDOW_SPAN} window aren’t shown.
+                        </span>
+                    )}
+                </>
             )}
         </div>
     )

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, path, props, selectors } from 'kea'
+import { connect, kea, key, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
@@ -37,7 +37,7 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
     key((props) => props.skillName),
 
     connect(() => ({
-        values: [scoutFleetLogic, ['rollups', 'runsWindowLoadedOnce']],
+        values: [scoutFleetLogic, ['rollups', 'runsWindowLoadedOnce', 'runsWindowComplete']],
     })),
 
     loaders(({ values }) => ({
@@ -54,16 +54,35 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                     const settled = await Promise.allSettled(
                         runs.map((run) => api.signalScout.runs.emissions(run.run_id))
                     )
-                    return settled
-                        .filter(
-                            (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
-                                result.status === 'fulfilled'
-                        )
-                        .flatMap((result) => result.value)
+                    const fulfilled = settled.filter(
+                        (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
+                            result.status === 'fulfilled'
+                    )
+                    // Every fetch failed (outage / auth / scope) while the rollup says these runs
+                    // emitted — throw so the section shows an error, not a false "no signals". A
+                    // partial failure still returns the findings that did load.
+                    if (fulfilled.length === 0) {
+                        throw new Error('Failed to load scout emissions')
+                    }
+                    return fulfilled.flatMap((result) => result.value)
                 },
             },
         ],
     })),
+
+    reducers({
+        // True only when the most recent emissions load failed outright (all per-run fetches
+        // rejected). Reset when a fresh load starts or succeeds. Lets the Signals section show a
+        // retrying/error state instead of a false empty when findings exist but couldn't be loaded.
+        emissionsLoadFailed: [
+            false,
+            {
+                loadEmissions: () => false,
+                loadEmissionsSuccess: () => false,
+                loadEmissionsFailure: () => true,
+            },
+        ],
+    }),
 
     selectors({
         // This scout's runs that emitted at least one finding, newest first, capped to the most

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -153,14 +153,15 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                     state?.map((config) => (config.id === configId ? { ...config, ...updates } : config)) ?? state,
             },
         ],
-        // Flips true the first time the runs window settles (success or failure) and stays true
-        // across the 60s polls. Consumers (e.g. the scout detail Signals section) use it to tell
-        // "not loaded yet" from "loaded, genuinely empty" without flickering a skeleton on polls.
+        // Flips true the first time the runs window loads *successfully* and stays true across the
+        // 60s polls. Consumers (e.g. the scout detail Signals section) use it to tell "not loaded
+        // yet" from "loaded, genuinely empty" without flickering a skeleton on polls. Deliberately
+        // NOT set on failure: a failed first load must keep showing loading (the poll retries),
+        // not latch and let a consumer render a false "no signals" empty state over no data.
         runsWindowLoadedOnce: [
             false,
             {
                 loadRunsWindowSuccess: () => true,
-                loadRunsWindowFailure: () => true,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Follow-up to #64682 (merged). Three review findings from `chatgpt-codex` landed just before that PR merged, all pointing at one real gap: the scout-detail **Signals** section collapsed *loading*, *load-failed*, and *truncated-window* into a single "No signals emitted" empty state — so on a fresh deep-link mid-load, an API outage, or a busy project whose runs window is truncated, it could falsely tell the user the scout found nothing.

## Changes

- **Don't latch the first-load flag on failure.** `runsWindowLoadedOnce` now flips true only on a *successful* runs-window load. A failed fresh load keeps showing the skeleton (the 60s poll retries) instead of latching and letting the section render a false empty state over no data.
- **Surface total emission-fetch failure.** `loadEmissions` already uses `Promise.allSettled` for partial resilience; it now *throws* when **every** per-run fetch fails while the rollup says those runs emitted. A new `emissionsLoadFailed` flag drives a "Couldn't load signals — retrying…" state instead of a false empty. Partial failures still surface the findings that did load.
- **Truncation-aware empty/footer copy.** When the runs window hit its page cap (`runsWindowComplete === false`), the empty state no longer asserts "no signals in the last N", and a small note is shown beneath rendered cards that older signals beyond the loaded window aren't included.

## How did you test this code?

I'm an agent (Claude Code). Automated: `kea-typegen write`, `typescript:check` (clean for these files — unrelated `products/growth/*` and `DebugCHQueries` errors pre-exist on master), `oxlint` + `oxfmt` (0 warnings/errors on all three files).

Manual on the local dev stack (project 1) via Playwright: re-seeded a temporary emission and confirmed the happy path still renders (card + markdown) and that the loading gate shows a skeleton → card with no false-empty flash, then cleaned up the seed. The error and truncated states are driven by the same data paths but weren't force-triggered live (they need an induced fetch failure / >1500-run window).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy asked to watch #64682's bot comments and act on them; these three arrived right before merge, so they go here as a follow-up.

Built with Claude Code. Frontend-only; no repo skills required. The fixes are a direct response to three `chatgpt-codex` review comments on #64682 (replied to inline there, pointing here).
