### PR TITLE
feat(data-warehouse): add warehouse_sync_status API

### DIFF
--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -57,11 +57,15 @@ SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type
 # GitHub secret alert relay URL - set in US deployment to forward alerts to EU
 GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RELAY_URL", optional=True)
 
-# Internal team on PostHog Cloud US that receives `$ai_generation` /
-# `$ai_embedding` events emitted by PostHog products (PostHog Code,
-# background agents, etc). Used by /api/llm_analytics/personal_spend/.
+# Internal team on PostHog Cloud that receives capture events emitted by PostHog products
+# (PostHog Code, background agents, the warehouse event backfill, `$ai_generation`, etc).
+# Read back by features that report on PostHog's own product telemetry.
 # Override in tests via @override_settings to point at a per-test team.
-LLM_ANALYTICS_INTERNAL_TEAM_ID: int = 2
+INTERNAL_TELEMETRY_TEAM_ID: int = get_from_env("INTERNAL_TELEMETRY_TEAM_ID", 2, type_cast=int)
+
+# Back-compat alias for AI observability (/api/llm_analytics/personal_spend/), which reads
+# `$ai_generation` / `$ai_embedding` events from the same internal project.
+LLM_ANALYTICS_INTERNAL_TEAM_ID: int = INTERNAL_TELEMETRY_TEAM_ID
 
 # Duckgres - URL, internal secret, and PG endpoint for the managed warehouse service
 DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 from django.db import connection
@@ -34,6 +34,8 @@ from products.data_modeling.backend.models.data_modeling_job import DataModeling
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.api import managed_warehouse
 from products.data_warehouse.backend.models.team_data_warehouse_config import TeamDataWarehouseConfig
+from products.data_warehouse.backend.warehouse_sync.contracts import WarehouseSyncStatusSerializer
+from products.data_warehouse.backend.warehouse_sync.dagster_provider import DagsterBackfillStatusProvider
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -948,3 +950,14 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     def check_database_name(self, request: Request, **kwargs) -> Response:
         """Check if a database name is available."""
         return managed_warehouse.check_name(self.team.organization_id, request.query_params.get("name"))
+
+    @extend_schema(responses={200: WarehouseSyncStatusSerializer})
+    @action(methods=["GET"], detail=False, url_path="warehouse_sync_status")
+    def warehouse_sync_status(self, request: Request, **kwargs: Any) -> Response:
+        """Freshness of the managed warehouse's event data.
+
+        The event backfill is platform-global (one shared run covers every team's events), so this
+        reflects the whole deployment's freshness, not a per-organization value.
+        """
+        dto = DagsterBackfillStatusProvider().get_status()
+        return Response(WarehouseSyncStatusSerializer(dto).data)

--- a/products/data_warehouse/backend/api/test/test_warehouse_sync_status.py
+++ b/products/data_warehouse/backend/api/test/test_warehouse_sync_status.py
@@ -1,0 +1,41 @@
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from django.test import override_settings
+from django.utils import timezone
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_DISTINCT_ID, BACKFILL_PARTITION_EVENT
+
+
+class TestWarehouseSyncStatusAPI(ClickhouseTestMixin, APIBaseTest):
+    def test_returns_neutral_contract(self) -> None:
+        yesterday = (timezone.now().date() - timedelta(days=1)).isoformat()
+        _create_event(
+            team=self.team,
+            event=BACKFILL_PARTITION_EVENT,
+            distinct_id=BACKFILL_DISTINCT_ID,
+            properties={"partition_date": yesterday, "status": "success", "rows_exported": 5},
+        )
+        flush_persons_and_events()
+
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            res = self.client.get(f"/api/environments/{self.team.id}/data_warehouse/warehouse_sync_status/")
+
+        assert res.status_code == 200, res.json()
+        body = res.json()
+        assert set(body.keys()) >= {
+            "backend",
+            "state",
+            "fresh_through",
+            "lag_seconds",
+            "last_activity_at",
+            "initial_backfill",
+            "total_rows_synced",
+            "error",
+            "updated_at",
+        }
+        # The Dagster backend can't determine one-time-load completeness, so it reports null here.
+        assert body["initial_backfill"] is None
+        assert body["state"] == "caught_up"
+        assert body["total_rows_synced"] == 5

