### PR TITLE
fix(tasks): link Slack "View agent logs" to cloud task view

### DIFF
--- a/products/slack_app/backend/tests/test_post_slack_update.py
+++ b/products/slack_app/backend/tests/test_post_slack_update.py
@@ -116,6 +116,8 @@ class TestPostSlackUpdate(TestCase):
 
         mock_post_progress.assert_called_once()
         assert mock_post_progress.call_args[0][0] == "Cloning repository"
+        # The "View agent logs" button links to the cloud task view, not the desktop deep link.
+        assert mock_post_progress.call_args[0][1] == "http://localhost:8000/project/1/tasks/10?runId=run-1"
 
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
@@ -383,8 +385,7 @@ class TestPostSlackUpdate(TestCase):
         mock_post_completion,
     ):
         # When the task creator is not a PostHog Code user, every handler call
-        # receives ``task_url=None`` (and the progress handler receives
-        # ``logs_deeplink=None``) so the deep-link / web buttons are skipped.
+        # receives ``task_url=None`` so the task-view buttons are skipped.
         self._access_patcher.stop()
         deny_patcher = patch(
             "products.tasks.backend.temporal.process_task.activities.post_slack_update.has_tasks_access",

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -42,7 +42,9 @@ class TestSlackThreadHandler(TestCase):
         )
         handler = SlackThreadHandler(context)
 
-        handler.post_or_update_progress("In progress...", task_url="posthog-code://task/abc/run/xyz")
+        handler.post_or_update_progress(
+            "In progress...", task_url="https://us.posthog.com/project/1/tasks/abc?runId=xyz"
+        )
 
         mock_client.chat_postMessage.assert_called_once()
         blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]
@@ -50,6 +52,7 @@ class TestSlackThreadHandler(TestCase):
 
         assert len(actions) == 1
         assert actions[0]["text"]["text"] == "View agent logs"
+        assert actions[0]["url"] == "https://us.posthog.com/project/1/tasks/abc?runId=xyz"
 
     @patch.object(SlackThreadHandler, "_find_progress_message_ts", return_value="1234.9999")
     @patch.object(SlackThreadHandler, "_get_client")

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -60,9 +60,6 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             if creator_has_access
             else None
         )
-        logs_deeplink: str | None = (
-            f"posthog-code://task/{task_run.task_id}/run/{task_run.id}" if creator_has_access else None
-        )
         pr_url = (task_run.output or {}).get("pr_url")
 
         if input.sandbox_cleaned:
@@ -105,7 +102,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
                 handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)
-            handler.post_or_update_progress(stage, logs_deeplink)
+            handler.post_or_update_progress(stage, task_url)
     except Exception:
         logger.exception("post_slack_update_failed", run_id=input.run_id)
 


### PR DESCRIPTION
## Problem

The Slack bot's in-progress "View agent logs" button linked to a `posthog-code://` desktop deep link, while every other button in the thread (completion, error, cancelled, PR opened) links to the cloud task view. On mobile — where this button is pressed most — the deep link is awkward, and it makes it harder to jump in and see a task someone else created.

## Changes

The progress update now passes the cloud `task_url` (`{SITE_URL}/project/{team_id}/tasks/{task_id}?runId={run_id}`) instead of the `posthog-code://` deep link, matching the rest of the thread's buttons. Removed the now-unused `logs_deeplink` variable. The button label ("View agent logs") is unchanged.

## How did you test this code?

I'm an agent (PostHog Slack app). I updated the existing unit tests to assert the progress button now carries the cloud task URL (`test_post_slack_update.py`, `test_slack_thread.py`) and verified the files compile. I could not run the Python test suite — the sandbox lacks the project's Django/pytest environment — so the new assertions have not been executed locally; CI will run them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The fix is a one-line redirect: the progress handler was the only caller passing the desktop deep link rather than the cloud task URL that the other handlers already build. No skills were needed. Tests were adjusted to lock in the new URL; the project test environment wasn't available in the sandbox, so the assertions rely on CI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781853328516529?thread_ts=1781853328.516529&cid=C09SK2PAGKF)*
