### PR TITLE
fix(snowflake): treat unparseable key-pair PEM key as user error

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -23,6 +23,17 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 _SNOWFLAKE_IMPLEMENTATION = SnowflakeImplementation()
 
+# cryptography raises ValueError("Unable to load PEM file ...") when the key-pair private key can't
+# be parsed — typically the user pasted the bare base64 DER body without the
+# `-----BEGIN/END PRIVATE KEY-----` framing, or a truncated key. The `{action}` placeholder lets each
+# call site supply its own context-appropriate verb ("resync." on the sync path, "try again." during
+# credential validation) while keeping the guidance text defined once.
+_MALFORMED_PEM_MESSAGE = (
+    "Your Snowflake key-pair private key could not be read. Paste the full PEM private key including "
+    "the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines (not just the base64 body), "
+    "then {action}"
+)
+
 SnowflakeErrors = {
     "No active warehouse selected in the current session": "No warehouse found for selected role",
     "or attempt to login with another role": "Role specified doesn't exist or is not authorized",
@@ -217,11 +228,9 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # can never succeed until the customer re-registers the matching public key. The host and
             # request id in the message are volatile, so we match the stable phrase.
             "JWT token is invalid": "Snowflake rejected key-pair authentication because the signed token is invalid — the private key you configured doesn't match the public key registered on the Snowflake user (often after a key rotation, or if the public key was never set). Re-register the matching public key on your Snowflake user (ALTER USER ... SET RSA_PUBLIC_KEY), or paste the correct private key here, then resync.",
-            # cryptography raises ValueError("Unable to load PEM file ...") when the key-pair private
-            # key can't be parsed — typically the user pasted the bare base64 DER body without the
-            # `-----BEGIN/END PRIVATE KEY-----` framing, or a truncated key. Retrying can never
-            # succeed until they paste a valid PEM key.
-            "Unable to load PEM file": "Your Snowflake key-pair private key could not be read. Paste the full PEM private key including the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines (not just the base64 body), then resync.",
+            # See `_MALFORMED_PEM_MESSAGE`: the key-pair private key can't be parsed, so retrying can
+            # never succeed until the user pastes a valid PEM key.
+            "Unable to load PEM file": _MALFORMED_PEM_MESSAGE.format(action="resync."),
             # Snowflake error 002003 (SQLSTATE 42S02 for tables / 02000 for schemas): a table or
             # schema the source syncs was dropped or renamed in Snowflake, or the role's grant on it
             # was revoked, after the schema was discovered. The driver raises "<object> does not exist
@@ -265,10 +274,7 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # A malformed key-pair private key fails to parse in `load_pem_private_key` before we ever
             # reach Snowflake — a user config error, not an unexpected failure worth capturing.
             if "Unable to load PEM file" in str(e):
-                return (
-                    False,
-                    "Your Snowflake key-pair private key could not be read. Paste the full PEM private key including the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines (not just the base64 body), then try again.",
-                )
+                return False, _MALFORMED_PEM_MESSAGE.format(action="try again.")
             capture_exception(e)
             return False, "Could not connect to Snowflake. Please check all connection details are valid."
         except Exception as e:

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -217,6 +217,11 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # can never succeed until the customer re-registers the matching public key. The host and
             # request id in the message are volatile, so we match the stable phrase.
             "JWT token is invalid": "Snowflake rejected key-pair authentication because the signed token is invalid — the private key you configured doesn't match the public key registered on the Snowflake user (often after a key rotation, or if the public key was never set). Re-register the matching public key on your Snowflake user (ALTER USER ... SET RSA_PUBLIC_KEY), or paste the correct private key here, then resync.",
+            # cryptography raises ValueError("Unable to load PEM file ...") when the key-pair private
+            # key can't be parsed — typically the user pasted the bare base64 DER body without the
+            # `-----BEGIN/END PRIVATE KEY-----` framing, or a truncated key. Retrying can never
+            # succeed until they paste a valid PEM key.
+            "Unable to load PEM file": "Your Snowflake key-pair private key could not be read. Paste the full PEM private key including the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines (not just the base64 body), then resync.",
             # Snowflake error 002003 (SQLSTATE 42S02 for tables / 02000 for schemas): a table or
             # schema the source syncs was dropped or renamed in Snowflake, or the role's grant on it
             # was revoked, after the schema was discovered. The driver raises "<object> does not exist
@@ -254,6 +259,16 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
                 if key in error_msg:
                     return False, value
 
+            capture_exception(e)
+            return False, "Could not connect to Snowflake. Please check all connection details are valid."
+        except ValueError as e:
+            # A malformed key-pair private key fails to parse in `load_pem_private_key` before we ever
+            # reach Snowflake — a user config error, not an unexpected failure worth capturing.
+            if "Unable to load PEM file" in str(e):
+                return (
+                    False,
+                    "Your Snowflake key-pair private key could not be read. Paste the full PEM private key including the -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- lines (not just the base64 body), then try again.",
+                )
             capture_exception(e)
             return False, "Could not connect to Snowflake. Please check all connection details are valid."
         except Exception as e:

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -761,6 +761,18 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming",
+            "Unable to load PEM file.",
+        ],
+    )
+    def test_unparseable_private_key_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Unparseable private-key error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
             "Operation timed out while waiting for the warehouse to resume",
         ],