--- a/products/data_warehouse/backend/warehouse_sync/__init__.py
+++ b/products/data_warehouse/backend/warehouse_sync/__init__.py
@@ -1,0 +1,13 @@
+from products.data_warehouse.backend.warehouse_sync.contracts import (
+    InitialBackfill,
+    SyncError,
+    WarehouseSyncStatusDTO,
+    WarehouseSyncStatusSerializer,
+)
+
+__all__ = [
+    "InitialBackfill",
+    "SyncError",
+    "WarehouseSyncStatusDTO",
+    "WarehouseSyncStatusSerializer",
+]

--- a/products/data_warehouse/backend/warehouse_sync/contracts.py
+++ b/products/data_warehouse/backend/warehouse_sync/contracts.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from rest_framework import serializers
+
+# Backend-neutral freshness contract. Today only the Dagster event backfill fills it (backend
+# "dagster", initial_backfill null, never "seeding"). The "viaduck" backend, "seeding" state, and
+# the initial_backfill block are kept so a future CDC backend — which routes per tenant and tracks
+# real seeding progress — can populate them without an API or UI change.
+WAREHOUSE_SYNC_STATES = ["seeding", "caught_up", "lagging", "error", "not_started"]
+WAREHOUSE_SYNC_BACKENDS = ["dagster", "viaduck"]
+
+
+@dataclass
+class InitialBackfill:
+    complete: bool
+    progress_pct: int | None
+
+
+@dataclass
+class SyncError:
+    message: str
+    since: datetime
+
+
+@dataclass
+class WarehouseSyncStatusDTO:
+    backend: str
+    state: str
+    fresh_through: datetime | None
+    lag_seconds: int | None
+    last_activity_at: datetime | None
+    # Null when the backend can't determine one-time-load progress (e.g. the Dagster backfill, whose
+    # historical partitions predate this telemetry). The CDC backend reports real seeding progress.
+    initial_backfill: InitialBackfill | None
+    total_rows_synced: int | None
+    error: SyncError | None
+    updated_at: datetime
+
+
+class _InitialBackfillSerializer(serializers.Serializer[InitialBackfill]):  # type: ignore[type-arg]
+    complete = serializers.BooleanField(help_text="Whether the one-time historical load has finished.")
+    progress_pct = serializers.IntegerField(
+        allow_null=True, help_text="Historical load progress, 0-100, or null if unknown."
+    )
+
+
+class _SyncErrorSerializer(serializers.Serializer[SyncError]):  # type: ignore[type-arg]
+    message = serializers.CharField(help_text="Human-readable error message.")
+    since = serializers.DateTimeField(help_text="When the current error first occurred.")
+
+
+class WarehouseSyncStatusSerializer(serializers.Serializer[WarehouseSyncStatusDTO]):  # type: ignore[type-arg]
+    backend = serializers.ChoiceField(choices=WAREHOUSE_SYNC_BACKENDS, help_text="Pipeline moving the data (internal).")
+    state = serializers.ChoiceField(choices=WAREHOUSE_SYNC_STATES, help_text="Overall freshness state.")
+    fresh_through = serializers.DateTimeField(allow_null=True, help_text="Timestamp the warehouse is fresh through.")
+    lag_seconds = serializers.IntegerField(allow_null=True, help_text="Seconds behind now/source, or null if unknown.")
+    last_activity_at = serializers.DateTimeField(allow_null=True, help_text="Last time the pipeline made progress.")
+    initial_backfill = _InitialBackfillSerializer(
+        allow_null=True, help_text="One-time historical load status, or null if the backend can't determine it."
+    )
+    total_rows_synced = serializers.IntegerField(
+        allow_null=True, help_text="Cumulative events moved into the warehouse."
+    )
+    error = _SyncErrorSerializer(allow_null=True, help_text="Current error, or null when healthy.")
+    updated_at = serializers.DateTimeField(help_text="When this status was computed.")

