### PR TITLE
feat(mcp): add output_format=gcf option for GCF-encoded tool responses

### DIFF
--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -48,7 +48,7 @@
         "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
-        "@blackwell-systems/gcf": "^2.1.2",
+        "@blackwell-systems/gcf": "2.1.2",
         "@toon-format/toon": "^2.1.0",
         "ai": "^6.0.0",
         "esbuild": "^0.25.11",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -48,7 +48,7 @@
         "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
-        "@blackwell-systems/gcf": "2.1.2",
+        "@blackwell-systems/gcf": "^2.2.2",
         "@toon-format/toon": "^2.1.0",
         "ai": "^6.0.0",
         "esbuild": "^0.25.11",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -48,6 +48,7 @@
         "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
+        "@blackwell-systems/gcf": "^2.1.2",
         "@toon-format/toon": "^2.1.0",
         "ai": "^6.0.0",
         "esbuild": "^0.25.11",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -48,7 +48,7 @@
         "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
-        "@blackwell-systems/gcf": "^2.2.2",
+        "@blackwell-systems/gcf": "2.2.2",
         "@toon-format/toon": "^2.1.0",
         "ai": "^6.0.0",
         "esbuild": "^0.25.11",

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -776,7 +776,7 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         .enum(['json', 'optimized', 'gcf'])
         .optional()
         .describe(
-            "'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects."
+            "'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects. 'gcf' returns GCF-encoded output (compact, LLM-optimized)."
         ),
     refresh: zod
         .enum(['blocking', 'force_blocking', 'force_cache'])

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -773,7 +773,7 @@ export const DashboardsRunInsightsRetrieveQueryParams = /* @__PURE__ */ zod.obje
         ),
     format: zod.enum(['json', 'txt']).optional(),
     output_format: zod
-        .enum(['json', 'optimized'])
+        .enum(['json', 'optimized', 'gcf'])
         .optional()
         .describe(
             "'optimized' (default) returns LLM-friendly formatted text per insight. 'json' returns the raw query result objects."

--- a/services/mcp/src/lib/build-tool-result.ts
+++ b/services/mcp/src/lib/build-tool-result.ts
@@ -1,13 +1,13 @@
 import { RESOURCE_URI_META_KEY } from '@modelcontextprotocol/ext-apps/server'
 
 import { estimateTokens } from '@/lib/estimate-tokens'
-import { formatResponse } from '@/lib/response'
+import { formatResponse, formatResponseGcf } from '@/lib/response'
 import { POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY, POSTHOG_META_KEY } from '@/tools/types'
 import type { AnalyticsMetadata, WithAnalytics } from '@/ui-apps/types'
 
 export interface ToolResultMeta {
     ui?: { resourceUri?: string }
-    [POSTHOG_META_KEY]?: { outputFormat?: 'optimized' | 'json' }
+    [POSTHOG_META_KEY]?: { outputFormat?: 'optimized' | 'json' | 'gcf' }
 }
 
 export interface BuildToolResultOptions {
@@ -123,9 +123,10 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
     const resourceUri = toolMeta?.ui?.resourceUri
     const hasUiResource = !!resourceUri
     // Caller's per-call `output_format` wins over the tool's YAML default in `_meta`.
-    const callerOutputFormat = (params as { output_format?: 'optimized' | 'json' } | undefined)?.output_format
+    const callerOutputFormat = (params as { output_format?: 'optimized' | 'json' | 'gcf' } | undefined)?.output_format
     const effectiveOutputFormat = callerOutputFormat ?? toolMeta?.[POSTHOG_META_KEY]?.outputFormat
     const useJson = effectiveOutputFormat === 'json'
+    const useGcf = effectiveOutputFormat === 'gcf'
     const callerWantsJson = callerOutputFormat === 'json'
 
     let structuredContent: WithAnalytics<typeof rawResult> | typeof rawResult = rawResult
@@ -140,7 +141,7 @@ export function buildToolResultPayload(opts: BuildToolResultOptions): ToolResult
         }
     }
 
-    const text = formattedResults ?? (useJson ? JSON.stringify(rawResult) : formatResponse(rawResult))
+    const text = formattedResults ?? (useJson ? JSON.stringify(rawResult) : useGcf ? formatResponseGcf(rawResult) : formatResponse(rawResult))
 
     const suppressStructuredContent =
         formattedResults !== undefined && !callerWantsJson && !!suppressStructuredContentForFormattedResults

--- a/services/mcp/src/lib/response.ts
+++ b/services/mcp/src/lib/response.ts
@@ -1,4 +1,5 @@
 import { encode } from '@toon-format/toon'
+import { encodeGeneric } from '@blackwell-systems/gcf'
 
 const QUERY_PLACEHOLDER_PREFIX = '__QUERY_PLACEHOLDER_'
 
