### PR TITLE
feat(signals): add run history section to web inbox scout detail

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -12,6 +12,7 @@ import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { SCOUT_RUNS_WINDOW_SPAN, scoutRunsWindowLabel } from '../../../utils/scoutRunsWindow'
 import { ScoutEmissionCard } from './ScoutEmissionCard'
 import { ScoutRowCard } from './ScoutRowCard'
+import { ScoutRunHistorySection } from './ScoutRunHistorySection'
 
 /**
  * Full-width scout detail surface, rendered over the inbox list at `/inbox/scouts/:skillName`.
@@ -78,9 +79,7 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
 
                     <ScoutSignalsSection skillName={skillName} />
 
-                    <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
-                        Run history is coming to this view soon.
-                    </div>
+                    <ScoutRunHistorySection skillName={skillName} />
                 </>
             )}
         </div>

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRunHistorySection.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRunHistorySection.tsx
@@ -1,0 +1,202 @@
+import { useValues } from 'kea'
+import { useMemo, useState } from 'react'
+
+import { IconChevronDown, IconExternal } from '@posthog/icons'
+import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { pluralize } from 'lib/utils/strings'
+
+import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
+import { SignalScoutRunSummary } from '../../../types'
+import {
+    deriveRunFailureKind,
+    formatRunDuration,
+    normalizeRunStatus,
+    runDurationSeconds,
+    runMatchesFilter,
+    ScoutRunFilter,
+    SCOUT_RUNS_WINDOW_SPAN,
+} from '../../../utils/scoutRunsWindow'
+
+const FILTERS: { value: ScoutRunFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'emitted', label: 'Emitted' },
+    { value: 'quiet', label: 'Quiet' },
+    { value: 'failed', label: 'Failed' },
+]
+
+/** Truncated mono id (run ids are long ULIDs; only the leading chunk earns a row footer). */
+function truncateId(value: string): string {
+    return value.length > 12 ? `${value.slice(0, 12)}…` : value
+}
+
+/** A compact status glyph: ✗ failed · pulsing dot running/queued · ◆ emitted · · quiet. */
+function RunGlyph({ run }: { run: SignalScoutRunSummary }): JSX.Element {
+    const status = normalizeRunStatus(run.status)
+    if (status === 'failed') {
+        return <span className="text-danger text-sm font-medium leading-none">✗</span>
+    }
+    if (status === 'running' || status === 'queued') {
+        return <span className="inline-block size-2 shrink-0 rounded-full bg-primary animate-pulse" />
+    }
+    if ((run.emitted_count ?? 0) > 0) {
+        return <span className="text-primary-3000 text-sm font-medium leading-none">◆</span>
+    }
+    return <span className="text-muted text-sm leading-none">·</span>
+}
+
+/**
+ * One run in the history list. Shares the collapse/expand grammar of `ScoutEmissionCard`: a header
+ * (chevron · glyph · timestamp · duration · failure · emitted count) that stays visible, the run
+ * summary markdown (2-line preview collapsed, full expanded), and an id/task-run footer when open.
+ */
+function ScoutRunRow({ run }: { run: SignalScoutRunSummary }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const now = new Date()
+    const status = normalizeRunStatus(run.status)
+    const failureKind = deriveRunFailureKind(run, now)
+    const duration = formatRunDuration(runDurationSeconds(run, now))
+    const emitted = run.emitted_count ?? 0
+    const hasBody = Boolean(run.summary) || status === 'failed' || expanded
+
+    return (
+        <div className="flex flex-col rounded border border-primary bg-bg-light">
+            <button
+                type="button"
+                onClick={() => setExpanded((value) => !value)}
+                className="flex items-center gap-2 px-3 py-2 text-left"
+                aria-expanded={expanded}
+            >
+                <IconChevronDown
+                    className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
+                />
+                <RunGlyph run={run} />
+                <span className="whitespace-nowrap text-[11px] text-muted">
+                    {humanFriendlyDetailedTime(run.started_at)}
+                </span>
+                {duration && <span className="whitespace-nowrap text-[11px] text-muted">· {duration}</span>}
+                {failureKind && (
+                    <span className="whitespace-nowrap text-[11px] text-warning">
+                        · {failureKind === 'timed_out' ? 'timed out' : 'failed'}
+                    </span>
+                )}
+                <span className="flex-1" />
+                {emitted > 0 ? (
+                    <span className="whitespace-nowrap rounded bg-primary-highlight px-1.5 py-0.5 text-[11px] font-medium text-primary-3000">
+                        {pluralize(emitted, 'signal')} emitted
+                    </span>
+                ) : status === 'completed' ? (
+                    <span className="whitespace-nowrap text-[11px] text-muted">0 signals emitted</span>
+                ) : null}
+            </button>
+
+            {hasBody && (
+                <div className="px-3 pb-2 pl-9">
+                    {run.summary ? (
+                        <LemonMarkdown
+                            disableImages
+                            className={expanded ? 'text-sm text-primary' : 'text-sm text-primary line-clamp-2'}
+                        >
+                            {run.summary}
+                        </LemonMarkdown>
+                    ) : status === 'failed' ? (
+                        <span className="text-sm italic text-muted">
+                            No summary — the run ended before writing its close-out. The task run in PostHog is the only
+                            diagnostic.
+                        </span>
+                    ) : null}
+
+                    {expanded && (
+                        <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
+                            <span className="font-mono">{truncateId(run.run_id)}</span>
+                            {run.task_url && (
+                                <>
+                                    <span className="flex-1" />
+                                    <Link to={run.task_url} className="flex items-center gap-1 font-medium shrink-0">
+                                        Open task run <IconExternal className="size-3" />
+                                    </Link>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}
+
+/**
+ * The Runs section on the scout detail surface: this scout's runs in the recent window, newest
+ * first, with All/Emitted/Quiet/Failed filter chips (each showing its match count). Runs come
+ * from `scoutFleetLogic`'s already-polled window rollup (oldest-first timeline order, reversed
+ * here) — there's no per-scout runs endpoint yet (api gap 1), so the window is filtered client-side.
+ */
+export function ScoutRunHistorySection({ skillName }: { skillName: string }): JSX.Element {
+    const { rollups, runsWindowLoadedOnce, runsWindowComplete } = useValues(scoutFleetLogic)
+    const [filter, setFilter] = useState<ScoutRunFilter>('all')
+
+    // Newest first for a history list; the rollup keeps runs oldest-first for the header timeline.
+    const runs = useMemo(() => {
+        const windowRuns = rollups.get(skillName)?.runs ?? []
+        return [...windowRuns].reverse()
+    }, [rollups, skillName])
+
+    const filterCounts = useMemo(() => {
+        const counts = new Map<ScoutRunFilter, number>()
+        for (const entry of FILTERS) {
+            counts.set(entry.value, runs.filter((run) => runMatchesFilter(run, entry.value)).length)
+        }
+        return counts
+    }, [runs])
+
+    const filteredRuns = useMemo(() => runs.filter((run) => runMatchesFilter(run, filter)), [runs, filter])
+
+    // Hold the skeleton until the fleet's runs window has settled once — otherwise a fresh deep-link
+    // flashes the empty state before we know this scout's runs.
+    const loading = !runsWindowLoadedOnce
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs font-medium text-default uppercase tracking-wide">Runs</span>
+                <span className="flex-1" />
+                {FILTERS.map((entry) => (
+                    <LemonButton
+                        key={entry.value}
+                        size="xsmall"
+                        type="tertiary"
+                        active={filter === entry.value}
+                        onClick={() => setFilter(entry.value)}
+                    >
+                        {entry.label} {filterCounts.get(entry.value) ?? 0}
+                    </LemonButton>
+                ))}
+            </div>
+
+            {loading ? (
+                <LemonSkeleton className="h-12 w-full rounded" />
+            ) : filteredRuns.length === 0 ? (
+                <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
+                    {runs.length > 0
+                        ? `No runs match this filter in the last ${SCOUT_RUNS_WINDOW_SPAN}.`
+                        : runsWindowComplete
+                          ? `No runs in the last ${SCOUT_RUNS_WINDOW_SPAN}.`
+                          : `No runs in the recent window we could load (the last ${SCOUT_RUNS_WINDOW_SPAN} is truncated).`}
+                </div>
+            ) : (
+                <>
+                    {filteredRuns.map((run) => (
+                        <ScoutRunRow key={run.run_id} run={run} />
+                    ))}
+                    {!runsWindowComplete && (
+                        <span className="text-xs text-muted">
+                            Older runs beyond the loaded {SCOUT_RUNS_WINDOW_SPAN} window aren’t shown.
+                        </span>
+                    )}
+                </>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -168,6 +168,28 @@ export function deriveRunOutcome(run: SignalScoutRunSummary, now: Date): ScoutRu
     return 'unknown'
 }
 
+/** The run-history filter chips on the scout detail surface. */
+export type ScoutRunFilter = 'all' | 'emitted' | 'quiet' | 'failed'
+
+/**
+ * Whether a run belongs under a given filter chip. Emitted/Quiet split completed runs by
+ * whether they wrote findings; Failed is any failed/cancelled run. There is no server-side
+ * `status` filter yet (api gap 1), so the detail view filters its window client-side.
+ */
+export function runMatchesFilter(run: SignalScoutRunSummary, filter: ScoutRunFilter): boolean {
+    const status = normalizeRunStatus(run.status)
+    switch (filter) {
+        case 'all':
+            return true
+        case 'emitted':
+            return (run.emitted_count ?? 0) > 0
+        case 'quiet':
+            return status === 'completed' && (run.emitted_count ?? 0) === 0
+        case 'failed':
+            return status === 'failed'
+    }
+}
+
 export function scoutRunOutcomeLabel(run: SignalScoutRunSummary, now: Date): string {
     switch (deriveRunOutcome(run, now)) {
         case 'emitted': {


### PR DESCRIPTION
## Problem

The web inbox scout detail surface (`/inbox/scouts/:skillName`) shipped its header (W1) and Signals section (W2), but run history was still a "coming soon" placeholder. The desktop Code app has had a per-scout Runs section for a while — this brings the web surface to parity, so you can see a scout's recent runs and filter them without leaving the page.

## Changes

Adds the **Runs** section to the web scout detail page, replacing the placeholder. All in `frontend/src/scenes/inbox/`:

- **`utils/scoutRunsWindow.ts`** — `ScoutRunFilter` (`all`/`emitted`/`quiet`/`failed`) + `runMatchesFilter`, ported from the desktop `scoutPresentation.ts` (emitted = wrote findings, quiet = completed with 0 findings, failed = failed status).
- **`components/config/scouts/ScoutRunHistorySection.tsx`** (new):
  - `ScoutRunHistorySection` — `All / Emitted / Quiet / Failed` filter chips (`LemonButton`, with live match counts), the run list newest-first, skeleton until the fleet runs window settles, and empty states for no-match vs truncated-window.
  - `ScoutRunRow` — one run, sharing the existing `ScoutEmissionCard` collapse grammar: header (status glyph · timestamp · duration · `timed out`/`failed` label · emitted-count badge), collapsed shows the run summary as 2-line markdown (italic note for failed runs with no summary), expanded shows the full markdown plus a footer with the run id and an "Open task run ↗" link.
- **`ScoutDetailView.tsx`** — render `<ScoutRunHistorySection>` in place of the placeholder.

No new kea logic — the section reads the existing `scoutFleetLogic` rollups. There's still no per-scout/`status` runs endpoint, so the runs are filtered client-side off the already-polled 72h fleet window (the timed-out vs failed split is inferred client-side from run duration).

## How did you test this code?

I'm an agent (Claude Code). Automated checks I ran locally: oxlint and oxfmt (clean), and `typescript:check` (clean for the three changed files — only pre-existing unrelated errors remain).

I also drove the running local app with Playwright on project 1 (`/inbox/scouts/signals-scout-web-analytics`): the chips read `All 21 · Emitted 0 · Quiet 11 · Failed 9`, matching the rollup line (`21 runs · 11 completed · 9 failed`); clicking **Failed** activated the chip and rendered exactly 9 rows (7 `failed` + 2 `timed out`, confirming the timeout inference). No automated component tests added — matches the currently untested `scoutFleetLogic`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the work (assigned as DRI).

Built with Claude Code (Opus 4.8). Context came from the `scouts-ui` workstream skill (via the PostHog skills store), where this was tracked as item W3 of the web→desktop parity backlog. The desktop `ScoutDetailView` / `ScoutRunListItem` were the reference; the filter helper was ported verbatim and the row was rebuilt with LemonUI components to match the web Signals section's grammar rather than the desktop's Radix one.

Key decisions: no new kea logic (the section rides existing `scoutFleetLogic` selectors, so nothing to typegen); kept client-side filtering off the fleet window rather than waiting on a server-side `skill_name`/`status` filter (tracked separately as an API gap), since the timed-out/failed distinction is already inferred client-side. No skills with codegen/migration side effects were invoked.
