### PR TITLE
chore(llma): disable actions embedding workflow and semantic search

### DIFF
--- a/ee/hogai/chat_agent/insights_graph/graph.py
+++ b/ee/hogai/chat_agent/insights_graph/graph.py
@@ -142,9 +142,10 @@ class InsightsGraph(BaseAssistantGraph[AssistantState, PartialAssistantState]):
 
     def add_query_creation_flow(self, next_node: AssistantNodeName = AssistantNodeName.QUERY_EXECUTOR):
         """Add all nodes and edges EXCEPT query execution."""
+        # Semantic actions search (RAG context) is disabled — go straight to the query planner.
+        self.add_edge(AssistantNodeName.START, AssistantNodeName.QUERY_PLANNER)
         return (
-            self.add_rag_context()
-            .add_query_planner()
+            self.add_query_planner()
             .add_trends_generator(next_node=next_node)
             .add_funnel_generator(next_node=next_node)
             .add_retention_generator(next_node=next_node)

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -20,9 +20,6 @@ from temporalio.client import (
     ScheduleSpec,
 )
 
-from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
-from posthog.temporal.ai import SyncVectorsInputs
-from posthog.temporal.ai.sync_vectors import EmbeddingVersion
 from posthog.temporal.ai_observability.eval_reports.schedule import (
     create_count_trigger_schedule,
     create_eval_reports_schedule,
@@ -101,20 +98,10 @@ from ee.billing.salesforce_enrichment.constants import DEFAULT_CHUNK_SIZE
 logger = structlog.get_logger(__name__)
 
 
-async def create_sync_vectors_schedule(client: Client):
-    sync_vectors_schedule = Schedule(
-        action=ScheduleActionStartWorkflow(
-            "ai-sync-vectors",
-            asdict(SyncVectorsInputs(embedding_versions=EmbeddingVersion(actions=LATEST_ACTIONS_EMBEDDING_VERSION))),
-            id="ai-sync-vectors-schedule",
-            task_queue=settings.MAX_AI_TASK_QUEUE,
-        ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=30))]),
-    )
+async def cleanup_sync_vectors_schedule(client: Client):
+    """Disabled: delete the actions embedding sync schedule. Any in-flight runs die on their own execution_timeout."""
     if await a_schedule_exists(client, "ai-sync-vectors-schedule"):
-        await a_update_schedule(client, "ai-sync-vectors-schedule", sync_vectors_schedule)
-    else:
-        await a_create_schedule(client, "ai-sync-vectors-schedule", sync_vectors_schedule, trigger_immediately=True)
+        await a_delete_schedule(client, "ai-sync-vectors-schedule")
 
 
 async def create_run_quota_limiting_schedule(client: Client):
@@ -664,7 +651,7 @@ async def create_error_tracking_recommendations_refresh_schedule(client: Client)
 
 
 schedules = [
-    create_sync_vectors_schedule,
+    cleanup_sync_vectors_schedule,
     create_run_quota_limiting_schedule,
     create_upgrade_queries_schedule,
     create_count_all_playlists_schedule,


### PR DESCRIPTION
## Problem

Disable embeddings for actions since they're unused now. The workflow uses Azure models, which are not compliant.

## Changes

- **Actions embedding workflow disabled.** `create_sync_vectors_schedule` is replaced by `cleanup_sync_vectors_schedule`, which deletes the `ai-sync-vectors-schedule` if it exists. It stays in the init list so the live schedule is removed on next deploy (same pattern as `cleanup_legacy_session_summarization_schedules`). Any in-flight runs die on their own execution timeout. Removed the now-unused `SyncVectorsInputs` / `EmbeddingVersion` / `LATEST_ACTIONS_EMBEDDING_VERSION` imports.
- **Semantic actions search disabled.** `InsightsGraph.add_query_creation_flow()` no longer adds the RAG context node; START now edges straight to the query planner. The `add_rag_context()` method and `InsightRagContextNode` are left in place so this is easy to re-enable.

## How did you test this code?

I'm an agent. I ran `ruff check` on both changed files (passed). The `SyncVectorsWorkflow` and `InsightRagContextNode` classes and their existing unit tests are untouched — only their wiring into the schedule list and graph is removed. No automated graph-structure or schedule tests referenced the removed wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: disable the actions embedding workflow and turn off the semantic actions search in `ee/hogai`. Explored the codebase to map the two features — the `ai-sync-vectors` Temporal schedule (`posthog/temporal/schedule.py`) that summarizes + embeds actions, and the `InsightRagContextNode` (`ee/hogai/chat_agent/rag/nodes.py`) wired into the insights graph as the START step.

Chose to repurpose the schedule creator into a delete-if-exists cleanup rather than just dropping it from the list, since dropping it would leave an already-running Temporal schedule untouched. For the search, removed the node from `add_query_creation_flow` and wired START → query planner directly, leaving the node class and `add_rag_context()` intact for easy reversal. No skills were applicable.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1781847221378689)*