@@ -769,3 +781,34 @@ class TestSnowflakeSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Error should remain retryable: {error_msg}"
+
+
+class TestSnowflakeValidateCredentials:
+    @pytest.fixture
+    def source(self):
+        return SnowflakeSource()
+
+    def test_unparseable_private_key_returns_friendly_message_without_capture(self, source):
+        pem_error = ValueError(
+            "Unable to load PEM file. See https://cryptography.io/en/latest/faq/"
+            "#why-can-t-i-import-my-pem-file for more details. MalformedFraming"
+        )
+        with (
+            patch.object(source, "get_schemas", side_effect=pem_error),
+            patch("posthog.temporal.data_imports.sources.snowflake.source.capture_exception") as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("keypair"), team_id=1)
+
+        assert ok is False
+        assert message is not None and "PEM private key" in message
+        mock_capture.assert_not_called()
+
+    def test_unexpected_value_error_is_still_captured(self, source):
+        with (
+            patch.object(source, "get_schemas", side_effect=ValueError("something unexpected")),
+            patch("posthog.temporal.data_imports.sources.snowflake.source.capture_exception") as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("keypair"), team_id=1)
+
+        assert ok is False
+        mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `ValueError: Unable to load PEM file. ... MalformedFraming` originating in the Snowflake data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019edcf5-86ba-7041-803b-bce49b140488), same fingerprint as the active [`019e6ad8`](https://us.posthog.com/project/2/error_tracking/019e6ad8-2176-75e2-8cf0-62931cdcfb3a) — 10 occurrences across 5 customers, last seen the day this was triaged).

The stack is genuine and ours:

```
connect            posthog/temporal/data_imports/sources/snowflake/snowflake.py:213  (load_pem_private_key)
get_schemas        posthog/temporal/data_imports/sources/common/sql/base.py:112
validate_credentials  posthog/temporal/data_imports/sources/snowflake/source.py:250
```

`cryptography` raises this `ValueError` when the configured key-pair private key can't be parsed — almost always because the user pasted the bare base64 DER body without the `-----BEGIN/END PRIVATE KEY-----` framing (or a truncated key). It's a user/upstream config error: retrying can never succeed until they paste a valid PEM key.

Two things were wrong:

- All observed events fire from the schema-discovery path (`/external_data_sources/database_schema/` → `validate_credentials`), where this `ValueError` falls through to the generic `except Exception` and gets `capture_exception`'d — turning a plain config mistake into error-tracking noise with an unhelpful "Could not connect" message.
- On the sync path the same parse failure would retry indefinitely, since the string wasn't recognised as non-retryable.

## Changes

- `validate_credentials`: catch the malformed-PEM `ValueError` and return an actionable message ("paste the full PEM key including the BEGIN/END lines") **without** capturing it. Other `ValueError`s are still captured as before.
- `get_non_retryable_errors`: add `"Unable to load PEM file"` (a stable, low-false-positive substring) so a key that goes bad mid-sync stops retrying and surfaces the same guidance.

Scoped strictly to this error. A separate, valid-but-mismatched key (`JWT token is invalid`) is already handled, and the "Bad decrypt. Incorrect password?" case is a distinct issue left untouched.

## How did you test this code?

I'm an agent. I added and ran automated unit tests — no manual testing.

- `test_unparseable_private_key_is_non_retryable` — parametrized with the real production message; asserts it matches a non-retryable key.
- `test_transient_errors_are_retryable` — existing negative guard still passes (the new key doesn't over-match).
- `test_unparseable_private_key_returns_friendly_message_without_capture` / `test_unexpected_value_error_is_still_captured` — verify `validate_credentials` returns the friendly message and does not capture for the PEM case, but still captures other `ValueError`s.

Full file: `88 passed`. Ran `ruff check` / `ruff format --check` clean on both files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to pull the issue, stack trace, and a representative event, then read the source under `posthog/temporal/data_imports/sources/snowflake/`.

Decision: the failure is a user-supplied malformed PEM key, so the fix both treats it as non-retryable (sync path) and handles it gracefully in credential validation (the path actually generating the captured events) rather than continuing to capture it as an unexpected exception. Checked open PRs (including the maintainer's) and confirmed #64602 covers a different key-pair failure (`JWT token is invalid`), so this is not a duplicate.
