### PR TITLE
feat(experiments): use timeseries data as cold-start results for experiments

### DIFF
--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -42,6 +42,7 @@ const baseRecalculation = {
     completed_at: null,
     query_to: null,
     is_existing: false,
+    result_source: 'recalculation',
     results: [],
 }
 
@@ -101,6 +102,19 @@ const partialFailureRecalculation = {
         { metric_uuid: PRIMARY_METRIC_UUID, status: 'failed', result: null, error_message: 'boom' },
         { metric_uuid: SECONDARY_METRIC_UUID, status: 'completed', result: secondaryResult, error_message: null },
     ],
+}
+
+// Timeseries cold-start placeholder: completed-status, primary filled from timeseries, secondary is a gap.
+const timeseriesFallbackRecalculation = {
+    ...baseRecalculation,
+    id: 'timeseries-fallback',
+    status: 'completed',
+    trigger: 'cold_run',
+    completed_metrics: 1,
+    completed_at: '2026-06-10T00:05:00Z',
+    query_to: '2026-06-10T00:05:00Z',
+    result_source: 'timeseries_fallback',
+    results: [{ metric_uuid: PRIMARY_METRIC_UUID, status: 'completed', result: primaryResult, error_message: null }],
 }
 
 describe('experimentMetricsLogic', () => {
@@ -294,6 +308,8 @@ describe('experimentMetricsLogic', () => {
         })
 
         it('does not auto-trigger when the latest completed run is fresh', async () => {
+            // freshCompletedRecalculation has result_source 'recalculation' (a real run), so neither the
+            // staleness path nor the timeseries-fallback path fires.
             useMocks({
                 get: {
                     '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
@@ -307,6 +323,68 @@ describe('experimentMetricsLogic', () => {
             await expectLogic(logic)
                 .toDispatchActions(['setCurrentRecalculation'])
                 .toNotHaveDispatchedActions(['triggerRecalculation'])
+        })
+
+        it('renders the timeseries fallback and triggers a cold_run to fill gaps and refresh', async () => {
+            let capturedBody: any
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                        200,
+                        timeseriesFallbackRecalculation,
+                    ],
+                },
+                post: {
+                    // Return a terminal run so triggerRecalculation finishes without arming a poll timer.
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': async ({ request }) => {
+                        capturedBody = await request.json()
+                        return [201, completedRecalculation2]
+                    },
+                },
+            })
+            mountLogic()
+
+            await expectLogic(logic)
+                .toDispatchActions(['setCurrentRecalculation', 'triggerRecalculation'])
+                .toFinishAllListeners()
+            // The placeholder timeseries result is shown immediately for the metric it covered.
+            expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
+            // A real cold_run is fired to fill the gap (secondary) and refresh.
+            expect(capturedBody).toEqual({ trigger: 'cold_run' })
+        })
+
+        it('keeps the timeseries placeholder visible while the triggered cold_run is still pending', async () => {
+            // Regression: the cold_run's first poll tick carries an empty results list. applyResults must
+            // merge (not overwrite), so the already-shown placeholder is not blanked back to a loading cell.
+            const coldRunInProgressEmpty = { ...coldRunPending, status: 'in_progress', results: [] }
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                        200,
+                        timeseriesFallbackRecalculation,
+                    ],
+                    // The polled cold_run is still in progress with no results yet.
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        coldRunInProgressEmpty,
+                    ],
+                },
+                post: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': () => [201, coldRunPending],
+                },
+            })
+            jest.useFakeTimers()
+            mountLogic()
+
+            await jest.advanceTimersByTimeAsync(0)
+            // Drive a couple of poll ticks while the cold_run remains pending with empty results.
+            for (let i = 0; i < 2; i++) {
+                await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+            }
+
+            // The primary placeholder from the timeseries fallback survives the empty-results poll ticks.
+            expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
+            jest.useRealTimers()
         })
 
         it('starts polling after triggering a non-terminal recalculation', async () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -256,10 +256,60 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
             const alignPrimary = alignByMetricPosition(props.experiment, 'primary')
             const alignSecondary = alignByMetricPosition(props.experiment, 'secondary')
 
-            actions.setPrimaryMetricsResults(alignPrimary(resultFor))
-            actions.setSecondaryMetricsResults(alignSecondary(resultFor))
-            actions.setPrimaryMetricsResultsErrors(alignPrimary(errorFor))
-            actions.setSecondaryMetricsResultsErrors(alignSecondary(errorFor))
+            /**
+             * Merge, don't overwrite: keep whatever is already shown for a metric until its real result or
+             * error lands. A run that is still pending (or a cold_run mid-flight) carries an empty `results`
+             * list, so a plain overwrite would blank cells we already populated (e.g. timeseries cold-start
+             * placeholders), flipping them back to a loading spinner. A slot is updated only when this payload
+             * has a result OR an error for that metric; a new error clears the old result and vice versa, so a
+             * cell never shows a stale result alongside a fresh error.
+             */
+            const nextResults = alignPrimary(resultFor)
+            const nextSecondaryResults = alignSecondary(resultFor)
+            const nextErrors = alignPrimary(errorFor)
+            const nextSecondaryErrors = alignSecondary(errorFor)
+
+            const mergeResults = (
+                current: CachedNewExperimentQueryResponse[],
+                nextResult: (CachedNewExperimentQueryResponse | undefined)[],
+                nextError: MetricErrorState[]
+            ): CachedNewExperimentQueryResponse[] =>
+                nextResult.map((value, i) => {
+                    if (value !== undefined) {
+                        return value
+                    }
+                    // A fresh error for this slot supersedes any previously shown result.
+                    if (nextError[i]) {
+                        return undefined as unknown as CachedNewExperimentQueryResponse
+                    }
+                    return current[i]
+                })
+            const mergeErrors = (
+                current: (unknown | null)[],
+                nextError: MetricErrorState[],
+                nextResult: (CachedNewExperimentQueryResponse | undefined)[]
+            ): (unknown | null)[] =>
+                nextError.map((value, i) => {
+                    if (value) {
+                        return value
+                    }
+                    // A fresh result for this slot clears any previously shown error.
+                    if (nextResult[i] !== undefined) {
+                        return null
+                    }
+                    return current[i] ?? null
+                })
+
+            actions.setPrimaryMetricsResults(mergeResults(values.primaryMetricsResults, nextResults, nextErrors))
+            actions.setSecondaryMetricsResults(
+                mergeResults(values.secondaryMetricsResults, nextSecondaryResults, nextSecondaryErrors)
+            )
+            actions.setPrimaryMetricsResultsErrors(
+                mergeErrors(values.primaryMetricsResultsErrors, nextErrors, nextResults)
+            )
+            actions.setSecondaryMetricsResultsErrors(
+                mergeErrors(values.secondaryMetricsResultsErrors, nextSecondaryErrors, nextSecondaryResults)
+            )
         }
 
         return {
@@ -298,6 +348,16 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     )
                     actions.setCurrentRecalculation(recalculation)
                     applyResults(recalculation)
