### PR TITLE
feat(signals): surface a banner when inbox filters are active

### DIFF
--- a/frontend/src/scenes/inbox/InboxScene.stories.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { waitFor } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
 import { mswDecorator } from '~/mocks/browser'
 
 import {
@@ -70,4 +73,25 @@ export const Empty: Story = {
             },
         }),
     ],
+}
+
+// The active-filters banner shown above the list when a filter is set. Driven via the search input
+// because `searchQuery` is the one filter that isn't persisted to localStorage, so it can't leak into
+// the other stories' snapshots the way a persisted source/priority filter would.
+export const ActiveFiltersBanner: Story = {
+    play: async () => {
+        const searchInput = await waitFor(() => {
+            const el = document.querySelector<HTMLInputElement>('input[placeholder^="Search by title"]')
+            if (!el) {
+                throw new Error('Inbox search input not found')
+            }
+            return el
+        })
+        await userEvent.type(searchInput, 'checkout')
+        await waitFor(() => {
+            if (!document.body.textContent?.includes('some reports may be hidden')) {
+                throw new Error('Active-filters banner did not render')
+            }
+        })
+    },
 }

--- a/frontend/src/scenes/inbox/InboxScene.stories.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.stories.tsx
@@ -1,8 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { waitFor } from '@testing-library/dom'
-import userEvent from '@testing-library/user-event'
-
 import { mswDecorator } from '~/mocks/browser'
 
 import {
@@ -73,25 +70,4 @@ export const Empty: Story = {
             },
         }),
     ],
-}
-
-// The active-filters banner shown above the list when a filter is set. Driven via the search input
-// because `searchQuery` is the one filter that isn't persisted to localStorage, so it can't leak into
-// the other stories' snapshots the way a persisted source/priority filter would.
-export const ActiveFiltersBanner: Story = {
-    play: async () => {
-        const searchInput = await waitFor(() => {
-            const el = document.querySelector<HTMLInputElement>('input[placeholder^="Search by title"]')
-            if (!el) {
-                throw new Error('Inbox search input not found')
-            }
-            return el
-        })
-        await userEvent.type(searchInput, 'checkout')
-        await waitFor(() => {
-            if (!document.body.textContent?.includes('some reports may be hidden')) {
-                throw new Error('Active-filters banner did not render')
-            }
-        })
-    },
 }

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -50,7 +50,7 @@ function ActiveFiltersBanner(): JSX.Element | null {
 
     return (
         <LemonBanner type="info" action={{ children: 'Clear', onClick: () => clearFilters() }}>
-            Filters are applied - some reports may be hidden.
+            Filters are applied – some reports may be hidden.
         </LemonBanner>
     )
 }

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -50,7 +50,7 @@ function ActiveFiltersBanner(): JSX.Element | null {
 
     return (
         <LemonBanner type="info" action={{ children: 'Clear', onClick: () => clearFilters() }}>
-            Filters are applied — some reports may be hidden.
+            Filters are applied - some reports may be hidden.
         </LemonBanner>
     )
 }

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -1,6 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { ComponentType, JSX, useEffect, useRef } from 'react'
 
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { inboxFiltersLogic } from '../logics/inboxFiltersLogic'
 import { reportListLogic, ReportListLogicProps } from '../logics/reportListLogic'
 import { InboxFlatListTabKey, SignalReport } from '../types'
 import { DismissalReasonValue } from '../utils/dismissalReasons'
@@ -33,6 +36,22 @@ export function InboxReportList(props: InboxReportListProps): JSX.Element {
         <BindLogic logic={reportListLogic} props={{ tabKey: props.tabKey, listParams: props.listParams }}>
             <InboxReportListInner {...props} />
         </BindLogic>
+    )
+}
+
+/** Sleek reminder that the list is filtered, with a one-click reset. Renders nothing when no filter is active. */
+function ActiveFiltersBanner(): JSX.Element | null {
+    const { hasActiveFilters } = useValues(inboxFiltersLogic)
+    const { clearFilters } = useActions(inboxFiltersLogic)
+
+    if (!hasActiveFilters) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info" action={{ children: 'Clear', onClick: () => clearFilters() }}>
+            Filters are applied — some reports may be hidden.
+        </LemonBanner>
     )
 }
 
