### PR TITLE
chore: allow pushing to open PRs without human guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,9 @@ Pass the description straight to the `body` argument of the PR-creation tool (th
 
 ### Pushing to remote
 
-Pushes trigger CI, which burns runner credits. Refrain from pushing unless explicitly instructed or until the task is complete — batch local commits and push once at the end rather than after every change. If you're mid-task or iterating, keep work local.
+Don't open GitHub issues or pull requests without human instruction.
+Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
+Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 
 ### Public open source repo guidance
 


### PR DESCRIPTION
## Problem

The `AGENTS.md` "Pushing to remote" guidance told agents to refrain from pushing unless explicitly instructed or until a task was complete, and to keep work local while iterating. In practice that creates friction for the common, low-risk case: a branch that already has an open PR and just needs incremental fixes (review feedback, CI fixups). Agents end up asking for permission to push every small change to a PR a human already opened and is reviewing.

The thing we actually want to gate is the outward-facing, hard-to-reverse action — creating issues and PRs — not every subsequent push to a branch that's already under review.

## Changes

Reframes the "Pushing to remote" section:

- Agents must **not open GitHub issues or PRs without human instruction**.
- Once a branch **already has an open PR**, agents **can push incremental changes and fixes** to keep it current, without waiting for per-push approval.
- Keeps the CI-credit awareness: batch related commits and push when the increment is ready, not after every change.

Docs-only change to `AGENTS.md` (which `CLAUDE.md` symlinks to).

## How did you test this code?

I'm an agent (PostHog Code). This is a documentation-only change — no automated tests apply and none were run. The wording was reviewed for consistency with the surrounding commit/PR conventions in the same file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul D'Ambra directed this change directly, asking to remove the blanket "don't push without human control" instruction and replace it with a narrower boundary: don't open issues/PRs autonomously, but freely push incremental fixes to an already-open PR. No skills were invoked; this is a single-line edit to `AGENTS.md`. Assigned to Paul as DRI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
