### PR TITLE
feat(cohorts): allow group property filters on behavioral event conditions

### DIFF
--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -21,6 +21,8 @@ from posthog.clickhouse.client import sync_execute
 from posthog.hogql_queries.hogql_cohort_query import TestWrapperCohortQuery as CohortQuery
 from posthog.models import Team
 from posthog.models.filters.filter import Filter
+from posthog.models.group.util import create_group
+from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
@@ -575,6 +577,143 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                             "event_filters": [
                                 {"key": "$filter_prop", "value": "something", "operator": "exact", "type": "event"},
                                 {"key": "$filter_prop", "value": "some", "operator": "icontains", "type": "event"},
+                            ],
+                        }
+                    ],
+                }
+            }
+        )
+
+        res = execute(filter, self.team)
+
+        assert [p1.uuid] == [r[0] for r in res]
+
+    def test_performed_event_with_group_property_event_filter(self):
+        create_group_type_mapping_without_created_at(
+            team=self.team, project_id=self.team.project_id, group_type="clinic", group_type_index=0
+        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="clinic:us", properties={"country": "US"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="clinic:uk", properties={"country": "UK"})
+
+        # p1 performed the event tied to the US clinic
+        p1 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={"name": "test", "email": "test@posthog.com"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={"$group_0": "clinic:us"},
+            distinct_id="p1",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+
+        # p2 performed the same event but tied to the UK clinic
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2"],
+            properties={"name": "test", "email": "test@posthog.com"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={"$group_0": "clinic:uk"},
+            distinct_id="p2",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+        flush_persons_and_events()
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event",
+                            "type": "behavioral",
+                            "event_filters": [
+                                {
+                                    "key": "country",
+                                    "value": "US",
+                                    "operator": "exact",
+                                    "type": "group",
+                                    "group_type_index": 0,
+                                },
+                            ],
+                        }
+                    ],
+                }
+            }
+        )
+
+        res = execute(filter, self.team)
+
+        assert [p1.uuid] == [r[0] for r in res]
+
+    def test_performed_event_multiple_with_group_property_event_filter(self):
+        create_group_type_mapping_without_created_at(
+            team=self.team, project_id=self.team.project_id, group_type="clinic", group_type_index=0
+        )
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="clinic:us", properties={"country": "US"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="clinic:uk", properties={"country": "UK"})
+
+        p1 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={"name": "test", "email": "test@posthog.com"},
+        )
+        for _ in range(2):
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                properties={"$group_0": "clinic:us"},
+                distinct_id="p1",
+                timestamp=datetime.now() - timedelta(days=2),
+            )
+
+        # p2 hit the threshold but against the UK clinic, so should be excluded
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2"],
+            properties={"name": "test", "email": "test@posthog.com"},
+        )
+        for _ in range(2):
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                properties={"$group_0": "clinic:uk"},
+                distinct_id="p2",
+                timestamp=datetime.now() - timedelta(days=2),
+            )
+        flush_persons_and_events()
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "operator": "gte",
+                            "operator_value": 2,
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event_multiple",
+                            "type": "behavioral",
+                            "event_filters": [
+                                {
+                                    "key": "country",
+                                    "value": "US",
+                                    "operator": "exact",
+                                    "type": "group",
+                                    "group_type_index": 0,
+                                },
                             ],
                         }
                     ],

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -28,6 +28,7 @@ import {
     FieldOptionsType,
 } from 'scenes/cohorts/CohortFilters/types'
 