@@ -76,6 +95,7 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     return (
         <div className="@container mx-auto max-w-4xl flex flex-col gap-4 px-6 py-4">
             <InboxSearchFilterBar onRefresh={() => refresh()} refreshing={reportsResponseLoading} />
+            <ActiveFiltersBanner />
             <InboxBulkSelectionBar />
 
             {showSkeleton ? (

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -53,54 +53,16 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
     return field === 'updated_at' ? `${fieldKey},status` : `${fieldKey},status,-updated_at`
 }
 
-/** The subset of filter state we mirror into sessionStorage. `searchQuery` is intentionally excluded. */
-export interface InboxStoredFilters {
-    scope: InboxScope
-    sortField: InboxSortField
-    sortDirection: InboxSortDirection
-    sourceProductFilter: string[]
-    priorityFilter: SignalReportPriority[]
-}
-
 /**
- * Inbox filter state, backed by `sessionStorage` (not `localStorage`). Filters
- * survive in-session reloads but reset when the tab — or, in the desktop app, the
- * window — closes. Persisting them across sessions was confusing: an empty inbox
- * left by a forgotten filter looked broken (PostHog papercut).
- *
- * State covered: `scope` (default "for-you"), `sortField`/`sortDirection` (default
- * priority/asc), `sourceProductFilter`, `priorityFilter`. `searchQuery` is never
- * stored.
- *
- * Hydration runs in `afterMount` (not in the reducer defaults) so the current
- * sessionStorage values are re-read on every mount — including when the logic
- * unmounts and remounts on SPA navigation back into the inbox. Writes happen only
- * on user-initiated filter actions (listeners below), never on mount, so a remount
- * can't clobber storage with stale defaults before hydration has run.
+ * Persisted inbox filter state. Mirrors desktop's zustand stores:
+ * - `inboxReviewerScopeStore` → `scope` (persisted, default "for-you")
+ * - `inboxSignalsFilterStore` v2 → `sortField`/`sortDirection` (default priority/asc),
+ *   `sourceProductFilter`, `priorityFilter` (all persisted). `searchQuery` is NOT
+ *   persisted on desktop, so it isn't here either.
  *
  * The central `inboxSceneLogic` connects these values, maps them to list-API
  * params (`source_product`, `priority`, `ordering`), and reloads on change.
  */
-const SESSION_STORAGE_PREFIX = 'posthog.inboxFilters'
-
-function readSessionFilter<T>(key: string, fallback: T): T {
-    try {
-        const raw = window.sessionStorage?.getItem(`${SESSION_STORAGE_PREFIX}.${key}`)
-        return raw != null ? (JSON.parse(raw) as T) : fallback
-    } catch {
-        // sessionStorage unavailable (private mode / restricted) or malformed JSON — fall back to default.
-        return fallback
-    }
-}
-
-function writeSessionFilter(key: string, value: unknown): void {
-    try {
-        window.sessionStorage?.setItem(`${SESSION_STORAGE_PREFIX}.${key}`, JSON.stringify(value))
-    } catch {
-        // sessionStorage unavailable — filters just won't survive a reload, which is acceptable.
-    }
-}
-
 export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
     path(['scenes', 'inbox', 'logics', 'inboxFiltersLogic']),
 
@@ -111,8 +73,6 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         toggleSourceProduct: (source: string) => ({ source }),
         togglePriority: (priority: SignalReportPriority) => ({ priority }),
         clearFilters: true,
-        // Restore all stored filters at once on mount (hydration from sessionStorage).
-        restoreFilters: (filters: InboxStoredFilters) => ({ filters }),
         // Debounced server-side org-member search for the scope (teammate) picker.
         searchAvailableReviewers: (query: string) => ({ query }),
     }),
