### PR TITLE
feat(experiments): expose running_time_calculation on experiment-update

### DIFF
--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -824,10 +824,10 @@ tools:
                 description: >
                     Persist a running-time / sample-size plan onto the experiment (the planning target shown in the
                     experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage,
-                    e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time
-                    (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys
-                    during the deprecation window, so prefer this field over writing the calculator keys inside
-                    parameters.
+                    e.g. 20 for a 20% lift), recommended_sample_size (total across all variants),
+                    recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with
+                    the legacy parameters.* keys during the deprecation window, so prefer this field over writing the
+                    calculator keys inside parameters.
         ui_app: experiment
         response:
             include:

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -806,6 +806,7 @@ tools:
             - name
             - description
             - parameters
+            - running_time_calculation
             - metrics
             - metrics_secondary
             - stats_config
@@ -819,6 +820,14 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+            running_time_calculation:
+                description: >
+                    Persist a running-time / sample-size plan onto the experiment (the planning target shown in the
+                    experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage,
+                    e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time
+                    (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys
+                    during the deprecation window, so prefer this field over writing the calculator keys inside
+                    parameters.
         ui_app: experiment
         response:
             include:
@@ -833,6 +842,7 @@ tools:
                 - end_date
                 - created_at
                 - parameters
+                - running_time_calculation
                 - metrics
                 - metrics_secondary
                 - conclusion

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -726,7 +726,6 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
             start_date: true,
             end_date: true,
             feature_flag_key: true,
-            running_time_calculation: true,
             secondary_metrics: true,
             saved_metrics_ids: true,
             filters: true,
@@ -739,7 +738,12 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
             only_count_matured_users: true,
         }).shape
     )
-    .extend({ id: z.preprocess(castStringToInt, ExperimentsPartialUpdateParams.shape['id']) })
+    .extend({
+        id: z.preprocess(castStringToInt, ExperimentsPartialUpdateParams.shape['id']),
+        running_time_calculation: ExperimentsPartialUpdateBody.shape['running_time_calculation'].describe(
+            "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
+        ),
+    })
 
 const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHogUrl<Schemas.Experiment>> =>
     withUiApp('experiment', {
@@ -759,6 +763,9 @@ const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHog
             }
             if (params.parameters !== undefined) {
                 body['parameters'] = params.parameters
+            }
+            if (params.running_time_calculation !== undefined) {
+                body['running_time_calculation'] = params.running_time_calculation
             }
             if (params.archived !== undefined) {
                 body['archived'] = params.archived
@@ -804,6 +811,7 @@ const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHog
                 'end_date',
                 'created_at',
                 'parameters',
+                'running_time_calculation',
                 'metrics',
                 'metrics_secondary',
                 'conclusion',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -3643,6 +3643,105 @@
             ],
             "description": "Experiment parameters JSON. Supported keys include `feature_flag_variants`, `rollout_percentage`, `minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `custom_exposure_filter`, and `excluded_variants` (list of variant keys to drop from statistical analysis; the baseline variant and holdout pseudo-variants cannot be excluded). The running-time calculator keys (`minimum_detectable_effect`, `recommended_running_time`, `recommended_sample_size`, `exposure_estimate_config`) are deprecated here — prefer `running_time_calculation`."
         },
+        "running_time_calculation": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "exposure_estimate_config": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "conversionRateInputType": {
+                                            "description": "'manual' when the baseline value and exposure rate were entered by hand, 'automatic' when derived from live experiment data.",
+                                            "enum": ["manual", "automatic"],
+                                            "type": "string"
+                                        },
+                                        "manualBaselineValue": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Manually entered baseline metric value (a conversion percentage for funnel metrics). Only used in manual mode."
+                                        },
+                                        "manualExposureRate": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Manually entered estimate of users exposed to the experiment per day. Only used in manual mode."
+                                        },
+                                        "manualMetricType": {
+                                            "anyOf": [
+                                                {
+                                                    "enum": ["funnel", "mean_count", "mean_sum_or_avg"],
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Metric type the manual baseline value refers to. Only used in manual mode."
+                                        }
+                                    },
+                                    "required": ["conversionRateInputType"],
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "How the exposure estimate is configured: manual user-entered values or automatic from live experiment data."
+                        },
+                        "minimum_detectable_effect": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes."
+                        },
+                        "recommended_running_time": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Estimated number of days needed to reach the recommended sample size."
+                        },
+                        "recommended_sample_size": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Recommended number of exposed users needed for statistical significance."
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
+        },
         "stats_config": {},
         "update_feature_flag_params": {
             "description": "When true, sync feature flag configuration from parameters to the linked feature flag. Draft experiments always sync regardless of update_feature_flag_params, so only required for non-drafts.",


### PR DESCRIPTION
## Problem

The `experiment-calculate-running-time` MCP tool lets an agent compute a recommended sample size and running time, but there was no way to **persist** that result onto an experiment through MCP. The `experiment-update` tool's `include_params` allowlist omitted `running_time_calculation`, so an agent could calculate a plan and then had no first-class way to save it (short of a manual DB write).

## Changes

Surfaces `running_time_calculation` on the `experiment-update` MCP tool:

- `products/experiments/mcp/tools.yaml`: adds `running_time_calculation` to `experiment-update`'s `include_params`, an imperative `param_overrides` description, and a `response.include` echo so the write is confirmable.
- `services/mcp/src/tools/generated/experiments.ts` (regenerated): the field is now in the update schema, forwarded to the PATCH body, and returned in the filtered response.

No backend changes. `ExperimentSerializer.running_time_calculation` is already a writable field, validated by `ExperimentService.validate_running_time_calculation`, and the service already dual-writes it into both the canonical `running_time_calculation` column and the legacy `parameters.*` keys during the deprecation window. This PR only exposes that existing capability through MCP.

This is independent of the running-time calculator tool — the serializer field, model, migrations (`0019`/`0020`), and generated request schema are all already on `master`.

## How did you test this code?

I'm an agent; I did not exercise a manual end-to-end MCP call against a running server. Automated checks run locally:

- `pnpm --filter=@posthog/mcp run generate-tools` — regenerated the tool; the resulting diff is limited to `experiment-update`.
- `pnpm --filter=@posthog/mcp exec vitest run tests/unit/generate-tools.test.ts` — passes (81 tests, snapshot unchanged: adding a param to an existing tool doesn't alter the tool-metadata snapshot).
- `pnpm --filter=@posthog/mcp exec tsc --noEmit` — no new type errors in the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal MCP tooling change; no user-facing docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). The work began from a request to persist a running-time / sample-size plan onto an experiment via MCP. Investigation showed the entire gap was the `experiment-update` tool's `include_params` allowlist — the Django serializer and dual-write service were already complete on `master`.

Skills invoked: `/implementing-mcp-tools` (the YAML → OpenAPI → generated-tool workflow), plus `creating-experiments` and `configuring-experiment-analytics` during earlier exploration.

Decisions:
- Branched fresh from `master` after verifying the change doesn't depend on the `experiment-calculate-running-time` branch (serializer field, model, migrations, and generated request schema all already on `master`).
- Worded the `param_overrides` description to **not** name the calculator tool, since that tool isn't on `master` yet — keeps this PR self-contained.
- Left `experiment-create` unchanged; the `creating-experiments` skill is deliberately "draft first," so persisting a running-time plan is a post-creation step.
- Regeneration also wanted to refresh a **pre-existing, unrelated** stale hunk in `experiment-list` (`PaginatedExperimentList` → `PaginatedExperimentBasicList`). That drift exists on `master` independent of this change, so I reverted it to keep the diff focused; it should be picked up by the normal generated-types refresh.