+import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import {
     AnyPropertyFilter,
@@ -226,6 +227,7 @@ export function CohortEventFiltersField({
     })
     const { value } = useValues(logic)
     const { onChange } = useActions(logic)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
     const componentRef = useRef<HTMLDivElement>(null)
 
     const valueExists = ((value as AnyPropertyFilter[]) || []).length > 0
@@ -258,6 +260,7 @@ export function CohortEventFiltersField({
                     TaxonomicFilterGroupType.EventFeatureFlags,
                     TaxonomicFilterGroupType.Elements,
                     TaxonomicFilterGroupType.HogQLExpression,
+                    ...groupsTaxonomicTypes,
                 ]}
                 onChange={(newValue: AnyPropertyFilter[]) => {
                     onChange({ [fieldKey]: newValue })

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -256,6 +256,14 @@ class HogQLFilter(BaseModel, extra="forbid"):
     value: Any | None = None
 
 
+class GroupPropFilter(BaseModel, extra="forbid"):
+    type: Literal["group"]
+    key: str
+    value: Any | None = None
+    operator: str | None = None
+    group_type_index: int | None = None
+
+
 class BehavioralFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
     type: Literal["behavioral"]
     key: Union[str, int]  # action IDs can be ints
@@ -272,7 +280,7 @@ class BehavioralFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
     seq_event_type: str | None = None
     total_periods: int | None = None
     min_periods: int | None = None
-    event_filters: list[Union[EventPropFilter, HogQLFilter]] | None = None
+    event_filters: list[Union[EventPropFilter, HogQLFilter, GroupPropFilter]] | None = None
     explicit_datetime: str | None = None
     explicit_datetime_to: str | None = None
 

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -19,6 +19,7 @@ from posthog.schema import (
     FunnelsActorsQuery,
     FunnelsFilter,
     FunnelsQuery,
+    GroupPropertyFilter,
     HogQLPropertyFilter,
     HogQLQueryModifiers,
     InsightActorsQuery,
@@ -205,12 +206,14 @@ def convert_property(prop: Property) -> PersonPropertyFilter:
     return PersonPropertyFilter(key=prop.key, value=value, operator=prop.operator or PropertyOperator.EXACT)
 
 
-def property_to_typed_property(property: Property) -> EventPropertyFilter | HogQLPropertyFilter:
+def property_to_typed_property(property: Property) -> EventPropertyFilter | HogQLPropertyFilter | GroupPropertyFilter:
     type = get_property_type(property)
     if type == "event":
         return EventPropertyFilter(**property.to_dict())
     if type == "hogql":
         return HogQLPropertyFilter(**property.to_dict())
+    if type == "group":
+        return GroupPropertyFilter(**property.to_dict())
     raise ValidationError("Property type not supported")
 
 

--- a/products/cohorts/frontend/generated/api.schemas.ts
+++ b/products/cohorts/frontend/generated/api.schemas.ts
@@ -34,6 +34,14 @@ export interface HogQLFilterApi {
     value?: unknown
 }
 
+export interface GroupPropFilterApi {
+    type: 'group'
+    key: string
+    value?: unknown
+    operator?: string | null
+    group_type_index?: number | null
+}
+
 export interface BehavioralFilterApi {
     bytecode?: unknown[] | null
     bytecode_error?: string | null
@@ -53,7 +61,7 @@ export interface BehavioralFilterApi {
     seq_event_type?: string | null
     total_periods?: number | null
     min_periods?: number | null
-    event_filters?: (EventPropFilterApi | HogQLFilterApi)[] | null
+    event_filters?: (EventPropFilterApi | HogQLFilterApi | GroupPropFilterApi)[] | null
     explicit_datetime?: string | null
     explicit_datetime_to?: string | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11190,6 +11190,14 @@ export namespace Schemas {
       value?: unknown;
     }
 
+    export interface GroupPropFilter {
+      type: 'group';
+      key: string;
+      value?: unknown;
+      operator?: string | null;
+      group_type_index?: number | null;
+    }
+
     export interface BehavioralFilter {
       bytecode?: unknown[] | null;
       bytecode_error?: string | null;
@@ -11209,7 +11217,7 @@ export namespace Schemas {
       seq_event_type?: string | null;
       total_periods?: number | null;
       min_periods?: number | null;
-      event_filters?: (EventPropFilter | HogQLFilter)[] | null;
+      event_filters?: (EventPropFilter | HogQLFilter | GroupPropFilter)[] | null;
       explicit_datetime?: string | null;
       explicit_datetime_to?: string | null;
     }

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -97,6 +97,15 @@ export const CohortsCreateBody = /* @__PURE__ */ zod.object({
                                                         key: zod.string(),
                                                         value: zod.unknown().optional(),
                                                     }),
+                                                    zod.object({
+                                                        type: zod.literal('group'),
+                                                        key: zod.string(),
+                                                        value: zod.unknown().optional(),
+                                                        operator: zod.union([zod.string(), zod.null()]).optional(),
+                                                        group_type_index: zod
+                                                            .union([zod.number(), zod.null()])
+                                                            .optional(),
+                                                    }),
                                                 ])
                                             ),
                                             zod.null(),
@@ -234,6 +243,15 @@ export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                         type: zod.literal('hogql'),
                                                         key: zod.string(),
                                                         value: zod.unknown().optional(),
+                                                    }),
+                                                    zod.object({
+                                                        type: zod.literal('group'),
+                                                        key: zod.string(),
+                                                        value: zod.unknown().optional(),
+                                                        operator: zod.union([zod.string(), zod.null()]).optional(),
+                                                        group_type_index: zod
+                                                            .union([zod.number(), zod.null()])
+                                                            .optional(),
                                                     }),
                                                 ])
                                             ),


