### PR TITLE
feat(mcp-analytics): add property filtering to the overview dashboard

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
@@ -124,6 +124,30 @@ const TOOL_CALL_LIST = {
     ],
 }
 
+// Scoped to $mcp_tool_call via eventNames — these populate the property-filter picker.
+const MCP_PROPERTY_DEFINITIONS = {
+    count: 5,
+    results: [
+        { id: 'tool', name: '$mcp_tool_name', property_type: 'String', is_seen_on_filtered_events: true },
+        { id: 'err', name: '$mcp_is_error', property_type: 'Boolean', is_seen_on_filtered_events: true },
+        { id: 'client', name: '$mcp_client_name', property_type: 'String', is_seen_on_filtered_events: true },
+        { id: 'session', name: '$mcp_session_id', property_type: 'String', is_seen_on_filtered_events: true },
+        { id: 'duration', name: '$mcp_duration_ms', property_type: 'Numeric', is_seen_on_filtered_events: true },
+    ],
+}
+
+const MCP_FEATURE_FLAG_DEFINITIONS = {
+    count: 1,
+    results: [
+        {
+            id: 'flag',
+            name: '$feature/mcp-new-thing',
+            property_type: 'String',
+            is_seen_on_filtered_events: true,
+        },
+    ],
+}
+
 const CLUSTER_SNAPSHOT = {
     status: 'ready',
     error_message: '',
@@ -151,6 +175,15 @@ const meta: Meta = {
                 '/api/environments/:team_id/mcp_analytics/intent_clusters/': CLUSTER_SNAPSHOT,
                 '/api/environments/:team_id/mcp_analytics/sessions/': SESSION_LIST,
                 '/api/environments/:team_id/mcp_analytics/sessions/:session_id/tool_calls/': TOOL_CALL_LIST,
+                '/api/projects/:team_id/property_definitions': ({ request }) => {
+                    const isFeatureFlag = new URL(request.url).searchParams.get('is_feature_flag') === 'true'
+                    return [200, isFeatureFlag ? MCP_FEATURE_FLAG_DEFINITIONS : MCP_PROPERTY_DEFINITIONS]
+                },
+                '/api/environments/:team_id/events/values/': [
+                    { name: 'execute-sql' },
+                    { name: 'read-data-schema' },
+                    { name: 'query-trends' },
+                ],
             },
             post: {
                 '/api/environments/:team_id/query/:kind': async ({ request }) => {

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
 import { type ChartTheme } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -36,8 +38,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         dateFilter,
         interval,
         filterTestAccounts,
+        propertyFilters,
     } = useValues(mcpDashboardOverviewLogic)
-    const { setDateFilter, setFilterTestAccounts } = useActions(mcpDashboardOverviewLogic)
+    const { setDateFilter, setFilterTestAccounts, setPropertyFilters } = useActions(mcpDashboardOverviewLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
@@ -48,12 +51,27 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
     return (
         <div className="flex flex-col gap-4" data-quill>
             <div className="flex flex-wrap items-center justify-between gap-3">
-                <McpDateFilter
-                    dateFrom={dateFilter.dateFrom}
-                    dateTo={dateFilter.dateTo}
-                    onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
-                    dataAttr="mcp-dashboard-date-filter"
-                />
+                <div className="flex flex-wrap items-center gap-3">
+                    <McpDateFilter
+                        dateFrom={dateFilter.dateFrom}
+                        dateTo={dateFilter.dateTo}
+                        onChange={(dateFrom, dateTo) => setDateFilter(dateFrom, dateTo)}
+                        dataAttr="mcp-dashboard-date-filter"
+                    />
+                    <div data-attr="mcp-dashboard-property-filter">
+                        <PropertyFilters
+                            pageKey="mcp-dashboard-overview"
+                            propertyFilters={propertyFilters}
+                            onChange={setPropertyFilters}
+                            taxonomicGroupTypes={[
+                                TaxonomicFilterGroupType.EventProperties,
+                                TaxonomicFilterGroupType.EventFeatureFlags,
+                            ]}
+                            eventNames={['$mcp_tool_call']}
+                            buttonText="Add filter"
+                        />
+                    </div>
+                </div>
                 <TestAccountFilterSwitch
                     checked={filterTestAccounts}
                     onChange={setFilterTestAccounts}

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -360,7 +360,7 @@ describe('mcpDashboardOverviewLogic', () => {
         }
         // Feature-flag filters arrive as ordinary $feature/<key> event-property filters.
         const FLAG_FILTER: AnyPropertyFilter = {
-            key: '$feature/new-thing',
+            key: '$feature/mcp-new-thing',
             value: ['test'],
             operator: PropertyOperator.Exact,
             type: PropertyFilterType.Event,

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -1,11 +1,14 @@
 import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
+import { urls } from 'scenes/urls'
 
 import { initKeaTests } from '~/test/init'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import {
     aggregateHarnessRows,
@@ -347,6 +350,64 @@ describe('mcpDashboardOverviewLogic', () => {
             const reloads = mockApi.query.mock.calls.map((call) => call[0] as any)
             expect(reloads.length).toBeGreaterThanOrEqual(6)
             expect(reloads.every((call) => call.filters.filterTestAccounts === true)).toBe(true)
+        })
+
+        const EVENT_FILTER: AnyPropertyFilter = {
+            key: '$mcp_tool_name',
+            value: ['create_insight'],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        }
+        // Feature-flag filters arrive as ordinary $feature/<key> event-property filters.
+        const FLAG_FILTER: AnyPropertyFilter = {
+            key: '$feature/new-thing',
+            value: ['test'],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        }
+
+        it.each([
+            ['event property', EVENT_FILTER],
+            ['feature flag', FLAG_FILTER],
+        ])('passes %s filters to every tile', async (_label, filter) => {
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            const callsBefore = mockApi.query.mock.calls.length
+
+            await expectLogic(logic, () => {
+                logic.actions.setPropertyFilters([filter])
+            }).toFinishAllListeners()
+
+            const reloads = reloadCallsSince(callsBefore)
+            expect(reloads.length).toBe(6)
+            expect(reloads.every((call) => JSON.stringify(call.filters.properties) === JSON.stringify([filter]))).toBe(
+                true
+            )
+        })
+
+        it('syncs property filters to the URL and clears the param when emptied', async () => {
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setPropertyFilters([EVENT_FILTER])
+            }).toFinishAllListeners()
+            expect(router.values.searchParams.properties).toEqual([EVENT_FILTER])
+
+            await expectLogic(logic, () => {
+                logic.actions.setPropertyFilters([])
+            }).toFinishAllListeners()
+            expect(router.values.searchParams.properties).toBeUndefined()
+        })
+
+        it('hydrates property filters from the URL on mount', async () => {
+            router.actions.push(urls.mcpAnalyticsDashboard(), { properties: [EVENT_FILTER] })
+            const logic = mcpDashboardOverviewLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.propertyFilters).toEqual([EVENT_FILTER])
         })
     })
 })

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
+import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { dateStringToComponents, dateStringToDayJs, getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
@@ -598,7 +599,8 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             ): HogQLFilters => ({
                 dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
                 filterTestAccounts,
-                properties: propertyFilters,
+                // Drop incomplete picker rows and any malformed URL-hydrated entries before they fan out to every tile.
+                properties: propertyFilters.filter(isValidPropertyFilter),
             }),
         ],
         interval: [

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -9,7 +9,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { HogQLFilters, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
-import { IntervalType, TeamType } from '~/types'
+import { AnyPropertyFilter, IntervalType, TeamType } from '~/types'
 
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import { categorizeHarness } from './dashboard/harnessRegistry'
@@ -433,6 +433,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
     actions({
         setDateFilter: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
         setFilterTestAccounts: (filterTestAccounts: boolean | null) => ({ filterTestAccounts }),
+        setPropertyFilters: (properties: AnyPropertyFilter[]) => ({ properties }),
         reloadAll: true,
     }),
     reducers({
@@ -448,6 +449,12 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             null as boolean | null,
             {
                 setFilterTestAccounts: (_, { filterTestAccounts }): boolean | null => filterTestAccounts,
+            },
+        ],
+        propertyFilters: [
+            [] as AnyPropertyFilter[],
+            {
+                setPropertyFilters: (_, { properties }): AnyPropertyFilter[] => properties,
             },
         ],
     }),
@@ -583,10 +590,15 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                 override ?? !!currentTeam?.test_account_filters_default_checked,
         ],
         queryFilters: [
-            (s) => [s.dateFilter, s.filterTestAccounts],
-            (dateFilter: DateFilter, filterTestAccounts: boolean): HogQLFilters => ({
+            (s) => [s.dateFilter, s.filterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: DateFilter,
+                filterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): HogQLFilters => ({
                 dateRange: { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo },
                 filterTestAccounts,
+                properties: propertyFilters,
             }),
         ],
         interval: [
@@ -628,6 +640,9 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         setFilterTestAccounts: () => {
             actions.reloadAll()
         },
+        setPropertyFilters: () => {
+            actions.reloadAll()
+        },
         reloadAll: () => {
             actions.loadKPIs()
             actions.loadToolRows()
@@ -657,11 +672,17 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             } else {
                 searchParams.filter_test_accounts = values.filterTestAccountsOverride
             }
+            if (values.propertyFilters.length > 0) {
+                searchParams.properties = values.propertyFilters
+            } else {
+                delete searchParams.properties
+            }
             return [currentLocation.pathname, searchParams, currentLocation.hashParams, { replace: true }]
         }
         return {
             setDateFilter: syncUrl,
             setFilterTestAccounts: syncUrl,
+            setPropertyFilters: syncUrl,
         }
     }),
     urlToAction(({ actions, values, cache }) => ({
@@ -672,17 +693,22 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             // Absent param leaves the override null (effective value follows the team default).
             const rawFilter = searchParams.filter_test_accounts
             const filterOverride = rawFilter === undefined ? null : rawFilter === true || rawFilter === 'true'
+            const properties = Array.isArray(searchParams.properties) ? searchParams.properties : []
             const dateChanged = dateFrom !== values.dateFilter.dateFrom || dateTo !== values.dateFilter.dateTo
             const filterChanged = filterOverride !== values.filterTestAccountsOverride
-            // setDateFilter / setFilterTestAccounts each reload via their listeners.
+            const propertiesChanged = JSON.stringify(properties) !== JSON.stringify(values.propertyFilters)
+            // setDateFilter / setFilterTestAccounts / setPropertyFilters each reload via their listeners.
             if (dateChanged) {
                 actions.setDateFilter(dateFrom, dateTo)
             }
             if (filterChanged) {
                 actions.setFilterTestAccounts(filterOverride)
             }
+            if (propertiesChanged) {
+                actions.setPropertyFilters(properties)
+            }
             // URL already matches state (e.g. default filters) and afterMount deferred — load once.
-            if (!dateChanged && !filterChanged && !cache.hasLoaded) {
+            if (!dateChanged && !filterChanged && !propertiesChanged && !cache.hasLoaded) {
                 actions.reloadAll()
             }
             cache.hasLoaded = true
@@ -697,7 +723,8 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         const hasUrlFilters =
             typeof searchParams.date_from === 'string' ||
             typeof searchParams.date_to === 'string' ||
-            typeof searchParams.filter_test_accounts !== 'undefined'
+            typeof searchParams.filter_test_accounts !== 'undefined' ||
+            Array.isArray(searchParams.properties)
         if (!hasUrlFilters && !cache.hasLoaded) {
             cache.hasLoaded = true
             actions.reloadAll()


### PR DESCRIPTION
## Problem

The MCP analytics overview dashboard only let you slice by date (and the internal/test-account toggle). There was no way to scope the whole dashboard to a single tool, client/harness, region, error-only traffic, or a feature flag value without leaving the page. People wanting to answer "how does this look just for Claude Code?" or "what's the error rate behind this flag?" had to drop into raw SQL.

## Changes

Adds an **"Add filter"** property picker to the overview toolbar, between the date picker and the test-account switch.

- The picker is **scoped to the `$mcp_tool_call` event** (`eventNames={['$mcp_tool_call']}`), so it only offers properties and feature flags actually seen on MCP tool calls — inherently MCP-first, and it leaves the app-wide taxonomic Recents store untouched (no cross-scene pollution). The 42 `$mcp_*` properties are already in the core taxonomy, so they render with friendly labels and descriptions.
- **Feature flags are a first-class filter category** (`EventFeatureFlags`), so you can slice MCP traffic by `$feature/<key>` values.
- Filters thread through the shared `queryFilters` selector into all six tile queries via the existing `{filters}` placeholder — no per-tile wiring.
- Filters **sync to the URL** alongside `date_from` / `date_to` / `filter_test_accounts`, so a filtered view is deep-linkable and survives refresh.

The implementation mirrors the existing date-filter / test-account pattern already in `mcpDashboardOverviewLogic.ts` (action + reducer + selector input + listener + `syncUrl` closure).

### Screenshots

Storybook (`Scenes-App/MCP Analytics` → `Dashboard`), picker open showing the scoped event properties (5) and feature flags (1) fed by a new mock:

The picker surfaces `$mcp_tool_name`, `$mcp_is_error`, `$mcp_client_name`, `$mcp_session_id`, `$mcp_duration_ms` under Event properties, and `$feature/mcp-new-thing` under Feature flags.

## How did you test this code?

I'm an agent. I did not perform manual QA beyond driving the Storybook story in a browser to confirm the picker renders and populates from the mock.

Automated:

- `pnpm --filter=@posthog/frontend exec jest products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts` — **44 pass** (4 new, parameterized over event-property vs feature-flag shapes, plus URL round-trip and hydration).
- `pnpm --filter=@posthog/frontend format` — clean.
- TypeScript: the only diagnostics touching these files are pre-existing local-env artifacts (missing kea-typegen `*LogicType` modules, missing `@posthog/quill-*` declarations) that CI regenerates; the new action throws the identical typegen-missing error as the already-merged `setDateFilter`/`setFilterTestAccounts`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this work and is the DRI (assigned). Built with PostHog Code.

- The promotion mechanism for surfacing MCP events/properties was a deliberate decision: rather than seeding the global taxonomic Recents store (which would leak MCP props into every other scene), we scope the picker to `$mcp_tool_call`. Paul chose this explicitly over a curated "Suggested" group or recents-seeding.
- URL persistence reuses the existing `syncUrl` closure and `cache.hasLoaded` first-load guard, so the new `properties` param can't race the date/test-account params into a double load.
- Added a `property_definitions` mock (branching on the `is_feature_flag` query param) plus an `events/values/` mock to the existing dashboard story so the picker is demoable and the closed-state visual snapshot stays clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
