### PR TITLE
feat(oauth): support MCP enterprise-managed authorization (ID-JAG)

### DIFF
--- a/frontend/src/scenes/settings/organization/VerifiedDomains/ConfigureIdJagModal.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/ConfigureIdJagModal.tsx
@@ -71,6 +71,11 @@ export function ConfigureIdJagModal(): JSX.Element {
                             a draft.
                         </LemonBanner>
                     )}
+                    <LemonBanner type="info">
+                        Configure your IdP to grant <code>user:read</code> plus the scopes each tool needs (for the MCP
+                        server, also <code>organization:read</code> and <code>project:read</code>). Tokens issued
+                        without these will be rejected with an insufficient-scope error.
+                    </LemonBanner>
                 </LemonModal.Content>
                 <LemonModal.Footer>
                     <LemonButton loading={isIdJagConfigSubmitting} type="primary" htmlType="submit">

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/ConfigureIdJagModal.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/ConfigureIdJagModal.tsx
@@ -72,9 +72,9 @@ export function ConfigureIdJagModal(): JSX.Element {
                         </LemonBanner>
                     )}
                     <LemonBanner type="info">
-                        Configure your IdP to grant <code>user:read</code> plus the scopes each tool needs (for the MCP
-                        server, also <code>organization:read</code> and <code>project:read</code>). Tokens issued
-                        without these will be rejected with an insufficient-scope error.
+                        Configure your IdP to grant <code>user:read</code> plus the scopes each integration needs (for
+                        project-scoped APIs, also <code>organization:read</code> and <code>project:read</code>). Tokens
+                        issued without the required scopes are rejected with an insufficient-scope error.
                     </LemonBanner>
                 </LemonModal.Content>
                 <LemonModal.Footer>

--- a/posthog/api/id_jag.py
+++ b/posthog/api/id_jag.py
@@ -37,6 +37,9 @@ ACCESS_TOKEN_TYPE = "at+jwt"
 # RFC 7521/7523 — JWT Bearer grant type identifier.
 JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
+# draft-ietf-oauth-identity-assertion-authz-grant §7.2 — advertised in metadata for ID-JAG discovery.
+ID_JAG_GRANT_PROFILE = "urn:ietf:params:oauth:grant-profile:id-jag"
+
 
 GENERIC_ID_JAG_REJECTION = "ID-JAG could not be verified"
 
@@ -121,6 +124,20 @@ def _get_site_url() -> str:
             error_code="server_error",
         )
     return site_url
+
+
+def _get_allowed_audiences() -> list[str]:
+    """Accepted ID-JAG `aud` values — the authorization-server issuer the client discovered.
+    Always includes SITE_URL; Cloud adds the OAuth proxy via ID_JAG_ALLOWED_AUDIENCES."""
+    extra = [a.rstrip("/") for a in (settings.ID_JAG_ALLOWED_AUDIENCES or []) if a]
+    return [_get_site_url(), *extra]
+
+
+def _get_allowed_resources() -> list[str]:
+    """Accepted ID-JAG `resource` values — the MCP resource identifier the client discovered.
+    Always includes SITE_URL; Cloud adds the MCP hosts via ID_JAG_ALLOWED_RESOURCES."""
+    extra = [r.rstrip("/") for r in (settings.ID_JAG_ALLOWED_RESOURCES or []) if r]
+    return [_get_site_url(), *extra]
 
 
 def _get_jwks_client(issuer: str, jwks_url: str | None = None) -> jwt.PyJWKClient:
@@ -268,7 +285,7 @@ def _verify_and_extract_id_jag_token(assertion: str) -> tuple[IdJagClaims, str, 
     except jwt.PyJWTError as e:
         raise InvalidGrantError(f"ID-JAG signing key resolution failed: {e}")
 
-    expected_audience = _get_site_url()
+    allowed_audiences = _get_allowed_audiences()
 
     try:
         claims = cast(
@@ -277,7 +294,7 @@ def _verify_and_extract_id_jag_token(assertion: str) -> tuple[IdJagClaims, str, 
                 assertion,
                 signing_key.key,
                 algorithms=["RS256", "RS384", "RS512"],
-                audience=expected_audience,
+                audience=allowed_audiences,
                 leeway=settings.ID_JAG_CLOCK_SKEW_SECONDS,
                 options={
                     "require": ["iss", "sub", "aud", "exp", "iat", "client_id"],
@@ -322,7 +339,7 @@ def _verify_and_extract_id_jag_token(assertion: str) -> tuple[IdJagClaims, str, 
     resource = claims.get("resource")
     if not resource:
         raise InvalidGrantError("ID-JAG is missing the resource claim (RFC 8707)")
-    if resource.rstrip("/") != expected_audience:
+    if resource.rstrip("/") not in _get_allowed_resources():
         raise InvalidTargetError(f"ID-JAG resource {resource!r} does not match this resource server")
 
     client_id = claims.get("client_id")
@@ -397,7 +414,7 @@ def _construct_access_token_payload(
         "iss": _get_site_url(),
         "sub": _get_sub(provider_name, cast(str, claims.get("sub"))),
         "email": verified_email,
-        "aud": claims.get("resource"),
+        "aud": str(claims.get("resource") or "").rstrip("/"),
         "client_id": claims.get("client_id"),
         "scope": " ".join(granted_scopes),
         "app_org": provider_name,

--- a/posthog/api/id_jag.py
+++ b/posthog/api/id_jag.py
@@ -126,18 +126,22 @@ def _get_site_url() -> str:
     return site_url
 
 
+def _id_jag_allowlist(extra: list[str] | None) -> list[str]:
+    """SITE_URL plus the trailing-slash-normalized `extra` values."""
+    return [_get_site_url(), *[v.rstrip("/") for v in (extra or []) if v]]
+
+
 def _get_allowed_audiences() -> list[str]:
     """Accepted ID-JAG `aud` values — the authorization-server issuer the client discovered.
     Always includes SITE_URL; Cloud adds the OAuth proxy via ID_JAG_ALLOWED_AUDIENCES."""
-    extra = [a.rstrip("/") for a in (settings.ID_JAG_ALLOWED_AUDIENCES or []) if a]
-    return [_get_site_url(), *extra]
+    return _id_jag_allowlist(settings.ID_JAG_ALLOWED_AUDIENCES)
 
 
-def _get_allowed_resources() -> list[str]:
-    """Accepted ID-JAG `resource` values — the MCP resource identifier the client discovered.
-    Always includes SITE_URL; Cloud adds the MCP hosts via ID_JAG_ALLOWED_RESOURCES."""
-    extra = [r.rstrip("/") for r in (settings.ID_JAG_ALLOWED_RESOURCES or []) if r]
-    return [_get_site_url(), *extra]
+def get_allowed_resources() -> list[str]:
+    """Accepted ID-JAG `resource` values — the resource identifier the client discovered.
+    Always includes SITE_URL; Cloud adds extra resource servers via ID_JAG_ALLOWED_RESOURCES.
+    Also used by the resource server (posthog.auth) to validate the minted token's `aud`."""
+    return _id_jag_allowlist(settings.ID_JAG_ALLOWED_RESOURCES)
 
 
 def _get_jwks_client(issuer: str, jwks_url: str | None = None) -> jwt.PyJWKClient:
@@ -339,7 +343,7 @@ def _verify_and_extract_id_jag_token(assertion: str) -> tuple[IdJagClaims, str, 
     resource = claims.get("resource")
     if not resource:
         raise InvalidGrantError("ID-JAG is missing the resource claim (RFC 8707)")
-    if resource.rstrip("/") not in _get_allowed_resources():
+    if resource.rstrip("/") not in get_allowed_resources():
         raise InvalidTargetError(f"ID-JAG resource {resource!r} does not match this resource server")
 
     client_id = claims.get("client_id")
@@ -414,7 +418,7 @@ def _construct_access_token_payload(
         "iss": _get_site_url(),
         "sub": _get_sub(provider_name, cast(str, claims.get("sub"))),
         "email": verified_email,
-        "aud": str(claims.get("resource") or "").rstrip("/"),
+        "aud": claims["resource"].rstrip("/"),
         "client_id": claims.get("client_id"),
         "scope": " ".join(granted_scopes),
         "app_org": provider_name,

--- a/posthog/api/id_jag.py
+++ b/posthog/api/id_jag.py
@@ -343,8 +343,11 @@ def _verify_and_extract_id_jag_token(assertion: str) -> tuple[IdJagClaims, str, 
     resource = claims.get("resource")
     if not resource:
         raise InvalidGrantError("ID-JAG is missing the resource claim (RFC 8707)")
-    if resource.rstrip("/") not in get_allowed_resources():
+    resource = resource.rstrip("/")
+    if resource not in get_allowed_resources():
         raise InvalidTargetError(f"ID-JAG resource {resource!r} does not match this resource server")
+    # Store the normalized value back so the minted token's `aud` is consistent.
+    claims["resource"] = resource
 
     client_id = claims.get("client_id")
     if not client_id:
@@ -418,7 +421,7 @@ def _construct_access_token_payload(
         "iss": _get_site_url(),
         "sub": _get_sub(provider_name, cast(str, claims.get("sub"))),
         "email": verified_email,
-        "aud": claims["resource"].rstrip("/"),
+        "aud": claims.get("resource"),
         "client_id": claims.get("client_id"),
         "scope": " ".join(granted_scopes),
         "app_org": provider_name,

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3998,15 +3998,6 @@ class TestOAuthAuthorizationServerMetadata(APIBaseTest):
             ["urn:ietf:params:oauth:grant-profile:id-jag"],
         )
 
-    def test_openid_configuration_advertises_id_jag_grant_profile(self):
-        response = self.client.get("/.well-known/openid-configuration")
-        metadata = response.json()
-
-        self.assertEqual(
-            metadata["authorization_grant_profiles_supported"],
-            ["urn:ietf:params:oauth:grant-profile:id-jag"],
-        )
-
     def test_metadata_includes_scopes(self):
         response = self.client.get("/.well-known/oauth-authorization-server")
         metadata = response.json()

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3989,6 +3989,24 @@ class TestOAuthAuthorizationServerMetadata(APIBaseTest):
         self.assertEqual(metadata["code_challenge_methods_supported"], ["S256"])
         self.assertIn("none", metadata["token_endpoint_auth_methods_supported"])
 
+    def test_metadata_advertises_id_jag_grant_profile(self):
+        response = self.client.get("/.well-known/oauth-authorization-server")
+        metadata = response.json()
+
+        self.assertEqual(
+            metadata["authorization_grant_profiles_supported"],
+            ["urn:ietf:params:oauth:grant-profile:id-jag"],
+        )
+
+    def test_openid_configuration_advertises_id_jag_grant_profile(self):
+        response = self.client.get("/.well-known/openid-configuration")
+        metadata = response.json()
+
+        self.assertEqual(
+            metadata["authorization_grant_profiles_supported"],
+            ["urn:ietf:params:oauth:grant-profile:id-jag"],
+        )
+
     def test_metadata_includes_scopes(self):
         response = self.client.get("/.well-known/oauth-authorization-server")
         metadata = response.json()

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -1507,14 +1507,7 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
 
 
 class OAuthConnectDiscoveryInfoView(ConnectDiscoveryInfoView):
-    def get(self, request, *args, **kwargs):
-        response = super().get(request, *args, **kwargs)
-        # Mirror the ID-JAG grant profile for clients that read OIDC discovery instead of RFC 8414 metadata.
-        if response.status_code == 200:
-            data = json.loads(response.content)
-            data["authorization_grant_profiles_supported"] = [id_jag.ID_JAG_GRANT_PROFILE]
-            response.content = json.dumps(data)
-        return response
+    pass
 
 
 class OAuthJwksInfoView(JwksInfoView):

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -1507,7 +1507,17 @@ class OAuthIntrospectTokenView(ClientProtectedScopedResourceView):
 
 
 class OAuthConnectDiscoveryInfoView(ConnectDiscoveryInfoView):
-    pass
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        # Mirror the ID-JAG grant profile for clients that read OIDC discovery instead of RFC 8414 metadata.
+        if response.status_code == 200:
+            data = json.loads(response.content)
+            data["authorization_grant_profiles_supported"] = [id_jag.ID_JAG_GRANT_PROFILE]
+            patched = JsonResponse(data)
+            for header, value in response.items():
+                patched[header] = value
+            return patched
+        return response
 
 
 class OAuthJwksInfoView(JwksInfoView):
@@ -1570,6 +1580,7 @@ class OAuthAuthorizationServerMetadataView(_PublicMetadataView):
                 "refresh_token",
                 id_jag.JWT_BEARER_GRANT_TYPE,
             ],
+            "authorization_grant_profiles_supported": [id_jag.ID_JAG_GRANT_PROFILE],
             "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
             "code_challenge_methods_supported": ["S256"],
             # Service documentation

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -1513,10 +1513,7 @@ class OAuthConnectDiscoveryInfoView(ConnectDiscoveryInfoView):
         if response.status_code == 200:
             data = json.loads(response.content)
             data["authorization_grant_profiles_supported"] = [id_jag.ID_JAG_GRANT_PROFILE]
-            patched = JsonResponse(data)
-            for header, value in response.items():
-                patched[header] = value
-            return patched
+            response.content = json.dumps(data)
         return response
 
 

--- a/posthog/api/test/test_id_jag.py
+++ b/posthog/api/test/test_id_jag.py
@@ -581,6 +581,47 @@ class TestIdJagTokenEndpoint(APIBaseTest):
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(resp.json()["error"], "invalid_target")
 
+    @override_settings(ID_JAG_ALLOWED_AUDIENCES=["https://oauth.posthog.com"])
+    def test_accepts_aud_matching_configured_allowed_audience(self) -> None:
+        # A spec-compliant client derives `aud` from the advertised auth-server issuer
+        # (the OAuth proxy), not SITE_URL. That value must be accepted when allowlisted.
+        assertion = _make_id_jag(audience="https://oauth.posthog.com")
+        resp = self._post_token({"grant_type": JWT_BEARER_GRANT_TYPE, "assertion": assertion})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+    @override_settings(ID_JAG_ALLOWED_RESOURCES=["https://mcp.posthog.com"])
+    def test_accepts_resource_matching_configured_allowed_resource(self) -> None:
+        # The ID-JAG `resource` is the advertised MCP resource identifier, not SITE_URL.
+        # The minted access token is audience-restricted to that resource (EMA §5.1).
+        assertion = _make_id_jag(resource="https://mcp.posthog.com/")
+        resp = self._post_token({"grant_type": JWT_BEARER_GRANT_TYPE, "assertion": assertion})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        claims = jwt.decode(
+            resp.json()["access_token"],
+            _public_key_for(_AS_PRIVATE_KEY_PEM),
+            algorithms=["RS256"],
+            audience="https://mcp.posthog.com",
+            issuer=_AUTH_SERVER_URL,
+        )
+        self.assertEqual(claims["aud"], "https://mcp.posthog.com")
+
+    @override_settings(ID_JAG_ALLOWED_RESOURCES=["https://mcp.posthog.com"])
+    def test_round_trip_with_mcp_resource_authenticates_on_resource_side(self) -> None:
+        # End-to-end: a token minted for the MCP resource must be accepted by the
+        # resource server (IDJagAccessTokenAuthentication), not just issued.
+        assertion = _make_id_jag(
+            resource="https://mcp.posthog.com",
+            scope="user:read",
+            extra_claims={"email": "user@example.com", "email_verified": True},
+        )
+        issue_resp = self._post_token({"grant_type": JWT_BEARER_GRANT_TYPE, "assertion": assertion})
+        self.assertEqual(issue_resp.status_code, status.HTTP_200_OK, issue_resp.content)
+        access_token = issue_resp.json()["access_token"]
+
+        api_resp = self.client.get("/api/users/@me/", HTTP_AUTHORIZATION=f"Bearer {access_token}")
+        self.assertEqual(api_resp.status_code, status.HTTP_200_OK, api_resp.content)
+        self.assertEqual(api_resp.json()["email"], "user@example.com")
+
     def test_rejects_when_domain_has_no_id_jag_issuer_configured(self) -> None:
         # ID-JAG is opt-in per domain. With `id_jag_issuer_url` cleared, an
         # otherwise valid ID-JAG must be rejected — the org hasn't bound an IdP yet.

--- a/posthog/api/test/test_id_jag.py
+++ b/posthog/api/test/test_id_jag.py
@@ -591,7 +591,7 @@ class TestIdJagTokenEndpoint(APIBaseTest):
 
     @override_settings(ID_JAG_ALLOWED_RESOURCES=["https://mcp.posthog.com"])
     def test_accepts_resource_matching_configured_allowed_resource(self) -> None:
-        # The ID-JAG `resource` is the advertised MCP resource identifier, not SITE_URL.
+        # The ID-JAG `resource` is the advertised resource-server identifier, not SITE_URL.
         # The minted access token is audience-restricted to that resource (EMA §5.1).
         assertion = _make_id_jag(resource="https://mcp.posthog.com/")
         resp = self._post_token({"grant_type": JWT_BEARER_GRANT_TYPE, "assertion": assertion})
@@ -606,8 +606,8 @@ class TestIdJagTokenEndpoint(APIBaseTest):
         self.assertEqual(claims["aud"], "https://mcp.posthog.com")
 
     @override_settings(ID_JAG_ALLOWED_RESOURCES=["https://mcp.posthog.com"])
-    def test_round_trip_with_mcp_resource_authenticates_on_resource_side(self) -> None:
-        # End-to-end: a token minted for the MCP resource must be accepted by the
+    def test_round_trip_with_allowed_resource_authenticates_on_resource_side(self) -> None:
+        # End-to-end: a token minted for an allowlisted resource must be accepted by the
         # resource server (IDJagAccessTokenAuthentication), not just issued.
         assertion = _make_id_jag(
             resource="https://mcp.posthog.com",

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -591,9 +591,12 @@ class IDJagAccessTokenAuthentication(authentication.BaseAuthentication):
             if not site_url:
                 raise AuthenticationFailed(detail="ID-JAG access tokens are not configured on this server.")
 
-            # The token's `aud` is the MCP resource it was minted for (id_jag._construct_access_token_payload).
-            # Accept SITE_URL plus any advertised MCP resource identifier; `iss` stays SITE_URL (we mint it).
-            allowed_audiences = [site_url, *(r.rstrip("/") for r in (settings.ID_JAG_ALLOWED_RESOURCES or []) if r)]
+            # The token's `aud` is the resource it was minted for (id_jag._construct_access_token_payload).
+            # Accept SITE_URL plus any advertised resource identifier; `iss` stays SITE_URL (we mint it).
+            # Function-level import keeps the heavier id_jag module off auth.py's foundational import path.
+            from posthog.api.id_jag import get_allowed_resources  # noqa: PLC0415
+
+            allowed_audiences = get_allowed_resources()
 
             # Try the active signing key first, then any keys being rotated out. A wrong
             # key fails the signature check, so we move on; a key that matches but fails

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -591,6 +591,10 @@ class IDJagAccessTokenAuthentication(authentication.BaseAuthentication):
             if not site_url:
                 raise AuthenticationFailed(detail="ID-JAG access tokens are not configured on this server.")
 
+            # The token's `aud` is the MCP resource it was minted for (id_jag._construct_access_token_payload).
+            # Accept SITE_URL plus any advertised MCP resource identifier; `iss` stays SITE_URL (we mint it).
+            allowed_audiences = [site_url, *(r.rstrip("/") for r in (settings.ID_JAG_ALLOWED_RESOURCES or []) if r)]
+
             # Try the active signing key first, then any keys being rotated out. A wrong
             # key fails the signature check, so we move on; a key that matches but fails
             # claim validation (expiry, audience, …) raises the real error to report.
@@ -601,7 +605,7 @@ class IDJagAccessTokenAuthentication(authentication.BaseAuthentication):
                         token,
                         verification_key,
                         algorithms=["RS256"],
-                        audience=site_url,
+                        audience=allowed_audiences,
                         issuer=site_url,
                         leeway=settings.ID_JAG_CLOCK_SKEW_SECONDS,
                         options={

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -596,7 +596,7 @@ class IDJagAccessTokenAuthentication(authentication.BaseAuthentication):
             # Function-level import keeps the heavier id_jag module off auth.py's foundational import path.
             from posthog.api.id_jag import get_allowed_resources  # noqa: PLC0415
 
-            allowed_audiences = get_allowed_resources()
+            allowed_resources = get_allowed_resources()
 
             # Try the active signing key first, then any keys being rotated out. A wrong
             # key fails the signature check, so we move on; a key that matches but fails
@@ -608,7 +608,7 @@ class IDJagAccessTokenAuthentication(authentication.BaseAuthentication):
                         token,
                         verification_key,
                         algorithms=["RS256"],
-                        audience=allowed_audiences,
+                        audience=allowed_resources,
                         issuer=site_url,
                         leeway=settings.ID_JAG_CLOCK_SKEW_SECONDS,
                         options={

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -933,8 +933,8 @@ ID_JAG_JWKS_CACHE_TTL_SECONDS: int = get_from_env("ID_JAG_JWKS_CACHE_TTL_SECONDS
 # Extra accepted ID-JAG `aud` values (the advertised authorization-server issuer) beyond SITE_URL —
 # e.g. the OAuth proxy "https://oauth.posthog.com" on Cloud. SITE_URL is always accepted.
 ID_JAG_ALLOWED_AUDIENCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_AUDIENCES", ""))
-# Extra accepted ID-JAG `resource` values (the advertised MCP resource identifier) beyond SITE_URL —
-# e.g. the MCP hosts "https://mcp.posthog.com,https://mcp.us.posthog.com" on Cloud. SITE_URL is always accepted.
+# Extra accepted ID-JAG `resource` values (the advertised resource-server identifier) beyond SITE_URL —
+# e.g. "https://mcp.posthog.com,https://mcp.us.posthog.com" on Cloud. SITE_URL is always accepted.
 ID_JAG_ALLOWED_RESOURCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_RESOURCES", ""))
 
 TOOLBAR_OAUTH_STATE_TTL_SECONDS = 60 * 5

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -930,6 +930,13 @@ ID_JAG_ACCESS_TOKEN_TTL_SECONDS: int = get_from_env("ID_JAG_ACCESS_TOKEN_TTL_SEC
 ID_JAG_CLOCK_SKEW_SECONDS: int = get_from_env("ID_JAG_CLOCK_SKEW_SECONDS", 30, type_cast=int)
 ID_JAG_JWKS_CACHE_TTL_SECONDS: int = get_from_env("ID_JAG_JWKS_CACHE_TTL_SECONDS", 60 * 60, type_cast=int)
 
+# Extra accepted ID-JAG `aud` values (the advertised authorization-server issuer) beyond SITE_URL —
+# e.g. the OAuth proxy "https://oauth.posthog.com" on Cloud. SITE_URL is always accepted.
+ID_JAG_ALLOWED_AUDIENCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_AUDIENCES", ""))
+# Extra accepted ID-JAG `resource` values (the advertised MCP resource identifier) beyond SITE_URL —
+# e.g. the MCP hosts "https://mcp.posthog.com,https://mcp.us.posthog.com" on Cloud. SITE_URL is always accepted.
+ID_JAG_ALLOWED_RESOURCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_RESOURCES", ""))
+
 TOOLBAR_OAUTH_STATE_TTL_SECONDS = 60 * 5
 TOOLBAR_OAUTH_EXCHANGE_TIMEOUT_SECONDS = 10
 TOOLBAR_OAUTH_APPLICATION_NAME = "PostHog Toolbar"

--- a/services/oauth-proxy/src/handlers/metadata.ts
+++ b/services/oauth-proxy/src/handlers/metadata.ts
@@ -24,6 +24,7 @@ interface WellKnownOAuthAuthorizationServerMetadata {
     response_types_supported: string[]
     response_modes_supported: string[]
     grant_types_supported: string[]
+    authorization_grant_profiles_supported: string[]
     token_endpoint_auth_methods_supported: string[]
     code_challenge_methods_supported: string[]
     service_documentation: string

--- a/services/oauth-proxy/tests/metadata.test.ts
+++ b/services/oauth-proxy/tests/metadata.test.ts
@@ -12,7 +12,8 @@ const AUTHORITATIVE_METADATA = {
     scopes_supported: ['openid', 'profile', 'email'],
     response_types_supported: ['code'],
     response_modes_supported: ['query'],
-    grant_types_supported: ['authorization_code', 'refresh_token'],
+    grant_types_supported: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+    authorization_grant_profiles_supported: ['urn:ietf:params:oauth:grant-profile:id-jag'],
     token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
     code_challenge_methods_supported: ['S256'],
     service_documentation: 'https://posthog.com/docs/model-context-protocol',
@@ -61,6 +62,9 @@ describe('handleMetadata', () => {
         expect(data.scopes_supported).toEqual(AUTHORITATIVE_METADATA.scopes_supported)
         expect(data.response_types_supported).toEqual(AUTHORITATIVE_METADATA.response_types_supported)
         expect(data.grant_types_supported).toEqual(AUTHORITATIVE_METADATA.grant_types_supported)
+        expect(data.authorization_grant_profiles_supported).toEqual(
+            AUTHORITATIVE_METADATA.authorization_grant_profiles_supported
+        )
         expect(data.code_challenge_methods_supported).toContain('S256')
         expect(data.service_documentation).toBe(AUTHORITATIVE_METADATA.service_documentation)
         expect(data.client_id_metadata_document_supported).toBe(true)


### PR DESCRIPTION
## Problem

PostHog already ships the full ID-JAG (XAA) grant, but it didn't actually work with MCP clients that implement the [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension. Two gaps blocked the spec-compliant path:

1. **No discovery signal.** A compliant client decides the flow is available by checking for `urn:ietf:params:oauth:grant-profile:id-jag` in `authorization_grant_profiles_supported` on the authorization-server metadata. We never advertised it.
2. **`aud`/`resource` mismatch.** Following discovery, a client derives the ID-JAG `aud` from the advertised AS issuer (`oauth.posthog.com`, via the proxy) and the `resource` from the MCP server's RFC 9728 resource id (`mcp.*.posthog.com`). Validation required both claims to equal `SITE_URL`, so those requests were rejected.

## Changes

**Discovery** — advertise the ID-JAG grant profile so clients can find the flow:
- `authorization_grant_profiles_supported` added to the RFC 8414 authorization-server metadata (the document the EMA discovery step and our MCP discovery chain use).
- Forwarded through the `oauth.posthog.com` proxy (typed into its metadata contract; the runtime spread already passed it through).

**Audience/resource** — accept the discovered values instead of forcing `SITE_URL`:
- New config-driven allowlists `ID_JAG_ALLOWED_AUDIENCES` and `ID_JAG_ALLOWED_RESOURCES`. Both always fold in `SITE_URL`, so self-hosted and current behavior are unchanged.
- The incoming ID-JAG `aud` is checked against the allowed AS-issuers and `resource` against the allowed MCP-resources.
- The minted access token is audience-restricted to the validated resource (EMA §5.1), and the resource server (`IDJagAccessTokenAuthentication`) accepts that audience. `iss` stays `SITE_URL`. This also fixes a latent trailing-slash inconsistency between the minted `aud` and the resource-server check.

**Docs** — the ID-JAG config modal now states the minimum scopes an IdP must grant (`user:read`, plus `organization:read`/`project:read` for the MCP server); tokens without them get a clear insufficient-scope error, which the MCP server already surfaces as an RFC 6750 challenge.

This is gated by config: **Cloud opts in** by setting the two new env vars (the proxy URL and the `mcp.*.posthog.com` hosts) in the charts repo. Without them, nothing changes.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — I did not manually exercise a live IdP:

- `posthog/api/test/test_id_jag.py` — added tests for accepting an allowlisted `aud`, accepting an allowlisted `resource` (and the minted token's audience), and an end-to-end round trip where a token minted for the MCP resource authenticates on the resource server. Full suite green (64 tests).
- `posthog/api/oauth/test_views.py::TestOAuthAuthorizationServerMetadata` — assert the grant profile appears in the RFC 8414 metadata.
- `services/oauth-proxy/tests/metadata.test.ts` — assert the proxy forwards the new field (6 tests green).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Rafael directed the work and is the DRI.

Built with Claude Code (Opus 4.8). The task started as "what would it take to implement Enterprise-Managed Authorization in our MCP server" — exploration found PostHog already had the entire ID-JAG stack (grant, per-org IdP trust config, admin UI, resource-server auth), so the real scope narrowed to the discovery signal and the `aud`/`resource` semantics.

Key decision: the `aud`/`resource` relaxation was chosen over the alternative of documenting fixed values for admins to hardcode, because spec-compliant clients auto-derive those values from discovery and can't easily be overridden. The relaxation is a coordinated change across the issuance path (`id_jag.py`) and the resource server (`auth.py`) since both are PostHog-controlled; allowlists keep it config-gated so self-hosted is untouched.

Skills invoked: `/improving-drf-endpoints` (the metadata endpoints are intentionally raw-dict RFC responses, not serializer-driven, so no schema restructuring was needed).

Reviewers: worth a close look at the `auth.py` audience change and the `id_jag.py` validation — these are the security-sensitive bits.

