### PR TITLE
fix(insights): open rebuild taxonomic input trigger in one commit

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.test.ts
@@ -1,5 +1,9 @@
 import { TaxonomicFilterGroupType } from '../types'
-import { eventSelectionWasStale } from './TaxonomicFilterMenu'
+import { eventSelectionWasStale, resolveInitialMenuState, resolveSelectedOpenState } from './TaxonomicFilterMenu'
+import { MenuFilterEntry, MenuFilterState } from './types'
+
+const entryFor = (type: TaxonomicFilterGroupType): MenuFilterEntry =>
+    ({ item: { id: 'a', name: 'a' }, group: { type }, name: 'a' }) as unknown as MenuFilterEntry
 
 describe('eventSelectionWasStale', () => {
     const staleEvent = { name: 'old', last_seen_at: '2000-01-01T00:00:00Z' } as any
@@ -13,5 +17,39 @@ describe('eventSelectionWasStale', () => {
         ['event row without last_seen_at', TaxonomicFilterGroupType.Events, { name: 'x' }, undefined],
     ])('%s -> %s', (_label, groupType, item, expected) => {
         expect(eventSelectionWasStale(groupType as TaxonomicFilterGroupType, item)).toBe(expected)
+    })
+})
+
+describe('resolveSelectedOpenState', () => {
+    const hogqlEntry = entryFor(TaxonomicFilterGroupType.HogQLExpression)
+    const dwhEntry = entryFor(TaxonomicFilterGroupType.DataWarehouse)
+    const eventEntry = entryFor(TaxonomicFilterGroupType.Events)
+
+    it.each<[string, MenuFilterEntry | null, MenuFilterState]>([
+        ['no selection -> menu', null, { kind: 'menu' }],
+        ['hogql selection -> hogql editor', hogqlEntry, { kind: 'hogql-edit' }],
+        [
+            'data warehouse selection -> dwh config (origin menu)',
+            dwhEntry,
+            { kind: 'dwh-config', table: dwhEntry.item, group: dwhEntry.group, origin: 'menu' },
+        ],
+        ['other selection -> combobox all', eventEntry, { kind: 'combobox', drillTo: 'all' }],
+    ])('%s', (_label, selected, expected) => {
+        expect(resolveSelectedOpenState(selected)).toEqual(expected)
+    })
+})
+
+describe('resolveInitialMenuState', () => {
+    const hogqlEntry = entryFor(TaxonomicFilterGroupType.HogQLExpression)
+
+    it.each<[string, boolean, 'menu' | 'combobox' | undefined, MenuFilterEntry | null, MenuFilterState]>([
+        ['closed when not defaultOpen', false, undefined, null, { kind: 'closed' }],
+        ['not defaultOpen ignores defaultOpenState and selection', false, 'combobox', hogqlEntry, { kind: 'closed' }],
+        ['defaultOpenState combobox -> combobox all', true, 'combobox', null, { kind: 'combobox', drillTo: 'all' }],
+        ['defaultOpenState menu -> menu', true, 'menu', null, { kind: 'menu' }],
+        ['no defaultOpenState falls back to selection (none -> menu)', true, undefined, null, { kind: 'menu' }],
+        ['no defaultOpenState falls back to selection (hogql)', true, undefined, hogqlEntry, { kind: 'hogql-edit' }],
+    ])('%s', (_label, defaultOpen, defaultOpenState, selected, expected) => {
+        expect(resolveInitialMenuState(defaultOpen, defaultOpenState, selected)).toEqual(expected)
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -176,6 +176,58 @@ export function eventSelectionWasStale(
     return isDefinitionStale(item as unknown as EventDefinition)
 }
 
+/**
+ * Resolve the panel a trigger open should land on from the current selection.
+ * If `selected` is set, jump straight into the panel that matches its group so
+ * the user lands on something editable (e.g. the HogQL editor pre-filled with
+ * the existing expression) instead of having to re-traverse the dropdown menu.
+ * With no selection we fall back to the menu.
+ */
+function resolveSelectedOpenState(selected: MenuFilterEntry | null): MenuFilterState {
+    if (!selected) {
+        return { kind: 'menu' }
+    }
+    if (selected.group.type === TaxonomicFilterGroupType.HogQLExpression) {
+        return { kind: 'hogql-edit' }
+    }
+    if (selected.group.type === TaxonomicFilterGroupType.DataWarehouse) {
+        // origin='menu' so X / Esc / Cancel return to the dropdown menu rather
+        // than dropping the user into the (unscrolled) dwh-pick list they never
+        // visited.
+        return { kind: 'dwh-config', table: selected.item, group: selected.group, origin: 'menu' }
+    }
+    // Land on the regular combobox on the "All" scope. The committed selection
+    // floats to the first row (and stays highlighted) so the user can verify it
+    // at a glance, while still seeing recents/pinned and being able to search
+    // across every category.
+    return { kind: 'combobox', drillTo: 'all' }
+}
+
+/**
+ * Initial menu state at mount. `defaultOpen` consumers lazily mount this
+ * component on the user's first trigger interaction, so opening is a one-shot
+ * mount concern — it belongs in the initial state, not a post-paint effect, so
+ * the picker opens in the same commit it mounts (no intermediate closed frame).
+ * `defaultOpenState` routes the open to the panel matching the interaction (the
+ * input trigger's search box -> combobox, its filter icon -> menu).
+ */
+function resolveInitialMenuState(
+    defaultOpen: boolean,
+    defaultOpenState: 'menu' | 'combobox' | undefined,
+    selected: MenuFilterEntry | null
+): MenuFilterState {
+    if (!defaultOpen) {
+        return { kind: 'closed' }
+    }
+    if (defaultOpenState === 'combobox') {
+        return { kind: 'combobox', drillTo: 'all' }
+    }
+    if (defaultOpenState === 'menu') {
+        return { kind: 'menu' }
+    }
+    return resolveSelectedOpenState(selected)
+}
+
 export function TaxonomicFilterMenu({
     triggerLabel,
     selected,
@@ -193,7 +245,9 @@ export function TaxonomicFilterMenu({
 }: TaxonomicFilterMenuProps): JSX.Element {
     const { groups, selectItem, inputProps, searchQuery, setSearchQuery, selectingKeyOnly, excludedOperators } =
         useTaxonomicFilterContext()
-    const [state, setState] = useState<MenuFilterState>({ kind: 'closed' })
+    const [state, setState] = useState<MenuFilterState>(() =>
+        resolveInitialMenuState(defaultOpen, defaultOpenState, selected ?? null)
+    )
 
     // Telemetry — track open dwell + commit funnel so we can compare
     // against legacy `taxonomic filter *` events. Stored in refs so the
@@ -271,48 +325,7 @@ export function TaxonomicFilterMenu({
         action()
     }, [])
 
-    /**
-     * Resolve the initial state when the trigger opens. If `selected` is
-     * set, jump straight into the panel that matches its group so the
-     * user lands on something editable (e.g. the HogQL editor pre-filled
-     * with the existing expression) instead of having to re-traverse the
-     * dropdown menu. With no selection we fall back to the menu.
-     */
-    const resolveOpenState = useCallback((): MenuFilterState => {
-        if (!selected) {
-            return { kind: 'menu' }
-        }
-        if (selected.group.type === TaxonomicFilterGroupType.HogQLExpression) {
-            return { kind: 'hogql-edit' }
-        }
-        if (selected.group.type === TaxonomicFilterGroupType.DataWarehouse) {
-            // origin='menu' so X / Esc / Cancel return to the dropdown
-            // menu rather than dropping the user into the (unscrolled)
-            // dwh-pick list they never visited.
-            return { kind: 'dwh-config', table: selected.item, group: selected.group, origin: 'menu' }
-        }
-        // Land on the regular combobox on the "All" scope. The committed selection
-        // floats to the first row (and stays highlighted) so the user can verify it
-        // at a glance, while still seeing recents/pinned and being able to search
-        // across every category.
-        return { kind: 'combobox', drillTo: 'all' }
-    }, [selected])
-
-    // Open on mount when the consumer lazily mounts this component in
-    // response to the user's first click (see `TaxonomicPopoverMenu`).
-    // Runs once — opening is a one-shot mount concern, not reactive.
-    useEffect(() => {
-        if (defaultOpen) {
-            setState(
-                defaultOpenState === 'combobox'
-                    ? { kind: 'combobox', drillTo: 'all' }
-                    : defaultOpenState === 'menu'
-                      ? { kind: 'menu' }
-                      : resolveOpenState()
-            )
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    const resolveOpenState = useCallback((): MenuFilterState => resolveSelectedOpenState(selected ?? null), [selected])
 
     // -- Recent / Pinned shortcuts -- read from kea so menu items reflect
     // the live counts. Mapped back to entries via source group.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -176,6 +176,11 @@ export function eventSelectionWasStale(
     return isDefinitionStale(item as unknown as EventDefinition)
 }
 
+/** The default combobox landing — the "All" scope, where recents/pinned lead and
+ *  the user can search across every category. The one home for this state so the
+ *  initial-mount and runtime open paths can't drift. */
+const comboboxAllState = (): MenuFilterState => ({ kind: 'combobox', drillTo: 'all' })
+
 /**
  * Resolve the panel a trigger open should land on from the current selection.
  * If `selected` is set, jump straight into the panel that matches its group so
@@ -183,7 +188,7 @@ export function eventSelectionWasStale(
  * the existing expression) instead of having to re-traverse the dropdown menu.
  * With no selection we fall back to the menu.
  */
-function resolveSelectedOpenState(selected: MenuFilterEntry | null): MenuFilterState {
+export function resolveSelectedOpenState(selected: MenuFilterEntry | null): MenuFilterState {
     if (!selected) {
         return { kind: 'menu' }
     }
@@ -196,11 +201,9 @@ function resolveSelectedOpenState(selected: MenuFilterEntry | null): MenuFilterS
         // visited.
         return { kind: 'dwh-config', table: selected.item, group: selected.group, origin: 'menu' }
     }
-    // Land on the regular combobox on the "All" scope. The committed selection
-    // floats to the first row (and stays highlighted) so the user can verify it
-    // at a glance, while still seeing recents/pinned and being able to search
-    // across every category.
-    return { kind: 'combobox', drillTo: 'all' }
+    // The committed selection floats to the first row (and stays highlighted) so
+    // the user can verify it at a glance.
+    return comboboxAllState()
 }
 
 /**
@@ -211,7 +214,7 @@ function resolveSelectedOpenState(selected: MenuFilterEntry | null): MenuFilterS
  * `defaultOpenState` routes the open to the panel matching the interaction (the
  * input trigger's search box -> combobox, its filter icon -> menu).
  */
-function resolveInitialMenuState(
+export function resolveInitialMenuState(
     defaultOpen: boolean,
     defaultOpenState: 'menu' | 'combobox' | undefined,
     selected: MenuFilterEntry | null
@@ -220,7 +223,7 @@ function resolveInitialMenuState(
         return { kind: 'closed' }
     }
     if (defaultOpenState === 'combobox') {
-        return { kind: 'combobox', drillTo: 'all' }
+        return comboboxAllState()
     }
     if (defaultOpenState === 'menu') {
         return { kind: 'menu' }


### PR DESCRIPTION
making the filter chrome wrap the input in insights was janky so...

## Problem

The rebuild taxonomic filter (behind `TAXONOMIC_FILTER_MENU_REBUILD`) renders insight property filtering with an input-style trigger: a replay-style search box where focusing the box is meant to make the filter chrome (the popover panel — header above, results below, border/background) appear to wrap around the existing input as it widens. Intended feel: one continuous input that the chrome grows around.

What actually happened: you click the box, the input/cursor visibly disappears, there's a noticeable beat, and then the chrome pops in. Janky instead of smooth.

The cause was a two-stage mount. The lazily-armed menu (`TaxonomicPopoverMenu` -> `ArmedTaxonomicPopoverMenu` -> `TaxonomicFilterMenu`) mounted in a `closed` state, painted a fresh, empty, unfocused input for one frame (the cursor visibly vanishes), and only on the *next* commit did a mount `useEffect` fire `setState({ kind: 'combobox' })` to flip the trigger to an invisible spacer and open the panel over it. That deferred-effect gap is the "input disappears, delay, chrome appears" sequence.

## Changes

Open synchronously via a lazy `useState` initializer instead of a post-mount `useEffect`, so the resting input is replaced directly by the open, focused panel in a single atomic React commit — no intermediate unfocused-input frame and no extra render cycle. Opening is expressed as what it is: a one-shot mount concern, not a reactive effect.

Also extracts the open-state resolution into two pure module-level helpers (`resolveSelectedOpenState`, `resolveInitialMenuState`) so the initial state and the runtime `resolveOpenState` callback share one definition instead of duplicating the branch logic.

Rebuild-only presentation change — the input-trigger overlay mechanic has no legacy equivalent, so no legacy/rebuild mirroring is needed. No ordering, promotion, group-definition, or telemetry-payload changes; the `taxonomic filter menu opened` / `taxonomic filter ...` events still fire identically (just one frame earlier).

Storybook surface to test: **Filters/Taxonomic Filter Gallery -> Rebuild Menu**, the right-hand "PropertyFilters — input trigger" cell. Click the resting search box — the chrome now appears immediately wrapping the input with the search field focused.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran locally:

- `jest --testPathPattern "TaxonomicFilter/menu|TaxonomicPopover"` — 57/57 pass, including the dedicated `*.inputTrigger.test.tsx` suites that assert focus-opens-combobox and the single-input / chrome-wraps invariant.
- `tsgo --noEmit` — no errors in the changed file.
- `pnpm --filter=@posthog/frontend format`.

I also ran the change in Storybook and rendered the Rebuild Menu gallery story to confirm the input-trigger cell opens the combobox chrome around the input. I did not run the full app end-to-end.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this work. Authored with PostHog Code (Opus 4.8). Invoked the repo `/modifying-taxonomic-filter` skill before touching the component, which front-loads the three-variant reality (legacy-control, legacy-pill, rebuild-menu) and the legacy/rebuild mirroring matrix — that's what confirmed this is a rebuild-only presentation concern needing no mirrored legacy edit.

Decision trail: traced the jank to the deferred mount `useEffect` rather than to CSS/positioning (there are no transitions involved; the overlay is pure Floating-UI positioning of the panel's own search field over the trigger row). Chose the lazy-initializer approach over keeping the input mounted across the arm boundary because it's the minimal, single-commit fix and preserves the existing telemetry and button-trigger paths unchanged. Noted but did not pre-implement a focus-continuity hardening step — flagged to confirm against the running app first.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
