### PR TITLE
fix(experiments): infer chart tooltip generic in VariantTimeseriesChart

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -1,4 +1,3 @@
-import { Chart, ChartType, TooltipModel } from 'lib/Chart'
 import { useChart } from 'lib/hooks/useChart'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 
@@ -90,7 +89,7 @@ export function VariantTimeseriesChart({
                         },
                         tooltip: {
                             enabled: false,
-                            external: ({ chart, tooltip }: { chart: Chart; tooltip: TooltipModel<ChartType> }) => {
+                            external: ({ chart, tooltip }) => {
                                 const canvas = chart.canvas
                                 if (!canvas) {
                                     return


### PR DESCRIPTION
## Problem

`Frontend typechecking` is currently broken on `master` (and every open PR that compiles against it) — it just isn't visible because the workflow only runs on PRs, not on master pushes.

`VariantTimeseriesChart` pins its chart config to `useChart<'line'>` (#64108), but the `plugins.tooltip.external` callback is annotated with the *wide* `{ chart: Chart; tooltip: TooltipModel<ChartType> }`. When `chart.js` was bumped to `4.5.1`, its generics became invariant enough that the wide annotation no longer satisfies the `'line'`-pinned config, so the whole `getConfig` return type fails to assign:

```
VariantTimeseriesChart.tsx(22,9): error TS2322: Type '() => { ... } | null' is not
assignable to type '() => ChartConfiguration<"line", (number | Point | null)[], unknown> | null'.
  The types of 'options.plugins.tooltip.external' are incompatible between these types.
```

#64108 passed CI when it merged because chart.js was still loose at the time; the 4.5.1 bump landed afterwards and silently broke it.

## Changes

Drop the explicit annotation on the `external` callback so `chart` and `tooltip` infer as `'line'` from the surrounding `useChart<'line'>` config. This removes the now-unused `Chart`, `ChartType`, and `TooltipModel` imports. No runtime behaviour change.

## How did you test this code?

I'm an agent (Claude Code), so I have not manually exercised the chart UI. Verification done:

- Reproduced the exact `TS2322` against the installed `chart.js@4.5.1` with a standalone `tsc` project, and confirmed the callback body type-checks once the params infer as `'line'`.
- `oxlint` clean on the changed file; `bin/hogli format:js` (lint-staged) ran on commit.
- Full `kea-typegen` + `tsgo` could not run in my sandbox (kea-typegen is Electron-based and blocked), so the authoritative check is this PR's `Frontend typechecking` job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced while investigating a red `Frontend typechecking` check on an unrelated gateway PR. Traced the single error to this pre-existing `master` break (chart.js 4.5.1 vs the `useChart<'line'>` pin from #64108), rather than to the gateway PR's changes. Split the fix into this standalone PR so it lands for everyone instead of riding along in unrelated work. Considered narrowing `ProcessedChartData.datasets` instead, but the real incompatibility is the wide tooltip-callback annotation, so removing it (letting inference do the work) is the minimal correct fix. Tool: Claude Code.