### PR TITLE
feat(data-warehouse): capture duckling backfill partition telemetry

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -66,6 +66,7 @@ from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.ducklake.backfill_telemetry import emit_backfill_partition_event
 from posthog.ducklake.client import make_duckgres_conninfo
 from posthog.ducklake.common import _get_org_id_for_team, derive_duckling_bucket
 from posthog.ducklake.models import DuckLakeBackfill
@@ -1694,6 +1695,33 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
             files_registered=total_registered,
         )
 
+        if dates and not config.dry_run:
+            try:
+                emit_backfill_partition_event(
+                    team_id=team_id,
+                    partition_date=max(dates).date(),
+                    status="success",
+                    run_id=context.run.run_id,
+                    files_exported=total_exported,
+                    files_registered=total_registered,
+                    dates_processed=len(dates),
+                )
+            except Exception:
+                context.log.exception("Failed to emit backfill success telemetry (non-fatal)")
+
+    except Exception as exc:
+        if dates and not config.dry_run:
+            try:
+                emit_backfill_partition_event(
+                    team_id=team_id,
+                    partition_date=max(dates).date(),
+                    status="failed",
+                    run_id=context.run.run_id,
+                    error_message=str(exc)[:1000],
+                )
+            except Exception:
+                context.log.exception("Failed to emit backfill failure telemetry (non-fatal)")
+        raise
     finally:
         if session is not None:
             session.close()

--- a/posthog/ducklake/backfill_telemetry.py
+++ b/posthog/ducklake/backfill_telemetry.py
@@ -1,0 +1,38 @@
+from datetime import date
+
+from posthog.ph_client import ph_scoped_capture
+
+# One capture event per duckling backfill partition run, emitted to the internal telemetry project.
+# Carries the customer team_id as a property so the warehouse freshness API can report per team.
+BACKFILL_PARTITION_EVENT = "warehouse_event_backfill_partition"
+BACKFILL_DISTINCT_ID = "warehouse-event-backfill"
+
+
+def emit_backfill_partition_event(
+    *,
+    team_id: int,
+    partition_date: date,
+    status: str,
+    run_id: str,
+    files_exported: int | None = None,
+    files_registered: int | None = None,
+    dates_processed: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    """Capture one terminal event per backfill partition run (status: "success" | "failed").
+
+    Best-effort: on Cloud the event lands in the internal project; off Cloud `ph_scoped_capture`
+    is a no-op. `partition_date` is the most recent day the partition covers (the freshness edge).
+    """
+    properties: dict[str, object] = {
+        "team_id": team_id,
+        "partition_date": partition_date.isoformat(),
+        "status": status,
+        "run_id": run_id,
+        "files_exported": files_exported,
+        "files_registered": files_registered,
+        "dates_processed": dates_processed,
+        "error_message": error_message,
+    }
+    with ph_scoped_capture() as capture:
+        capture(distinct_id=BACKFILL_DISTINCT_ID, event=BACKFILL_PARTITION_EVENT, properties=properties)

--- a/posthog/ducklake/test/test_backfill_telemetry.py
+++ b/posthog/ducklake/test/test_backfill_telemetry.py
@@ -1,0 +1,29 @@
+from datetime import date
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_PARTITION_EVENT, emit_backfill_partition_event
+
+
+class TestBackfillTelemetry(BaseTest):
+    def test_emits_event_with_team_and_properties(self) -> None:
+        capture = MagicMock()
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=capture)
+        cm.__exit__ = MagicMock(return_value=False)
+        with patch("posthog.ducklake.backfill_telemetry.ph_scoped_capture", return_value=cm):
+            emit_backfill_partition_event(
+                team_id=42,
+                partition_date=date(2024, 5, 1),
+                status="success",
+                run_id="r1",
+                files_exported=3,
+            )
+        capture.assert_called_once()
+        props = capture.call_args.kwargs["properties"]
+        assert capture.call_args.kwargs["event"] == BACKFILL_PARTITION_EVENT
+        assert props["team_id"] == 42
+        assert props["partition_date"] == "2024-05-01"
+        assert props["status"] == "success"
+        assert props["files_exported"] == 3


### PR DESCRIPTION
## Problem

There's no signal for how up-to-date a project's event data is in its managed warehouse. To surface that without a new table or DB migration, the (current, per-team) duckling backfill needs to report its per-partition progress.

## Changes

The `duckling_events_backfill` Dagster asset now emits one best-effort PostHog capture event per partition run (`success`/`failed`, carrying the customer `team_id`, partition date, file counts) via `ph_scoped_capture`. Best-effort: a telemetry failure never fails the backfill (success and failure paths both wrapped; failure re-raised after emitting). Adds `posthog/ducklake/backfill_telemetry.py` + its test.

No consumer yet — the read side is the next PR in the stack.

## How did you test this code?

I'm an agent; automated only: `posthog/ducklake/test/test_backfill_telemetry.py` (emitter produces the expected event/properties) + a dag import smoke-check. No manual run of the Dagster job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @EDsCODE .

**Stack (merge bottom-up):** this PR → `eric/dw-freshness-api` → `eric/dw-freshness-overview`.

Context: an earlier version of this feature was built against the now-retired `events_backfill_to_ducklake` dag on a stale base; this rebuild targets the current per-team `duckling_events_backfill` asset on latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
