### PR TITLE
fix(inbox): let tab bar scroll on mobile so agents are reachable

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -588,6 +588,10 @@ snapshots:
         hash: v1.k794b7964.586cbc343561fe2ea416c4e8a15661d80f0dc0e6602c4c4505fb763a960e3fec.wnr2iqA9493GIdPtZgO3pqa1uiD9pZcM3L01W8_FZ-Q
     components-hogcharts-defaulttooltip--total-excludes-overlay--light:
         hash: v1.k794b7964.cf566924008a871da770d7d0a0b7a2ac6748823639d3d60ca60344770f581a2a.7s92rB7AHoeq-uQd_tSJGFVCn3cU-LQeOQVJ2qyvLWo
+    components-hogcharts-legend--built-in-toggle--dark:
+        hash: v1.k794b7964.a44913b0e0cdf88b5d0d8960560fa4ce5a663f0b187cdcc5a723d1bb9b653fc6.pxcAORXTtyj4dK4h_9PUe9keV7tagKmaBvwS56KoeXI
+    components-hogcharts-legend--built-in-toggle--light:
+        hash: v1.k794b7964.dc8065b867dd309ca1c05935745e283b13d2fd7ebb7ddde80c9b5e8c24ee6cec.BzRyo-huuWL4HvNyXrykyXbCBuFTjeQKpECqODhn7AE
     components-hogcharts-legend--horizontal--dark:
         hash: v1.k794b7964.748c8221979ca1984c3ef06b0a2d5016e683810a2530a2b7549ff2994484d32d.WlgOW_onzflesCUfetduXiySjbl4uF8oTLxdKf4xYso
     components-hogcharts-legend--horizontal--light:

--- a/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
@@ -52,6 +52,10 @@ export function InboxTabBar({ showConfigTab }: { showConfigTab?: boolean }): JSX
     return (
         <LemonTabs
             activeKey={activeTab}
+            // min-w-0 lets the tab bar shrink inside the header flex row so its own overflow-x scroll
+            // engages on narrow/mobile widths – otherwise it grows to fit every tab and the last ones
+            // (e.g. Configuration) overflow off-screen with no way to reach them.
+            className="min-w-0"
             // Hide LemonTabs' own bottom border + margin so the single full-width border lives on the
             // scene header row; the active-tab slider then sits directly on that one border.
             barClassName="before:hidden mb-0"


### PR DESCRIPTION
## Problem

On narrow/mobile widths the inbox setup rail (Agents / Connections / Preferences) is intentionally dropped and its content moves into a **Configuration** tab. But the tab bar couldn't scroll horizontally, so on a phone the later tabs — including **Configuration** — sat off-screen with no way to reach them. Net effect: the agents section was completely inaccessible on mobile.

## Changes

Add `min-w-0` to the inbox `LemonTabs` container. `.LemonTabs__bar` already has `overflow-x: auto`, but inside the header's flex row the tabs container had the default `min-width: auto`, so it grew to fit every tab and overflowed the row instead of letting its own bar scroll. Allowing it to shrink makes the internal horizontal scroll engage on narrow widths. One-line, scoped to the inbox tab bar — shared `LemonTabs` behavior and every other usage are untouched.

| | Before | After |
|---|---|---|
| Mobile | last tabs (Configuration) off-screen, no scroll | tab bar scrolls, Configuration reachable → agents section visible |
| Desktop | rail on the right | unchanged |

## How did you test this code?

I'm an agent (Claude Code). Verified manually against the local dev app with Playwright:

- **Mobile (390px):** confirmed the tab bar is now overflowing *and* scrollable (`scrollWidth 550 > clientWidth 163`), scrolled to reveal the **Configuration** tab, tapped it, and confirmed the full Agents / Connections / Preferences section renders.
- **Desktop (1440px):** confirmed the setup rail still renders on the right and the tab row is unchanged — no regression.

No automated tests were added for this CSS-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy reported that the agents section on the right of the inbox reports list wasn't visible on mobile, and narrowed it down himself to "I can't scroll the tab list." Diagnosed it as the classic flexbox `min-width: auto` trap: the tabs container grew to fit content and overflowed the header row instead of triggering the bar's existing `overflow-x: auto`. Fixed with `min-w-0` on the inbox `LemonTabs` rather than touching the shared component, to avoid affecting other tab bars. Verified both breakpoints live with the Playwright MCP tools.
