### PR TITLE
fix(batch-exports): Wait for at least workflows to be available

### DIFF
--- a/products/batch_exports/backend/tests/temporal/backfills/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/conftest.py
@@ -1,3 +1,4 @@
+import typing
 import asyncio
 import datetime as dt
 
@@ -13,9 +14,19 @@ async def wait_for_workflows(
     temporal_client: temporalio.client.Client,
     schedule_id: str,
     expected_count: int,
+    comparison_mode: typing.Literal["EXACT", "GTE"] = "EXACT",
     timeout: int = 60,
 ) -> list[temporalio.client.WorkflowExecution]:
-    """Wait for workflows to be queryable and return them."""
+    """Wait for workflows to be queryable and return them.
+
+    Arguments:
+        temporal_client: A Temporal client to be used to check for workflows.
+        schedule_id: The schedule whose workflows we are looking for.
+        expected_count: Wait for this number of workflows.
+        comparison_mode: Define whether to treat expected count as an exact
+            requirement ('EXACT') or as a lower bound ('GTE').
+        timeout: Wait for at most this amount of seconds.
+    """
     query = f'TemporalScheduledById="{schedule_id}" order by StartTime asc'
     workflows: list[temporalio.client.WorkflowExecution] = []
     elapsed = 0.0
@@ -32,6 +43,11 @@ async def wait_for_workflows(
         elapsed += delay
         delay = min(delay * 2, 5)
         workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
+
+    if comparison_mode == "EXACT":
+        assert len(workflows) == expected_count
+    elif comparison_mode == "GTE":
+        assert len(workflows) >= expected_count
 
     return workflows
 

--- a/products/batch_exports/backend/tests/temporal/backfills/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/conftest.py
@@ -1,4 +1,3 @@
-import typing
 import asyncio
 import datetime as dt
 
@@ -14,7 +13,7 @@ async def wait_for_workflows(
     temporal_client: temporalio.client.Client,
     schedule_id: str,
     expected_count: int,
-    comparison_mode: typing.Literal["EXACT", "GTE"] = "EXACT",
+    assert_exact: bool = True,
     timeout: int = 60,
 ) -> list[temporalio.client.WorkflowExecution]:
     """Wait for workflows to be queryable and return them.
@@ -23,8 +22,9 @@ async def wait_for_workflows(
         temporal_client: A Temporal client to be used to check for workflows.
         schedule_id: The schedule whose workflows we are looking for.
         expected_count: Wait for this number of workflows.
-        comparison_mode: Define whether to treat expected count as an exact
-            requirement ('EXACT') or as a lower bound ('GTE').
+        assert_exact: Whether to assert that the exact expected_count of
+            workflows is availale. Set this to False if any number of workflows
+            past expected_count is expected rather than an exact match.
         timeout: Wait for at most this amount of seconds.
     """
     query = f'TemporalScheduledById="{schedule_id}" order by StartTime asc'
@@ -44,10 +44,8 @@ async def wait_for_workflows(
         delay = min(delay * 2, 5)
         workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
 
-    if comparison_mode == "EXACT":
+    if assert_exact:
         assert len(workflows) == expected_count
-    elif comparison_mode == "GTE":
-        assert len(workflows) >= expected_count
 
     return workflows
 

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
@@ -300,7 +300,6 @@ async def test_backfill_batch_export_workflow(
         raise AssertionError("Backfill completed early with no records")
 
     workflows = await wait_for_workflows(temporal_client, batch_export.id, expected_num_workflows, timeout=50)
-    assert len(workflows) == expected_num_workflows
 
     # Check that the individual workflow IDs and TemporalScheduledStartTime search attributes are set correctly.
     for index, workflow in enumerate(workflows, start=1):
@@ -353,7 +352,6 @@ async def test_backfill_batch_export_workflow_no_end_at(
     )
 
     workflows = await wait_for_workflows(temporal_client, desc.id, expected_count=2)
-    assert len(workflows) == 2
 
     event_backfill_ids = await assert_backfill_details_in_workflow_events(
         temporal_client,
@@ -439,7 +437,7 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     )
 
     # Wait for at least one workflow to start running before deleting the schedule
-    await wait_for_workflows(temporal_client, desc.id, expected_count=1, comparison_mode="GTE", timeout=10)
+    await wait_for_workflows(temporal_client, desc.id, expected_count=1, assert_exact=False, timeout=10)
 
     await temporal_schedule_every_5_minutes.delete()
 

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
@@ -439,7 +439,7 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     )
 
     # Wait for at least one workflow to start running before deleting the schedule
-    await wait_for_workflows(temporal_client, desc.id, expected_count=1, timeout=10)
+    await wait_for_workflows(temporal_client, desc.id, expected_count=1, comparison_mode="GTE", timeout=10)
 
     await temporal_schedule_every_5_minutes.delete()
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

A test requires at least some workflow to be available, but it is doing an exact comparison on the number of workflows. This is bound to fail occassionally when more than the required number of workflows pop up on the same loop interation.

I added support for skipping the exact comparison, when we only need to check that some number of workflows was created.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I haven't
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

The flakey test bot told me this was flaking, besides that all me.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