--- a/products/data_warehouse/backend/warehouse_sync/dagster_provider.py
+++ b/products/data_warehouse/backend/warehouse_sync/dagster_provider.py
@@ -1,0 +1,113 @@
+from datetime import UTC, date, datetime, time, timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from posthog.clickhouse.client import sync_execute
+from posthog.ducklake.backfill_telemetry import BACKFILL_PARTITION_EVENT
+
+from products.data_warehouse.backend.warehouse_sync.contracts import SyncError, WarehouseSyncStatusDTO
+
+PARTITION_START = date(2019, 1, 1)
+RECENT_FAILURE_WINDOW = timedelta(days=7)
+# A daily batch is "up to date" once its frontier is within ~2 days of now.
+CAUGHT_UP_LAG_SECONDS = 2 * 24 * 60 * 60
+
+# Latest event per partition_date for the telemetry team.
+_QUERY = """
+SELECT
+    JSONExtractString(properties, 'partition_date') AS partition_date,
+    argMax(JSONExtractString(properties, 'status'), timestamp) AS status,
+    argMax(JSONExtractInt(properties, 'rows_exported'), timestamp) AS rows_exported,
+    argMax(JSONExtractString(properties, 'error_message'), timestamp) AS error_message,
+    max(timestamp) AS last_event_at
+FROM events
+WHERE team_id = %(team_id)s AND event = %(event)s
+GROUP BY partition_date
+"""
+
+
+def _empty(now: datetime, state: str) -> WarehouseSyncStatusDTO:
+    return WarehouseSyncStatusDTO(
+        backend="dagster",
+        state=state,
+        fresh_through=None,
+        lag_seconds=None,
+        last_activity_at=None,
+        initial_backfill=None,
+        total_rows_synced=None,
+        error=None,
+        updated_at=now,
+    )
+
+
+class DagsterBackfillStatusProvider:
+    """Platform-global backfill freshness.
+
+    The `events_ducklake_backfill` job runs once per day for every team's events, so this status is
+    a single deployment-wide fact, not per-organization. Freshness is the latest successful partition
+    date; it deliberately does NOT report one-time-backfill completeness, because historical
+    partitions predate this telemetry and a sparse event stream can't prove a contiguous load.
+    """
+
+    backend = "dagster"
+
+    def get_status(self) -> WarehouseSyncStatusDTO:
+        now = timezone.now()
+        # Backfill telemetry is captured by ph_scoped_capture into the internal project that
+        # receives PostHog products' own events.
+        team_id = settings.INTERNAL_TELEMETRY_TEAM_ID
+        if not team_id:
+            return _empty(now, "not_started")
+
+        rows = sync_execute(_QUERY, {"team_id": int(team_id), "event": BACKFILL_PARTITION_EVENT})
+        if not rows:
+            return _empty(now, "not_started")
+
+        done = 0
+        total_rows = 0
+        fresh_date: date | None = None
+        last_event_at: datetime | None = None
+        latest_failure: tuple[datetime, str] | None = None
+
+        for partition_date_str, status, row_count, error_message, event_at in rows:
+            if last_event_at is None or event_at > last_event_at:
+                last_event_at = event_at
+            if status == "success":
+                done += 1
+                total_rows += int(row_count or 0)
+                pd = date.fromisoformat(partition_date_str)
+                if fresh_date is None or pd > fresh_date:
+                    fresh_date = pd
+            elif status == "failed":
+                if latest_failure is None or event_at > latest_failure[0]:
+                    latest_failure = (event_at, error_message or "Backfill partition failed")
+
+        fresh_through = datetime.combine(fresh_date, time.max, tzinfo=UTC) if fresh_date is not None else None
+        lag_seconds = int((now - fresh_through).total_seconds()) if fresh_through is not None else None
+
+        # Only surface failures whose latest event is recent; a stale historical failure must not
+        # pin the warehouse to an error state forever.
+        recent_failure = latest_failure is not None and latest_failure[0] >= now - RECENT_FAILURE_WINDOW
+        error = SyncError(message=latest_failure[1], since=latest_failure[0]) if recent_failure else None
+
+        if recent_failure:
+            state = "error"
+        elif done == 0:
+            state = "not_started"
+        elif lag_seconds is not None and lag_seconds <= CAUGHT_UP_LAG_SECONDS:
+            state = "caught_up"
+        else:
+            state = "lagging"
+
+        return WarehouseSyncStatusDTO(
+            backend=self.backend,
+            state=state,
+            fresh_through=fresh_through,
+            lag_seconds=lag_seconds,
+            last_activity_at=last_event_at,
+            initial_backfill=None,
+            total_rows_synced=total_rows or None,
+            error=error,
+            updated_at=now,
+        )

