### PR TITLE
fix(signals): link inbox Slack notification to web app, not PostHog Code

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -351,8 +351,8 @@ def _build_message_blocks(
     action_elements.append(
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Open in PostHog Code", "emoji": True},
-            "url": f"{POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME}://inbox/{report.id}",
+            "text": {"type": "plain_text", "text": "Open in PostHog", "emoji": True},
+            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
         }
     )
     if dismiss_button_value:

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -348,11 +348,13 @@ def _build_message_blocks(
                 "url": implementation_pr_url,
             }
         )
+    # Reports with an implementation PR live under the "pulls" tab; everything else under "reports".
+    inbox_tab = "pulls" if implementation_pr_url else "reports"
     action_elements.append(
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Open in PostHog", "emoji": True},
-            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
+            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/{inbox_tab}/{report.id}",
         }
     )
     if dismiss_button_value:

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -348,13 +348,11 @@ def _build_message_blocks(
                 "url": implementation_pr_url,
             }
         )
-    # Reports with an implementation PR live under the "pulls" tab; everything else under "reports".
-    inbox_tab = "pulls" if implementation_pr_url else "reports"
     action_elements.append(
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Open in PostHog", "emoji": True},
-            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/{inbox_tab}/{report.id}",
+            "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
         }
     )
     if dismiss_button_value:

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -82,7 +82,7 @@ def _plain_text_block_texts(blocks: list[dict]) -> list[str]:
     return texts
 
 