+
+                    /**
+                     * Timeseries fallback is a placeholder: it may cover only some metrics and is cumulative
+                     * daily data, not a fresh point-in-time result. Always trigger a real cold_run to fill the
+                     * gaps and refresh; the placeholder stays visible and cells update in place as it polls.
+                     */
+                    if (recalculation.result_source === 'timeseries_fallback') {
+                        actions.triggerRecalculation('cold_run')
+                        return
+                    }
 
                     /**
                      * if the recalculation resutls are stale, trigger a new recalculation

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -748,6 +748,18 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
     is_existing = serializers.BooleanField(
         read_only=True, required=False, help_text="True if returning an existing job rather than a newly created one"
     )
+    # Named result_source (not source) to avoid shadowing DRF's reserved Field.source attribute, mirroring
+    # the metric_errors-vs-errors rename above.
+    result_source = serializers.ChoiceField(
+        choices=["recalculation", "timeseries_fallback"],
+        required=False,
+        default="recalculation",
+        read_only=True,
+        help_text=(
+            "Where these results came from: 'recalculation' for a real metrics-recalculation run, "
+            "'timeseries_fallback' for a cold-start placeholder built from the latest daily timeseries data."
+        ),
+    )
     # Populated by the GET endpoints (latest / by-id). Omitted from the POST response payload (which doesn't carry
     # per-metric results yet — the workflow has just started).
     results = MetricRecalculationResultSerializer(

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -63,6 +63,7 @@ from products.experiments.backend.presentation.serializers import (
 )
 from products.experiments.backend.recalculation import (
     build_job_payload,
+    build_timeseries_cold_start_payload,
     get_latest_recalculation,
     get_recalculation_by_id,
     get_run_results,
@@ -915,9 +916,14 @@ class EnterpriseExperimentsViewSet(
     def metrics_recalculation_latest(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         experiment: Experiment = self.get_object()
         recalc = get_latest_recalculation(experiment)
-        if recalc is None:
-            return Response({"detail": "No completed recalculation found"}, status=404)
-        return Response(_serialize_recalculation(recalc))
+        if recalc is not None:
+            return Response(_serialize_recalculation(recalc))
+        # Cold start: no completed run yet. Fall back to the latest timeseries data as a read-only
+        # placeholder so the user sees results immediately. Pure read, no workflow start.
+        fallback = build_timeseries_cold_start_payload(experiment)
+        if fallback is not None:
+            return Response(ExperimentMetricsRecalculationSerializer(fallback).data)
+        return Response({"detail": "No completed recalculation found"}, status=404)
 
     @extend_schema(responses={200: ExperimentMetricsRecalculationSerializer, 404: None})
     @action(

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -264,3 +264,75 @@ def get_run_results(recalc: ExperimentMetricsRecalculation) -> list[dict]:
         }
         for row in rows
     ]
+
+
+def build_timeseries_cold_start_payload(experiment: Experiment) -> dict | None:
+    """Synthetic 'completed' recalculation payload built from each metric's latest completed timeseries point.
+
+    Pure read. Used by GET /metrics_recalculation/latest as a cold-start placeholder when no real
+    metrics-recalculation run exists yet. Timeseries rows live in ExperimentMetricResult under the metric's
+    CONFIG fingerprint (not a per-run recalc fingerprint), so they're found without any recalc row.
+
+    Returns None when no metric has a completed timeseries point (caller then keeps the 404). query_to and
+    completed_at both pin to the freshest point's date so the frontend's >24h staleness path fires its own
+    recompute trigger (GET never triggers anything itself).
+    """
+    with team_scope(experiment.team_id, canonical=True):
+        metrics = discover_experiment_metrics(experiment)
+        stats_method = get_experiment_stats_method(experiment)
+
+        results: list[dict] = []
+        latest_query_to = None
+        for metric in metrics:
+            metric_dict = find_metric_dict(experiment, metric.metric_uuid)
+            if metric_dict is None:
+                continue
+            config_fp = compute_metric_fingerprint(
+                metric_dict,
+                experiment.start_date,
+                stats_method,
+                experiment.exposure_criteria,
+                only_count_matured_users=experiment.only_count_matured_users,
+            )
+            row = (
+                ExperimentMetricResult.objects.filter(
+                    experiment=experiment,
+                    metric_uuid=metric.metric_uuid,
+                    fingerprint=config_fp,
+                    status=ExperimentMetricResult.Status.COMPLETED,
+                )
+                .order_by("-query_to")
+                .first()
+            )
+            if row is None:
+                continue
+            results.append(
+                {
+                    "metric_uuid": row.metric_uuid,
+                    "status": row.status,
+                    "result": strip_step_sessions(row.result),
+                    "error_message": None,
+                }
+            )
+            if latest_query_to is None or row.query_to > latest_query_to:
+                latest_query_to = row.query_to
+
+        if not results:
+            return None
+
+        return {
+            "id": "timeseries-fallback",
+            "experiment_id": experiment.id,
+            "status": ExperimentMetricsRecalculation.Status.COMPLETED,
+            "total_metrics": len(metrics),
+            "completed_metrics": len(results),
+            "failed_metrics": 0,
+            "metric_errors": {},
+            "trigger": ExperimentMetricsRecalculation.Trigger.COLD_RUN,
+            "created_at": latest_query_to,
+            "started_at": latest_query_to,
+            "completed_at": latest_query_to,
+            "query_to": latest_query_to,
+            "results": results,
+            "result_source": "timeseries_fallback",
+        }

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -202,8 +202,9 @@ class TestMetricsRecalculationAPI(APIBaseTest):
 
     def _store_timeseries_point(self, exp: Experiment, metric_uuid: str, query_to: datetime) -> None:
         assert exp.metrics and exp.start_date is not None
+        metric_dict = next(m for m in exp.metrics if m["uuid"] == metric_uuid)
         config_fp = compute_metric_fingerprint(
-            exp.metrics[0],
+            metric_dict,
             exp.start_date,
             get_experiment_stats_method(exp),
             exp.exposure_criteria,

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -195,3 +195,54 @@ class TestMetricsRecalculationAPI(APIBaseTest):
         row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=other, status="completed")
         resp = self.client.get(self._by_id_url(exp.id, str(row.id)))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    # ------------------------------------------------------------------
+    # GET /metrics_recalculation/latest/ — timeseries cold-start fallback
+    # ------------------------------------------------------------------
+
+    def _store_timeseries_point(self, exp: Experiment, metric_uuid: str, query_to: datetime) -> None:
+        assert exp.metrics and exp.start_date is not None
+        config_fp = compute_metric_fingerprint(
+            exp.metrics[0],
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid=metric_uuid,
+            fingerprint=config_fp,
+            query_from=exp.start_date,
+            query_to=query_to,
+            status="completed",
+            result={"ok": True},
+        )
+
+    def test_get_latest_returns_timeseries_fallback_on_cold_start(self):
+        # No real recalc row, but a completed timeseries point exists → 200 with source=timeseries_fallback.
+        exp = self._launched_experiment(flag_key="ts-fallback")
+        self._store_timeseries_point(exp, "m1", datetime(2026, 2, 2, tzinfo=UTC))
+
+        resp = self.client.get(self._latest_url(exp.id))
+        assert resp.status_code == status.HTTP_200_OK, resp.content
+        body = resp.json()
+        assert body["result_source"] == "timeseries_fallback"
+        assert body["status"] == "completed"
+        assert len(body["results"]) == 1
+        assert body["results"][0]["result"] == {"ok": True}
+
+    def test_get_latest_still_404_when_no_recalc_and_no_timeseries(self):
+        exp = self._launched_experiment(flag_key="ts-empty")
+        resp = self.client.get(self._latest_url(exp.id))
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    def test_get_latest_fallback_does_not_start_a_workflow(self, mock_connect):
+        # GET stays a pure read: the fallback path must never connect to Temporal.
+        exp = self._launched_experiment(flag_key="ts-pure-read")
+        self._store_timeseries_point(exp, "m1", datetime(2026, 2, 2, tzinfo=UTC))
+
+        resp = self.client.get(self._latest_url(exp.id))
+        assert resp.status_code == status.HTTP_200_OK
+        assert not mock_connect.called

--- a/products/experiments/backend/test/test_metrics_recalculation_serializer.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_serializer.py
@@ -81,6 +81,18 @@ class TestExperimentMetricsRecalculationSerializer(BaseTest):
         data = ExperimentMetricsRecalculationSerializer({}).data
         assert "is_existing" not in data
 
+    def test_result_source_defaults_to_recalculation_when_absent(self):
+        # required=False + default means a real payload that never sets result_source still serializes it as
+        # "recalculation", so clients can always read a concrete source.
+        data = ExperimentMetricsRecalculationSerializer({"status": "completed"}).data
+        assert data["result_source"] == "recalculation"
+
+    def test_result_source_round_trips_timeseries_fallback(self):
+        data = ExperimentMetricsRecalculationSerializer(
+            {"status": "completed", "result_source": "timeseries_fallback"}
+        ).data
+        assert data["result_source"] == "timeseries_fallback"
+
 
 class TestRecalculateMetricsRequestSerializer(BaseTest):
     def test_defaults_trigger_to_manual_when_omitted(self):

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -18,6 +18,7 @@ from products.experiments.backend.models.experiment import (
     ExperimentToSavedMetric,
 )
 from products.experiments.backend.recalculation import (
+    build_timeseries_cold_start_payload,
     get_latest_recalculation,
     get_recalculation_by_id,
     get_run_results,
@@ -325,3 +326,91 @@ class TestRecalculationService(BaseTest):
         exp = self._launched_experiment()
         recalc = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
         assert get_run_results(recalc) == []
+
+
+@pytest.mark.django_db(transaction=True)
+class TestTimeseriesColdStartPayload(BaseTest):
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            name=f"Flag for {key}",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+    def _experiment(self, flag_key: str, metric_uuids: list[str]) -> Experiment:
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=self._flag(flag_key),
+            name="exp",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        exp.metrics = [_mean_metric(uuid) for uuid in metric_uuids]
+        exp.save()
+        return exp
+
+    def _config_fp(self, exp: Experiment, metric_uuid: str) -> str:
+        metric_dict = next(m for m in exp.metrics if m["uuid"] == metric_uuid)
+        return compute_metric_fingerprint(
+            metric_dict,
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+
+    def _timeseries_point(self, exp: Experiment, metric_uuid: str, query_to: datetime, result: dict | None) -> None:
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid=metric_uuid,
+            fingerprint=self._config_fp(exp, metric_uuid),
+            query_from=exp.start_date,
+            query_to=query_to,
+            status="completed" if result is not None else "failed",
+            result=result,
+        )
+
+    def test_returns_none_when_no_timeseries_data(self):
+        exp = self._experiment("ts-none", ["m1"])
+        assert build_timeseries_cold_start_payload(exp) is None
+
+    def test_builds_completed_fallback_from_latest_point(self):
+        exp = self._experiment("ts-one", ["m1"])
+        older = datetime(2026, 2, 1, tzinfo=UTC)
+        latest = datetime(2026, 2, 2, tzinfo=UTC)
+        self._timeseries_point(exp, "m1", older, {"stale": True})
+        self._timeseries_point(exp, "m1", latest, {"ok": True})
+
+        payload = build_timeseries_cold_start_payload(exp)
+        assert payload is not None
+        assert payload["result_source"] == "timeseries_fallback"
+        assert payload["status"] == "completed"
+        # query_to and completed_at both pin to the freshest point so the frontend staleness path can fire.
+        assert payload["query_to"] == latest
+        assert payload["completed_at"] == latest
+        assert payload["completed_metrics"] == 1
+        results = {r["metric_uuid"]: r for r in payload["results"]}
+        assert results["m1"]["status"] == "completed"
+        assert results["m1"]["result"] == {"ok": True}
+
+    def test_omits_metrics_without_a_timeseries_point(self):
+        exp = self._experiment("ts-partial", ["m1", "m2"])
+        self._timeseries_point(exp, "m1", datetime(2026, 2, 2, tzinfo=UTC), {"ok": True})
+        # m2 has no point.
+
+        payload = build_timeseries_cold_start_payload(exp)
+        assert payload is not None
+        assert payload["total_metrics"] == 2
+        assert payload["completed_metrics"] == 1
+        uuids = {r["metric_uuid"] for r in payload["results"]}
+        assert uuids == {"m1"}
+
+    def test_config_fingerprint_mismatch_yields_no_point(self):
+        exp = self._experiment("ts-drift", ["m1"])
+        # Store a point under a stale fingerprint, then change config so the recomputed fp won't match.
+        self._timeseries_point(exp, "m1", datetime(2026, 2, 2, tzinfo=UTC), {"ok": True})
+        exp.exposure_criteria = {"filterTestAccounts": True}
+        exp.save()
+        assert build_timeseries_cold_start_payload(exp) is None

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -352,6 +352,7 @@ class TestTimeseriesColdStartPayload(BaseTest):
         return exp
 
     def _config_fp(self, exp: Experiment, metric_uuid: str) -> str:
+        assert exp.metrics and exp.start_date is not None
         metric_dict = next(m for m in exp.metrics if m["uuid"] == metric_uuid)
         return compute_metric_fingerprint(
             metric_dict,
@@ -362,6 +363,7 @@ class TestTimeseriesColdStartPayload(BaseTest):
         )
 
     def _timeseries_point(self, exp: Experiment, metric_uuid: str, query_to: datetime, result: dict | None) -> None:
+        assert exp.start_date is not None
         ExperimentMetricResult.objects.create(
             experiment=exp,
             metric_uuid=metric_uuid,

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -816,6 +816,17 @@ export const ExperimentMetricsRecalculationStatusEnumApi = {
 } as const
 
 /**
+ * * `recalculation` - recalculation
+ * * `timeseries_fallback` - timeseries_fallback
+ */
+export type ResultSourceEnumApi = (typeof ResultSourceEnumApi)[keyof typeof ResultSourceEnumApi]
+
+export const ResultSourceEnumApi = {
+    Recalculation: 'recalculation',
+    TimeseriesFallback: 'timeseries_fallback',
+} as const
+
+/**
  * * `pending` - pending
  * * `completed` - completed
  * * `failed` - failed
@@ -903,6 +914,11 @@ export interface ExperimentMetricsRecalculationApi {
     readonly query_to: string | null
     /** True if returning an existing job rather than a newly created one */
     readonly is_existing: boolean
