### PR TITLE
feat(data-warehouse): add warehouse_sync_status API

### DIFF
--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -58,11 +58,15 @@ SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type
 # GitHub secret alert relay URL - set in US deployment to forward alerts to EU
 GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RELAY_URL", optional=True)
 
-# Internal team on PostHog Cloud US that receives `$ai_generation` /
-# `$ai_embedding` events emitted by PostHog products (PostHog Code,
-# background agents, etc). Used by /api/llm_analytics/personal_spend/.
+# Internal team on PostHog Cloud that receives capture events emitted by PostHog products
+# (PostHog Code, background agents, the warehouse event backfill, `$ai_generation`, etc).
+# Read back by features that report on PostHog's own product telemetry.
 # Override in tests via @override_settings to point at a per-test team.
-LLM_ANALYTICS_INTERNAL_TEAM_ID: int = 2
+INTERNAL_TELEMETRY_TEAM_ID: int = get_from_env("INTERNAL_TELEMETRY_TEAM_ID", 2, type_cast=int)
+
+# Back-compat alias for AI observability (/api/llm_analytics/personal_spend/), which reads
+# `$ai_generation` / `$ai_embedding` events from the same internal project.
+LLM_ANALYTICS_INTERNAL_TEAM_ID: int = INTERNAL_TELEMETRY_TEAM_ID
 
 # Duckgres - URL, internal secret, and PG endpoint for the managed warehouse service
 DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -34,6 +34,8 @@ from products.data_modeling.backend.models.data_modeling_job import DataModeling
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.api import managed_warehouse
 from products.data_warehouse.backend.models.team_data_warehouse_config import TeamDataWarehouseConfig
+from products.data_warehouse.backend.warehouse_sync.contracts import WarehouseSyncStatusSerializer
+from products.data_warehouse.backend.warehouse_sync.status import get_warehouse_sync_status
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -907,6 +909,13 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     def warehouse_status(self, request: Request, **kwargs) -> Response:
         """Get the current provisioning status of the managed warehouse."""
         return managed_warehouse.status_for(self.team.organization_id)
