### PR TITLE
feat(data-warehouse): capture event backfill partition telemetry

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -38,6 +38,7 @@ from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.ducklake.backfill_telemetry import emit_backfill_partition_event
 from posthog.ducklake.common import attach_catalog, escape, get_config
 from posthog.ducklake.storage import DuckLakeStorageConfig, configure_connection
 from posthog.settings.base_variables import DEBUG
@@ -365,7 +366,7 @@ def export_events_to_s3(
     partition_date: datetime,
     run_id: str,
     settings: dict[str, Any],
-) -> list[str]:
+) -> tuple[list[str], int]:
     """Export events for a specific team_id chunk to S3 as Parquet.
 
     Returns list of S3 paths that were written.
@@ -410,7 +411,7 @@ def export_events_to_s3(
     SETTINGS s3_truncate_on_insert=1, use_hive_partitioning=0
     """
         context.log.info(f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}...")
-        return []
+        return [], 0
 
     context.log.info(f"Exporting events chunk {chunk_info} to {s3_path}")
     logger.info(
@@ -423,9 +424,15 @@ def export_events_to_s3(
 
     try:
         _execute_export_with_retry(client, export_sql, settings, chunk_info)
-        context.log.info(f"Successfully exported chunk {chunk_info}")
-        logger.info("export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks)
-        return [s3_path]
+        written_rows = 0
+        try:
+            progress = client.last_query.progress if client.last_query else None
+            written_rows = int(progress.written_rows) if progress else 0
+        except Exception:
+            written_rows = 0
+        context.log.info(f"Successfully exported chunk {chunk_info} ({written_rows} rows)")
+        logger.info("export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks, written_rows=written_rows)
+        return [s3_path], written_rows
     except Exception:
         context.log.exception(f"Failed to export chunk {chunk_info} after {MAX_RETRY_ATTEMPTS} attempts")
         logger.exception("export_chunk_failed", chunk=team_id_chunk, total_chunks=total_chunks)
@@ -630,8 +637,9 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
     workload = Workload.OFFLINE if is_cloud() else Workload.DEFAULT
 
     all_s3_paths: list[str] = []
+    total_rows_exported = 0
 
-    def export_single_chunk(chunk_i: int) -> list[str]:
+    def export_single_chunk(chunk_i: int) -> tuple[list[str], int]:
         """Export a single chunk with its own client connection.
 
         Each thread gets its own ClickHouse client via any_host_by_role() because
@@ -639,7 +647,7 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
         threads cannot use the same Client instance.
         """
 
-        def do_export(client: Client) -> list[str]:
+        def do_export(client: Client) -> tuple[list[str], int]:
             with tags_context(kind="dagster", dagster=tags):
                 return export_events_to_s3(
                     context=context,
@@ -659,52 +667,80 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
             node_role=NodeRole.DATA,
         ).result()
 
-    if parallel_chunks > 1:
-        context.log.info(f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers")
-        with ThreadPoolExecutor(max_workers=parallel_chunks) as executor:
-            futures = {executor.submit(export_single_chunk, i): i for i in range(team_id_chunks)}
-            for future in as_completed(futures):
-                chunk_i = futures[future]
-                try:
-                    paths = future.result()
-                    all_s3_paths.extend(paths)
-                    context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
-                except Exception:
-                    context.log.exception(f"Chunk {chunk_i + 1}/{team_id_chunks} failed")
-                    raise
-    else:
-        for chunk_i in range(team_id_chunks):
-            context.log.info(f"Processing chunk {chunk_i + 1}/{team_id_chunks}")
-            paths = export_single_chunk(chunk_i)
-            all_s3_paths.extend(paths)
-            context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
+    try:
+        if parallel_chunks > 1:
+            context.log.info(f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers")
+            with ThreadPoolExecutor(max_workers=parallel_chunks) as executor:
+                futures = {executor.submit(export_single_chunk, i): i for i in range(team_id_chunks)}
+                for future in as_completed(futures):
+                    chunk_i = futures[future]
+                    try:
+                        paths, rows = future.result()
+                        all_s3_paths.extend(paths)
+                        total_rows_exported += rows
+                        context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
+                    except Exception:
+                        context.log.exception(f"Chunk {chunk_i + 1}/{team_id_chunks} failed")
+                        raise
+        else:
+            for chunk_i in range(team_id_chunks):
+                context.log.info(f"Processing chunk {chunk_i + 1}/{team_id_chunks}")
+                paths, rows = export_single_chunk(chunk_i)
+                all_s3_paths.extend(paths)
+                total_rows_exported += rows
+                context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
 
-    context.log.info(f"Exported {len(all_s3_paths)} files to S3")
-    logger.info("export_complete", files_exported=len(all_s3_paths))
+        context.log.info(f"Exported {len(all_s3_paths)} files to S3")
+        logger.info("export_complete", files_exported=len(all_s3_paths))
 
-    registered_count = register_files_with_ducklake(context, all_s3_paths, config)
+        registered_count = register_files_with_ducklake(context, all_s3_paths, config)
 
-    context.add_output_metadata(
-        {
-            "partition_date": partition_range_str,
-            "team_id_chunks": team_id_chunks,
-            "parallel_chunks": parallel_chunks,
-            "files_exported": len(all_s3_paths),
-            "files_registered": registered_count,
-            "s3_paths": dagster.MetadataValue.json(all_s3_paths[:10]),
-        }
-    )
+        context.add_output_metadata(
+            {
+                "partition_date": partition_range_str,
+                "team_id_chunks": team_id_chunks,
+                "parallel_chunks": parallel_chunks,
+                "files_exported": len(all_s3_paths),
+                "files_registered": registered_count,
+                "rows_exported": total_rows_exported,
+                "s3_paths": dagster.MetadataValue.json(all_s3_paths[:10]),
+            }
+        )
 
-    context.log.info(
-        f"Successfully backfilled events for partitions {partition_range_str}: "
-        f"{len(all_s3_paths)} files exported, {registered_count} files registered with DuckLake"
-    )
-    logger.info(
-        "events_backfill_complete",
-        partition_range=partition_range_str,
-        files_exported=len(all_s3_paths),
-        files_registered=registered_count,
-    )
+        context.log.info(
+            f"Successfully backfilled events for partitions {partition_range_str}: "
+            f"{len(all_s3_paths)} files exported, {registered_count} files registered with DuckLake"
+        )
+        logger.info(
+            "events_backfill_complete",
+            partition_range=partition_range_str,
+            files_exported=len(all_s3_paths),
+            files_registered=registered_count,
+        )
+        if not config.dry_run:
+            try:
+                emit_backfill_partition_event(
+                    partition_date=partition_date.date(),
+                    status="success",
+                    run_id=context.run.run_id,
+                    rows_exported=total_rows_exported,
+                    files_exported=len(all_s3_paths),
+                    files_registered=registered_count,
+                )
+            except Exception:
+                context.log.exception("Failed to emit backfill success event (non-fatal)")
+    except Exception as exc:
+        if not config.dry_run:
+            try:
+                emit_backfill_partition_event(
+                    partition_date=partition_date.date(),
+                    status="failed",
+                    run_id=context.run.run_id,
+                    error_message=str(exc)[:1000],
+                )
+            except Exception:
+                context.log.exception("Failed to emit backfill failure event (non-fatal)")
+        raise
 
 
 events_ducklake_backfill_job = define_asset_job(

--- a/posthog/ducklake/backfill_telemetry.py
+++ b/posthog/ducklake/backfill_telemetry.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+from posthog.ph_client import ph_scoped_capture
+
+BACKFILL_PARTITION_EVENT = "warehouse_event_backfill_partition"
+BACKFILL_DISTINCT_ID = "warehouse-event-backfill"
+
+
+def emit_backfill_partition_event(
+    *,
+    partition_date: date,
+    status: str,
+    run_id: str,
+    rows_exported: int | None = None,
+    files_exported: int | None = None,
+    files_registered: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    """Capture one terminal event per backfill partition run. Best-effort: on Cloud the event
+    lands in the internal project; off Cloud `ph_scoped_capture` is a no-op."""
+    properties: dict[str, object] = {
+        "partition_date": partition_date.isoformat(),
+        "status": status,
+        "run_id": run_id,
+        "rows_exported": rows_exported,
+        "files_exported": files_exported,
+        "files_registered": files_registered,
+        "error_message": error_message,
+    }
+    with ph_scoped_capture() as capture:
+        capture(distinct_id=BACKFILL_DISTINCT_ID, event=BACKFILL_PARTITION_EVENT, properties=properties)

--- a/posthog/ducklake/test/test_backfill_telemetry.py
+++ b/posthog/ducklake/test/test_backfill_telemetry.py
@@ -1,0 +1,24 @@
+from datetime import date
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_PARTITION_EVENT, emit_backfill_partition_event
+
+
+class TestBackfillTelemetry(BaseTest):
+    def test_emits_event_with_properties(self) -> None:
+        capture = MagicMock()
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=capture)
+        cm.__exit__ = MagicMock(return_value=False)
+        with patch("posthog.ducklake.backfill_telemetry.ph_scoped_capture", return_value=cm):
+            emit_backfill_partition_event(
+                partition_date=date(2020, 5, 1), status="success", run_id="r1", rows_exported=99
+            )
+        capture.assert_called_once()
+        kwargs = capture.call_args.kwargs
+        assert kwargs["event"] == BACKFILL_PARTITION_EVENT
+        assert kwargs["properties"]["partition_date"] == "2020-05-01"
+        assert kwargs["properties"]["status"] == "success"
+        assert kwargs["properties"]["rows_exported"] == 99


### PR DESCRIPTION
## Problem

There was no signal for how up-to-date the managed warehouse's event data is. To surface that without a new table or migration, the Dagster event backfill needs to report its per-partition progress.

## Changes

The `events_ducklake_backfill` asset now emits one best-effort PostHog capture event per partition run (`success`/`failed`, with row and file counts) via `ph_scoped_capture`. The capture is fully best-effort — a telemetry failure never fails the backfill (success/failure both wrapped, failure re-raised after emitting). Adds `posthog/ducklake/backfill_telemetry.py` (event name/constants + emitter) and its test.

No consumer yet — the read side is the next PR in the stack.

## How did you test this code?

I'm an agent; automated only: `posthog/ducklake/test/test_backfill_telemetry.py` (writer emits the expected event/properties), plus a dag import smoke-check. No manual run of the Dagster job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @eric.

**Stack:** #64741 (copy) → **this PR** → `eric/dw-sync-status-api` → `eric/dw-overview-tab`. Split from #64733.

Decision: chose capture-events over a new Postgres table (this backfill backend is being retired) and over querying the customer warehouse (avoid added load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
