### PR TITLE
fix(inbox): make report cards and detail header mobile friendly

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5297,17 +5297,17 @@ snapshots:
     scenes-app-inbox-cards--agent-run-cards--light:
         hash: v1.k794b7964.4fced4761948504f507f7c797cca06f09b9384dc13e053f3af5c893e7c0cd2d2.J1aM-6ZJAZvKQnV4Zd93kTJUK9pMEQYYWijc25ewVbQ
     scenes-app-inbox-cards--pull-request-cards--dark:
-        hash: v1.k794b7964.b53c9bb3fd2de55e52f275baa9bb90d7bad568b5c759979522a9ad8429b92f28.WKBQ_N5vGFXTeW_v7A4rrdXeKZM0af-pZuw5o7YMZ00
+        hash: v1.k794b7964.497e11ffa4bd37a28f23346c9de83855be14498a84152fde99f9c9d78cb0ee79.5Ekzd1b8rnOBxbnBX-gSRgF3J7nMRnZi7hG-3Q25c4k
     scenes-app-inbox-cards--pull-request-cards--light:
-        hash: v1.k794b7964.a708b3221d13ade6c1422f5b1a3c100d2c026caa53f466e15817f1a8eb0f3e3d.1UZEVt0l5W7r1ClQ7TwPPYXiKpsu46sSQ5VlziKIC2M
+        hash: v1.k794b7964.3fc2e2866feb9be1b05c7a17a8e7165d321f2694f4639805c7e74083b4aa14f7.RfSfQmQWBF48GY1wDF76z-hN09r3Fwz4bSG6GFqNseo
     scenes-app-inbox-cards--report-card-states--dark:
-        hash: v1.k794b7964.6488ec9c5ea1a15b0f48a9ccb2d4d63181b65717fba00a369d2edc561a54f58a.-JdaI9RPkMvpsHA5m68iyuSoVid8wYKyFeS7heFLrcM
+        hash: v1.k794b7964.ad2381f9f853e117fc1bb32a5b52df82fa140887429d40cfe47f0af571dea8ff.IixA--QW9BdKnE0eKsnR9sKwcW63o5KNIOmyrTnFO5U
     scenes-app-inbox-cards--report-card-states--light:
-        hash: v1.k794b7964.1bcaa3f21f83ce7aff492151c5766f0468c0ac5001119f4976a909dae010d930.bIK_qGwJqmk4st2S34_eTMvuSEu14g5MozbyqXXujss
+        hash: v1.k794b7964.d49cbf402191824c2177369beb09f95cd19cb50234196c536fe42214f894c0ff.-d2_s6pz-ytJ7BfzqPnUE41Lo6ppPbi7bSvLyYz3-pA
     scenes-app-inbox-cards--report-cards--dark:
-        hash: v1.k794b7964.4557defabb8b6dcd2b11f2fe6ec8c844e75b613de3c048311871ef3d98298d20.cqt3LDe-eirmnHTS7DYOgjBFon2v4jQFJzcdsPt01Ao
+        hash: v1.k794b7964.461ca058bc8d0c7d0018f9a7b87f41839f000676d1e6cdce81473f1ad2170da7.6u6Cm_0P6wvoQdO5yIVGdKtWj7PCXYmT2xsvTulynRE
     scenes-app-inbox-cards--report-cards--light:
-        hash: v1.k794b7964.5bb0adad16641c593c2f9099d80745749c4e8593b3282540ff391351765ee1cc.xhHXAYDICcr0KlGgZ4C0Kyc_zLqvcr8HBV_1kB9lC4Q
+        hash: v1.k794b7964.2e3e0099408744c0b80b0884f23ac8d7e1a6e19da5eed2c8b74282bbb94ceef6.SPXO5NaPdNI7nzYMxGjSjrVzX5lXA19lYGq5voBMoww
     scenes-app-inbox-cards--skeleton--dark:
         hash: v1.k794b7964.4ab1f8cb97f347a2aae442ca814c70c538c54e4a9efb1c3cdd6681a56cad5e90.wVmcanELl0wz7-rhcnN8K5MGXmKMMxXELkYcCEpCxKs
     scenes-app-inbox-cards--skeleton--light:

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -74,7 +74,7 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     const showSkeleton = !isLoaded && (reportsResponseLoading || (count ?? 0) > 0)
 
     return (
-        <div className="mx-auto max-w-4xl flex flex-col gap-4 px-6 py-4">
+        <div className="@container mx-auto max-w-4xl flex flex-col gap-4 px-6 py-4">
             <InboxSearchFilterBar onRefresh={() => refresh()} refreshing={reportsResponseLoading} />
             <InboxBulkSelectionBar />
 

--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -165,15 +165,6 @@ export function ReportCard({
                 </div>
             ) : null}
 
-            {/* Desktop: timestamp anchored bottom-right. On mobile the card stacks, so it moves inline (below). */}
-            <div className="absolute right-4 bottom-3 z-10 hidden @lg:block">
-                <TZLabel
-                    time={report.updated_at ?? report.created_at}
-                    className="text-xs text-tertiary tabular-nums"
-                    title="Last updated"
-                />
-            </div>
-
             <Link to={detailUrl} className="flex min-w-0 flex-1 items-start gap-3 text-left text-inherit no-underline">
                 {report.priority && (
                     <div className="shrink-0">
@@ -222,12 +213,14 @@ export function ReportCard({
                         </div>
                     ) : null}
 
-                    {/* Mobile-only timestamp (desktop pins it to the card's bottom-right corner). */}
-                    <TZLabel
-                        time={report.updated_at ?? report.created_at}
-                        className="@lg:hidden mt-0.5 text-xs text-tertiary tabular-nums"
-                        title="Last updated"
-                    />
+                    {/* In flow on mobile (the card stacks); pinned to the card's bottom-right corner on desktop. */}
+                    <div className="mt-0.5 @lg:absolute @lg:right-4 @lg:bottom-3 @lg:z-10 @lg:mt-0">
+                        <TZLabel
+                            time={report.updated_at ?? report.created_at}
+                            className="text-xs text-tertiary tabular-nums"
+                            title="Last updated"
+                        />
+                    </div>
                 </div>
             </Link>
 

--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -165,7 +165,8 @@ export function ReportCard({
                 </div>
             ) : null}
 
-            <div className="absolute right-4 bottom-3 z-10">
+            {/* Desktop: timestamp anchored bottom-right. On mobile the card stacks, so it moves inline (below). */}
+            <div className="absolute right-4 bottom-3 z-10 hidden @lg:block">
                 <TZLabel
                     time={report.updated_at ?? report.created_at}
                     className="text-xs text-tertiary tabular-nums"
@@ -181,7 +182,13 @@ export function ReportCard({
                 )}
 
                 <div className="flex flex-col gap-1.5 min-w-0 flex-1">
-                    <div className="min-w-0 break-words font-semibold text-sm leading-snug">
+                    {/* Pad clear of the absolute PR badge on mobile, where the title spans the full card width. */}
+                    <div
+                        className={clsx(
+                            'min-w-0 break-words font-semibold text-sm leading-snug',
+                            hasPr && 'pr-14 @lg:pr-0'
+                        )}
+                    >
                         {conventionalTitle && (
                             <ConventionalCommitScopeTag type={conventionalTitle.type} scope={conventionalTitle.scope} />
                         )}
@@ -214,10 +221,17 @@ export function ReportCard({
                             )}
                         </div>
                     ) : null}
+
+                    {/* Mobile-only timestamp (desktop pins it to the card's bottom-right corner). */}
+                    <TZLabel
+                        time={report.updated_at ?? report.created_at}
+                        className="@lg:hidden mt-0.5 text-xs text-tertiary tabular-nums"
+                        title="Last updated"
+                    />
                 </div>
             </Link>
 
-            <div className="flex items-center gap-2.5 self-stretch shrink-0 border-l border-primary pl-3">
+            <div className="flex items-center justify-end gap-2.5 shrink-0 @lg:self-stretch @lg:border-l @lg:border-primary @lg:pl-3">
                 <LemonButton
                     type="secondary"
                     size="small"

--- a/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
+++ b/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
@@ -61,7 +61,7 @@ export function useReportArchive({
  */
 export function inboxCardRowClassName(attached: boolean, opts?: { dashed?: boolean }): string {
     return clsx(
-        'group flex w-full items-stretch gap-3 bg-surface-primary px-4 py-3.5 transition-all duration-150 hover:bg-surface-secondary',
+        'group flex w-full flex-col gap-2.5 @lg:flex-row @lg:items-stretch @lg:gap-3 bg-surface-primary px-4 py-3.5 transition-all duration-150 hover:bg-surface-secondary',
         attached
             ? 'border-b border-primary last:border-b-0'
             : opts?.dashed

--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -179,15 +179,15 @@ export function ReportDetailSkeleton(): JSX.Element {
         <div className="@container w-full max-w-[calc(160ch+5rem)] mx-auto px-6 py-5 text-sm" aria-hidden>
             <div className="flex flex-col gap-3.5 mb-6 pb-5 border-b border-primary">
                 <div className="h-3.5 w-24 rounded bg-fill-highlight-50 animate-pulse" />
-                <div className="flex items-start justify-between gap-4 flex-wrap">
-                    <div className="flex items-start gap-3 min-w-0 flex-1">
+                <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-start @2xl:justify-between @2xl:gap-4">
+                    <div className="flex items-start gap-3 min-w-0 @2xl:flex-1">
                         <div className="size-7 shrink-0 mt-0.5 rounded bg-fill-highlight-100 animate-pulse" />
                         <div className="flex flex-col gap-2 min-w-0 flex-1">
                             <div className="h-6 w-2/3 rounded bg-fill-highlight-100 animate-pulse" />
                             <div className="h-3 w-1/2 rounded bg-fill-highlight-50 animate-pulse" />
                         </div>
                     </div>
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex items-center flex-wrap gap-2 @2xl:shrink-0">
                         <div className="h-8 w-24 rounded bg-fill-highlight-50 animate-pulse" />
                         <div className="h-8 w-20 rounded bg-fill-highlight-50 animate-pulse" />
                     </div>
@@ -265,9 +265,9 @@ export function InboxDetailFrame({
                 >
                     {INBOX_TAB_LABEL[tab]}
                 </LemonButton>
-                <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-start @2xl:justify-between @2xl:gap-4">
                     {/* Priority square anchors the title; everything else collapses into the meta line. */}
-                    <div className="flex items-start gap-3 min-w-0 flex-1">
+                    <div className="flex items-start gap-3 min-w-0 @2xl:flex-1">
                         {report.priority && (
                             <div className="shrink-0 mt-0.5">
                                 <SignalReportPriorityBadge
@@ -293,7 +293,7 @@ export function InboxDetailFrame({
                             />
                         </div>
                     </div>
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex items-center flex-wrap gap-2 @2xl:shrink-0">
                         <LemonButton
                             type="secondary"
                             size="small"


### PR DESCRIPTION
## Problem

The Inbox report views were built desktop-first and broke badly on narrow screens. On a phone-width viewport:

- **Report/PR list cards** crushed the title into a ~110px column (every word wrapped onto its own line) because the Archive/Review button column is `shrink-0` next to a `flex-1 min-w-0` content column with no responsive stacking.
- **The report detail header** was worse — the title rendered one character per line, vertically, and the action buttons (Copy link / Archive / Create PR) overlapped the priority badge. Same root cause: a `flex-1 min-w-0` title block sitting beside a `shrink-0` actions block, so the title collapsed to min-content instead of wrapping below the buttons.

## Changes

All changes are container-query driven, so desktop layout is byte-for-byte unchanged and the new stacked layout only kicks in on narrow widths (the inbox can also render in a narrow side panel, so container queries are more correct than viewport breakpoints here).

- **List cards** (`ReportCard` / shared row class): stack vertically below `@lg`, with the action buttons dropping to a right-aligned row underneath the content. The desktop-only `border-l` divider and the absolutely-positioned timestamp are gated to `@lg`; on mobile the timestamp moves inline into the content column. Titles get right padding on mobile so they clear the absolute PR badge.
- **Detail header** (`InboxDetailFrame` + its skeleton): the title block and action buttons stack vertically below `@2xl` and the actions can wrap, instead of being forced side-by-side.

### Screenshots (390px viewport)

| | Before | After |
|---|---|---|
| List card | title crushed to one word per line | full-width title, inline timestamp, buttons below |
| Detail header | title rendered one char per line | title wraps normally, actions on their own row |

Desktop (1440px) list and detail were re-checked and render identically to before.

## How did you test this code?

I'm an agent (Claude Code). No automated tests were added — this is a CSS/responsive-layout-only change (Tailwind class changes plus one `clsx` wrap). I verified manually by driving the local dev app with Playwright at 390px and 1440px across the Reports list, Pull requests list, and a report detail page, confirming mobile is fixed and desktop is unchanged. Changed files were formatted with oxfmt.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to make Inbox reports more mobile friendly and to inspect the current state on mobile. Built with Claude Code (Opus 4.8); used the Playwright MCP server to screenshot the live local app at mobile/desktop widths before and after.

Key decisions:
- **Container queries over viewport breakpoints.** The inbox list also renders inside a ~320px setup-rail split on desktop, so keying off the container width (added `@container` to the list wrapper) avoids the layout flipping based on the wrong dimension. The detail view already used `@container`/`@4xl`, so this is consistent with the existing approach.
- **Preserve desktop exactly.** Rather than redesign the card (e.g. moving the timestamp/PR badge out of their absolute corners for everyone), the absolute positioning and `border-l` divider are gated behind `@lg` and mobile gets in-flow equivalents. Costs one duplicated `TZLabel` per card but keeps the desktop design the team built untouched.
- Breakpoints: cards go horizontal at `@lg` (512px container — room for content + two buttons); the detail header, which carries up to three action buttons, goes horizontal at `@2xl` (672px).
