### PR TITLE
fix(signals): match web scout run-box colors to desktop

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -52,7 +52,10 @@ export function ScoutRowCard({
             <div className="flex items-center gap-4">
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                     {asHeader ? (
-                        <span className="truncate font-medium text-sm">{displayName}</span>
+                        // min-w keeps the name from being squeezed to zero width by the
+                        // trailing metadata (badges, cadence, emitted count) — truncate
+                        // should clip to an ellipsis, never vanish entirely.
+                        <span className="truncate font-medium text-sm min-w-[6rem]">{displayName}</span>
                     ) : (
                         <Tooltip title={`${config.skill_name} · view scout`}>
                             <Link
@@ -61,7 +64,7 @@ export function ScoutRowCard({
                                 // (hidden) list subtree — close it so it doesn't cover the detail page.
                                 onClick={() => closeSetupModal()}
                                 subtle
-                                className="truncate font-medium text-sm"
+                                className="truncate font-medium text-sm min-w-[6rem]"
                             >
                                 {displayName}
                             </Link>

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
@@ -14,13 +14,14 @@ import {
 } from '../../../utils/scoutRunsWindow'
 
 // Quiet is the common, healthy baseline so it recedes to muted; saturated color
-// only means something happened – purple emission payoff, red/amber trouble.
+// only means something happened – blue emission payoff, red/amber trouble. Blue
+// (not the orange brand primary) keeps this in step with the desktop Code app.
 const OUTCOME_BOX_CLASS: Record<ScoutRunOutcome, string> = {
-    emitted: 'bg-primary-3000',
+    emitted: 'bg-brand-blue',
     quiet: 'bg-border-bold',
     error: 'bg-danger',
     timed_out: 'bg-warning',
-    running: 'bg-primary animate-pulse',
+    running: 'bg-brand-blue animate-pulse',
     stuck: 'bg-danger animate-pulse',
     queued: 'border border-border-bold bg-transparent',
     unknown: 'bg-border',


### PR DESCRIPTION
## Problem

In the web inbox scouts fleet, run-outcome boxes don't match the desktop Code app. Emitted runs render in the orange brand color (`primary-3000` → `#f54e01`) instead of the blue the desktop app uses (`--iris-9`), and an in-progress `running` run is also orange — so "signals emitted" and "trouble" (red/amber) all read as warm tones and the emission payoff doesn't pop. Separately, a scout row whose name had to compete with a lot of trailing metadata could see its name collapse to zero width (the `signals-scout-discord-feedback` row showed no name at all).

## Changes

`frontend/src/scenes/inbox/components/config/scouts/`:

- **`ScoutRunBoxes.tsx`** — point `emitted` and `running` at `bg-brand-blue` (`#1d4aff`, the closest Lemon analogue to the desktop `--iris-9`; the Lemon palette has no iris token) instead of the orange brand primary. The desktop app already uses blue for both; the other outcomes (error/timed_out/quiet/stuck/queued/unknown) were already correct. The stale "purple emission payoff" comment is updated to reflect blue.
- **`ScoutRowCard.tsx`** — the scout name uses `truncate` (`overflow:hidden`), which makes it the only flex child that can shrink below its content width. On a crowded row (badges + cadence + "· N signals emitted" + run history) it could collapse to nothing. Added a `min-w-[6rem]` floor to the title (both the header span and the linked variant) so it clips to an ellipsis instead of vanishing.

This is part of the ongoing web ↔ desktop scouts parity work.

## How did you test this code?

I'm an agent (Claude Code). Automated checks only:

- `bin/hogli format:js` ran on both files via lint-staged at commit time (oxlint + oxfmt) — clean.

No manual UI verification was performed. Visual confirmation against a running stack is still worth a reviewer's glance, since the change is purely presentational.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy reported that cloud scout runs weren't showing the same blue as the desktop Code app for emitted signals, and that one row's name had disappeared. Investigation traced the color drift to the web `ScoutRunBoxes` mapping `emitted`/`running` to the orange brand primary while the desktop equivalent uses iris/blue Radix tokens, and the missing name to `truncate` collapsing under trailing metadata rather than any data problem (the name derives fine from `prettifyScoutSkillName`).

`brand-blue` was chosen over inventing an iris token because Lemon has no iris in its palette and `brand-blue` is the established blue already used elsewhere in the app. `min-w-[6rem]` was chosen as a conservative floor that guarantees the name never fully disappears while still allowing ellipsis truncation in narrow panes.

Skills invoked: `/phs scouts-ui` (workstream context), `/phs make-pr`.