@@ -36,6 +37,22 @@ export function formatResponse(data: any): string {
     const placeholderMap = new Map<string, string>()
     const processed = preprocessKeys(data, placeholderMap)
     let result = encode(processed)
+
+    for (const [placeholder, jsonValue] of placeholderMap.entries()) {
+        result = result.replace(`${placeholder}`, jsonValue)
+    }
+
+    return result
+}
+
+export function formatResponseGcf(data: any): string {
+    if (typeof data === 'string') {
+        return data
+    }
+
+    const placeholderMap = new Map<string, string>()
+    const processed = preprocessKeys(data, placeholderMap)
+    let result = encodeGeneric(processed)
 
     for (const [placeholder, jsonValue] of placeholderMap.entries()) {
         result = result.replace(`${placeholder}`, jsonValue)

--- a/services/mcp/src/lib/response.ts
+++ b/services/mcp/src/lib/response.ts
@@ -29,14 +29,14 @@ function preprocessKeys(obj: any, placeholderMap: Map<string, string>, placehold
     return obj
 }
 
-export function formatResponse(data: any): string {
+function formatResponseWithEncoder(data: any, encoder: (data: any) => string): string {
     if (typeof data === 'string') {
         return data
     }
 
     const placeholderMap = new Map<string, string>()
     const processed = preprocessKeys(data, placeholderMap)
-    let result = encode(processed)
+    let result = encoder(processed)
 
     for (const [placeholder, jsonValue] of placeholderMap.entries()) {
         result = result.replace(`${placeholder}`, jsonValue)
@@ -45,18 +45,10 @@ export function formatResponse(data: any): string {
     return result
 }
 
+export function formatResponse(data: any): string {
+    return formatResponseWithEncoder(data, encode)
+}
+
 export function formatResponseGcf(data: any): string {
-    if (typeof data === 'string') {
-        return data
-    }
-
-    const placeholderMap = new Map<string, string>()
-    const processed = preprocessKeys(data, placeholderMap)
-    let result = encodeGeneric(processed)
-
-    for (const [placeholder, jsonValue] of placeholderMap.entries()) {
-        result = result.replace(`${placeholder}`, jsonValue)
-    }
-
-    return result
+    return formatResponseWithEncoder(data, encodeGeneric)
 }

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1302,7 +1302,7 @@ const QueryTrendsSchema = AssistantTrendsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1312,7 +1312,7 @@ const QueryFunnelSchema = AssistantFunnelsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1322,7 +1322,7 @@ const QueryRetentionSchema = AssistantRetentionQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1332,7 +1332,7 @@ const QueryStickinessSchema = AssistantStickinessQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1342,7 +1342,7 @@ const QueryPathsSchema = AssistantPathsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1352,7 +1352,7 @@ const QueryLifecycleSchema = AssistantLifecycleQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1362,7 +1362,7 @@ const QueryTrendsActorsSchema = AssistantTrendsActorsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1372,7 +1372,7 @@ const QueryLifecycleActorsSchema = AssistantLifecycleActorsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1382,7 +1382,7 @@ const QueryPathsActorsSchema = AssistantPathsActorsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 
@@ -1392,7 +1392,7 @@ const QueryRetentionActorsSchema = AssistantRetentionActorsQuery.extend({
         .default('optimized')
         .optional()
         .describe(
-            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON.'
+            'Output format. "optimized" returns a human-readable summary from server-side formatters (recommended for analysis). "json" returns the raw query results as JSON. "gcf" returns GCF-encoded output (compact, LLM-optimized).'
         ),
 })
 

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1298,7 +1298,7 @@ const AssistantRetentionActorsQuery = z.object({
 
 const QueryTrendsSchema = AssistantTrendsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1308,7 +1308,7 @@ const QueryTrendsSchema = AssistantTrendsQuery.extend({
 
 const QueryFunnelSchema = AssistantFunnelsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1318,7 +1318,7 @@ const QueryFunnelSchema = AssistantFunnelsQuery.extend({
 
 const QueryRetentionSchema = AssistantRetentionQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1328,7 +1328,7 @@ const QueryRetentionSchema = AssistantRetentionQuery.extend({
 
 const QueryStickinessSchema = AssistantStickinessQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1338,7 +1338,7 @@ const QueryStickinessSchema = AssistantStickinessQuery.extend({
 
 const QueryPathsSchema = AssistantPathsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1348,7 +1348,7 @@ const QueryPathsSchema = AssistantPathsQuery.extend({
 
 const QueryLifecycleSchema = AssistantLifecycleQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1358,7 +1358,7 @@ const QueryLifecycleSchema = AssistantLifecycleQuery.extend({
 
 const QueryTrendsActorsSchema = AssistantTrendsActorsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1368,7 +1368,7 @@ const QueryTrendsActorsSchema = AssistantTrendsActorsQuery.extend({
 
 const QueryLifecycleActorsSchema = AssistantLifecycleActorsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1378,7 +1378,7 @@ const QueryLifecycleActorsSchema = AssistantLifecycleActorsQuery.extend({
 
 const QueryPathsActorsSchema = AssistantPathsActorsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(
@@ -1388,7 +1388,7 @@ const QueryPathsActorsSchema = AssistantPathsActorsQuery.extend({
 
 const QueryRetentionActorsSchema = AssistantRetentionActorsQuery.extend({
     output_format: z
-        .enum(['optimized', 'json'])
+        .enum(['optimized', 'json', 'gcf'])
         .default('optimized')
         .optional()
         .describe(

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -79,7 +79,7 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             }
 
             const data = await context.api.query({ projectId }).runQuery({ query })
-            const shouldSurfaceFormatted = effectiveOutputFormat !== 'json' && data.formatted_results
+            const shouldSurfaceFormatted = effectiveOutputFormat !== 'json' && effectiveOutputFormat !== 'gcf' && data.formatted_results
             // Include `query` in the payload so UI apps (TrendsVisualizer, LifecycleVisualizer)
             // can honor query-level filters like `lifecycleFilter.toggledLifecycles` and
             // `trendsFilter.display`.

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -18,7 +18,7 @@ interface QueryWrapperConfig<T extends ZodObjectAny> {
      * (`formatted_results`) as the text content when available; `'json'` skips the formatter
      * override entirely and returns raw JSON. Omit to fall back to the default TOON encoding.
      */
-    outputFormat?: 'optimized' | 'json'
+    outputFormat?: 'optimized' | 'json' | 'gcf'
     /** When set, `_posthogUrl` uses `{baseUrl}{urlPrefix}` instead of `/insights/new#q=...`. */
     urlPrefix?: string
 }
@@ -46,7 +46,7 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             // `output_format` is a tool-level control, not part of the query body. Strip it before
             // POSTing so it doesn't leak into the backend `kind: ...Query` payload.
             const { output_format: callerOutputFormat, ...queryParams } = params as typeof params & {
-                output_format?: 'optimized' | 'json'
+                output_format?: 'optimized' | 'json' | 'gcf'
             }
             const query: Record<string, unknown> = { ...queryParams, kind: config.kind }
             const baseUrl = context.api.getProjectBaseUrl(projectId)


### PR DESCRIPTION
## Summary

Add `output_format=gcf` as a third output format option for MCP tool responses, alongside existing `optimized` and `json`. No changes to existing behavior.

## Why

### TOON increases token count on PostHog data

TOON's tree-based encoding is less efficient than JSON on nested analytics data. Benchmarked on realistic PostHog data shapes:

| Dataset | JSON | TOON | GCF | TOON vs JSON | GCF vs JSON | GCF vs TOON |
|---------|------|------|-----|-------------|-------------|-------------|
| Events (50) | 2,829 | 3,266 | 1,333 | -15.4% | 52.9% | +59.2% |
| Events (200) | 11,297 | 13,046 | 5,251 | -15.5% | 53.5% | +59.8% |
| Insights (10) | 550 | 562 | 514 | -2.2% | 6.5% | +8.5% |
| Insights (50) | 2,665 | 2,727 | 2,449 | -2.3% | 8.1% | +10.2% |
| Persons (50) | 3,016 | 3,291 | 1,816 | -9.1% | 39.8% | +44.8% |
| Persons (200) | 12,148 | 13,248 | 7,298 | -9.1% | 39.9% | +44.9% |
| **Total** | **32,505** | **36,140** | **18,661** | **-11.2%** | **42.6%** | **+48.4%** |

TOON makes PostHog event data 15% larger than JSON. GCF saves 42.6% vs JSON and 48.4% vs TOON. The difference comes from nested objects (events have a `properties` sub-object): GCF uses inline schemas, TOON repeats key paths.

### LLM comprehension

GCF scores 100% on general structured data and 90.7% on adversarial payloads across GPT-4o, GPT-5.5, Claude, and Gemini. JSON drops to 53.6%. TOON scores 68.5%. (1,700+ evaluations.)

Full eval data: [GCF benchmarks](https://gcformat.com/guide/benchmarks)

### Data integrity

GCF is verified lossless across 43 billion+ round-trips in 5 formats and 6 languages. Zero failures. Zero runtime dependencies.

## Changes

| File | Change |
|------|--------|
| `services/mcp/src/lib/response.ts` | Add `formatResponseGcf` using `@blackwell-systems/gcf` |
| `services/mcp/src/lib/build-tool-result.ts` | Handle `output_format=gcf` |
| `services/mcp/src/tools/query-wrapper-factory.ts` | Skip `formatted_results` for GCF (same as JSON) |
| `services/mcp/src/tools/generated/query-wrappers.ts` | Add `'gcf'` to `output_format` enums |
| `services/mcp/src/generated/dashboards/api.ts` | Add `'gcf'` to `output_format` enum |
| `services/mcp/package.json` | Add `@blackwell-systems/gcf` dependency |

**Note:** Two generated files were edited directly. The `output_format` enum change should be reflected in `definitions/query-wrappers.yaml` and the OpenAPI spec before regenerating.

## Usage

```
output_format=gcf
```

Works on all query tools and dashboard retrieval, same as the existing `json` option.

## Links

- GCF spec and docs: https://gcformat.com
- GCF TypeScript SDK: https://www.npmjs.com/package/@blackwell-systems/gcf
- Benchmarks: https://gcformat.com/guide/benchmarks
- Lossless verification: https://gcformat.com/guide/lossless-verification