@@ -131,35 +91,22 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         searchAvailableReviewers: async ({ query }, breakpoint) => {
             await breakpoint(300)
             actions.loadAvailableReviewers({ query: query.trim() || undefined })
-        },
-        // Write back to sessionStorage only on user-initiated changes (listeners run after the reducer,
-        // so `values` already reflect the new state). Mount-time hydration never triggers these.
-        setScope: () => writeSessionFilter('scope', values.scope),
-        setSort: () => {
-            writeSessionFilter('sortField', values.sortField)
-            writeSessionFilter('sortDirection', values.sortDirection)
-        },
-        toggleSourceProduct: () => writeSessionFilter('sourceProductFilter', values.sourceProductFilter),
-        togglePriority: () => writeSessionFilter('priorityFilter', values.priorityFilter),
-        clearFilters: () => {
-            writeSessionFilter('sourceProductFilter', values.sourceProductFilter)
-            writeSessionFilter('priorityFilter', values.priorityFilter)
         },
     })),
 
     reducers({
         scope: [
             INBOX_SCOPE_FOR_YOU as InboxScope,
+            { persist: true },
             {
                 setScope: (_, { scope }) => scope,
-                restoreFilters: (_, { filters }) => filters.scope,
             },
         ],
-        // Never stored — matches desktop (searchQuery is excluded from `partialize`).
+        // Not persisted – matches desktop (searchQuery is excluded from `partialize`).
         searchQuery: [
             '',
             {
@@ -169,47 +116,49 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         ],
         sortField: [
             'priority' as InboxSortField,
+            { persist: true },
             {
                 setSort: (_, { field }) => field,
-                restoreFilters: (_, { filters }) => filters.sortField,
             },
         ],
         sortDirection: [
             'asc' as InboxSortDirection,
+            { persist: true },
             {
                 setSort: (_, { direction }) => direction,
-                restoreFilters: (_, { filters }) => filters.sortDirection,
             },
         ],
         sourceProductFilter: [
             [] as string[],
+            { persist: true },
             {
                 toggleSourceProduct: (state, { source }) =>
                     state.includes(source) ? state.filter((s) => s !== source) : [...state, source],
                 clearFilters: () => [],
-                restoreFilters: (_, { filters }) => filters.sourceProductFilter,
             },
         ],
         priorityFilter: [
             [] as SignalReportPriority[],
+            { persist: true },
             {
                 togglePriority: (state, { priority }) =>
                     state.includes(priority) ? state.filter((p) => p !== priority) : [...state, priority],
                 clearFilters: () => [],
-                restoreFilters: (_, { filters }) => filters.priorityFilter,
             },
+        ],
+    }),
+
+    selectors({
+        // Whether any list-narrowing filter is active. Scope and sort are excluded: they don't hide
+        // reports the way search/source/priority do, and `clearFilters` leaves them untouched.
+        hasActiveFilters: [
+            (s) => [s.searchQuery, s.sourceProductFilter, s.priorityFilter],
+            (searchQuery, sourceProductFilter, priorityFilter): boolean =>
+                searchQuery.trim().length > 0 || sourceProductFilter.length > 0 || priorityFilter.length > 0,
         ],
     }),
 
     afterMount(({ actions }) => {
         actions.loadAvailableReviewers()
-        // Re-read sessionStorage on every mount so SPA nav back into the inbox restores the latest filters.
-        actions.restoreFilters({
-            scope: readSessionFilter<InboxScope>('scope', INBOX_SCOPE_FOR_YOU),
-            sortField: readSessionFilter<InboxSortField>('sortField', 'priority'),
-            sortDirection: readSessionFilter<InboxSortDirection>('sortDirection', 'asc'),
-            sourceProductFilter: readSessionFilter<string[]>('sourceProductFilter', []),
-            priorityFilter: readSessionFilter<SignalReportPriority[]>('priorityFilter', []),
-        })
     }),
 ])

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -54,7 +54,7 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
 }
 
 /** The subset of filter state we mirror into sessionStorage. `searchQuery` is intentionally excluded. */
