### PR TITLE
feat(funnels): add compare to previous for top-to-bottom steps layout

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -588,6 +588,10 @@ snapshots:
         hash: v1.k794b7964.586cbc343561fe2ea416c4e8a15661d80f0dc0e6602c4c4505fb763a960e3fec.wnr2iqA9493GIdPtZgO3pqa1uiD9pZcM3L01W8_FZ-Q
     components-hogcharts-defaulttooltip--total-excludes-overlay--light:
         hash: v1.k794b7964.cf566924008a871da770d7d0a0b7a2ac6748823639d3d60ca60344770f581a2a.7s92rB7AHoeq-uQd_tSJGFVCn3cU-LQeOQVJ2qyvLWo
+    components-hogcharts-legend--built-in-toggle--dark:
+        hash: v1.k794b7964.a44913b0e0cdf88b5d0d8960560fa4ce5a663f0b187cdcc5a723d1bb9b653fc6.pxcAORXTtyj4dK4h_9PUe9keV7tagKmaBvwS56KoeXI
+    components-hogcharts-legend--built-in-toggle--light:
+        hash: v1.k794b7964.dc8065b867dd309ca1c05935745e283b13d2fd7ebb7ddde80c9b5e8c24ee6cec.BzRyo-huuWL4HvNyXrykyXbCBuFTjeQKpECqODhn7AE
     components-hogcharts-legend--horizontal--dark:
         hash: v1.k794b7964.748c8221979ca1984c3ef06b0a2d5016e683810a2530a2b7549ff2994484d32d.WlgOW_onzflesCUfetduXiySjbl4uF8oTLxdKf4xYso
     components-hogcharts-legend--horizontal--light:
@@ -2336,6 +2340,10 @@ snapshots:
         hash: v1.k794b7964.ed8dcfd0398a52a184600b34416183c0e4f7db42860db1fed3e3631b31819a9c.VemuVUNUEgJsYOIWX8UgRIlBSIs9GeBXCSJsTV8nzAg
     insights-funnelbarhorizontalchart--default-narrow--light:
         hash: v1.k794b7964.b6543758ca04b2e970af5d54a370ba18ced44e9ae8fc75814f19392942db7abc.y9qjx5SS8j1iMTyUqdHLGqjEZuGfzS23ao2GcioBRUc
