### PR TITLE
feat(experiments): single activity workflow for manual error retries

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
@@ -19,10 +19,17 @@ type MetricErrorStateProps = {
     metric: ExperimentMetric
     query?: Record<string, any>
     onRetry?: () => void
+    retrying?: boolean
     height?: number
 }
 
-export const MetricErrorState = ({ error, query, onRetry, height = 200 }: MetricErrorStateProps): JSX.Element => {
+export const MetricErrorState = ({
+    error,
+    query,
+    onRetry,
+    retrying = false,
+    height = 200,
+}: MetricErrorStateProps): JSX.Element => {
     const { openSupportForm } = useActions(supportLogic)
 
     const errorMessage = parseErrorMessage(error.detail)
@@ -51,6 +58,8 @@ export const MetricErrorState = ({ error, query, onRetry, height = 200 }: Metric
                         type="primary"
                         size="xsmall"
                         onClick={onRetry}
+                        loading={retrying}
+                        disabledReason={retrying ? 'Retrying…' : undefined}
                         sideAction={
                             query
                                 ? {

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -120,6 +120,7 @@ interface CollapsibleBreakdownSectionProps {
     scale: ReturnType<typeof useAxisScale>
     onRemoveBreakdown: (index: number) => void
     onRetry: () => void
+    retrying?: boolean
     query?: Record<string, any>
     handleTooltipMouseEnter: (e: React.MouseEvent, variantResult: ExperimentVariantResult) => void
     handleTooltipMouseLeave: (e: React.MouseEvent) => void
@@ -139,6 +140,7 @@ function CollapsibleBreakdownSection({
     scale,
     onRemoveBreakdown,
     onRetry,
+    retrying,
     query,
     handleTooltipMouseEnter,
     handleTooltipMouseLeave,
@@ -253,7 +255,10 @@ function CollapsibleBreakdownSection({
                                                                             experimentStarted={isLaunched(experiment)}
                                                                             metric={metric}
                                                                             query={query}
-                                                                            onRetry={onRetry}
+                                                                            onRetry={
+                                                                                isRecalculating ? undefined : onRetry
+                                                                            }
+                                                                            retrying={retrying}
                                                                         />
                                                                     )}
                                                                 </td>
@@ -595,18 +600,16 @@ export function MetricRowGroup({
 
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
-    const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric, refreshExperimentResults } =
-        useActions(experimentLogic)
+    const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric } = useActions(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { isRecalculating } = useValues(experimentMetricsLogic({ experiment }))
-    const { triggerRecalculation } = useActions(experimentMetricsLogic({ experiment }))
+    const { isRecalculating, retryingMetrics } = useValues(experimentMetricsLogic({ experiment }))
+    const { retryMetric } = useActions(experimentMetricsLogic({ experiment }))
 
-    // On the recalculation flow, retrying a single metric just re-runs the whole recalculation (plus
-    // exposures) — same as the manual reload. The legacy flow retries the single metric in place.
+    // On the recalculation flow, retry just this metric within the existing run (reusing its query_to)
+    // instead of re-running every metric. The legacy flow retries the single metric in place.
     const handleRetry = (): void => {
         if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]) {
-            triggerRecalculation()
-            refreshExperimentResults(true, 'manual')
+            retryMetric(metric.uuid as string)
             return
         }
         if (isSecondary) {
@@ -615,6 +618,8 @@ export function MetricRowGroup({
             retryPrimaryMetric(metricIndex)
         }
     }
+
+    const isThisMetricRetrying = !!metric?.uuid && retryingMetrics.includes(metric.uuid as string)
 
     // Build query for debugger link
     const debugQuery = metric
@@ -764,7 +769,8 @@ export function MetricRowGroup({
                                 metric={metric}
                                 error={error}
                                 query={debugQuery}
-                                onRetry={handleRetry}
+                                onRetry={isRecalculating ? undefined : handleRetry}
+                                retrying={isThisMetricRetrying}
                             />
                         )}
                     </td>
@@ -1074,6 +1080,7 @@ export function MetricRowGroup({
                     scale={scale}
                     onRemoveBreakdown={onRemoveBreakdown}
                     onRetry={handleRetry}
+                    retrying={isThisMetricRetrying}
                     query={debugQuery}
                     handleTooltipMouseEnter={handleTooltipMouseEnter}
                     handleTooltipMouseLeave={handleTooltipMouseLeave}

--- a/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
@@ -15,6 +15,7 @@ interface ChartEmptyStateProps {
     error?: any
     query?: Record<string, any>
     onRetry?: () => void
+    retrying?: boolean
 }
 
 export function ChartEmptyState({
@@ -24,6 +25,7 @@ export function ChartEmptyState({
     metric,
     query,
     onRetry,
+    retrying = false,
 }: ChartEmptyStateProps): JSX.Element | null {
     /**
      * early return if experiment has not started
@@ -69,7 +71,14 @@ export function ChartEmptyState({
                 <ErrorChecklist error={error} metric={metric} />
             ) : (
                 // Use rich error state for all other errors
-                <MetricErrorState error={error} metric={metric} query={query} onRetry={onRetry} height={height} />
+                <MetricErrorState
+                    error={error}
+                    metric={metric}
+                    query={query}
+                    onRetry={onRetry}
+                    retrying={retrying}
+                    height={height}
+                />
             )}
         </div>
     )

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -589,6 +589,95 @@ describe('experimentMetricsLogic', () => {
         })
     })
 
+    describe('retryMetric', () => {
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        // The retry succeeds: the failed primary metric now has a result and its error is cleared.
+        const retriedRun = {
+            ...partialFailureRecalculation,
+            status: 'completed',
+            failed_metrics: 0,
+            metric_errors: {},
+            results: [
+                { metric_uuid: PRIMARY_METRIC_UUID, status: 'completed', result: primaryResult, error_message: null },
+                {
+                    metric_uuid: SECONDARY_METRIC_UUID,
+                    status: 'completed',
+                    result: secondaryResult,
+                    error_message: null,
+                },
+            ],
+        }
+
+        it('calls retry, marks the metric retrying, then polls until it resolves and clears its error', async () => {
+            let retryBody: any
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [200, retriedRun],
+                },
+                post: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': () => [201, pendingRecalculation],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/retry_metric/': async ({
+                        request,
+                    }) => {
+                        retryBody = await request.json()
+                        return [200, partialFailureRecalculation]
+                    },
+                },
+            })
+            jest.useFakeTimers()
+            mountLogic()
+            await jest.advanceTimersByTimeAsync(0)
+
+            // Seed a terminal failed run with the primary metric failed, then retry just that metric.
+            logic.actions.setCurrentRecalculation(partialFailureRecalculation as any)
+            logic.actions.retryMetric(PRIMARY_METRIC_UUID)
+            await jest.advanceTimersByTimeAsync(0)
+            expect(logic.values.retryingMetrics).toContain(PRIMARY_METRIC_UUID)
+
+            for (let i = 0; i < 2; i++) {
+                await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+            }
+
+            expect(retryBody).toEqual({ metric_uuid: PRIMARY_METRIC_UUID })
+            expect(logic.values.retryingMetrics).not.toContain(PRIMARY_METRIC_UUID)
+            expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
+            expect(logic.values.primaryMetricsResultsErrors[0]).toBeNull()
+        })
+
+        it('does not start a second retry for a metric already retrying', async () => {
+            const retryMock = jest.fn(() => [200, partialFailureRecalculation])
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        partialFailureRecalculation,
+                    ],
+                },
+                post: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': () => [201, pendingRecalculation],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/retry_metric/': retryMock,
+                },
+            })
+            jest.useFakeTimers()
+            mountLogic()
+            await jest.advanceTimersByTimeAsync(0)
+
+            logic.actions.setCurrentRecalculation(partialFailureRecalculation as any)
+            logic.actions.retryMetric(PRIMARY_METRIC_UUID)
+            await jest.advanceTimersByTimeAsync(0)
+            // Second dispatch while the first is in flight is a no-op (guarded on retryingMetrics).
+            logic.actions.retryMetric(PRIMARY_METRIC_UUID)
+            await jest.advanceTimersByTimeAsync(0)
+
+            expect(retryMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
     describe('tab focus does not clobber a loaded run', () => {
         it('does not reload latest on focus once a run is already loaded', async () => {
             const latestMock = jest.fn(() => [200, completedRecalculation])

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -15,6 +15,7 @@ import {
     experimentsMetricsRecalculationCreate,
     experimentsMetricsRecalculationLatestRetrieve,
     experimentsMetricsRecalculationRetrieve,
+    experimentsMetricsRecalculationRetryMetricCreate,
 } from 'products/experiments/frontend/generated/api'
 import type {
     ExperimentMetricsRecalculationApi,
@@ -139,6 +140,9 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
         setPrimaryMetricsResultsErrors: (errors: (unknown | null)[]) => ({ errors }),
         setSecondaryMetricsResultsErrors: (errors: (unknown | null)[]) => ({ errors }),
         setRecalculationLoading: (loading: boolean) => ({ loading }),
+        retryMetric: (metricUuid: string) => ({ metricUuid }),
+        startMetricRetry: (metricUuid: string) => ({ metricUuid }),
+        finishMetricRetry: (metricUuid: string) => ({ metricUuid }),
     }),
     reducers({
         currentRecalculation: [
@@ -179,6 +183,15 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 setSecondaryMetricsResultsErrors: (_, { errors }) => errors,
             },
         ],
+        // metric_uuids with an in-flight single-metric retry. A set, so independent metrics retry concurrently.
+        retryingMetrics: [
+            [] as string[],
+            {
+                startMetricRetry: (state, { metricUuid }) =>
+                    state.includes(metricUuid) ? state : [...state, metricUuid],
+                finishMetricRetry: (state, { metricUuid }) => state.filter((uuid) => uuid !== metricUuid),
+            },
+        ],
     }),
     selectors({
         // True while a recalculation is being fetched or is still running.
@@ -197,6 +210,12 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
             }),
         ],
         lastRefresh: [(s) => [s.currentRecalculation], (recalc): string | null => recalc?.query_to ?? null],
+        isMetricRetrying: [
+            (s) => [s.retryingMetrics],
+            (retryingMetrics): ((metricUuid: string) => boolean) =>
+                (metricUuid) =>
+                    retryingMetrics.includes(metricUuid),
+        ],
     }),
     listeners(({ actions, values, props, cache }) => {
         const flagEnabled = (): boolean => !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]
@@ -478,6 +497,58 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     lemonToast.error(
                         `${recalculation.failed_metrics} of ${recalculation.total_metrics} metrics failed to load`
                     )
+                }
+            },
+            /**
+             * Recompute a single failed metric within the existing run, reusing its query_to. Sets a per-metric
+             * loading flag, then polls the run until that metric's slot resolves (a completed result or a fresh
+             * error). Each poll re-applies the whole payload (idempotent, positional), so only the retried cell
+             * changes. breakpoint cancels the poll if a newer retry of the same metric fires or the logic unmounts.
+             */
+            retryMetric: async ({ metricUuid }, breakpoint) => {
+                if (!flagEnabled() || !experimentIsLaunched()) {
+                    return
+                }
+                const recalc = values.currentRecalculation
+                const resolvedIds = ids()
+                if (!recalc || !resolvedIds || values.retryingMetrics.includes(metricUuid)) {
+                    return
+                }
+                const { projectId, experimentId } = resolvedIds
+                actions.startMetricRetry(metricUuid)
+                try {
+                    await experimentsMetricsRecalculationRetryMetricCreate(String(projectId), experimentId, recalc.id, {
+                        metric_uuid: metricUuid,
+                    })
+
+                    // Poll until this metric's slot is no longer pending: a completed result OR a fresh error.
+                    for (let attempt = 0; attempt < MAX_POLL_RETRIES; attempt++) {
+                        await breakpoint(RECALCULATION_POLL_INTERVAL_MS)
+                        let updated: ExperimentMetricsRecalculationApi
+                        try {
+                            updated = await experimentsMetricsRecalculationRetrieve(
+                                String(projectId),
+                                experimentId,
+                                recalc.id
+                            )
+                        } catch {
+                            continue
+                        }
+                        actions.setCurrentRecalculation(updated)
+                        applyResults(updated)
+
+                        const hasResult = (updated.results ?? []).some(
+                            (r) => r.metric_uuid === metricUuid && r.status === 'completed'
+                        )
+                        const hasError = !!(updated.metric_errors as Record<string, unknown> | null)?.[metricUuid]
+                        if (hasResult || hasError) {
+                            break
+                        }
+                    }
+                } catch (error: any) {
+                    lemonToast.error(error?.detail || 'Failed to retry metric')
+                } finally {
+                    actions.finishMetricRetry(metricUuid)
                 }
             },
         }

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -705,6 +705,14 @@ class RecalculateMetricsRequestSerializer(serializers.Serializer):
     )
 
 
+class RetryMetricRequestSerializer(serializers.Serializer):
+    """Request body for retrying a single failed metric within an existing recalculation."""
+
+    metric_uuid = serializers.CharField(
+        help_text="UUID of the failed metric to recompute within the existing recalculation run."
+    )
+
+
 class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
     """Serializer for metrics recalculation status responses."""
 

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -57,6 +57,7 @@ from products.experiments.backend.presentation.serializers import (
     ExperimentMetricsRecalculationSerializer,
     ExperimentSerializer,
     RecalculateMetricsRequestSerializer,
+    RetryMetricRequestSerializer,
     RunningTimeCalculationInputSerializer,
     RunningTimeCalculationResultSerializer,
     ShipVariantSerializer,
@@ -67,6 +68,7 @@ from products.experiments.backend.recalculation import (
     get_recalculation_by_id,
     get_run_results,
     request_recalculation,
+    request_single_metric_retry,
 )
 from products.experiments.backend.running_time_calculator import (
     BaselineStats,
@@ -78,6 +80,7 @@ from products.experiments.backend.running_time_calculator import (
 )
 from products.experiments.backend.temporal.models import (
     ExperimentMetricsRecalculationWorkflowInputs as MetricsRecalcInputs,
+    ExperimentSingleMetricRetryWorkflowInputs as SingleMetricRetryInputs,
 )
 from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
 from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
@@ -935,6 +938,47 @@ class EnterpriseExperimentsViewSet(
         if recalc is None:
             return Response({"detail": "Recalculation not found"}, status=404)
         return Response(_serialize_recalculation(recalc))
+
+    @extend_schema(
+        request=RetryMetricRequestSerializer,
+        responses={200: ExperimentMetricsRecalculationSerializer, 404: None},
+    )
+    @action(
+        methods=["POST"],
+        detail=True,
+        url_path=r"metrics_recalculation/(?P<recalculation_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/retry_metric",
+        required_scopes=["experiment:write"],
+    )
+    def retry_metric(self, request: Request, recalculation_id: str, *args: Any, **kwargs: Any) -> Response:
+        """Recompute a single failed metric within an existing recalculation, reusing the run's query_to.
+
+        Returns the recalculation payload (still `failed` while the retry runs). Clients poll
+        `GET metrics_recalculation/{id}/` to see the metric's result/error update.
+        """
+        experiment: Experiment = self.get_object()
+        recalc = get_recalculation_by_id(experiment, recalculation_id)
+        if recalc is None:
+            return Response({"detail": "Recalculation not found"}, status=404)
+
+        request_serializer = RetryMetricRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        metric_uuid = request_serializer.validated_data["metric_uuid"]
+
+        result = request_single_metric_retry(experiment, recalc, metric_uuid)
+
+        # No rollback-to-FAILED here (unlike the batch create path): the run is already terminal, so a
+        # failed-to-start retry leaves it exactly as it was. Surface the error to the caller.
+        temporal = sync_connect()
+        asyncio.run(
+            temporal.start_workflow(
+                "experiment-single-metric-retry-workflow",
+                SingleMetricRetryInputs(recalculation_id=str(recalc.id), metric_uuid=metric_uuid),
+                id=f"experiment-metric-retry-{recalc.id}-{metric_uuid}",
+                task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
+            )
+        )
+
+        return Response(ExperimentMetricsRecalculationSerializer(result).data, status=200)
 
     @action(methods=["GET"], detail=False, url_path="stats", required_scopes=["experiment:read"])
     def stats(self, request: Request, **kwargs: Any) -> Response:

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -12,15 +12,17 @@ Module-level free functions (not methods on ExperimentService) so the API view c
 from datetime import timedelta
 from uuid import UUID
 
-from django.db import transaction
+from django.db import close_old_connections, transaction
 from django.db.models import Q
 from django.utils import timezone
 
 from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
+from temporalio.exceptions import ApplicationError
 
 from posthog.models.scoping import team_scope
 from posthog.models.user import User
+from posthog.sync import database_sync_to_async
 
 from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
 from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
@@ -31,7 +33,12 @@ from products.experiments.backend.models.experiment import (
 )
 from products.experiments.backend.result_serialization import strip_step_sessions
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
-from products.experiments.backend.temporal.recalculation_logic import discover_experiment_metrics, find_metric_dict
+from products.experiments.backend.temporal.recalculation_logic import (
+    _get_recalc_state,
+    discover_experiment_metrics,
+    find_metric_dict,
+    resolve_metric_type,
+)
 
 # How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
 # stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
@@ -264,3 +271,115 @@ def get_run_results(recalc: ExperimentMetricsRecalculation) -> list[dict]:
         }
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Single-metric retry
+#
+# Recompute one failed metric inside an existing (terminal) recalculation, reusing the run's pinned query_to.
+# The calc activity (shared with the batch flow) overwrites the metric's result row in place; the finalize step
+# below clears the metric's error entry on success and recomputes run status. The run is never reopened to
+# in_progress, so the per-experiment active-run uniqueness constraint is never engaged.
+# ---------------------------------------------------------------------------
+
+
+def request_single_metric_retry(
+    experiment: Experiment, recalc: ExperimentMetricsRecalculation, metric_uuid: str
+) -> dict:
+    """Validate a single-metric retry against an existing run and return its serialized payload.
+
+    The caller (view) starts the retry workflow when this returns. Rejects: metric not in the run, the metric
+    is not currently failed, or the run never started (no query_to to reuse).
+    """
+    if recalc.experiment_id != experiment.id:
+        raise ValidationError("Recalculation does not belong to this experiment")
+    if metric_uuid not in (recalc.metric_uuids or []):
+        raise ValidationError("Metric is not part of this recalculation")
+    if recalc.query_to is None:
+        raise ValidationError("Recalculation has not started; nothing to retry against")
+
+    results = get_run_results(recalc)
+    result_by_uuid = {r["metric_uuid"]: r for r in results}
+    has_error_entry = metric_uuid in (recalc.metric_errors or {})
+    row = result_by_uuid.get(metric_uuid)
+    is_failed_row = row is not None and row["status"] == ExperimentMetricResult.Status.FAILED
+    if not has_error_entry and not is_failed_row:
+        raise ValidationError("Metric is not in a failed state")
+
+    payload = build_job_payload(recalc, results=results)
+    payload["results"] = results
+    return payload
+
+
+def _resolve_single_metric_retry_context_sync(recalculation_id: str, metric_uuid: str) -> dict:
+    """Sync core of the context resolver (see resolve_single_metric_retry_context). Unit-testable directly."""
+    state = _get_recalc_state(recalculation_id)
+    if metric_uuid not in state.metric_uuids:
+        raise ApplicationError(
+            f"metric_uuid {metric_uuid} is not in recalc {recalculation_id}'s metric set", non_retryable=True
+        )
+    if state.query_to is None:
+        raise ApplicationError(
+            f"recalc {recalculation_id} has no query_to — cannot retry a metric on a run that never started",
+            non_retryable=True,
+        )
+    with team_scope(state.team_id, canonical=True):
+        experiment = Experiment.objects.get(id=state.experiment_id)
+        metric_type = resolve_metric_type(experiment, metric_uuid)
+    return {
+        "experiment_id": state.experiment_id,
+        "query_to": state.query_to.isoformat(),
+        "metric_type": metric_type,
+    }
+
+
+def _finalize_single_metric_retry_sync(recalculation_id: str, metric_uuid: str) -> None:
+    """Sync core of the finalize step (see finalize_single_metric_retry). Unit-testable directly."""
+    state = _get_recalc_state(recalculation_id)
+    with team_scope(state.team_id, canonical=True), transaction.atomic():
+        recalc = (
+            ExperimentMetricsRecalculation.objects.select_for_update()
+            .select_related("experiment")
+            .get(id=recalculation_id)
+        )
+        results = get_run_results(recalc)
+        result_by_uuid = {r["metric_uuid"]: r for r in results}
+
+        metric_errors = recalc.metric_errors or {}
+        retried = result_by_uuid.get(metric_uuid)
+        if retried is not None and retried["status"] == ExperimentMetricResult.Status.COMPLETED:
+            metric_errors.pop(metric_uuid, None)
+
+        # Assign before deriving counters: _derive_counters reads recalc.metric_errors for discovery-only
+        # failures, so the cleared entry must be reflected to flip status correctly.
+        recalc.metric_errors = metric_errors
+        _, failed = _derive_counters(recalc, results=results)
+        recalc.status = (
+            ExperimentMetricsRecalculation.Status.COMPLETED
+            if failed == 0
+            else ExperimentMetricsRecalculation.Status.FAILED
+        )
+        recalc.save(update_fields=["metric_errors", "status"])
+
+
+@database_sync_to_async
+def resolve_single_metric_retry_context(recalculation_id: str, metric_uuid: str) -> dict:
+    """Read the run's experiment_id, query_to (ISO), and the metric's type, for the retry calc activity.
+
+    Validates the metric belongs to the run and the run has a query_to (it must already have started). Runs in
+    the retry workflow before the calc activity, since workflows can't touch the DB.
+    """
+    close_old_connections()
+    return _resolve_single_metric_retry_context_sync(recalculation_id, metric_uuid)
+
+
+@database_sync_to_async
+def finalize_single_metric_retry(recalculation_id: str, metric_uuid: str) -> None:
+    """Reconcile the run row after a single-metric retry calc.
+
+    Clears the metric's error entry if it now has a COMPLETED result row, then recomputes status (completed
+    only when no failures remain). query_to / started_at / completed_at are left untouched: a single-metric
+    retry never reopens the run.
+    """
+    close_old_connections()
+    _finalize_single_metric_retry_sync(recalculation_id, metric_uuid)

--- a/products/experiments/backend/temporal/__init__.py
+++ b/products/experiments/backend/temporal/__init__.py
@@ -7,18 +7,26 @@ from products.experiments.backend.temporal.canary_workflow import ExperimentPrec
 from products.experiments.backend.temporal.recalculation_activities import (
     calculate_experiment_metric_for_recalculation,
     discover_experiment_metrics,
+    finalize_single_metric_retry,
+    resolve_single_metric_retry_context,
     update_recalculation_progress,
 )
-from products.experiments.backend.temporal.recalculation_workflow import ExperimentMetricsRecalculationWorkflow
+from products.experiments.backend.temporal.recalculation_workflow import (
+    ExperimentMetricsRecalculationWorkflow,
+    ExperimentSingleMetricRetryWorkflow,
+)
 
 WORKFLOWS = [
     ExperimentMetricsRecalculationWorkflow,
+    ExperimentSingleMetricRetryWorkflow,
     ExperimentPrecomputeCanaryWorkflow,
 ]
 ACTIVITIES = [
     discover_experiment_metrics,
     calculate_experiment_metric_for_recalculation,
     update_recalculation_progress,
+    resolve_single_metric_retry_context,
+    finalize_single_metric_retry,
     sample_experiment_canary_targets,
     run_experiment_metric_canary,
     report_experiment_canary_results,
@@ -29,9 +37,12 @@ __all__ = [
     "WORKFLOWS",
     "ExperimentMetricsRecalculationWorkflow",
     "ExperimentPrecomputeCanaryWorkflow",
+    "ExperimentSingleMetricRetryWorkflow",
     "calculate_experiment_metric_for_recalculation",
     "discover_experiment_metrics",
+    "finalize_single_metric_retry",
     "report_experiment_canary_results",
+    "resolve_single_metric_retry_context",
     "run_experiment_metric_canary",
     "sample_experiment_canary_targets",
     "update_recalculation_progress",

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -22,6 +22,14 @@ class ExperimentMetricsRecalculationWorkflowInputs:
 
 
 @dataclasses.dataclass
+class ExperimentSingleMetricRetryWorkflowInputs:
+    """Input to the single-metric retry workflow: recompute one failed metric inside an existing run."""
+
+    recalculation_id: str  # UUID as string
+    metric_uuid: str
+
+
+@dataclasses.dataclass
 class ExperimentMetricToRecalculate:
     """A single metric to recalculate.
 

--- a/products/experiments/backend/temporal/recalculation_activities.py
+++ b/products/experiments/backend/temporal/recalculation_activities.py
@@ -52,3 +52,26 @@ async def calculate_experiment_metric_for_recalculation(
     return await _calculate_experiment_metric_for_recalculation_sync(
         experiment_id, metric_uuid, recalculation_id, query_to, metric_type
     )
+
+
+@temporalio.activity.defn
+async def resolve_single_metric_retry_context(recalculation_id: str, metric_uuid: str) -> dict:
+    """Resolve experiment_id / query_to / metric_type for a single-metric retry from the run row.
+
+    Runs before the calc activity in the retry workflow, since the workflow can't read the DB directly.
+    """
+    # Deferred import to break a load-time cycle: recalculation.py imports recalculation_logic.py, and the
+    # worker registry imports this activities module, so importing recalculation.py at top would partially
+    # initialize it during codegen/startup. noqa: PLC0415 — justified circular-import break.
+    from products.experiments.backend.recalculation import resolve_single_metric_retry_context as _impl  # noqa: PLC0415
+
+    return await _impl(recalculation_id, metric_uuid)
+
+
+@temporalio.activity.defn
+async def finalize_single_metric_retry(recalculation_id: str, metric_uuid: str) -> None:
+    """Reconcile the run row after a single-metric retry: clear the metric's error on success, recompute status."""
+    # Deferred import to break a load-time cycle (see resolve_single_metric_retry_context above).
+    from products.experiments.backend.recalculation import finalize_single_metric_retry as _impl  # noqa: PLC0415
+
+    return await _impl(recalculation_id, metric_uuid)

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -129,6 +129,18 @@ def discover_experiment_metrics(experiment: Experiment) -> list[ExperimentMetric
     return metrics_to_recalculate
 
 
+def resolve_metric_type(experiment: Experiment, metric_uuid: str) -> str:
+    """Primary/secondary classification for one metric, matching discovery's labeling. Defaults to 'primary'.
+
+    Used by the single-metric retry to thread the same metric_type into the calc activity that the batch
+    workflow derives from discovery.
+    """
+    for metric in discover_experiment_metrics(experiment):
+        if metric.metric_uuid == metric_uuid:
+            return metric.metric_type
+    return "primary"
+
+
 @database_sync_to_async
 def _discover_experiment_metrics_sync(recalculation_id: str) -> list[ExperimentMetricToRecalculate]:
     close_old_connections()

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -10,11 +10,14 @@ from posthog.temporal.common.base import PostHogWorkflow
 with temporalio.workflow.unsafe.imports_passed_through():
     from products.experiments.backend.temporal.models import (
         ExperimentMetricsRecalculationWorkflowInputs,
+        ExperimentSingleMetricRetryWorkflowInputs,
         RecalculationProgressUpdate,
     )
     from products.experiments.backend.temporal.recalculation_activities import (
         calculate_experiment_metric_for_recalculation,
         discover_experiment_metrics,
+        finalize_single_metric_retry,
+        resolve_single_metric_retry_context,
         update_recalculation_progress,
     )
     from products.experiments.backend.temporal.recalculation_metrics import increment_workflow_finished
@@ -144,3 +147,58 @@ class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
         )
         increment_workflow_finished(final_status)
         return {"total": len(metrics), "succeeded": succeeded, "failed": failed}
+
+
+@temporalio.workflow.defn(name="experiment-single-metric-retry-workflow")
+class ExperimentSingleMetricRetryWorkflow(PostHogWorkflow):
+    """Recompute one failed metric inside an existing recalculation, reusing the run's query_to.
+
+    No discovery/start step: the run already exists with a pinned query_to and metric set. Resolves the metric's
+    calc context from the row, runs the same calc activity as the batch flow for the single metric, then
+    finalizes (clears the metric's error on success, recomputes run status). The run is never reopened to
+    in_progress, so the per-experiment active-run uniqueness constraint is untouched.
+    """
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> ExperimentSingleMetricRetryWorkflowInputs:
+        return ExperimentSingleMetricRetryWorkflowInputs(recalculation_id=inputs[0], metric_uuid=inputs[1])
+
+    @temporalio.workflow.run
+    async def run(self, inputs: ExperimentSingleMetricRetryWorkflowInputs) -> dict:
+        recalculation_id = inputs.recalculation_id
+        metric_uuid = inputs.metric_uuid
+
+        # Workflows can't touch the DB; read experiment_id / query_to / metric_type via an activity.
+        context = await temporalio.workflow.execute_activity(
+            resolve_single_metric_retry_context,
+            args=[recalculation_id, metric_uuid],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+        await temporalio.workflow.execute_activity(
+            calculate_experiment_metric_for_recalculation,
+            args=[
+                context["experiment_id"],
+                metric_uuid,
+                recalculation_id,
+                context["query_to"],
+                context["metric_type"],
+            ],
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=5),
+                maximum_interval=timedelta(seconds=30),
+            ),
+        )
+
+        await temporalio.workflow.execute_activity(
+            finalize_single_metric_retry,
+            args=[recalculation_id, metric_uuid],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+        temporalio.workflow.logger.info(f"single-metric retry done: recalc {recalculation_id} metric {metric_uuid}")
+        return {"recalculation_id": recalculation_id, "metric_uuid": metric_uuid}

--- a/products/experiments/backend/temporal/test_registration.py
+++ b/products/experiments/backend/temporal/test_registration.py
@@ -1,6 +1,9 @@
 from products.experiments.backend.temporal import ACTIVITIES, WORKFLOWS
 from products.experiments.backend.temporal.canary_workflow import ExperimentPrecomputeCanaryWorkflow
-from products.experiments.backend.temporal.recalculation_workflow import ExperimentMetricsRecalculationWorkflow
+from products.experiments.backend.temporal.recalculation_workflow import (
+    ExperimentMetricsRecalculationWorkflow,
+    ExperimentSingleMetricRetryWorkflow,
+)
 
 
 def test_activities_registered():
@@ -9,6 +12,8 @@ def test_activities_registered():
         "discover_experiment_metrics",
         "calculate_experiment_metric_for_recalculation",
         "update_recalculation_progress",
+        "resolve_single_metric_retry_context",
+        "finalize_single_metric_retry",
         "sample_experiment_canary_targets",
         "run_experiment_metric_canary",
         "report_experiment_canary_results",
@@ -16,4 +21,8 @@ def test_activities_registered():
 
 
 def test_workflow_registered():
-    assert WORKFLOWS == [ExperimentMetricsRecalculationWorkflow, ExperimentPrecomputeCanaryWorkflow]
+    assert WORKFLOWS == [
+        ExperimentMetricsRecalculationWorkflow,
+        ExperimentSingleMetricRetryWorkflow,
+        ExperimentPrecomputeCanaryWorkflow,
+    ]

--- a/products/experiments/backend/test/test_metrics_recalculation_api.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_api.py
@@ -195,3 +195,70 @@ class TestMetricsRecalculationAPI(APIBaseTest):
         row = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=other, status="completed")
         resp = self.client.get(self._by_id_url(exp.id, str(row.id)))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    # ------------------------------------------------------------------
+    # POST /metrics_recalculation/{id}/retry_metric/
+    # ------------------------------------------------------------------
+
+    def _retry_url(self, exp_id: int, recalc_id: str) -> str:
+        return f"/api/projects/{self.team.id}/experiments/{exp_id}/metrics_recalculation/{recalc_id}/retry_metric/"
+
+    def _failed_recalc_with_metric(self, exp: Experiment, *, metric_status: str) -> ExperimentMetricsRecalculation:
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status="failed" if metric_status == "failed" else "completed",
+            metric_uuids=["m1"],
+            query_to=datetime(2026, 2, 1, tzinfo=UTC),
+            metric_errors={"m1": {"step": "calculation", "message": "boom"}} if metric_status == "failed" else {},
+        )
+        assert exp.metrics and exp.start_date is not None and recalc.query_to is not None
+        config_fp = compute_metric_fingerprint(
+            exp.metrics[0],
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=compute_recalc_fingerprint(config_fp, str(recalc.id)),
+            query_from=exp.start_date,
+            query_to=recalc.query_to,
+            status=metric_status,
+            result=None if metric_status == "failed" else {"ok": True},
+            error_message="boom" if metric_status == "failed" else None,
+        )
+        return recalc
+
+    @mock.patch("products.experiments.backend.presentation.views.sync_connect")
+    @mock.patch("products.experiments.backend.presentation.views.asyncio.run")
+    def test_retry_metric_starts_workflow_and_returns_payload(self, mock_run, mock_connect):
+        exp = self._launched_experiment(flag_key="retry-ok")
+        recalc = self._failed_recalc_with_metric(exp, metric_status="failed")
+        resp = self.client.post(self._retry_url(exp.id, str(recalc.id)), {"metric_uuid": "m1"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK, resp.content
+        assert resp.json()["id"] == str(recalc.id)
+        assert mock_run.called
+
+    def test_retry_metric_404_for_unknown_recalc(self):
+        exp = self._launched_experiment(flag_key="retry-404")
+        resp = self.client.post(
+            self._retry_url(exp.id, "00000000-0000-0000-0000-000000000001"),
+            {"metric_uuid": "m1"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_retry_metric_400_for_non_failed_metric(self):
+        exp = self._launched_experiment(flag_key="retry-not-failed")
+        recalc = self._failed_recalc_with_metric(exp, metric_status="completed")
+        resp = self.client.post(self._retry_url(exp.id, str(recalc.id)), {"metric_uuid": "m1"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_retry_metric_400_for_missing_metric_uuid(self):
+        exp = self._launched_experiment(flag_key="retry-no-uuid")
+        recalc = self._failed_recalc_with_metric(exp, metric_status="failed")
+        resp = self.client.post(self._retry_url(exp.id, str(recalc.id)), {}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/products/experiments/backend/test/test_metrics_recalculation_serializer.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_serializer.py
@@ -9,6 +9,7 @@ from products.experiments.backend.presentation.serializers import (
     ExperimentMetricsRecalculationSerializer,
     MetricRecalculationResultSerializer,
     RecalculateMetricsRequestSerializer,
+    RetryMetricRequestSerializer,
 )
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
@@ -109,6 +110,18 @@ class TestRecalculateMetricsRequestSerializer(BaseTest):
         s = RecalculateMetricsRequestSerializer(data={"trigger": "nonsense"})
         assert not s.is_valid()
         assert "trigger" in s.errors
+
+
+class TestRetryMetricRequestSerializer(BaseTest):
+    def test_requires_metric_uuid(self):
+        s = RetryMetricRequestSerializer(data={})
+        assert not s.is_valid()
+        assert "metric_uuid" in s.errors
+
+    def test_accepts_metric_uuid(self):
+        s = RetryMetricRequestSerializer(data={"metric_uuid": "m1"})
+        assert s.is_valid(), s.errors
+        assert s.validated_data["metric_uuid"] == "m1"
 
 
 class TestMetricRecalculationResultSerializer(BaseTest):

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -18,10 +18,12 @@ from products.experiments.backend.models.experiment import (
     ExperimentToSavedMetric,
 )
 from products.experiments.backend.recalculation import (
+    _finalize_single_metric_retry_sync,
     get_latest_recalculation,
     get_recalculation_by_id,
     get_run_results,
     request_recalculation,
+    request_single_metric_retry,
 )
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -325,3 +327,136 @@ class TestRecalculationService(BaseTest):
         exp = self._launched_experiment()
         recalc = ExperimentMetricsRecalculation.objects.create(team=self.team, experiment=exp, status="pending")
         assert get_run_results(recalc) == []
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSingleMetricRetry(BaseTest):
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            name=f"Flag for {key}",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+    def _experiment_with_metrics(self, flag_key: str, metric_uuids: list[str]) -> Experiment:
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=self._flag(flag_key),
+            name="exp",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        exp.metrics = [_mean_metric(uuid) for uuid in metric_uuids]
+        exp.save()
+        return exp
+
+    def _recalc_fp(self, exp: Experiment, recalc: ExperimentMetricsRecalculation, metric_uuid: str) -> str:
+        metric_dict = next(m for m in exp.metrics if m["uuid"] == metric_uuid)
+        config_fp = compute_metric_fingerprint(
+            metric_dict,
+            exp.start_date,
+            get_experiment_stats_method(exp),
+            exp.exposure_criteria,
+            only_count_matured_users=exp.only_count_matured_users,
+        )
+        return compute_recalc_fingerprint(config_fp, str(recalc.id))
+
+    def _failed_recalc(
+        self,
+        flag_key: str,
+        metric_uuids: list[str],
+        *,
+        query_to: datetime | None,
+        failing: list[str],
+    ) -> tuple[Experiment, ExperimentMetricsRecalculation]:
+        exp = self._experiment_with_metrics(flag_key, metric_uuids)
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            status="failed",
+            metric_uuids=metric_uuids,
+            query_to=query_to,
+            metric_errors={uuid: {"step": "calculation", "message": "boom"} for uuid in failing},
+        )
+        if query_to is not None:
+            for uuid in metric_uuids:
+                is_failing = uuid in failing
+                ExperimentMetricResult.objects.create(
+                    experiment=exp,
+                    metric_uuid=uuid,
+                    fingerprint=self._recalc_fp(exp, recalc, uuid),
+                    query_from=exp.start_date,
+                    query_to=query_to,
+                    status="failed" if is_failing else "completed",
+                    result=None if is_failing else {"ok": True},
+                    error_message="boom" if is_failing else None,
+                )
+        return exp, recalc
+
+    def _store_completed(self, exp: Experiment, recalc: ExperimentMetricsRecalculation, metric_uuid: str) -> None:
+        # Simulate the retry's calc activity overwriting the failed row with a completed one.
+        ExperimentMetricResult.objects.update_or_create(
+            experiment=exp,
+            metric_uuid=metric_uuid,
+            fingerprint=self._recalc_fp(exp, recalc, metric_uuid),
+            query_to=recalc.query_to,
+            defaults={
+                "query_from": exp.start_date,
+                "status": "completed",
+                "result": {"ok": True},
+                "error_message": None,
+            },
+        )
+
+    def test_request_rejects_metric_not_in_run(self):
+        exp, recalc = self._failed_recalc("r1", ["m1"], query_to=timezone.now(), failing=["m1"])
+        with self.assertRaises(ValidationError):
+            request_single_metric_retry(exp, recalc, "not-in-run")
+
+    def test_request_rejects_when_metric_not_failed(self):
+        exp, recalc = self._failed_recalc("r2", ["m1"], query_to=timezone.now(), failing=[])
+        with self.assertRaises(ValidationError):
+            request_single_metric_retry(exp, recalc, "m1")
+
+    def test_request_rejects_when_query_to_missing(self):
+        exp, recalc = self._failed_recalc("r3", ["m1"], query_to=None, failing=["m1"])
+        with self.assertRaises(ValidationError):
+            request_single_metric_retry(exp, recalc, "m1")
+
+    def test_request_returns_payload_for_failed_metric(self):
+        exp, recalc = self._failed_recalc("r4", ["m1"], query_to=timezone.now(), failing=["m1"])
+        payload = request_single_metric_retry(exp, recalc, "m1")
+        assert payload["id"] == str(recalc.id)
+        assert payload["status"] == "failed"
+
+    def test_finalize_clears_error_and_completes_when_last_failure(self):
+        exp, recalc = self._failed_recalc("r5", ["m1"], query_to=timezone.now(), failing=["m1"])
+        self._store_completed(exp, recalc, "m1")
+
+        _finalize_single_metric_retry_sync(str(recalc.id), "m1")
+
+        recalc.refresh_from_db()
+        assert "m1" not in (recalc.metric_errors or {})
+        assert recalc.status == ExperimentMetricsRecalculation.Status.COMPLETED
+
+    def test_finalize_keeps_failed_when_another_metric_still_failing(self):
+        exp, recalc = self._failed_recalc("r6", ["m1", "m2"], query_to=timezone.now(), failing=["m1", "m2"])
+        self._store_completed(exp, recalc, "m1")  # only m1 recovers
+
+        _finalize_single_metric_retry_sync(str(recalc.id), "m1")
+
+        recalc.refresh_from_db()
+        assert "m1" not in (recalc.metric_errors or {})
+        assert "m2" in (recalc.metric_errors or {})
+        assert recalc.status == ExperimentMetricsRecalculation.Status.FAILED
+
+    def test_finalize_keeps_error_when_retry_failed_again(self):
+        # No completed result stored: the retry's calc wrote a fresh FAILED row + error.
+        exp, recalc = self._failed_recalc("r7", ["m1"], query_to=timezone.now(), failing=["m1"])
+
+        _finalize_single_metric_retry_sync(str(recalc.id), "m1")
+
+        recalc.refresh_from_db()
+        assert recalc.status == ExperimentMetricsRecalculation.Status.FAILED

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -907,6 +907,14 @@ export interface ExperimentMetricsRecalculationApi {
     readonly results: readonly MetricRecalculationResultApi[]
 }
 
+/**
+ * Request body for retrying a single failed metric within an existing recalculation.
+ */
+export interface RetryMetricRequestApi {
+    /** UUID of the failed metric to recompute within the existing recalculation run. */
+    metric_uuid: string
+}
+
 export interface ShipVariantApi {
     /** The conclusion of the experiment.
      *

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -28,6 +28,7 @@ import type {
     PatchedExperimentHoldoutApi,
     PatchedExperimentSavedMetricApi,
     RecalculateMetricsRequestApi,
+    RetryMetricRequestApi,
     RunningTimeCalculationInputApi,
     RunningTimeCalculationResultApi,
     ShipVariantApi,
@@ -609,6 +610,38 @@ export const experimentsMetricsRecalculationRetrieve = async (
         {
             ...options,
             method: 'GET',
+        }
+    )
+}
+
+export const getExperimentsMetricsRecalculationRetryMetricCreateUrl = (
+    projectId: string,
+    id: number,
+    recalculationId: string
+) => {
+    return `/api/projects/${projectId}/experiments/${id}/metrics_recalculation/${recalculationId}/retry_metric/`
+}
+
+/**
+ * Recompute a single failed metric within an existing recalculation, reusing the run's query_to.
+ *
+ * Returns the recalculation payload (still `failed` while the retry runs). Clients poll
+ * `GET metrics_recalculation/{id}/` to see the metric's result/error update.
+ */
+export const experimentsMetricsRecalculationRetryMetricCreate = async (
+    projectId: string,
+    id: number,
+    recalculationId: string,
+    retryMetricRequestApi: RetryMetricRequestApi,
+    options?: RequestInit
+): Promise<ExperimentMetricsRecalculationApi> => {
+    return apiMutator<ExperimentMetricsRecalculationApi>(
+        getExperimentsMetricsRecalculationRetryMetricCreateUrl(projectId, id, recalculationId),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(retryMetricRequestApi),
         }
     )
 }

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -245,6 +245,20 @@ export const ExperimentsMetricsRecalculationCreateBody = /* @__PURE__ */ zod
     .describe('Request body for triggering a metrics recalculation.')
 
 /**
+ * Recompute a single failed metric within an existing recalculation, reusing the run's query_to.
+ *
+ * Returns the recalculation payload (still `failed` while the retry runs). Clients poll
+ * `GET metrics_recalculation/{id}/` to see the metric's result/error update.
+ */
+export const ExperimentsMetricsRecalculationRetryMetricCreateBody = /* @__PURE__ */ zod
+    .object({
+        metric_uuid: zod
+            .string()
+            .describe('UUID of the failed metric to recompute within the existing recalculation run.'),
+    })
+    .describe('Request body for retrying a single failed metric within an existing recalculation.')
+
+/**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
  *
  * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -858,6 +858,9 @@ tools:
     experiments-metrics-recalculation-retrieve:
         operation: experiments_metrics_recalculation_retrieve
         enabled: false
+    experiments-metrics-recalculation-retry-metric-create:
+        operation: experiments_metrics_recalculation_retry_metric_create
+        enabled: false
     experiments-prompt-templates-retrieve:
         operation: experiments_prompt_templates_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44325,6 +44325,14 @@ export namespace Schemas {
 
     export type RetrieveFileDownloadResponse = RetrieveBasicOutput | RetrieveCompletedOutput | RetrieveFailedOutput;
 
+    /**
+     * Request body for retrying a single failed metric within an existing recalculation.
+     */
+    export interface RetryMetricRequest {
+      /** UUID of the failed metric to recompute within the existing recalculation run. */
+      metric_uuid: string;
+    }
+
     export interface ReviewQueueCreate {
       /**
          * Human-readable queue name.


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