-interface InboxStoredFilters {
+export interface InboxStoredFilters {
     scope: InboxScope
     sortField: InboxSortField
     sortDirection: InboxSortDirection

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -1,6 +1,5 @@
 import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
-import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 
@@ -54,6 +53,15 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
     return field === 'updated_at' ? `${fieldKey},status` : `${fieldKey},status,-updated_at`
 }
 
+/** The subset of filter state we mirror into sessionStorage. `searchQuery` is intentionally excluded. */
+interface InboxStoredFilters {
+    scope: InboxScope
+    sortField: InboxSortField
+    sortDirection: InboxSortDirection
+    sourceProductFilter: string[]
+    priorityFilter: SignalReportPriority[]
+}
+
 /**
  * Inbox filter state, backed by `sessionStorage` (not `localStorage`). Filters
  * survive in-session reloads but reset when the tab — or, in the desktop app, the
@@ -62,8 +70,13 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
  *
  * State covered: `scope` (default "for-you"), `sortField`/`sortDirection` (default
  * priority/asc), `sourceProductFilter`, `priorityFilter`. `searchQuery` is never
- * stored. Defaults hydrate from `sessionStorage` at build time; a subscription
- * writes each value back on change (see below).
+ * stored.
+ *
+ * Hydration runs in `afterMount` (not in the reducer defaults) so the current
+ * sessionStorage values are re-read on every mount — including when the logic
+ * unmounts and remounts on SPA navigation back into the inbox. Writes happen only
+ * on user-initiated filter actions (listeners below), never on mount, so a remount
+ * can't clobber storage with stale defaults before hydration has run.
  *
  * The central `inboxSceneLogic` connects these values, maps them to list-API
  * params (`source_product`, `priority`, `ordering`), and reloads on change.
@@ -98,6 +111,8 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         toggleSourceProduct: (source: string) => ({ source }),
         togglePriority: (priority: SignalReportPriority) => ({ priority }),
         clearFilters: true,
+        // Restore all stored filters at once on mount (hydration from sessionStorage).
+        restoreFilters: (filters: InboxStoredFilters) => ({ filters }),
         // Debounced server-side org-member search for the scope (teammate) picker.
         searchAvailableReviewers: (query: string) => ({ query }),
     }),
@@ -116,18 +131,32 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         ],
     }),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         searchAvailableReviewers: async ({ query }, breakpoint) => {
             await breakpoint(300)
             actions.loadAvailableReviewers({ query: query.trim() || undefined })
+        },
+        // Write back to sessionStorage only on user-initiated changes (listeners run after the reducer,
+        // so `values` already reflect the new state). Mount-time hydration never triggers these.
+        setScope: () => writeSessionFilter('scope', values.scope),
+        setSort: () => {
+            writeSessionFilter('sortField', values.sortField)
+            writeSessionFilter('sortDirection', values.sortDirection)
+        },
+        toggleSourceProduct: () => writeSessionFilter('sourceProductFilter', values.sourceProductFilter),
+        togglePriority: () => writeSessionFilter('priorityFilter', values.priorityFilter),
+        clearFilters: () => {
+            writeSessionFilter('sourceProductFilter', values.sourceProductFilter)
+            writeSessionFilter('priorityFilter', values.priorityFilter)
         },
     })),
 
     reducers({
         scope: [
-            readSessionFilter<InboxScope>('scope', INBOX_SCOPE_FOR_YOU),
+            INBOX_SCOPE_FOR_YOU as InboxScope,
             {
                 setScope: (_, { scope }) => scope,
+                restoreFilters: (_, { filters }) => filters.scope,
             },
         ],
         // Never stored — matches desktop (searchQuery is excluded from `partialize`).
@@ -139,47 +168,48 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             },
         ],
         sortField: [
-            readSessionFilter<InboxSortField>('sortField', 'priority'),
+            'priority' as InboxSortField,
             {
                 setSort: (_, { field }) => field,
+                restoreFilters: (_, { filters }) => filters.sortField,
             },
         ],
         sortDirection: [
-            readSessionFilter<InboxSortDirection>('sortDirection', 'asc'),
+            'asc' as InboxSortDirection,
             {
                 setSort: (_, { direction }) => direction,
+                restoreFilters: (_, { filters }) => filters.sortDirection,
             },
         ],
         sourceProductFilter: [
-            readSessionFilter<string[]>('sourceProductFilter', []),
+            [] as string[],
             {
                 toggleSourceProduct: (state, { source }) =>
                     state.includes(source) ? state.filter((s) => s !== source) : [...state, source],
                 clearFilters: () => [],
+                restoreFilters: (_, { filters }) => filters.sourceProductFilter,
             },
         ],
         priorityFilter: [
-            readSessionFilter<SignalReportPriority[]>('priorityFilter', []),
+            [] as SignalReportPriority[],
             {
                 togglePriority: (state, { priority }) =>
                     state.includes(priority) ? state.filter((p) => p !== priority) : [...state, priority],
                 clearFilters: () => [],
+                restoreFilters: (_, { filters }) => filters.priorityFilter,
             },
         ],
     }),
 
-    // Mirror each filter into sessionStorage so it survives in-session reloads but resets on tab/window close.
-    subscriptions(() => ({
-        scope: (scope: InboxScope) => writeSessionFilter('scope', scope),
-        sortField: (sortField: InboxSortField) => writeSessionFilter('sortField', sortField),
-        sortDirection: (sortDirection: InboxSortDirection) => writeSessionFilter('sortDirection', sortDirection),
-        sourceProductFilter: (sourceProductFilter: string[]) =>
-            writeSessionFilter('sourceProductFilter', sourceProductFilter),
-        priorityFilter: (priorityFilter: SignalReportPriority[]) =>
-            writeSessionFilter('priorityFilter', priorityFilter),
-    })),
-
     afterMount(({ actions }) => {
         actions.loadAvailableReviewers()
+        // Re-read sessionStorage on every mount so SPA nav back into the inbox restores the latest filters.
+        actions.restoreFilters({
+            scope: readSessionFilter<InboxScope>('scope', INBOX_SCOPE_FOR_YOU),
+            sortField: readSessionFilter<InboxSortField>('sortField', 'priority'),
+            sortDirection: readSessionFilter<InboxSortDirection>('sortDirection', 'asc'),
+            sourceProductFilter: readSessionFilter<string[]>('sourceProductFilter', []),
+            priorityFilter: readSessionFilter<SignalReportPriority[]>('priorityFilter', []),
+        })
     }),
 ])

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -1,5 +1,6 @@
 import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 
@@ -54,15 +55,39 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
 }
 
 /**
- * Persisted inbox filter state. Mirrors desktop's zustand stores:
- * - `inboxReviewerScopeStore` → `scope` (persisted, default "for-you")
- * - `inboxSignalsFilterStore` v2 → `sortField`/`sortDirection` (default priority/asc),
- *   `sourceProductFilter`, `priorityFilter` (all persisted). `searchQuery` is NOT
- *   persisted on desktop, so it isn't here either.
+ * Inbox filter state, backed by `sessionStorage` (not `localStorage`). Filters
+ * survive in-session reloads but reset when the tab — or, in the desktop app, the
+ * window — closes. Persisting them across sessions was confusing: an empty inbox
+ * left by a forgotten filter looked broken (PostHog papercut).
+ *
+ * State covered: `scope` (default "for-you"), `sortField`/`sortDirection` (default
+ * priority/asc), `sourceProductFilter`, `priorityFilter`. `searchQuery` is never
+ * stored. Defaults hydrate from `sessionStorage` at build time; a subscription
+ * writes each value back on change (see below).
  *
  * The central `inboxSceneLogic` connects these values, maps them to list-API
  * params (`source_product`, `priority`, `ordering`), and reloads on change.
  */
+const SESSION_STORAGE_PREFIX = 'posthog.inboxFilters'
+
+function readSessionFilter<T>(key: string, fallback: T): T {
+    try {
+        const raw = window.sessionStorage?.getItem(`${SESSION_STORAGE_PREFIX}.${key}`)
+        return raw != null ? (JSON.parse(raw) as T) : fallback
+    } catch {
+        // sessionStorage unavailable (private mode / restricted) or malformed JSON — fall back to default.
+        return fallback
+    }
+}
+
+function writeSessionFilter(key: string, value: unknown): void {
+    try {
+        window.sessionStorage?.setItem(`${SESSION_STORAGE_PREFIX}.${key}`, JSON.stringify(value))
+    } catch {
+        // sessionStorage unavailable — filters just won't survive a reload, which is acceptable.
+    }
+}
+
 export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
     path(['scenes', 'inbox', 'logics', 'inboxFiltersLogic']),
 
@@ -100,13 +125,12 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
 
     reducers({
         scope: [
-            INBOX_SCOPE_FOR_YOU as InboxScope,
-            { persist: true },
+            readSessionFilter<InboxScope>('scope', INBOX_SCOPE_FOR_YOU),
             {
                 setScope: (_, { scope }) => scope,
             },
         ],
-        // Not persisted – matches desktop (searchQuery is excluded from `partialize`).
+        // Never stored — matches desktop (searchQuery is excluded from `partialize`).
         searchQuery: [
             '',
             {
@@ -115,22 +139,19 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             },
         ],
         sortField: [
-            'priority' as InboxSortField,
-            { persist: true },
+            readSessionFilter<InboxSortField>('sortField', 'priority'),
             {
                 setSort: (_, { field }) => field,
             },
         ],
         sortDirection: [
-            'asc' as InboxSortDirection,
-            { persist: true },
+            readSessionFilter<InboxSortDirection>('sortDirection', 'asc'),
             {
                 setSort: (_, { direction }) => direction,
             },
         ],
         sourceProductFilter: [
-            [] as string[],
-            { persist: true },
+            readSessionFilter<string[]>('sourceProductFilter', []),
             {
                 toggleSourceProduct: (state, { source }) =>
                     state.includes(source) ? state.filter((s) => s !== source) : [...state, source],
@@ -138,8 +159,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             },
         ],
         priorityFilter: [
-            [] as SignalReportPriority[],
-            { persist: true },
+            readSessionFilter<SignalReportPriority[]>('priorityFilter', []),
             {
                 togglePriority: (state, { priority }) =>
                     state.includes(priority) ? state.filter((p) => p !== priority) : [...state, priority],
@@ -147,6 +167,17 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             },
         ],
     }),
+
+    // Mirror each filter into sessionStorage so it survives in-session reloads but resets on tab/window close.
+    subscriptions(() => ({
+        scope: (scope: InboxScope) => writeSessionFilter('scope', scope),
+        sortField: (sortField: InboxSortField) => writeSessionFilter('sortField', sortField),
+        sortDirection: (sortDirection: InboxSortDirection) => writeSessionFilter('sortDirection', sortDirection),
+        sourceProductFilter: (sourceProductFilter: string[]) =>
+            writeSessionFilter('sourceProductFilter', sourceProductFilter),
+        priorityFilter: (priorityFilter: SignalReportPriority[]) =>
+            writeSessionFilter('priorityFilter', priorityFilter),
+    })),
 
     afterMount(({ actions }) => {
         actions.loadAvailableReviewers()


### PR DESCRIPTION
## Problem

Inbox filters persist across sessions, so a filter set once (e.g. a source or priority filter) can quietly carry over and leave the inbox looking empty — which reads as broken, with no obvious cause. Reported as a papercut.

## Changes

Rather than changing the persistence model, make active filters discoverable: a minimal `LemonBanner` renders below the filter bar whenever a list-narrowing filter (search, source, or priority) is active, with a one-click **Clear**.

- `inboxFiltersLogic` keeps its existing persistence; adds a `hasActiveFilters` selector (search / source / priority — scope and sort are excluded, matching what `clearFilters` resets).
- `InboxReportList` renders the banner directly under the filter bar.

An earlier iteration of this PR moved filters to sessionStorage so they'd reset on tab/window close. That added remount/hydration complexity, so we ditched it in favour of this simpler discoverability fix.

## How did you test this code?

I'm an agent. `node_modules` wasn't installed in my environment, so I couldn't run the frontend typecheck or Jest locally — CI covers both. No new automated tests were added; the existing `inboxFiltersLogic.test.ts` only covers `buildSignalReportListOrdering`, which is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The ask started as "stop persisting inbox filters", was implemented as a sessionStorage swap, then the PR author redirected to a banner-based discoverability fix instead — keep persistence, just make active filters obvious with a Clear action. This commit reverts the logic to master's persistence behaviour and adds the banner.

The desktop app (PostHog/code) has the same filter persistence and could get a matching banner — not included here.