### PR TITLE
fix(llma): Set max width on sessions page for large screens

### DIFF
--- a/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
@@ -145,7 +145,7 @@ function SessionSceneWrapper(): JSX.Element {
     }
 
     return (
-        <div className="relative flex flex-col gap-4">
+        <div className="relative flex flex-col gap-4 max-w-300">
             <SceneBreadcrumbBackButton />
             {heroTitle && <h1 className="text-2xl font-semibold leading-tight m-0 break-words">{heroTitle}</h1>}
             <header className="flex items-start justify-between gap-3 flex-wrap">

--- a/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
@@ -145,7 +145,7 @@ function SessionSceneWrapper(): JSX.Element {
     }
 
     return (
-        <div className="relative flex flex-col gap-4 max-w-300">
+        <div className="relative flex flex-col gap-4 max-w-[75rem]">
             <SceneBreadcrumbBackButton />
             {heroTitle && <h1 className="text-2xl font-semibold leading-tight m-0 break-words">{heroTitle}</h1>}
             <header className="flex items-start justify-between gap-3 flex-wrap">


### PR DESCRIPTION
## Problem

The sessions page with it's left/right chat layout wasn't easy to read on large screens.

## Considered options

Have done some local experiments with the layout:
- Centered column (Max-style): looked inconsistent with app
- Capping only the chat but not the summarize button: looked misplaced
- Capping only the conversation width, but not the date-swimlanes: looked misaligned
- No left/right layout, but flow of messages with agent messages not as bubbles: Found it harder to read, but could work with more exploration
- Current left/right with meta data (steps, sentiment, trace) below the turn: Found it harder to read, but could work with more exploration

## Changes

Came to the conclusion that the current layout works best until further UX exploration. Added max-width: `max-w-300` (75rem, 1200px) which is used on other pages too.

## How did you test this code?

Manually

<img width="1503" height="475" alt="Screenshot 2026-06-19 at 13 01 26" src="https://github.com/user-attachments/assets/e8b8aa34-7b18-4cc9-8912-69d92621d9de" />