--- a/products/data_warehouse/backend/warehouse_sync/test/test_contracts.py
+++ b/products/data_warehouse/backend/warehouse_sync/test/test_contracts.py
@@ -1,0 +1,30 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import BaseTest
+
+from products.data_warehouse.backend.warehouse_sync.contracts import (
+    InitialBackfill,
+    WarehouseSyncStatusDTO,
+    WarehouseSyncStatusSerializer,
+)
+
+
+class TestWarehouseSyncStatusSerializer(BaseTest):
+    def test_serializes_nested_shape(self) -> None:
+        dto = WarehouseSyncStatusDTO(
+            backend="dagster",
+            state="caught_up",
+            fresh_through=datetime(2026, 6, 17, 23, 59, tzinfo=UTC),
+            lag_seconds=3600,
+            last_activity_at=datetime(2026, 6, 18, 1, 0, tzinfo=UTC),
+            initial_backfill=InitialBackfill(complete=True, progress_pct=100),
+            total_rows_synced=8_900_000_000,
+            error=None,
+            updated_at=datetime(2026, 6, 18, 2, 0, tzinfo=UTC),
+        )
+        data = WarehouseSyncStatusSerializer(dto).data
+        assert data["backend"] == "dagster"
+        assert data["state"] == "caught_up"
+        assert data["initial_backfill"] == {"complete": True, "progress_pct": 100}
+        assert data["error"] is None
+        assert data["total_rows_synced"] == 8_900_000_000

