### PR TITLE
perf(max): memoize thread messages to cut re-renders in long threads

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -384,7 +384,10 @@ interface MessageProps {
     isSlashCommandResponse?: boolean
 }
 
-function Message({
+// Memoized so a thread re-render (e.g. on every streaming token) only re-renders messages whose
+// props actually changed. Relies on threadGrouped preserving message object identity for unchanged
+// messages — see enhanceThreadToolCalls in maxThreadLogic.
+const Message = React.memo(function Message({
     message,
     nextMessage,
     isLastInGroup,
@@ -722,7 +725,7 @@ function Message({
             </div>
         </MessageContainer>
     )
-}
+})
 
 function MessageGroupSkeleton({
     groupType,

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -2025,12 +2025,12 @@ function enhanceThreadToolCalls(
 
     // Enhance assistant messages with tool call status
     return group.map((message, messageIndex) => {
-        message = { ...message }
         // A message is in the final group if it comes after or is the last human message
         const isFinalGroup = messageIndex >= lastHumanMessageIndex
         if (isAssistantMessage(message) && message.tool_calls && message.tool_calls.length > 0) {
             const isLastPlanningMessage = message.id === lastPlanningMessageId
-            message.tool_calls = message.tool_calls.map<EnhancedToolCall>((toolCall) => {
+            const enhancedMessage = { ...message }
+            enhancedMessage.tool_calls = message.tool_calls.map<EnhancedToolCall>((toolCall) => {
                 const resultMessage = toolCallCompletions.get(toolCall.id)
                 const isCompleted = !!resultMessage
                 // create_form is an interactive tool - it's "completed" once rendered (waiting for user input)
@@ -2054,7 +2054,10 @@ function enhanceThreadToolCalls(
                     result: isAssistantToolCallMessage(resultMessage) ? resultMessage : undefined,
                 }
             })
+            return enhancedMessage
         }
+        // Messages we don't enhance are returned by reference so their identity stays stable
+        // across recomputes — this is what lets React.memo(Message) skip them on each token.
         return message
     })
 }


### PR DESCRIPTION
## Problem

The Max AI thread re-renders on every streaming token (its `threadGrouped` selector depends on `threadRaw`, which updates per token). On each of those re-renders it re-rendered **every** message in the thread, so cost scaled with conversation length — contributing to the sluggishness users report in long threads. This is a pre-existing cost (separate from the input-lag regression in #64785), surfaced while investigating that report.

Two things caused it:

1. The `Message` component was not wrapped in `React.memo`, so a parent re-render re-rendered all N messages.
2. Even with memoization, `enhanceThreadToolCalls` cloned **every** message (`message = { ...message }`) on every `threadGrouped` recompute, handing each one a fresh object identity — which defeats `React.memo` regardless.

Markdown rendering was already memoized (`MarkdownMessage` is `React.memo`, memoized per block), so the dominant remaining cost was React reconciling N message subtrees per token.

## Changes

- **Preserve message identity** in `enhanceThreadToolCalls` (`maxThreadLogic.tsx`): only assistant messages that actually have tool calls get a new object; everything else (human messages, plain assistant text) is returned by reference, so its identity is stable across recomputes. `threadRaw`'s reducers already preserve identity for unchanged messages, so this carries through.
- **Wrap `Message` in `React.memo`** (`Thread.tsx`). Its props are primitives plus the now-stable message references, so the default shallow compare works.

Net effect: a streaming token re-renders only the message that actually changed (plus its immediate predecessor, whose `nextMessage` prop points at the changed object) instead of the entire thread.

Out of scope (possible follow-ups): each `Message` still subscribes to `pendingApprovalsData`/`resolvedApprovalStatuses` directly, so an approval change re-renders all messages; and completed tool-call messages are still re-cloned per token. The thread is also not virtualized.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- `oxfmt` + `oxlint` on both changed files — clean, 0 errors.
- `tsgo` typecheck — no new errors in either file (the only `maxThreadLogic.tsx` errors are pre-existing local kea-typegen staleness at unrelated lines; CI regenerates types).

I did **not** run a manual profiling pass. Recommended verification: React DevTools Profiler while streaming into a long thread — before, every message row re-renders per token; after, only the actively-streaming message (and its immediate predecessor) should. Also sanity-check that tool-call status, planning cards, and approval cards still update correctly during a run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #64785. While diagnosing the input-lag regression I mapped the thread render path and found these two coupled memoization wins. The key insight is that `React.memo` on `Message` is inert until message object identity is stable, which the unconditional clone in `enhanceThreadToolCalls` was breaking. Verified `threadRaw`'s reducers (`addMessage`/`replaceMessage`/`setMessageStatus`) already preserve identity for untouched messages, so preserving it through the enhance step is sufficient. Kept the change minimal and deferred the deeper wins (per-message approval subscriptions, tool-call re-clone, virtualization) noted above.