+
+    @extend_schema(responses={200: WarehouseSyncStatusSerializer})
+    @action(methods=["GET"], detail=False, url_path="warehouse_sync_status")
+    def warehouse_sync_status(self, request: Request, **kwargs) -> Response:
+        """Freshness of this project's event data in the managed warehouse."""
+        dto = get_warehouse_sync_status(self.team.id)
+        return Response(WarehouseSyncStatusSerializer(dto).data)
 
     @extend_schema(
         responses={

--- a/products/data_warehouse/backend/api/test/test_warehouse_sync_status.py
+++ b/products/data_warehouse/backend/api/test/test_warehouse_sync_status.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from django.test import override_settings
+from django.utils import timezone
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_DISTINCT_ID, BACKFILL_PARTITION_EVENT
+
+
+class TestWarehouseSyncStatusAPI(ClickhouseTestMixin, APIBaseTest):
+    def test_returns_contract_for_this_team(self) -> None:
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        _create_event(
+            team=self.team,
+            event=BACKFILL_PARTITION_EVENT,
+            distinct_id=BACKFILL_DISTINCT_ID,
+            timestamp=now,
+            properties={"team_id": self.team.id, "partition_date": yesterday, "status": "success"},
+        )
+        flush_persons_and_events()
+
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            res = self.client.get(f"/api/environments/{self.team.id}/data_warehouse/warehouse_sync_status/")
+
+        assert res.status_code == 200, res.json()
+        body = res.json()
+        assert set(body.keys()) == {"state", "fresh_through", "lag_seconds", "last_activity_at", "error", "updated_at"}
+        assert body["state"] == "caught_up"
+        assert body["error"] is None

--- a/products/data_warehouse/backend/warehouse_sync/__init__.py
+++ b/products/data_warehouse/backend/warehouse_sync/__init__.py
@@ -1,0 +1,13 @@
+from products.data_warehouse.backend.warehouse_sync.contracts import (
+    SyncError,
+    WarehouseSyncStatusDTO,
+    WarehouseSyncStatusSerializer,
+)
+from products.data_warehouse.backend.warehouse_sync.status import get_warehouse_sync_status
+
+__all__ = [
+    "SyncError",
+    "WarehouseSyncStatusDTO",
+    "WarehouseSyncStatusSerializer",
+    "get_warehouse_sync_status",
+]

--- a/products/data_warehouse/backend/warehouse_sync/contracts.py
+++ b/products/data_warehouse/backend/warehouse_sync/contracts.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from rest_framework import serializers
+
+WAREHOUSE_SYNC_STATES = ["caught_up", "lagging", "error", "not_started"]
+
+
+@dataclass
+class SyncError:
+    message: str
+    since: datetime
+
+
+@dataclass
+class WarehouseSyncStatusDTO:
+    state: str
+    fresh_through: datetime | None
+    lag_seconds: int | None
+    last_activity_at: datetime | None
+    error: SyncError | None
+    updated_at: datetime
+
+
+class _SyncErrorSerializer(serializers.Serializer[SyncError]):  # type: ignore[type-arg]  # DRF Serializer isn't generic at runtime
+    message = serializers.CharField(help_text="Human-readable error message.")
+    since = serializers.DateTimeField(help_text="When the current error first occurred.")
+
+
+class WarehouseSyncStatusSerializer(serializers.Serializer[WarehouseSyncStatusDTO]):  # type: ignore[type-arg]  # DRF Serializer isn't generic at runtime
+    state = serializers.ChoiceField(choices=WAREHOUSE_SYNC_STATES, help_text="Overall freshness state.")
+    fresh_through = serializers.DateTimeField(
+        allow_null=True, help_text="Timestamp the warehouse is fresh through for this project, or null if no data yet."
+    )
+    lag_seconds = serializers.IntegerField(allow_null=True, help_text="Seconds behind now, or null if unknown.")
+    last_activity_at = serializers.DateTimeField(allow_null=True, help_text="Last time the backfill made progress.")
+    error = _SyncErrorSerializer(allow_null=True, help_text="Current error, or null when healthy.")
+    updated_at = serializers.DateTimeField(help_text="When this status was computed.")

--- a/products/data_warehouse/backend/warehouse_sync/status.py
+++ b/products/data_warehouse/backend/warehouse_sync/status.py
@@ -1,0 +1,94 @@
+from datetime import UTC, date, datetime, time, timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from posthog.clickhouse.client import sync_execute
+from posthog.ducklake.backfill_telemetry import BACKFILL_PARTITION_EVENT
+
+from products.data_warehouse.backend.warehouse_sync.contracts import SyncError, WarehouseSyncStatusDTO
+
+RECENT_FAILURE_WINDOW = timedelta(days=7)
+# A daily backfill is "up to date" once its frontier is within ~2 days of now.
+CAUGHT_UP_LAG_SECONDS = 2 * 24 * 60 * 60
+
+# Latest backfill telemetry event per partition_date, for one customer team. The events live in
+# the internal telemetry project; the customer team is a property on each event.
+_QUERY = """
+SELECT
+    JSONExtractString(properties, 'partition_date') AS partition_date,
+    argMax(JSONExtractString(properties, 'status'), timestamp) AS status,
+    argMax(JSONExtractString(properties, 'error_message'), timestamp) AS error_message,
+    max(timestamp) AS last_event_at
+FROM events
+WHERE team_id = %(internal_team_id)s
+  AND event = %(event)s
+  AND JSONExtractInt(properties, 'team_id') = %(customer_team_id)s
+GROUP BY partition_date
+"""
+
+
+def _empty(now: datetime, state: str) -> WarehouseSyncStatusDTO:
+    return WarehouseSyncStatusDTO(
+        state=state, fresh_through=None, lag_seconds=None, last_activity_at=None, error=None, updated_at=now
+    )
+
+
+def get_warehouse_sync_status(team_id: int) -> WarehouseSyncStatusDTO:
+    """Freshness of one team's managed-warehouse event data, derived from backfill telemetry.
+
+    Freshness is the latest successful partition date; it deliberately does not assert historical
+    completeness, which sparse telemetry can't prove.
+    """
+    now = timezone.now()
+    internal_team_id = settings.INTERNAL_TELEMETRY_TEAM_ID
+    if not internal_team_id:
+        return _empty(now, "not_started")
+
+    rows = sync_execute(
+        _QUERY,
+        {"internal_team_id": int(internal_team_id), "event": BACKFILL_PARTITION_EVENT, "customer_team_id": team_id},
+    )
+    if not rows:
+        return _empty(now, "not_started")
+
+    done = 0
+    fresh_date: date | None = None
+    last_event_at: datetime | None = None
+    latest_failure: tuple[datetime, str] | None = None
+
+    for partition_date_str, status, error_message, event_at in rows:
+        if last_event_at is None or event_at > last_event_at:
+            last_event_at = event_at
+        if status == "success":
+            done += 1
+            pd = date.fromisoformat(partition_date_str)
+            if fresh_date is None or pd > fresh_date:
+                fresh_date = pd
+        elif status == "failed":
+            if latest_failure is None or event_at > latest_failure[0]:
+                latest_failure = (event_at, error_message or "Backfill partition failed")
+
+    fresh_through = datetime.combine(fresh_date, time.max, tzinfo=UTC) if fresh_date is not None else None
+    lag_seconds = int((now - fresh_through).total_seconds()) if fresh_through is not None else None
+
+    recent_failure = latest_failure is not None and latest_failure[0] >= now - RECENT_FAILURE_WINDOW
+    error = SyncError(message=latest_failure[1], since=latest_failure[0]) if recent_failure else None
+
+    if recent_failure:
+        state = "error"
+    elif done == 0:
+        state = "not_started"
+    elif lag_seconds is not None and lag_seconds <= CAUGHT_UP_LAG_SECONDS:
+        state = "caught_up"
+    else:
+        state = "lagging"
+
+    return WarehouseSyncStatusDTO(
+        state=state,
+        fresh_through=fresh_through,
+        lag_seconds=lag_seconds,
+        last_activity_at=last_event_at,
+        error=error,
+        updated_at=now,
+    )

--- a/products/data_warehouse/backend/warehouse_sync/test/test_contracts.py
+++ b/products/data_warehouse/backend/warehouse_sync/test/test_contracts.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import BaseTest
+
+from products.data_warehouse.backend.warehouse_sync.contracts import (
+    SyncError,
+    WarehouseSyncStatusDTO,
+    WarehouseSyncStatusSerializer,
+)
+
+
+class TestWarehouseSyncStatusSerializer(BaseTest):
+    def test_serializes_healthy(self) -> None:
+        dto = WarehouseSyncStatusDTO(
+            state="caught_up",
+            fresh_through=datetime(2026, 6, 17, 23, 59, tzinfo=UTC),
+            lag_seconds=3600,
+            last_activity_at=datetime(2026, 6, 18, 1, 0, tzinfo=UTC),
+            error=None,
+            updated_at=datetime(2026, 6, 18, 2, 0, tzinfo=UTC),
+        )
+        data = WarehouseSyncStatusSerializer(dto).data
+        assert data["state"] == "caught_up"
+        assert data["lag_seconds"] == 3600
+        assert data["error"] is None
+
+    def test_serializes_error(self) -> None:
+        dto = WarehouseSyncStatusDTO(
+            state="error",
+            fresh_through=None,
+            lag_seconds=None,
+            last_activity_at=None,
+            error=SyncError(message="boom", since=datetime(2026, 6, 18, tzinfo=UTC)),
+            updated_at=datetime(2026, 6, 18, 2, 0, tzinfo=UTC),
+        )
+        data = WarehouseSyncStatusSerializer(dto).data
+        assert data["error"]["message"] == "boom"

--- a/products/data_warehouse/backend/warehouse_sync/test/test_status.py
+++ b/products/data_warehouse/backend/warehouse_sync/test/test_status.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+
+from django.test import override_settings
+from django.utils import timezone
+
+from posthog.ducklake.backfill_telemetry import BACKFILL_DISTINCT_ID, BACKFILL_PARTITION_EVENT
+
+from products.data_warehouse.backend.warehouse_sync.status import get_warehouse_sync_status
+
+
+class TestWarehouseSyncStatus(ClickhouseTestMixin, APIBaseTest):
+    def _emit(
+        self, customer_team_id: int, partition_date: str, status: str, timestamp: datetime, **props: object
+    ) -> None:
+        # Telemetry lands in the internal team (self.team here) with the customer team as a property.
+        _create_event(
+            team=self.team,
+            event=BACKFILL_PARTITION_EVENT,
+            distinct_id=BACKFILL_DISTINCT_ID,
+            timestamp=timestamp,
+            properties={"team_id": customer_team_id, "partition_date": partition_date, "status": status, **props},
+        )
+
+    @override_settings(INTERNAL_TELEMETRY_TEAM_ID=None)
+    def test_not_started_without_telemetry_team(self) -> None:
+        dto = get_warehouse_sync_status(team_id=123)
+        assert dto.state == "not_started"
+
+    def test_not_started_when_no_events_for_team(self) -> None:
+        now = timezone.now()
+        self._emit(999, (now.date() - timedelta(days=1)).isoformat(), "success", timestamp=now)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = get_warehouse_sync_status(team_id=123)  # different customer team
+        assert dto.state == "not_started"
+
+    def test_caught_up_for_requested_team(self) -> None:
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        self._emit(123, yesterday, "success", timestamp=now)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = get_warehouse_sync_status(team_id=123)
+        assert dto.state == "caught_up"
+        assert dto.fresh_through is not None
+
+    def test_lagging_when_frontier_behind(self) -> None:
+        now = timezone.now()
+        self._emit(123, "2021-06-01", "success", timestamp=now)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto = get_warehouse_sync_status(team_id=123)
+        assert dto.state == "lagging"
+        assert dto.lag_seconds is not None and dto.lag_seconds > 0
+
+    def test_recent_failure_is_error_stale_is_not(self) -> None:
+        now = timezone.now()
+        yesterday = (now.date() - timedelta(days=1)).isoformat()
+        # Recent failure for team 123 -> error.
+        self._emit(123, "2020-01-01", "failed", timestamp=now, error_message="boom")
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            flush_persons_and_events()
+            dto = get_warehouse_sync_status(team_id=123)
+        assert dto.state == "error"
+        assert dto.error is not None and dto.error.message == "boom"
+
+        # A stale failure (old event) plus a recent success -> caught_up, no error.
+        self._emit(456, "2020-01-01", "failed", timestamp=now - timedelta(days=400), error_message="old")
+        self._emit(456, yesterday, "success", timestamp=now)
+        flush_persons_and_events()
+        with override_settings(INTERNAL_TELEMETRY_TEAM_ID=self.team.id):
+            dto2 = get_warehouse_sync_status(team_id=456)
+        assert dto2.state == "caught_up"
+        assert dto2.error is None

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -152,6 +152,58 @@ export interface WarehouseStatusResponseApi {
 }
 
 /**
+ * * `caught_up` - caught_up
+ * * `lagging` - lagging
+ * * `error` - error
+ * * `not_started` - not_started
+ */
+export type WarehouseSyncStatusStateEnumApi =
+    (typeof WarehouseSyncStatusStateEnumApi)[keyof typeof WarehouseSyncStatusStateEnumApi]
+
+export const WarehouseSyncStatusStateEnumApi = {
+    CaughtUp: 'caught_up',
+    Lagging: 'lagging',
+    Error: 'error',
+    NotStarted: 'not_started',
+} as const
+
+export interface _SyncErrorApi {
+    /** Human-readable error message. */
+    message: string
+    /** When the current error first occurred. */
+    since: string
+}
+
+export interface WarehouseSyncStatusApi {
+    /** Overall freshness state.
+     *
+     * * `caught_up` - caught_up
+     * * `lagging` - lagging
+     * * `error` - error
+     * * `not_started` - not_started */
+    state: WarehouseSyncStatusStateEnumApi
+    /**
+     * Timestamp the warehouse is fresh through for this project, or null if no data yet.
+     * @nullable
+     */
+    fresh_through: string | null
+    /**
+     * Seconds behind now, or null if unknown.
+     * @nullable
+     */
+    lag_seconds: number | null
+    /**
+     * Last time the backfill made progress.
+     * @nullable
+     */
+    last_activity_at: string | null
+    /** Current error, or null when healthy. */
+    error: _SyncErrorApi | null
+    /** When this status was computed. */
+    updated_at: string
+}
+
+/**
  * * `String` - String
  * * `Number` - Number
  * * `Boolean` - Boolean

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -48,6 +48,7 @@ import type {
     WarehouseSavedQueriesListParams,
     WarehouseSavedQueryDraftsListParams,
     WarehouseStatusResponseApi,
+    WarehouseSyncStatusApi,
     WarehouseTablesListParams,
     WarehouseViewLinkListParams,
     WarehouseViewLinksListParams,
@@ -363,6 +364,23 @@ export const dataWarehouseWarehouseStatusRetrieve = async (
     options?: RequestInit
 ): Promise<WarehouseStatusResponseApi> => {
     return apiMutator<WarehouseStatusResponseApi>(getDataWarehouseWarehouseStatusRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDataWarehouseWarehouseSyncStatusRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/data_warehouse/warehouse_sync_status/`
+}
+
+/**
+ * Freshness of this project's event data in the managed warehouse.
+ */
+export const dataWarehouseWarehouseSyncStatusRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<WarehouseSyncStatusApi> => {
+    return apiMutator<WarehouseSyncStatusApi>(getDataWarehouseWarehouseSyncStatusRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -71,6 +71,9 @@ tools:
     data-warehouse-warehouse-status-retrieve:
         operation: data_warehouse_warehouse_status_retrieve
         enabled: false
+    data-warehouse-warehouse-sync-status-retrieve:
+        operation: data_warehouse_warehouse_sync_status_retrieve
+        enabled: false
     fix-hogql-create:
         operation: fix_hogql_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48989,6 +48989,58 @@ export namespace Schemas {
       connection?: WarehouseConnection | null;
     }
 
+    /**
+     * * `caught_up` - caught_up
+     * * `lagging` - lagging
+     * * `error` - error
+     * * `not_started` - not_started
+     */
+    export type WarehouseSyncStatusStateEnum = typeof WarehouseSyncStatusStateEnum[keyof typeof WarehouseSyncStatusStateEnum];
+
+
+    export const WarehouseSyncStatusStateEnum = {
+      CaughtUp: 'caught_up',
+      Lagging: 'lagging',
+      Error: 'error',
+      NotStarted: 'not_started',
+    } as const;
+
+    export interface _SyncError {
+      /** Human-readable error message. */
+      message: string;
+      /** When the current error first occurred. */
+      since: string;
+    }
+
+    export interface WarehouseSyncStatus {
+      /** Overall freshness state.
+       *
+       * * `caught_up` - caught_up
+       * * `lagging` - lagging
+       * * `error` - error
+       * * `not_started` - not_started */
+      state: WarehouseSyncStatusStateEnum;
+      /**
+         * Timestamp the warehouse is fresh through for this project, or null if no data yet.
+         * @nullable
+         */
+      fresh_through: string | null;
+      /**
+         * Seconds behind now, or null if unknown.
+         * @nullable
+         */
+      lag_seconds: number | null;
+      /**
+         * Last time the backfill made progress.
+         * @nullable
+         */
+      last_activity_at: string | null;
+      /** Current error, or null when healthy. */
+      error: _SyncError | null;
+      /** When this status was computed. */
+      updated_at: string;
+    }
+
     export interface WeeklyDigestResponse {
       /** Unique visitors. */
       visitors: NumericMetric;


### PR DESCRIPTION
## Problem

The frontend needs a simple, honest way to show "how fresh is this project's warehouse event data."

## Changes

- A lean `WarehouseSyncStatus` contract (`state`, `fresh_through`, `lag_seconds`, `last_activity_at`, `error`) and an org/team-scoped `warehouse_sync_status` GET action on `DataWarehouseViewSet`.
- Reads the backfill telemetry events (from the previous PR) out of ClickHouse, **filtered to the requesting project's `team_id`** — genuinely per-team, since the duckling backfill is per-team. **No queries against the customer warehouse.** Freshness = latest successful partition date; state derives from lag, and error is time-bounded to recent failures. It deliberately makes no historical-completeness claim (sparse telemetry can't prove it).
- Introduces a product-neutral `INTERNAL_TELEMETRY_TEAM_ID` setting; `LLM_ANALYTICS_INTERNAL_TEAM_ID` becomes a back-compat alias.
- Regenerated API/MCP types.

## How did you test this code?

I'm an agent; automated only: contract serializer tests; per-team status tests against real ClickHouse rows (caught_up / lagging / recent-error / stale-failure-ignored / wrong-team-isolation); the API action test; and `ai_observability` `personal_spend` tests pass (alias unbroken). `hogli build:openapi` regenerated types cleanly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @EDsCODE .

**Stack:** `eric/dw-freshness-telemetry` → this PR → `eric/dw-freshness-overview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