--- a/products/data_warehouse/backend/warehouse_sync/test/test_dagster_provider.py
+++ b/products/data_warehouse/backend/warehouse_sync/test/test_dagster_provider.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timedelta
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from django.test import override_settings
+from django.utils import timezone
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_DISTINCT_ID, BACKFILL_PARTITION_EVENT
+
+from products.data_warehouse.backend.warehouse_sync.dagster_provider import DagsterBackfillStatusProvider
+
+
+class TestDagsterProvider(ClickhouseTestMixin, APIBaseTest):
+    def _emit(
+        self,
+        partition_date: str,
+        status: str,
+        timestamp: datetime | None = None,
+        **props: object,
+    ) -> None:
+        kwargs: dict[str, object] = {
+            "team": self.team,
+            "event": BACKFILL_PARTITION_EVENT,
+            "distinct_id": BACKFILL_DISTINCT_ID,
+            "properties": {"partition_date": partition_date, "status": status, **props},
+        }
+        if timestamp is not None:
+            kwargs["timestamp"] = timestamp
+        _create_event(**kwargs)
+
+    @override_settings(INTERNAL_TELEMETRY_TEAM_ID=None)
+    def test_not_started_without_telemetry_team(self) -> None:
+        dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.state == "not_started"
+        assert dto.initial_backfill is None
+
+    def test_error_state_when_a_partition_failed(self) -> None:
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        self._emit(yesterday, "success", timestamp=now, rows_exported=5)
+        self._emit("2020-01-01", "failed", timestamp=now, error_message="boom")
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.state == "error"
+        assert dto.error is not None
+        assert dto.error.message == "boom"
+        assert dto.total_rows_synced == 5
+
+    def test_stale_failure_does_not_pin_error(self) -> None:
+        # An old failure (outside the recent-failure window) plus a recent success for yesterday
+        # should NOT produce an error; the state should be caught_up.
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        self._emit("2020-06-01", "failed", timestamp=now - timedelta(days=400), error_message="old error")
+        self._emit(yesterday, "success", timestamp=now, rows_exported=7)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.state == "caught_up"
+        assert dto.error is None
+
+    def test_lagging_when_frontier_is_behind(self) -> None:
+        # Latest success is far in the past, so the warehouse is behind the live edge.
+        # The Dagster backend never reports initial-backfill progress (it can't prove completeness).
+        now = timezone.now()
+        self._emit("2021-06-01", "success", timestamp=now, rows_exported=3)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.state == "lagging"
+        assert dto.initial_backfill is None
+        assert dto.fresh_through is not None
+        assert dto.lag_seconds is not None and dto.lag_seconds > 0
+
+    def test_caught_up_when_frontier_reaches_yesterday(self) -> None:
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        self._emit(yesterday, "success", timestamp=now, rows_exported=9)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.state == "caught_up"
+        assert dto.initial_backfill is None
+
+    def test_latest_event_per_partition_wins(self) -> None:
+        d = "2020-01-01"
+        now = timezone.now()
+        # Emit the failure first with an earlier timestamp, then success with a later one.
+        # argMax picks the row with the greatest timestamp, so success should win.
+        self._emit(d, "failed", timestamp=now - timedelta(seconds=10), error_message="first")
+        self._emit(d, "success", timestamp=now, rows_exported=10)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = DagsterBackfillStatusProvider().get_status()
+        assert dto.error is None  # the success supersedes the earlier failure
+        assert dto.total_rows_synced == 10

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -152,6 +152,94 @@ export interface WarehouseStatusResponseApi {
 }
 
 /**
+ * * `dagster` - dagster
+ * * `viaduck` - viaduck
+ */
+export type BackendEnumApi = (typeof BackendEnumApi)[keyof typeof BackendEnumApi]
+
+export const BackendEnumApi = {
+    Dagster: 'dagster',
+    Viaduck: 'viaduck',
+} as const
+
+/**
+ * * `seeding` - seeding
+ * * `caught_up` - caught_up
+ * * `lagging` - lagging
+ * * `error` - error
+ * * `not_started` - not_started
+ */
+export type WarehouseSyncStatusStateEnumApi =
+    (typeof WarehouseSyncStatusStateEnumApi)[keyof typeof WarehouseSyncStatusStateEnumApi]
+
+export const WarehouseSyncStatusStateEnumApi = {
+    Seeding: 'seeding',
+    CaughtUp: 'caught_up',
+    Lagging: 'lagging',
+    Error: 'error',
+    NotStarted: 'not_started',
+} as const
+
+export interface _InitialBackfillApi {
+    /** Whether the one-time historical load has finished. */
+    complete: boolean
+    /**
+     * Historical load progress, 0-100, or null if unknown.
+     * @nullable
+     */
+    progress_pct: number | null
+}
+
+export interface _SyncErrorApi {
+    /** Human-readable error message. */
+    message: string
+    /** When the current error first occurred. */
+    since: string
+}
+
+export interface WarehouseSyncStatusApi {
+    /** Pipeline moving the data (internal).
+     *
+     * * `dagster` - dagster
+     * * `viaduck` - viaduck */
+    backend: BackendEnumApi
+    /** Overall freshness state.
+     *
+     * * `seeding` - seeding
+     * * `caught_up` - caught_up
+     * * `lagging` - lagging
+     * * `error` - error
+     * * `not_started` - not_started */
+    state: WarehouseSyncStatusStateEnumApi
+    /**
+     * Timestamp the warehouse is fresh through.
+     * @nullable
+     */
+    fresh_through: string | null
+    /**
+     * Seconds behind now/source, or null if unknown.
+     * @nullable
+     */
+    lag_seconds: number | null
+    /**
+     * Last time the pipeline made progress.
+     * @nullable
+     */
+    last_activity_at: string | null
+    /** One-time historical load status, or null if the backend can't determine it. */
+    initial_backfill: _InitialBackfillApi | null
+    /**
+     * Cumulative events moved into the warehouse.
+     * @nullable
+     */
+    total_rows_synced: number | null
+    /** Current error, or null when healthy. */
+    error: _SyncErrorApi | null
+    /** When this status was computed. */
+    updated_at: string
+}
+
+/**
  * * `full_refresh` - full_refresh
  * * `incremental` - incremental
  * * `append` - append

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -70,6 +70,7 @@ import type {
     WarehouseSavedQueriesListParams,
     WarehouseSavedQueryDraftsListParams,
     WarehouseStatusResponseApi,
+    WarehouseSyncStatusApi,
     WarehouseTablesListParams,
     WarehouseViewLinkListParams,
     WarehouseViewLinksListParams,
@@ -385,6 +386,26 @@ export const dataWarehouseWarehouseStatusRetrieve = async (
     options?: RequestInit
 ): Promise<WarehouseStatusResponseApi> => {
     return apiMutator<WarehouseStatusResponseApi>(getDataWarehouseWarehouseStatusRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDataWarehouseWarehouseSyncStatusRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/data_warehouse/warehouse_sync_status/`
+}
+
+/**
+ * Freshness of the managed warehouse's event data.
+ *
+ * The event backfill is platform-global (one shared run covers every team's events), so this
+ * reflects the whole deployment's freshness, not a per-organization value.
+ */
+export const dataWarehouseWarehouseSyncStatusRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<WarehouseSyncStatusApi> => {
+    return apiMutator<WarehouseSyncStatusApi>(getDataWarehouseWarehouseSyncStatusRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -145,6 +145,9 @@ tools:
     data-warehouse-warehouse-status-retrieve:
         operation: data_warehouse_warehouse_status_retrieve
         enabled: false
+    data-warehouse-warehouse-sync-status-retrieve:
+        operation: data_warehouse_warehouse_sync_status_retrieve
+        enabled: false
     external-data-schemas-cancel:
         operation: external_data_schemas_cancel_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9329,6 +9329,18 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `dagster` - dagster
+     * * `viaduck` - viaduck
+     */
+    export type BackendEnum = typeof BackendEnum[keyof typeof BackendEnum];
+
+
+    export const BackendEnum = {
+      Dagster: 'dagster',
+      Viaduck: 'viaduck',
+    } as const;
+
+    /**
      * * `AED` - AED
      * * `AFN` - AFN
      * * `ALL` - ALL
@@ -47635,6 +47647,83 @@ export namespace Schemas {
          */
       failed_at: string | null;
       connection?: WarehouseConnection | null;
+    }
+
+    /**
+     * * `seeding` - seeding
+     * * `caught_up` - caught_up
+     * * `lagging` - lagging
+     * * `error` - error
+     * * `not_started` - not_started
+     */
+    export type WarehouseSyncStatusStateEnum = typeof WarehouseSyncStatusStateEnum[keyof typeof WarehouseSyncStatusStateEnum];
+
+
+    export const WarehouseSyncStatusStateEnum = {
+      Seeding: 'seeding',
+      CaughtUp: 'caught_up',
+      Lagging: 'lagging',
+      Error: 'error',
+      NotStarted: 'not_started',
+    } as const;
+
+    export interface _InitialBackfill {
+      /** Whether the one-time historical load has finished. */
+      complete: boolean;
+      /**
+         * Historical load progress, 0-100, or null if unknown.
+         * @nullable
+         */
+      progress_pct: number | null;
+    }
+
+    export interface _SyncError {
+      /** Human-readable error message. */
+      message: string;
+      /** When the current error first occurred. */
+      since: string;
+    }
+
+    export interface WarehouseSyncStatus {
+      /** Pipeline moving the data (internal).
+       *
+       * * `dagster` - dagster
+       * * `viaduck` - viaduck */
+      backend: BackendEnum;
+      /** Overall freshness state.
+       *
+       * * `seeding` - seeding
+       * * `caught_up` - caught_up
+       * * `lagging` - lagging
+       * * `error` - error
+       * * `not_started` - not_started */
+      state: WarehouseSyncStatusStateEnum;
+      /**
+         * Timestamp the warehouse is fresh through.
+         * @nullable
+         */
+      fresh_through: string | null;
+      /**
+         * Seconds behind now/source, or null if unknown.
+         * @nullable
+         */
+      lag_seconds: number | null;
+      /**
+         * Last time the pipeline made progress.
+         * @nullable
+         */
+      last_activity_at: string | null;
+      /** One-time historical load status, or null if the backend can't determine it. */
+      initial_backfill: _InitialBackfill | null;
+      /**
+         * Cumulative events moved into the warehouse.
+         * @nullable
+         */
+      total_rows_synced: number | null;
+      /** Current error, or null when healthy. */
+      error: _SyncError | null;
+      /** When this status was computed. */
+      updated_at: string;
     }
 
     export interface WeeklyDigestResponse {


### PR DESCRIPTION
## Problem

The frontend needs a backend-neutral way to show "how fresh is my warehouse's event data", readable without coupling to the specific pipeline (today Dagster, later a CDC service).

## Changes

- A backend-neutral `WarehouseSyncStatus` contract (DTO + DRF serializer) and an org-scoped `warehouse_sync_status` action on `DataWarehouseViewSet`.
- `DagsterBackfillStatusProvider` reads the backfill telemetry events (from the previous PR) out of ClickHouse and derives a freshness frontier + lag — **no queries against the customer warehouse**. It's explicitly platform-global (the backfill covers all teams) and deliberately does not claim historical-backfill completeness it can't prove from sparse telemetry (`initial_backfill` is null for this backend).
- Introduces a product-neutral `INTERNAL_TELEMETRY_TEAM_ID` setting (the internal project that receives PostHog products' own capture events); `LLM_ANALYTICS_INTERNAL_TEAM_ID` becomes a back-compat alias.
- Regenerated API/MCP types.

The contract keeps forward-looking fields (`backend`, `seeding`, nullable `initial_backfill`), documented in `contracts.py`, so a future CDC backend can populate them without an API/UI change.

## How did you test this code?

I'm an agent; automated only: contract serializer test; `DagsterBackfillStatusProvider` tests against real ClickHouse rows (caught_up / lagging / recent-error / stale-failure-ignored / latest-event-per-partition); the API action test; and `ai_observability` `personal_spend` tests pass (alias unbroken). `hogli build:openapi` regenerated types cleanly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @eric.

**Stack:** #64741 → `eric/dw-backfill-telemetry` → **this PR** → `eric/dw-overview-tab`. Split from #64733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
