### PR TITLE
fix(mysql): retry connect timeouts in-process

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -378,7 +378,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
             ):
                 raise
             structlog.get_logger().warning(
-                "Transient MySQL connection drop during connect; retrying",
+                "Transient MySQL connect error (drop or timeout); retrying",
                 attempt=attempt,
                 max_attempts=_MAX_CONNECT_ATTEMPTS,
                 exc_info=e,

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -96,6 +96,13 @@ _LOST_CONNECTION_DURING_QUERY_CODE = 2013
 # resolves it.
 _OUT_OF_SORT_MEMORY_CODE = 1038
 
+# pymysql error code for "Can't connect to MySQL server on '...'" — raised at
+# connect time when the socket connect can't be established. The parenthesised
+# suffix carries the underlying cause (a timeout vs. a refused connection vs. a
+# failed DNS lookup), which is how we tell a transient timeout apart from a hard
+# config error.
+_CANT_CONNECT_CODE = 2003
+
 _SYSTEM_SCHEMAS = ("information_schema", "mysql", "performance_schema", "sys")
 
 
@@ -331,13 +338,34 @@ def _is_transient_connect_drop(e: BaseException) -> bool:
     return False
 
 
+def _is_transient_connect_timeout(e: BaseException) -> bool:
+    """Return True if the initial connect timed out — a transient blip.
+
+    A connect that outruns `connect_timeout` surfaces as pymysql 2003
+    ("Can't connect to MySQL server on '...' (timed out)") wrapping the socket
+    `TimeoutError`. Unlike the other 2003 causes — a refused connection or a
+    failed DNS lookup, both deterministic host/port misconfig that stay
+    non-retryable via the "Can't connect to MySQL server on" classifier — a
+    timeout usually means the server was momentarily slow or unreachable (an
+    overloaded server, a cold PlanetScale endpoint, a brief network blip), so a
+    fresh attempt recovers. Match only the "timed out" payload so the persistent
+    failures still surface.
+    """
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    if code != _CANT_CONNECT_CODE:
+        return False
+    return "timed out" in " ".join(str(arg) for arg in e.args)
+
+
 def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
-    """Open a pymysql connection, retrying a transient drop during the handshake.
+    """Open a pymysql connection, retrying a transient drop or timeout on connect.
 
     Mirrors the in-process connect retry the Postgres source uses: a momentary
-    drop while establishing the connection recovers on a fresh attempt, so retry
-    it here with a bounded backoff instead of failing schema discovery / sync setup
-    on the first blip and surfacing it as captured error-tracking noise.
+    drop or timeout while establishing the connection recovers on a fresh attempt,
+    so retry it here with a bounded backoff instead of failing schema discovery /
+    sync setup on the first blip and surfacing it as captured error-tracking noise.
     """
     attempt = 0
     while True:
@@ -345,7 +373,9 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
             return pymysql.connect(**kwargs)
         except pymysql.err.OperationalError as e:
             attempt += 1
-            if attempt >= _MAX_CONNECT_ATTEMPTS or not _is_transient_connect_drop(e):
+            if attempt >= _MAX_CONNECT_ATTEMPTS or not (
+                _is_transient_connect_drop(e) or _is_transient_connect_timeout(e)
+            ):
                 raise
             structlog.get_logger().warning(
                 "Transient MySQL connection drop during connect; retrying",

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -21,6 +21,7 @@ from posthog.temporal.data_imports.sources.mysql.mysql import (
     _build_query,
     _is_bad_plan_error,
     _is_transient_connect_drop,
+    _is_transient_connect_timeout,
     _is_transient_tablet_unavailable,
     _release_streaming_cursor,
     _retry_on_transient_tablet_unavailable,
@@ -890,6 +891,43 @@ class TestIsTransientConnectDrop:
         assert not _is_transient_connect_drop(pymysql.err.OperationalError())
 
 
+class TestIsTransientConnectTimeout:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Can't connect to MySQL server on 'gcp.connect.psdb.cloud' (timed out)",
+            "Can't connect to MySQL server on 'db.example.com' ([Errno 110] Connection timed out)",
+        ],
+    )
+    def test_matches_connect_timeout(self, message):
+        assert _is_transient_connect_timeout(pymysql.err.OperationalError(2003, message))
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Refused connection and failed DNS lookup are also 2003 but deterministic
+            # host/port misconfig — they must stay non-retryable, not be absorbed here.
+            "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)",
+            "Can't connect to MySQL server on 'nope.example.com' ([Errno -2] Name or service not known)",
+        ],
+    )
+    def test_does_not_match_non_timeout_connect_errors(self, message):
+        assert not _is_transient_connect_timeout(pymysql.err.OperationalError(2003, message))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            (2013, "Lost connection to MySQL server during query"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_error_codes(self, code, message):
+        assert not _is_transient_connect_timeout(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_connect_timeout(pymysql.err.OperationalError())
+
+
 class TestConnectTransientRetry:
     @pytest.mark.parametrize(
         "fail_count,expected_sleeps",
@@ -936,6 +974,40 @@ class TestConnectTransientRetry:
 
         assert mock_connect.call_count == 2
         sleep.assert_called_once_with(2)
+
+    def test_retries_connect_timeout_then_succeeds(self, mocker):
+        sleep = mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "posthog.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[
+                pymysql.err.OperationalError(2003, "Can't connect to MySQL server on 'host' (timed out)"),
+                conn,
+            ],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
+    def test_does_not_retry_connection_refused(self, mocker):
+        sleep = mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        mock_connect = mocker.patch(
+            "posthog.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=pymysql.err.OperationalError(
+                2003, "Can't connect to MySQL server on 'host' ([Errno 111] Connection refused)"
+            ),
+        )
+
+        with pytest.raises(pymysql.err.OperationalError):
+            with MySQLImplementation().connect(_make_config()):
+                pass
+
+        assert mock_connect.call_count == 1
+        sleep.assert_not_called()
 
     def test_gives_up_after_max_attempts(self, mocker):
         mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.time.sleep")


### PR DESCRIPTION
## Problem

A MySQL data-warehouse import surfaced a `TimeoutError: timed out` in error tracking, raised from `_connect_with_transient_retry` in `posthog/temporal/data_imports/sources/mysql/mysql.py`. The underlying exception is a pymysql `OperationalError(2003, "Can't connect to MySQL server on '...' (timed out)")` — the initial socket connect outran the 10s `connect_timeout` (here, a PlanetScale `*.psdb.cloud` endpoint).

This source already has an in-process transient-retry layer (`_connect_with_transient_retry` / `_is_transient_connect_drop`) whose whole purpose is to absorb a momentary connect blip "instead of failing schema discovery / sync setup on the first blip and surfacing it as captured error-tracking noise." But it only matched the **2013** handshake drop — the **2003** connect timeout fell through and was raised (and captured) on the very first attempt.

A connect timeout is the canonical transient blip — an overloaded server, a cold PlanetScale endpoint, or a brief network hiccup — and a fresh attempt usually recovers, so it belongs in that same retry window.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019edeeb-6f01-7ce1-bb64-b4fa93ae940a

## Changes

- Added `_is_transient_connect_timeout`, which matches pymysql `OperationalError(2003, ...)` **only** when the message carries the `timed out` payload.
- `_connect_with_transient_retry` now retries when either a transient drop (2013) or a connect timeout (2003 + "timed out") is seen.

This is deliberately narrow. The other 2003 causes — a refused connection (`Connection refused`) or a failed DNS lookup (`Name or service not known`) — are deterministic host/port misconfig and are left untouched, so they still surface and stay non-retryable via the existing `"Can't connect to MySQL server on"` classifier. No change to `get_non_retryable_errors` or global retry policy. A persistently-timing-out host still surfaces the same `"Can't connect"` error after the bounded in-process attempts — just gives a genuinely transient timeout a chance to recover first.

This is distinct from the open PR #64740, which widens the retry *window* (`_MAX_CONNECT_ATTEMPTS`, backoff) for the already-retried 2013 drop. That PR does not make the 2003 connect timeout retryable; the two changes are independent.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated tests only — no manual testing:

- New `TestIsTransientConnectTimeout` unit tests: matches `2003 + timed out`, rejects refused/DNS (`Connection refused`, `Name or service not known`), rejects other error codes (2013, 1045), and rejects an arg-less error.
- New `TestConnectTransientRetry` cases: retries a 2003 timeout then succeeds; does **not** retry a 2003 `Connection refused`.
- Full file: `posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py` — 141 passed.
- `ruff check` and `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MySQL import source. Used PostHog error-tracking MCP tools to confirm the issue (1 occurrence, 1 user), pull the full stack trace, and verify the failure genuinely originates in `mysql.py` (`build_pipeline` → `connect` → `_connect_with_transient_retry`) rather than only appearing inside serialized log context.

Decision path: the underlying error is a transient connect *timeout*, not a user/upstream credential/config error, so extending `get_non_retryable_errors` would have been wrong. The error-tracking capture happens at the activity-interceptor boundary regardless of retryability, so the right lever for reducing the noise is the existing in-process transient-retry layer — extended to cover the connect timeout, kept narrow enough that persistent connect failures still surface. Checked open PRs (including the maintainer's) for duplicates; #64740 touches the same function but addresses a different root cause (2013 window vs. 2003 timeout).