### PR TITLE
fix(square): tolerate repeated cursor expiry on full-refresh streams

### DIFF
--- a/posthog/temporal/data_imports/sources/square/square.py
+++ b/posthog/temporal/data_imports/sources/square/square.py
@@ -25,6 +25,11 @@ SQUARE_HOSTS = {
 PAGE_SIZE = 100
 REQUEST_TIMEOUT_SECONDS = 60
 
+# A Square cursor that outlives its ~5 minute TTL mid-stream forces a full restart.
+# Allow a few restarts so a transient stall during the re-scan doesn't fail the sync,
+# while still bounding the work for a stream that paginates slower than its cursor lives.
+MAX_CURSOR_RESTARTS = 3
+
 
 class SquareRetryableError(Exception):
     pass
@@ -165,7 +170,7 @@ def get_rows(
 
         return response.json()
 
-    restarted_after_invalid_cursor = False
+    restarts_remaining = MAX_CURSOR_RESTARTS
     while True:
         # Square encodes the original query in the cursor, so subsequent pages are
         # requested with the cursor alone — re-sending filters/sort can error.
@@ -174,10 +179,13 @@ def get_rows(
             data = fetch_page(params)
         except SquareInvalidCursorError:
             # An expired cursor can't be recovered by retrying it, so restart the
-            # stream from the beginning (merge dedupes on the primary key). Bounded
-            # to a single restart so a genuinely malformed query can't loop forever.
-            if cursor is None or restarted_after_invalid_cursor:
+            # stream from the beginning (merge dedupes on the primary key). A cursor-less
+            # initial request can't trigger this error, so a rejection there signals a
+            # malformed query rather than expiry — surface it instead of looping. The
+            # restart budget bounds the work when a stream keeps outliving its cursor.
+            if cursor is None or restarts_remaining <= 0:
                 raise
+            restarts_remaining -= 1
             logger.warning(f"Square: cursor for {endpoint} was rejected, restarting stream from the beginning")
             # Overwrite the stale cursor in the resume store now. Otherwise, if the
             # restart finishes within a single page (no fresh next_cursor to save),
@@ -187,7 +195,6 @@ def get_rows(
             if config.paginated:
                 resumable_source_manager.save_state(SquareResumeConfig(cursor=""))
             cursor = None
-            restarted_after_invalid_cursor = True
             continue
 
         items = data.get(config.data_key, [])

--- a/posthog/temporal/data_imports/sources/square/test_square.py
+++ b/posthog/temporal/data_imports/sources/square/test_square.py
@@ -11,6 +11,7 @@ from requests import Response
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.square.settings import SQUARE_ENDPOINTS
 from posthog.temporal.data_imports.sources.square.square import (
+    MAX_CURSOR_RESTARTS,
     SQUARE_HOSTS,
     SquareInvalidCursorError,
     SquareResumeConfig,
@@ -285,7 +286,10 @@ class TestGetRowsPagination:
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [SquareResumeConfig(cursor="")]
 
-    def test_invalid_cursor_only_restarts_once(self) -> None:
+    def test_invalid_cursor_restarts_again_when_re_scan_also_expires(self) -> None:
+        # A cursor can expire more than once on a slow full-refresh stream: the first
+        # restart re-scans, makes progress, then a later cursor expires too. As long as
+        # the restart budget isn't spent, the stream restarts again rather than crashing.
         manager = MagicMock(spec=ResumableSourceManager)
         manager.can_resume.return_value = True
         manager.load_state.return_value = SquareResumeConfig(cursor="stale-cursor")
@@ -295,7 +299,28 @@ class TestGetRowsPagination:
             invalid,
             _make_response({"customers": [{"id": "c1"}], "cursor": "cur-1"}),
             invalid,
+            _make_response({"customers": [{"id": "c2"}]}),
         ]
+        sent_params = self._drive("customers", manager, responses)
+
+        # stale cursor rejected -> restart -> page (cur-1) -> cur-1 rejected -> restart -> final page.
+        assert sent_params[0] == {"cursor": "stale-cursor"}
+        assert "cursor" not in sent_params[1]
+        assert sent_params[2] == {"cursor": "cur-1"}
+        assert "cursor" not in sent_params[3]
+
+    def test_invalid_cursor_gives_up_after_restart_budget_exhausted(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = SquareResumeConfig(cursor="stale-cursor")
+
+        invalid = _make_response({"errors": [{"field": "cursor", "code": "INVALID_CURSOR"}]}, status_code=400)
+        # Each restart re-scans one page then expires again; once the budget is spent
+        # the next rejection is surfaced.
+        responses = [invalid]
+        for _ in range(MAX_CURSOR_RESTARTS):
+            responses.append(_make_response({"customers": [{"id": "c"}], "cursor": "cur"}))
+            responses.append(invalid)
         with pytest.raises(SquareInvalidCursorError):
             self._drive("customers", manager, responses)
 


### PR DESCRIPTION
## Problem

Error tracking surfaced [`SquareInvalidCursorError: Square rejected the pagination cursor for customers`](https://us.posthog.com/project/2/error_tracking/019eddab-cd66-7d51-9399-abcad01f3706), raised in `posthog/temporal/data_imports/sources/square/square.py`. It fired across several teams in a tight ~70-second window, all on the `customers` endpoint — the signature of a transient stall, not a per-customer config issue.

Square pagination cursors have a ~5 minute TTL. The `customers` endpoint is full-refresh (no server-side time filter), so every sync re-scans the entire customer list. When a cursor expires mid-stream, the source already restarts the stream from the beginning (merge dedupes on the primary key) — but that restart was capped at exactly **one**. A *second*, independent cursor expiry during the re-scan (e.g. another stall) escaped the recovery and crashed the whole sync with an uncaught exception. The captured local variables confirm the failure: a non-empty cursor with `restarted_after_invalid_cursor = True`.

## Changes

This is a transient/timing condition, not a credential or config problem, so it should stay retryable — adding it to `get_non_retryable_errors` would disable the schema (`should_sync = False`), which is the wrong response for a one-off stall that hit multiple teams at once.

Instead, the fix widens the recovery: replace the one-shot restart flag with a small bounded restart budget (`MAX_CURSOR_RESTARTS = 3`). A transient stall during the re-scan no longer fails the sync. Termination is still guaranteed:

- A cursor-less initial request can't trigger an invalid-cursor error, so a restart that fails on its very first page is surfaced rather than looped (the existing `cursor is None` guard).
- The budget caps the total re-scans for a stream that genuinely paginates slower than its cursor lives.

No change to global retry policy; the fix is scoped to this one error path.

## How did you test this code?

I'm an agent. I ran the source's unit test suite (`posthog/temporal/data_imports/sources/square/test_square.py`, 34 tests) — all pass, plus `ruff check`/`ruff format`. Added/updated tests at the same layer as the fix:

- A regression test where the re-scan also expires and the stream restarts again instead of crashing.
- A test that the sync still gives up (and surfaces `SquareInvalidCursorError`) once the restart budget is exhausted.
- Replaced the previous `test_invalid_cursor_only_restarts_once`, which encoded the old capped-at-one behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Square warehouse source. Confirmed the issue in error tracking (stack trace genuinely rooted in `square.py`, captured locals showing the second-expiry state), read the source and the `get_non_retryable_errors` consumption path, and decided this is a fixable fragility rather than a user/upstream error. Checked open PRs (including the maintainer's) for an existing fix — none touch the Square cursor logic. No skills were applicable to this Temporal data-import source change.