+    insights-funnelbarhorizontalchart--funnel-top-to-bottom-compare--dark:
+        hash: v1.k794b7964.72d237b21ff6966313ce6117b09181395d56a21f3826cd06eb7de95d118389d4.aTEfL9HGvWY3WO-TKr-bs8nvdEuVWauwCh3BWg4n7iU
+    insights-funnelbarhorizontalchart--funnel-top-to-bottom-compare--light:
+        hash: v1.k794b7964.8faec9e7852253456408ac542e54813dca156da131c8a9a3f3be2abce804e8c5.H71T2F5dlR2cNdBQ2EhRysiy-c0VzNWUiiaHDxHC7Co
     insights-funnelcorrelationtable--default--dark:
         hash: v1.k794b7964.0c70fac4deda9be64c8b0c0d06eb0149e9d11176c31ab5861f6657fa80714836.YqZL0Grf9CN71TbXgR_pGO23EfnukP5X-Doi0-Xy48A
     insights-funnelcorrelationtable--default--light:

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottomCompare.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottomCompare.json
@@ -1,0 +1,175 @@
+{
+    "id": 5152,
+    "short_id": "funCmpTB",
+    "name": "Funnel steps compare (top to bottom)",
+    "derived_name": "Pageview \u2192 Pageview \u2192 Pageview user conversion rate",
+    "filters": {},
+    "filters_hash": "cache_85ca8909ab22e34f387fa4f17e919410",
+    "order": null,
+    "deleted": false,
+    "dashboard": null,
+    "layouts": {},
+    "color": null,
+    "last_refresh": null,
+    "refreshing": false,
+    "resolved_date_range": {
+        "date_from": "2022-03-08T00:00:00Z",
+        "date_to": "2022-03-15T23:59:59Z"
+    },
+    "result": [
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 0,
+            "people": [],
+            "count": 20166,
+            "type": "events",
+            "average_conversion_time": null,
+            "median_conversion_time": null,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": null,
+            "compare_label": "current"
+        },
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 1,
+            "people": [],
+            "count": 8438,
+            "type": "events",
+            "average_conversion_time": 370.48673834484913,
+            "median_conversion_time": 0,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "compare_label": "current"
+        },
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 2,
+            "people": [],
+            "count": 2864,
+            "type": "events",
+            "average_conversion_time": 398.36358625967165,
+            "median_conversion_time": 0,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "compare_label": "current"
+        },
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 0,
+            "people": [],
+            "count": 16000,
+            "type": "events",
+            "average_conversion_time": null,
+            "median_conversion_time": null,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=1&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": null,
+            "compare_label": "previous"
+        },
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 1,
+            "people": [],
+            "count": 6200,
+            "type": "events",
+            "average_conversion_time": 426.05974909657647,
+            "median_conversion_time": 0,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "compare_label": "previous"
+        },
+        {
+            "action_id": "$pageview",
+            "name": "$pageview",
+            "custom_name": null,
+            "order": 2,
+            "people": [],
+            "count": 1900,
+            "type": "events",
+            "average_conversion_time": 458.11812419862235,
+            "median_conversion_time": 0,
+            "converted_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "dropped_people_url": "/api/person/funnel/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A42%3A48.469119%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-3&funnel_viz_type=steps&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
+            "compare_label": "previous"
+        }
+    ],
+    "created_at": "2022-03-15T21:31:00.192917Z",
+    "created_by": {
+        "id": 1,
+        "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
+        "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
+        "first_name": "Marius",
+        "email": "marius@posthog.com"
+    },
+    "description": "",
+    "updated_at": "2022-03-15T21:42:52.989476Z",
+    "tags": [],
+    "favorited": false,
+    "saved": true,
+    "last_modified_at": "2022-03-15T21:42:52.984610Z",
+    "last_modified_by": {
+        "id": 1,
+        "uuid": "017f7913-c1ee-0000-faff-0fe5ace3849a",
+        "distinct_id": "Q1OD2NmnqqbqrLR45mYm2p1VNNbSO9DBFsMig90GWkK",
+        "first_name": "Marius",
+        "email": "marius@posthog.com"
+    },
+    "is_sample": false,
+    "query": {
+        "kind": "InsightVizNode",
+        "source": {
+            "funnelsFilter": {
+                "exclusions": [],
+                "funnelVizType": "steps",
+                "layout": "horizontal"
+            },
+            "interval": "day",
+            "kind": "FunnelsQuery",
+            "properties": {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": []
+                    }
+                ]
+            },
+            "samplingFactor": 0.1,
+            "series": [
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview"
+                },
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview",
+                    "optionalInFunnel": true
+                },
+                {
+                    "event": "$pageview",
+                    "kind": "EventsNode",
+                    "name": "$pageview"
+                }
+            ],
+            "compareFilter": {
+                "compare": true
+            },
+            "dateRange": {
+                "date_from": "2022-03-08",
+                "date_to": "2022-03-15"
+            }
+        },
+        "full": true
+    }
+}

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.stories.tsx
@@ -2,10 +2,12 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
 import { useState } from 'react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import funnelTopToBottomFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottom.json'
 import funnelTopToBottomBreakdownFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottomBreakdown.json'
+import funnelTopToBottomCompareFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottomCompare.json'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
@@ -64,6 +66,15 @@ export const Default: Story = {
 
 export const Breakdown: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownFixture} width={720} />,
+}
+
+// Compare to previous: each step renders two stacked bars (current solid above, previous desaturated
+// below), each scaled to the shared baseline — not two periods crammed into one bar.
+export const FunnelTopToBottomCompare: Story = {
+    render: () => <StoryRender insightFixture={funnelTopToBottomCompareFixture} width={720} />,
+    parameters: {
+        featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE],
+    },
 }
 
 // Narrow widths force the step footers to wrap — each row should grow to fit its own text

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -11,10 +11,14 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { type ChartParams, FunnelStepReference, StepOrderValue } from '~/types'
+import { type ChartParams, FunnelStepReference, type FunnelStepWithConversionMetrics, StepOrderValue } from '~/types'
 
 import { FunnelBarHorizontalTooltip } from './FunnelBarHorizontalTooltip'
-import { buildFunnelBarHorizontalData, type FunnelBarHorizontalSegmentMeta } from './funnelBarHorizontalTransforms'
+import {
+    buildFunnelBarHorizontalCompareData,
+    buildFunnelBarHorizontalData,
+    type FunnelBarHorizontalSegmentMeta,
+} from './funnelBarHorizontalTransforms'
 import { GlyphColumn } from './GlyphColumn'
 import { SingleStepBar } from './SingleStepBar'
 import { StepFooter } from './StepFooter'