-def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> None:
+def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() -> None:
     report = SignalReport(
         id="report-uuid",
         team_id=42,
@@ -167,6 +167,7 @@ def test_build_message_blocks_escapes_mrkdwn_in_llm_derived_fields() -> None:
 def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -> None:
     report = SignalReport(
         id="report-uuid",
+        team_id=42,
         title="Checkout errors spiked",
         summary="Error rate rose after deploy.",
         signal_count=12,
@@ -185,6 +186,8 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
     assert buttons[0]["text"]["text"] == "Review PR"
     assert buttons[0]["url"] == pr_url
     assert buttons[1]["text"]["text"] == "Open in PostHog"
+    # A report with an implementation PR lives under the "pulls" tab.
+    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/42/inbox/pulls/report-uuid"
 
 
 def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
@@ -599,6 +602,8 @@ def test_dispatch_includes_github_pr_button_when_implementation_task_has_pr(org_
     buttons = fake_client.chat_postMessage.call_args.kwargs["blocks"][3]["elements"]
     assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
     assert buttons[0]["url"] == "https://github.com/org/repo/pull/99"
+    # A report with an implementation PR deep-links to the "pulls" tab.
+    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/pulls/{report.id}"
     assert buttons[-1]["action_id"] == "signals_dismiss_report"
 
 

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -186,8 +186,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
     assert buttons[0]["text"]["text"] == "Review PR"
     assert buttons[0]["url"] == pr_url
     assert buttons[1]["text"]["text"] == "Open in PostHog"
-    # A report with an implementation PR lives under the "pulls" tab.
-    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/42/inbox/pulls/report-uuid"
+    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
 
 
 def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
@@ -602,8 +601,7 @@ def test_dispatch_includes_github_pr_button_when_implementation_task_has_pr(org_
     buttons = fake_client.chat_postMessage.call_args.kwargs["blocks"][3]["elements"]
     assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
     assert buttons[0]["url"] == "https://github.com/org/repo/pull/99"
-    # A report with an implementation PR deep-links to the "pulls" tab.
-    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/pulls/{report.id}"
+    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/reports/{report.id}"
     assert buttons[-1]["action_id"] == "signals_dismiss_report"
 
 

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -3,6 +3,8 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
+
 from social_django.models import UserSocialAuth
 
 from posthog.models import Organization, Team, User
@@ -83,6 +85,7 @@ def _plain_text_block_texts(blocks: list[dict]) -> list[str]:
 def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> None:
     report = SignalReport(
         id="report-uuid",
+        team_id=42,
         title="Checkout errors spiked",
         summary="Error rate rose after deploy.\nIgnored second line.",
         signal_count=12,
@@ -106,8 +109,8 @@ def test_build_message_blocks_includes_recipient_and_posthog_code_button() -> No
     assert "👤 Suggested reviewers: <@U123>" in context_text
     assert "Inbox" not in context_text
     button = blocks[3]["elements"][0]
-    assert button["text"]["text"] == "Open in PostHog Code"
-    assert button["url"] == "posthog-code://inbox/report-uuid"
+    assert button["text"]["text"] == "Open in PostHog"
+    assert button["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
     assert text == "Inbox item (P1): Checkout errors spiked"
 
 
@@ -181,7 +184,7 @@ def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -
     assert len(buttons) == 2
     assert buttons[0]["text"]["text"] == "Review PR"
     assert buttons[0]["url"] == pr_url
-    assert buttons[1]["text"]["text"] == "Open in PostHog Code"
+    assert buttons[1]["text"]["text"] == "Open in PostHog"
 
 
 def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
@@ -212,7 +215,7 @@ def test_build_message_blocks_appends_dismiss_button_last_with_action_id() -> No
     )
 
     buttons = blocks[3]["elements"]
-    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog Code", "Dismiss"]
+    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
     dismiss = buttons[-1]
     assert dismiss["action_id"] == "signals_dismiss_report"
     assert dismiss["value"] == dismiss_value
@@ -415,7 +418,7 @@ def test_dispatch_sends_to_configured_reviewer(org_and_team):
     assert blocks[1]["text"]["text"].startswith("*❗ P1 · Error tracking*")
     assert "👤 Suggested reviewers: <@U_REVIEWER>" in blocks[2]["elements"][0]["text"]
     assert all("<@" not in t for t in _plain_text_block_texts(blocks))
-    assert blocks[3]["elements"][0]["url"] == f"posthog-code://inbox/{report.id}"
+    assert blocks[3]["elements"][0]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/reports/{report.id}"
 
 
 @pytest.mark.django_db
@@ -594,7 +597,7 @@ def test_dispatch_includes_github_pr_button_when_implementation_task_has_pr(org_
 
     assert sent == 1
     buttons = fake_client.chat_postMessage.call_args.kwargs["blocks"][3]["elements"]
-    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog Code", "Dismiss"]
+    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
     assert buttons[0]["url"] == "https://github.com/org/repo/pull/99"
     assert buttons[-1]["action_id"] == "signals_dismiss_report"
 


### PR DESCRIPTION
## Problem

Andy flagged that the "Open in PostHog Code" button on the signals inbox Slack notification used a `posthog-code://inbox/<id>` desktop deep link, which only opens the PostHog Code desktop app. It doesn't work from mobile or for people who want to land in the cloud inbox.

## Changes

The button now links to the web app inbox URL (`{SITE_URL}/project/<team_id>/inbox/reports/<id>`) and is relabeled "Open in PostHog". This resolves to us/eu.posthog.com in production and opens in any browser, including mobile.

Only the inbox notification button changed — the `posthog-code://` deep-link scheme is still used elsewhere (e.g. the auto-start PR footer and task logs), so the constant stays.

## How did you test this code?

I'm an agent. I updated the existing unit tests for the message blocks and ran the non-DB suite for `test_slack_inbox_notifications.py` (46 passed). The DB-backed dispatch tests couldn't run in this environment (no Postgres), but their URL assertions were updated to match.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Swapped the inbox notification button URL in `products/signals/backend/slack_inbox_notifications.py` from the desktop deep link to a `settings.SITE_URL`-based web link, and updated the corresponding assertions in the test file. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781851575694139?thread_ts=1781851575.694139&cid=C09SK2PAGKF)*
