### PR TITLE
fix(data-warehouse): update managed warehouse copy

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -581,8 +581,7 @@ export const productConfiguration: Record<string, any> = {
         name: 'Data ops',
         projectBased: true,
         activityScope: 'DataWarehouse',
-        description:
-            'Manage your data warehouse sources and queries. New source syncs are always free for the first 7 days',
+        description: "Manage your organization's shared data warehouse.",
         iconType: 'data_warehouse',
     },
     Models: {

--- a/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
@@ -117,10 +117,7 @@ export function SettingsTab(): JSX.Element {
             <div>
                 <h2 className="mb-2">Managed warehouse</h2>
                 {!isReady && (
-                    <p className="text-muted mb-4">
-                        Provision a dedicated data warehouse with Aurora, S3, and isolated compute for your
-                        organization. It's shared by every project in the organization.
-                    </p>
+                    <p className="text-muted mb-4">This warehouse is shared by every project in the organization.</p>
                 )}
             </div>
 
@@ -211,7 +208,7 @@ export function SettingsTab(): JSX.Element {
                                     ? 'Retry managed warehouse provisioning?'
                                     : 'Provision managed warehouse?',
                                 description:
-                                    'This will create dedicated AWS resources (Aurora database, S3 bucket, IAM roles) for your organization, shared by every project in it. This typically takes 5-15 minutes.',
+                                    'This will create a managed warehouse for your organization, shared by every project in it. This typically takes 5-15 minutes.',
                                 primaryButton: {
                                     children: isFailed ? 'Retry provisioning' : 'Provision',
                                     onClick: () => provisionWarehouse({ databaseName: retryDatabaseName }),
@@ -294,7 +291,7 @@ export function SettingsTab(): JSX.Element {
                                     LemonDialog.open({
                                         title: 'Deprovision managed warehouse?',
                                         description:
-                                            'This will delete all AWS resources (Aurora database, S3 bucket, IAM roles) for your organization and every project in it. This action cannot be undone.',
+                                            'This will delete the managed warehouse for your organization and every project in it. This action cannot be undone.',
                                         primaryButton: {
                                             children: 'Deprovision',
                                             status: 'danger',

--- a/products/data_warehouse/manifest.tsx
+++ b/products/data_warehouse/manifest.tsx
@@ -16,8 +16,7 @@ export const manifest: ProductManifest = {
             import: () => import('./DataWarehouseScene'),
             projectBased: true,
             activityScope: 'DataWarehouse',
-            description:
-                'Manage your data warehouse sources and queries. New source syncs are always free for the first 7 days',
+            description: "Manage your organization's shared data warehouse.",
             iconType: 'data_warehouse',
         },
         Models: {


### PR DESCRIPTION
## Problem

The Data ops scene's description and the managed-warehouse settings copy were stale/verbose.

## Changes

Tightens the Data ops product description and the managed-warehouse copy in `SettingsTab`.

## How did you test this code?

I'm an agent; copy-only change. No automated tests beyond the repo's standard lint/format on commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @eric.

**Stack (merge bottom-up):**
1. **this PR** — managed warehouse copy
2. backfill telemetry (write path) → `eric/dw-backfill-telemetry`
3. warehouse_sync_status API (read path) → `eric/dw-sync-status-api`
4. warehouse Overview tab (frontend) → `eric/dw-overview-tab`

Split out of the original combined PR #64733 for reviewability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