@@ -51,6 +55,8 @@ export function FunnelBarHorizontalChart({
         isStepOptional,
         getFunnelsColor,
         querySource,
+        isComparedFunnel,
+        insightData,
     } = useValues(funnelDataLogic(insightProps))
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
     const { openPersonsModalForStep, openPersonsModalForSeries } = useActions(funnelPersonsModalLogic(insightProps))
@@ -64,16 +70,25 @@ export function FunnelBarHorizontalChart({
     const hasOptionalSteps = steps.some((_, stepIndex) => isStepOptional(stepIndex + 1))
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
 
+    const buildOptions = useMemo(
+        () => ({
+            stepReference,
+            breakdownFilter,
+            getColor: getFunnelsColor,
+            getLabel: (variant: FunnelStepWithConversionMetrics) =>
+                String(variant.breakdown_value ?? variant.name ?? ''),
+            fillerColor,
+        }),
+        [stepReference, breakdownFilter, getFunnelsColor, fillerColor]
+    )
+
     const stepsData = useMemo(
-        () =>
-            buildFunnelBarHorizontalData(steps, {
-                stepReference,
-                breakdownFilter,
-                getColor: getFunnelsColor,
-                getLabel: (variant) => String(variant.breakdown_value ?? variant.name ?? ''),
-                fillerColor,
-            }),
-        [steps, stepReference, breakdownFilter, getFunnelsColor, fillerColor]
+        () => (isComparedFunnel ? [] : buildFunnelBarHorizontalData(steps, buildOptions)),
+        [steps, buildOptions, isComparedFunnel]
+    )
+    const compareStepsData = useMemo(
+        () => (isComparedFunnel ? buildFunnelBarHorizontalCompareData(steps, buildOptions) : []),
+        [steps, buildOptions, isComparedFunnel]
     )
 
     if (steps.length === 0) {
@@ -87,6 +102,21 @@ export function FunnelBarHorizontalChart({
                     const isOptional = isStepOptional(stepIndex + 1)
 
                     const onSegmentClick = (meta: FunnelBarHorizontalSegmentMeta): void => {
+                        // Compare: both the bar and its drop-off filler carry a period breakdownIndex, so
+                        // route the matching period series (converted vs. dropped-off) — handled before the
+                        // generic drop-off branch, which would otherwise open the aggregate step.
+                        if (
+                            isComparedFunnel &&
+                            meta.breakdownIndex != null &&
+                            step.nested_breakdown?.[meta.breakdownIndex]
+                        ) {
+                            openPersonsModalForSeries({
+                                step,
+                                series: step.nested_breakdown[meta.breakdownIndex],
+                                converted: !meta.isDropOff,
+                            })
+                            return
+                        }
                         if (meta.isDropOff) {
                             openPersonsModalForStep({ step, converted: false })
                             return
@@ -110,6 +140,8 @@ export function FunnelBarHorizontalChart({
                             breakdownFilter={breakdownFilter}
                             groupTypeLabel={groupTypeLabel}
                             showPersonsModal={showPersonsModal}
+                            resolvedDateRange={insightData?.resolved_date_range}
+                            compareTo={querySource?.compareFilter?.compare_to}
                         />
                     )
 
@@ -131,14 +163,29 @@ export function FunnelBarHorizontalChart({
                                     isUnordered={isUnordered}
                                     isOptional={isOptional}
                                 />
-                                <SingleStepBar
-                                    stepData={stepsData[stepIndex]}
-                                    theme={theme}
-                                    interactive={interactive}
-                                    onSegmentClick={onSegmentClick}
-                                    renderTooltip={renderTooltip}
-                                    onError={handleChartError}
-                                />
+                                {isComparedFunnel ? (
+                                    compareStepsData[stepIndex]?.bars.map((bar) => (
+                                        <SingleStepBar
+                                            key={bar.series[0].key}
+                                            stepData={bar}
+                                            theme={theme}
+                                            interactive={interactive}
+                                            onSegmentClick={onSegmentClick}
+                                            renderTooltip={renderTooltip}
+                                            onError={handleChartError}
+                                            heightClassName="h-5"
+                                        />
+                                    ))
+                                ) : (
+                                    <SingleStepBar
+                                        stepData={stepsData[stepIndex]}
+                                        theme={theme}
+                                        interactive={interactive}
+                                        onSegmentClick={onSegmentClick}
+                                        renderTooltip={renderTooltip}
+                                        onError={handleChartError}
+                                    />
+                                )}
                                 <StepFooter
                                     step={step}
                                     stepIndex={stepIndex}

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
@@ -1,6 +1,7 @@
 import type { TooltipContext } from '@posthog/quill-charts'
 
 import { FunnelTooltip } from 'scenes/funnels/FunnelTooltip'
+import { funnelComparePeriodDateRange } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import type { FunnelStepWithConversionMetrics } from '~/types'
@@ -14,6 +15,8 @@ interface FunnelBarHorizontalTooltipProps {
     breakdownFilter: BreakdownFilter | null | undefined
     groupTypeLabel: string
     showPersonsModal: boolean
+    resolvedDateRange?: Parameters<typeof funnelComparePeriodDateRange>[1]
+    compareTo?: Parameters<typeof funnelComparePeriodDateRange>[2]
 }
 
 export function FunnelBarHorizontalTooltip({
@@ -23,6 +26,8 @@ export function FunnelBarHorizontalTooltip({
     breakdownFilter,
     groupTypeLabel,
     showPersonsModal,
+    resolvedDateRange,
+    compareTo,
 }: FunnelBarHorizontalTooltipProps): JSX.Element | null {
     const entry = context.seriesData[0]
     if (!entry) {
@@ -40,6 +45,11 @@ export function FunnelBarHorizontalTooltip({
             series={series}
             groupTypeLabel={groupTypeLabel}
             breakdownFilter={breakdownFilter}
+            comparePeriodDateRange={
+                series.compare_label
+                    ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
+                    : null
+            }
         />
     )
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/SingleStepBar.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/SingleStepBar.tsx
@@ -23,6 +23,9 @@ interface SingleStepBarProps {
     onSegmentClick: (meta: FunnelBarHorizontalSegmentMeta) => void
     renderTooltip: (ctx: TooltipContext<FunnelBarHorizontalSegmentMeta>) => JSX.Element | null
     onError: (error: Error, info: ErrorInfo) => void
+    /** Tailwind height of the bar track. Compare mode stacks two bars per step, so it passes a
+     *  shorter height to keep the step row close to a single bar's footprint. */
+    heightClassName?: string
 }
 
 const CHART_CONFIG: BarChartConfig = {
@@ -50,6 +53,7 @@ export function SingleStepBar({
     onSegmentClick,
     renderTooltip,
     onError,
+    heightClassName = 'h-8',
 }: SingleStepBarProps): JSX.Element {
     const onPointClick = useMemo(
         () =>
@@ -65,7 +69,7 @@ export function SingleStepBar({
     )
 
     return (
-        <div className="flex flex-col h-8 my-1">
+        <div className={`flex flex-col ${heightClassName} my-1`}>
             <BarChart<FunnelBarHorizontalSegmentMeta>
                 series={stepData.series}
                 labels={[stepData.label]}

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -319,21 +319,47 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(result.map((s) => s.bars[1].series[1].data[0])).toEqual([20, 60])
         })
 
-        it('does not force the current step-0 bar to 100 when the previous period is larger', () => {
-            const previousLeads: FunnelStepWithConversionMetrics[] = [
-                makeStep({
-                    count: 80,
-                    fromBasisStep: 0.8,
-                    compare_label: 'current',
-                    nested_breakdown: [
-                        makeStep({ count: 80, fromBasisStep: 0.8, compare_label: 'current' }),
-                        makeStep({ count: 100, fromBasisStep: 1, compare_label: 'previous' }),
-                    ],
-                }),
+        it.each([
+            {
+                description: 'does not force the current step-0 bar to 100 when the previous period is larger',
+                nested_breakdown: [
+                    makeStep({ count: 80, fromBasisStep: 0.8, compare_label: 'current' }),
+                    makeStep({ count: 100, fromBasisStep: 1, compare_label: 'previous' }),
+                ],
+                // current sits below the shared baseline; previous fills the track
+                expectedBars: [
+                    { segment: [80], filler: [20], breakdownIndex: 0 },
+                    { segment: [100], filler: [0], breakdownIndex: 1 },
+                ],
+            },
+            {
+                description: 'renders a zeroed previous period as an empty track without error',
+                nested_breakdown: [
+                    makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' }),
+                    makeStep({ count: 0, fromBasisStep: 0, compare_label: 'previous' }),
+                ],
+                expectedBars: [
+                    { segment: [100], filler: [0], breakdownIndex: 0 },
+                    { segment: [0], filler: [100], breakdownIndex: 1 },
+                ],
+            },
+            {
+                description: 'renders a single bar when the step has no previous-period series',
+                nested_breakdown: [makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' })],
+                expectedBars: [{ segment: [100], filler: [0], breakdownIndex: 0 }],
+            },
+        ])('$description', ({ nested_breakdown, expectedBars }) => {
+            const steps: FunnelStepWithConversionMetrics[] = [
+                makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current', nested_breakdown }),
             ]
-            const [step] = buildFunnelBarHorizontalCompareData(previousLeads, options)
-            expect(step.bars[0].series[0].data).toEqual([80]) // current sits below the shared baseline
-            expect(step.bars[1].series[0].data).toEqual([100]) // previous fills the track
+            const [step] = buildFunnelBarHorizontalCompareData(steps, options)
+
+            expect(step.bars).toHaveLength(expectedBars.length)
+            expectedBars.forEach((expected, barIndex) => {
+                expect(step.bars[barIndex].series[0].data).toEqual(expected.segment)
+                expect(step.bars[barIndex].series[1].data).toEqual(expected.filler)
+                expect(step.bars[barIndex].series[0].meta?.breakdownIndex).toBe(expected.breakdownIndex)
+            })
         })
 
         it('colors each bar from the current step’s own variant, dimming the previous period', () => {
@@ -356,37 +382,6 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(step.bars[0].series[1].meta).toEqual({ isDropOff: true, breakdownIndex: 0 })
             expect(step.bars[1].series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 1 })
             expect(step.bars[1].series[1].meta).toEqual({ isDropOff: true, breakdownIndex: 1 })
-        })
-
-        it('renders a zeroed previous period as an empty track without error', () => {
-            const zeroedPrevious: FunnelStepWithConversionMetrics[] = [
-                makeStep({
-                    count: 100,
-                    fromBasisStep: 1,
-                    compare_label: 'current',
-                    nested_breakdown: [
-                        makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' }),
-                        makeStep({ count: 0, fromBasisStep: 0, compare_label: 'previous' }),
-                    ],
-                }),
-            ]
-            const [step] = buildFunnelBarHorizontalCompareData(zeroedPrevious, options)
-            expect(step.bars[1].series[0].data).toEqual([0])
-            expect(step.bars[1].series[1].data).toEqual([100])
-        })
-
-        it('renders a single bar when the step has no previous-period series', () => {
-            const noPrevious: FunnelStepWithConversionMetrics[] = [
-                makeStep({
-                    count: 100,
-                    fromBasisStep: 1,
-                    compare_label: 'current',
-                    nested_breakdown: [makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' })],
-                }),
-            ]
-            const [step] = buildFunnelBarHorizontalCompareData(noPrevious, options)
-            expect(step.bars).toHaveLength(1)
-            expect(step.bars[0].series[0].meta?.breakdownIndex).toBe(0)
         })
     })
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -1,6 +1,7 @@
 import { EntityTypes, FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
 import {
+    buildFunnelBarHorizontalCompareData,
     buildFunnelBarHorizontalData,
     type FunnelBarHorizontalStepData,
     FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
@@ -271,6 +272,121 @@ describe('buildFunnelBarHorizontalData', () => {
                 [0, 0],
                 [100, 100],
             ])
+        })
+    })
+
+    describe('compare funnel', () => {
+        // Shared baseline: the larger period's first step (100) is the basis, so the previous bar
+        // shows its real volume (0.8) rather than always filling the track.
+        const compareSteps: FunnelStepWithConversionMetrics[] = [
+            makeStep({
+                count: 100,
+                fromBasisStep: 1,
+                name: 'Viewed',
+                compare_label: 'current',
+                nested_breakdown: [
+                    makeStep({ count: 100, fromBasisStep: 1, name: 'Viewed', compare_label: 'current' }),
+                    makeStep({ count: 80, fromBasisStep: 0.8, name: 'Viewed', compare_label: 'previous' }),
+                ],
+            }),
+            makeStep({
+                count: 50,
+                fromBasisStep: 0.5,
+                name: 'Signed up',
+                compare_label: 'current',
+                nested_breakdown: [
+                    makeStep({ count: 50, fromBasisStep: 0.5, name: 'Signed up', compare_label: 'current' }),
+                    makeStep({ count: 40, fromBasisStep: 0.4, name: 'Signed up', compare_label: 'previous' }),
+                ],
+            }),
+        ]
+
+        it('gives each step two bars (current then previous), each its own segment + filler', () => {
+            const result = buildFunnelBarHorizontalCompareData(compareSteps, options)
+
+            expect(result).toHaveLength(2)
+            expect(result.every((step) => step.bars.length === 2)).toBe(true)
+            expect(result.every((step) => step.bars.every((bar) => bar.series.length === 2))).toBe(true)
+        })
+
+        it('scales each bar to the shared baseline via fromBasisStep, each track summing segment + filler to 100', () => {
+            const result = buildFunnelBarHorizontalCompareData(compareSteps, options)
+
+            // current: 100% then 50%; previous: 80% then 40% — each on its own 0–100 track
+            expect(result.map((s) => s.bars[0].series[0].data[0])).toEqual([100, 50])
+            expect(result.map((s) => s.bars[0].series[1].data[0])).toEqual([0, 50])
+            expect(result.map((s) => s.bars[1].series[0].data[0])).toEqual([80, 40])
+            expect(result.map((s) => s.bars[1].series[1].data[0])).toEqual([20, 60])
+        })
+
+        it('does not force the current step-0 bar to 100 when the previous period is larger', () => {
+            const previousLeads: FunnelStepWithConversionMetrics[] = [
+                makeStep({
+                    count: 80,
+                    fromBasisStep: 0.8,
+                    compare_label: 'current',
+                    nested_breakdown: [
+                        makeStep({ count: 80, fromBasisStep: 0.8, compare_label: 'current' }),
+                        makeStep({ count: 100, fromBasisStep: 1, compare_label: 'previous' }),
+                    ],
+                }),
+            ]
+            const [step] = buildFunnelBarHorizontalCompareData(previousLeads, options)
+            expect(step.bars[0].series[0].data).toEqual([80]) // current sits below the shared baseline
+            expect(step.bars[1].series[0].data).toEqual([100]) // previous fills the track
+        })
+
+        it('colors each bar from the current step’s own variant, dimming the previous period', () => {
+            const getColor = jest.fn((v: FunnelStepWithConversionMetrics) =>
+                v.compare_label === 'previous' ? '#dimmed' : '#solid'
+            )
+            const result = buildFunnelBarHorizontalCompareData(compareSteps, { ...options, getColor })
+
+            expect(result[1].bars[0].series[0].color).toBe('#solid')
+            expect(result[1].bars[1].series[0].color).toBe('#dimmed')
+            // representative is step 1's own variant (per-step color), not step 0's
+            expect(getColor).toHaveBeenCalledWith(compareSteps[1].nested_breakdown![0])
+            expect(getColor).toHaveBeenCalledWith(compareSteps[1].nested_breakdown![1])
+        })
+
+        it('tags both the segment and filler of each bar with its period breakdownIndex', () => {
+            const [step] = buildFunnelBarHorizontalCompareData(compareSteps, options)
+
+            expect(step.bars[0].series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 0 })
+            expect(step.bars[0].series[1].meta).toEqual({ isDropOff: true, breakdownIndex: 0 })
+            expect(step.bars[1].series[0].meta).toEqual({ isDropOff: false, breakdownIndex: 1 })
+            expect(step.bars[1].series[1].meta).toEqual({ isDropOff: true, breakdownIndex: 1 })
+        })
+
+        it('renders a zeroed previous period as an empty track without error', () => {
+            const zeroedPrevious: FunnelStepWithConversionMetrics[] = [
+                makeStep({
+                    count: 100,
+                    fromBasisStep: 1,
+                    compare_label: 'current',
+                    nested_breakdown: [
+                        makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' }),
+                        makeStep({ count: 0, fromBasisStep: 0, compare_label: 'previous' }),
+                    ],
+                }),
+            ]
+            const [step] = buildFunnelBarHorizontalCompareData(zeroedPrevious, options)
+            expect(step.bars[1].series[0].data).toEqual([0])
+            expect(step.bars[1].series[1].data).toEqual([100])
+        })
+
+        it('renders a single bar when the step has no previous-period series', () => {
+            const noPrevious: FunnelStepWithConversionMetrics[] = [
+                makeStep({
+                    count: 100,
+                    fromBasisStep: 1,
+                    compare_label: 'current',
+                    nested_breakdown: [makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' })],
+                }),
+            ]
+            const [step] = buildFunnelBarHorizontalCompareData(noPrevious, options)
+            expect(step.bars).toHaveLength(1)
+            expect(step.bars[0].series[0].meta?.breakdownIndex).toBe(0)
         })
     })
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -89,7 +89,6 @@ function buildBreakdownSegments(
  *  rather than two segments sharing one track. `bars[0]` is current, `bars[1]` previous; previous is
  *  omitted only when the backend sent no previous-period series for the step. */
 export interface FunnelBarHorizontalCompareStep {
-    label: string
     bars: FunnelBarHorizontalStepData[]
 }
 
@@ -116,7 +115,7 @@ export function buildFunnelBarHorizontalCompareData(
                 series: [segment, buildFunnelBarHorizontalFiller([segment], options.fillerColor, breakdownIndex)],
             }
         })
-        return { label: String(stepIndex), bars }
+        return { bars }
     })
 }
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -85,6 +85,41 @@ function buildBreakdownSegments(
     return [...segments, buildFunnelBarHorizontalFiller(segments, options.fillerColor)]
 }
 
+/** One step in compare mode: two stacked bars (current, then previous), each a full 0–100 track
+ *  rather than two segments sharing one track. `bars[0]` is current, `bars[1]` previous; previous is
+ *  omitted only when the backend sent no previous-period series for the step. */
+export interface FunnelBarHorizontalCompareStep {
+    label: string
+    bars: FunnelBarHorizontalStepData[]
+}
+
+/** Builds the top-to-bottom compare layout: one bar per period, per step. Each bar is scaled to the
+ *  shared baseline already baked into `conversionRates.fromBasisStep` (so the larger period's first
+ *  step fills the track and the other is proportional), and takes its color from the *current step's*
+ *  variant — both periods share step i's color, with `getColor` dimming the `previous` series. This is
+ *  the key difference from `buildBreakdownSegments`, whose representative comes from step 0. */
+export function buildFunnelBarHorizontalCompareData(
+    steps: FunnelStepWithConversionMetrics[],
+    options: BuildOptions
+): FunnelBarHorizontalCompareStep[] {
+    return steps.map((step, stepIndex) => {
+        const bars = (step.nested_breakdown ?? []).map((variant, breakdownIndex) => {
+            const segment: Series<FunnelBarHorizontalSegmentMeta> = {
+                key: `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}${breakdownIndex}`,
+                label: options.getLabel(variant),
+                data: [variant.conversionRates.fromBasisStep * RATE_TO_PERCENT],
+                color: options.getColor(variant),
+                meta: { isDropOff: false, breakdownIndex },
+            }
+            return {
+                label: String(stepIndex),
+                series: [segment, buildFunnelBarHorizontalFiller([segment], options.fillerColor, breakdownIndex)],
+            }
+        })
+        return { label: String(stepIndex), bars }
+    })
+}
+
 function buildSingleSegment(
     step: FunnelStepWithConversionMetrics,
     options: BuildOptions

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -50,7 +50,7 @@ export function FunnelStepsBarChart({
     // when the user toggles dark mode even though the function takes no arguments.
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
     const { insightProps } = useValues(insightLogic)
-    const { visibleStepsWithConversionMetrics, getFunnelsColor, breakdownFilter, querySource } = useValues(
+    const { visibleStepsWithConversionMetrics, getFunnelsColor, breakdownFilter, querySource, insightData } = useValues(
         funnelDataLogic(insightProps)
     )
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
@@ -98,9 +98,11 @@ export function FunnelStepsBarChart({
                 breakdownFilter={breakdownFilter}
                 groupTypeLabel={groupTypeLabel}
                 showPersonsModal={showPersonsModal}
+                resolvedDateRange={insightData?.resolved_date_range}
+                compareTo={querySource?.compareFilter?.compare_to}
             />
         ),
-        [steps, breakdownFilter, groupTypeLabel, showPersonsModal]
+        [steps, breakdownFilter, groupTypeLabel, showPersonsModal, insightData?.resolved_date_range, querySource]
     )
 
     if (steps.length === 0) {

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
@@ -1,6 +1,7 @@
 import type { TooltipContext } from '@posthog/quill-charts'
 
 import { FunnelTooltip } from 'scenes/funnels/FunnelTooltip'
+import { funnelComparePeriodDateRange } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import type { FunnelStepWithConversionMetrics } from '~/types'
@@ -13,6 +14,8 @@ interface FunnelStepsBarTooltipProps {
     breakdownFilter: BreakdownFilter | null | undefined
     groupTypeLabel: string
     showPersonsModal: boolean
+    resolvedDateRange?: Parameters<typeof funnelComparePeriodDateRange>[1]
+    compareTo?: Parameters<typeof funnelComparePeriodDateRange>[2]
 }
 
 export function FunnelStepsBarTooltip({
@@ -21,6 +24,8 @@ export function FunnelStepsBarTooltip({
     breakdownFilter,
     groupTypeLabel,
     showPersonsModal,
+    resolvedDateRange,
+    compareTo,
 }: FunnelStepsBarTooltipProps): JSX.Element | null {
     const stepIndex = context.dataIndex
     const step = steps[stepIndex]
@@ -39,6 +44,11 @@ export function FunnelStepsBarTooltip({
             series={series}
             groupTypeLabel={groupTypeLabel}
             breakdownFilter={breakdownFilter}
+            comparePeriodDateRange={
+                series.compare_label
+                    ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
+                    : null
+            }
         />
     )
 }

--- a/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.test.ts
@@ -38,6 +38,13 @@ describe('funnelBarHorizontalShared', () => {
             expect(filler.meta).toEqual({ isDropOff: true, breakdownIndex: null })
             expect(filler.visibility).toEqual({ tooltip: false })
         })
+
+        it('carries a breakdownIndex when given one, so compare drop-off clicks resolve the period series', () => {
+            expect(buildFunnelBarHorizontalFiller([segment(30)], '#ccc', 1).meta).toEqual({
+                isDropOff: true,
+                breakdownIndex: 1,
+            })
+        })
     })
 
     describe('buildFunnelConversionStep', () => {

--- a/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
+++ b/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
@@ -33,10 +33,13 @@ export interface FunnelBarHorizontalStepData {
     series: Series<FunnelBarHorizontalSegmentMeta>[]
 }
 
-/** Trailing grey band that fills the bar up to 100% so every step reads against the same axis. */
+/** Trailing grey band that fills the bar up to 100% so every step reads against the same axis.
+ *  `breakdownIndex` tags the filler with its period/variant in compare mode so a drop-off click
+ *  resolves the right series; it stays null for the single-bar and breakdown paths. */
 export function buildFunnelBarHorizontalFiller(
     segments: Series<FunnelBarHorizontalSegmentMeta>[],
-    color: string
+    color: string,
+    breakdownIndex: number | null = null
 ): Series<FunnelBarHorizontalSegmentMeta> {
     const covered = segments.reduce((sum, s) => sum + (s.data[0] ?? 0), 0)
     return {
@@ -45,7 +48,7 @@ export function buildFunnelBarHorizontalFiller(
         data: [Math.max(0, RATE_TO_PERCENT - covered)],
         color,
         visibility: { tooltip: false },
-        meta: { isDropOff: true, breakdownIndex: null },
+        meta: { isDropOff: true, breakdownIndex },
     }
 }
 


### PR DESCRIPTION
## Problem

The funnel STEPS viz has two layouts. Slice 2 added "compare to previous" to the left-to-right (vertical) hog-chart, but the top-to-bottom (horizontal) hog-chart still rendered compare wrong: it routed compare data through the breakdown path, stacking both periods inside a single bar with a shared drop-off filler (the two fractions sum past 100% and the filler collapses). This slice closes that gap.

## Changes

`FunnelBarHorizontalChart` now has a dedicated compare branch (detected via `isComparedFunnel`) that renders **two stacked bars per step** — current on top (solid), previous below (desaturated) — each its own 0–100 track scaled to the shared baseline (`conversionRates.fromBasisStep`), instead of two segments crammed into one bar.

- New `buildFunnelBarHorizontalCompareData` transform builds one bar per period per step. Color comes from the **current step's own variant** (per-step color; `getFunnelsColor` dims the `previous` series) — unlike the breakdown path, which takes its representative from step 0.
- `buildFunnelBarHorizontalFiller` gained an optional `breakdownIndex` so each period's drop-off filler resolves the right period series; both the bar and its drop-off region route through `openPersonsModalForSeries`. Period-correct actor scoping is delivered separately by Slice 5.
- Both hog-chart tooltips (`FunnelBarHorizontalTooltip` and `FunnelStepsBarTooltip`) now surface the compare period date range ("Current (range)" / "Previous (range)"). This also fills in the previously-missing date range on the existing left-to-right tooltip.
- The per-step footer is unchanged: the outer step is the current-period aggregate, so it keeps showing the current period's converted/dropped-off counts (parity with the left-to-right `StepLegend`).
- Non-compare and breakdown top-to-bottom layouts render exactly as before.

The legacy `FunnelBarVertical`/`FunnelBarHorizontal` are being removed, so compare was not added to them. Note: the `PRODUCT_ANALYTICS_HOG_CHARTS_FUNNEL` flag referenced in the ticket no longer exists — the hog-charts are now the default in `Funnel.tsx` — so the new story is gated on `PRODUCT_ANALYTICS_FUNNELS_COMPARE` only.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- `funnelBarHorizontalTransforms.test.ts` — new TDD coverage for the compare branch: two bars per step, shared-baseline scaling (including the current step-0 bar not being forced to 100% when the previous period is larger), per-step color with dimmed previous, `breakdownIndex` on both segment and filler, a zeroed previous period, and a previous-absent single-bar fallback.
- `funnelBarHorizontalShared.test.ts` — the filler carries the new `breakdownIndex`.
- All funnel transform/shared suites green (51 tests). `tsgo` typecheck clean for every touched file (after regenerating kea types). oxfmt + oxlint clean.
- Added a `FunnelTopToBottomCompare` storybook story + `funnelTopToBottomCompare.json` fixture for the visual-regression snapshot. I did not manually drive the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus) following the repo `/tdd` skill — red→green per behavior, transform-first so the existing breakdown/non-compare path stayed untouched.

Key decisions:

- Rendered two separate single-band `SingleStepBar`s per step rather than refactoring `SingleStepBar` into a multi-band chart — lower risk, keeps the non-compare path byte-for-byte unchanged, and each period gets its own tooltip/hover context. `SingleStepBar` gained a `heightClassName` prop so the two compare bars are thinner (`h-5`) and the row stays close to a single bar's footprint.
- Put the compare transform in its own function (different return shape: N bars vs 1) and detect compare in the component via the existing `isComparedFunnel` selector, leaving `buildFunnelBarHorizontalData` and its tests untouched.
- Verified `openPersonsModalForSeries` honors `converted: false` (maps to `funnelStep: -stepNo`) before routing drop-off clicks through it.

No skills beyond `/tdd` were needed — no DRF, migration, or generated-API-type surface was touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