+    /** Where these results came from: 'recalculation' for a real metrics-recalculation run, 'timeseries_fallback' for a cold-start placeholder built from the latest daily timeseries data.
+     *
+     * * `recalculation` - recalculation
+     * * `timeseries_fallback` - timeseries_fallback */
+    readonly result_source: ResultSourceEnumApi
     /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
     readonly results: readonly MetricRecalculationResultApi[]
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20632,6 +20632,18 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `recalculation` - recalculation
+     * * `timeseries_fallback` - timeseries_fallback
+     */
+    export type ResultSourceEnum = typeof ResultSourceEnum[keyof typeof ResultSourceEnum];
+
+
+    export const ResultSourceEnum = {
+      Recalculation: 'recalculation',
+      TimeseriesFallback: 'timeseries_fallback',
+    } as const;
+
+    /**
      * * `pending` - pending
      * * `completed` - completed
      * * `failed` - failed
@@ -20719,6 +20731,11 @@ export namespace Schemas {
       readonly query_to: string | null;
       /** True if returning an existing job rather than a newly created one */
       readonly is_existing: boolean;
+      /** Where these results came from: 'recalculation' for a real metrics-recalculation run, 'timeseries_fallback' for a cold-start placeholder built from the latest daily timeseries data.
+       *
+       * * `recalculation` - recalculation
+       * * `timeseries_fallback` - timeseries_fallback */
+      readonly result_source: ResultSourceEnum;
       /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
       readonly results: readonly MetricRecalculationResult[];
     }