### PR DESCRIPTION
## Problem

A common ask for groups (e.g. a "clinic" group type): build a cohort of *people who did an event tied to a specific group or group property* — for example "users who performed `$pageview` where the clinic's country is US". Today the event filter inside a cohort "completed event" condition only offers event, feature-flag, element, and HogQL properties, so there's no way to filter the matched event by a group property. This forces customers to denormalize group identifiers onto person properties just to segment by them.

Refs #62986

## Changes

- **Frontend** (`CohortField.tsx`): the property filter inside cohort behavioral event criteria now includes the project's group taxonomic types (`...groupsTaxonomicTypes`), so group properties show up alongside event properties in the picker.
- **Backend validation** (`api/cohort.py`): the behavioral `event_filters` model accepts a new `group` filter type (`GroupPropFilter`) in addition to event and HogQL filters.
- **Backend query builder** (`hogql_cohort_query.py`): `property_to_typed_property` now maps a `group` property to `GroupPropertyFilter`. This flows through both the `performed_event` path (via `EventsNode.properties`, which already accepts group filters in the schema) and the `performed_event_multiple` path (via `EventsQuery.properties`).

A group-property filter compiles to the same `LEFT JOIN` against the `groups` table that trends/funnels group breakdowns already use, so no new query machinery — and cohort conditions run as batch recalculations, not latency-sensitive live queries.

## How did you test this code?

I'm an agent (PostHog Slack app). I added two functional tests in `test_cohort_query.py` that create a `clinic` group type, two clinics (US/UK), and persons with events tied to each, then assert a cohort filtered by `country = US` matches only the US-clinic person — one for `performed_event` and one for `performed_event_multiple`.

I could not run the ClickHouse/Postgres integration tests in my sandbox (no DB services available), so they need to run in CI. I did verify locally: ruff passes on all changed Python, and `GroupPropertyFilter` constructs cleanly from a group `Property.to_dict()` (the group path is the exact analog of the existing event-property path, adding only `group_type_index`, which the schema accepts).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Originated from a Slack thread about groups in cohorts: the team confirmed you currently can't filter a cohort's event condition by a group property, blocking the natural "people who did an event at clinic X" workaround. Before implementing, I traced both the frontend taxonomic-type wiring and the backend HogQL group-property join cost to confirm it reuses the well-trodden trends/funnels group-join path rather than adding new query load.

Decisions: used `Refs` not `Closes` on #62986 because that issue ("Allow cohorts to be created using group properties") is broader than the event-filter path delivered here. Wired the frontend off `groupsModel.groupsTaxonomicTypes` (same selector used by insights/breakdowns) rather than hardcoding `groups_0..N`, so it adapts to the project's actual group types.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0656PRPJJX/p1781815273019759?thread_ts=1781815273.019759&cid=C0656PRPJJX)*
