### PR TITLE
fix(endpoints): return 4xx not 500 for bad materialize queries

### DIFF
--- a/products/endpoints/backend/services/crud.py
+++ b/products/endpoints/backend/services/crud.py
@@ -240,6 +240,8 @@ class EndpointCrudService:
 
         except APIException:
             raise
+        except ValidationError:
+            raise
         except Exception as e:
             current_version = endpoint.get_version()
             capture_exception(

--- a/products/endpoints/backend/services/materialization.py
+++ b/products/endpoints/backend/services/materialization.py
@@ -16,6 +16,7 @@ from rest_framework.request import Request
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.printer.utils import print_prepared_ast
@@ -148,6 +149,10 @@ class EndpointMaterializationService:
         except ValidationError:
             ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="validation_error").inc()
             raise
+        except ExposedHogQLError as e:
+            # A bad user query, not a system fault — surface as a 400.
+            ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="validation_error").inc()
+            raise ValidationError(f"Cannot materialize endpoint. Reason: {e}")
         except Exception:
             ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="error").inc()
             # Not a request-validation problem — surface as a server error, not a 400.

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -17,6 +17,8 @@ from rest_framework.response import Response
 
 from posthog.schema import RetentionQuery
 
+from posthog.hogql.errors import QueryError
+
 from posthog.constants import RETENTION_FIRST_EVER_OCCURRENCE, TREND_FILTER_TYPE_EVENTS
 from posthog.settings.temporal import DATA_MODELING_TASK_QUEUE
 from posthog.sync import database_sync_to_async
@@ -324,6 +326,30 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         # Should indicate variable metadata issue
         self.assertIn("Cannot materialize endpoint", response.json()["detail"])
+
+    def test_enable_materialization_user_query_error_returns_400(self):
+        endpoint = create_endpoint_with_version(
+            name="test_hogql_error",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        with mock.patch.object(
+            EndpointMaterializationService,
+            "_enable_materialization_inner",
+            autospec=True,
+            side_effect=QueryError("Unresolved placeholder: {variables.event_id}"),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+                {"is_materialized": True, "data_freshness_seconds": 86400},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertIn("Unresolved placeholder", str(response.json()))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Enabling materialization on an endpoint whose query raises a HogQL error (e.g. an unresolved variable placeholder, or an invalid query) returned a 500 and was counted as a system error — tripping the materialization-failure alert — when it's really an invalid user query.

## Changes

- `enable_materialization` catches `ExposedHogQLError` (`QueryError`, `SyntaxError`) → 400 `ValidationError` with `status="validation_error"`. Genuine system faults still bucket as `status="error"` / 500.
- `crud.update()` re-raises `ValidationError` so the real reason surfaces instead of a generic "Failed to update endpoint."

## How did you test this code?

Agent (Claude Code). Added a backend test asserting a HogQL `QueryError` during enable returns 400 with the reason (not 500). Ran `test_endpoint_materialization.py` + `test_endpoint.py`: 144 passed; ruff clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while triaging a materialization-failure alert — user-facing HogQL errors were bucketed as system errors. Test-first fix. A separate, benign preview-path resolution error was investigated and ruled out as the alert's cause, left for a follow-up.