### PR DESCRIPTION
## Problem

When an experiment has no completed metrics recalculation yet, `GET .../metrics_recalculation/latest/` returns 404, so the frontend shows every metric cell as a loading spinner and kicks off a fresh "cold run". With many or slow metrics, the user stares at empty cells for the whole run.

We already compute the same numbers in a separate system: the timeseries recalculation. Those results live in the **same table** (`ExperimentMetricResult`) and carry the **same blob shape** (`ExperimentQueryResponse`), so the latest completed timeseries point for a metric is a directly renderable stand-in, no transformation needed. This PR uses it as cold-start data.

## Changes

This PR makes `/latest` return the latest timeseries data as a read-only placeholder on cold start, and has the frontend immediately trigger a real recalculation to fill gaps and refresh.

### Timeseries fallback on the latest endpoint

`GET /metrics_recalculation/latest/` stays a pure read. On its 404 branch (no completed run), it now builds a synthetic `completed`-status payload from each metric's latest completed timeseries point, looked up by the metric's config fingerprint (timeseries rows use config fingerprints, not per-run recalc fingerprints, so they resolve without any recalc row). If at least one metric has a point it returns 200 with that payload; otherwise it still 404s. The payload carries a `result_source` field (`recalculation` vs `timeseries_fallback`) so a placeholder is never mistaken for a real, pollable run. The field is `result_source`, not `source`, because `source` collides with DRF's reserved `Field.source` (same reason `metric_errors` is not `errors` here).

- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/presentation/views.py`
- `products/experiments/backend/presentation/serializers.py`
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

### Frontend: render the placeholder, always recompute, never blank

`loadLatestRecalculation` renders the fallback like any completed run, then, when `result_source === 'timeseries_fallback'`, always triggers a real `cold_run`. Timeseries data is a placeholder: it may cover only some metrics and is cumulative daily data, not a fresh point-in-time result, so we always refresh and fill the gaps.

`applyResults` now merges instead of overwriting. A `cold_run` applies results on every poll tick, and an early tick carries an empty `results` list; a plain overwrite blanked the already-shown placeholder cells back to spinners. The merge updates a metric's slot only when the payload has a result or error for it, so placeholders stay visible and each cell updates in place as its real result lands. A fresh error clears a stale result and vice versa.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/86bba240-4c74-4b4a-9eb0-3537796f66d2)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /improving-drf-endpoints (local)
- /adopting-generated-api-types (local)
- /writing-pull-requests (local)

Relevant decisions:

- The fallback is served from `/latest` itself rather than a new endpoint, keeping it a pure read; triggering the real recalc stays the frontend's job (on seeing `result_source`), so GET never starts a workflow.
- Timeseries rows are matched by config fingerprint (the same key the timeseries writer uses), so no recalc row is needed and a metric whose config drifted simply yields no placeholder and renders empty.
- `applyResults` merges per metric slot instead of overwriting, the load-bearing fix so the cold_run's empty pending ticks don't blank the placeholders the fallback just rendered.