### PR TITLE
fix(cymbal): run local resolution process on the cymbal binary

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -125,8 +125,10 @@ case "$RS_SVC" in
     # output is still noisy. Unconditional export — flox activate exports its
     # own RUST_LOG, so a conditional default would silently inherit that and
     # match no cymbal modules.
-    export RUST_LOG=info,cymbal=debug,cymbal_resolution=debug,cymbal_proto=debug,rdkafka=warn
+    export RUST_LOG=info,cymbal=debug,cymbal_proto=debug,rdkafka=warn
     export RUST_BACKTRACE=1
+    # Default mode, but set explicitly now that cymbal is multi-mode.
+    export CYMBAL_MODE=processing
     export OBJECT_STORAGE_BUCKET=posthog
     export FRAME_CACHE_TTL_SECONDS=1
     export FRAME_RESULT_TTL_MINUTES=0
@@ -157,15 +159,16 @@ case "$RS_SVC" in
     ;;
 
   cymbal-resolution)
-    # Symbol-resolution service that cymbal offloads to via cymbal.resolution.v1.
-    # Uses cymbal::app_context::build_symbol_resolver which only connects to
-    # Postgres and S3 — NOT Kafka, NOT Redis, NOT signals. That's why this
-    # block is so much narrower than the cymbal block: anything cymbal needs
-    # for the fingerprinting / issue path is genuinely irrelevant here.
+    # The cymbal binary in resolution mode (gRPC symbol-resolution service that
+    # cymbal offloads to). Resolution mode only needs Postgres and S3 — no
+    # Kafka/Redis/signals — hence the narrower env than the cymbal block.
+    export CYMBAL_MODE=resolution
+    # Run the `cymbal` binary; mode is selected via CYMBAL_MODE above.
+    export DEV_RUST_SVC_OVERRIDE=cymbal
     # Only cymbal crates at debug; everything else at info. Unconditional
     # export — flox activate exports its own RUST_LOG, so a conditional
     # default would silently inherit that and match no cymbal modules.
-    export RUST_LOG=info,cymbal=debug,cymbal_resolution=debug,cymbal_proto=debug,rdkafka=warn
+    export RUST_LOG=info,cymbal=debug,cymbal_proto=debug,rdkafka=warn
     export RUST_BACKTRACE=1
     # S3 / MinIO bucket for symbol-file fetches.
     export OBJECT_STORAGE_BUCKET=posthog


### PR DESCRIPTION
## Problem

[#64567](https://github.com/PostHog/posthog/pull/64567) folded the `cymbal-resolution` crate into `cymbal` as a run mode (`CYMBAL_MODE=resolution`) and deleted the standalone binary. But `bin/start-rust-service` still ran `cargo run --bin cymbal-resolution` for the local `cymbal-resolution` process — which now fails (no such binary), breaking the local error-tracking stack.

## Changes

`bin/start-rust-service`, `cymbal-resolution)` case:
- `export DEV_RUST_SVC_OVERRIDE=cymbal` so it runs `cargo run --bin cymbal` (the same override pattern `capture-replay` / `capture-ai` already use to run the `capture` binary in a different mode).
- `export CYMBAL_MODE=resolution` to select the gRPC service stack.

Also set `CYMBAL_MODE=processing` explicitly on the `cymbal)` case (it's the default, but clearer now that cymbal is multi-mode), and dropped the dead `cymbal_resolution=debug` `RUST_LOG` directive from both cases — that crate no longer exists; the resolution code lives in the `cymbal` crate, covered by `cymbal=debug`.

Net local stack (both processes kept, just repointed at the one binary):
- `cymbal` proc → `cymbal` binary, processing mode, HTTP `:3302`, offloads to `127.0.0.1:50061`
- `cymbal-resolution` proc → `cymbal` binary, resolution mode, gRPC `:50061`, metrics `:9106`

`bin/mprocs.yaml` is unchanged — it still launches both procs; the binary/mode switch happens inside `start-rust-service`. The existing `ready_pattern`s still match the new binary's logs.

## How did you test this code?

I'm an agent (Claude Code). I verified by inspection + `bash -n bin/start-rust-service` (passes), and confirmed `hogli dev:setup` resolves `error_symbolication` to both procs and emits their `shell:` commands verbatim — so it inherits this fix with no change needed (intent-map.yaml has no cymbal references; the unit mapping is the `capability:` tags in `bin/mprocs.yaml`). I did **not** boot the full stack — resolution mode needs Postgres + object storage up to get past `build_symbol_resolver`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #64567, which I authored. This is a one-file dev-tooling fix; no repo skills applied. The non-obvious bit reviewers should sanity-check: `DEV_RUST_SVC_OVERRIDE=cymbal` causes `RS_SVC` to be rewritten to `cymbal` before `cargo run --bin "$RS_SVC"`, so the `cymbal-resolution` mprocs entry boots the `cymbal` binary in resolution mode.
