### PR TITLE
feat(logs): wire facets to cross-filtered counts endpoint

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -7,12 +7,12 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 import { LogSeverityLevel } from '~/queries/schema/schema-general'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
-import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { serviceFilterLogic } from 'products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic'
 import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 
 import { Facet, FacetOption } from './Facet'
+import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
 
 const DEFAULT_WIDTH_PX = 240
@@ -39,11 +39,11 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
     const { severityLevels, serviceNames, utcDateRange } = useValues(logsViewerFiltersLogic)
-    const { severityTotals } = useValues(logsViewerDataLogic)
+    const { levelCounts, serviceCounts } = useValues(facetCountsLogic({ id }))
     const { collapsedFacets } = useValues(facetRailLogic({ id }))
     const { toggleSeverityLevel, toggleServiceName, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
 
-    const levelOptions = SEVERITY_OPTIONS.map((option) => ({ ...option, count: severityTotals?.[option.value] }))
+    const levelOptions = SEVERITY_OPTIONS.map((option) => ({ ...option, count: levelCounts[option.value] }))
 
     const onToggleClosed = useCallback(
         (shouldBeClosed: boolean) => setFacetRailCollapsed(shouldBeClosed),
@@ -90,6 +90,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                     <ServiceFacet
                         selected={serviceNames ?? []}
                         onToggle={toggleServiceName}
+                        counts={serviceCounts}
                         collapsed={collapsedFacets.includes('service')}
                         onToggleCollapsed={() => toggleFacetCollapsed('service')}
                     />
@@ -103,18 +104,20 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
 function ServiceFacet({
     selected,
     onToggle,
+    counts,
     collapsed,
     onToggleCollapsed,
 }: {
     selected: string[]
     onToggle: (name: string) => void
+    counts: Record<string, number>
     collapsed: boolean
     onToggleCollapsed: () => void
 }): JSX.Element {
-    const { serviceValues, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
+    const { serviceNames, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
     const { setSearch } = useActions(serviceFilterLogic)
 
-    const options: FacetOption[] = serviceValues.map((s) => ({ value: s.name, label: s.name, count: s.count }))
+    const options: FacetOption[] = serviceNames.map((name) => ({ value: name, label: name, count: counts[name] }))
 
     return (
         <Facet

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -1,0 +1,105 @@
+import { connect, kea, key, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { UniversalFiltersGroup } from '~/types'
+
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+
+import { logsFacetValuesCreate } from '../../../generated/api'
+import { _LogFacetValueApi, _LogPropertyFilterApi } from '../../../generated/api.schemas'
+import type { facetCountsLogicType } from './facetCountsLogicType'
+
+export interface FacetCountsLogicProps {
+    id: string
+}
+
+type FacetField = 'severity_text' | 'service_name'
+
+function toCountMap(results: _LogFacetValueApi[]): Record<string, number> {
+    return Object.fromEntries(results.map((r) => [r.value, r.count]))
+}
+
+/**
+ * Per-facet value counts, cross-filtered server-side: each facet's counts reflect every active
+ * filter except its own selection. Refetches whenever the filters change.
+ */
+export const facetCountsLogic = kea<facetCountsLogicType>([
+    props({ id: 'default' } as FacetCountsLogicProps),
+    key((props) => props.id),
+    path((key) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'FacetRail', 'facetCountsLogic', key]),
+
+    connect((props: FacetCountsLogicProps) => ({
+        values: [
+            logsViewerFiltersLogic({ id: props.id }),
+            ['filters', 'utcDateRange', 'queryFilterGroup'],
+            teamLogic,
+            ['currentTeamId'],
+        ],
+    })),
+
+    loaders(({ values }) => {
+        const fetchCounts = async (facetField: FacetField): Promise<Record<string, number>> => {
+            if (!values.currentTeamId) {
+                return {}
+            }
+            const group = values.queryFilterGroup as UniversalFiltersGroup
+            const filterGroup = ((group?.values?.[0] as UniversalFiltersGroup | undefined)?.values ??
+                []) as unknown as _LogPropertyFilterApi[]
+            const response = await logsFacetValuesCreate(String(values.currentTeamId), {
+                query: {
+                    facetField,
+                    dateRange: values.utcDateRange,
+                    severityLevels: values.filters.severityLevels ?? [],
+                    serviceNames: values.filters.serviceNames ?? [],
+                    searchTerm: values.filters.searchTerm || undefined,
+                    filterGroup,
+                },
+            })
+            return toCountMap(response.results)
+        }
+
+        return {
+            levelCounts: [
+                {} as Record<string, number>,
+                {
+                    loadLevelCounts: async (_: null, breakpoint) => {
+                        await breakpoint(300)
+                        const counts = await fetchCounts('severity_text')
+                        breakpoint()
+                        return counts
+                    },
+                },
+            ],
+            serviceCounts: [
+                {} as Record<string, number>,
+                {
+                    loadServiceCounts: async (_: null, breakpoint) => {
+                        await breakpoint(300)
+                        const counts = await fetchCounts('service_name')
+                        breakpoint()
+                        return counts
+                    },
+                },
+            ],
+        }
+    }),
+
+    subscriptions(({ actions }) => {
+        // Fires on mount (initial load) and on any change. We watch both `filters` (severity,
+        // service, search, date, user filterGroup) and `queryFilterGroup` (which folds in
+        // pinnedFilters, e.g. the person-tab distinct_id pin) so counts re-fetch when the pinned
+        // scope changes too. `filterGroup` feeds both, so a normal edit fires both — the 300ms
+        // debounce in each loader collapses that into one request.
+        const reload = (): void => {
+            actions.loadLevelCounts(null)
+            actions.loadServiceCounts(null)
+        }
+        return {
+            filters: reload,
+            queryFilterGroup: reload,
+        }
+    }),
+])

--- a/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic.ts
@@ -13,11 +13,6 @@ export interface ServiceFilterLogicProps {
     dateRange?: DateRange
 }
 
-export interface ServiceValue {
-    name: string
-    count?: number
-}
-
 export const serviceFilterLogic = kea<serviceFilterLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'Filters', 'serviceFilterLogic']),
     props({} as ServiceFilterLogicProps),
@@ -37,7 +32,7 @@ export const serviceFilterLogic = kea<serviceFilterLogicType>([
 
     loaders(({ values, props: logicProps }) => ({
         allServiceNames: [
-            [] as ServiceValue[],
+            [] as string[],
             {
                 loadServiceNames: async () => {
                     const url = combineUrl(`api/environments/${values.currentTeamId}/logs/values`, {
@@ -49,17 +44,14 @@ export const serviceFilterLogic = kea<serviceFilterLogicType>([
                     }).url
                     // nosemgrep: prefer-codegen-api
                     const response = await api.get(url)
-                    return (response.results ?? []) as ServiceValue[]
+                    return ((response.results ?? []) as { name: string }[]).map((r) => r.name)
                 },
             },
         ],
     })),
 
     selectors({
-        // Names only — kept for the legacy ServiceFilter dropdown (flag off).
-        serviceNames: [(s) => [s.allServiceNames], (allServiceNames): string[] => allServiceNames.map((r) => r.name)],
-        // Name + count — used by the facet rail to show per-value counts.
-        serviceValues: [(s) => [s.allServiceNames], (allServiceNames): ServiceValue[] => allServiceNames],
+        serviceNames: [(s) => [s.allServiceNames], (allServiceNames): string[] => allServiceNames],
     }),
 
     listeners(({ actions }) => ({

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -481,26 +481,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             (s) => [s.sparkline],
             (sparkline): number => sparkline?.reduce((sum: number, item: any) => sum + item.count, 0) ?? 0,
         ],
-        // Per-severity totals for the facet rail's Level counts, summed from the already-loaded
-        // sparkline. Only available when the sparkline is broken down by severity (the default);
-        // returns null otherwise so the Level facet just omits counts rather than showing wrong ones.
-        severityTotals: [
-            (s) => [s.sparkline, s.sparklineBreakdownBy],
-            (
-                sparkline: any[] | null,
-                sparklineBreakdownBy: LogsSparklineBreakdownBy
-            ): Record<string, number> | null => {
-                if (!sparkline || sparklineBreakdownBy !== 'severity') {
-                    return null
-                }
-                return sparkline.reduce((acc: Record<string, number>, row: any) => {
-                    if (row.severity) {
-                        acc[row.severity] = (acc[row.severity] ?? 0) + row.count
-                    }
-                    return acc
-                }, {})
-            },
-        ],
         logsRemainingToLoad: [
             (s) => [s.totalLogsMatchingFilters, s.logs],
             (totalLogsMatchingFilters, logs): number => totalLogsMatchingFilters - logs.length,


### PR DESCRIPTION
## Problem

Facet rail counts for severity levels were derived by summing the already-loaded sparkline data, which only worked when the sparkline was broken down by severity and produced no counts for services at all. This meant service facet counts were missing entirely, and level counts would silently show nothing if the breakdown changed.

## Changes

Introduces `facetCountsLogic`, a dedicated logic that fetches per-value counts for both `severity_text` and `service_name` directly from the server via the `logsFacetValuesCreate` API. Counts are cross-filtered: each facet's counts reflect all active filters except its own selection. The logic subscribes to filter changes and debounces refetches by 300 ms.

`serviceFilterLogic` is simplified — the `ServiceValue` type (which bundled name + count together) is removed, and `allServiceNames` now stores plain strings. The `serviceValues` selector is dropped; counts are sourced exclusively from `facetCountsLogic` and passed into `ServiceFacet` as a `counts` prop.

The `severityTotals` selector in `logsViewerDataLogic` is removed since counts are now fetched independently.

## How did you test this code?

This PR was agent-assisted. Automated type-checking and existing unit tests were relied upon for verification. No manual testing was performed by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Refactored facet count sourcing from a sparkline-derived selector to a dedicated server-side fetch logic.
- Decided to use `kea-subscriptions` on `filters` to trigger reloads rather than wiring individual filter selectors, keeping the subscription surface minimal.
- Chose to pass `counts` as a prop to `ServiceFacet` rather than having it reach into `facetCountsLogic` directly, keeping the component's data dependencies explicit.