### PR TITLE
fix(dev): strip read-denied $HOME dirs from sandbox PATH

### DIFF
--- a/bin/dev-sandbox
+++ b/bin/dev-sandbox
@@ -134,6 +134,31 @@ if [[ "$rendered" -nt "$stamp" ]]; then
     fi
 fi
 
+# Drop $HOME PATH entries the sandbox denies, so bare-command spawns keep working.
+# node/libuv resolve a bare command name with execvP, which walks $PATH and aborts
+# the ENTIRE search on the first EPERM — and Seatbelt returns EPERM (not ENOENT) for
+# a dir that exists but is read-denied. So a single unreadable $HOME dir on PATH
+# (fnm/nvm/asdf/pyenv shims under ~/.local, ~/.nvm, …) breaks every bare-name spawn
+# before it can reach a usable binary — e.g. pnpm's lifecycle scripts during install
+# fail with `spawn EPERM`. Keep only the repo's own bins (node_modules/.bin) and
+# non-$HOME dirs (system, the flox/nix store) — the full toolchain the dev stack
+# actually uses. $HOME interpreters were already unusable inside the sandbox by
+# design (contents unreadable → exec fails); this just makes the search skip them
+# instead of dying on them.
+sandboxed_path=""
+_oldifs="$IFS"
+set -f # PATH entries are literal paths; never glob-expand them
+IFS=':'
+for _pdir in $PATH; do
+    case "$_pdir" in
+        "$project"/* | "$mainrepo"/*) ;;   # repo bins (node_modules/.bin) — keep
+        "$HOME"/* | "") continue ;;        # read-denied $HOME shim dir / empty — drop
+    esac
+    sandboxed_path+="${sandboxed_path:+:}$_pdir"
+done
+IFS="$_oldifs"
+set +f
+
 # Strip ambient personal tokens the dev stack doesn't need from the child env.
 # The application's own config env (DB URLs, OBJECT_STORAGE_* keys, 1Password-
 # injected API keys) is left intact — only credentials that happen to live in the
@@ -156,4 +181,5 @@ exec env \
     -u CARGO_REGISTRY_TOKEN \
     -u HUGGING_FACE_HUB_TOKEN \
     -u HF_TOKEN \
+    PATH="$sandboxed_path" \
     "${sandbox[@]}" /bin/bash -c "$cmd"

--- a/bin/dev-sandbox-selftest
+++ b/bin/dev-sandbox-selftest
@@ -189,6 +189,24 @@ else
     die "rendered profile not found (expected after earlier sandbox runs)"
 fi
 
+# 13. PATH is sanitized: read-denied $HOME dirs are dropped from the child PATH so a
+#     bare-command spawn keeps working. node/libuv resolve bare names via posix_spawnp,
+#     which aborts the whole PATH search on the first EPERM Seatbelt returns for an
+#     existing-but-denied dir — so one unreadable $HOME shim dir (nvm/fnm/asdf/pyenv)
+#     ahead of the real binary breaks every bare spawn (e.g. pnpm lifecycle scripts).
+#     Assert a $HOME dir is dropped while system + repo bins survive. String-only, so
+#     the probe dir need not exist.
+repo="$(pwd -P)"
+shim="$HOME/.dev_sandbox_selftest_shim/bin"
+child_path="$(PATH="$shim:/usr/bin:/bin:$repo/bin" $SANDBOX 'printf %s "$PATH"' 2>/dev/null)"
+if [[ ":$child_path:" == *":$shim:"* ]]; then
+    die "PATH not sanitized: read-denied \$HOME dir survived in child PATH"
+elif [[ ":$child_path:" != *":/usr/bin:"* ]] || [[ ":$child_path:" != *":$repo/bin:"* ]]; then
+    die "PATH over-sanitized: dropped a system or repo dir (got: $child_path)"
+else
+    pass "PATH sanitized: denied \$HOME dir dropped, system + repo bins kept"
+fi
+
 echo
 if [[ $fail -eq 0 ]]; then
     echo "PASS — all dev-sandbox self-tests passed"


### PR DESCRIPTION
## Problem

The local dev sandbox (Seatbelt, on by default since #64392) wraps `pnpm install` on every `flox activate` where `pnpm-lock.yaml` changed. pnpm runs its lifecycle scripts (`postinstall`) by bare command name, and node/libuv resolve those via `posix_spawnp`, which walks `$PATH` and aborts the entire search on the first `EPERM`. Seatbelt returns `EPERM` (not `ENOENT`) for a directory that exists but is read-denied — so a single `$HOME` version-manager shim dir on `$PATH` ahead of the real binary kills every bare-name spawn. Activation dies with `spawn EPERM` before pnpm finishes.

This bites anyone with a `$HOME` Node/Python version manager (fnm, nvm, asdf, pyenv, volta…) whose shim dir sorts before the toolchain that actually has the binary — here it was `~/.local/state/fnm_multishells/*/bin`. Pure-flox setups don't hit it, which is why it slipped through the opt-in window.

## Changes

Sanitize the child `$PATH` in `bin/dev-sandbox`: keep the repo's own bins (`node_modules/.bin`) and non-`$HOME` dirs (system, the flox/nix store) — the full toolchain the dev stack uses — and drop everything else under `$HOME`.

`$HOME` interpreters were already unusable inside the sandbox by design (contents unreadable → exec fails; the selftest header already calls this out), so this just makes the PATH search *skip* them instead of *dying* on them. The read-deny model is untouched, and as a small bonus sandboxed spawns are now confined to the flox/nix toolchain — a compromised dep can't reach your version-manager-installed binaries either.

Considered instead allowing `file-read-metadata` on `$HOME` (so the PATH stat returns `ENOENT` and the search continues). Rejected: it leaks `$HOME` filenames/existence and weakens the deny-by-default intent, whereas PATH sanitization keeps read-deny fully intact.

## How did you test this code?

I'm an agent (Claude Code), human-driven. Verification actually run on macOS:

- Reproduced the original failure: `node spawnSync('git')` under `bin/dev-sandbox` → `EPERM`; isolated it to a denied `$HOME` shim dir on `$PATH` via an errno-per-dir PATH walk.
- After the fix: same spawn returns `git version …`; `$PATH` inside the sandbox no longer contains the `$HOME` shim dirs; repo + system bins remain.
- `bin/dev-sandbox-selftest` passes including the new check — credential reads still blocked, persistence writes still blocked, docker/ssh-agent still unreachable.
- End-to-end: `bin/dev-sandbox "pnpm install"` completes — the `postinstall` (`git config` / `bin/fix-rdkafka-paths`) and `prepare` (`husky install`) steps that were throwing `spawn EPERM` now run clean.

CI: `dev-sandbox-selftest.yml`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

cc @tom.p — follow-up to your sandbox-on-by-default (#64392). Surfaced while merging master into another branch (the sandbox re-ran `pnpm install` and broke). Shell-only change to `bin/dev-sandbox` + its selftest; no skills invoked.
