### PR TITLE
chore(retention): compare legacy vs dwh retention [do not merge]

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -41,6 +41,15 @@ def retention_fixed_interval_base_query_use_dwh_variant(team: "Team") -> bool:
     )
 
 
+# Patch target for forcing the variant on/off. Defined here rather than in test helpers so the
+# compare_retention_* management commands stay importable in production images, which don't
+# install test-only dependencies.
+RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
+    "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
+    "retention_fixed_interval_base_query_use_dwh_variant"
+)
+
+
 class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     def build_base_query(
         self,

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -41,15 +41,6 @@ def retention_fixed_interval_base_query_use_dwh_variant(team: "Team") -> bool:
     )
 
 
-# Patch target for forcing the variant on/off. Defined here rather than in test helpers so the
-# compare_retention_* management commands stay importable in production images, which don't
-# install test-only dependencies.
-RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
-    "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
-    "retention_fixed_interval_base_query_use_dwh_variant"
-)
-
-
 class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     def build_base_query(
         self,

--- a/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
+++ b/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
@@ -4,8 +4,10 @@ from typing import Any, TypeVar, cast
 
 from unittest.mock import patch
 
-from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RETENTION_BASE_QUERY_VARIANT_PATCH_PATH
-
+RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
+    "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
+    "retention_fixed_interval_base_query_use_dwh_variant"
+)
 SKIP_RETENTION_BASE_QUERY_VARIANT_COMPARISON_ATTR = "_skip_retention_base_query_variant_comparison"
 
 Result = TypeVar("Result")

--- a/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
+++ b/posthog/hogql_queries/insights/retention/test/retention_base_query_variant.py
@@ -4,10 +4,8 @@ from typing import Any, TypeVar, cast
 
 from unittest.mock import patch
 
-RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
-    "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
-    "retention_fixed_interval_base_query_use_dwh_variant"
-)
+from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RETENTION_BASE_QUERY_VARIANT_PATCH_PATH
+
 SKIP_RETENTION_BASE_QUERY_VARIANT_COMPARISON_ATTR = "_skip_retention_base_query_variant_comparison"
 
 Result = TypeVar("Result")

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -230,6 +230,7 @@ def save_progress_state(path: str, state: ProgressState) -> None:
 def _run_variant(
     insight: Insight, use_dwh: bool, modifiers: HogQLQueryModifiers, override: Optional[dict[str, Any]]
 ) -> list:
+    assert insight.query is not None  # classify_insight has already validated the query shape
     source = deepcopy(insight.query["source"])
     if override is not None:
         source["dateRange"] = override

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -23,9 +23,25 @@ across worker threads) we install one process-wide patch whose return value is r
 ``ContextVar`` each worker sets before it runs. Threads start with a fresh context, so the workers
 never collide.
 
+Checking *all* insights is done as a resumable sweep, not one giant run. Pass ``--state-file
+progress.json`` and the command processes one ``--limit``-sized batch, writes a cursor (the highest
+insight id it reached) plus the running counts and accumulated findings back to that file, then exits.
+Re-run the same command and it resumes just past the cursor; repeat until it reports the sweep complete.
+The cursor is printed every run, so without a state file you can drive the same loop by hand with
+``--after-id``. It is a keyset cursor (``id > cursor``), not a row offset — concurrent inserts or
+deletes between runs never make it skip or re-check an insight, which a numeric offset would. The state
+file is tied to the filter set it was created with (``--team-id`` etc.); reusing it under a different
+scope is refused so a narrowed cursor can't silently leave insights unchecked.
+
 Examples:
     # All retention insights, up to 8 teams in parallel
     python manage.py compare_retention_correctness
+
+    # Resumable sweep over every insight: run this repeatedly until it reports "complete"
+    python manage.py compare_retention_correctness --state-file /tmp/retention_sweep.json --limit 500
+
+    # Drive the cursor by hand (no state file): each run prints the --after-id for the next
+    python manage.py compare_retention_correctness --limit 500 --after-id 0
 
     # One team, serial (e.g. to avoid extra ClickHouse load on prod)
     python manage.py compare_retention_correctness --team-id 42 --concurrency 1
@@ -34,7 +50,9 @@ Examples:
     python manage.py compare_retention_correctness --fail-on-mismatch
 """
 
+import os
 import sys
+import json
 import argparse
 import threading
 import contextvars
@@ -43,6 +61,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
+from datetime import UTC, datetime
 from typing import Any, Optional
 
 from unittest.mock import patch
@@ -71,13 +90,118 @@ from products.product_analytics.backend.models.insight import Insight
 _use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_use_dwh", default=False)
 
 
+PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "SKIPPED")
+
+
 @dataclasses.dataclass
 class Row:
+    id: int
     short_id: str
     team_id: int
     url: str
     status: str  # "OK" | "MISMATCH" | "ERROR" | "SKIPPED"
     detail: str = ""
+
+
+@dataclasses.dataclass
+class ProgressState:
+    """Resumable-sweep checkpoint, persisted as JSON between runs.
+
+    ``cursor`` is a keyset position: the next run checks insights with ``id`` greater than it. Counts and
+    findings accumulate across runs, so a completed file is itself the full report. ``scope`` fingerprints
+    the filter set the sweep was started with, so resuming under different filters can be refused.
+    """
+
+    cursor: int = 0  # highest insight id checked so far; next run filters id > cursor
+    processed: int = 0  # cumulative insights checked across all runs
+    counts: dict[str, int] = dataclasses.field(default_factory=lambda: dict.fromkeys(PROGRESS_STATUSES, 0))
+    mismatches: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    errors: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    complete: bool = False
+    scope: str = ""
+    updated_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ProgressState":
+        raw_counts = data.get("counts") or {}
+        return cls(
+            cursor=int(data.get("cursor", 0)),
+            processed=int(data.get("processed", 0)),
+            counts={s: int(raw_counts.get(s, 0)) for s in PROGRESS_STATUSES},
+            mismatches=list(data.get("mismatches") or []),
+            errors=list(data.get("errors") or []),
+            complete=bool(data.get("complete", False)),
+            scope=str(data.get("scope", "")),
+            updated_at=data.get("updated_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def _row_record(row: Row) -> dict[str, Any]:
+    return {"id": row.id, "short_id": row.short_id, "team_id": row.team_id, "url": row.url, "detail": row.detail}
+
+
+def merge_progress_state(
+    prev: Optional[ProgressState],
+    rows: list[Row],
+    *,
+    next_cursor: Optional[int],
+    limit: int,
+    scope: str = "",
+) -> ProgressState:
+    """Fold one batch's rows into the running checkpoint. Pure — no IO, no clock, never mutates ``prev``.
+
+    ``next_cursor`` is the highest insight id covered by the batch (``None`` when the batch was empty, e.g.
+    the sweep ran off the end). The sweep is ``complete`` once a batch returns fewer rows than ``limit``,
+    i.e. the source is exhausted. The cursor only ever advances.
+    """
+    base = prev or ProgressState(scope=scope)
+    counts = dict(base.counts)
+    for status in PROGRESS_STATUSES:
+        counts[status] = counts.get(status, 0) + sum(1 for r in rows if r.status == status)
+    return ProgressState(
+        cursor=max(base.cursor, next_cursor) if next_cursor is not None else base.cursor,
+        processed=base.processed + len(rows),
+        counts=counts,
+        mismatches=base.mismatches + [_row_record(r) for r in rows if r.status == "MISMATCH"],
+        errors=base.errors + [_row_record(r) for r in rows if r.status == "ERROR"],
+        complete=len(rows) < limit,
+        scope=scope or base.scope,
+    )
+
+
+def scope_signature(options: dict[str, Any]) -> str:
+    """Stable fingerprint of the filters that define the insight universe and result comparability.
+
+    Two runs sharing a state file must agree on this, otherwise the saved cursor could skip insights the
+    new scope cares about (or mix frozen and live results in the accumulated findings).
+    """
+    return json.dumps(
+        {
+            "team_id": sorted(options.get("team_id") or []),
+            "insight_id": sorted(options.get("insight_id") or []),
+            "short_id": sorted(options.get("short_id") or []),
+            "freeze_window": bool(options.get("freeze_window")),
+        },
+        sort_keys=True,
+    )
+
+
+def load_progress_state(path: str) -> Optional[ProgressState]:
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return ProgressState.from_dict(json.load(f))
+
+
+def save_progress_state(path: str, state: ProgressState) -> None:
+    # Write-then-replace so a crash mid-write can't corrupt an in-progress sweep's checkpoint.
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(state.to_dict(), f, indent=2, sort_keys=True)
+    os.replace(tmp, path)
 
 
 def _run_variant(
@@ -95,9 +219,9 @@ def _check_one(insight: Insight, url: str, freeze: bool) -> Row:
     try:
         action, reason = classify_insight(insight)
         if action == "error":
-            return Row(insight.short_id, insight.team_id, url, "ERROR", reason)
+            return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", reason)
         if action == "skip":
-            return Row(insight.short_id, insight.team_id, url, "SKIPPED", reason)
+            return Row(insight.id, insight.short_id, insight.team_id, url, "SKIPPED", reason)
 
         modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
         ctx = compute_interval_context(insight, modifiers, freeze=freeze)
@@ -116,9 +240,9 @@ def _check_one(insight: Insight, url: str, freeze: bool) -> Row:
             detail = (
                 f"{len(diff.cell_diffs)} cell diff(s), rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
             )
-        return Row(insight.short_id, insight.team_id, url, diff.status, detail)
+        return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)
     except Exception as exc:
-        return Row(insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
+        return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
 
 
 def _check_team(
@@ -146,8 +270,29 @@ class Command(BaseCommand):
         parser.add_argument("--team-id", type=int, action="append", help="Restrict to team id(s); repeatable")
         parser.add_argument("--insight-id", type=int, action="append", help="Restrict to insight DB id(s); repeatable")
         parser.add_argument("--short-id", type=str, action="append", help="Restrict to insight short_id(s); repeatable")
-        parser.add_argument("--limit", type=int, default=100, help="Max insights to process (default 100)")
-        parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by date")
+        parser.add_argument("--limit", type=int, default=100, help="Max insights per batch (default 100)")
+        parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by id")
+        parser.add_argument(
+            "--state-file",
+            type=str,
+            default=None,
+            help="JSON checkpoint for a resumable sweep. If it exists the run resumes from its saved cursor; "
+            "afterwards it is rewritten with the new cursor plus accumulated counts and findings. Re-run the "
+            "same command to walk every matching insight in --limit-sized batches until it reports complete.",
+        )
+        parser.add_argument(
+            "--after-id",
+            type=int,
+            default=None,
+            help="Resume cursor: only check insights with a DB id greater than this. Overrides the cursor in "
+            "--state-file when both are given. Keyset, not a row offset — it never skips or repeats insights "
+            "when rows are added or deleted between runs.",
+        )
+        parser.add_argument(
+            "--restart",
+            action="store_true",
+            help="Ignore any existing --state-file and start the sweep over (the file is overwritten).",
+        )
         parser.add_argument(
             "--concurrency",
             type=int,
@@ -166,13 +311,100 @@ class Command(BaseCommand):
         parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
 
     def handle(self, *args: Any, **options: Any) -> None:
-        insights = self._select_insights(options)
-        if not insights:
-            self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
+        if options["limit"] < 1:
+            raise CommandError("--limit must be at least 1")
+
+        state_file: Optional[str] = options["state_file"]
+        after_id: Optional[int] = options["after_id"]
+        scope = scope_signature(options)
+
+        if options["sample"] is not None and (state_file or after_id is not None):
+            raise CommandError(
+                "--sample picks a random set and can't drive a resumable sweep (--state-file / --after-id)."
+            )
+
+        prev_state, already_complete = self._load_resume_state(state_file, scope, after_id, options["restart"])
+        if already_complete:
             return
 
-        base_url = options["base_url"].rstrip("/")
-        freeze = options["freeze_window"]
+        # Explicit --after-id wins; otherwise resume from the saved checkpoint (None = start from the top).
+        cursor = after_id if after_id is not None else (prev_state.cursor if prev_state else None)
+
+        insights = self._select_insights(options, after_id=cursor)
+        if not insights:
+            self._handle_empty(options, state_file, scope, prev_state, cursor)
+            return
+
+        rows = self._run(insights, options["base_url"].rstrip("/"), options["freeze_window"], options["concurrency"])
+        self._print_summary(rows)
+
+        next_cursor = max(i.id for i in insights)
+        if state_file:
+            new_state = merge_progress_state(
+                prev_state, rows, next_cursor=next_cursor, limit=options["limit"], scope=scope
+            )
+            new_state.updated_at = datetime.now(UTC).isoformat()
+            save_progress_state(state_file, new_state)
+            self._print_checkpoint(state_file, new_state)
+            self._print_cumulative(new_state)
+        else:
+            self._print_next_cursor(next_cursor, len(insights), options["limit"])
+
+        mismatches = sum(1 for r in rows if r.status == "MISMATCH")
+        if options["fail_on_mismatch"] and mismatches:
+            raise CommandError(f"{mismatches} insight(s) mismatched between variants")
+
+    def _load_resume_state(
+        self, state_file: Optional[str], scope: str, after_id: Optional[int], restart: bool
+    ) -> tuple[Optional[ProgressState], bool]:
+        """Load the checkpoint to resume from. The bool is ``True`` when the caller should stop because the
+        sweep in ``state_file`` is already finished (and no explicit ``--after-id`` is forcing a re-run)."""
+        if not state_file or restart:
+            return None, False
+        prev = load_progress_state(state_file)
+        if prev is None:
+            return None, False
+        if prev.scope and prev.scope != scope:
+            raise CommandError(
+                f"State file {state_file} was written for a different filter set. "
+                "Use a separate --state-file, or pass --restart to overwrite it."
+            )
+        if prev.complete and after_id is None:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Sweep already complete: {prev.processed} insight(s) checked, cursor at id {prev.cursor}. "
+                    "Pass --restart to run it again."
+                )
+            )
+            self._print_cumulative(prev)
+            return prev, True
+        return prev, False
+
+    def _handle_empty(
+        self,
+        options: dict[str, Any],
+        state_file: Optional[str],
+        scope: str,
+        prev_state: Optional[ProgressState],
+        cursor: Optional[int],
+    ) -> None:
+        """Nothing left to check: either the filters match nothing or the sweep just ran off the end."""
+        if state_file:
+            new_state = merge_progress_state(prev_state, [], next_cursor=None, limit=options["limit"], scope=scope)
+            new_state.updated_at = datetime.now(UTC).isoformat()
+            save_progress_state(state_file, new_state)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"No insights past cursor id {cursor or 0} — sweep complete after {new_state.processed} insight(s)."
+                )
+            )
+            self._print_cumulative(new_state)
+        elif cursor is not None:
+            self.stdout.write(self.style.SUCCESS(f"No insights past id {cursor} — nothing left to check."))
+        else:
+            self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
+
+    def _run(self, insights: list[Insight], base_url: str, freeze: bool, concurrency_opt: int) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
         # One lane per team: the team's insights run serially within the lane, distinct teams in
@@ -180,7 +412,7 @@ class Command(BaseCommand):
         teams: dict[int, list[Insight]] = defaultdict(list)
         for insight in insights:
             teams[insight.team_id].append(insight)
-        concurrency = max(1, min(options["concurrency"], len(teams)))
+        concurrency = max(1, min(concurrency_opt, len(teams)))
         self.stdout.write(
             f"Checking {len(insights)} retention insight(s) across {len(teams)} team(s), "
             f"up to {concurrency} team(s) in parallel…"
@@ -205,14 +437,9 @@ class Command(BaseCommand):
                 ]
                 for future in as_completed(futures):
                     rows.extend(future.result())
+        return rows
 
-        self._print_summary(rows)
-
-        mismatches = sum(1 for r in rows if r.status == "MISMATCH")
-        if options["fail_on_mismatch"] and mismatches:
-            raise CommandError(f"{mismatches} insight(s) mismatched between variants")
-
-    def _select_insights(self, options: dict[str, Any]) -> list[Insight]:
+    def _select_insights(self, options: dict[str, Any], after_id: Optional[int] = None) -> list[Insight]:
         queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")
         if options["team_id"]:
             queryset = queryset.filter(team_id__in=options["team_id"])
@@ -223,7 +450,10 @@ class Command(BaseCommand):
         queryset = queryset.select_related("team")
         if options["sample"]:
             return list(queryset.order_by("?")[: options["sample"]])
-        return list(queryset.order_by("created_at")[: options["limit"]])
+        # Keyset pagination: ascending id is a stable, unique sweep order and the cursor is just the last id.
+        if after_id is not None:
+            queryset = queryset.filter(id__gt=after_id)
+        return list(queryset.order_by("id")[: options["limit"]])
 
     def _print_progress(self, done: int, total: int, row: Row) -> None:
         if row.status == "OK":
@@ -247,3 +477,39 @@ class Command(BaseCommand):
             for r in mismatches:
                 self.stdout.write(self.style.ERROR(f"  {r.short_id} (team {r.team_id}) {r.url} — {r.detail}"))
         sys.stdout.flush()
+
+    def _print_next_cursor(self, next_cursor: int, batch_size: int, limit: int) -> None:
+        self.stdout.write("")
+        if batch_size < limit:
+            self.stdout.write(self.style.SUCCESS(f"Reached the end of the set (last insight id {next_cursor})."))
+        else:
+            self.stdout.write(f"Next cursor: {next_cursor}. Continue the sweep with --after-id {next_cursor}")
+
+    def _print_checkpoint(self, state_file: str, state: ProgressState) -> None:
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING("Sweep progress"))
+        self.stdout.write(
+            f"Checked {state.processed} insight(s) so far — OK={state.counts['OK']} "
+            f"MISMATCH={state.counts['MISMATCH']} ERROR={state.counts['ERROR']} SKIPPED={state.counts['SKIPPED']}"
+        )
+        self.stdout.write(f"Checkpoint written to {state_file} (cursor at insight id {state.cursor}).")
+        if state.complete:
+            self.stdout.write(self.style.SUCCESS("Sweep complete — every matching insight has been checked."))
+        else:
+            self.stdout.write("Re-run the same command to check the next batch (resumes from this cursor).")
+
+    def _print_cumulative(self, state: ProgressState) -> None:
+        """List the findings accumulated across the whole sweep so far (capped; the full set is in the file)."""
+        self._print_record_list("Accumulated mismatches", state.mismatches, self.style.ERROR)
+        self._print_record_list("Accumulated errors", state.errors, self.style.WARNING)
+
+    def _print_record_list(self, heading: str, records: list[dict[str, Any]], style: Callable[[str], str]) -> None:
+        if not records:
+            return
+        cap = 50
+        self.stdout.write(style(f"\n{heading} ({len(records)}):"))
+        for rec in records[:cap]:
+            detail = f" — {rec['detail']}" if rec.get("detail") else ""
+            self.stdout.write(style(f"  {rec['short_id']} (team {rec['team_id']}) {rec['url']}{detail}"))
+        if len(records) > cap:
+            self.stdout.write(style(f"  …and {len(records) - cap} more (see state file)"))

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -18,6 +18,16 @@ Correctness semantics are *identical* to the full tool — it imports and reuses
 the trailing-period exclusion that keeps live-ingest drift on the in-progress interval from showing
 up as a false mismatch. Strictly read-only.
 
+Failures are attributed per variant: each side runs under its own guard, so an insight is reported
+as ERROR_DWH (legacy succeeded, the variant failed — a regression candidate that gates rollout),
+ERROR_LEGACY (the variant fixes an insight that is broken today), or ERROR_BOTH (parity-in-failure:
+broken regardless of the toggle). Plain ERROR is reserved for failures outside the two variant runs.
+Insights whose referenced actions/cohorts were deleted are SKIPPED up front by ``classify_insight``
+instead of erroring on both sides. A first-pass mismatch is re-run once and only the differences
+that reproduce are kept (``--no-recheck-mismatches`` to disable): late-arriving events and person
+merges move *historical* buckets between the two sequential runs, so a single pass can report live
+drift as a parity bug.
+
 The variant toggle is process-global, so instead of nesting a ``patch`` per call (which would race
 across worker threads) we install one process-wide patch whose return value is read from a
 ``ContextVar`` each worker sets before it runs. Threads start with a fresh context, so the workers
@@ -78,9 +88,11 @@ from posthog.hogql_queries.insights.retention.test.retention_base_query_variant 
 )
 from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    attribute_variant_errors,
     classify_insight,
     compute_interval_context,
     diff_retention_results,
+    intersect_stable_mismatch,
 )
 
 from products.product_analytics.backend.models.insight import Insight
@@ -90,7 +102,7 @@ from products.product_analytics.backend.models.insight import Insight
 _use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_use_dwh", default=False)
 
 
-PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "SKIPPED")
+PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
 
 
 @dataclasses.dataclass
@@ -99,7 +111,7 @@ class Row:
     short_id: str
     team_id: int
     url: str
-    status: str  # "OK" | "MISMATCH" | "ERROR" | "SKIPPED"
+    status: str  # one of PROGRESS_STATUSES
     detail: str = ""
 
 
@@ -140,7 +152,14 @@ class ProgressState:
 
 
 def _row_record(row: Row) -> dict[str, Any]:
-    return {"id": row.id, "short_id": row.short_id, "team_id": row.team_id, "url": row.url, "detail": row.detail}
+    return {
+        "id": row.id,
+        "short_id": row.short_id,
+        "team_id": row.team_id,
+        "url": row.url,
+        "status": row.status,
+        "detail": row.detail,
+    }
 
 
 def merge_progress_state(
@@ -166,7 +185,8 @@ def merge_progress_state(
         processed=base.processed + len(rows),
         counts=counts,
         mismatches=base.mismatches + [_row_record(r) for r in rows if r.status == "MISMATCH"],
-        errors=base.errors + [_row_record(r) for r in rows if r.status == "ERROR"],
+        # All attributed variants (ERROR_LEGACY / ERROR_DWH / ERROR_BOTH) accumulate here too.
+        errors=base.errors + [_row_record(r) for r in rows if r.status.startswith("ERROR")],
         complete=len(rows) < limit,
         scope=scope or base.scope,
     )
@@ -184,6 +204,9 @@ def scope_signature(options: dict[str, Any]) -> str:
             "insight_id": sorted(options.get("insight_id") or []),
             "short_id": sorted(options.get("short_id") or []),
             "freeze_window": bool(options.get("freeze_window")),
+            # Changes what MISMATCH means (stability-filtered vs raw), so accumulated findings
+            # from runs with different settings must not mix in one sweep.
+            "recheck_mismatches": bool(options.get("recheck_mismatches", True)),
         },
         sort_keys=True,
     )
@@ -215,7 +238,16 @@ def _run_variant(
     return response.results or []
 
 
-def _check_one(insight: Insight, url: str, freeze: bool) -> Row:
+def _try_variant(
+    insight: Insight, use_dwh: bool, modifiers: HogQLQueryModifiers, override: Optional[dict[str, Any]]
+) -> tuple[Optional[list], Optional[BaseException]]:
+    try:
+        return _run_variant(insight, use_dwh, modifiers, override), None
+    except Exception as exc:
+        return None, exc
+
+
+def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
     try:
         action, reason = classify_insight(insight)
         if action == "error":
@@ -227,33 +259,57 @@ def _check_one(insight: Insight, url: str, freeze: bool) -> Row:
         ctx = compute_interval_context(insight, modifiers, freeze=freeze)
         override = ctx.frozen_date_range
 
-        legacy = _run_variant(insight, False, modifiers, override)
-        dwh = _run_variant(insight, True, modifiers, override)
-        diff = diff_retention_results(
-            legacy,
-            dwh,
-            latest_interval_start=ctx.latest_interval_start,
-            interval_delta=ctx.trailing_delta,
-        )
+        # Per-variant guards so a failure is attributed to the side that raised it (ERROR_DWH /
+        # ERROR_LEGACY / ERROR_BOTH) instead of one opaque ERROR that hides which side broke.
+        legacy, legacy_exc = _try_variant(insight, False, modifiers, override)
+        dwh, dwh_exc = _try_variant(insight, True, modifiers, override)
+        if legacy_exc is not None or dwh_exc is not None:
+            status, _error_type, summary = attribute_variant_errors(legacy_exc, dwh_exc)
+            return Row(insight.id, insight.short_id, insight.team_id, url, status, summary)
+        assert legacy is not None and dwh is not None
+
+        diff_kwargs: dict[str, Any] = {
+            "latest_interval_start": ctx.latest_interval_start,
+            "interval_delta": ctx.trailing_delta,
+        }
+        diff = diff_retention_results(legacy, dwh, **diff_kwargs)
+
+        # Re-run a first-pass mismatch once and keep only the differences that reproduce: live
+        # ingest and person merges shift historical buckets between the sequential runs, so an
+        # unrepeated diff is drift, not a parity bug. Bounded cost — mismatches only.
+        rechecked = False
+        if recheck and diff.status == "MISMATCH":
+            legacy2, legacy2_exc = _try_variant(insight, False, modifiers, override)
+            dwh2, dwh2_exc = _try_variant(insight, True, modifiers, override)
+            if legacy2_exc is None and dwh2_exc is None:
+                assert legacy2 is not None and dwh2 is not None
+                diff = intersect_stable_mismatch(diff, diff_retention_results(legacy2, dwh2, **diff_kwargs))
+                rechecked = True
+            # On a recheck failure keep the (valid) first-pass verdict and say it's unverified.
+
         detail = ""
         if diff.status == "MISMATCH":
+            stable = "stable " if rechecked else ""
             detail = (
-                f"{len(diff.cell_diffs)} cell diff(s), rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
+                f"{len(diff.cell_diffs)} {stable}cell diff(s), "
+                f"rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
             )
+            if recheck and not rechecked:
+                detail += " (recheck errored — stability unverified)"
         return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)
     except Exception as exc:
         return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
 
 
 def _check_team(
-    insights: list[Insight], urls: dict[int, str], freeze: bool, report: Callable[[Row], None]
+    insights: list[Insight], urls: dict[int, str], freeze: bool, recheck: bool, report: Callable[[Row], None]
 ) -> list[Row]:
     """One lane = one team. Its insights are checked serially so a team's data is never read
     concurrently with itself; distinct teams run in parallel across lanes."""
     rows: list[Row] = []
     try:
         for insight in insights:
-            row = _check_one(insight, urls[insight.id], freeze)
+            row = _check_one(insight, urls[insight.id], freeze, recheck)
             rows.append(row)
             report(row)
     finally:
@@ -308,6 +364,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Compare over a frozen snapshot ending at the last complete interval (drops the in-progress period)",
         )
+        parser.add_argument(
+            "--recheck-mismatches",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Re-run both variants once on a mismatch and keep only differences that reproduce (default on)",
+        )
         parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -335,7 +397,13 @@ class Command(BaseCommand):
             self._handle_empty(options, state_file, scope, prev_state, cursor)
             return
 
-        rows = self._run(insights, options["base_url"].rstrip("/"), options["freeze_window"], options["concurrency"])
+        rows = self._run(
+            insights,
+            options["base_url"].rstrip("/"),
+            options["freeze_window"],
+            options["recheck_mismatches"],
+            options["concurrency"],
+        )
         self._print_summary(rows)
 
         next_cursor = max(i.id for i in insights)
@@ -404,7 +472,9 @@ class Command(BaseCommand):
         else:
             self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
 
-    def _run(self, insights: list[Insight], base_url: str, freeze: bool, concurrency_opt: int) -> list[Row]:
+    def _run(
+        self, insights: list[Insight], base_url: str, freeze: bool, recheck: bool, concurrency_opt: int
+    ) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
         # One lane per team: the team's insights run serially within the lane, distinct teams in
@@ -433,7 +503,8 @@ class Command(BaseCommand):
         with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, side_effect=lambda team: _use_dwh_var.get()):
             with ThreadPoolExecutor(max_workers=concurrency) as pool:
                 futures = [
-                    pool.submit(_check_team, team_insights, urls, freeze, report) for team_insights in teams.values()
+                    pool.submit(_check_team, team_insights, urls, freeze, recheck, report)
+                    for team_insights in teams.values()
                 ]
                 for future in as_completed(futures):
                     rows.extend(future.result())
@@ -458,23 +529,25 @@ class Command(BaseCommand):
     def _print_progress(self, done: int, total: int, row: Row) -> None:
         if row.status == "OK":
             return  # keep the stream quiet; only surface the interesting outcomes
-        style = {"MISMATCH": self.style.ERROR, "ERROR": self.style.ERROR}.get(row.status, self.style.WARNING)
+        is_bad = row.status == "MISMATCH" or row.status.startswith("ERROR")
+        style = self.style.ERROR if is_bad else self.style.WARNING
         suffix = f" — {row.detail}" if row.detail else ""
         self.stdout.write(style(f"[{done}/{total}] {row.status} {row.short_id} (team {row.team_id}){suffix}"))
 
     def _print_summary(self, rows: list[Row]) -> None:
-        counts = {
-            status: sum(1 for r in rows if r.status == status) for status in ("OK", "MISMATCH", "ERROR", "SKIPPED")
-        }
+        counts = {status: sum(1 for r in rows if r.status == status) for status in PROGRESS_STATUSES}
         self.stdout.write("")
         self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
-        self.stdout.write(
-            f"OK={counts['OK']} MISMATCH={counts['MISMATCH']} ERROR={counts['ERROR']} SKIPPED={counts['SKIPPED']}"
-        )
+        self.stdout.write(" ".join(f"{status}={counts[status]}" for status in PROGRESS_STATUSES))
         mismatches = [r for r in rows if r.status == "MISMATCH"]
         if mismatches:
             self.stdout.write(self.style.ERROR("\nMismatches:"))
             for r in mismatches:
+                self.stdout.write(self.style.ERROR(f"  {r.short_id} (team {r.team_id}) {r.url} — {r.detail}"))
+        dwh_only = [r for r in rows if r.status == "ERROR_DWH"]
+        if dwh_only:
+            self.stdout.write(self.style.ERROR("\nDWH-only errors (variant regression candidates):"))
+            for r in dwh_only:
                 self.stdout.write(self.style.ERROR(f"  {r.short_id} (team {r.team_id}) {r.url} — {r.detail}"))
         sys.stdout.flush()
 
@@ -488,10 +561,8 @@ class Command(BaseCommand):
     def _print_checkpoint(self, state_file: str, state: ProgressState) -> None:
         self.stdout.write("")
         self.stdout.write(self.style.MIGRATE_HEADING("Sweep progress"))
-        self.stdout.write(
-            f"Checked {state.processed} insight(s) so far — OK={state.counts['OK']} "
-            f"MISMATCH={state.counts['MISMATCH']} ERROR={state.counts['ERROR']} SKIPPED={state.counts['SKIPPED']}"
-        )
+        counts_line = " ".join(f"{status}={state.counts.get(status, 0)}" for status in PROGRESS_STATUSES)
+        self.stdout.write(f"Checked {state.processed} insight(s) so far — {counts_line}")
         self.stdout.write(f"Checkpoint written to {state_file} (cursor at insight id {state.cursor}).")
         if state.complete:
             self.stdout.write(self.style.SUCCESS("Sweep complete — every matching insight has been checked."))
@@ -509,7 +580,9 @@ class Command(BaseCommand):
         cap = 50
         self.stdout.write(style(f"\n{heading} ({len(records)}):"))
         for rec in records[:cap]:
+            # Attribution matters within the errors list; older state files have no status field.
+            label = f"[{rec['status']}] " if rec.get("status", "").startswith("ERROR") else ""
             detail = f" — {rec['detail']}" if rec.get("detail") else ""
-            self.stdout.write(style(f"  {rec['short_id']} (team {rec['team_id']}) {rec['url']}{detail}"))
+            self.stdout.write(style(f"  {label}{rec['short_id']} (team {rec['team_id']}) {rec['url']}{detail}"))
         if len(records) > cap:
             self.stdout.write(style(f"  …and {len(records) - cap} more (see state file)"))

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -1,0 +1,249 @@
+"""Fast correctness-only check: legacy vs new ("DWH variant") retention base query.
+
+A stripped-down companion to ``compare_retention_legacy_vs_dwh``: no timing, no query-log
+resource stats, no HogQL embedding, no per-insight report blocks. It runs each affected
+RetentionQuery insight twice (variant OFF then ON), diffs the two result sets, and prints a
+one-line-per-mismatch summary. The expensive parts of the full tool are gone and insights are
+checked concurrently, so a correctness sweep finishes in a fraction of the time.
+
+Concurrency is spread *across teams*, never within one. The unit of parallelism is a team: each
+team's insights are checked serially in a single lane, and up to ``--concurrency`` distinct teams
+run at once. This means two concurrent queries always hit different teams' data — different
+primary-key ranges in ClickHouse — rather than hammering the same team's event granules twice over.
+A consequence worth knowing: if the selected set is dominated by one team, effective parallelism
+drops toward serial, which is the intended safety behaviour.
+
+Correctness semantics are *identical* to the full tool — it imports and reuses the same
+``classify_insight`` / ``diff_retention_results`` / ``compute_interval_context`` helpers, including
+the trailing-period exclusion that keeps live-ingest drift on the in-progress interval from showing
+up as a false mismatch. Strictly read-only.
+
+The variant toggle is process-global, so instead of nesting a ``patch`` per call (which would race
+across worker threads) we install one process-wide patch whose return value is read from a
+``ContextVar`` each worker sets before it runs. Threads start with a fresh context, so the workers
+never collide.
+
+Examples:
+    # All retention insights, up to 8 teams in parallel
+    python manage.py compare_retention_correctness
+
+    # One team, serial (e.g. to avoid extra ClickHouse load on prod)
+    python manage.py compare_retention_correctness --team-id 42 --concurrency 1
+
+    # CI gate: non-zero exit if anything mismatches
+    python manage.py compare_retention_correctness --fail-on-mismatch
+"""
+
+import sys
+import argparse
+import threading
+import contextvars
+import dataclasses
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from copy import deepcopy
+from typing import Any, Optional
+
+from unittest.mock import patch
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connections
+
+from posthog.schema import HogQLQueryModifiers
+
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+
+from posthog.hogql_queries.insights.retention.test.retention_base_query_variant import (
+    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
+)
+from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    classify_insight,
+    compute_interval_context,
+    diff_retention_results,
+)
+
+from products.product_analytics.backend.models.insight import Insight
+
+# Per-thread variant selector. The single process-wide patch below reads this, so concurrent
+# workers each pick their own variant without stepping on a shared global.
+_use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_use_dwh", default=False)
+
+
+@dataclasses.dataclass
+class Row:
+    short_id: str
+    team_id: int
+    url: str
+    status: str  # "OK" | "MISMATCH" | "ERROR" | "SKIPPED"
+    detail: str = ""
+
+
+def _run_variant(
+    insight: Insight, use_dwh: bool, modifiers: HogQLQueryModifiers, override: Optional[dict[str, Any]]
+) -> list:
+    source = deepcopy(insight.query["source"])
+    if override is not None:
+        source["dateRange"] = override
+    _use_dwh_var.set(use_dwh)
+    response = get_query_runner(source, insight.team, modifiers=deepcopy(modifiers)).calculate()
+    return response.results or []
+
+
+def _check_one(insight: Insight, url: str, freeze: bool) -> Row:
+    try:
+        action, reason = classify_insight(insight)
+        if action == "error":
+            return Row(insight.short_id, insight.team_id, url, "ERROR", reason)
+        if action == "skip":
+            return Row(insight.short_id, insight.team_id, url, "SKIPPED", reason)
+
+        modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
+        ctx = compute_interval_context(insight, modifiers, freeze=freeze)
+        override = ctx.frozen_date_range
+
+        legacy = _run_variant(insight, False, modifiers, override)
+        dwh = _run_variant(insight, True, modifiers, override)
+        diff = diff_retention_results(
+            legacy,
+            dwh,
+            latest_interval_start=ctx.latest_interval_start,
+            interval_delta=ctx.trailing_delta,
+        )
+        detail = ""
+        if diff.status == "MISMATCH":
+            detail = (
+                f"{len(diff.cell_diffs)} cell diff(s), rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
+            )
+        return Row(insight.short_id, insight.team_id, url, diff.status, detail)
+    except Exception as exc:
+        return Row(insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
+
+
+def _check_team(
+    insights: list[Insight], urls: dict[int, str], freeze: bool, report: Callable[[Row], None]
+) -> list[Row]:
+    """One lane = one team. Its insights are checked serially so a team's data is never read
+    concurrently with itself; distinct teams run in parallel across lanes."""
+    rows: list[Row] = []
+    try:
+        for insight in insights:
+            row = _check_one(insight, urls[insight.id], freeze)
+            rows.append(row)
+            report(row)
+    finally:
+        # This lane's worker thread opened its own Django DB connection lazily; close it so a large
+        # fan-out across teams does not exhaust the Postgres connection pool.
+        connections.close_all()
+    return rows
+
+
+class Command(BaseCommand):
+    help = "Fast correctness-only comparison of legacy vs DWH retention variant (no perf, concurrent)"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--team-id", type=int, action="append", help="Restrict to team id(s); repeatable")
+        parser.add_argument("--insight-id", type=int, action="append", help="Restrict to insight DB id(s); repeatable")
+        parser.add_argument("--short-id", type=str, action="append", help="Restrict to insight short_id(s); repeatable")
+        parser.add_argument("--limit", type=int, default=100, help="Max insights to process (default 100)")
+        parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by date")
+        parser.add_argument(
+            "--concurrency",
+            type=int,
+            default=8,
+            help="Distinct teams checked in parallel (default 8; 1 = serial). A team's own insights are "
+            "always checked serially, so two concurrent queries never read the same team's data.",
+        )
+        parser.add_argument("--base-url", type=str, default="https://us.posthog.com", help="Base URL for insight links")
+        parser.add_argument(
+            "--freeze-window",
+            "--exclude-current-period",
+            dest="freeze_window",
+            action="store_true",
+            help="Compare over a frozen snapshot ending at the last complete interval (drops the in-progress period)",
+        )
+        parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        insights = self._select_insights(options)
+        if not insights:
+            self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
+            return
+
+        base_url = options["base_url"].rstrip("/")
+        freeze = options["freeze_window"]
+        urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
+
+        # One lane per team: the team's insights run serially within the lane, distinct teams in
+        # parallel — so concurrent queries always read different teams' data, never the same team's.
+        teams: dict[int, list[Insight]] = defaultdict(list)
+        for insight in insights:
+            teams[insight.team_id].append(insight)
+        concurrency = max(1, min(options["concurrency"], len(teams)))
+        self.stdout.write(
+            f"Checking {len(insights)} retention insight(s) across {len(teams)} team(s), "
+            f"up to {concurrency} team(s) in parallel…"
+        )
+
+        total = len(insights)
+        progress_lock = threading.Lock()
+        done = 0
+
+        def report(row: Row) -> None:
+            nonlocal done
+            with progress_lock:
+                done += 1
+                self._print_progress(done, total, row)
+
+        rows: list[Row] = []
+        # One process-wide patch; each worker selects its variant via the ContextVar.
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, side_effect=lambda team: _use_dwh_var.get()):
+            with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                futures = [
+                    pool.submit(_check_team, team_insights, urls, freeze, report) for team_insights in teams.values()
+                ]
+                for future in as_completed(futures):
+                    rows.extend(future.result())
+
+        self._print_summary(rows)
+
+        mismatches = sum(1 for r in rows if r.status == "MISMATCH")
+        if options["fail_on_mismatch"] and mismatches:
+            raise CommandError(f"{mismatches} insight(s) mismatched between variants")
+
+    def _select_insights(self, options: dict[str, Any]) -> list[Insight]:
+        queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")
+        if options["team_id"]:
+            queryset = queryset.filter(team_id__in=options["team_id"])
+        if options["insight_id"]:
+            queryset = queryset.filter(id__in=options["insight_id"])
+        if options["short_id"]:
+            queryset = queryset.filter(short_id__in=options["short_id"])
+        queryset = queryset.select_related("team")
+        if options["sample"]:
+            return list(queryset.order_by("?")[: options["sample"]])
+        return list(queryset.order_by("created_at")[: options["limit"]])
+
+    def _print_progress(self, done: int, total: int, row: Row) -> None:
+        if row.status == "OK":
+            return  # keep the stream quiet; only surface the interesting outcomes
+        style = {"MISMATCH": self.style.ERROR, "ERROR": self.style.ERROR}.get(row.status, self.style.WARNING)
+        suffix = f" — {row.detail}" if row.detail else ""
+        self.stdout.write(style(f"[{done}/{total}] {row.status} {row.short_id} (team {row.team_id}){suffix}"))
+
+    def _print_summary(self, rows: list[Row]) -> None:
+        counts = {
+            status: sum(1 for r in rows if r.status == status) for status in ("OK", "MISMATCH", "ERROR", "SKIPPED")
+        }
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
+        self.stdout.write(
+            f"OK={counts['OK']} MISMATCH={counts['MISMATCH']} ERROR={counts['ERROR']} SKIPPED={counts['SKIPPED']}"
+        )
+        mismatches = [r for r in rows if r.status == "MISMATCH"]
+        if mismatches:
+            self.stdout.write(self.style.ERROR("\nMismatches:"))
+            for r in mismatches:
+                self.stdout.write(self.style.ERROR(f"  {r.short_id} (team {r.team_id}) {r.url} — {r.detail}"))
+        sys.stdout.flush()

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -127,6 +127,7 @@ from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
+from posthog.git import get_git_commit_short
 from posthog.hogql_queries.query_runner import get_query_runner
 
 # The patch path comes from the sibling command (which defines it locally, not via import) so this
@@ -148,6 +149,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     is_object_storage_path,
     object_storage_key,
     read_state_text,
+    shape_fingerprint,
     write_state_text,
 )
 
@@ -459,8 +461,12 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
         detail = ""
         if diff.status == "MISMATCH":
             stable = "stable " if rechecked else ""
+            agg_diffs = sum(1 for c in diff.cell_diffs if c.field == "aggregation_value")
+            field_split = (
+                f" ({len(diff.cell_diffs) - agg_diffs} count, {agg_diffs} aggregation_value)" if agg_diffs else ""
+            )
             detail = (
-                f"{len(diff.cell_diffs)} {stable}cell diff(s), "
+                f"{len(diff.cell_diffs)} {stable}cell diff(s){field_split}, "
                 f"rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
             )
             if rechecked and diff.cell_diffs:
@@ -473,6 +479,12 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
                     detail += ", all values moved between passes (churn, not deterministic)"
             if recheck and not rechecked:
                 detail += " (recheck errored — stability unverified)"
+            # The shape tag turns the mismatch list into a classification: which query families
+            # still diverge. Only three have structurally different SQL between the variants
+            # (first_time / first_ever anchoring, property aggregation); a mismatch outside them
+            # points at execution-level causes (replica state, code vintage), not query semantics.
+            assert insight.query is not None
+            detail += f"; shape: {shape_fingerprint(insight.query['source'])}"
         return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)
     except Exception as exc:
         return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
@@ -559,6 +571,10 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         if options["limit"] < 1:
             raise CommandError("--limit must be at least 1")
+
+        # Mismatch verdicts are only comparable across runs at a known code version: a finding that
+        # reproduces on an old image may already be fixed on master.
+        self.stdout.write(f"Code version: {get_git_commit_short() or 'unknown'}")
 
         state_file: Optional[str] = options["state_file"]
         after_id: Optional[int] = options["after_id"]

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -64,12 +64,24 @@ sweep.json`` is a single resumable run. The journal is absorbed into the state f
 finishes. The cursor alone can't provide this: teams run in parallel lanes, so an interrupted run's
 completed ids are scattered across the id range, not a contiguous prefix a cursor could describe.
 
+Pods are ephemeral, so a state file on the pod's own disk dies with the pod. Prefix ``--state-file``
+with ``s3://`` (e.g. ``s3://retention_compare/sweep.json``, a key in the default object-storage
+bucket) to keep the checkpoint and journal in object storage instead: any other pod with the same
+command then resumes the sweep. Object storage can't append, so the remote journal is uploaded whole
+at most every ~30s and on SIGTERM (evictions grant a grace period); a hard kill (OOM) loses at most
+that window of finished insights, which the resumed run simply re-checks. The state file records
+which host last wrote it, and resuming from a different host prints a notice, since nothing stops
+two pods from writing the same key.
+
 Examples:
     # All retention insights, up to 8 teams in parallel
     python manage.py compare_retention_correctness
 
     # Every matching insight in one run; Ctrl-C safe — re-run the same command to resume
     python manage.py compare_retention_correctness --all --state-file /tmp/retention_sweep.json
+
+    # Same, but the state survives the pod: resume from any other pod with the same command
+    python manage.py compare_retention_correctness --all --state-file s3://retention_compare/sweep.json
 
     # Resumable sweep over every insight: run this repeatedly until it reports "complete"
     python manage.py compare_retention_correctness --state-file /tmp/retention_sweep.json --limit 500
@@ -87,6 +99,7 @@ Examples:
 import os
 import sys
 import json
+import socket
 import argparse
 import threading
 import contextvars
@@ -94,10 +107,11 @@ import dataclasses
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import nullcontext
 from copy import deepcopy
 from datetime import UTC, datetime
 from time import perf_counter
-from typing import Any, Optional, TextIO
+from typing import Any, Optional
 
 from unittest.mock import patch
 
@@ -115,12 +129,21 @@ from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     HEARTBEAT_EVERY,
     RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
+    FileLineSink,
+    LineSink,
+    ObjectStorageLineSink,
     _fmt_duration,
     attribute_variant_errors,
     classify_insight,
     compute_interval_context,
+    delete_state_path,
     diff_retention_results,
+    flush_on_sigterm,
     intersect_stable_mismatch,
+    is_object_storage_path,
+    object_storage_key,
+    read_state_text,
+    write_state_text,
 )
 
 from products.product_analytics.backend.models.insight import Insight
@@ -152,6 +175,8 @@ class ProgressState:
     ``cursor`` is a keyset position: the next run checks insights with ``id`` greater than it. Counts and
     findings accumulate across runs, so a completed file is itself the full report. ``scope`` fingerprints
     the filter set the sweep was started with, so resuming under different filters can be refused.
+    ``writer`` is the host that last saved the checkpoint: a shared (object-storage) state file has no
+    locking, so a resume from a different host prints a notice in case the previous pod is still running.
     """
 
     cursor: int = 0  # highest insight id checked so far; next run filters id > cursor
@@ -164,6 +189,7 @@ class ProgressState:
     errors: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     complete: bool = False
     scope: str = ""
+    writer: str = ""
     updated_at: Optional[str] = None
 
     @classmethod
@@ -178,6 +204,7 @@ class ProgressState:
             errors=list(data.get("errors") or []),
             complete=bool(data.get("complete", False)),
             scope=str(data.get("scope", "")),
+            writer=str(data.get("writer", "")),
             updated_at=data.get("updated_at"),
         )
 
@@ -324,18 +351,35 @@ def parse_journal_lines(lines: list[str], scope: str) -> list[Row]:
 
 
 def load_progress_state(path: str) -> Optional[ProgressState]:
-    if not os.path.exists(path):
+    text = read_state_text(path)
+    if text is None:
         return None
-    with open(path) as f:
-        return ProgressState.from_dict(json.load(f))
+    return ProgressState.from_dict(json.loads(text))
 
 
 def save_progress_state(path: str, state: ProgressState) -> None:
-    # Write-then-replace so a crash mid-write can't corrupt an in-progress sweep's checkpoint.
-    tmp = f"{path}.tmp"
-    with open(tmp, "w") as f:
-        json.dump(state.to_dict(), f, indent=2, sort_keys=True)
-    os.replace(tmp, path)
+    write_state_text(path, json.dumps(state.to_dict(), indent=2, sort_keys=True))
+
+
+def stamp_progress_state(state: ProgressState) -> ProgressState:
+    state.updated_at = datetime.now(UTC).isoformat()
+    state.writer = socket.gethostname()
+    return state
+
+
+def unabsorbed_journal_rows(rows: list[Row], cursor: Optional[int]) -> list[Row]:
+    """Journal rows not yet folded into the checkpoint. Pure.
+
+    A journal normally disappears when its batch completes (the absorb deletes it right after the
+    state write). If that delete never lands — a crash between the two writes, or an object-storage
+    delete failing — the next run would fold the leftover rows a second time and double-count every
+    one of them. Absorbed rows are exactly those at or below the checkpoint cursor: a batch only
+    journals ids above the cursor it started from, and the cursor only advances when a batch's rows
+    are absorbed.
+    """
+    if cursor is None:
+        return rows
+    return [row for row in rows if row.id > cursor]
 
 
 def _run_variant(
@@ -465,7 +509,10 @@ class Command(BaseCommand):
             "afterwards it is rewritten with the new cursor plus accumulated counts and findings. Re-run the "
             "same command to walk every matching insight in --limit-sized batches until it reports complete. "
             "Interrupted runs resume too: each finished insight is journaled to <state-file>.journal as it "
-            "completes, and the next run skips the journaled insights and keeps their results.",
+            "completes, and the next run skips the journaled insights and keeps their results. Prefix with "
+            "s3:// to keep the checkpoint and journal in object storage (the key lands in the default "
+            "bucket), so the sweep outlives an ephemeral pod and any other pod can resume it; the journal "
+            "is uploaded every ~30s and on SIGTERM.",
         )
         parser.add_argument(
             "--after-id",
@@ -522,6 +569,7 @@ class Command(BaseCommand):
         prev_state, already_complete = self._load_resume_state(state_file, scope, after_id, options["restart"])
         journal_file = f"{state_file}{JOURNAL_SUFFIX}" if state_file else None
         journal_rows = self._load_journal(journal_file, scope, restart=options["restart"])
+        journal_rows = unabsorbed_journal_rows(journal_rows, prev_state.cursor if prev_state else None)
 
         # Re-verify mismatches recorded by earlier batches before doing new work: enough time has
         # usually passed for in-motion data (merges, replica divergence) to settle, so artifacts
@@ -529,8 +577,7 @@ class Command(BaseCommand):
         # command on an already-complete sweep does just this re-verification.
         if state_file and prev_state is not None and prev_state.mismatches and options["recheck_mismatches"]:
             prev_state = self._revalidate_previous_mismatches(prev_state, options)
-            prev_state.updated_at = datetime.now(UTC).isoformat()
-            save_progress_state(state_file, prev_state)
+            save_progress_state(state_file, stamp_progress_state(prev_state))
 
         if already_complete:
             assert prev_state is not None  # already_complete implies a loaded checkpoint
@@ -545,16 +592,20 @@ class Command(BaseCommand):
             self._handle_empty(options, state_file, scope, prev_state, cursor, journal_rows, journal_file)
             return
 
-        journal = self._open_journal(journal_file, scope)
+        journal = self._open_journal(journal_file, scope, recovered=journal_rows)
+        # A local journal flushes every row to disk, so only the buffering object-storage sink
+        # needs the eviction (SIGTERM) flush.
+        sigterm_guard = flush_on_sigterm(journal.flush) if isinstance(journal, ObjectStorageLineSink) else nullcontext()
         try:
-            rows = self._run(
-                insights,
-                options["base_url"].rstrip("/"),
-                options["freeze_window"],
-                options["recheck_mismatches"],
-                options["concurrency"],
-                journal,
-            )
+            with sigterm_guard:
+                rows = self._run(
+                    insights,
+                    options["base_url"].rstrip("/"),
+                    options["freeze_window"],
+                    options["recheck_mismatches"],
+                    options["concurrency"],
+                    journal,
+                )
         finally:
             if journal is not None:
                 journal.close()
@@ -569,8 +620,7 @@ class Command(BaseCommand):
             new_state = merge_progress_state(
                 prev_state, all_rows, next_cursor=next_cursor, complete=fresh_exhausted, scope=scope
             )
-            new_state.updated_at = datetime.now(UTC).isoformat()
-            save_progress_state(state_file, new_state)
+            save_progress_state(state_file, stamp_progress_state(new_state))
             self._absorb_journal(journal_file)
             self._print_checkpoint(state_file, new_state)
             self._print_cumulative(new_state)
@@ -604,29 +654,45 @@ class Command(BaseCommand):
                 )
             )
             return prev, True
+        # A shared state file has no locking; two writers would silently clobber each other's batches.
+        if prev.writer and prev.writer != socket.gethostname():
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Resuming a sweep last written by {prev.writer} at {prev.updated_at or 'an unknown time'}. "
+                    "Make sure that run is no longer active before continuing."
+                )
+            )
         return prev, False
 
     def _load_journal(self, path: Optional[str], scope: str, restart: bool) -> list[Row]:
         """Rows persisted per-insight by an interrupted run. They are excluded from this run's
         selection and their recorded results folded into the checkpoint when the batch completes."""
-        if path is None or not os.path.exists(path):
+        if path is None:
             return []
         if restart:
-            os.remove(path)
+            delete_state_path(path)
             return []
-        with open(path) as f:
-            lines = f.read().splitlines()
+        text = read_state_text(path)
+        if text is None:
+            return []
         try:
-            rows = parse_journal_lines(lines, scope)
+            rows = parse_journal_lines(text.splitlines(), scope)
         except ValueError as exc:
             raise CommandError(f"{path}: {exc}. Use a separate --state-file, or pass --restart to overwrite it.")
         if rows:
             self.stdout.write(f"Recovered {len(rows)} finished insight(s) from the interrupted run in {path}.")
         return rows
 
-    def _open_journal(self, path: Optional[str], scope: str) -> Optional[TextIO]:
+    def _open_journal(self, path: Optional[str], scope: str, recovered: list[Row]) -> Optional[LineSink]:
         if path is None:
             return None
+        if is_object_storage_path(path):
+            # Every upload replaces the whole object, so the buffer must start with everything the
+            # journal still needs to hold: the scope header plus the interrupted run's recovered
+            # rows, which are only safe to drop once the batch-end absorb folds them into the
+            # state file.
+            lines = [json.dumps({"scope": scope}), *(journal_line(row) for row in recovered)]
+            return ObjectStorageLineSink(object_storage_key(path), lines)
         handle = open(path, "a")
         if handle.tell() == 0:
             handle.write(json.dumps({"scope": scope}) + "\n")
@@ -639,12 +705,12 @@ class Command(BaseCommand):
                 # record isn't glued onto the fragment (which would corrupt both).
                 handle.write("\n")
         handle.flush()
-        return handle
+        return FileLineSink(handle)
 
     def _absorb_journal(self, path: Optional[str]) -> None:
         # The batch's rows are in the state file now; a leftover journal would double-fold them.
-        if path is not None and os.path.exists(path):
-            os.remove(path)
+        if path is not None:
+            delete_state_path(path)
 
     def _revalidate_previous_mismatches(self, state: ProgressState, options: dict[str, Any]) -> ProgressState:
         self.stdout.write(f"Re-verifying {len(state.mismatches)} previously recorded mismatch(es)…")
@@ -693,8 +759,7 @@ class Command(BaseCommand):
             new_state = merge_progress_state(
                 prev_state, journal_rows, next_cursor=next_cursor, complete=True, scope=scope
             )
-            new_state.updated_at = datetime.now(UTC).isoformat()
-            save_progress_state(state_file, new_state)
+            save_progress_state(state_file, stamp_progress_state(new_state))
             self._absorb_journal(journal_file)
             self.stdout.write(
                 self.style.SUCCESS(
@@ -714,7 +779,7 @@ class Command(BaseCommand):
         freeze: bool,
         recheck: bool,
         concurrency_opt: int,
-        journal: Optional[TextIO] = None,
+        journal: Optional[LineSink] = None,
     ) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
@@ -739,10 +804,10 @@ class Command(BaseCommand):
             nonlocal done
             with progress_lock:
                 if journal is not None:
-                    # Persist before printing, flushed per row, so an interrupt loses at most the
-                    # insights still in flight.
-                    journal.write(journal_line(row) + "\n")
-                    journal.flush()
+                    # Persist before printing: a local journal flushes every row to disk, the
+                    # object-storage one uploads on its cadence and on SIGTERM, so an interrupt
+                    # loses at most the in-flight window.
+                    journal.append(journal_line(row))
                 done += 1
                 counts[row.status] += 1
                 self._print_progress(done, total, row)

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -410,7 +410,20 @@ def _try_variant(
         return None, exc
 
 
-def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
+def format_cell_sample(cell_diffs: Sequence[Any], limit: int) -> str:
+    """Compact rendering of the largest differing cells, in diff_retention_results' order
+    (abs_diff descending). The legacy value always prints left of the dwh value — swapping
+    them would invert every triage conclusion drawn from the output."""
+    cells = []
+    for cell in cell_diffs[:limit]:
+        prefix = f"[{cell.breakdown_value}] " if cell.breakdown_value is not None else ""
+        field = "" if cell.field == "count" else " agg"
+        cells.append(f"{prefix}{cell.row_label}/{cell.value_label}{field} {cell.legacy:g}≠{cell.dwh:g}")
+    suffix = f" (+{len(cell_diffs) - limit} more)" if len(cell_diffs) > limit else ""
+    return "; ".join(cells) + suffix
+
+
+def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool, dump_cells: int = 0) -> Row:
     try:
         action, reason = classify_insight(insight)
         if action == "error":
@@ -485,20 +498,27 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
             # points at execution-level causes (replica state, code vintage), not query semantics.
             assert insight.query is not None
             detail += f"; shape: {shape_fingerprint(insight.query['source'])}"
+            if dump_cells and diff.cell_diffs:
+                detail += f" | cells: {format_cell_sample(diff.cell_diffs, dump_cells)}"
         return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)
     except Exception as exc:
         return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", f"{type(exc).__name__}: {exc}")
 
 
 def _check_team(
-    insights: list[Insight], urls: dict[int, str], freeze: bool, recheck: bool, report: Callable[[Row], None]
+    insights: list[Insight],
+    urls: dict[int, str],
+    freeze: bool,
+    recheck: bool,
+    report: Callable[[Row], None],
+    dump_cells: int = 0,
 ) -> list[Row]:
     """One lane = one team. Its insights are checked serially so a team's data is never read
     concurrently with itself; distinct teams run in parallel across lanes."""
     rows: list[Row] = []
     try:
         for insight in insights:
-            row = _check_one(insight, urls[insight.id], freeze, recheck)
+            row = _check_one(insight, urls[insight.id], freeze, recheck, dump_cells)
             rows.append(row)
             report(row)
     finally:
@@ -565,6 +585,15 @@ class Command(BaseCommand):
             action=argparse.BooleanOptionalAction,
             default=True,
             help="Re-run both variants once on a mismatch and keep only differences that reproduce (default on)",
+        )
+        parser.add_argument(
+            "--dump-cells",
+            type=int,
+            default=0,
+            metavar="N",
+            help="Append the N largest differing cells (row/column coordinates with legacy≠dwh values) to each "
+            "mismatch line. The coordinate pattern shows which part of the result diverges — e.g. values shifted "
+            "into a neighbouring bracket vs a missing Day 0 — without running the full report tool.",
         )
         parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
 
@@ -641,6 +670,7 @@ class Command(BaseCommand):
                     options["concurrency"],
                     journal,
                     recovered=journal_rows,
+                    dump_cells=options["dump_cells"],
                 )
         finally:
             if journal is not None:
@@ -760,7 +790,7 @@ class Command(BaseCommand):
             )
             if insight is None:
                 return None
-            return _check_one(insight, rec.get("url", ""), freeze, recheck=True)
+            return _check_one(insight, rec.get("url", ""), freeze, recheck=True, dump_cells=options["dump_cells"])
 
         with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, side_effect=lambda team: _use_dwh_var.get()):
             kept, resolved, counts = revalidate_mismatches(state.mismatches, state.counts, check)
@@ -817,6 +847,7 @@ class Command(BaseCommand):
         concurrency_opt: int,
         journal: Optional[LineSink] = None,
         recovered: Sequence[Row] = (),
+        dump_cells: int = 0,
     ) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
@@ -860,7 +891,7 @@ class Command(BaseCommand):
         with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, side_effect=lambda team: _use_dwh_var.get()):
             with ThreadPoolExecutor(max_workers=concurrency) as pool:
                 futures = [
-                    pool.submit(_check_team, team_insights, urls, freeze, recheck, report)
+                    pool.submit(_check_team, team_insights, urls, freeze, recheck, report, dump_cells)
                     for team_insights in teams.values()
                 ]
                 for future in as_completed(futures):

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -63,6 +63,11 @@ the journaled insights and folds their recorded results into the report — so `
 sweep.json`` is a single resumable run. The journal is absorbed into the state file when a batch
 finishes. The cursor alone can't provide this: teams run in parallel lanes, so an interrupted run's
 completed ids are scattered across the id range, not a contiguous prefix a cursor could describe.
+A resumed run says so up front (recovered and remaining counts) and its progress counter and status
+totals continue from the recovered position instead of restarting at zero; only the ETA rate comes
+from insights this run finished itself. The checkpoint file is also written the moment a run starts,
+so the key exists (and names the active writer) mid-sweep — until a batch completes it records no
+progress, which lives in the journal.
 
 Pods are ephemeral, so a state file on the pod's own disk dies with the pod. Prefix ``--state-file``
 with ``s3://`` (e.g. ``s3://retention_compare/sweep.json``, a key in the default object-storage
@@ -105,7 +110,7 @@ import threading
 import contextvars
 import dataclasses
 from collections import Counter, defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from copy import deepcopy
@@ -512,7 +517,8 @@ class Command(BaseCommand):
             "completes, and the next run skips the journaled insights and keeps their results. Prefix with "
             "s3:// to keep the checkpoint and journal in object storage (the key lands in the default "
             "bucket), so the sweep outlives an ephemeral pod and any other pod can resume it; the journal "
-            "is uploaded every ~30s and on SIGTERM.",
+            "is uploaded every ~30s and on SIGTERM. The checkpoint file is created as soon as the run "
+            "starts; mid-run progress lives in the journal until the batch completes.",
         )
         parser.add_argument(
             "--after-id",
@@ -592,6 +598,19 @@ class Command(BaseCommand):
             self._handle_empty(options, state_file, scope, prev_state, cursor, journal_rows, journal_file)
             return
 
+        if journal_rows:
+            total = len(journal_rows) + len(insights)
+            self.stdout.write(
+                f"Resuming: {len(journal_rows)}/{total} insight(s) already checked, {len(insights)} to go."
+            )
+        if state_file:
+            # Claim the checkpoint up front. The only other write is at batch end — for --all the
+            # end of the whole sweep — so until then the key would not exist and a mid-sweep look
+            # at it reads as a run that never persisted anything. Claiming also records this host
+            # as the active writer, and on --restart it replaces the finished checkpoint right
+            # away, so a crashed restart resumes instead of reporting the old sweep complete.
+            save_progress_state(state_file, stamp_progress_state(prev_state or ProgressState(scope=scope)))
+
         journal = self._open_journal(journal_file, scope, recovered=journal_rows)
         # A local journal flushes every row to disk, so only the buffering object-storage sink
         # needs the eviction (SIGTERM) flush.
@@ -605,6 +624,7 @@ class Command(BaseCommand):
                     options["recheck_mismatches"],
                     options["concurrency"],
                     journal,
+                    recovered=journal_rows,
                 )
         finally:
             if journal is not None:
@@ -780,6 +800,7 @@ class Command(BaseCommand):
         recheck: bool,
         concurrency_opt: int,
         journal: Optional[LineSink] = None,
+        recovered: Sequence[Row] = (),
     ) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
@@ -794,14 +815,18 @@ class Command(BaseCommand):
             f"up to {concurrency} team(s) in parallel…"
         )
 
-        total = len(insights)
+        total = len(insights) + len(recovered)
         progress_lock = threading.Lock()
-        done = 0
-        counts: Counter[str] = Counter()
+        # Recovered rows pre-seed the position and status totals so [done/total] tracks the whole
+        # sweep rather than restarting at zero on resume; fresh_done feeds the ETA separately,
+        # because the recovered rows cost this run nothing and would collapse the rate.
+        done = len(recovered)
+        fresh_done = 0
+        counts: Counter[str] = Counter(row.status for row in recovered)
         started_at = perf_counter()
 
         def report(row: Row) -> None:
-            nonlocal done
+            nonlocal done, fresh_done
             with progress_lock:
                 if journal is not None:
                     # Persist before printing: a local journal flushes every row to disk, the
@@ -809,9 +834,10 @@ class Command(BaseCommand):
                     # loses at most the in-flight window.
                     journal.append(journal_line(row))
                 done += 1
+                fresh_done += 1
                 counts[row.status] += 1
                 self._print_progress(done, total, row)
-                self._print_heartbeat(done, total, started_at, counts)
+                self._print_heartbeat(done, total, fresh_done, started_at, counts)
 
         rows: list[Row] = []
         # One process-wide patch; each worker selects its variant via the ContextVar.
@@ -856,13 +882,13 @@ class Command(BaseCommand):
         suffix = f" — {row.detail}" if row.detail else ""
         self.stdout.write(style(f"[{done}/{total}] {row.status} {row.short_id} (team {row.team_id}){suffix}"))
 
-    def _print_heartbeat(self, done: int, total: int, started_at: float, counts: Counter[str]) -> None:
+    def _print_heartbeat(self, done: int, total: int, fresh_done: int, started_at: float, counts: Counter[str]) -> None:
         """Elapsed/ETA line every HEARTBEAT_EVERY insights: per-row output stays quiet on OK, so a
         long healthy run would otherwise print nothing. Called with the progress lock held."""
         if done != total and done % HEARTBEAT_EVERY:
             return
         elapsed = perf_counter() - started_at
-        eta = (elapsed / done) * (total - done)
+        eta = (elapsed / fresh_done) * (total - done)
         errors = sum(count for status, count in counts.items() if status.startswith("ERROR"))
         self.stdout.write(
             f"[{done}/{total}] elapsed={_fmt_duration(elapsed)} eta={_fmt_duration(eta)} — "

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -83,9 +83,7 @@ from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
-from posthog.hogql_queries.insights.retention.test.retention_base_query_variant import (
-    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
-)
+from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RETENTION_BASE_QUERY_VARIANT_PATCH_PATH
 from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     attribute_variant_errors,

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -296,6 +296,14 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
                 f"{len(diff.cell_diffs)} {stable}cell diff(s), "
                 f"rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
             )
+            if rechecked and diff.cell_diffs:
+                # Value-identical cells reproduce exactly (deterministic difference); moved values
+                # mean the data changed under the queries in both passes (merge/late-ingest churn).
+                identical = sum(1 for c in diff.cell_diffs if c.values_stable)
+                if identical:
+                    detail += f", {identical}/{len(diff.cell_diffs)} value-identical (deterministic)"
+                else:
+                    detail += ", all values moved between passes (churn, not deterministic)"
             if recheck and not rechecked:
                 detail += " (recheck errored — stability unverified)"
         return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -26,7 +26,18 @@ Insights whose referenced actions/cohorts were deleted are SKIPPED up front by `
 instead of erroring on both sides. A first-pass mismatch is re-run once and only the differences
 that reproduce are kept (``--no-recheck-mismatches`` to disable): late-arriving events and person
 merges move *historical* buckets between the two sequential runs, so a single pass can report live
-drift as a parity bug.
+drift as a parity bug. The recheck runs the variants in reversed order (dwh before legacy) so that
+replica part-set divergence — replicas mid-way through applying the same rewrites can serve
+different data for minutes, and a fixed query cadence phase-locks each variant onto one replica
+state — shows up as moved values (churn) rather than masquerading as a value-identical
+deterministic difference.
+
+Mismatches also age: when a sweep run starts (or an already-complete sweep is re-run) with a
+``--state-file``, every previously accumulated mismatch is first re-verified against current data.
+Ones that no longer reproduce move to a ``resolved_mismatches`` list — typically artifacts of data
+that was being rewritten (merge campaigns collapsing re-emitted rows) when the original batch ran —
+and the counts move from MISMATCH to the settled status. Only differences that keep reproducing
+across runs, usually hours apart, stay in the report.
 
 The variant toggle is process-global, so instead of nesting a ``patch`` per call (which would race
 across worker threads) we install one process-wide patch whose return value is read from a
@@ -129,6 +140,9 @@ class ProgressState:
     processed: int = 0  # cumulative insights checked across all runs
     counts: dict[str, int] = dataclasses.field(default_factory=lambda: dict.fromkeys(PROGRESS_STATUSES, 0))
     mismatches: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Mismatches from earlier batches that stopped reproducing when re-verified on a later run
+    # (data settled), annotated with a "resolution" field.
+    resolved_mismatches: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     errors: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     complete: bool = False
     scope: str = ""
@@ -142,6 +156,7 @@ class ProgressState:
             processed=int(data.get("processed", 0)),
             counts={s: int(raw_counts.get(s, 0)) for s in PROGRESS_STATUSES},
             mismatches=list(data.get("mismatches") or []),
+            resolved_mismatches=list(data.get("resolved_mismatches") or []),
             errors=list(data.get("errors") or []),
             complete=bool(data.get("complete", False)),
             scope=str(data.get("scope", "")),
@@ -186,11 +201,55 @@ def merge_progress_state(
         processed=base.processed + len(rows),
         counts=counts,
         mismatches=base.mismatches + [_row_record(r) for r in rows if r.status == "MISMATCH"],
+        resolved_mismatches=base.resolved_mismatches,
         # All attributed variants (ERROR_LEGACY / ERROR_DWH / ERROR_BOTH) accumulate here too.
         errors=base.errors + [_row_record(r) for r in rows if r.status.startswith("ERROR")],
         complete=len(rows) < limit,
         scope=scope or base.scope,
     )
+
+
+def revalidate_mismatches(
+    records: list[dict[str, Any]],
+    counts: dict[str, int],
+    check: Callable[[dict[str, Any]], Optional[Row]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int]]:
+    """Re-verify previously recorded mismatches against current data. Pure — inputs are not mutated.
+
+    A batch runs minutes to hours after the batch that recorded a mismatch. A difference that was an
+    artifact of data in motion (merges collapsing re-emitted rows while replicas serve divergent part
+    sets) has converged by then and stops reproducing; a genuine query-semantics difference keeps
+    reproducing. Returns (still_mismatched, resolved, adjusted_counts):
+
+    - re-checks OK, or SKIPPED, or the insight is gone → resolved, annotated with a "resolution"
+    - still MISMATCH → kept, with the detail refreshed to the latest verdict
+    - re-check errored → kept untouched (no evidence either way; the next run retries)
+
+    ``adjusted_counts`` moves each resolved record from MISMATCH to its settled status so the sweep
+    totals reflect final verdicts.
+    """
+    kept: list[dict[str, Any]] = []
+    resolved: list[dict[str, Any]] = []
+    new_counts = dict(counts)
+
+    def resolve(rec: dict[str, Any], status: str, resolution: str) -> None:
+        new_counts["MISMATCH"] = max(0, new_counts.get("MISMATCH", 0) - 1)
+        new_counts[status] = new_counts.get(status, 0) + 1
+        resolved.append({**rec, "resolution": resolution})
+
+    for rec in records:
+        row = check(rec)
+        if row is None:
+            resolve(rec, "SKIPPED", "insight no longer exists")
+        elif row.status == "OK":
+            resolve(rec, "OK", "no longer reproduces (data settled)")
+        elif row.status == "SKIPPED":
+            resolve(rec, "SKIPPED", f"now skipped: {row.detail}")
+        elif row.status == "MISMATCH":
+            kept.append({**rec, "detail": row.detail})
+        else:
+            kept.append(rec)
+    return kept, resolved, new_counts
 
 
 def scope_signature(options: dict[str, Any]) -> str:
@@ -279,10 +338,18 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
         # Re-run a first-pass mismatch once and keep only the differences that reproduce: live
         # ingest and person merges shift historical buckets between the sequential runs, so an
         # unrepeated diff is drift, not a parity bug. Bounded cost — mismatches only.
+        #
+        # The recheck runs the variants in REVERSED order (dwh first). Consecutive queries can be
+        # served from different replicas whose part sets diverge while data is being rewritten
+        # (e.g. merges collapsing re-emitted person-merge rows), and a fixed legacy→dwh→legacy→dwh
+        # cadence phase-locks each variant onto one replica state — the skew then reproduces
+        # value-identically and reads as a deterministic query bug. Reversing the recheck order
+        # flips which state each variant reads: replica skew surfaces as moved values (churn),
+        # while a genuine query difference still reproduces with identical values.
         rechecked = False
         if recheck and diff.status == "MISMATCH":
-            legacy2, legacy2_exc = _try_variant(insight, False, modifiers, override)
             dwh2, dwh2_exc = _try_variant(insight, True, modifiers, override)
+            legacy2, legacy2_exc = _try_variant(insight, False, modifiers, override)
             if legacy2_exc is None and dwh2_exc is None:
                 assert legacy2 is not None and dwh2 is not None
                 diff = intersect_stable_mismatch(diff, diff_retention_results(legacy2, dwh2, **diff_kwargs))
@@ -396,7 +463,19 @@ class Command(BaseCommand):
             )
 
         prev_state, already_complete = self._load_resume_state(state_file, scope, after_id, options["restart"])
+
+        # Re-verify mismatches recorded by earlier batches before doing new work: enough time has
+        # usually passed for in-motion data (merges, replica divergence) to settle, so artifacts
+        # drop out of the accumulated findings and only reproducing differences stay. Re-running the
+        # command on an already-complete sweep does just this re-verification.
+        if state_file and prev_state is not None and prev_state.mismatches and options["recheck_mismatches"]:
+            prev_state = self._revalidate_previous_mismatches(prev_state, options)
+            prev_state.updated_at = datetime.now(UTC).isoformat()
+            save_progress_state(state_file, prev_state)
+
         if already_complete:
+            assert prev_state is not None  # already_complete implies a loaded checkpoint
+            self._print_cumulative(prev_state)
             return
 
         # Explicit --after-id wins; otherwise resume from the saved checkpoint (None = start from the top).
@@ -454,9 +533,38 @@ class Command(BaseCommand):
                     "Pass --restart to run it again."
                 )
             )
-            self._print_cumulative(prev)
             return prev, True
         return prev, False
+
+    def _revalidate_previous_mismatches(self, state: ProgressState, options: dict[str, Any]) -> ProgressState:
+        self.stdout.write(f"Re-verifying {len(state.mismatches)} previously recorded mismatch(es)…")
+        freeze: bool = options["freeze_window"]
+
+        def check(rec: dict[str, Any]) -> Optional[Row]:
+            insight = (
+                Insight.objects.filter(pk=rec["id"], saved=True, deleted=False, query__source__kind="RetentionQuery")
+                .select_related("team")
+                .first()
+            )
+            if insight is None:
+                return None
+            return _check_one(insight, rec.get("url", ""), freeze, recheck=True)
+
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, side_effect=lambda team: _use_dwh_var.get()):
+            kept, resolved, counts = revalidate_mismatches(state.mismatches, state.counts, check)
+
+        for rec in resolved:
+            self.stdout.write(
+                self.style.SUCCESS(f"  RESOLVED {rec['short_id']} (team {rec['team_id']}) — {rec['resolution']}")
+            )
+        if kept:
+            self.stdout.write(self.style.ERROR(f"  {len(kept)} mismatch(es) still reproduce"))
+        return dataclasses.replace(
+            state,
+            mismatches=kept,
+            resolved_mismatches=state.resolved_mismatches + resolved,
+            counts=counts,
+        )
 
     def _handle_empty(
         self,
@@ -582,6 +690,9 @@ class Command(BaseCommand):
     def _print_cumulative(self, state: ProgressState) -> None:
         """List the findings accumulated across the whole sweep so far (capped; the full set is in the file)."""
         self._print_record_list("Accumulated mismatches", state.mismatches, self.style.ERROR)
+        self._print_record_list(
+            "Resolved mismatches (stopped reproducing)", state.resolved_mismatches, self.style.SUCCESS
+        )
         self._print_record_list("Accumulated errors", state.errors, self.style.WARNING)
 
     def _print_record_list(self, heading: str, records: list[dict[str, Any]], style: Callable[[str], str]) -> None:
@@ -593,6 +704,9 @@ class Command(BaseCommand):
             # Attribution matters within the errors list; older state files have no status field.
             label = f"[{rec['status']}] " if rec.get("status", "").startswith("ERROR") else ""
             detail = f" — {rec['detail']}" if rec.get("detail") else ""
-            self.stdout.write(style(f"  {label}{rec['short_id']} (team {rec['team_id']}) {rec['url']}{detail}"))
+            resolution = f" → {rec['resolution']}" if rec.get("resolution") else ""
+            self.stdout.write(
+                style(f"  {label}{rec['short_id']} (team {rec['team_id']}) {rec['url']}{detail}{resolution}")
+            )
         if len(records) > cap:
             self.stdout.write(style(f"  …and {len(records) - cap} more (see state file)"))

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -83,9 +83,12 @@ from posthog.schema import HogQLQueryModifiers
 
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
-from posthog.hogql_queries.insights.retention.retention_base_query_fixed import RETENTION_BASE_QUERY_VARIANT_PATCH_PATH
 from posthog.hogql_queries.query_runner import get_query_runner
+
+# The patch path comes from the sibling command (which defines it locally, not via import) so this
+# pair of files stays runnable when copied onto a prod pod regardless of the image's vintage.
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
     attribute_variant_errors,
     classify_insight,
     compute_interval_context,

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -23,11 +23,7 @@ as ERROR_DWH (legacy succeeded, the variant failed — a regression candidate th
 ERROR_LEGACY (the variant fixes an insight that is broken today), or ERROR_BOTH (parity-in-failure:
 broken regardless of the toggle). Plain ERROR is reserved for failures outside the two variant runs.
 Insights whose referenced actions/cohorts were deleted are SKIPPED up front by ``classify_insight``
-instead of erroring on both sides. 24h rolling window insights have no legacy/new split to diff
-(their builder routes by series type, not by the flag), so they get one health-check run and are
-reported OK_SINGLE, or an ERROR if the single run fails.
-
-A first-pass mismatch is re-run once and only the differences
+instead of erroring on both sides. A first-pass mismatch is re-run once and only the differences
 that reproduce are kept (``--no-recheck-mismatches`` to disable): late-arriving events and person
 merges move *historical* buckets between the two sequential runs, so a single pass can report live
 drift as a parity bug. The recheck runs the variants in reversed order (dwh before legacy) so that
@@ -118,7 +114,7 @@ from products.product_analytics.backend.models.insight import Insight
 _use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_use_dwh", default=False)
 
 
-PROGRESS_STATUSES = ("OK", "OK_SINGLE", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
+PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
 
 
 @dataclasses.dataclass
@@ -225,7 +221,7 @@ def revalidate_mismatches(
     sets) has converged by then and stops reproducing; a genuine query-semantics difference keeps
     reproducing. Returns (still_mismatched, resolved, adjusted_counts):
 
-    - re-checks OK (or OK_SINGLE), or SKIPPED, or the insight is gone → resolved, annotated with a "resolution"
+    - re-checks OK, or SKIPPED, or the insight is gone → resolved, annotated with a "resolution"
     - still MISMATCH → kept, with the detail refreshed to the latest verdict
     - re-check errored → kept untouched (no evidence either way; the next run retries)
 
@@ -247,8 +243,6 @@ def revalidate_mismatches(
             resolve(rec, "SKIPPED", "insight no longer exists")
         elif row.status == "OK":
             resolve(rec, "OK", "no longer reproduces (data settled)")
-        elif row.status == "OK_SINGLE":
-            resolve(rec, "OK_SINGLE", f"now single-path, runs cleanly: {row.detail}")
         elif row.status == "SKIPPED":
             resolve(rec, "SKIPPED", f"now skipped: {row.detail}")
         elif row.status == "MISMATCH":
@@ -321,22 +315,6 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
             return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", reason)
         if action == "skip":
             return Row(insight.id, insight.short_id, insight.team_id, url, "SKIPPED", reason)
-
-        if action == "single":
-            # No legacy/new split (24h rolling window): both flag arms compile the same query, so
-            # run it once as a health check instead of diffing the code against itself.
-            modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
-            _results, exc = _try_variant(insight, True, modifiers, None)
-            if exc is not None:
-                return Row(
-                    insight.id,
-                    insight.short_id,
-                    insight.team_id,
-                    url,
-                    "ERROR",
-                    f"single-path run failed ({reason}): {type(exc).__name__}: {exc}",
-                )
-            return Row(insight.id, insight.short_id, insight.team_id, url, "OK_SINGLE", reason)
 
         modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
         ctx = compute_interval_context(insight, modifiers, freeze=freeze)
@@ -667,7 +645,7 @@ class Command(BaseCommand):
         return list(queryset.order_by("id")[: options["limit"]])
 
     def _print_progress(self, done: int, total: int, row: Row) -> None:
-        if row.status in ("OK", "OK_SINGLE"):
+        if row.status == "OK":
             return  # keep the stream quiet; only surface the interesting outcomes
         is_bad = row.status == "MISMATCH" or row.status.startswith("ERROR")
         style = self.style.ERROR if is_bad else self.style.WARNING

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -57,12 +57,19 @@ deletes between runs never make it skip or re-check an insight, which a numeric 
 file is tied to the filter set it was created with (``--team-id`` etc.); reusing it under a different
 scope is refused so a narrowed cursor can't silently leave insights unchecked.
 
+With a ``--state-file``, interrupting a run (Ctrl-C, pod eviction) loses nothing: every finished
+insight is also appended to ``<state-file>.journal`` the moment it completes, and the next run skips
+the journaled insights and folds their recorded results into the report — so ``--all --state-file
+sweep.json`` is a single resumable run. The journal is absorbed into the state file when a batch
+finishes. The cursor alone can't provide this: teams run in parallel lanes, so an interrupted run's
+completed ids are scattered across the id range, not a contiguous prefix a cursor could describe.
+
 Examples:
     # All retention insights, up to 8 teams in parallel
     python manage.py compare_retention_correctness
 
-    # Every matching insight in one run, no batching
-    python manage.py compare_retention_correctness --all
+    # Every matching insight in one run; Ctrl-C safe — re-run the same command to resume
+    python manage.py compare_retention_correctness --all --state-file /tmp/retention_sweep.json
 
     # Resumable sweep over every insight: run this repeatedly until it reports "complete"
     python manage.py compare_retention_correctness --state-file /tmp/retention_sweep.json --limit 500
@@ -90,7 +97,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from datetime import UTC, datetime
 from time import perf_counter
-from typing import Any, Optional
+from typing import Any, Optional, TextIO
 
 from unittest.mock import patch
 
@@ -124,6 +131,8 @@ _use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_u
 
 
 PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
+
+JOURNAL_SUFFIX = ".journal"
 
 
 @dataclasses.dataclass
@@ -192,14 +201,15 @@ def merge_progress_state(
     rows: list[Row],
     *,
     next_cursor: Optional[int],
-    limit: int,
+    complete: bool,
     scope: str = "",
 ) -> ProgressState:
     """Fold one batch's rows into the running checkpoint. Pure — no IO, no clock, never mutates ``prev``.
 
-    ``next_cursor`` is the highest insight id covered by the batch (``None`` when the batch was empty, e.g.
-    the sweep ran off the end). The sweep is ``complete`` once a batch returns fewer rows than ``limit``,
-    i.e. the source is exhausted. The cursor only ever advances.
+    ``next_cursor`` is the highest insight id covered so far (``None`` when nothing new was covered, e.g.
+    the sweep ran off the end). ``complete`` — the fresh selection came up short of ``--limit``, i.e. the
+    source is exhausted — is decided by the caller, because ``rows`` may also carry journal-recovered rows
+    from an interrupted run, so its length says nothing about exhaustion. The cursor only ever advances.
     """
     base = prev or ProgressState(scope=scope)
     counts = dict(base.counts)
@@ -213,7 +223,7 @@ def merge_progress_state(
         resolved_mismatches=base.resolved_mismatches,
         # All attributed variants (ERROR_LEGACY / ERROR_DWH / ERROR_BOTH) accumulate here too.
         errors=base.errors + [_row_record(r) for r in rows if r.status.startswith("ERROR")],
-        complete=len(rows) < limit,
+        complete=complete,
         scope=scope or base.scope,
     )
 
@@ -279,6 +289,38 @@ def scope_signature(options: dict[str, Any]) -> str:
         },
         sort_keys=True,
     )
+
+
+def journal_line(row: Row) -> str:
+    return json.dumps(_row_record(row))
+
+
+def parse_journal_lines(lines: list[str], scope: str) -> list[Row]:
+    """Decode the rows journaled by an interrupted run. Pure.
+
+    The first line is a scope header; a mismatch raises ``ValueError`` so results from a
+    differently-filtered run can't be folded into this sweep. Undecodable row lines (a write torn by
+    the interrupt) are dropped — the worst case is re-checking that one insight. On a duplicate id
+    the latest record wins, so a re-checked insight is only counted once.
+    """
+    if not lines:
+        return []
+    try:
+        header = json.loads(lines[0])
+    except ValueError:
+        raise ValueError("journal header is unreadable")
+    if not isinstance(header, dict) or "scope" not in header:
+        raise ValueError("journal has no scope header")
+    if header["scope"] != scope:
+        raise ValueError("journal was written for a different filter set")
+    rows: dict[int, Row] = {}
+    for line in lines[1:]:
+        try:
+            row = Row(**json.loads(line))
+        except (ValueError, TypeError):
+            continue
+        rows[row.id] = row
+    return list(rows.values())
 
 
 def load_progress_state(path: str) -> Optional[ProgressState]:
@@ -421,7 +463,9 @@ class Command(BaseCommand):
             default=None,
             help="JSON checkpoint for a resumable sweep. If it exists the run resumes from its saved cursor; "
             "afterwards it is rewritten with the new cursor plus accumulated counts and findings. Re-run the "
-            "same command to walk every matching insight in --limit-sized batches until it reports complete.",
+            "same command to walk every matching insight in --limit-sized batches until it reports complete. "
+            "Interrupted runs resume too: each finished insight is journaled to <state-file>.journal as it "
+            "completes, and the next run skips the journaled insights and keeps their results.",
         )
         parser.add_argument(
             "--after-id",
@@ -476,6 +520,8 @@ class Command(BaseCommand):
             )
 
         prev_state, already_complete = self._load_resume_state(state_file, scope, after_id, options["restart"])
+        journal_file = f"{state_file}{JOURNAL_SUFFIX}" if state_file else None
+        journal_rows = self._load_journal(journal_file, scope, restart=options["restart"])
 
         # Re-verify mismatches recorded by earlier batches before doing new work: enough time has
         # usually passed for in-motion data (merges, replica divergence) to settle, so artifacts
@@ -494,36 +540,44 @@ class Command(BaseCommand):
         # Explicit --after-id wins; otherwise resume from the saved checkpoint (None = start from the top).
         cursor = after_id if after_id is not None else (prev_state.cursor if prev_state else None)
 
-        insights = self._select_insights(options, after_id=cursor)
+        insights = self._select_insights(options, after_id=cursor, exclude_ids={r.id for r in journal_rows})
         if not insights:
-            self._handle_empty(options, state_file, scope, prev_state, cursor)
+            self._handle_empty(options, state_file, scope, prev_state, cursor, journal_rows, journal_file)
             return
 
-        rows = self._run(
-            insights,
-            options["base_url"].rstrip("/"),
-            options["freeze_window"],
-            options["recheck_mismatches"],
-            options["concurrency"],
-        )
-        self._print_summary(rows)
+        journal = self._open_journal(journal_file, scope)
+        try:
+            rows = self._run(
+                insights,
+                options["base_url"].rstrip("/"),
+                options["freeze_window"],
+                options["recheck_mismatches"],
+                options["concurrency"],
+                journal,
+            )
+        finally:
+            if journal is not None:
+                journal.close()
+        all_rows = journal_rows + rows
+        self._print_summary(all_rows)
 
-        next_cursor = max(i.id for i in insights)
-        # --all drains everything past the cursor in one batch, so the sweep is complete by
-        # construction; a limit above the batch size makes the "fewer rows than limit" test agree.
-        effective_limit = len(insights) + 1 if options["all"] else options["limit"]
+        next_cursor = max(r.id for r in all_rows)
+        # Exhaustion is judged on the fresh selection alone: --all drains everything past the
+        # cursor, and journal-recovered rows don't count against the batch size.
+        fresh_exhausted = options["all"] or len(insights) < options["limit"]
         if state_file:
             new_state = merge_progress_state(
-                prev_state, rows, next_cursor=next_cursor, limit=effective_limit, scope=scope
+                prev_state, all_rows, next_cursor=next_cursor, complete=fresh_exhausted, scope=scope
             )
             new_state.updated_at = datetime.now(UTC).isoformat()
             save_progress_state(state_file, new_state)
+            self._absorb_journal(journal_file)
             self._print_checkpoint(state_file, new_state)
             self._print_cumulative(new_state)
         else:
-            self._print_next_cursor(next_cursor, len(insights), effective_limit)
+            self._print_next_cursor(next_cursor, fresh_exhausted)
 
-        mismatches = sum(1 for r in rows if r.status == "MISMATCH")
+        mismatches = sum(1 for r in all_rows if r.status == "MISMATCH")
         if options["fail_on_mismatch"] and mismatches:
             raise CommandError(f"{mismatches} insight(s) mismatched between variants")
 
@@ -551,6 +605,46 @@ class Command(BaseCommand):
             )
             return prev, True
         return prev, False
+
+    def _load_journal(self, path: Optional[str], scope: str, restart: bool) -> list[Row]:
+        """Rows persisted per-insight by an interrupted run. They are excluded from this run's
+        selection and their recorded results folded into the checkpoint when the batch completes."""
+        if path is None or not os.path.exists(path):
+            return []
+        if restart:
+            os.remove(path)
+            return []
+        with open(path) as f:
+            lines = f.read().splitlines()
+        try:
+            rows = parse_journal_lines(lines, scope)
+        except ValueError as exc:
+            raise CommandError(f"{path}: {exc}. Use a separate --state-file, or pass --restart to overwrite it.")
+        if rows:
+            self.stdout.write(f"Recovered {len(rows)} finished insight(s) from the interrupted run in {path}.")
+        return rows
+
+    def _open_journal(self, path: Optional[str], scope: str) -> Optional[TextIO]:
+        if path is None:
+            return None
+        handle = open(path, "a")
+        if handle.tell() == 0:
+            handle.write(json.dumps({"scope": scope}) + "\n")
+        else:
+            with open(path, "rb") as tail:
+                tail.seek(-1, os.SEEK_END)
+                ends_clean = tail.read(1) == b"\n"
+            if not ends_clean:
+                # The previous interrupt tore a write mid-line; start on a fresh line so the next
+                # record isn't glued onto the fragment (which would corrupt both).
+                handle.write("\n")
+        handle.flush()
+        return handle
+
+    def _absorb_journal(self, path: Optional[str]) -> None:
+        # The batch's rows are in the state file now; a leftover journal would double-fold them.
+        if path is not None and os.path.exists(path):
+            os.remove(path)
 
     def _revalidate_previous_mismatches(self, state: ProgressState, options: dict[str, Any]) -> ProgressState:
         self.stdout.write(f"Re-verifying {len(state.mismatches)} previously recorded mismatch(es)…")
@@ -589,12 +683,19 @@ class Command(BaseCommand):
         scope: str,
         prev_state: Optional[ProgressState],
         cursor: Optional[int],
+        journal_rows: list[Row],
+        journal_file: Optional[str],
     ) -> None:
-        """Nothing left to check: either the filters match nothing or the sweep just ran off the end."""
+        """Nothing newly selected: the filters match nothing, the sweep ran off the end, or an
+        interrupted run already journaled everything that was left."""
         if state_file:
-            new_state = merge_progress_state(prev_state, [], next_cursor=None, limit=options["limit"], scope=scope)
+            next_cursor = max((r.id for r in journal_rows), default=None)
+            new_state = merge_progress_state(
+                prev_state, journal_rows, next_cursor=next_cursor, complete=True, scope=scope
+            )
             new_state.updated_at = datetime.now(UTC).isoformat()
             save_progress_state(state_file, new_state)
+            self._absorb_journal(journal_file)
             self.stdout.write(
                 self.style.SUCCESS(
                     f"No insights past cursor id {cursor or 0} — sweep complete after {new_state.processed} insight(s)."
@@ -607,7 +708,13 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
 
     def _run(
-        self, insights: list[Insight], base_url: str, freeze: bool, recheck: bool, concurrency_opt: int
+        self,
+        insights: list[Insight],
+        base_url: str,
+        freeze: bool,
+        recheck: bool,
+        concurrency_opt: int,
+        journal: Optional[TextIO] = None,
     ) -> list[Row]:
         urls = {i.id: f"{base_url}/project/{i.team_id}/insights/{i.short_id}/edit" for i in insights}
 
@@ -631,6 +738,11 @@ class Command(BaseCommand):
         def report(row: Row) -> None:
             nonlocal done
             with progress_lock:
+                if journal is not None:
+                    # Persist before printing, flushed per row, so an interrupt loses at most the
+                    # insights still in flight.
+                    journal.write(journal_line(row) + "\n")
+                    journal.flush()
                 done += 1
                 counts[row.status] += 1
                 self._print_progress(done, total, row)
@@ -648,7 +760,9 @@ class Command(BaseCommand):
                     rows.extend(future.result())
         return rows
 
-    def _select_insights(self, options: dict[str, Any], after_id: Optional[int] = None) -> list[Insight]:
+    def _select_insights(
+        self, options: dict[str, Any], after_id: Optional[int] = None, exclude_ids: Optional[set[int]] = None
+    ) -> list[Insight]:
         queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")
         if options["team_id"]:
             queryset = queryset.filter(team_id__in=options["team_id"])
@@ -656,6 +770,8 @@ class Command(BaseCommand):
             queryset = queryset.filter(id__in=options["insight_id"])
         if options["short_id"]:
             queryset = queryset.filter(short_id__in=options["short_id"])
+        if exclude_ids:
+            queryset = queryset.exclude(id__in=exclude_ids)
         queryset = queryset.select_related("team")
         if options["sample"]:
             return list(queryset.order_by("?")[: options["sample"]])
@@ -705,9 +821,9 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.ERROR(f"  {r.short_id} (team {r.team_id}) {r.url} — {r.detail}"))
         sys.stdout.flush()
 
-    def _print_next_cursor(self, next_cursor: int, batch_size: int, limit: int) -> None:
+    def _print_next_cursor(self, next_cursor: int, exhausted: bool) -> None:
         self.stdout.write("")
-        if batch_size < limit:
+        if exhausted:
             self.stdout.write(self.style.SUCCESS(f"Reached the end of the set (last insight id {next_cursor})."))
         else:
             self.stdout.write(f"Next cursor: {next_cursor}. Continue the sweep with --after-id {next_cursor}")

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -44,8 +44,9 @@ across worker threads) we install one process-wide patch whose return value is r
 ``ContextVar`` each worker sets before it runs. Threads start with a fresh context, so the workers
 never collide.
 
-Checking *all* insights is done as a resumable sweep, not one giant run. Pass ``--state-file
-progress.json`` and the command processes one ``--limit``-sized batch, writes a cursor (the highest
+Checking *all* insights can be one giant run (``--all``, which ignores ``--limit``) or a resumable
+sweep. For the sweep, pass ``--state-file progress.json`` and the command processes one
+``--limit``-sized batch, writes a cursor (the highest
 insight id it reached) plus the running counts and accumulated findings back to that file, then exits.
 Re-run the same command and it resumes just past the cursor; repeat until it reports the sweep complete.
 The cursor is printed every run, so without a state file you can drive the same loop by hand with
@@ -57,6 +58,9 @@ scope is refused so a narrowed cursor can't silently leave insights unchecked.
 Examples:
     # All retention insights, up to 8 teams in parallel
     python manage.py compare_retention_correctness
+
+    # Every matching insight in one run, no batching
+    python manage.py compare_retention_correctness --all
 
     # Resumable sweep over every insight: run this repeatedly until it reports "complete"
     python manage.py compare_retention_correctness --state-file /tmp/retention_sweep.json --limit 500
@@ -404,6 +408,7 @@ class Command(BaseCommand):
         parser.add_argument("--insight-id", type=int, action="append", help="Restrict to insight DB id(s); repeatable")
         parser.add_argument("--short-id", type=str, action="append", help="Restrict to insight short_id(s); repeatable")
         parser.add_argument("--limit", type=int, default=100, help="Max insights per batch (default 100)")
+        parser.add_argument("--all", action="store_true", help="Process every matching insight (ignores --limit)")
         parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by id")
         parser.add_argument(
             "--state-file",
@@ -457,6 +462,9 @@ class Command(BaseCommand):
         after_id: Optional[int] = options["after_id"]
         scope = scope_signature(options)
 
+        if options["all"] and options["sample"]:
+            raise CommandError("--all and --sample are mutually exclusive")
+
         if options["sample"] is not None and (state_file or after_id is not None):
             raise CommandError(
                 "--sample picks a random set and can't drive a resumable sweep (--state-file / --after-id)."
@@ -496,16 +504,19 @@ class Command(BaseCommand):
         self._print_summary(rows)
 
         next_cursor = max(i.id for i in insights)
+        # --all drains everything past the cursor in one batch, so the sweep is complete by
+        # construction; a limit above the batch size makes the "fewer rows than limit" test agree.
+        effective_limit = len(insights) + 1 if options["all"] else options["limit"]
         if state_file:
             new_state = merge_progress_state(
-                prev_state, rows, next_cursor=next_cursor, limit=options["limit"], scope=scope
+                prev_state, rows, next_cursor=next_cursor, limit=effective_limit, scope=scope
             )
             new_state.updated_at = datetime.now(UTC).isoformat()
             save_progress_state(state_file, new_state)
             self._print_checkpoint(state_file, new_state)
             self._print_cumulative(new_state)
         else:
-            self._print_next_cursor(next_cursor, len(insights), options["limit"])
+            self._print_next_cursor(next_cursor, len(insights), effective_limit)
 
         mismatches = sum(1 for r in rows if r.status == "MISMATCH")
         if options["fail_on_mismatch"] and mismatches:
@@ -642,7 +653,10 @@ class Command(BaseCommand):
         # Keyset pagination: ascending id is a stable, unique sweep order and the cursor is just the last id.
         if after_id is not None:
             queryset = queryset.filter(id__gt=after_id)
-        return list(queryset.order_by("id")[: options["limit"]])
+        queryset = queryset.order_by("id")
+        if options["all"]:
+            return list(queryset)
+        return list(queryset[: options["limit"]])
 
     def _print_progress(self, done: int, total: int, row: Row) -> None:
         if row.status == "OK":

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -23,7 +23,11 @@ as ERROR_DWH (legacy succeeded, the variant failed — a regression candidate th
 ERROR_LEGACY (the variant fixes an insight that is broken today), or ERROR_BOTH (parity-in-failure:
 broken regardless of the toggle). Plain ERROR is reserved for failures outside the two variant runs.
 Insights whose referenced actions/cohorts were deleted are SKIPPED up front by ``classify_insight``
-instead of erroring on both sides. A first-pass mismatch is re-run once and only the differences
+instead of erroring on both sides. 24h rolling window insights have no legacy/new split to diff
+(their builder routes by series type, not by the flag), so they get one health-check run and are
+reported OK_SINGLE, or an ERROR if the single run fails.
+
+A first-pass mismatch is re-run once and only the differences
 that reproduce are kept (``--no-recheck-mismatches`` to disable): late-arriving events and person
 merges move *historical* buckets between the two sequential runs, so a single pass can report live
 drift as a parity bug. The recheck runs the variants in reversed order (dwh before legacy) so that
@@ -114,7 +118,7 @@ from products.product_analytics.backend.models.insight import Insight
 _use_dwh_var: contextvars.ContextVar[bool] = contextvars.ContextVar("retention_use_dwh", default=False)
 
 
-PROGRESS_STATUSES = ("OK", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
+PROGRESS_STATUSES = ("OK", "OK_SINGLE", "MISMATCH", "ERROR", "ERROR_LEGACY", "ERROR_DWH", "ERROR_BOTH", "SKIPPED")
 
 
 @dataclasses.dataclass
@@ -221,7 +225,7 @@ def revalidate_mismatches(
     sets) has converged by then and stops reproducing; a genuine query-semantics difference keeps
     reproducing. Returns (still_mismatched, resolved, adjusted_counts):
 
-    - re-checks OK, or SKIPPED, or the insight is gone → resolved, annotated with a "resolution"
+    - re-checks OK (or OK_SINGLE), or SKIPPED, or the insight is gone → resolved, annotated with a "resolution"
     - still MISMATCH → kept, with the detail refreshed to the latest verdict
     - re-check errored → kept untouched (no evidence either way; the next run retries)
 
@@ -243,6 +247,8 @@ def revalidate_mismatches(
             resolve(rec, "SKIPPED", "insight no longer exists")
         elif row.status == "OK":
             resolve(rec, "OK", "no longer reproduces (data settled)")
+        elif row.status == "OK_SINGLE":
+            resolve(rec, "OK_SINGLE", f"now single-path, runs cleanly: {row.detail}")
         elif row.status == "SKIPPED":
             resolve(rec, "SKIPPED", f"now skipped: {row.detail}")
         elif row.status == "MISMATCH":
@@ -315,6 +321,22 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
             return Row(insight.id, insight.short_id, insight.team_id, url, "ERROR", reason)
         if action == "skip":
             return Row(insight.id, insight.short_id, insight.team_id, url, "SKIPPED", reason)
+
+        if action == "single":
+            # No legacy/new split (24h rolling window): both flag arms compile the same query, so
+            # run it once as a health check instead of diffing the code against itself.
+            modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
+            _results, exc = _try_variant(insight, True, modifiers, None)
+            if exc is not None:
+                return Row(
+                    insight.id,
+                    insight.short_id,
+                    insight.team_id,
+                    url,
+                    "ERROR",
+                    f"single-path run failed ({reason}): {type(exc).__name__}: {exc}",
+                )
+            return Row(insight.id, insight.short_id, insight.team_id, url, "OK_SINGLE", reason)
 
         modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers())
         ctx = compute_interval_context(insight, modifiers, freeze=freeze)
@@ -645,7 +667,7 @@ class Command(BaseCommand):
         return list(queryset.order_by("id")[: options["limit"]])
 
     def _print_progress(self, done: int, total: int, row: Row) -> None:
-        if row.status == "OK":
+        if row.status in ("OK", "OK_SINGLE"):
             return  # keep the stream quiet; only surface the interesting outcomes
         is_bad = row.status == "MISMATCH" or row.status.startswith("ERROR")
         style = self.style.ERROR if is_bad else self.style.WARNING

--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -3,8 +3,10 @@
 A stripped-down companion to ``compare_retention_legacy_vs_dwh``: no timing, no query-log
 resource stats, no HogQL embedding, no per-insight report blocks. It runs each affected
 RetentionQuery insight twice (variant OFF then ON), diffs the two result sets, and prints a
-one-line-per-mismatch summary. The expensive parts of the full tool are gone and insights are
-checked concurrently, so a correctness sweep finishes in a fraction of the time.
+one-line-per-mismatch summary. A heartbeat line every 10 insights shows elapsed time, ETA, and the
+running counts, so a long healthy (all-OK) run still shows liveness. The expensive parts of the
+full tool are gone and insights are checked concurrently, so a correctness sweep finishes in a
+fraction of the time.
 
 Concurrency is spread *across teams*, never within one. The unit of parallelism is a team: each
 team's insights are checked serially in a single lane, and up to ``--concurrency`` distinct teams
@@ -82,11 +84,12 @@ import argparse
 import threading
 import contextvars
 import dataclasses
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from datetime import UTC, datetime
+from time import perf_counter
 from typing import Any, Optional
 
 from unittest.mock import patch
@@ -103,7 +106,9 @@ from posthog.hogql_queries.query_runner import get_query_runner
 # The patch path comes from the sibling command (which defines it locally, not via import) so this
 # pair of files stays runnable when copied onto a prod pod regardless of the image's vintage.
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    HEARTBEAT_EVERY,
     RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
+    _fmt_duration,
     attribute_variant_errors,
     classify_insight,
     compute_interval_context,
@@ -620,12 +625,16 @@ class Command(BaseCommand):
         total = len(insights)
         progress_lock = threading.Lock()
         done = 0
+        counts: Counter[str] = Counter()
+        started_at = perf_counter()
 
         def report(row: Row) -> None:
             nonlocal done
             with progress_lock:
                 done += 1
+                counts[row.status] += 1
                 self._print_progress(done, total, row)
+                self._print_heartbeat(done, total, started_at, counts)
 
         rows: list[Row] = []
         # One process-wide patch; each worker selects its variant via the ContextVar.
@@ -665,6 +674,19 @@ class Command(BaseCommand):
         style = self.style.ERROR if is_bad else self.style.WARNING
         suffix = f" — {row.detail}" if row.detail else ""
         self.stdout.write(style(f"[{done}/{total}] {row.status} {row.short_id} (team {row.team_id}){suffix}"))
+
+    def _print_heartbeat(self, done: int, total: int, started_at: float, counts: Counter[str]) -> None:
+        """Elapsed/ETA line every HEARTBEAT_EVERY insights: per-row output stays quiet on OK, so a
+        long healthy run would otherwise print nothing. Called with the progress lock held."""
+        if done != total and done % HEARTBEAT_EVERY:
+            return
+        elapsed = perf_counter() - started_at
+        eta = (elapsed / done) * (total - done)
+        errors = sum(count for status, count in counts.items() if status.startswith("ERROR"))
+        self.stdout.write(
+            f"[{done}/{total}] elapsed={_fmt_duration(elapsed)} eta={_fmt_duration(eta)} — "
+            f"ok={counts['OK']} mismatch={counts['MISMATCH']} errors={errors} skipped={counts['SKIPPED']}"
+        )
 
     def _print_summary(self, rows: list[Row]) -> None:
         counts = {status: sum(1 for r in rows if r.status == status) for status in PROGRESS_STATUSES}

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -1,0 +1,1207 @@
+"""Compare the legacy vs new ("DWH variant") retention fixed-interval base query.
+
+Runs every affected RetentionQuery insight twice — once with the variant toggle forced OFF
+(legacy) and once ON (new) — diffs the results for correctness and benchmarks performance
+with an interleaved, multi-iteration protocol plus load-independent ClickHouse resource stats
+read back from the query log. Emits a self-contained, LLM-pasteable Markdown report so any
+regression can be handed to another model to fix.
+
+The toggle lives in
+``posthog.hogql_queries.insights.retention.retention_base_query_fixed.retention_fixed_interval_base_query_use_dwh_variant``
+and is forced via ``unittest.mock.patch`` (the patch target is the shared
+``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant). Two insight shapes are NOT affected by the
+toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path) and
+the 24h rolling window mode (a different builder with no legacy/new split).
+
+This command is strictly read-only: it never saves or mutates insights.
+
+Examples:
+    # Local: a single insight, light perf, default system.query_log resource stats
+    python manage.py compare_retention_legacy_vs_dwh --insight-id 1234 --perf-iterations 3
+
+    # All retention insights for a team, correctness only
+    python manage.py compare_retention_legacy_vs_dwh --team-id 42 --no-perf
+
+    # Production (multi-node): read resource stats from the distributed archive table
+    python manage.py compare_retention_legacy_vs_dwh --limit 200 \\
+        --query-log-table query_log_archive --no-flush-query-log --query-log-wait 90
+"""
+
+import re
+import json
+import time
+import uuid
+import argparse
+import traceback
+import statistics
+import dataclasses
+from collections.abc import Callable, Sequence
+from contextlib import nullcontext
+from copy import deepcopy
+from time import perf_counter
+from typing import Any, Optional
+
+from unittest.mock import patch
+
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.schema import HogQLQueryModifiers, RetentionResult
+
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+
+import posthog.clickhouse.client.execute as ch_execute
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
+    RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG,
+)
+from posthog.hogql_queries.insights.retention.test.retention_base_query_variant import (
+    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
+)
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
+from posthog.hogql_queries.query_runner import get_query_runner
+
+from products.product_analytics.backend.models.insight import Insight
+
+DATA_WAREHOUSE_ENTITY_TYPE = "data_warehouse"
+ROLLING_24H_WINDOW_MODE = "24_hour_windows"
+CLICKHOUSE_EXECUTE_TIMING_KEY = "clickhouse_execute"
+DEFAULT_MAX_CELL_DIFFS = 25
+DEFAULT_WORST_N = 15
+_SAFE_TABLE_RE = re.compile(r"^[A-Za-z0-9_.]+$")
+
+
+# --------------------------------------------------------------------------------------
+# Data structures
+# --------------------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class VariantRun:
+    results: list[RetentionResult]
+    hogql: Optional[str]
+    wall_s: float
+    ch_s: float
+    query_ids: list[str]
+
+
+@dataclasses.dataclass
+class CellDiff:
+    breakdown_value: Any
+    row_label: str
+    value_label: Optional[str]
+    field: str  # "count" | "aggregation_value"
+    legacy: float
+    dwh: float
+    abs_diff: float
+    rel_diff: Optional[float]  # None when legacy == 0
+
+
+@dataclasses.dataclass
+class CorrectnessDiff:
+    status: str  # "OK" | "MISMATCH"
+    row_count_legacy: int
+    row_count_dwh: int
+    breakdown_keys_legacy: list[Any]
+    breakdown_keys_dwh: list[Any]
+    breakdown_only_legacy: list[Any]
+    breakdown_only_dwh: list[Any]
+    other_bucket_changed: bool
+    cell_diffs: list[CellDiff]
+    notes: list[str]
+
+
+@dataclasses.dataclass
+class VariantTiming:
+    samples_ms: list[float]
+    min_ms: float
+    median_ms: float
+    p95_ms: float
+    stdev_ms: float
+
+
+@dataclasses.dataclass
+class ResourceStats:
+    read_bytes: int
+    read_rows: int
+    memory_usage: int
+    query_duration_ms: int
+    ch_query_count: int
+
+
+@dataclasses.dataclass
+class PerfResult:
+    wall_legacy: VariantTiming
+    wall_dwh: VariantTiming
+    ch_legacy: VariantTiming
+    ch_dwh: VariantTiming
+    ratio_median_wall: Optional[float]
+    ratio_min_wall: Optional[float]
+    ratio_median_ch: Optional[float]
+    delta_median_wall_ms: float
+    is_regression: bool
+    is_improvement: bool
+
+
+@dataclasses.dataclass
+class InsightFinding:
+    insight_id: int
+    short_id: str
+    team_id: int
+    name: str
+    url: str
+    status: str  # "OK" | "MISMATCH" | "ERROR" | "SKIPPED"
+    has_breakdown: bool = False
+    skip_reason: Optional[str] = None
+    error_type: Optional[str] = None
+    error_detail: Optional[str] = None
+    source_json: Optional[str] = None
+    correctness: Optional[CorrectnessDiff] = None
+    legacy_hogql: Optional[str] = None
+    dwh_hogql: Optional[str] = None
+    perf: Optional[PerfResult] = None
+    resource_legacy: Optional[ResourceStats] = None
+    resource_dwh: Optional[ResourceStats] = None
+    legacy_query_ids: list[str] = dataclasses.field(default_factory=list)
+    dwh_query_ids: list[str] = dataclasses.field(default_factory=list)
+    bytes_ratio: Optional[float] = None
+
+
+@dataclasses.dataclass
+class PerfAggregate:
+    n_compared: int
+    wall_ratio_dist: dict[str, float]
+    bytes_ratio_dist: dict[str, float]
+    n_regressions: int
+    n_improvements: int
+    regressions: list[InsightFinding]
+    improvements: list[InsightFinding]
+    worst_by_rel: list[InsightFinding]
+    worst_by_abs: list[InsightFinding]
+    worst_by_bytes: list[InsightFinding]
+
+
+# --------------------------------------------------------------------------------------
+# Pure helpers (unit-tested without a DB / ClickHouse)
+# --------------------------------------------------------------------------------------
+
+
+def _attr(obj: Any, name: str) -> Any:
+    return obj.get(name) if isinstance(obj, dict) else getattr(obj, name, None)
+
+
+def classify_insight(insight: Insight) -> tuple[str, str]:
+    """Return ("compare"|"skip"|"error", reason) without executing anything."""
+    query = insight.query
+    if not isinstance(query, dict):
+        return ("error", "insight.query is not a dict")
+    source = query.get("source")
+    if not isinstance(source, dict) or source.get("kind") != "RetentionQuery":
+        return ("error", "query.source is not a RetentionQuery")
+    retention_filter = source.get("retentionFilter")
+    if not isinstance(retention_filter, dict):
+        return ("error", "RetentionQuery has no retentionFilter")
+    if retention_filter.get("timeWindowMode") == ROLLING_24H_WINDOW_MODE:
+        return ("skip", "24h rolling window (toggle has no effect)")
+    for entity_key in ("targetEntity", "returningEntity"):
+        entity = retention_filter.get(entity_key)
+        if isinstance(entity, dict) and entity.get("type") == DATA_WAREHOUSE_ENTITY_TYPE:
+            return ("skip", "data_warehouse (new-path only)")
+    return ("compare", "")
+
+
+def _clickhouse_seconds(timings: Optional[Sequence[Any]]) -> float:
+    """Sum the seconds of every timing entry whose leaf key is ``clickhouse_execute``.
+
+    Timing keys are hierarchical (e.g. ``./retention_query/.../clickhouse_execute``); a single
+    ``.calculate()`` can issue several ClickHouse queries, so we sum rather than take the first.
+    """
+    if not timings:
+        return 0.0
+    total = 0.0
+    for timing in timings:
+        key = _attr(timing, "k") or ""
+        if key.split("/")[-1] == CLICKHOUSE_EXECUTE_TIMING_KEY:
+            total += float(_attr(timing, "t") or 0.0)
+    return total
+
+
+def _within(legacy: float, dwh: float, tol_abs: float, tol_rel: float) -> bool:
+    if legacy == dwh:
+        return True
+    diff = abs(legacy - dwh)
+    if diff <= tol_abs:
+        return True
+    return legacy != 0 and diff / abs(legacy) <= tol_rel
+
+
+def _rel_diff(legacy: float, dwh: float) -> Optional[float]:
+    if legacy == 0:
+        return None
+    return (dwh - legacy) / abs(legacy)
+
+
+def _breakdown_values_in_order(results: Sequence[Any]) -> list[Any]:
+    ordered: list[Any] = []
+    for result in results:
+        breakdown_value = _attr(result, "breakdown_value")
+        if breakdown_value not in ordered:
+            ordered.append(breakdown_value)
+    return ordered
+
+
+def diff_retention_results(
+    legacy: Sequence[Any],
+    dwh: Sequence[Any],
+    *,
+    count_tol_abs: float = 0.0,
+    count_tol_rel: float = 0.0,
+    agg_tol_rel: float = 1e-6,
+) -> CorrectnessDiff:
+    """Diff two retention result sets, keyed by (breakdown_value, row label).
+
+    ``format_results`` is shared between the legacy and new SQL paths, so the row/label structure
+    is expected to be identical; the only legitimate differences are numeric counts/aggregation
+    values. A large enough count delta, however, can change which breakdown values get ranked into
+    the "Other" bucket — hence the breakdown-set and Other-bucket checks.
+    """
+    legacy_by_key = {(_attr(r, "breakdown_value"), _attr(r, "label")): r for r in legacy}
+    dwh_by_key = {(_attr(r, "breakdown_value"), _attr(r, "label")): r for r in dwh}
+
+    breakdowns_legacy = _breakdown_values_in_order(legacy)
+    breakdowns_dwh = _breakdown_values_in_order(dwh)
+    set_legacy, set_dwh = set(breakdowns_legacy), set(breakdowns_dwh)
+    only_legacy = [b for b in breakdowns_legacy if b not in set_dwh]
+    only_dwh = [b for b in breakdowns_dwh if b not in set_legacy]
+    other_bucket_changed = (BREAKDOWN_OTHER_STRING_LABEL in set_legacy) != (BREAKDOWN_OTHER_STRING_LABEL in set_dwh)
+
+    cell_diffs: list[CellDiff] = []
+    notes: list[str] = []
+    for key in legacy_by_key:
+        if key not in dwh_by_key:
+            continue
+        legacy_values = _attr(legacy_by_key[key], "values") or []
+        dwh_values = _attr(dwh_by_key[key], "values") or []
+        dwh_by_label = {_attr(v, "label"): v for v in dwh_values}
+        for legacy_value in legacy_values:
+            value_label = _attr(legacy_value, "label")
+            dwh_value = dwh_by_label.get(value_label)
+            if dwh_value is None:
+                notes.append(f"value label {value_label!r} missing in DWH for {key}")
+                continue
+            legacy_count = float(_attr(legacy_value, "count") or 0.0)
+            dwh_count = float(_attr(dwh_value, "count") or 0.0)
+            if not _within(legacy_count, dwh_count, count_tol_abs, count_tol_rel):
+                cell_diffs.append(
+                    CellDiff(
+                        breakdown_value=key[0],
+                        row_label=key[1],
+                        value_label=value_label,
+                        field="count",
+                        legacy=legacy_count,
+                        dwh=dwh_count,
+                        abs_diff=abs(legacy_count - dwh_count),
+                        rel_diff=_rel_diff(legacy_count, dwh_count),
+                    )
+                )
+            legacy_agg = _attr(legacy_value, "aggregation_value")
+            dwh_agg = _attr(dwh_value, "aggregation_value")
+            if legacy_agg is not None or dwh_agg is not None:
+                legacy_agg_f = float(legacy_agg or 0.0)
+                dwh_agg_f = float(dwh_agg or 0.0)
+                if not _within(legacy_agg_f, dwh_agg_f, 0.0, agg_tol_rel):
+                    cell_diffs.append(
+                        CellDiff(
+                            breakdown_value=key[0],
+                            row_label=key[1],
+                            value_label=value_label,
+                            field="aggregation_value",
+                            legacy=legacy_agg_f,
+                            dwh=dwh_agg_f,
+                            abs_diff=abs(legacy_agg_f - dwh_agg_f),
+                            rel_diff=_rel_diff(legacy_agg_f, dwh_agg_f),
+                        )
+                    )
+
+    cell_diffs.sort(key=lambda c: c.abs_diff, reverse=True)
+    is_mismatch = len(legacy) != len(dwh) or bool(only_legacy) or bool(only_dwh) or bool(cell_diffs)
+    return CorrectnessDiff(
+        status="MISMATCH" if is_mismatch else "OK",
+        row_count_legacy=len(legacy),
+        row_count_dwh=len(dwh),
+        breakdown_keys_legacy=breakdowns_legacy,
+        breakdown_keys_dwh=breakdowns_dwh,
+        breakdown_only_legacy=only_legacy,
+        breakdown_only_dwh=only_dwh,
+        other_bucket_changed=other_bucket_changed,
+        cell_diffs=cell_diffs,
+        notes=notes,
+    )
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    low = int(rank)
+    high = min(low + 1, len(sorted_values) - 1)
+    frac = rank - low
+    return sorted_values[low] * (1 - frac) + sorted_values[high] * frac
+
+
+def summarize_samples(samples_ms: list[float]) -> VariantTiming:
+    if not samples_ms:
+        return VariantTiming(samples_ms=[], min_ms=0.0, median_ms=0.0, p95_ms=0.0, stdev_ms=0.0)
+    ordered = sorted(samples_ms)
+    return VariantTiming(
+        samples_ms=list(samples_ms),
+        min_ms=ordered[0],
+        median_ms=statistics.median(ordered),
+        p95_ms=_percentile(ordered, 95),
+        stdev_ms=statistics.stdev(ordered) if len(ordered) > 1 else 0.0,
+    )
+
+
+def compute_perf_result(
+    wall_legacy: list[float],
+    wall_dwh: list[float],
+    ch_legacy: list[float],
+    ch_dwh: list[float],
+    *,
+    regression_rel: float,
+    regression_ms: float,
+) -> PerfResult:
+    wl = summarize_samples(wall_legacy)
+    wd = summarize_samples(wall_dwh)
+    cl = summarize_samples(ch_legacy)
+    cd = summarize_samples(ch_dwh)
+
+    ratio_median_wall = wd.median_ms / wl.median_ms if wl.median_ms > 0 else None
+    ratio_min_wall = wd.min_ms / wl.min_ms if wl.min_ms > 0 else None
+    ratio_median_ch = cd.median_ms / cl.median_ms if cl.median_ms > 0 else None
+    delta_median_wall_ms = wd.median_ms - wl.median_ms
+
+    # A regression needs BOTH a relative slowdown beyond the threshold AND a meaningful absolute
+    # delta — the ms floor keeps noise on tiny queries from masquerading as regressions.
+    is_regression = (
+        ratio_median_wall is not None
+        and (ratio_median_wall - 1) > regression_rel
+        and delta_median_wall_ms > regression_ms
+    )
+    is_improvement = (
+        ratio_median_wall is not None
+        and (1 - ratio_median_wall) > regression_rel
+        and (-delta_median_wall_ms) > regression_ms
+    )
+    return PerfResult(
+        wall_legacy=wl,
+        wall_dwh=wd,
+        ch_legacy=cl,
+        ch_dwh=cd,
+        ratio_median_wall=ratio_median_wall,
+        ratio_min_wall=ratio_min_wall,
+        ratio_median_ch=ratio_median_ch,
+        delta_median_wall_ms=delta_median_wall_ms,
+        is_regression=is_regression,
+        is_improvement=is_improvement,
+    )
+
+
+def _distribution(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {}
+    ordered = sorted(values)
+    return {
+        "n": float(len(ordered)),
+        "min": ordered[0],
+        "p25": _percentile(ordered, 25),
+        "median": _percentile(ordered, 50),
+        "p75": _percentile(ordered, 75),
+        "p90": _percentile(ordered, 90),
+        "max": ordered[-1],
+    }
+
+
+def parse_query_log_rows(rows: Sequence[Sequence[Any]]) -> dict[str, ResourceStats]:
+    """Turn raw query-log aggregate rows into a {query_id: ResourceStats} map."""
+    stats: dict[str, ResourceStats] = {}
+    for row in rows:
+        stats[row[0]] = ResourceStats(
+            read_bytes=int(row[1] or 0),
+            read_rows=int(row[2] or 0),
+            memory_usage=int(row[3] or 0),
+            query_duration_ms=int(row[4] or 0),
+            ch_query_count=int(row[5] or 0),
+        )
+    return stats
+
+
+def aggregate_resource_stats(
+    query_ids: Sequence[str], stats_by_id: dict[str, ResourceStats]
+) -> Optional[ResourceStats]:
+    matched = [stats_by_id[q] for q in query_ids if q in stats_by_id]
+    if not matched:
+        return None
+    return ResourceStats(
+        read_bytes=sum(s.read_bytes for s in matched),
+        read_rows=sum(s.read_rows for s in matched),
+        memory_usage=max(s.memory_usage for s in matched),
+        query_duration_ms=sum(s.query_duration_ms for s in matched),
+        ch_query_count=sum(s.ch_query_count for s in matched),
+    )
+
+
+def build_perf_aggregate(findings: list[InsightFinding], *, worst_n: int) -> PerfAggregate:
+    compared = [f for f in findings if f.perf is not None]
+    wall_ratios = [f.perf.ratio_median_wall for f in compared if f.perf and f.perf.ratio_median_wall]
+    bytes_ratios = [f.bytes_ratio for f in compared if f.bytes_ratio]
+    regressions = [f for f in compared if f.perf and f.perf.is_regression]
+    improvements = [f for f in compared if f.perf and f.perf.is_improvement]
+    with_ratio = [f for f in compared if f.perf and f.perf.ratio_median_wall is not None]
+    with_bytes = [f for f in compared if f.bytes_ratio is not None]
+    return PerfAggregate(
+        n_compared=len(compared),
+        wall_ratio_dist=_distribution(wall_ratios),
+        bytes_ratio_dist=_distribution(bytes_ratios),
+        n_regressions=len(regressions),
+        n_improvements=len(improvements),
+        regressions=sorted(regressions, key=lambda f: f.perf.ratio_median_wall or 0, reverse=True),
+        improvements=sorted(improvements, key=lambda f: f.perf.ratio_median_wall or 0),
+        worst_by_rel=sorted(with_ratio, key=lambda f: f.perf.ratio_median_wall, reverse=True)[:worst_n],
+        worst_by_abs=sorted(compared, key=lambda f: f.perf.delta_median_wall_ms if f.perf else 0, reverse=True)[
+            :worst_n
+        ],
+        worst_by_bytes=sorted(with_bytes, key=lambda f: f.bytes_ratio, reverse=True)[:worst_n],
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Execution (touches the query runner + ClickHouse)
+# --------------------------------------------------------------------------------------
+
+
+def run_variant(
+    insight: Insight,
+    use_dwh: bool,
+    modifiers: HogQLQueryModifiers,
+    *,
+    marker: Optional[str] = None,
+    capture_query_ids: bool = False,
+) -> VariantRun:
+    """Execute one retention variant. Read-only: deepcopies the query, scopes the patch."""
+    source = deepcopy(insight.query["source"])
+    if marker:
+        # The query_id ClickHouse records becomes f"{team_id}_{client_query_id}_{random}", so the
+        # marker makes captured query_ids self-describing in the report. Setting client_query_id
+        # requires team_id in the tags as well.
+        tag_queries(client_query_id=marker, team_id=insight.team_id)
+
+    captured: list[str] = []
+    real_validated_client_query_id = ch_execute.validated_client_query_id
+
+    def _capture() -> Optional[str]:
+        query_id = real_validated_client_query_id()
+        if query_id is not None:
+            captured.append(query_id)
+        return query_id
+
+    capture_ctx = (
+        patch.object(ch_execute, "validated_client_query_id", side_effect=_capture)
+        if capture_query_ids
+        else nullcontext()
+    )
+    with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=use_dwh), capture_ctx:
+        start = perf_counter()
+        response = get_query_runner(source, insight.team, modifiers=deepcopy(modifiers)).calculate()
+        wall_s = perf_counter() - start
+
+    return VariantRun(
+        results=response.results or [],
+        hogql=response.hogql,
+        wall_s=wall_s,
+        ch_s=_clickhouse_seconds(response.timings),
+        query_ids=captured,
+    )
+
+
+def fetch_query_log_stats(
+    query_ids: Sequence[str],
+    *,
+    table: str,
+    flush: bool,
+    wait_seconds: float,
+    log: Optional[Callable[[str], None]] = None,
+) -> dict[str, ResourceStats]:
+    """Read per-query resource stats from the query log, polling until rows appear.
+
+    Degrades gracefully: any failure (missing table, no privileges, lag) returns whatever was
+    found so far so the run continues with timing-only stats.
+    """
+    unique_ids = list(dict.fromkeys(query_ids))
+    if not unique_ids:
+        return {}
+    if not _SAFE_TABLE_RE.match(table):
+        raise CommandError(f"Unsafe --query-log-table value: {table!r}")
+
+    def _emit(message: str) -> None:
+        if log:
+            log(message)
+
+    if flush:
+        try:
+            sync_execute("SYSTEM FLUSH LOGS")
+        except Exception as exc:
+            _emit(f"SYSTEM FLUSH LOGS failed ({exc}); continuing without it")
+
+    # is_initial_query = 1 keeps distributed sub-query rows from double-counting read_bytes on a
+    # multi-node cluster; on a single node it simply selects the one row per ClickHouse query.
+    query = f"""
+        SELECT
+            query_id,
+            sum(read_bytes),
+            sum(read_rows),
+            max(memory_usage),
+            sum(query_duration_ms),
+            count()
+        FROM {table}
+        WHERE query_id IN %(query_ids)s
+          AND type IN ('QueryFinish', 'ExceptionWhileProcessing')
+          AND is_initial_query = 1
+        GROUP BY query_id
+    """  # noqa: S608 — table is operator-supplied and validated against _SAFE_TABLE_RE above
+
+    deadline = perf_counter() + max(0.0, wait_seconds)
+    found: dict[str, ResourceStats] = {}
+    while True:
+        try:
+            rows = sync_execute(query, {"query_ids": unique_ids})
+        except Exception as exc:
+            _emit(f"query_log lookup failed on {table} ({exc}); continuing with timing only")
+            return found
+        found = parse_query_log_rows(rows)
+        if len(found) >= len(unique_ids) or perf_counter() >= deadline:
+            break
+        time.sleep(1.0)
+    if len(found) < len(unique_ids):
+        _emit(f"query_log: matched {len(found)}/{len(unique_ids)} query_ids on {table} (some stats omitted)")
+    return found
+
+
+# --------------------------------------------------------------------------------------
+# Formatting / report
+# --------------------------------------------------------------------------------------
+
+
+def _trim(text: Optional[str], max_chars: int) -> Optional[str]:
+    if text is None:
+        return None
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n… (trimmed, {len(text) - max_chars} more chars)"
+
+
+def _fmt_ms(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}ms" if value < 1000 else f"{value / 1000:.2f}s"
+
+
+def _fmt_bytes(num: Optional[int]) -> str:
+    if num is None:
+        return "n/a"
+    size = float(num)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.1f}{unit}" if unit != "B" else f"{int(size)}B"
+        size /= 1024
+    return f"{size:.1f}TiB"
+
+
+def _fmt_ratio(ratio: Optional[float]) -> str:
+    if ratio is None:
+        return "n/a"
+    pct = (ratio - 1) * 100
+    sign = "+" if pct >= 0 else ""
+    return f"{ratio:.2f}× ({sign}{pct:.0f}%)"
+
+
+def _fmt_breakdown(value: Any) -> str:
+    if value is None:
+        return "—"
+    return str(value)
+
+
+def _verdict(ratio: Optional[float]) -> str:
+    if ratio is None:
+        return "n/a"
+    if ratio > 1.05:
+        return "slower"
+    if ratio < 0.95:
+        return "faster"
+    return "~even"
+
+
+def render_markdown_report(
+    findings: list[InsightFinding],
+    aggregate: PerfAggregate,
+    run_meta: dict[str, Any],
+) -> str:
+    counts = run_meta["counts"]
+    lines: list[str] = []
+    out = lines.append
+
+    out("# Retention legacy vs DWH-variant comparison\n")
+    out(f"- Generated: {run_meta['timestamp']}")
+    out(f"- Feature flag: `{RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG}`")
+    out(f"- Patch target: `{RETENTION_BASE_QUERY_VARIANT_PATCH_PATH}`")
+    out(f"- Args: `{run_meta['args']}`\n")
+    out(
+        "> **Reading the perf numbers.** `.calculate()` bypasses PostHog's result cache, but "
+        "ClickHouse's own mark/page cache still warms across the interleaved runs, so absolute "
+        "millisecond values reflect a warm cache and run faster than a cold production first-hit. "
+        "Trust the **ratios** and **read_bytes** (load-independent); treat absolute ms as "
+        "indicative. Interleaving legacy/new and reporting median + min (not mean) cancels "
+        "asymmetric cache warming and one-off spikes.\n"
+    )
+
+    out("## Summary\n")
+    out("| Result | Count |")
+    out("| --- | --- |")
+    out(f"| Compared | {counts['compared']} |")
+    out(f"| ✅ OK | {counts['ok']} |")
+    out(f"| ❌ MISMATCH | {counts['mismatch']} |")
+    out(f"| ⚠️ ERROR | {counts['error']} |")
+    out(f"| ⏭️ SKIPPED | {counts['skipped']} |")
+    out("")
+    if aggregate.n_compared:
+        wall_median = aggregate.wall_ratio_dist.get("median")
+        bytes_median = aggregate.bytes_ratio_dist.get("median")
+        out(
+            f"Performance: median wall ratio **{_fmt_ratio(wall_median)}** ({_verdict(wall_median)}), "
+            f"median bytes ratio **{_fmt_ratio(bytes_median)}**, "
+            f"**{aggregate.n_regressions}** regressions / **{aggregate.n_improvements}** improvements "
+            f"(threshold: > {run_meta['regression_rel'] * 100:.0f}% and "
+            f"> {run_meta['regression_ms']:.0f}ms slower).\n"
+        )
+
+    _render_perf_distribution(out, aggregate)
+    _render_mismatches(out, findings, run_meta)
+    _render_regressions(out, aggregate.regressions, run_meta)
+    _render_errors(out, [f for f in findings if f.status == "ERROR"])
+    _render_skipped(out, [f for f in findings if f.status == "SKIPPED"])
+
+    return "\n".join(lines) + "\n"
+
+
+def _render_perf_distribution(out: Callable[[str], None], aggregate: PerfAggregate) -> None:
+    if not aggregate.n_compared:
+        return
+    out("## Performance distribution\n")
+    out("Distribution of the per-insight median ratio (DWH ÷ legacy) across all compared insights.")
+    out("A single timing is dominated by per-query variance; the distribution cancels that noise")
+    out("and exposes the tail (the few insights that regress even when the median is fine).\n")
+
+    def dist_row(label: str, dist: dict[str, float]) -> str:
+        if not dist:
+            return f"| {label} | n/a | n/a | n/a | n/a | n/a | n/a |"
+        return (
+            f"| {label} | {dist['min']:.2f}× | {dist['p25']:.2f}× | {dist['median']:.2f}× | "
+            f"{dist['p75']:.2f}× | {dist['p90']:.2f}× | {dist['max']:.2f}× |"
+        )
+
+    out("| Metric | min | p25 | median | p75 | p90 | max |")
+    out("| --- | --- | --- | --- | --- | --- | --- |")
+    out(dist_row("Wall time", aggregate.wall_ratio_dist))
+    out(dist_row("Bytes read", aggregate.bytes_ratio_dist))
+    out("")
+
+    if aggregate.worst_by_rel:
+        out("### Worst by relative slowdown\n")
+        _render_worst_table(out, aggregate.worst_by_rel)
+    if aggregate.worst_by_abs:
+        out("### Worst by absolute slowdown (ms)\n")
+        _render_worst_table(out, aggregate.worst_by_abs)
+    if aggregate.worst_by_bytes:
+        out("### Worst by bytes read\n")
+        _render_worst_table(out, aggregate.worst_by_bytes, show_bytes=True)
+
+
+def _render_worst_table(
+    out: Callable[[str], None], findings: list[InsightFinding], *, show_bytes: bool = False
+) -> None:
+    if show_bytes:
+        out("| Insight | Wall ratio | Legacy bytes | DWH bytes | Bytes ratio |")
+        out("| --- | --- | --- | --- | --- |")
+        for f in findings:
+            legacy_bytes = f.resource_legacy.read_bytes if f.resource_legacy else None
+            dwh_bytes = f.resource_dwh.read_bytes if f.resource_dwh else None
+            ratio = f.perf.ratio_median_wall if f.perf else None
+            out(
+                f"| [{f.short_id}]({f.url}) | {_fmt_ratio(ratio)} | {_fmt_bytes(legacy_bytes)} | "
+                f"{_fmt_bytes(dwh_bytes)} | {_fmt_ratio(f.bytes_ratio)} |"
+            )
+        out("")
+        return
+    out("| Insight | Legacy median | DWH median | Wall ratio | Δ median |")
+    out("| --- | --- | --- | --- | --- |")
+    for f in findings:
+        if not f.perf:
+            continue
+        out(
+            f"| [{f.short_id}]({f.url}) | {_fmt_ms(f.perf.wall_legacy.median_ms)} | "
+            f"{_fmt_ms(f.perf.wall_dwh.median_ms)} | {_fmt_ratio(f.perf.ratio_median_wall)} | "
+            f"{f.perf.delta_median_wall_ms:+.1f}ms |"
+        )
+    out("")
+
+
+def _render_finding_header(out: Callable[[str], None], f: InsightFinding, title: str) -> None:
+    out(f"### {title} — insight {f.insight_id} (`{f.short_id}`), team {f.team_id}\n")
+    if f.name:
+        out(f"- Name: {f.name}")
+    out(f"- URL: {f.url}")
+    out(f"- Has breakdown: {'yes' if f.has_breakdown else 'no'}\n")
+
+
+def _render_source_and_hogql(out: Callable[[str], None], f: InsightFinding) -> None:
+    if f.source_json:
+        out("**RetentionQuery source:**\n")
+        out("```json")
+        out(f.source_json)
+        out("```\n")
+    if f.legacy_hogql:
+        out("**Generated HogQL — LEGACY:**\n")
+        out("```sql")
+        out(f.legacy_hogql)
+        out("```\n")
+    if f.dwh_hogql:
+        out("**Generated HogQL — DWH:**\n")
+        out("```sql")
+        out(f.dwh_hogql)
+        out("```\n")
+
+
+def _render_mismatches(out: Callable[[str], None], findings: list[InsightFinding], run_meta: dict[str, Any]) -> None:
+    mismatches = [f for f in findings if f.status == "MISMATCH"]
+    if not mismatches:
+        return
+    out("## Correctness mismatches\n")
+    out("Each block is self-contained — paste one into an LLM to diagnose that regression.\n")
+    # Non-breakdown first (more surprising); breakdowns are a declared known parity gap.
+    ordered = sorted(mismatches, key=lambda f: f.has_breakdown)
+    for f in ordered:
+        diff = f.correctness
+        _render_finding_header(out, f, "MISMATCH")
+        if diff is not None:
+            if diff.row_count_legacy != diff.row_count_dwh:
+                out(f"- Row count differs: legacy={diff.row_count_legacy}, dwh={diff.row_count_dwh}")
+            if diff.breakdown_only_legacy:
+                out(f"- Breakdown values only in legacy: {[_fmt_breakdown(b) for b in diff.breakdown_only_legacy]}")
+            if diff.breakdown_only_dwh:
+                out(f"- Breakdown values only in dwh: {[_fmt_breakdown(b) for b in diff.breakdown_only_dwh]}")
+            if diff.other_bucket_changed:
+                out("- ⚠️ 'Other' bucket membership changed between variants (breakdown ranking diverged)")
+            if diff.cell_diffs:
+                out(f"- {len(diff.cell_diffs)} differing cell(s)\n")
+                _render_cell_diff_table(out, diff.cell_diffs, run_meta["max_cell_diffs"])
+            for note in diff.notes[:10]:
+                out(f"- Note: {note}")
+            out("")
+        _render_source_and_hogql(out, f)
+
+
+def _render_cell_diff_table(out: Callable[[str], None], cell_diffs: list[CellDiff], max_rows: int) -> None:
+    out("| Breakdown | Cohort | Period | Field | Legacy | DWH | Δabs | Δrel |")
+    out("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    for diff in cell_diffs[:max_rows]:
+        rel = "n/a" if diff.rel_diff is None else f"{diff.rel_diff * 100:+.1f}%"
+        out(
+            f"| {_fmt_breakdown(diff.breakdown_value)} | {diff.row_label} | {diff.value_label} | "
+            f"{diff.field} | {diff.legacy:g} | {diff.dwh:g} | {diff.abs_diff:g} | {rel} |"
+        )
+    if len(cell_diffs) > max_rows:
+        out(f"| … | | | | | | +{len(cell_diffs) - max_rows} more | |")
+    out("")
+
+
+def _render_regressions(
+    out: Callable[[str], None], regressions: list[InsightFinding], run_meta: dict[str, Any]
+) -> None:
+    if not regressions:
+        return
+    out("## Performance regressions\n")
+    for f in regressions:
+        _render_finding_header(out, f, "REGRESSION")
+        if f.perf:
+            _render_perf_table(out, f)
+        _render_source_and_hogql(out, f)
+
+
+def _render_perf_table(out: Callable[[str], None], f: InsightFinding) -> None:
+    perf = f.perf
+    assert perf is not None
+    out(
+        f"- Wall ratio (median): **{_fmt_ratio(perf.ratio_median_wall)}**, "
+        f"min: {_fmt_ratio(perf.ratio_min_wall)}, "
+        f"ClickHouse-execute ratio: {_fmt_ratio(perf.ratio_median_ch)}, "
+        f"Δ median: {perf.delta_median_wall_ms:+.1f}ms"
+    )
+    if f.bytes_ratio is not None:
+        out(f"- Bytes read ratio: **{_fmt_ratio(f.bytes_ratio)}**")
+    out("")
+    out("| Metric | Legacy | DWH |")
+    out("| --- | --- | --- |")
+    out(f"| Wall median | {_fmt_ms(perf.wall_legacy.median_ms)} | {_fmt_ms(perf.wall_dwh.median_ms)} |")
+    out(f"| Wall min | {_fmt_ms(perf.wall_legacy.min_ms)} | {_fmt_ms(perf.wall_dwh.min_ms)} |")
+    out(f"| Wall p95 | {_fmt_ms(perf.wall_legacy.p95_ms)} | {_fmt_ms(perf.wall_dwh.p95_ms)} |")
+    out(f"| CH median | {_fmt_ms(perf.ch_legacy.median_ms)} | {_fmt_ms(perf.ch_dwh.median_ms)} |")
+    if f.resource_legacy and f.resource_dwh:
+        out(f"| Read bytes | {_fmt_bytes(f.resource_legacy.read_bytes)} | {_fmt_bytes(f.resource_dwh.read_bytes)} |")
+        out(f"| Read rows | {f.resource_legacy.read_rows:,} | {f.resource_dwh.read_rows:,} |")
+        out(
+            f"| Peak memory | {_fmt_bytes(f.resource_legacy.memory_usage)} | {_fmt_bytes(f.resource_dwh.memory_usage)} |"
+        )
+    out("")
+
+
+def _render_errors(out: Callable[[str], None], errors: list[InsightFinding]) -> None:
+    if not errors:
+        return
+    out("## Errors\n")
+    for f in errors:
+        _render_finding_header(out, f, "ERROR")
+        out(f"- Error: `{f.error_type}`")
+        if f.error_detail:
+            out("```")
+            out(f.error_detail)
+            out("```\n")
+        if f.source_json:
+            out("```json")
+            out(f.source_json)
+            out("```\n")
+
+
+def _render_skipped(out: Callable[[str], None], skipped: list[InsightFinding]) -> None:
+    if not skipped:
+        return
+    out("## Skipped\n")
+    out("| Insight | Team | Reason |")
+    out("| --- | --- | --- |")
+    for f in skipped:
+        out(f"| [{f.short_id}]({f.url}) | {f.team_id} | {f.skip_reason} |")
+    out("")
+
+
+# --------------------------------------------------------------------------------------
+# Command
+# --------------------------------------------------------------------------------------
+
+
+class Command(BaseCommand):
+    help = "Compare legacy vs new (DWH variant) retention insights for correctness and performance"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--team-id", type=int, action="append", help="Restrict to team id(s); repeatable")
+        parser.add_argument("--insight-id", type=int, action="append", help="Restrict to insight DB id(s); repeatable")
+        parser.add_argument("--short-id", type=str, action="append", help="Restrict to insight short_id(s); repeatable")
+        parser.add_argument("--limit", type=int, default=100, help="Max insights to process (default 100)")
+        parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by date")
+        parser.add_argument("--perf-iterations", type=int, default=5, help="Interleaved timing iterations per variant")
+        parser.add_argument("--warmup", action="store_true", help="Run one discarded warmup per variant first")
+        parser.add_argument("--no-perf", action="store_true", help="Correctness only; skip timing and resource stats")
+        parser.add_argument("--count-tolerance-abs", type=float, default=0.0, help="Absolute count tolerance")
+        parser.add_argument(
+            "--count-tolerance-rel", type=float, default=0.0, help="Relative count tolerance (fraction)"
+        )
+        parser.add_argument(
+            "--agg-tolerance-rel", type=float, default=1e-6, help="Relative aggregation_value tolerance"
+        )
+        parser.add_argument(
+            "--regression-threshold-rel", type=float, default=0.10, help="Slowdown fraction = regression"
+        )
+        parser.add_argument(
+            "--regression-threshold-ms", type=float, default=50.0, help="Min absolute Δms for a regression"
+        )
+        parser.add_argument(
+            "--clickhouse-stats",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Read per-query resource stats from the query log (default on)",
+        )
+        parser.add_argument(
+            "--query-log-table",
+            type=str,
+            default="system.query_log",
+            help="Query-log table (default system.query_log; use query_log_archive on prod clusters)",
+        )
+        parser.add_argument(
+            "--flush-query-log",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Run SYSTEM FLUSH LOGS before reading (default on; ignored if unprivileged)",
+        )
+        parser.add_argument("--query-log-wait", type=float, default=10.0, help="Seconds to poll for query-log rows")
+        parser.add_argument("--report-path", type=str, default=None, help="Markdown report path")
+        parser.add_argument("--json-path", type=str, default=None, help="Optional machine-readable JSON dump path")
+        parser.add_argument("--base-url", type=str, default="https://us.posthog.com", help="Base URL for insight links")
+        parser.add_argument("--max-source-json-chars", type=int, default=6000, help="Trim embedded query JSON")
+        parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        insights = self._select_insights(options)
+        if not insights:
+            self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
+            return
+
+        self.stdout.write(f"Comparing {len(insights)} retention insight(s)…")
+        run_id = uuid.uuid4().hex[:8]
+        findings: list[InsightFinding] = []
+        all_query_ids: list[str] = []
+
+        for index, insight in enumerate(insights, start=1):
+            finding = self._process_insight(insight, run_id, options)
+            findings.append(finding)
+            all_query_ids.extend(finding.legacy_query_ids)
+            all_query_ids.extend(finding.dwh_query_ids)
+            self._print_progress(index, len(insights), finding, options["verbosity"])
+
+        if options["clickhouse_stats"] and not options["no_perf"] and all_query_ids:
+            self._attach_resource_stats(findings, all_query_ids, options)
+
+        aggregate = build_perf_aggregate(findings, worst_n=DEFAULT_WORST_N)
+        run_meta = self._build_run_meta(findings, options)
+        report = render_markdown_report(findings, aggregate, run_meta)
+
+        report_path = options["report_path"] or f"retention_dwh_comparison_{run_id}.md"
+        with open(report_path, "w") as handle:
+            handle.write(report)
+        if options["json_path"]:
+            self._write_json(options["json_path"], findings, aggregate, run_meta)
+
+        self._print_summary(run_meta["counts"], aggregate, report_path, options.get("json_path"))
+
+        if options["fail_on_mismatch"] and run_meta["counts"]["mismatch"]:
+            raise CommandError(f"{run_meta['counts']['mismatch']} insight(s) mismatched between variants")
+
+    def _select_insights(self, options: dict[str, Any]) -> list[Insight]:
+        queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")
+        if options["team_id"]:
+            queryset = queryset.filter(team_id__in=options["team_id"])
+        if options["insight_id"]:
+            queryset = queryset.filter(id__in=options["insight_id"])
+        if options["short_id"]:
+            queryset = queryset.filter(short_id__in=options["short_id"])
+        queryset = queryset.select_related("team")
+        if options["sample"]:
+            return list(queryset.order_by("?")[: options["sample"]])
+        return list(queryset.order_by("created_at")[: options["limit"]])
+
+    def _process_insight(self, insight: Insight, run_id: str, options: dict[str, Any]) -> InsightFinding:
+        base_url = options["base_url"].rstrip("/")
+        url = f"{base_url}/project/{insight.team_id}/insights/{insight.short_id}/edit"
+        finding = InsightFinding(
+            insight_id=insight.id,
+            short_id=insight.short_id,
+            team_id=insight.team_id,
+            name=insight.name or "",
+            url=url,
+            status="OK",
+        )
+        try:
+            source = insight.query.get("source") if isinstance(insight.query, dict) else None
+            finding.has_breakdown = bool(isinstance(source, dict) and source.get("breakdownFilter"))
+            if isinstance(source, dict):
+                finding.source_json = _trim(json.dumps(source, indent=2, default=str), options["max_source_json_chars"])
+
+            action, reason = classify_insight(insight)
+            if action == "error":
+                finding.status = "ERROR"
+                finding.error_type = "ClassificationError"
+                finding.error_detail = reason
+                return finding
+            if action == "skip":
+                finding.status = "SKIPPED"
+                finding.skip_reason = reason
+                return finding
+
+            self._run_comparison(insight, run_id, options, finding)
+        except Exception as exc:
+            finding.status = "ERROR"
+            finding.error_type = type(exc).__name__
+            finding.error_detail = traceback.format_exc()[-4000:]
+        return finding
+
+    def _run_comparison(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
+        modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers(timings=True))
+        do_perf = not options["no_perf"]
+        capture = do_perf and options["clickhouse_stats"]
+
+        if options["warmup"]:
+            run_variant(insight, False, modifiers)
+            run_variant(insight, True, modifiers)
+
+        legacy_run = run_variant(
+            insight,
+            False,
+            modifiers,
+            marker=f"rcmp_{run_id}_{insight.id}_legacy" if capture else None,
+            capture_query_ids=capture,
+        )
+        dwh_run = run_variant(
+            insight,
+            True,
+            modifiers,
+            marker=f"rcmp_{run_id}_{insight.id}_dwh" if capture else None,
+            capture_query_ids=capture,
+        )
+        finding.legacy_hogql = _trim(legacy_run.hogql, options["max_source_json_chars"])
+        finding.dwh_hogql = _trim(dwh_run.hogql, options["max_source_json_chars"])
+        finding.legacy_query_ids = legacy_run.query_ids
+        finding.dwh_query_ids = dwh_run.query_ids
+
+        finding.correctness = diff_retention_results(
+            legacy_run.results,
+            dwh_run.results,
+            count_tol_abs=options["count_tolerance_abs"],
+            count_tol_rel=options["count_tolerance_rel"],
+            agg_tol_rel=options["agg_tolerance_rel"],
+        )
+        finding.status = finding.correctness.status
+
+        if not do_perf:
+            return
+
+        wall_legacy = [legacy_run.wall_s * 1000]
+        wall_dwh = [dwh_run.wall_s * 1000]
+        ch_legacy = [legacy_run.ch_s * 1000]
+        ch_dwh = [dwh_run.ch_s * 1000]
+        for _ in range(max(0, options["perf_iterations"] - 1)):
+            legacy_iter = run_variant(insight, False, modifiers)
+            dwh_iter = run_variant(insight, True, modifiers)
+            wall_legacy.append(legacy_iter.wall_s * 1000)
+            wall_dwh.append(dwh_iter.wall_s * 1000)
+            ch_legacy.append(legacy_iter.ch_s * 1000)
+            ch_dwh.append(dwh_iter.ch_s * 1000)
+
+        finding.perf = compute_perf_result(
+            wall_legacy,
+            wall_dwh,
+            ch_legacy,
+            ch_dwh,
+            regression_rel=options["regression_threshold_rel"],
+            regression_ms=options["regression_threshold_ms"],
+        )
+
+    def _attach_resource_stats(
+        self, findings: list[InsightFinding], all_query_ids: list[str], options: dict[str, Any]
+    ) -> None:
+        self.stdout.write(f"Reading ClickHouse resource stats for {len(set(all_query_ids))} query id(s)…")
+        stats_by_id = fetch_query_log_stats(
+            all_query_ids,
+            table=options["query_log_table"],
+            flush=options["flush_query_log"],
+            wait_seconds=options["query_log_wait"],
+            log=lambda message: self.stdout.write(self.style.WARNING(f"  {message}")),
+        )
+        if not stats_by_id:
+            return
+        for finding in findings:
+            finding.resource_legacy = aggregate_resource_stats(finding.legacy_query_ids, stats_by_id)
+            finding.resource_dwh = aggregate_resource_stats(finding.dwh_query_ids, stats_by_id)
+            if finding.resource_legacy and finding.resource_dwh and finding.resource_legacy.read_bytes > 0:
+                finding.bytes_ratio = finding.resource_dwh.read_bytes / finding.resource_legacy.read_bytes
+
+    def _build_run_meta(self, findings: list[InsightFinding], options: dict[str, Any]) -> dict[str, Any]:
+        counts = {
+            "compared": sum(1 for f in findings if f.status in ("OK", "MISMATCH")),
+            "ok": sum(1 for f in findings if f.status == "OK"),
+            "mismatch": sum(1 for f in findings if f.status == "MISMATCH"),
+            "error": sum(1 for f in findings if f.status == "ERROR"),
+            "skipped": sum(1 for f in findings if f.status == "SKIPPED"),
+        }
+        return {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S %Z"),
+            "args": self._args_summary(options),
+            "counts": counts,
+            "regression_rel": options["regression_threshold_rel"],
+            "regression_ms": options["regression_threshold_ms"],
+            "max_cell_diffs": DEFAULT_MAX_CELL_DIFFS,
+        }
+
+    @staticmethod
+    def _args_summary(options: dict[str, Any]) -> str:
+        keys = [
+            "team_id",
+            "insight_id",
+            "short_id",
+            "limit",
+            "sample",
+            "perf_iterations",
+            "warmup",
+            "no_perf",
+            "clickhouse_stats",
+            "query_log_table",
+        ]
+        return ", ".join(f"{key}={options[key]}" for key in keys)
+
+    def _write_json(
+        self, path: str, findings: list[InsightFinding], aggregate: PerfAggregate, run_meta: dict[str, Any]
+    ) -> None:
+        payload = {
+            "run_meta": run_meta,
+            "aggregate": {
+                "n_compared": aggregate.n_compared,
+                "wall_ratio_dist": aggregate.wall_ratio_dist,
+                "bytes_ratio_dist": aggregate.bytes_ratio_dist,
+                "n_regressions": aggregate.n_regressions,
+                "n_improvements": aggregate.n_improvements,
+                "regression_insight_ids": [f.insight_id for f in aggregate.regressions],
+                "improvement_insight_ids": [f.insight_id for f in aggregate.improvements],
+            },
+            "findings": [dataclasses.asdict(f) for f in findings],
+        }
+        with open(path, "w") as handle:
+            json.dump(payload, handle, indent=2, default=str)
+
+    def _print_progress(self, index: int, total: int, finding: InsightFinding, verbosity: int) -> None:
+        if verbosity < 2 and finding.status in ("OK", "SKIPPED"):
+            return
+        style = {
+            "OK": self.style.SUCCESS,
+            "MISMATCH": self.style.ERROR,
+            "ERROR": self.style.ERROR,
+            "SKIPPED": self.style.WARNING,
+        }.get(finding.status, self.style.NOTICE)
+        detail = ""
+        if finding.status == "MISMATCH" and finding.correctness:
+            detail = f" cells={len(finding.correctness.cell_diffs)}"
+        elif finding.status == "SKIPPED":
+            detail = f" ({finding.skip_reason})"
+        elif finding.status == "ERROR":
+            detail = f" ({finding.error_type})"
+        regressed = " REGRESSION" if finding.perf and finding.perf.is_regression else ""
+        self.stdout.write(
+            style(f"[{index}/{total}] {finding.status}{regressed} {finding.short_id} (team {finding.team_id}){detail}")
+        )
+
+    def _print_summary(
+        self, counts: dict[str, int], aggregate: PerfAggregate, report_path: str, json_path: Optional[str]
+    ) -> None:
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
+        self.stdout.write(
+            f"COMPARED={counts['compared']} OK={counts['ok']} MISMATCH={counts['mismatch']} "
+            f"ERROR={counts['error']} SKIPPED={counts['skipped']} REGRESSIONS={aggregate.n_regressions}"
+        )
+        if aggregate.n_compared:
+            wall_median = aggregate.wall_ratio_dist.get("median")
+            bytes_median = aggregate.bytes_ratio_dist.get("median")
+            self.stdout.write(
+                f"Median wall ratio: {_fmt_ratio(wall_median)} | median bytes ratio: {_fmt_ratio(bytes_median)} | "
+                f"improvements: {aggregate.n_improvements}"
+            )
+        self.stdout.write(self.style.SUCCESS(f"Report: {report_path}"))
+        if json_path:
+            self.stdout.write(self.style.SUCCESS(f"JSON: {json_path}"))

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -9,9 +9,16 @@ regression can be handed to another model to fix.
 The toggle lives in
 ``posthog.hogql_queries.insights.retention.retention_base_query_fixed.retention_fixed_interval_base_query_use_dwh_variant``
 and is forced via ``unittest.mock.patch`` (the patch target is the shared
-``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant). Two insight shapes are NOT affected by the
-toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path) and
-the 24h rolling window mode (a different builder with no legacy/new split).
+``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant). Three insight shapes are NOT affected by the
+toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path), the
+24h rolling window mode (a different builder with no legacy/new split), and insights whose
+referenced actions/cohorts were deleted (both variants fail identically today, so there is no
+parity signal — only broken references to clean up).
+
+Run failures are attributed per variant: ERROR_DWH (legacy succeeded, the variant failed — a
+regression candidate that gates rollout), ERROR_LEGACY (the variant fixes an insight that is
+broken today), ERROR_BOTH (parity-in-failure), and plain ERROR for anything outside the two
+attributed correctness runs (classification, diffing, perf iterations).
 
 This command is strictly read-only: it never saves or mutates insights.
 
@@ -35,7 +42,7 @@ import argparse
 import traceback
 import statistics
 import dataclasses
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -63,6 +70,8 @@ from posthog.hogql_queries.insights.retention.test.retention_base_query_variant 
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.query_runner import get_query_runner
 
+from products.actions.backend.models.action import Action
+from products.cohorts.backend.models.cohort import Cohort
 from products.product_analytics.backend.models.insight import Insight
 
 DATA_WAREHOUSE_ENTITY_TYPE = "data_warehouse"
@@ -172,7 +181,7 @@ class InsightFinding:
     team_id: int
     name: str
     url: str
-    status: str  # "OK" | "MISMATCH" | "ERROR" | "SKIPPED"
+    status: str  # "OK" | "MISMATCH" | "ERROR" | "ERROR_LEGACY" | "ERROR_DWH" | "ERROR_BOTH" | "SKIPPED"
     has_breakdown: bool = False
     skip_reason: Optional[str] = None
     error_type: Optional[str] = None
@@ -212,8 +221,89 @@ def _attr(obj: Any, name: str) -> Any:
     return obj.get(name) if isinstance(obj, dict) else getattr(obj, name, None)
 
 
+def _walk_dicts(node: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk_dicts(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk_dicts(value)
+
+
+def _int_ids(value: Any) -> set[int]:
+    values = value if isinstance(value, list) else [value]
+    ids: set[int] = set()
+    for candidate in values:
+        if candidate is None or isinstance(candidate, bool):
+            continue
+        try:
+            ids.add(int(candidate))
+        except (TypeError, ValueError):
+            continue  # e.g. the "all" pseudo-cohort, or a malformed id — let the real run decide
+    return ids
+
+
+def referenced_ids(source: dict[str, Any]) -> tuple[set[int], set[int]]:
+    """(action_ids, cohort_ids) referenced anywhere in a RetentionQuery source.
+
+    Walks the raw query JSON so every reference site is covered with one rule set: action
+    entities ({"type": "actions", "id": …}), cohort property filters at any nesting depth
+    ({"type": "cohort", "value": …}), cohort breakdowns ({"type": "cohort", "property": …}),
+    and the legacy single-breakdown shape ({"breakdown_type": "cohort", "breakdown": …}).
+    The "all users" pseudo-cohort (id 0 / "all") is never a real reference.
+    """
+    action_ids: set[int] = set()
+    cohort_ids: set[int] = set()
+    for node in _walk_dicts(source):
+        node_type = node.get("type")
+        if node_type == "actions":
+            action_ids |= _int_ids(node.get("id"))
+        elif node_type == "cohort":
+            cohort_ids |= _int_ids(node.get("value")) | _int_ids(node.get("property"))
+        if node.get("breakdown_type") == "cohort":
+            cohort_ids |= _int_ids(node.get("breakdown"))
+    cohort_ids.discard(0)  # "all users"
+    return action_ids, cohort_ids
+
+
+def _missing_reference_reason(insight: Insight, source: dict[str, Any]) -> Optional[str]:
+    """A skip reason when the insight references actions/cohorts that no longer resolve, else None.
+
+    Mirrors the runtime lookups exactly, so this predicts the DoesNotExist / "Could not find
+    cohort" errors both variants raise identically today: actions resolve project-wide with no
+    deleted filter (RetentionQueryRunner.get_events_for_entity), cohorts project-wide with
+    deleted=False (the IN COHORT transform).
+    """
+    action_ids, cohort_ids = referenced_ids(source)
+    missing_parts: list[str] = []
+    if action_ids:
+        found = set(
+            Action.objects.filter(pk__in=action_ids, team__project_id=insight.team.project_id).values_list(
+                "id", flat=True
+            )
+        )
+        if action_ids - found:
+            missing_parts.append(f"action(s) {sorted(action_ids - found)}")
+    if cohort_ids:
+        found = set(
+            Cohort.objects.filter(
+                pk__in=cohort_ids, team__project_id=insight.team.project_id, deleted=False
+            ).values_list("id", flat=True)
+        )
+        if cohort_ids - found:
+            missing_parts.append(f"cohort(s) {sorted(cohort_ids - found)}")
+    if not missing_parts:
+        return None
+    return f"references missing {' and '.join(missing_parts)} — fails identically on both variants"
+
+
 def classify_insight(insight: Insight) -> tuple[str, str]:
-    """Return ("compare"|"skip"|"error", reason) without executing anything."""
+    """Return ("compare"|"skip"|"error", reason) without executing any query.
+
+    Touches Postgres (never ClickHouse) only when the insight references actions or cohorts,
+    to pre-classify dangling references as a skip instead of letting both variants error.
+    """
     query = insight.query
     if not isinstance(query, dict):
         return ("error", "insight.query is not a dict")
@@ -229,6 +319,9 @@ def classify_insight(insight: Insight) -> tuple[str, str]:
         entity = retention_filter.get(entity_key)
         if isinstance(entity, dict) and entity.get("type") == DATA_WAREHOUSE_ENTITY_TYPE:
             return ("skip", "data_warehouse (new-path only)")
+    missing_reason = _missing_reference_reason(insight, source)
+    if missing_reason is not None:
+        return ("skip", missing_reason)
     return ("compare", "")
 
 
@@ -474,6 +567,42 @@ def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -
     )
 
 
+def _fmt_exception(exc: BaseException, max_chars: int = 500) -> str:
+    message = str(exc)
+    if len(message) > max_chars:
+        message = message[:max_chars] + "…"
+    return f"{type(exc).__name__}: {message}"
+
+
+def attribute_variant_errors(
+    legacy_exc: Optional[BaseException], dwh_exc: Optional[BaseException]
+) -> tuple[str, str, str]:
+    """Attribute run failure(s) to a variant: (status, error_type, summary).
+
+    The distinction is the whole signal: ERROR_DWH (legacy succeeded) is a variant regression
+    candidate that gates rollout, ERROR_LEGACY means the variant fixes an insight that is broken
+    today, and ERROR_BOTH is parity-in-failure — the insight is broken regardless of the toggle.
+    Call with at least one exception.
+    """
+    if legacy_exc is not None and dwh_exc is not None:
+        same_error = type(legacy_exc) is type(dwh_exc) and str(legacy_exc) == str(dwh_exc)
+        if same_error:
+            return (
+                "ERROR_BOTH",
+                type(legacy_exc).__name__,
+                f"both variants fail identically — {_fmt_exception(legacy_exc)}",
+            )
+        return (
+            "ERROR_BOTH",
+            f"legacy={type(legacy_exc).__name__}, dwh={type(dwh_exc).__name__}",
+            f"legacy: {_fmt_exception(legacy_exc)} | dwh: {_fmt_exception(dwh_exc)}",
+        )
+    if dwh_exc is not None:
+        return ("ERROR_DWH", type(dwh_exc).__name__, f"legacy OK, DWH variant failed — {_fmt_exception(dwh_exc)}")
+    assert legacy_exc is not None
+    return ("ERROR_LEGACY", type(legacy_exc).__name__, f"DWH variant OK, legacy failed — {_fmt_exception(legacy_exc)}")
+
+
 def _frozen_date_range(
     date_from: datetime, latest_interval_start: datetime, interval_delta: timedelta
 ) -> dict[str, Any]:
@@ -702,6 +831,35 @@ def run_variant(
     )
 
 
+def _attempt_variant(
+    insight: Insight,
+    use_dwh: bool,
+    modifiers: HogQLQueryModifiers,
+    date_range_override: Optional[dict[str, Any]],
+    *,
+    marker: Optional[str] = None,
+    capture_query_ids: bool = False,
+) -> tuple[Optional[VariantRun], Optional[BaseException]]:
+    """run_variant with the exception captured instead of raised, so failures stay attributed
+    to the variant that produced them."""
+    try:
+        run = run_variant(
+            insight,
+            use_dwh,
+            modifiers,
+            marker=marker,
+            capture_query_ids=capture_query_ids,
+            date_range_override=date_range_override,
+        )
+        return run, None
+    except Exception as exc:
+        return None, exc
+
+
+def _exception_traceback(exc: BaseException, max_chars: int = 2000) -> str:
+    return "".join(traceback.format_exception(exc))[-max_chars:]
+
+
 def compute_interval_context(insight: Insight, modifiers: HogQLQueryModifiers, *, freeze: bool) -> IntervalContext:
     """Derive the in-progress interval (and, if freezing, an explicit frozen window) for an insight.
 
@@ -891,7 +1049,10 @@ def render_markdown_report(
     out(f"| Compared | {counts['compared']} |")
     out(f"| ✅ OK | {counts['ok']} |")
     out(f"| ❌ MISMATCH | {counts['mismatch']} |")
-    out(f"| ⚠️ ERROR | {counts['error']} |")
+    out(f"| 🚨 ERROR_DWH (legacy OK — variant regression candidate) | {counts['error_dwh']} |")
+    out(f"| ♻️ ERROR_LEGACY (DWH OK — variant fixes it) | {counts['error_legacy']} |")
+    out(f"| 🪦 ERROR_BOTH (broken regardless of toggle) | {counts['error_both']} |")
+    out(f"| ⚠️ ERROR (outside the attributed variant runs) | {counts['error']} |")
     out(f"| ⏭️ SKIPPED | {counts['skipped']} |")
     out(f"| 🌀 Trailing-period drift (excluded from verdict) | {counts['trailing_drift']} |")
     out("")
@@ -910,7 +1071,7 @@ def render_markdown_report(
     _render_mismatches(out, findings, run_meta)
     _render_trailing_drift(out, findings, run_meta)
     _render_regressions(out, aggregate.regressions, run_meta)
-    _render_errors(out, [f for f in findings if f.status == "ERROR"])
+    _render_errors(out, [f for f in findings if f.status.startswith("ERROR")])
     _render_skipped(out, [f for f in findings if f.status == "SKIPPED"])
 
     return "\n".join(lines) + "\n"
@@ -1107,21 +1268,27 @@ def _render_perf_table(out: Callable[[str], None], f: InsightFinding) -> None:
     out("")
 
 
+_ERROR_STATUS_ORDER = {"ERROR_DWH": 0, "ERROR_LEGACY": 1, "ERROR_BOTH": 2, "ERROR": 3}
+
+
 def _render_errors(out: Callable[[str], None], errors: list[InsightFinding]) -> None:
     if not errors:
         return
     out("## Errors\n")
-    for f in errors:
-        _render_finding_header(out, f, "ERROR")
+    out(
+        "Ordered by rollout relevance: ERROR_DWH (legacy succeeded, the variant failed) gates the "
+        "rollout; ERROR_LEGACY means the variant fixes an insight that is broken today; ERROR_BOTH "
+        "is parity-in-failure — broken regardless of the toggle.\n"
+    )
+    for f in sorted(errors, key=lambda f: (_ERROR_STATUS_ORDER.get(f.status, 9), f.insight_id)):
+        _render_finding_header(out, f, f.status)
         out(f"- Error: `{f.error_type}`")
         if f.error_detail:
             out("```")
             out(f.error_detail)
             out("```\n")
-        if f.source_json:
-            out("```json")
-            out(f.source_json)
-            out("```\n")
+        # Includes the surviving variant's HogQL when one side succeeded — context for diagnosis.
+        _render_source_and_hogql(out, f)
 
 
 def _render_skipped(out: Callable[[str], None], skipped: list[InsightFinding]) -> None:
@@ -1303,44 +1470,78 @@ class Command(BaseCommand):
             "interval_delta": ctx.trailing_delta,
         }
 
+        # Each variant runs under its own guard so a failure is attributed to the side that raised
+        # it — ERROR_DWH vs ERROR_LEGACY vs ERROR_BOTH — instead of one opaque ERROR. A variant
+        # whose warmup failed is not re-run: the measured run would fail the same way, and for
+        # resource errors that second attempt is as expensive as the first.
+        legacy_exc: Optional[BaseException] = None
+        dwh_exc: Optional[BaseException] = None
         if options["warmup"]:
-            run_variant(insight, False, modifiers, date_range_override=override)
-            run_variant(insight, True, modifiers, date_range_override=override)
+            _, legacy_exc = _attempt_variant(insight, False, modifiers, override)
+            _, dwh_exc = _attempt_variant(insight, True, modifiers, override)
 
-        legacy_run = run_variant(
-            insight,
-            False,
-            modifiers,
-            marker=f"rcmp_{run_id}_{insight.id}_legacy" if capture else None,
-            capture_query_ids=capture,
-            date_range_override=override,
-        )
-        dwh_run = run_variant(
-            insight,
-            True,
-            modifiers,
-            marker=f"rcmp_{run_id}_{insight.id}_dwh" if capture else None,
-            capture_query_ids=capture,
-            date_range_override=override,
-        )
-        finding.legacy_hogql = _trim(legacy_run.hogql, options["max_source_json_chars"])
-        finding.dwh_hogql = _trim(dwh_run.hogql, options["max_source_json_chars"])
-        finding.legacy_query_ids = legacy_run.query_ids
-        finding.dwh_query_ids = dwh_run.query_ids
+        legacy_run: Optional[VariantRun] = None
+        dwh_run: Optional[VariantRun] = None
+        if legacy_exc is None:
+            legacy_run, legacy_exc = _attempt_variant(
+                insight,
+                False,
+                modifiers,
+                override,
+                marker=f"rcmp_{run_id}_{insight.id}_legacy" if capture else None,
+                capture_query_ids=capture,
+            )
+        if dwh_exc is None:
+            dwh_run, dwh_exc = _attempt_variant(
+                insight,
+                True,
+                modifiers,
+                override,
+                marker=f"rcmp_{run_id}_{insight.id}_dwh" if capture else None,
+                capture_query_ids=capture,
+            )
 
-        finding.correctness = diff_retention_results(legacy_run.results, dwh_run.results, **diff_kwargs)
-        finding.status = finding.correctness.status
+        # Keep whatever the surviving side produced: its HogQL (for diagnosis) and its query ids
+        # (so resource stats still show how expensive the succeeding variant was).
+        if legacy_run is not None:
+            finding.legacy_hogql = _trim(legacy_run.hogql, options["max_source_json_chars"])
+            finding.legacy_query_ids = legacy_run.query_ids
+        if dwh_run is not None:
+            finding.dwh_hogql = _trim(dwh_run.hogql, options["max_source_json_chars"])
+            finding.dwh_query_ids = dwh_run.query_ids
+
+        if legacy_exc is not None or dwh_exc is not None:
+            finding.status, finding.error_type, summary = attribute_variant_errors(legacy_exc, dwh_exc)
+            detail_parts = [summary]
+            if legacy_exc is not None:
+                detail_parts.append(f"--- legacy traceback ---\n{_exception_traceback(legacy_exc)}")
+            if dwh_exc is not None:
+                detail_parts.append(f"--- dwh traceback ---\n{_exception_traceback(dwh_exc)}")
+            finding.error_detail = "\n\n".join(detail_parts)
+            return
+
+        assert legacy_run is not None and dwh_run is not None
+        correctness = diff_retention_results(legacy_run.results, dwh_run.results, **diff_kwargs)
 
         # Re-test a residual (non-trailing) mismatch once and keep only differences that reproduce in
         # both passes: a transient diff from live ingest landing outside the trailing window drops
         # out, while a genuine systematic difference survives. Plain runs (no marker/capture) keep the
         # perf protocol and query-log stats untouched. Bounded cost — only runs on a first-pass mismatch.
-        if options["recheck_mismatches"] and finding.status == "MISMATCH":
-            recheck_legacy = run_variant(insight, False, modifiers, date_range_override=override)
-            recheck_dwh = run_variant(insight, True, modifiers, date_range_override=override)
-            diff2 = diff_retention_results(recheck_legacy.results, recheck_dwh.results, **diff_kwargs)
-            finding.correctness = intersect_stable_mismatch(finding.correctness, diff2)
-            finding.status = finding.correctness.status
+        if options["recheck_mismatches"] and correctness.status == "MISMATCH":
+            recheck_legacy, recheck_legacy_exc = _attempt_variant(insight, False, modifiers, override)
+            recheck_dwh, recheck_dwh_exc = _attempt_variant(insight, True, modifiers, override)
+            if recheck_legacy is not None and recheck_dwh is not None:
+                diff2 = diff_retention_results(recheck_legacy.results, recheck_dwh.results, **diff_kwargs)
+                correctness = intersect_stable_mismatch(correctness, diff2)
+            else:
+                # Keep the first-pass verdict rather than discarding a valid diff over a flaky re-run.
+                failed = recheck_legacy_exc or recheck_dwh_exc
+                assert failed is not None
+                correctness.notes.append(
+                    f"recheck failed ({_fmt_exception(failed)}) — mismatch is first-pass only, not stability-verified"
+                )
+        finding.correctness = correctness
+        finding.status = correctness.status
 
         if not do_perf:
             return
@@ -1391,6 +1592,9 @@ class Command(BaseCommand):
             "ok": sum(1 for f in findings if f.status == "OK"),
             "mismatch": sum(1 for f in findings if f.status == "MISMATCH"),
             "error": sum(1 for f in findings if f.status == "ERROR"),
+            "error_legacy": sum(1 for f in findings if f.status == "ERROR_LEGACY"),
+            "error_dwh": sum(1 for f in findings if f.status == "ERROR_DWH"),
+            "error_both": sum(1 for f in findings if f.status == "ERROR_BOTH"),
             "skipped": sum(1 for f in findings if f.status == "SKIPPED"),
             "trailing_drift": sum(1 for f in findings if f.correctness and f.correctness.trailing_cell_diffs),
         }
@@ -1444,18 +1648,18 @@ class Command(BaseCommand):
     def _print_progress(self, index: int, total: int, finding: InsightFinding, verbosity: int) -> None:
         if verbosity < 2 and finding.status in ("OK", "SKIPPED"):
             return
-        style = {
-            "OK": self.style.SUCCESS,
-            "MISMATCH": self.style.ERROR,
-            "ERROR": self.style.ERROR,
-            "SKIPPED": self.style.WARNING,
-        }.get(finding.status, self.style.NOTICE)
+        if finding.status == "OK":
+            style = self.style.SUCCESS
+        elif finding.status == "MISMATCH" or finding.status.startswith("ERROR"):
+            style = self.style.ERROR
+        else:
+            style = self.style.WARNING
         detail = ""
         if finding.status == "MISMATCH" and finding.correctness:
             detail = f" cells={len(finding.correctness.cell_diffs)}"
         elif finding.status == "SKIPPED":
             detail = f" ({finding.skip_reason})"
-        elif finding.status == "ERROR":
+        elif finding.status.startswith("ERROR"):
             detail = f" ({finding.error_type})"
         if finding.correctness and finding.correctness.trailing_cell_diffs:
             detail += f" trailing_drift={len(finding.correctness.trailing_cell_diffs)}"
@@ -1471,8 +1675,9 @@ class Command(BaseCommand):
         self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
         self.stdout.write(
             f"COMPARED={counts['compared']} OK={counts['ok']} MISMATCH={counts['mismatch']} "
-            f"ERROR={counts['error']} SKIPPED={counts['skipped']} REGRESSIONS={aggregate.n_regressions} "
-            f"TRAILING_DRIFT={counts['trailing_drift']}"
+            f"ERROR_DWH={counts['error_dwh']} ERROR_LEGACY={counts['error_legacy']} "
+            f"ERROR_BOTH={counts['error_both']} ERROR={counts['error']} SKIPPED={counts['skipped']} "
+            f"REGRESSIONS={aggregate.n_regressions} TRAILING_DRIFT={counts['trailing_drift']}"
         )
         if aggregate.n_compared:
             wall_median = aggregate.wall_ratio_dist.get("median")

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -277,6 +277,14 @@ def diff_retention_results(
 
     cell_diffs: list[CellDiff] = []
     notes: list[str] = []
+    # Row keys should be identical between variants (format_results is shared); flag — never
+    # silently drop — any that aren't, so an OK verdict can't mask differing row coverage.
+    rows_only_legacy = [k for k in legacy_by_key if k not in dwh_by_key]
+    rows_only_dwh = [k for k in dwh_by_key if k not in legacy_by_key]
+    for key in rows_only_legacy:
+        notes.append(f"row (breakdown={key[0]!r}, label={key[1]!r}) present in legacy but missing in DWH")
+    for key in rows_only_dwh:
+        notes.append(f"row (breakdown={key[0]!r}, label={key[1]!r}) present in DWH but missing in legacy")
     for key in legacy_by_key:
         if key not in dwh_by_key:
             continue
@@ -324,7 +332,14 @@ def diff_retention_results(
                     )
 
     cell_diffs.sort(key=lambda c: c.abs_diff, reverse=True)
-    is_mismatch = len(legacy) != len(dwh) or bool(only_legacy) or bool(only_dwh) or bool(cell_diffs)
+    is_mismatch = (
+        len(legacy) != len(dwh)
+        or bool(only_legacy)
+        or bool(only_dwh)
+        or bool(rows_only_legacy)
+        or bool(rows_only_dwh)
+        or bool(cell_diffs)
+    )
     return CorrectnessDiff(
         status="MISMATCH" if is_mismatch else "OK",
         row_count_legacy=len(legacy),
@@ -527,10 +542,15 @@ def run_variant(
         if capture_query_ids
         else nullcontext()
     )
-    with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=use_dwh), capture_ctx:
-        start = perf_counter()
-        response = get_query_runner(source, insight.team, modifiers=deepcopy(modifiers)).calculate()
-        wall_s = perf_counter() - start
+    try:
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=use_dwh), capture_ctx:
+            start = perf_counter()
+            response = get_query_runner(source, insight.team, modifiers=deepcopy(modifiers)).calculate()
+            wall_s = perf_counter() - start
+    finally:
+        if marker:
+            # Clear the marker so later perf-only iterations don't tag their query-log rows with it.
+            tag_queries(client_query_id=None)
 
     return VariantRun(
         results=response.results or [],

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -38,6 +38,7 @@ import dataclasses
 from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from copy import deepcopy
+from datetime import datetime, timedelta
 from time import perf_counter
 from typing import Any, Optional
 
@@ -55,6 +56,7 @@ from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
     RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG,
 )
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
 from posthog.hogql_queries.insights.retention.test.retention_base_query_variant import (
     RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
 )
@@ -109,6 +111,26 @@ class CorrectnessDiff:
     other_bucket_changed: bool
     cell_diffs: list[CellDiff]
     notes: list[str]
+    # Row keys present on only one side — the structural row-coverage signal that (with cell_diffs,
+    # breakdown_only_*, and row counts) drives the verdict. Stored separately from ``notes`` so the
+    # stability re-test can intersect them without parsing note strings.
+    rows_only_legacy: list[Any] = dataclasses.field(default_factory=list)
+    rows_only_dwh: list[Any] = dataclasses.field(default_factory=list)
+    # Cells whose count/aggregation differs only because they sit in the inherently-racy in-progress
+    # period (live ingest lands between the two variant runs). Reported separately, never counted
+    # toward the MISMATCH verdict.
+    trailing_cell_diffs: list[CellDiff] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class IntervalContext:
+    """Per-insight interval metadata, derived once from the query runner's own date math."""
+
+    latest_interval_start: Optional[datetime] = None
+    # ``None`` for custom-bracket retention, where value index does not map to ``offset * delta``.
+    trailing_delta: Optional[timedelta] = None
+    # Explicit, current-period-excluding date range, set only when --freeze-window is requested.
+    frozen_date_range: Optional[dict[str, Any]] = None
 
 
 @dataclasses.dataclass
@@ -250,6 +272,28 @@ def _breakdown_values_in_order(results: Sequence[Any]) -> list[Any]:
     return ordered
 
 
+def _cell_is_trailing(
+    cohort_date: Optional[datetime],
+    offset: int,
+    latest_interval_start: Optional[datetime],
+    interval_delta: Optional[timedelta],
+) -> bool:
+    """Is this cell anchored on the in-progress (current) interval, and therefore racy?
+
+    A retention cell is a (cohort interval, period offset) pair; its returning bucket is
+    ``cohort_interval + offset``. The cell is trailing if either the cohort interval or the returning
+    interval is the latest (now-containing) one. ``interval_delta`` is ``None`` when offset→date math
+    is unreliable (custom brackets), leaving only the offset-agnostic cohort check.
+    """
+    if latest_interval_start is None or cohort_date is None:
+        return False
+    if cohort_date == latest_interval_start:
+        return True
+    if interval_delta is None:
+        return False
+    return cohort_date + offset * interval_delta == latest_interval_start
+
+
 def diff_retention_results(
     legacy: Sequence[Any],
     dwh: Sequence[Any],
@@ -257,6 +301,8 @@ def diff_retention_results(
     count_tol_abs: float = 0.0,
     count_tol_rel: float = 0.0,
     agg_tol_rel: float = 1e-6,
+    latest_interval_start: Optional[datetime] = None,
+    interval_delta: Optional[timedelta] = None,
 ) -> CorrectnessDiff:
     """Diff two retention result sets, keyed by (breakdown_value, row label).
 
@@ -264,6 +310,11 @@ def diff_retention_results(
     is expected to be identical; the only legitimate differences are numeric counts/aggregation
     values. A large enough count delta, however, can change which breakdown values get ranked into
     the "Other" bucket — hence the breakdown-set and Other-bucket checks.
+
+    When ``latest_interval_start`` is given, cells anchored on the in-progress interval are split out
+    into ``trailing_cell_diffs`` and excluded from the MISMATCH verdict: events ingested between the
+    two variant runs land in that bucket, so a small count delta there is live-ingest drift, not a
+    parity bug. Passing ``None`` (the default) disables the split and preserves the original behaviour.
     """
     legacy_by_key = {(_attr(r, "breakdown_value"), _attr(r, "label")): r for r in legacy}
     dwh_by_key = {(_attr(r, "breakdown_value"), _attr(r, "label")): r for r in dwh}
@@ -276,6 +327,7 @@ def diff_retention_results(
     other_bucket_changed = (BREAKDOWN_OTHER_STRING_LABEL in set_legacy) != (BREAKDOWN_OTHER_STRING_LABEL in set_dwh)
 
     cell_diffs: list[CellDiff] = []
+    trailing_cell_diffs: list[CellDiff] = []
     notes: list[str] = []
     # Row keys should be identical between variants (format_results is shared); flag — never
     # silently drop — any that aren't, so an OK verdict can't mask differing row coverage.
@@ -291,16 +343,21 @@ def diff_retention_results(
         legacy_values = _attr(legacy_by_key[key], "values") or []
         dwh_values = _attr(dwh_by_key[key], "values") or []
         dwh_by_label = {_attr(v, "label"): v for v in dwh_values}
-        for legacy_value in legacy_values:
+        cohort_date = _attr(legacy_by_key[key], "date")
+        # The value at index ``offset`` carries period offset ``offset`` (format_results builds them
+        # in return-interval order), so its returning bucket is ``cohort_date + offset * delta``.
+        for offset, legacy_value in enumerate(legacy_values):
             value_label = _attr(legacy_value, "label")
             dwh_value = dwh_by_label.get(value_label)
             if dwh_value is None:
                 notes.append(f"value label {value_label!r} missing in DWH for {key}")
                 continue
+            is_trailing = _cell_is_trailing(cohort_date, offset, latest_interval_start, interval_delta)
+            target = trailing_cell_diffs if is_trailing else cell_diffs
             legacy_count = float(_attr(legacy_value, "count") or 0.0)
             dwh_count = float(_attr(dwh_value, "count") or 0.0)
             if not _within(legacy_count, dwh_count, count_tol_abs, count_tol_rel):
-                cell_diffs.append(
+                target.append(
                     CellDiff(
                         breakdown_value=key[0],
                         row_label=key[1],
@@ -318,7 +375,7 @@ def diff_retention_results(
                 legacy_agg_f = float(legacy_agg or 0.0)
                 dwh_agg_f = float(dwh_agg or 0.0)
                 if not _within(legacy_agg_f, dwh_agg_f, 0.0, agg_tol_rel):
-                    cell_diffs.append(
+                    target.append(
                         CellDiff(
                             breakdown_value=key[0],
                             row_label=key[1],
@@ -332,6 +389,7 @@ def diff_retention_results(
                     )
 
     cell_diffs.sort(key=lambda c: c.abs_diff, reverse=True)
+    trailing_cell_diffs.sort(key=lambda c: c.abs_diff, reverse=True)
     is_mismatch = (
         len(legacy) != len(dwh)
         or bool(only_legacy)
@@ -351,7 +409,86 @@ def diff_retention_results(
         other_bucket_changed=other_bucket_changed,
         cell_diffs=cell_diffs,
         notes=notes,
+        rows_only_legacy=rows_only_legacy,
+        rows_only_dwh=rows_only_dwh,
+        trailing_cell_diffs=trailing_cell_diffs,
     )
+
+
+def _cell_key(cell: CellDiff) -> tuple[Any, str, Optional[str], str]:
+    return (cell.breakdown_value, cell.row_label, cell.value_label, cell.field)
+
+
+def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -> CorrectnessDiff:
+    """Keep only the differences present in BOTH passes, so transient drift drops out.
+
+    Re-running both variants and intersecting the two diffs distinguishes a genuine, systematic
+    mismatch (reproduces) from live-ingest noise that happened to land outside the trailing window on
+    the first pass (does not reproduce). Every MISMATCH signal is intersected, since live ingest can
+    perturb breakdown ranking and row coverage as well as raw cell counts.
+    """
+    second_keys = {_cell_key(c) for c in second.cell_diffs}
+    stable_cells = [c for c in first.cell_diffs if _cell_key(c) in second_keys]
+
+    second_only_legacy = set(second.breakdown_only_legacy)
+    second_only_dwh = set(second.breakdown_only_dwh)
+    stable_only_legacy = [b for b in first.breakdown_only_legacy if b in second_only_legacy]
+    stable_only_dwh = [b for b in first.breakdown_only_dwh if b in second_only_dwh]
+
+    second_rows_only_legacy = set(second.rows_only_legacy)
+    second_rows_only_dwh = set(second.rows_only_dwh)
+    stable_rows_only_legacy = [k for k in first.rows_only_legacy if k in second_rows_only_legacy]
+    stable_rows_only_dwh = [k for k in first.rows_only_dwh if k in second_rows_only_dwh]
+
+    second_notes = set(second.notes)
+    stable_notes = [n for n in first.notes if n in second_notes]
+
+    row_count_stable = (first.row_count_legacy != first.row_count_dwh) and (
+        second.row_count_legacy != second.row_count_dwh
+    )
+
+    # Mirror diff_retention_results' is_mismatch exactly: cells, breakdown sets, row coverage, and row
+    # counts. ``other_bucket_changed`` and ``notes`` are reported but never drive the verdict.
+    is_mismatch = bool(
+        stable_cells
+        or stable_only_legacy
+        or stable_only_dwh
+        or stable_rows_only_legacy
+        or stable_rows_only_dwh
+        or row_count_stable
+    )
+    return CorrectnessDiff(
+        status="MISMATCH" if is_mismatch else "OK",
+        row_count_legacy=first.row_count_legacy,
+        row_count_dwh=first.row_count_dwh,
+        breakdown_keys_legacy=first.breakdown_keys_legacy,
+        breakdown_keys_dwh=first.breakdown_keys_dwh,
+        breakdown_only_legacy=stable_only_legacy,
+        breakdown_only_dwh=stable_only_dwh,
+        other_bucket_changed=first.other_bucket_changed and second.other_bucket_changed,
+        cell_diffs=stable_cells,
+        notes=stable_notes,
+        rows_only_legacy=stable_rows_only_legacy,
+        rows_only_dwh=stable_rows_only_dwh,
+        trailing_cell_diffs=first.trailing_cell_diffs,
+    )
+
+
+def _frozen_date_range(
+    date_from: datetime, latest_interval_start: datetime, interval_delta: timedelta
+) -> dict[str, Any]:
+    """Explicit date range whose effective end is the start of the current period.
+
+    ``QueryDateRangeWithIntervals.date_to()`` pads by one interval then truncates, so an explicit
+    ``date_to`` of ``latest_interval_start - delta`` yields an effective ``date_to`` of
+    ``latest_interval_start`` — making the last (in-progress) cohort drop off and the final bucket be
+    the last *complete* interval. This removes drift by comparing over a frozen snapshot.
+    """
+    return {
+        "date_from": date_from.isoformat(),
+        "date_to": (latest_interval_start - interval_delta).isoformat(),
+        "explicitDate": True,
+    }
 
 
 def _percentile(sorted_values: list[float], pct: float) -> float:
@@ -516,12 +653,16 @@ def run_variant(
     *,
     marker: Optional[str] = None,
     capture_query_ids: bool = False,
+    date_range_override: Optional[dict[str, Any]] = None,
 ) -> VariantRun:
     """Execute one retention variant. Read-only: deepcopies the query, scopes the patch."""
     query = insight.query
     if not isinstance(query, dict):
         raise ValueError(f"insight {insight.id} has a non-dict query")
     source = deepcopy(query["source"])
+    if date_range_override is not None:
+        # --freeze-window: pin both variants to the same explicit, current-period-excluding window.
+        source["dateRange"] = date_range_override
     if marker:
         # The query_id ClickHouse records becomes f"{team_id}_{client_query_id}_{random}", so the
         # marker makes captured query_ids self-describing in the report. Setting client_query_id
@@ -559,6 +700,43 @@ def run_variant(
         ch_s=_clickhouse_seconds(response.timings),
         query_ids=captured,
     )
+
+
+def compute_interval_context(insight: Insight, modifiers: HogQLQueryModifiers, *, freeze: bool) -> IntervalContext:
+    """Derive the in-progress interval (and, if freezing, an explicit frozen window) for an insight.
+
+    Best-effort and read-only: it builds the runner purely to read its date math and never executes a
+    retention query. Any failure, a non-retention runner, or a window that is fully historical (no
+    in-progress period) returns an empty context, which disables trailing classification and freezing —
+    the diff then behaves exactly as before.
+
+    ``latest_interval_start`` is derived as ``date_to() - delta`` rather than from a fresh
+    ``datetime.now()``: by construction ``date_from() + intervals_between * delta == date_to()``, so
+    this is byte-identical to the last cohort row's ``date`` and immune to timezone-truncation skew.
+    """
+    try:
+        query = insight.query
+        if not isinstance(query, dict):
+            return IntervalContext()
+        runner = get_query_runner(deepcopy(query["source"]), insight.team, modifiers=deepcopy(modifiers))
+        if not isinstance(runner, RetentionQueryRunner):
+            return IntervalContext()
+        qdr = runner.query_date_range
+        interval_delta = qdr.determine_time_delta(1, qdr.interval_name)
+        date_to = qdr.date_to()
+        if qdr.now_with_timezone >= date_to:
+            # The whole window is in the past — nothing is in progress, so nothing is racy.
+            return IntervalContext()
+        latest_interval_start = date_to - interval_delta
+        trailing_delta = None if runner.is_custom_bracket_retention else interval_delta
+        frozen = _frozen_date_range(qdr.date_from(), latest_interval_start, interval_delta) if freeze else None
+        return IntervalContext(
+            latest_interval_start=latest_interval_start,
+            trailing_delta=trailing_delta,
+            frozen_date_range=frozen,
+        )
+    except Exception:
+        return IntervalContext()
 
 
 def fetch_query_log_stats(
@@ -700,6 +878,12 @@ def render_markdown_report(
         "indicative. Interleaving legacy/new and reporting median + min (not mean) cancels "
         "asymmetric cache warming and one-off spikes.\n"
     )
+    if run_meta.get("freeze_window"):
+        out(
+            "> **Frozen window.** `--freeze-window` was set: each insight's date range was rewritten to an "
+            "explicit range ending at the last complete interval, excluding the in-progress period. This "
+            "removes live-ingest drift, but means the validated window differs from the stored insight.\n"
+        )
 
     out("## Summary\n")
     out("| Result | Count |")
@@ -709,6 +893,7 @@ def render_markdown_report(
     out(f"| ❌ MISMATCH | {counts['mismatch']} |")
     out(f"| ⚠️ ERROR | {counts['error']} |")
     out(f"| ⏭️ SKIPPED | {counts['skipped']} |")
+    out(f"| 🌀 Trailing-period drift (excluded from verdict) | {counts['trailing_drift']} |")
     out("")
     if aggregate.n_compared:
         wall_median = aggregate.wall_ratio_dist.get("median")
@@ -723,6 +908,7 @@ def render_markdown_report(
 
     _render_perf_distribution(out, aggregate)
     _render_mismatches(out, findings, run_meta)
+    _render_trailing_drift(out, findings, run_meta)
     _render_regressions(out, aggregate.regressions, run_meta)
     _render_errors(out, [f for f in findings if f.status == "ERROR"])
     _render_skipped(out, [f for f in findings if f.status == "SKIPPED"])
@@ -845,6 +1031,26 @@ def _render_mismatches(out: Callable[[str], None], findings: list[InsightFinding
                 out(f"- Note: {note}")
             out("")
         _render_source_and_hogql(out, f)
+
+
+def _render_trailing_drift(
+    out: Callable[[str], None], findings: list[InsightFinding], run_meta: dict[str, Any]
+) -> None:
+    drifting = [f for f in findings if f.correctness and f.correctness.trailing_cell_diffs]
+    if not drifting:
+        return
+    out("## Trailing-period drift (excluded from MISMATCH)\n")
+    out(
+        "These cells differ only on the in-progress (current) interval. Events ingested between the "
+        "legacy and DWH runs land in that trailing bucket, so a small delta here is live-ingest drift, "
+        "not a parity bug — it does not count toward the verdict. Shown for visibility.\n"
+    )
+    for f in drifting:
+        diff = f.correctness
+        assert diff is not None
+        _render_finding_header(out, f, f"TRAILING DRIFT ({f.status})")
+        out(f"- {len(diff.trailing_cell_diffs)} trailing cell(s)\n")
+        _render_cell_diff_table(out, diff.trailing_cell_diffs, run_meta["max_cell_diffs"])
 
 
 def _render_cell_diff_table(out: Callable[[str], None], cell_diffs: list[CellDiff], max_rows: int) -> None:
@@ -983,6 +1189,20 @@ class Command(BaseCommand):
         parser.add_argument("--base-url", type=str, default="https://us.posthog.com", help="Base URL for insight links")
         parser.add_argument("--max-source-json-chars", type=int, default=6000, help="Trim embedded query JSON")
         parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
+        parser.add_argument(
+            "--recheck-mismatches",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Re-run both variants once on a mismatch and keep only differences that reproduce (default on)",
+        )
+        parser.add_argument(
+            "--freeze-window",
+            "--exclude-current-period",
+            dest="freeze_window",
+            action="store_true",
+            help="Compare over a frozen snapshot ending at the last complete interval — removes live-ingest "
+            "drift entirely but CHANGES the validated window (drops the in-progress period)",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         insights = self._select_insights(options)
@@ -1073,9 +1293,19 @@ class Command(BaseCommand):
         do_perf = not options["no_perf"]
         capture = do_perf and options["clickhouse_stats"]
 
+        ctx = compute_interval_context(insight, modifiers, freeze=options["freeze_window"])
+        override = ctx.frozen_date_range
+        diff_kwargs: dict[str, Any] = {
+            "count_tol_abs": options["count_tolerance_abs"],
+            "count_tol_rel": options["count_tolerance_rel"],
+            "agg_tol_rel": options["agg_tolerance_rel"],
+            "latest_interval_start": ctx.latest_interval_start,
+            "interval_delta": ctx.trailing_delta,
+        }
+
         if options["warmup"]:
-            run_variant(insight, False, modifiers)
-            run_variant(insight, True, modifiers)
+            run_variant(insight, False, modifiers, date_range_override=override)
+            run_variant(insight, True, modifiers, date_range_override=override)
 
         legacy_run = run_variant(
             insight,
@@ -1083,6 +1313,7 @@ class Command(BaseCommand):
             modifiers,
             marker=f"rcmp_{run_id}_{insight.id}_legacy" if capture else None,
             capture_query_ids=capture,
+            date_range_override=override,
         )
         dwh_run = run_variant(
             insight,
@@ -1090,20 +1321,26 @@ class Command(BaseCommand):
             modifiers,
             marker=f"rcmp_{run_id}_{insight.id}_dwh" if capture else None,
             capture_query_ids=capture,
+            date_range_override=override,
         )
         finding.legacy_hogql = _trim(legacy_run.hogql, options["max_source_json_chars"])
         finding.dwh_hogql = _trim(dwh_run.hogql, options["max_source_json_chars"])
         finding.legacy_query_ids = legacy_run.query_ids
         finding.dwh_query_ids = dwh_run.query_ids
 
-        finding.correctness = diff_retention_results(
-            legacy_run.results,
-            dwh_run.results,
-            count_tol_abs=options["count_tolerance_abs"],
-            count_tol_rel=options["count_tolerance_rel"],
-            agg_tol_rel=options["agg_tolerance_rel"],
-        )
+        finding.correctness = diff_retention_results(legacy_run.results, dwh_run.results, **diff_kwargs)
         finding.status = finding.correctness.status
+
+        # Re-test a residual (non-trailing) mismatch once and keep only differences that reproduce in
+        # both passes: a transient diff from live ingest landing outside the trailing window drops
+        # out, while a genuine systematic difference survives. Plain runs (no marker/capture) keep the
+        # perf protocol and query-log stats untouched. Bounded cost — only runs on a first-pass mismatch.
+        if options["recheck_mismatches"] and finding.status == "MISMATCH":
+            recheck_legacy = run_variant(insight, False, modifiers, date_range_override=override)
+            recheck_dwh = run_variant(insight, True, modifiers, date_range_override=override)
+            diff2 = diff_retention_results(recheck_legacy.results, recheck_dwh.results, **diff_kwargs)
+            finding.correctness = intersect_stable_mismatch(finding.correctness, diff2)
+            finding.status = finding.correctness.status
 
         if not do_perf:
             return
@@ -1113,8 +1350,8 @@ class Command(BaseCommand):
         ch_legacy = [legacy_run.ch_s * 1000]
         ch_dwh = [dwh_run.ch_s * 1000]
         for _ in range(max(0, options["perf_iterations"] - 1)):
-            legacy_iter = run_variant(insight, False, modifiers)
-            dwh_iter = run_variant(insight, True, modifiers)
+            legacy_iter = run_variant(insight, False, modifiers, date_range_override=override)
+            dwh_iter = run_variant(insight, True, modifiers, date_range_override=override)
             wall_legacy.append(legacy_iter.wall_s * 1000)
             wall_dwh.append(dwh_iter.wall_s * 1000)
             ch_legacy.append(legacy_iter.ch_s * 1000)
@@ -1155,6 +1392,7 @@ class Command(BaseCommand):
             "mismatch": sum(1 for f in findings if f.status == "MISMATCH"),
             "error": sum(1 for f in findings if f.status == "ERROR"),
             "skipped": sum(1 for f in findings if f.status == "SKIPPED"),
+            "trailing_drift": sum(1 for f in findings if f.correctness and f.correctness.trailing_cell_diffs),
         }
         return {
             "timestamp": time.strftime("%Y-%m-%d %H:%M:%S %Z"),
@@ -1163,6 +1401,7 @@ class Command(BaseCommand):
             "regression_rel": options["regression_threshold_rel"],
             "regression_ms": options["regression_threshold_ms"],
             "max_cell_diffs": DEFAULT_MAX_CELL_DIFFS,
+            "freeze_window": options["freeze_window"],
         }
 
     @staticmethod
@@ -1178,6 +1417,8 @@ class Command(BaseCommand):
             "no_perf",
             "clickhouse_stats",
             "query_log_table",
+            "recheck_mismatches",
+            "freeze_window",
         ]
         return ", ".join(f"{key}={options[key]}" for key in keys)
 
@@ -1216,6 +1457,8 @@ class Command(BaseCommand):
             detail = f" ({finding.skip_reason})"
         elif finding.status == "ERROR":
             detail = f" ({finding.error_type})"
+        if finding.correctness and finding.correctness.trailing_cell_diffs:
+            detail += f" trailing_drift={len(finding.correctness.trailing_cell_diffs)}"
         regressed = " REGRESSION" if finding.perf and finding.perf.is_regression else ""
         self.stdout.write(
             style(f"[{index}/{total}] {finding.status}{regressed} {finding.short_id} (team {finding.team_id}){detail}")
@@ -1228,7 +1471,8 @@ class Command(BaseCommand):
         self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
         self.stdout.write(
             f"COMPARED={counts['compared']} OK={counts['ok']} MISMATCH={counts['mismatch']} "
-            f"ERROR={counts['error']} SKIPPED={counts['skipped']} REGRESSIONS={aggregate.n_regressions}"
+            f"ERROR={counts['error']} SKIPPED={counts['skipped']} REGRESSIONS={aggregate.n_regressions} "
+            f"TRAILING_DRIFT={counts['trailing_drift']}"
         )
         if aggregate.n_compared:
             wall_median = aggregate.wall_ratio_dist.get("median")

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -39,7 +39,6 @@ import json
 import time
 import uuid
 import argparse
-import traceback
 import statistics
 import dataclasses
 from collections.abc import Callable, Iterator, Sequence
@@ -568,7 +567,14 @@ def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -
 
 
 def _fmt_exception(exc: BaseException, max_chars: int = 500) -> str:
+    """Exception class plus the first line of the message, length-capped.
+
+    Reports must never accumulate raw failure internals: ClickHouse errors embed the full SQL and a
+    server stack trace in the message, so anything beyond the first line is dropped and the rest is
+    truncated. This is the only form in which failures are persisted.
+    """
     message = str(exc)
+    message = message.splitlines()[0] if message else ""
     if len(message) > max_chars:
         message = message[:max_chars] + "…"
     return f"{type(exc).__name__}: {message}"
@@ -854,10 +860,6 @@ def _attempt_variant(
         return run, None
     except Exception as exc:
         return None, exc
-
-
-def _exception_traceback(exc: BaseException, max_chars: int = 2000) -> str:
-    return "".join(traceback.format_exception(exc))[-max_chars:]
 
 
 def compute_interval_context(insight: Insight, modifiers: HogQLQueryModifiers, *, freeze: bool) -> IntervalContext:
@@ -1287,8 +1289,6 @@ def _render_errors(out: Callable[[str], None], errors: list[InsightFinding]) -> 
             out("```")
             out(f.error_detail)
             out("```\n")
-        # Includes the surviving variant's HogQL when one side succeeded — context for diagnosis.
-        _render_source_and_hogql(out, f)
 
 
 def _render_skipped(out: Callable[[str], None], skipped: list[InsightFinding]) -> None:
@@ -1452,7 +1452,15 @@ class Command(BaseCommand):
         except Exception as exc:
             finding.status = "ERROR"
             finding.error_type = type(exc).__name__
-            finding.error_detail = traceback.format_exc()[-4000:]
+            finding.error_detail = _fmt_exception(exc)
+        if finding.status.startswith("ERROR"):
+            # Failures persist only identifying metadata (insight id/URL) and the one-line error
+            # summary — never the query payload or generated SQL, so ordinary query errors don't
+            # accumulate internals in the Markdown report or JSON output. Reproduce a single
+            # failure with --insight-id to inspect it in full.
+            finding.source_json = None
+            finding.legacy_hogql = None
+            finding.dwh_hogql = None
         return finding
 
     def _run_comparison(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
@@ -1501,8 +1509,9 @@ class Command(BaseCommand):
                 capture_query_ids=capture,
             )
 
-        # Keep whatever the surviving side produced: its HogQL (for diagnosis) and its query ids
-        # (so resource stats still show how expensive the succeeding variant was).
+        # Keep whatever the surviving side produced: its HogQL (for diagnosis; cleared again for
+        # error findings) and its query ids (so resource stats still show how expensive the
+        # succeeding variant was).
         if legacy_run is not None:
             finding.legacy_hogql = _trim(legacy_run.hogql, options["max_source_json_chars"])
             finding.legacy_query_ids = legacy_run.query_ids
@@ -1511,13 +1520,7 @@ class Command(BaseCommand):
             finding.dwh_query_ids = dwh_run.query_ids
 
         if legacy_exc is not None or dwh_exc is not None:
-            finding.status, finding.error_type, summary = attribute_variant_errors(legacy_exc, dwh_exc)
-            detail_parts = [summary]
-            if legacy_exc is not None:
-                detail_parts.append(f"--- legacy traceback ---\n{_exception_traceback(legacy_exc)}")
-            if dwh_exc is not None:
-                detail_parts.append(f"--- dwh traceback ---\n{_exception_traceback(dwh_exc)}")
-            finding.error_detail = "\n\n".join(detail_parts)
+            finding.status, finding.error_type, finding.error_detail = attribute_variant_errors(legacy_exc, dwh_exc)
             return
 
         assert legacy_run is not None and dwh_run is not None

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -453,6 +453,20 @@ def aggregate_resource_stats(
     )
 
 
+def _wall_ratio_key(finding: InsightFinding) -> float:
+    if finding.perf is None or finding.perf.ratio_median_wall is None:
+        return 0.0
+    return finding.perf.ratio_median_wall
+
+
+def _delta_key(finding: InsightFinding) -> float:
+    return finding.perf.delta_median_wall_ms if finding.perf else 0.0
+
+
+def _bytes_ratio_key(finding: InsightFinding) -> float:
+    return finding.bytes_ratio if finding.bytes_ratio is not None else 0.0
+
+
 def build_perf_aggregate(findings: list[InsightFinding], *, worst_n: int) -> PerfAggregate:
     compared = [f for f in findings if f.perf is not None]
     wall_ratios = [f.perf.ratio_median_wall for f in compared if f.perf and f.perf.ratio_median_wall]
@@ -467,13 +481,11 @@ def build_perf_aggregate(findings: list[InsightFinding], *, worst_n: int) -> Per
         bytes_ratio_dist=_distribution(bytes_ratios),
         n_regressions=len(regressions),
         n_improvements=len(improvements),
-        regressions=sorted(regressions, key=lambda f: f.perf.ratio_median_wall or 0, reverse=True),
-        improvements=sorted(improvements, key=lambda f: f.perf.ratio_median_wall or 0),
-        worst_by_rel=sorted(with_ratio, key=lambda f: f.perf.ratio_median_wall, reverse=True)[:worst_n],
-        worst_by_abs=sorted(compared, key=lambda f: f.perf.delta_median_wall_ms if f.perf else 0, reverse=True)[
-            :worst_n
-        ],
-        worst_by_bytes=sorted(with_bytes, key=lambda f: f.bytes_ratio, reverse=True)[:worst_n],
+        regressions=sorted(regressions, key=_wall_ratio_key, reverse=True),
+        improvements=sorted(improvements, key=_wall_ratio_key),
+        worst_by_rel=sorted(with_ratio, key=_wall_ratio_key, reverse=True)[:worst_n],
+        worst_by_abs=sorted(compared, key=_delta_key, reverse=True)[:worst_n],
+        worst_by_bytes=sorted(with_bytes, key=_bytes_ratio_key, reverse=True)[:worst_n],
     )
 
 
@@ -491,7 +503,10 @@ def run_variant(
     capture_query_ids: bool = False,
 ) -> VariantRun:
     """Execute one retention variant. Read-only: deepcopies the query, scopes the patch."""
-    source = deepcopy(insight.query["source"])
+    query = insight.query
+    if not isinstance(query, dict):
+        raise ValueError(f"insight {insight.id} has a non-dict query")
+    source = deepcopy(query["source"])
     if marker:
         # The query_id ClickHouse records becomes f"{team_id}_{client_query_id}_{random}", so the
         # marker makes captured query_ids self-describing in the report. Setting client_query_id
@@ -612,9 +627,9 @@ def _fmt_bytes(num: Optional[int]) -> str:
     if num is None:
         return "n/a"
     size = float(num)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if size < 1024 or unit == "TiB":
-            return f"{size:.1f}{unit}" if unit != "B" else f"{int(size)}B"
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024:
+            return f"{int(size)}B" if unit == "B" else f"{size:.1f}{unit}"
         size /= 1024
     return f"{size:.1f}TiB"
 

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -356,6 +356,98 @@ def classify_insight(insight: Insight) -> tuple[str, str]:
     return ("compare", "")
 
 
+_ENTITY_IDENTITY_KEYS = ("id", "type", "table_name", "timestamp_field", "properties")
+
+
+def _entity_identity(entity: Any) -> tuple[Any, ...]:
+    """Order-stable identity of a retention entity, mirroring the runner's same-entity check.
+
+    Display-only keys (uuid, name, order, custom_name) are excluded, and None-valued keys inside
+    property dicts are dropped — the runner compares pydantic dumps where an explicit null and an
+    absent key are the same thing, so a raw-dict comparison must not tell them apart either.
+    """
+    if not isinstance(entity, dict):
+        entity = {"id": "$pageview", "type": "events"}  # the runner's DEFAULT_ENTITY
+    normalized: list[Any] = []
+    for key in _ENTITY_IDENTITY_KEYS:
+        value = entity.get(key)
+        if key == "properties":
+            props = value if isinstance(value, list) else []
+            value = json.dumps(
+                [{k: v for k, v in p.items() if v is not None} if isinstance(p, dict) else p for p in props],
+                sort_keys=True,
+                default=str,
+            )
+        normalized.append(value)
+    return tuple(normalized)
+
+
+def shape_fingerprint(source: dict[str, Any]) -> str:
+    """One-line query-shape tag for a RetentionQuery source, for triaging mismatches.
+
+    Deliberately total over raw insight JSON (no schema parse, nothing raises) and free of
+    customer values: only structural facts — retention type, entity sameness/types, breakdown
+    kinds, aggregation, thresholds, flags — so the tag is safe to print and paste anywhere.
+    """
+    retention_filter = source.get("retentionFilter") if isinstance(source.get("retentionFilter"), dict) else {}
+
+    retention_type = {
+        "retention_first_time": "first_time",
+        "retention_first_ever_occurrence": "first_ever",
+    }.get(retention_filter.get("retentionType"), "recurring")
+
+    target = retention_filter.get("targetEntity")
+    returning = retention_filter.get("returningEntity")
+    sameness = "same" if _entity_identity(target) == _entity_identity(returning) else "diff"
+    entity_types = sorted({(e.get("type") if isinstance(e, dict) else None) or "events" for e in (target, returning)})
+
+    parts = [
+        retention_type,
+        f"entities={sameness}({'/'.join(entity_types)})",
+        f"period={retention_filter.get('period') or 'Day'}",
+        f"intervals={retention_filter.get('totalIntervals') or 7}",
+    ]
+
+    date_range = source.get("dateRange") if isinstance(source.get("dateRange"), dict) else {}
+    if date_range.get("date_from") or date_range.get("date_to"):
+        parts.append(f"range={date_range.get('date_from') or 'default'}..{date_range.get('date_to') or 'now'}")
+
+    breakdown_filter = source.get("breakdownFilter") if isinstance(source.get("breakdownFilter"), dict) else {}
+    breakdowns = breakdown_filter.get("breakdowns")
+    if isinstance(breakdowns, list) and breakdowns:
+        kinds = [(b.get("type") if isinstance(b, dict) else None) or "event" for b in breakdowns]
+        counted = [f"{kind}×{n}" if (n := kinds.count(kind)) > 1 else kind for kind in dict.fromkeys(kinds)]
+        parts.append(f"bd={'+'.join(counted)}")
+    elif breakdown_filter.get("breakdown") is not None:
+        parts.append(f"bd={breakdown_filter.get('breakdown_type') or 'event'}")
+
+    if retention_filter.get("aggregationType") in ("sum", "avg") and retention_filter.get("aggregationProperty"):
+        parts.append(
+            f"agg={retention_filter['aggregationType']}({retention_filter.get('aggregationPropertyType') or 'event'})"
+        )
+    try:
+        minimum_occurrences = int(retention_filter.get("minimumOccurrences") or 1)
+    except (TypeError, ValueError):
+        minimum_occurrences = 1
+    if minimum_occurrences > 1:
+        parts.append(f"minocc={minimum_occurrences}")
+    if retention_filter.get("cumulative"):
+        parts.append("cumulative")
+    if retention_filter.get("retentionCustomBrackets"):
+        parts.append(f"brackets={len(retention_filter['retentionCustomBrackets'])}")
+    if source.get("samplingFactor") is not None:
+        parts.append(f"sampling={source['samplingFactor']}")
+    if source.get("aggregation_group_type_index") is not None:
+        parts.append(f"groups={source['aggregation_group_type_index']}")
+    properties = source.get("properties")
+    if properties.get("values") if isinstance(properties, dict) else properties:
+        parts.append("filters")
+    if source.get("filterTestAccounts"):
+        parts.append("test_accounts")
+
+    return " ".join(parts)
+
+
 def _clickhouse_seconds(timings: Optional[Sequence[Any]]) -> float:
     """Sum the seconds of every timing entry whose leaf key is ``clickhouse_execute``.
 

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -39,6 +39,12 @@ Examples:
     python manage.py compare_retention_legacy_vs_dwh --all --progress-path retention_cmp.jsonl
     python manage.py compare_retention_legacy_vs_dwh --all --progress-path retention_cmp.jsonl --resume
 
+    # Progress state in object storage (the path names a key in the default OBJECT_STORAGE_BUCKET),
+    # for ephemeral pods: the recorded findings survive the pod, and any other pod resumes the run
+    # with the same command. Uploaded every ~30s, on SIGTERM (evictions), and at the end of the run.
+    python manage.py compare_retention_legacy_vs_dwh --all \\
+        --progress-path s3://retention_compare/perf_run.jsonl --resume
+
 (For a correctness-only sweep over everything, the concurrent ``compare_retention_correctness``
 command with ``--state-file`` is much faster — this command is the one that also measures perf.)
 """
@@ -48,16 +54,18 @@ import re
 import json
 import time
 import uuid
+import signal
 import argparse
+import threading
 import statistics
 import dataclasses
 from collections import Counter
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from datetime import datetime, timedelta
 from time import perf_counter
-from typing import Any, Optional
+from typing import Any, Optional, TextIO, Union
 
 from unittest.mock import patch
 
@@ -76,6 +84,7 @@ from posthog.hogql_queries.insights.retention.retention_base_query_fixed import 
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.storage import object_storage
 
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
@@ -816,6 +825,153 @@ def build_perf_aggregate(findings: list[InsightFinding], *, worst_n: int) -> Per
 
 
 # --------------------------------------------------------------------------------------
+# Pod-survivable state storage: plain local paths, or "s3://<key>" in object storage
+# --------------------------------------------------------------------------------------
+
+OBJECT_STORAGE_PATH_PREFIX = "s3://"
+# Object storage has no append, so buffered progress lines are re-uploaded whole at most this
+# often. A pod killed without SIGTERM (an OOM kill) loses at most this window of finished
+# insights; re-checking them on resume is safe because these commands are read-only.
+OBJECT_STORAGE_FLUSH_SECONDS = 30.0
+
+
+def is_object_storage_path(path: str) -> bool:
+    return path.startswith(OBJECT_STORAGE_PATH_PREFIX)
+
+
+def object_storage_key(path: str) -> str:
+    key = path.removeprefix(OBJECT_STORAGE_PATH_PREFIX)
+    if not key:
+        raise CommandError(f"{path!r} names no object storage key")
+    return key
+
+
+def read_state_text(path: str) -> Optional[str]:
+    """Contents of a local or object-storage state path, or ``None`` when nothing is stored there.
+
+    ``s3://<key>`` addresses <key> in the default object-storage bucket (``OBJECT_STORAGE_BUCKET``),
+    not an arbitrary S3 bucket. State kept there outlives the pod, so a sweep interrupted by an
+    eviction can be resumed from any other pod.
+    """
+    if is_object_storage_path(path):
+        return object_storage.read(object_storage_key(path), missing_ok=True)
+    if not os.path.exists(path):
+        return None
+    with open(path) as handle:
+        return handle.read()
+
+
+def write_state_text(path: str, content: str) -> None:
+    if is_object_storage_path(path):
+        object_storage.write(object_storage_key(path), content)
+        return
+    # Write-then-replace so a crash mid-write can't corrupt the previous good state (an object
+    # storage PUT is already all-or-nothing).
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w") as handle:
+        handle.write(content)
+    os.replace(tmp_path, path)
+
+
+def delete_state_path(path: str) -> None:
+    if is_object_storage_path(path):
+        object_storage.delete(object_storage_key(path))
+    elif os.path.exists(path):
+        os.remove(path)
+
+
+class FileLineSink:
+    """Append-only line log on local disk; every line is flushed as written, so an interrupt
+    loses only the insights still in flight."""
+
+    def __init__(self, handle: TextIO) -> None:
+        self._handle = handle
+
+    def append(self, line: str) -> None:
+        self._handle.write(line + "\n")
+        self._handle.flush()
+
+    def flush(self) -> None:
+        return None  # append() already flushed every line to disk
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+class ObjectStorageLineSink:
+    """Append-only line log mirrored to object storage, for pods whose disk dies with them.
+
+    An S3 object can't be appended to, so lines accumulate in memory and the whole log is
+    re-uploaded at most every ``flush_seconds`` plus on ``flush()``/``close()``. Because each
+    upload replaces the object outright, the buffer is seeded with the object's prior lines;
+    starting empty would erase the recorded work the moment the first re-upload lands. Worker
+    threads append while a SIGTERM handler may flush from the main thread, hence the lock.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        initial_lines: list[str],
+        *,
+        flush_seconds: float = OBJECT_STORAGE_FLUSH_SECONDS,
+        now: Callable[[], float] = perf_counter,
+    ) -> None:
+        self._key = key
+        self._lines = list(initial_lines)
+        self._flush_seconds = flush_seconds
+        self._now = now
+        self._last_upload = now()
+        self._dirty = False
+        self._lock = threading.Lock()
+
+    def append(self, line: str) -> None:
+        with self._lock:
+            self._lines.append(line)
+            self._dirty = True
+            if self._now() - self._last_upload >= self._flush_seconds:
+                self._upload()
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._dirty:
+                self._upload()
+
+    def close(self) -> None:
+        self.flush()
+
+    def _upload(self) -> None:
+        # Callers hold self._lock.
+        object_storage.write(self._key, "\n".join(self._lines) + "\n")
+        self._dirty = False
+        self._last_upload = self._now()
+
+
+LineSink = Union[FileLineSink, ObjectStorageLineSink]
+
+
+@contextmanager
+def flush_on_sigterm(flush: Callable[[], None]) -> Iterator[None]:
+    """Upload buffered progress when the pod is told to shut down.
+
+    Pod evictions and deletions deliver SIGTERM and wait out a grace period before SIGKILL, so
+    flushing here hands the interrupted run's full progress to whichever pod resumes it. The
+    handler hard-exits via ``os._exit`` because worker threads may be blocked mid-query and the
+    process is being killed regardless. SIGKILL itself can't be caught; the periodic upload
+    bounds that loss instead.
+    """
+
+    def _handler(_signum: int, _frame: Any) -> None:
+        flush()
+        os._exit(143)
+
+    previous = signal.signal(signal.SIGTERM, _handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
+
+
+# --------------------------------------------------------------------------------------
 # Progress state (JSONL: one finding per line, appended as each insight finishes)
 # --------------------------------------------------------------------------------------
 
@@ -877,32 +1033,44 @@ def finding_from_dict(payload: dict[str, Any]) -> InsightFinding:
     )
 
 
-def load_progress_findings(path: str) -> list[InsightFinding]:
+def parse_progress_findings(text: str, path: str) -> list[InsightFinding]:
     """Findings recorded by a previous run. On duplicate insight ids the last record wins — a crash
     between the per-insight append and the end-of-run rewrite can leave the same insight twice."""
     by_id: dict[int, InsightFinding] = {}
-    with open(path) as handle:
-        for line_number, line in enumerate(handle, start=1):
-            if not line.strip():
-                continue
-            try:
-                finding = finding_from_dict(json.loads(line))
-            except Exception as exc:
-                raise CommandError(
-                    f"Cannot parse {path}:{line_number} ({_fmt_exception(exc)}) — was it written by a "
-                    "different version of this command? Remove the file to start over."
-                ) from exc
-            by_id[finding.insight_id] = finding
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            finding = finding_from_dict(json.loads(line))
+        except Exception as exc:
+            raise CommandError(
+                f"Cannot parse {path}:{line_number} ({_fmt_exception(exc)}) — was it written by a "
+                "different version of this command? Remove the file to start over."
+            ) from exc
+        by_id[finding.insight_id] = finding
     return list(by_id.values())
 
 
+def load_progress_findings(path: str) -> list[InsightFinding]:
+    text = read_state_text(path)
+    if text is None:
+        raise CommandError(f"No progress state found at {path}")
+    return parse_progress_findings(text, path)
+
+
 def save_progress_findings(path: str, findings: list[InsightFinding]) -> None:
-    # Write-then-replace so a crash mid-write can't corrupt the progress file.
-    tmp_path = f"{path}.tmp"
-    with open(tmp_path, "w") as handle:
-        for finding in findings:
-            handle.write(finding_to_json_line(finding) + "\n")
-    os.replace(tmp_path, path)
+    write_state_text(path, "".join(finding_to_json_line(finding) + "\n" for finding in findings))
+
+
+def open_findings_sink(path: Optional[str]) -> Optional[LineSink]:
+    if not path:
+        return None
+    if is_object_storage_path(path):
+        # Seed with the object's current lines: every upload replaces the object, so starting
+        # empty would erase the findings a resumed run just loaded.
+        existing = read_state_text(path)
+        return ObjectStorageLineSink(object_storage_key(path), existing.splitlines() if existing else [])
+    return FileLineSink(open(path, "a"))
 
 
 def _fmt_duration(seconds: float) -> str:
@@ -1471,7 +1639,10 @@ class Command(BaseCommand):
             type=str,
             default=None,
             help="JSONL progress state: each finding is appended (and flushed) the moment its insight "
-            "finishes, so an interrupted run keeps its work. Pass the same path with --resume to continue.",
+            "finishes, so an interrupted run keeps its work. Pass the same path with --resume to continue. "
+            "Prefix with s3:// to keep it in object storage (the key lands in the default bucket) so the "
+            "state outlives an ephemeral pod and any other pod can resume the run; it is uploaded every "
+            "~30s, on SIGTERM, and at the end of the run.",
         )
         parser.add_argument(
             "--resume",
@@ -1556,21 +1727,26 @@ class Command(BaseCommand):
         all_query_ids: list[str] = [qid for f in loaded for qid in (*f.legacy_query_ids, *f.dwh_query_ids)]
         started_at = perf_counter()
 
-        progress_handle = open(options["progress_path"], "a") if options["progress_path"] else None
+        progress_sink = open_findings_sink(options["progress_path"])
+        # A local file needs no SIGTERM handling (every line is flushed as written); the
+        # object-storage sink buffers, so an evicted pod must upload before dying.
+        sigterm_guard = (
+            flush_on_sigterm(progress_sink.flush) if isinstance(progress_sink, ObjectStorageLineSink) else nullcontext()
+        )
         try:
-            for index, insight in enumerate(insights, start=1):
-                finding = self._process_insight(insight, run_id, options)
-                findings.append(finding)
-                all_query_ids.extend(finding.legacy_query_ids)
-                all_query_ids.extend(finding.dwh_query_ids)
-                if progress_handle is not None:
-                    progress_handle.write(finding_to_json_line(finding) + "\n")
-                    progress_handle.flush()
-                self._print_progress(index, len(insights), finding, options["verbosity"])
-                self._print_heartbeat(index, len(insights), started_at, findings)
+            with sigterm_guard:
+                for index, insight in enumerate(insights, start=1):
+                    finding = self._process_insight(insight, run_id, options)
+                    findings.append(finding)
+                    all_query_ids.extend(finding.legacy_query_ids)
+                    all_query_ids.extend(finding.dwh_query_ids)
+                    if progress_sink is not None:
+                        progress_sink.append(finding_to_json_line(finding))
+                    self._print_progress(index, len(insights), finding, options["verbosity"])
+                    self._print_heartbeat(index, len(insights), started_at, findings)
         finally:
-            if progress_handle is not None:
-                progress_handle.close()
+            if progress_sink is not None:
+                progress_sink.close()
 
         if options["clickhouse_stats"] and not options["no_perf"] and all_query_ids:
             self._attach_resource_stats(findings, all_query_ids, options)
@@ -1600,11 +1776,14 @@ class Command(BaseCommand):
             raise CommandError("--resume requires --progress-path")
         if options["resume"] and options["sample"]:
             raise CommandError("--sample picks a random set and cannot resume a sweep")
-        if not path or not os.path.exists(path):
+        if not path:
+            return []
+        text = read_state_text(path)
+        if text is None:
             return []
         if not options["resume"]:
-            raise CommandError(f"{path} already exists — pass --resume to continue that run, or remove the file")
-        return load_progress_findings(path)
+            raise CommandError(f"{path} already exists — pass --resume to continue that run, or delete it")
+        return parse_progress_findings(text, path)
 
     def _select_insights(self, options: dict[str, Any], exclude_ids: Optional[set[int]] = None) -> list[Insight]:
         queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -382,6 +382,11 @@ def _entity_identity(entity: Any) -> tuple[Any, ...]:
     return tuple(normalized)
 
 
+def _dict_field(container: dict[str, Any], key: str) -> dict[str, Any]:
+    value = container.get(key)
+    return value if isinstance(value, dict) else {}
+
+
 def shape_fingerprint(source: dict[str, Any]) -> str:
     """One-line query-shape tag for a RetentionQuery source, for triaging mismatches.
 
@@ -389,12 +394,12 @@ def shape_fingerprint(source: dict[str, Any]) -> str:
     customer values: only structural facts — retention type, entity sameness/types, breakdown
     kinds, aggregation, thresholds, flags — so the tag is safe to print and paste anywhere.
     """
-    retention_filter = source.get("retentionFilter") if isinstance(source.get("retentionFilter"), dict) else {}
+    retention_filter = _dict_field(source, "retentionFilter")
 
     retention_type = {
         "retention_first_time": "first_time",
         "retention_first_ever_occurrence": "first_ever",
-    }.get(retention_filter.get("retentionType"), "recurring")
+    }.get(retention_filter.get("retentionType") or "", "recurring")
 
     target = retention_filter.get("targetEntity")
     returning = retention_filter.get("returningEntity")
@@ -408,11 +413,11 @@ def shape_fingerprint(source: dict[str, Any]) -> str:
         f"intervals={retention_filter.get('totalIntervals') or 7}",
     ]
 
-    date_range = source.get("dateRange") if isinstance(source.get("dateRange"), dict) else {}
+    date_range = _dict_field(source, "dateRange")
     if date_range.get("date_from") or date_range.get("date_to"):
         parts.append(f"range={date_range.get('date_from') or 'default'}..{date_range.get('date_to') or 'now'}")
 
-    breakdown_filter = source.get("breakdownFilter") if isinstance(source.get("breakdownFilter"), dict) else {}
+    breakdown_filter = _dict_field(source, "breakdownFilter")
     breakdowns = breakdown_filter.get("breakdowns")
     if isinstance(breakdowns, list) and breakdowns:
         kinds = [(b.get("type") if isinstance(b, dict) else None) or "event" for b in breakdowns]

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -8,8 +8,8 @@ regression can be handed to another model to fix.
 
 The toggle lives in
 ``posthog.hogql_queries.insights.retention.retention_base_query_fixed.retention_fixed_interval_base_query_use_dwh_variant``
-and is forced via ``unittest.mock.patch`` (the patch target is the shared
-``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant). Three insight shapes are NOT affected by the
+and is forced via ``unittest.mock.patch`` (the patch target is the
+``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant below). Three insight shapes are NOT affected by the
 toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path), the
 24h rolling window mode (a different builder with no legacy/new split), and insights whose
 referenced actions/cohorts were deleted (both variants fail identically today, so there is no
@@ -60,7 +60,6 @@ import posthog.clickhouse.client.execute as ch_execute
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
-    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
     RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG,
 )
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
@@ -70,6 +69,15 @@ from posthog.hogql_queries.query_runner import get_query_runner
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
 from products.product_analytics.backend.models.insight import Insight
+
+# Deliberately duplicated from posthog.hogql_queries.insights.retention.test.retention_base_query_variant
+# rather than imported: this file gets copied onto prod pods whose images may not have that helper's
+# current shape, so it must only import modules that have long been deployed. ``patch`` raises at
+# runtime if this dotted path ever goes stale, so the duplication cannot drift silently.
+RETENTION_BASE_QUERY_VARIANT_PATCH_PATH = (
+    "posthog.hogql_queries.insights.retention.retention_base_query_fixed."
+    "retention_fixed_interval_base_query_use_dwh_variant"
+)
 
 DATA_WAREHOUSE_ENTITY_TYPE = "data_warehouse"
 ROLLING_24H_WINDOW_MODE = "24_hour_windows"

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -60,12 +60,10 @@ import posthog.clickhouse.client.execute as ch_execute
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.insights.retention.retention_base_query_fixed import (
+    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
     RETENTION_FIXED_INTERVAL_BASE_QUERY_DWH_VARIANT_FLAG,
 )
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
-from posthog.hogql_queries.insights.retention.test.retention_base_query_variant import (
-    RETENTION_BASE_QUERY_VARIANT_PATCH_PATH,
-)
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.hogql_queries.query_runner import get_query_runner
 

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -111,6 +111,11 @@ class CellDiff:
     dwh: float
     abs_diff: float
     rel_diff: Optional[float]  # None when legacy == 0
+    # Recheck verdict: True = the second pass returned the exact same legacy/dwh values
+    # (a deterministic difference), False = the cell differed again but with moved values
+    # (the data churned under the queries — merges/late ingest, not a systematic gap),
+    # None = no recheck information (single pass).
+    values_stable: Optional[bool] = None
 
 
 @dataclasses.dataclass
@@ -524,9 +529,18 @@ def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -
     mismatch (reproduces) from live-ingest noise that happened to land outside the trailing window on
     the first pass (does not reproduce). Every MISMATCH signal is intersected, since live ingest can
     perturb breakdown ranking and row coverage as well as raw cell counts.
+
+    Kept cells are annotated with ``values_stable``: a deterministic query difference returns the
+    exact same legacy/dwh values in both passes, while continuously-churning data (person merges,
+    late ingest into historical buckets) keeps the same busy cells differing with MOVED values.
+    Key-only matching cannot tell those apart; the annotation can.
     """
-    second_keys = {_cell_key(c) for c in second.cell_diffs}
-    stable_cells = [c for c in first.cell_diffs if _cell_key(c) in second_keys]
+    second_by_key = {_cell_key(c): c for c in second.cell_diffs}
+    stable_cells = [
+        dataclasses.replace(c, values_stable=(c.legacy == twin.legacy and c.dwh == twin.dwh))
+        for c in first.cell_diffs
+        if (twin := second_by_key.get(_cell_key(c))) is not None
+    ]
 
     second_only_legacy = set(second.breakdown_only_legacy)
     second_only_dwh = set(second.breakdown_only_dwh)
@@ -1223,16 +1237,25 @@ def _render_trailing_drift(
 
 
 def _render_cell_diff_table(out: Callable[[str], None], cell_diffs: list[CellDiff], max_rows: int) -> None:
-    out("| Breakdown | Cohort | Period | Field | Legacy | DWH | Δabs | Δrel |")
-    out("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    # The values column only exists when a recheck ran: "identical" = same values both passes
+    # (deterministic difference), "moved" = differed both passes with different values (data churn).
+    has_stability = any(diff.values_stable is not None for diff in cell_diffs)
+    stability_header = " Values |" if has_stability else ""
+    out(f"| Breakdown | Cohort | Period | Field | Legacy | DWH | Δabs | Δrel |{stability_header}")
+    out(f"| --- | --- | --- | --- | --- | --- | --- | --- |{' --- |' if has_stability else ''}")
     for diff in cell_diffs[:max_rows]:
         rel = "n/a" if diff.rel_diff is None else f"{diff.rel_diff * 100:+.1f}%"
+        stability_cell = ""
+        if has_stability:
+            stability_cell = (
+                f" {'identical' if diff.values_stable else 'moved' if diff.values_stable is not None else 'n/a'} |"
+            )
         out(
             f"| {_fmt_breakdown(diff.breakdown_value)} | {diff.row_label} | {diff.value_label} | "
-            f"{diff.field} | {diff.legacy:g} | {diff.dwh:g} | {diff.abs_diff:g} | {rel} |"
+            f"{diff.field} | {diff.legacy:g} | {diff.dwh:g} | {diff.abs_diff:g} | {rel} |{stability_cell}"
         )
     if len(cell_diffs) > max_rows:
-        out(f"| … | | | | | | +{len(cell_diffs) - max_rows} more | |")
+        out(f"| … | | | | | | +{len(cell_diffs) - max_rows} more | |{' |' if has_stability else ''}")
     out("")
 
 

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -534,6 +534,13 @@ def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -
     exact same legacy/dwh values in both passes, while continuously-churning data (person merges,
     late ingest into historical buckets) keeps the same busy cells differing with MOVED values.
     Key-only matching cannot tell those apart; the annotation can.
+
+    The annotation is only trustworthy when the recheck runs the variants in reversed order.
+    Replicas mid-way through the same rewrites (merges collapsing re-emitted rows) serve divergent
+    part sets for minutes, and with a fixed legacy→dwh→legacy→dwh cadence each variant phase-locks
+    onto one replica state — the skew then reproduces value-identically, exactly like a real bug.
+    Reversing the second pass flips which state each variant reads, so replica skew lands in the
+    MOVED-values bucket instead.
     """
     second_by_key = {_cell_key(c): c for c in second.cell_diffs}
     stable_cells = [
@@ -1559,9 +1566,14 @@ class Command(BaseCommand):
         # both passes: a transient diff from live ingest landing outside the trailing window drops
         # out, while a genuine systematic difference survives. Plain runs (no marker/capture) keep the
         # perf protocol and query-log stats untouched. Bounded cost — only runs on a first-pass mismatch.
+        # The recheck runs the variants in REVERSED order (dwh first): consecutive queries can land on
+        # replicas whose part sets diverge while data is being rewritten, and a fixed
+        # legacy→dwh→legacy→dwh cadence phase-locks each variant onto one replica state, making the
+        # skew reproduce value-identically like a real bug. Reversed order flips the states, so
+        # replica skew shows up as moved values (churn) instead.
         if options["recheck_mismatches"] and correctness.status == "MISMATCH":
-            recheck_legacy, recheck_legacy_exc = _attempt_variant(insight, False, modifiers, override)
             recheck_dwh, recheck_dwh_exc = _attempt_variant(insight, True, modifiers, override)
+            recheck_legacy, recheck_legacy_exc = _attempt_variant(insight, False, modifiers, override)
             if recheck_legacy is not None and recheck_dwh is not None:
                 diff2 = diff_retention_results(recheck_legacy.results, recheck_dwh.results, **diff_kwargs)
                 correctness = intersect_stable_mismatch(correctness, diff2)

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -45,6 +45,12 @@ Examples:
     python manage.py compare_retention_legacy_vs_dwh --all \\
         --progress-path s3://retention_compare/perf_run.jsonl --resume
 
+    # Perf pass over a representative sample: up to 10 insights per query-shape family, spread
+    # across teams. Deterministic selection, so re-running with --resume continues the same set.
+    python manage.py compare_retention_legacy_vs_dwh --sample-per-shape 10 --perf-iterations 3 \\
+        --query-log-table query_log_archive --no-flush-query-log --query-log-wait 90 \\
+        --progress-path s3://retention_compare/perf_run.jsonl
+
 (For a correctness-only sweep over everything, the concurrent ``compare_retention_correctness``
 command with ``--state-file`` is much faster — this command is the one that also measures perf.)
 """
@@ -70,6 +76,7 @@ from typing import Any, Optional, TextIO, Union
 from unittest.mock import patch
 
 from django.core.management.base import BaseCommand, CommandError
+from django.db.models import QuerySet
 
 from posthog.schema import HogQLQueryModifiers, RetentionResult
 
@@ -451,6 +458,76 @@ def shape_fingerprint(source: dict[str, Any]) -> str:
         parts.append("test_accounts")
 
     return " ".join(parts)
+
+
+_FAMILY_VOLATILE_PREFIXES = ("intervals=", "range=")
+_FAMILY_PARAMETERIZED_PREFIXES = ("minocc=", "brackets=", "sampling=", "groups=")
+_FAMILY_CONTEXT_TOKENS = frozenset({"filters", "test_accounts"})
+
+
+def shape_family(source: dict[str, Any]) -> str:
+    """Coarsened shape_fingerprint keeping only the tokens that select a builder code path.
+
+    Two insights share a family exactly when both variants build structurally the same SQL for
+    them: retention type, entity sameness/types, period (the timezone pin branches on hour/day
+    vs week/month), breakdown kind, aggregation, and the presence — not the value — of
+    minimum-occurrences, brackets, sampling, and group aggregation. Window size, date range,
+    and property filters change cost, not shape, so they are dropped.
+    """
+    tokens: list[str] = []
+    for token in shape_fingerprint(source).split(" "):
+        if token.startswith(_FAMILY_VOLATILE_PREFIXES) or token in _FAMILY_CONTEXT_TOKENS:
+            continue
+        for prefix in _FAMILY_PARAMETERIZED_PREFIXES:
+            if token.startswith(prefix):
+                token = prefix[:-1]
+                break
+        tokens.append(token)
+    return " ".join(tokens)
+
+
+@dataclasses.dataclass(frozen=True)
+class SampleCandidate:
+    insight_id: int
+    team_id: int
+    family: str
+
+
+def stratified_sample(
+    candidates: Sequence[SampleCandidate], per_family: int
+) -> tuple[list[int], list[tuple[str, int, int]]]:
+    """Pick up to per_family insight ids per shape family, spread across teams.
+
+    Deterministic — no randomness — so a resumed run re-derives the identical selection and
+    skips the finished ids instead of drawing replacements. Candidates must arrive newest-first
+    (id descending): within a family, teams rotate in order of their newest insight and each team
+    contributes newest-first, so one prolific team cannot fill a family's quota by itself.
+    Returns (selected ids in candidate order, census rows (family, candidates, selected) sorted
+    by candidate count descending).
+    """
+    by_family: dict[str, dict[int, list[int]]] = {}
+    for candidate in candidates:
+        by_family.setdefault(candidate.family, {}).setdefault(candidate.team_id, []).append(candidate.insight_id)
+
+    selected: set[int] = set()
+    census: list[tuple[str, int, int]] = []
+    for family, teams in by_family.items():
+        total = sum(len(ids) for ids in teams.values())
+        team_queues = list(teams.values())
+        taken = 0
+        while taken < per_family and team_queues:
+            still_have: list[list[int]] = []
+            for queue in team_queues:
+                if taken < per_family:
+                    selected.add(queue.pop(0))
+                    taken += 1
+                if queue:
+                    still_have.append(queue)
+            team_queues = still_have
+        census.append((family, total, taken))
+
+    census.sort(key=lambda row: (-row[1], row[0]))
+    return [candidate.insight_id for candidate in candidates if candidate.insight_id in selected], census
 
 
 def _clickhouse_seconds(timings: Optional[Sequence[Any]]) -> float:
@@ -1732,6 +1809,16 @@ class Command(BaseCommand):
         parser.add_argument("--all", action="store_true", help="Process every matching insight (ignores --limit)")
         parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by date")
         parser.add_argument(
+            "--sample-per-shape",
+            type=int,
+            default=None,
+            metavar="N",
+            help="Stratified sample: up to N insights per query-shape family (retention type, period, breakdown "
+            "kind, aggregation, brackets, …), spread across teams. Unlike --sample this weights the rare families "
+            "where the two builders' SQL actually differs, and the selection is deterministic so --resume "
+            "continues the same set. Ignores --limit.",
+        )
+        parser.add_argument(
             "--progress-path",
             type=str,
             default=None,
@@ -1805,6 +1892,8 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         if options["all"] and options["sample"]:
             raise CommandError("--all and --sample are mutually exclusive")
+        if options["sample_per_shape"] and (options["all"] or options["sample"]):
+            raise CommandError("--sample-per-shape is its own selection mode — drop --all/--sample")
         loaded = self._load_progress(options)
         insights = self._select_insights(options, exclude_ids={f.insight_id for f in loaded})
         if not insights and not loaded:
@@ -1890,6 +1979,8 @@ class Command(BaseCommand):
             queryset = queryset.filter(id__in=options["insight_id"])
         if options["short_id"]:
             queryset = queryset.filter(short_id__in=options["short_id"])
+        if options["sample_per_shape"]:
+            return self._select_stratified(queryset, options["sample_per_shape"], exclude_ids or set())
         if exclude_ids:
             queryset = queryset.exclude(id__in=exclude_ids)
         queryset = queryset.select_related("team")
@@ -1900,6 +1991,45 @@ class Command(BaseCommand):
         if options["all"]:
             return list(queryset)
         return list(queryset[: options["limit"]])
+
+    def _select_stratified(
+        self, queryset: "QuerySet[Insight]", per_family: int, exclude_ids: set[int]
+    ) -> list[Insight]:
+        """Deterministic shape-stratified sample.
+
+        The full candidate set is scanned and sampled BEFORE excluding already-finished ids, so a
+        resumed run re-derives the same selection and skips the done part rather than drawing
+        replacements — the sample stays the sample across interruptions.
+        """
+        candidates: list[SampleCandidate] = []
+        rows = queryset.order_by("-id").values_list("id", "team_id", "query").iterator(chunk_size=1000)
+        for insight_id, team_id, query in rows:
+            source = query.get("source") if isinstance(query, dict) else None
+            if not isinstance(source, dict):
+                continue
+            # The toggle cannot affect these two shapes, so sampling them buys only SKIPPED findings:
+            # 24h rolling windows use a different builder, and a data-warehouse entity always routes
+            # to the new path.
+            retention_filter = source.get("retentionFilter")
+            if isinstance(retention_filter, dict):
+                if retention_filter.get("timeWindowMode") == ROLLING_24H_WINDOW_MODE:
+                    continue
+                entities = (retention_filter.get("targetEntity"), retention_filter.get("returningEntity"))
+                if any(isinstance(e, dict) and e.get("type") == DATA_WAREHOUSE_ENTITY_TYPE for e in entities):
+                    continue
+            candidates.append(SampleCandidate(insight_id=insight_id, team_id=team_id, family=shape_family(source)))
+
+        selected_ids, census = stratified_sample(candidates, per_family)
+        self.stdout.write(
+            f"Shape census: {len(candidates)} candidate insight(s) in {len(census)} famil(ies), "
+            f"{len(selected_ids)} selected (≤{per_family} per family):"
+        )
+        for family, total, taken in census:
+            self.stdout.write(f"  {taken:>4} of {total:<7} {family}")
+
+        remaining = [insight_id for insight_id in selected_ids if insight_id not in exclude_ids]
+        by_id = {insight.id: insight for insight in Insight.objects.filter(id__in=remaining).select_related("team")}
+        return [by_id[insight_id] for insight_id in remaining if insight_id in by_id]
 
     def _process_insight(self, insight: Insight, run_id: str, options: dict[str, Any]) -> InsightFinding:
         base_url = options["base_url"].rstrip("/")

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -111,6 +111,7 @@ ROLLING_24H_WINDOW_MODE = "24_hour_windows"
 CLICKHOUSE_EXECUTE_TIMING_KEY = "clickhouse_execute"
 DEFAULT_MAX_CELL_DIFFS = 25
 DEFAULT_WORST_N = 15
+DEFAULT_SHAPE_ROWS = 25
 DEFAULT_QUERY_LOG_BATCH_SIZE = 500
 HEARTBEAT_EVERY = 10
 _SAFE_TABLE_RE = re.compile(r"^[A-Za-z0-9_.]+$")
@@ -235,6 +236,16 @@ class InsightFinding:
     legacy_query_ids: list[str] = dataclasses.field(default_factory=list)
     dwh_query_ids: list[str] = dataclasses.field(default_factory=list)
     bytes_ratio: Optional[float] = None
+
+
+@dataclasses.dataclass
+class ShapeRegressionRow:
+    family: str
+    n_compared: int
+    n_regressions: int
+    median_wall: Optional[float]
+    max_wall: Optional[float]
+    median_bytes: Optional[float]
 
 
 @dataclasses.dataclass
@@ -963,6 +974,61 @@ def aggregate_resource_stats(
     )
 
 
+def finding_shape_family(finding: InsightFinding) -> str:
+    """Shape family of a finding, from the query JSON recorded on it.
+
+    ``source_json`` is trimmed for embedding in the report, so a large query can arrive as invalid
+    JSON. Those bucket as unknown rather than raising — this runs while rendering the report, and a
+    decode error here would cost the whole run its output.
+    """
+    if not finding.source_json:
+        return "(no query recorded)"
+    try:
+        source = json.loads(finding.source_json)
+    except ValueError:
+        return "(query json trimmed)"
+    if not isinstance(source, dict):
+        return "(no query recorded)"
+    return shape_family(source)
+
+
+def summarize_regressions_by_shape(
+    findings: Sequence[InsightFinding], *, limit: int
+) -> tuple[list[ShapeRegressionRow], int]:
+    """Group compared insights by shape family, keeping the families that contain a regression.
+
+    A flat list of hundreds of regressions says nothing about *which* builder path got slower;
+    grouped by the family whose tokens select a code path, it becomes a diagnosis — one branch or
+    diffuse. Ranked by regression count, then by the family's worst ratio so a small family that
+    regresses hard still surfaces. Returns (rows, families omitted past the limit).
+    """
+    by_family: dict[str, list[InsightFinding]] = {}
+    for finding in findings:
+        if finding.perf is not None:
+            by_family.setdefault(finding_shape_family(finding), []).append(finding)
+
+    rows: list[ShapeRegressionRow] = []
+    for family, group in by_family.items():
+        n_regressions = sum(1 for f in group if f.perf and f.perf.is_regression)
+        if not n_regressions:
+            continue
+        walls = sorted(f.perf.ratio_median_wall for f in group if f.perf and f.perf.ratio_median_wall)
+        bytes_ratios = sorted(f.bytes_ratio for f in group if f.bytes_ratio)
+        rows.append(
+            ShapeRegressionRow(
+                family=family,
+                n_compared=len(group),
+                n_regressions=n_regressions,
+                median_wall=_percentile(walls, 50) if walls else None,
+                max_wall=walls[-1] if walls else None,
+                median_bytes=_percentile(bytes_ratios, 50) if bytes_ratios else None,
+            )
+        )
+
+    rows.sort(key=lambda row: (-row.n_regressions, -(row.max_wall or 0.0), row.family))
+    return rows[:limit], max(0, len(rows) - limit)
+
+
 def _wall_ratio_key(finding: InsightFinding) -> float:
     if finding.perf is None or finding.perf.ratio_median_wall is None:
         return 0.0
@@ -1604,7 +1670,7 @@ def render_markdown_report(
             f"> {run_meta['regression_ms']:.0f}ms slower).\n"
         )
 
-    _render_perf_distribution(out, aggregate)
+    _render_perf_distribution(out, aggregate, findings)
     _render_mismatches(out, findings, run_meta)
     _render_trailing_drift(out, findings, run_meta)
     _render_regressions(out, aggregate.regressions, run_meta)
@@ -1614,7 +1680,9 @@ def render_markdown_report(
     return "\n".join(lines) + "\n"
 
 
-def _render_perf_distribution(out: Callable[[str], None], aggregate: PerfAggregate) -> None:
+def _render_perf_distribution(
+    out: Callable[[str], None], aggregate: PerfAggregate, findings: list[InsightFinding]
+) -> None:
     if not aggregate.n_compared:
         return
     out("## Performance distribution\n")
@@ -1636,6 +1704,8 @@ def _render_perf_distribution(out: Callable[[str], None], aggregate: PerfAggrega
     out(dist_row("Bytes read", aggregate.bytes_ratio_dist))
     out("")
 
+    _render_regressions_by_shape(out, findings)
+
     if aggregate.worst_by_rel:
         out("### Worst by relative slowdown\n")
         _render_worst_table(out, aggregate.worst_by_rel)
@@ -1645,6 +1715,30 @@ def _render_perf_distribution(out: Callable[[str], None], aggregate: PerfAggrega
     if aggregate.worst_by_bytes:
         out("### Worst by bytes read\n")
         _render_worst_table(out, aggregate.worst_by_bytes, show_bytes=True)
+
+
+def _render_regressions_by_shape(out: Callable[[str], None], findings: list[InsightFinding]) -> None:
+    rows, omitted = summarize_regressions_by_shape(findings, limit=DEFAULT_SHAPE_ROWS)
+    if not rows:
+        return
+    out("### Regressions by query shape\n")
+    out("Which builder path got slower. A shape family is the query fingerprint reduced to the tokens")
+    out("that select a code path (retention type, period, breakdown kind, aggregation, and the")
+    out("presence of brackets / minimum-occurrences / sampling / group aggregation), so a family maps")
+    out("to a branch in the builder rather than to particular filter values.\n")
+    out("Read `n` as the denominator: a hard ratio over a small `n` is a narrow path worth fixing on")
+    out("its own, while a mild ratio over a large `n` is broad and shifts the whole median.\n")
+    out("| Shape family | n | Regressed | Median wall | Worst wall | Median bytes |")
+    out("| --- | --- | --- | --- | --- | --- |")
+    for row in rows:
+        share = row.n_regressions / row.n_compared
+        out(
+            f"| `{row.family}` | {row.n_compared} | {row.n_regressions} ({share:.0%}) | "
+            f"{_fmt_ratio(row.median_wall)} | {_fmt_ratio(row.max_wall)} | {_fmt_ratio(row.median_bytes)} |"
+        )
+    out("")
+    if omitted:
+        out(f"…and {omitted} further famil{'y' if omitted == 1 else 'ies'} with at least one regression.\n")
 
 
 def _render_worst_table(

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -1940,8 +1940,19 @@ class Command(BaseCommand):
             "still hit max_execution_time on a busy cluster; batches fail independently, so only the failing "
             "slice loses its stats.",
         )
-        parser.add_argument("--report-path", type=str, default=None, help="Markdown report path")
-        parser.add_argument("--json-path", type=str, default=None, help="Optional machine-readable JSON dump path")
+        parser.add_argument(
+            "--report-path",
+            type=str,
+            default=None,
+            help="Markdown report path. Accepts an s3://<key> object-storage path, which outlives the pod — "
+            "worth using on an ephemeral toolbox pod, where a local file dies with the container.",
+        )
+        parser.add_argument(
+            "--json-path",
+            type=str,
+            default=None,
+            help="Optional machine-readable JSON dump path (also accepts s3://<key>)",
+        )
         parser.add_argument("--base-url", type=str, default="https://us.posthog.com", help="Base URL for insight links")
         parser.add_argument("--max-source-json-chars", type=int, default=6000, help="Trim embedded query JSON")
         parser.add_argument("--fail-on-mismatch", action="store_true", help="Exit non-zero if any MISMATCH is found")
@@ -2013,20 +2024,21 @@ class Command(BaseCommand):
             if progress_sink is not None:
                 progress_sink.close()
 
+        report_path = options["report_path"] or f"retention_dwh_comparison_{run_id}.md"
+        # Emit the report BEFORE reading resource stats. That lookup is best-effort and, against the
+        # archive table, can run long enough to outlive an ephemeral pod — writing the report only
+        # afterwards meant a killed lookup threw away a completed run's entire verdict. Rendering is
+        # in-memory and cheap, so paying for it twice buys a timing-only report that always exists.
+        aggregate, run_meta = self._emit_report(report_path, findings, options)
+
         if options["clickhouse_stats"] and not options["no_perf"] and all_query_ids:
             self._attach_resource_stats(findings, all_query_ids, options)
+            aggregate, run_meta = self._emit_report(report_path, findings, options)
         if options["progress_path"]:
             # Rewrite with resource stats attached, so a later --resume or report regeneration
             # does not depend on the query log still retaining this run's rows.
             save_progress_findings(options["progress_path"], findings)
 
-        aggregate = build_perf_aggregate(findings, worst_n=DEFAULT_WORST_N)
-        run_meta = self._build_run_meta(findings, options)
-        report = render_markdown_report(findings, aggregate, run_meta)
-
-        report_path = options["report_path"] or f"retention_dwh_comparison_{run_id}.md"
-        with open(report_path, "w") as handle:
-            handle.write(report)
         if options["json_path"]:
             self._write_json(options["json_path"], findings, aggregate, run_meta)
 
@@ -2349,6 +2361,14 @@ class Command(BaseCommand):
         ]
         return ", ".join(f"{key}={options[key]}" for key in keys)
 
+    def _emit_report(
+        self, report_path: str, findings: list[InsightFinding], options: dict[str, Any]
+    ) -> tuple[PerfAggregate, dict[str, Any]]:
+        aggregate = build_perf_aggregate(findings, worst_n=DEFAULT_WORST_N)
+        run_meta = self._build_run_meta(findings, options)
+        write_state_text(report_path, render_markdown_report(findings, aggregate, run_meta))
+        return aggregate, run_meta
+
     def _write_json(
         self, path: str, findings: list[InsightFinding], aggregate: PerfAggregate, run_meta: dict[str, Any]
     ) -> None:
@@ -2365,8 +2385,7 @@ class Command(BaseCommand):
             },
             "findings": [dataclasses.asdict(f) for f in findings],
         }
-        with open(path, "w") as handle:
-            json.dump(payload, handle, indent=2, default=str)
+        write_state_text(path, json.dumps(payload, indent=2, default=str))
 
     def _print_heartbeat(self, index: int, total: int, started_at: float, findings: list[InsightFinding]) -> None:
         """Elapsed/ETA line every HEARTBEAT_EVERY insights, so a long run with quiet (all-OK)
@@ -2423,6 +2442,19 @@ class Command(BaseCommand):
                 f"Median wall ratio: {_fmt_ratio(wall_median)} | median bytes ratio: {_fmt_ratio(bytes_median)} | "
                 f"improvements: {aggregate.n_improvements}"
             )
+            # The rollout verdict lives in these percentiles, so print them rather than leaving them
+            # only in the report file — on an ephemeral pod stdout is the copy that survives.
+            self._print_ratio_distribution("wall ratio", aggregate.wall_ratio_dist)
+            self._print_ratio_distribution("bytes ratio", aggregate.bytes_ratio_dist)
         self.stdout.write(self.style.SUCCESS(f"Report: {report_path}"))
         if json_path:
             self.stdout.write(self.style.SUCCESS(f"JSON: {json_path}"))
+
+    def _print_ratio_distribution(self, label: str, dist: dict[str, float]) -> None:
+        if not dist:
+            self.stdout.write(f"  {label:<12} n/a (no paired measurements)")
+            return
+        self.stdout.write(
+            f"  {label:<12} n={int(dist['n'])} min={dist['min']:.2f}× p25={dist['p25']:.2f}× "
+            f"p50={dist['median']:.2f}× p75={dist['p75']:.2f}× p90={dist['p90']:.2f}× max={dist['max']:.2f}×"
+        )

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -111,6 +111,7 @@ ROLLING_24H_WINDOW_MODE = "24_hour_windows"
 CLICKHOUSE_EXECUTE_TIMING_KEY = "clickhouse_execute"
 DEFAULT_MAX_CELL_DIFFS = 25
 DEFAULT_WORST_N = 15
+DEFAULT_QUERY_LOG_BATCH_SIZE = 500
 HEARTBEAT_EVERY = 10
 _SAFE_TABLE_RE = re.compile(r"^[A-Za-z0-9_.]+$")
 
@@ -1387,9 +1388,16 @@ def fetch_query_log_stats(
     table: str,
     flush: bool,
     wait_seconds: float,
+    batch_size: int = DEFAULT_QUERY_LOG_BATCH_SIZE,
     log: Optional[Callable[[str], None]] = None,
 ) -> dict[str, ResourceStats]:
     """Read per-query resource stats from the query log, polling until rows appear.
+
+    The lookup is split into batches of ``batch_size`` ids. One IN-list covering a whole sweep is
+    a wide scan of the distributed archive table and exceeds max_execution_time — and because a
+    failure abandoned the lookup, that cost the run every resource stat it had. Batches now fail
+    independently, so a timeout costs only its own slice, and each poll retries just the ids still
+    missing (rows reach the log asynchronously, so early passes legitimately come back short).
 
     Degrades gracefully: any failure (missing table, no privileges, lag) returns whatever was
     found so far so the run continues with timing-only stats.
@@ -1429,14 +1437,32 @@ def fetch_query_log_stats(
 
     deadline = perf_counter() + max(0.0, wait_seconds)
     found: dict[str, ResourceStats] = {}
+    step = max(1, batch_size)
+    first_pass = True
     while True:
-        try:
-            rows = sync_execute(query, {"query_ids": unique_ids})
-        except Exception as exc:
-            _emit(f"query_log lookup failed on {table} ({exc}); continuing with timing only")
+        pending = [query_id for query_id in unique_ids if query_id not in found]
+        if not pending:
+            break
+        batches = [pending[start : start + step] for start in range(0, len(pending), step)]
+        failed = 0
+        last_error: Optional[Exception] = None
+        for batch in batches:
+            try:
+                rows = sync_execute(query, {"query_ids": batch})
+            except Exception as exc:
+                failed += 1
+                last_error = exc
+                continue
+            found.update(parse_query_log_rows(rows))
+        if failed:
+            _emit(f"query_log: {failed}/{len(batches)} batch(es) failed on {table} ({last_error})")
+        if first_pass and failed == len(batches):
+            # Nothing at all came back: a missing table or missing privileges, which no amount of
+            # polling fixes. Partial failure is the size/load case and stays in the retry loop.
+            _emit(f"query_log lookup failed on {table}; continuing with timing only")
             return found
-        found = parse_query_log_rows(rows)
-        if len(found) >= len(unique_ids) or perf_counter() >= deadline:
+        first_pass = False
+        if perf_counter() >= deadline:
             break
         time.sleep(1.0)
     if len(found) < len(unique_ids):
@@ -1869,6 +1895,15 @@ class Command(BaseCommand):
             help="Run SYSTEM FLUSH LOGS before reading (default on; ignored if unprivileged)",
         )
         parser.add_argument("--query-log-wait", type=float, default=10.0, help="Seconds to poll for query-log rows")
+        parser.add_argument(
+            "--query-log-batch-size",
+            type=int,
+            default=DEFAULT_QUERY_LOG_BATCH_SIZE,
+            metavar="N",
+            help=f"Query ids per query-log lookup (default {DEFAULT_QUERY_LOG_BATCH_SIZE}). Lower it if batches "
+            "still hit max_execution_time on a busy cluster; batches fail independently, so only the failing "
+            "slice loses its stats.",
+        )
         parser.add_argument("--report-path", type=str, default=None, help="Markdown report path")
         parser.add_argument("--json-path", type=str, default=None, help="Optional machine-readable JSON dump path")
         parser.add_argument("--base-url", type=str, default="https://us.posthog.com", help="Base URL for insight links")
@@ -1910,7 +1945,15 @@ class Command(BaseCommand):
         findings: list[InsightFinding] = list(loaded)
         # Loaded findings' query ids go into the lookup too, so a resumed run attaches resource
         # stats to work done before the interruption (the archive table still has those rows).
-        all_query_ids: list[str] = [qid for f in loaded for qid in (*f.legacy_query_ids, *f.dwh_query_ids)]
+        # …but only for the ones still missing them. Re-reading stats a previous run already
+        # attached grows the lookup by the whole sweep on every resume, which is what pushed it
+        # past max_execution_time.
+        all_query_ids: list[str] = [
+            qid
+            for f in loaded
+            if not (f.resource_legacy and f.resource_dwh)
+            for qid in (*f.legacy_query_ids, *f.dwh_query_ids)
+        ]
         started_at = perf_counter()
 
         progress_sink = open_findings_sink(options["progress_path"])
@@ -2195,6 +2238,7 @@ class Command(BaseCommand):
             table=options["query_log_table"],
             flush=options["flush_query_log"],
             wait_seconds=options["query_log_wait"],
+            batch_size=options["query_log_batch_size"],
             log=lambda message: self.stdout.write(self.style.WARNING(f"  {message}")),
         )
         if not stats_by_id:

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -2313,8 +2313,14 @@ class Command(BaseCommand):
         if not stats_by_id:
             return
         for finding in findings:
-            finding.resource_legacy = aggregate_resource_stats(finding.legacy_query_ids, stats_by_id)
-            finding.resource_dwh = aggregate_resource_stats(finding.dwh_query_ids, stats_by_id)
+            legacy = aggregate_resource_stats(finding.legacy_query_ids, stats_by_id)
+            dwh = aggregate_resource_stats(finding.dwh_query_ids, stats_by_id)
+            # A resumed run only asks for the ids whose stats are still missing, so a miss here means
+            # "an earlier run already covered this finding", not "no stats exist". Overwriting with the
+            # miss wiped those measurements — leaving a bytes_ratio with no byte counts under it in the
+            # report — and save_progress_findings then persisted the loss.
+            finding.resource_legacy = legacy or finding.resource_legacy
+            finding.resource_dwh = dwh or finding.resource_dwh
             if finding.resource_legacy and finding.resource_dwh and finding.resource_legacy.read_bytes > 0:
                 finding.bytes_ratio = finding.resource_dwh.read_bytes / finding.resource_legacy.read_bytes
 

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -1388,16 +1388,22 @@ def fetch_query_log_stats(
     table: str,
     flush: bool,
     wait_seconds: float,
+    team_ids: Sequence[int] = (),
+    lookback_hours: Optional[int] = None,
     batch_size: int = DEFAULT_QUERY_LOG_BATCH_SIZE,
     log: Optional[Callable[[str], None]] = None,
 ) -> dict[str, ResourceStats]:
     """Read per-query resource stats from the query log, polling until rows appear.
 
-    The lookup is split into batches of ``batch_size`` ids. One IN-list covering a whole sweep is
-    a wide scan of the distributed archive table and exceeds max_execution_time — and because a
-    failure abandoned the lookup, that cost the run every resource stat it had. Batches now fail
-    independently, so a timeout costs only its own slice, and each poll retries just the ids still
-    missing (rows reach the log asynchronously, so early passes legitimately come back short).
+    ``query_log_archive`` is ORDER BY (team_id, event_date, event_time, query_id), so a lookup
+    filtered on query_id alone prunes nothing and reads the entire retained log — it exceeds
+    max_execution_time, and splitting it into batches only multiplies the scan. ``team_ids`` is
+    the key prefix and does the actual pruning; ``lookback_hours`` narrows the range within each
+    team. Both are optional because the local default table (system.query_log) has neither column.
+
+    Batching remains as a size guard, not a speed fix: batches fail independently so a timeout
+    costs one slice rather than the whole lookup, and each poll retries only the ids still missing
+    (rows reach the log asynchronously, so early passes legitimately come back short).
 
     Degrades gracefully: any failure (missing table, no privileges, lag) returns whatever was
     found so far so the run continues with timing-only stats.
@@ -1418,8 +1424,28 @@ def fetch_query_log_stats(
         except Exception as exc:
             _emit(f"SYSTEM FLUSH LOGS failed ({exc}); continuing without it")
 
+    pruning_filters: list[str] = []
+    pruning_params: dict[str, Any] = {}
+    if team_ids:
+        pruning_filters.append("team_id IN %(team_ids)s")
+        pruning_params["team_ids"] = sorted(set(team_ids))
+    if lookback_hours:
+        # event_date is partition + key column, event_time the next key column; filtering both is
+        # what debug_ch_queries does and is what keeps the range small inside each team.
+        pruning_filters.append("event_date >= toDate(now() - INTERVAL %(lookback_hours)s HOUR)")
+        pruning_filters.append("event_time > now() - INTERVAL %(lookback_hours)s HOUR")
+        pruning_params["lookback_hours"] = int(lookback_hours)
+
     # is_initial_query = 1 keeps distributed sub-query rows from double-counting read_bytes on a
     # multi-node cluster; on a single node it simply selects the one row per ClickHouse query.
+    conditions = "\n          AND ".join(
+        [
+            *pruning_filters,
+            "query_id IN %(query_ids)s",
+            "type IN ('QueryFinish', 'ExceptionWhileProcessing')",
+            "is_initial_query = 1",
+        ]
+    )
     query = f"""
         SELECT
             query_id,
@@ -1429,9 +1455,7 @@ def fetch_query_log_stats(
             sum(query_duration_ms),
             count()
         FROM {table}
-        WHERE query_id IN %(query_ids)s
-          AND type IN ('QueryFinish', 'ExceptionWhileProcessing')
-          AND is_initial_query = 1
+        WHERE {conditions}
         GROUP BY query_id
     """  # noqa: S608 — table is operator-supplied and validated against _SAFE_TABLE_RE above
 
@@ -1446,14 +1470,17 @@ def fetch_query_log_stats(
         batches = [pending[start : start + step] for start in range(0, len(pending), step)]
         failed = 0
         last_error: Optional[Exception] = None
-        for batch in batches:
+        for index, batch in enumerate(batches, start=1):
             try:
-                rows = sync_execute(query, {"query_ids": batch})
+                rows = sync_execute(query, {**pruning_params, "query_ids": batch})
             except Exception as exc:
                 failed += 1
                 last_error = exc
                 continue
             found.update(parse_query_log_rows(rows))
+            if len(batches) > 1:
+                # This lookup can run for minutes; without progress it reads as a hang.
+                _emit(f"query_log: batch {index}/{len(batches)} — {len(found)}/{len(unique_ids)} matched")
         if failed:
             _emit(f"query_log: {failed}/{len(batches)} batch(es) failed on {table} ({last_error})")
         if first_pass and failed == len(batches):
@@ -1896,6 +1923,15 @@ class Command(BaseCommand):
         )
         parser.add_argument("--query-log-wait", type=float, default=10.0, help="Seconds to poll for query-log rows")
         parser.add_argument(
+            "--query-log-lookback-hours",
+            type=int,
+            default=24,
+            metavar="H",
+            help="Only look for query-log rows from the last H hours (default 24). Prunes the scan, so raise it "
+            "rather than lower it when resuming a run whose queries executed days ago — rows older than the window "
+            "are simply not found.",
+        )
+        parser.add_argument(
             "--query-log-batch-size",
             type=int,
             default=DEFAULT_QUERY_LOG_BATCH_SIZE,
@@ -2232,12 +2268,33 @@ class Command(BaseCommand):
     def _attach_resource_stats(
         self, findings: list[InsightFinding], all_query_ids: list[str], options: dict[str, Any]
     ) -> None:
-        self.stdout.write(f"Reading ClickHouse resource stats for {len(set(all_query_ids))} query id(s)…")
+        # Scope the lookup to the teams whose queries we are actually asking about: team_id is the
+        # archive's key prefix, so this is what keeps it from reading the whole log. system.query_log
+        # (the local default) has no team_id column, hence the table check.
+        wanted = set(all_query_ids)
+        team_ids = (
+            sorted(
+                {
+                    finding.team_id
+                    for finding in findings
+                    if wanted.intersection((*finding.legacy_query_ids, *finding.dwh_query_ids))
+                }
+            )
+            if "archive" in options["query_log_table"]
+            else []
+        )
+        self.stdout.write(
+            f"Reading ClickHouse resource stats for {len(wanted)} query id(s)"
+            + (f" across {len(team_ids)} team(s)" if team_ids else "")
+            + "…"
+        )
         stats_by_id = fetch_query_log_stats(
             all_query_ids,
             table=options["query_log_table"],
             flush=options["flush_query_log"],
             wait_seconds=options["query_log_wait"],
+            team_ids=team_ids,
+            lookback_hours=options["query_log_lookback_hours"],
             batch_size=options["query_log_batch_size"],
             log=lambda message: self.stdout.write(self.style.WARNING(f"  {message}")),
         )

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -9,16 +9,21 @@ regression can be handed to another model to fix.
 The toggle lives in
 ``posthog.hogql_queries.insights.retention.retention_base_query_fixed.retention_fixed_interval_base_query_use_dwh_variant``
 and is forced via ``unittest.mock.patch`` (the patch target is the
-``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant below). Three insight shapes are NOT affected by the
-toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path), the
-24h rolling window mode (a different builder with no legacy/new split), and insights whose
-referenced actions/cohorts were deleted (both variants fail identically today, so there is no
-parity signal — only broken references to clean up).
+``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant below). Two insight shapes are NOT affected by the
+toggle and are classified SKIPPED: fixed-interval data-warehouse retention (always routed to the
+new path), and insights whose referenced actions/cohorts were deleted (every run fails the same
+way today, so there is no parity signal — only broken references to clean up).
+
+24h rolling window insights are also toggle-independent (their builder routes by series type, not
+by the flag), but instead of being skipped they get a SINGLE health-check run: the one query each
+runs in production is executed once and reported OK_SINGLE, or ERROR if it fails today (e.g. a
+shape the retention validation rules reject). No A/B diff and no perf ratio — there is no second
+path to compare against.
 
 Run failures are attributed per variant: ERROR_DWH (legacy succeeded, the variant failed — a
 regression candidate that gates rollout), ERROR_LEGACY (the variant fixes an insight that is
 broken today), ERROR_BOTH (parity-in-failure), and plain ERROR for anything outside the two
-attributed correctness runs (classification, diffing, perf iterations).
+attributed correctness runs (classification, diffing, perf iterations, single health-check runs).
 
 This command is strictly read-only: it never saves or mutates insights.
 
@@ -203,9 +208,12 @@ class InsightFinding:
     team_id: int
     name: str
     url: str
-    status: str  # "OK" | "MISMATCH" | "ERROR" | "ERROR_LEGACY" | "ERROR_DWH" | "ERROR_BOTH" | "SKIPPED"
+    status: str  # "OK" | "OK_SINGLE" | "MISMATCH" | "ERROR" | "ERROR_LEGACY" | "ERROR_DWH" | "ERROR_BOTH" | "SKIPPED"
     has_breakdown: bool = False
     skip_reason: Optional[str] = None
+    # Why this insight ran once instead of as a legacy/dwh pair (24h rolling window). The run's
+    # HogQL and query ids live in the dwh_* fields — that is the path production executes.
+    single_path_reason: Optional[str] = None
     error_type: Optional[str] = None
     error_detail: Optional[str] = None
     source_json: Optional[str] = None
@@ -317,14 +325,19 @@ def _missing_reference_reason(insight: Insight, source: dict[str, Any]) -> Optio
             missing_parts.append(f"cohort(s) {sorted(cohort_ids - found)}")
     if not missing_parts:
         return None
-    return f"references missing {' and '.join(missing_parts)} — fails identically on both variants"
+    return f"references missing {' and '.join(missing_parts)} — fails on any variant"
 
 
 def classify_insight(insight: Insight) -> tuple[str, str]:
-    """Return ("compare"|"skip"|"error", reason) without executing any query.
+    """Return ("compare"|"single"|"skip"|"error", reason) without executing any query.
+
+    "single" marks insights with no legacy/new split to A/B (24h rolling window mode — its
+    builder routes by series type, not by the flag): they get one health-check run instead of a
+    variant comparison. The 24h check runs before the data-warehouse skip so a 24h DWH series
+    (a shape that only recently started running at all) is exercised rather than skipped.
 
     Touches Postgres (never ClickHouse) only when the insight references actions or cohorts,
-    to pre-classify dangling references as a skip instead of letting both variants error.
+    to pre-classify dangling references as a skip instead of letting the runs error.
     """
     query = insight.query
     if not isinstance(query, dict):
@@ -335,15 +348,15 @@ def classify_insight(insight: Insight) -> tuple[str, str]:
     retention_filter = source.get("retentionFilter")
     if not isinstance(retention_filter, dict):
         return ("error", "RetentionQuery has no retentionFilter")
+    missing_reason = _missing_reference_reason(insight, source)
+    if missing_reason is not None:
+        return ("skip", missing_reason)
     if retention_filter.get("timeWindowMode") == ROLLING_24H_WINDOW_MODE:
-        return ("skip", "24h rolling window (toggle has no effect)")
+        return ("single", "24h rolling window (no legacy/new split — one health-check run)")
     for entity_key in ("targetEntity", "returningEntity"):
         entity = retention_filter.get(entity_key)
         if isinstance(entity, dict) and entity.get("type") == DATA_WAREHOUSE_ENTITY_TYPE:
             return ("skip", "data_warehouse (new-path only)")
-    missing_reason = _missing_reference_reason(insight, source)
-    if missing_reason is not None:
-        return ("skip", missing_reason)
     return ("compare", "")
 
 
@@ -1190,6 +1203,7 @@ def render_markdown_report(
     out("| --- | --- |")
     out(f"| Compared | {counts['compared']} |")
     out(f"| ✅ OK | {counts['ok']} |")
+    out(f"| 🩺 OK_SINGLE (24h window health check — no legacy/new split, ran once) | {counts.get('ok_single', 0)} |")
     out(f"| ❌ MISMATCH | {counts['mismatch']} |")
     out(f"| 🚨 ERROR_DWH (legacy OK — variant regression candidate) | {counts['error_dwh']} |")
     out(f"| ♻️ ERROR_LEGACY (DWH OK — variant fixes it) | {counts['error_legacy']} |")
@@ -1653,7 +1667,11 @@ class Command(BaseCommand):
                 finding.skip_reason = reason
                 return finding
 
-            self._run_comparison(insight, run_id, options, finding)
+            if action == "single":
+                finding.single_path_reason = reason
+                self._run_single(insight, run_id, options, finding)
+            else:
+                self._run_comparison(insight, run_id, options, finding)
         except Exception as exc:
             finding.status = "ERROR"
             finding.error_type = type(exc).__name__
@@ -1667,6 +1685,35 @@ class Command(BaseCommand):
             finding.legacy_hogql = None
             finding.dwh_hogql = None
         return finding
+
+    def _run_single(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
+        """One health-check run for toggle-independent insights (24h rolling window): both flag
+        arms compile the same query, so an A/B run would diff the code against itself and double
+        the ClickHouse cost for no signal. A single run still surfaces insights that fail today
+        (e.g. shapes the retention validation rules reject) and records what the path costs.
+
+        ``use_dwh=True`` is arbitrary — the patched flag is never consulted on this route. The
+        run's HogQL/query ids go into the dwh_* fields: that is the query production executes.
+        """
+        modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers(timings=True))
+        capture = not options["no_perf"] and options["clickhouse_stats"]
+        run, exc = _attempt_variant(
+            insight,
+            True,
+            modifiers,
+            None,
+            marker=f"rcmp_{run_id}_{insight.id}_single" if capture else None,
+            capture_query_ids=capture,
+        )
+        if run is not None:
+            finding.dwh_hogql = _trim(run.hogql, options["max_source_json_chars"])
+            finding.dwh_query_ids = run.query_ids
+        if exc is not None:
+            finding.status = "ERROR"
+            finding.error_type = type(exc).__name__
+            finding.error_detail = f"single-path run failed: {_fmt_exception(exc)}"
+            return
+        finding.status = "OK_SINGLE"
 
     def _run_comparison(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
         modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers(timings=True))
@@ -1803,6 +1850,7 @@ class Command(BaseCommand):
         counts = {
             "compared": sum(1 for f in findings if f.status in ("OK", "MISMATCH")),
             "ok": sum(1 for f in findings if f.status == "OK"),
+            "ok_single": sum(1 for f in findings if f.status == "OK_SINGLE"),
             "mismatch": sum(1 for f in findings if f.status == "MISMATCH"),
             "error": sum(1 for f in findings if f.status == "ERROR"),
             "error_legacy": sum(1 for f in findings if f.status == "ERROR_LEGACY"),
@@ -1872,13 +1920,14 @@ class Command(BaseCommand):
         errors = sum(count for status, count in counts.items() if status.startswith("ERROR"))
         self.stdout.write(
             f"[{index}/{total}] elapsed={_fmt_duration(elapsed)} eta={_fmt_duration(eta)} — "
-            f"ok={counts['OK']} mismatch={counts['MISMATCH']} errors={errors} skipped={counts['SKIPPED']}"
+            f"ok={counts['OK']} single={counts['OK_SINGLE']} mismatch={counts['MISMATCH']} "
+            f"errors={errors} skipped={counts['SKIPPED']}"
         )
 
     def _print_progress(self, index: int, total: int, finding: InsightFinding, verbosity: int) -> None:
-        if verbosity < 2 and finding.status in ("OK", "SKIPPED"):
+        if verbosity < 2 and finding.status in ("OK", "OK_SINGLE", "SKIPPED"):
             return
-        if finding.status == "OK":
+        if finding.status in ("OK", "OK_SINGLE"):
             style = self.style.SUCCESS
         elif finding.status == "MISMATCH" or finding.status.startswith("ERROR"):
             style = self.style.ERROR
@@ -1889,6 +1938,8 @@ class Command(BaseCommand):
             detail = f" cells={len(finding.correctness.cell_diffs)}"
         elif finding.status == "SKIPPED":
             detail = f" ({finding.skip_reason})"
+        elif finding.status == "OK_SINGLE":
+            detail = f" ({finding.single_path_reason})"
         elif finding.status.startswith("ERROR"):
             detail = f" ({finding.error_type})"
         if finding.correctness and finding.correctness.trailing_cell_diffs:
@@ -1904,7 +1955,8 @@ class Command(BaseCommand):
         self.stdout.write("")
         self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
         self.stdout.write(
-            f"COMPARED={counts['compared']} OK={counts['ok']} MISMATCH={counts['mismatch']} "
+            f"COMPARED={counts['compared']} OK={counts['ok']} OK_SINGLE={counts['ok_single']} "
+            f"MISMATCH={counts['mismatch']} "
             f"ERROR_DWH={counts['error_dwh']} ERROR_LEGACY={counts['error_legacy']} "
             f"ERROR_BOTH={counts['error_both']} ERROR={counts['error']} SKIPPED={counts['skipped']} "
             f"REGRESSIONS={aggregate.n_regressions} TRAILING_DRIFT={counts['trailing_drift']}"

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -9,21 +9,16 @@ regression can be handed to another model to fix.
 The toggle lives in
 ``posthog.hogql_queries.insights.retention.retention_base_query_fixed.retention_fixed_interval_base_query_use_dwh_variant``
 and is forced via ``unittest.mock.patch`` (the patch target is the
-``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant below). Two insight shapes are NOT affected by the
-toggle and are classified SKIPPED: fixed-interval data-warehouse retention (always routed to the
-new path), and insights whose referenced actions/cohorts were deleted (every run fails the same
-way today, so there is no parity signal — only broken references to clean up).
-
-24h rolling window insights are also toggle-independent (their builder routes by series type, not
-by the flag), but instead of being skipped they get a SINGLE health-check run: the one query each
-runs in production is executed once and reported OK_SINGLE, or ERROR if it fails today (e.g. a
-shape the retention validation rules reject). No A/B diff and no perf ratio — there is no second
-path to compare against.
+``RETENTION_BASE_QUERY_VARIANT_PATCH_PATH`` constant below). Three insight shapes are NOT affected by the
+toggle and are classified SKIPPED: data-warehouse retention (always routed to the new path), the
+24h rolling window mode (a different builder with no legacy/new split), and insights whose
+referenced actions/cohorts were deleted (both variants fail identically today, so there is no
+parity signal — only broken references to clean up).
 
 Run failures are attributed per variant: ERROR_DWH (legacy succeeded, the variant failed — a
 regression candidate that gates rollout), ERROR_LEGACY (the variant fixes an insight that is
 broken today), ERROR_BOTH (parity-in-failure), and plain ERROR for anything outside the two
-attributed correctness runs (classification, diffing, perf iterations, single health-check runs).
+attributed correctness runs (classification, diffing, perf iterations).
 
 This command is strictly read-only: it never saves or mutates insights.
 
@@ -208,12 +203,9 @@ class InsightFinding:
     team_id: int
     name: str
     url: str
-    status: str  # "OK" | "OK_SINGLE" | "MISMATCH" | "ERROR" | "ERROR_LEGACY" | "ERROR_DWH" | "ERROR_BOTH" | "SKIPPED"
+    status: str  # "OK" | "MISMATCH" | "ERROR" | "ERROR_LEGACY" | "ERROR_DWH" | "ERROR_BOTH" | "SKIPPED"
     has_breakdown: bool = False
     skip_reason: Optional[str] = None
-    # Why this insight ran once instead of as a legacy/dwh pair (24h rolling window). The run's
-    # HogQL and query ids live in the dwh_* fields — that is the path production executes.
-    single_path_reason: Optional[str] = None
     error_type: Optional[str] = None
     error_detail: Optional[str] = None
     source_json: Optional[str] = None
@@ -325,19 +317,14 @@ def _missing_reference_reason(insight: Insight, source: dict[str, Any]) -> Optio
             missing_parts.append(f"cohort(s) {sorted(cohort_ids - found)}")
     if not missing_parts:
         return None
-    return f"references missing {' and '.join(missing_parts)} — fails on any variant"
+    return f"references missing {' and '.join(missing_parts)} — fails identically on both variants"
 
 
 def classify_insight(insight: Insight) -> tuple[str, str]:
-    """Return ("compare"|"single"|"skip"|"error", reason) without executing any query.
-
-    "single" marks insights with no legacy/new split to A/B (24h rolling window mode — its
-    builder routes by series type, not by the flag): they get one health-check run instead of a
-    variant comparison. The 24h check runs before the data-warehouse skip so a 24h DWH series
-    (a shape that only recently started running at all) is exercised rather than skipped.
+    """Return ("compare"|"skip"|"error", reason) without executing any query.
 
     Touches Postgres (never ClickHouse) only when the insight references actions or cohorts,
-    to pre-classify dangling references as a skip instead of letting the runs error.
+    to pre-classify dangling references as a skip instead of letting both variants error.
     """
     query = insight.query
     if not isinstance(query, dict):
@@ -348,15 +335,15 @@ def classify_insight(insight: Insight) -> tuple[str, str]:
     retention_filter = source.get("retentionFilter")
     if not isinstance(retention_filter, dict):
         return ("error", "RetentionQuery has no retentionFilter")
-    missing_reason = _missing_reference_reason(insight, source)
-    if missing_reason is not None:
-        return ("skip", missing_reason)
     if retention_filter.get("timeWindowMode") == ROLLING_24H_WINDOW_MODE:
-        return ("single", "24h rolling window (no legacy/new split — one health-check run)")
+        return ("skip", "24h rolling window (toggle has no effect)")
     for entity_key in ("targetEntity", "returningEntity"):
         entity = retention_filter.get(entity_key)
         if isinstance(entity, dict) and entity.get("type") == DATA_WAREHOUSE_ENTITY_TYPE:
             return ("skip", "data_warehouse (new-path only)")
+    missing_reason = _missing_reference_reason(insight, source)
+    if missing_reason is not None:
+        return ("skip", missing_reason)
     return ("compare", "")
 
 
@@ -1203,7 +1190,6 @@ def render_markdown_report(
     out("| --- | --- |")
     out(f"| Compared | {counts['compared']} |")
     out(f"| ✅ OK | {counts['ok']} |")
-    out(f"| 🩺 OK_SINGLE (24h window health check — no legacy/new split, ran once) | {counts.get('ok_single', 0)} |")
     out(f"| ❌ MISMATCH | {counts['mismatch']} |")
     out(f"| 🚨 ERROR_DWH (legacy OK — variant regression candidate) | {counts['error_dwh']} |")
     out(f"| ♻️ ERROR_LEGACY (DWH OK — variant fixes it) | {counts['error_legacy']} |")
@@ -1667,11 +1653,7 @@ class Command(BaseCommand):
                 finding.skip_reason = reason
                 return finding
 
-            if action == "single":
-                finding.single_path_reason = reason
-                self._run_single(insight, run_id, options, finding)
-            else:
-                self._run_comparison(insight, run_id, options, finding)
+            self._run_comparison(insight, run_id, options, finding)
         except Exception as exc:
             finding.status = "ERROR"
             finding.error_type = type(exc).__name__
@@ -1685,35 +1667,6 @@ class Command(BaseCommand):
             finding.legacy_hogql = None
             finding.dwh_hogql = None
         return finding
-
-    def _run_single(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
-        """One health-check run for toggle-independent insights (24h rolling window): both flag
-        arms compile the same query, so an A/B run would diff the code against itself and double
-        the ClickHouse cost for no signal. A single run still surfaces insights that fail today
-        (e.g. shapes the retention validation rules reject) and records what the path costs.
-
-        ``use_dwh=True`` is arbitrary — the patched flag is never consulted on this route. The
-        run's HogQL/query ids go into the dwh_* fields: that is the query production executes.
-        """
-        modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers(timings=True))
-        capture = not options["no_perf"] and options["clickhouse_stats"]
-        run, exc = _attempt_variant(
-            insight,
-            True,
-            modifiers,
-            None,
-            marker=f"rcmp_{run_id}_{insight.id}_single" if capture else None,
-            capture_query_ids=capture,
-        )
-        if run is not None:
-            finding.dwh_hogql = _trim(run.hogql, options["max_source_json_chars"])
-            finding.dwh_query_ids = run.query_ids
-        if exc is not None:
-            finding.status = "ERROR"
-            finding.error_type = type(exc).__name__
-            finding.error_detail = f"single-path run failed: {_fmt_exception(exc)}"
-            return
-        finding.status = "OK_SINGLE"
 
     def _run_comparison(self, insight: Insight, run_id: str, options: dict[str, Any], finding: InsightFinding) -> None:
         modifiers = create_default_modifiers_for_team(insight.team, HogQLQueryModifiers(timings=True))
@@ -1850,7 +1803,6 @@ class Command(BaseCommand):
         counts = {
             "compared": sum(1 for f in findings if f.status in ("OK", "MISMATCH")),
             "ok": sum(1 for f in findings if f.status == "OK"),
-            "ok_single": sum(1 for f in findings if f.status == "OK_SINGLE"),
             "mismatch": sum(1 for f in findings if f.status == "MISMATCH"),
             "error": sum(1 for f in findings if f.status == "ERROR"),
             "error_legacy": sum(1 for f in findings if f.status == "ERROR_LEGACY"),
@@ -1920,14 +1872,13 @@ class Command(BaseCommand):
         errors = sum(count for status, count in counts.items() if status.startswith("ERROR"))
         self.stdout.write(
             f"[{index}/{total}] elapsed={_fmt_duration(elapsed)} eta={_fmt_duration(eta)} — "
-            f"ok={counts['OK']} single={counts['OK_SINGLE']} mismatch={counts['MISMATCH']} "
-            f"errors={errors} skipped={counts['SKIPPED']}"
+            f"ok={counts['OK']} mismatch={counts['MISMATCH']} errors={errors} skipped={counts['SKIPPED']}"
         )
 
     def _print_progress(self, index: int, total: int, finding: InsightFinding, verbosity: int) -> None:
-        if verbosity < 2 and finding.status in ("OK", "OK_SINGLE", "SKIPPED"):
+        if verbosity < 2 and finding.status in ("OK", "SKIPPED"):
             return
-        if finding.status in ("OK", "OK_SINGLE"):
+        if finding.status == "OK":
             style = self.style.SUCCESS
         elif finding.status == "MISMATCH" or finding.status.startswith("ERROR"):
             style = self.style.ERROR
@@ -1938,8 +1889,6 @@ class Command(BaseCommand):
             detail = f" cells={len(finding.correctness.cell_diffs)}"
         elif finding.status == "SKIPPED":
             detail = f" ({finding.skip_reason})"
-        elif finding.status == "OK_SINGLE":
-            detail = f" ({finding.single_path_reason})"
         elif finding.status.startswith("ERROR"):
             detail = f" ({finding.error_type})"
         if finding.correctness and finding.correctness.trailing_cell_diffs:
@@ -1955,8 +1904,7 @@ class Command(BaseCommand):
         self.stdout.write("")
         self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
         self.stdout.write(
-            f"COMPARED={counts['compared']} OK={counts['ok']} OK_SINGLE={counts['ok_single']} "
-            f"MISMATCH={counts['mismatch']} "
+            f"COMPARED={counts['compared']} OK={counts['ok']} MISMATCH={counts['mismatch']} "
             f"ERROR_DWH={counts['error_dwh']} ERROR_LEGACY={counts['error_legacy']} "
             f"ERROR_BOTH={counts['error_both']} ERROR={counts['error']} SKIPPED={counts['skipped']} "
             f"REGRESSIONS={aggregate.n_regressions} TRAILING_DRIFT={counts['trailing_drift']}"

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -32,8 +32,18 @@ Examples:
     # Production (multi-node): read resource stats from the distributed archive table
     python manage.py compare_retention_legacy_vs_dwh --limit 200 \\
         --query-log-table query_log_archive --no-flush-query-log --query-log-wait 90
+
+    # Every retention insight, with progress state: each finding is appended to the JSONL file
+    # the moment its insight finishes, so an interrupted run keeps its work; rerun with --resume
+    # to skip what's done and fold the recorded findings into the final report
+    python manage.py compare_retention_legacy_vs_dwh --all --progress-path retention_cmp.jsonl
+    python manage.py compare_retention_legacy_vs_dwh --all --progress-path retention_cmp.jsonl --resume
+
+(For a correctness-only sweep over everything, the concurrent ``compare_retention_correctness``
+command with ``--state-file`` is much faster — this command is the one that also measures perf.)
 """
 
+import os
 import re
 import json
 import time
@@ -41,6 +51,7 @@ import uuid
 import argparse
 import statistics
 import dataclasses
+from collections import Counter
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import nullcontext
 from copy import deepcopy
@@ -84,6 +95,7 @@ ROLLING_24H_WINDOW_MODE = "24_hour_windows"
 CLICKHOUSE_EXECUTE_TIMING_KEY = "clickhouse_execute"
 DEFAULT_MAX_CELL_DIFFS = 25
 DEFAULT_WORST_N = 15
+HEARTBEAT_EVERY = 10
 _SAFE_TABLE_RE = re.compile(r"^[A-Za-z0-9_.]+$")
 
 
@@ -804,6 +816,107 @@ def build_perf_aggregate(findings: list[InsightFinding], *, worst_n: int) -> Per
 
 
 # --------------------------------------------------------------------------------------
+# Progress state (JSONL: one finding per line, appended as each insight finishes)
+# --------------------------------------------------------------------------------------
+
+
+def finding_to_json_line(finding: InsightFinding) -> str:
+    return json.dumps(dataclasses.asdict(finding), default=str)
+
+
+def _cell_diffs_from(payload: Optional[list[dict[str, Any]]]) -> list[CellDiff]:
+    return [CellDiff(**cell) for cell in payload or []]
+
+
+def _row_keys_from(payload: Optional[list[Any]]) -> list[Any]:
+    # JSON turns the (breakdown_value, label) tuple keys into lists; restore the tuples.
+    return [tuple(key) if isinstance(key, list) else key for key in payload or []]
+
+
+def _correctness_from(payload: Optional[dict[str, Any]]) -> Optional[CorrectnessDiff]:
+    if payload is None:
+        return None
+    return CorrectnessDiff(
+        **{
+            **payload,
+            "cell_diffs": _cell_diffs_from(payload.get("cell_diffs")),
+            "trailing_cell_diffs": _cell_diffs_from(payload.get("trailing_cell_diffs")),
+            "rows_only_legacy": _row_keys_from(payload.get("rows_only_legacy")),
+            "rows_only_dwh": _row_keys_from(payload.get("rows_only_dwh")),
+        }
+    )
+
+
+def _perf_from(payload: Optional[dict[str, Any]]) -> Optional[PerfResult]:
+    if payload is None:
+        return None
+    return PerfResult(
+        **{
+            **payload,
+            "wall_legacy": VariantTiming(**payload["wall_legacy"]),
+            "wall_dwh": VariantTiming(**payload["wall_dwh"]),
+            "ch_legacy": VariantTiming(**payload["ch_legacy"]),
+            "ch_dwh": VariantTiming(**payload["ch_dwh"]),
+        }
+    )
+
+
+def _resources_from(payload: Optional[dict[str, Any]]) -> Optional[ResourceStats]:
+    return ResourceStats(**payload) if payload is not None else None
+
+
+def finding_from_dict(payload: dict[str, Any]) -> InsightFinding:
+    return InsightFinding(
+        **{
+            **payload,
+            "correctness": _correctness_from(payload.get("correctness")),
+            "perf": _perf_from(payload.get("perf")),
+            "resource_legacy": _resources_from(payload.get("resource_legacy")),
+            "resource_dwh": _resources_from(payload.get("resource_dwh")),
+        }
+    )
+
+
+def load_progress_findings(path: str) -> list[InsightFinding]:
+    """Findings recorded by a previous run. On duplicate insight ids the last record wins — a crash
+    between the per-insight append and the end-of-run rewrite can leave the same insight twice."""
+    by_id: dict[int, InsightFinding] = {}
+    with open(path) as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                finding = finding_from_dict(json.loads(line))
+            except Exception as exc:
+                raise CommandError(
+                    f"Cannot parse {path}:{line_number} ({_fmt_exception(exc)}) — was it written by a "
+                    "different version of this command? Remove the file to start over."
+                ) from exc
+            by_id[finding.insight_id] = finding
+    return list(by_id.values())
+
+
+def save_progress_findings(path: str, findings: list[InsightFinding]) -> None:
+    # Write-then-replace so a crash mid-write can't corrupt the progress file.
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w") as handle:
+        for finding in findings:
+            handle.write(finding_to_json_line(finding) + "\n")
+    os.replace(tmp_path, path)
+
+
+def _fmt_duration(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes < 60:
+        return f"{minutes}m{secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"
+
+
+# --------------------------------------------------------------------------------------
 # Execution (touches the query runner + ClickHouse)
 # --------------------------------------------------------------------------------------
 
@@ -1351,7 +1464,21 @@ class Command(BaseCommand):
         parser.add_argument("--insight-id", type=int, action="append", help="Restrict to insight DB id(s); repeatable")
         parser.add_argument("--short-id", type=str, action="append", help="Restrict to insight short_id(s); repeatable")
         parser.add_argument("--limit", type=int, default=100, help="Max insights to process (default 100)")
+        parser.add_argument("--all", action="store_true", help="Process every matching insight (ignores --limit)")
         parser.add_argument("--sample", type=int, default=None, help="Randomly sample N insights instead of by date")
+        parser.add_argument(
+            "--progress-path",
+            type=str,
+            default=None,
+            help="JSONL progress state: each finding is appended (and flushed) the moment its insight "
+            "finishes, so an interrupted run keeps its work. Pass the same path with --resume to continue.",
+        )
+        parser.add_argument(
+            "--resume",
+            action="store_true",
+            help="Skip insights already recorded in --progress-path and fold the recorded findings into this "
+            "run's report. Use the same filters as the original run — recorded findings are included as-is.",
+        )
         parser.add_argument("--perf-iterations", type=int, default=5, help="Interleaved timing iterations per variant")
         parser.add_argument("--warmup", action="store_true", help="Run one discarded warmup per variant first")
         parser.add_argument("--no-perf", action="store_true", help="Correctness only; skip timing and resource stats")
@@ -1408,25 +1535,49 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
-        insights = self._select_insights(options)
-        if not insights:
+        if options["all"] and options["sample"]:
+            raise CommandError("--all and --sample are mutually exclusive")
+        loaded = self._load_progress(options)
+        insights = self._select_insights(options, exclude_ids={f.insight_id for f in loaded})
+        if not insights and not loaded:
             self.stdout.write(self.style.WARNING("No retention insights matched the given filters."))
             return
 
-        self.stdout.write(f"Comparing {len(insights)} retention insight(s)…")
+        if loaded:
+            self.stdout.write(f"Resuming: {len(loaded)} finding(s) loaded from {options['progress_path']}.")
+        if insights:
+            self.stdout.write(f"Comparing {len(insights)} retention insight(s)…")
+        else:
+            self.stdout.write("Nothing new to compare — regenerating the report from the recorded findings.")
         run_id = uuid.uuid4().hex[:8]
-        findings: list[InsightFinding] = []
-        all_query_ids: list[str] = []
+        findings: list[InsightFinding] = list(loaded)
+        # Loaded findings' query ids go into the lookup too, so a resumed run attaches resource
+        # stats to work done before the interruption (the archive table still has those rows).
+        all_query_ids: list[str] = [qid for f in loaded for qid in (*f.legacy_query_ids, *f.dwh_query_ids)]
+        started_at = perf_counter()
 
-        for index, insight in enumerate(insights, start=1):
-            finding = self._process_insight(insight, run_id, options)
-            findings.append(finding)
-            all_query_ids.extend(finding.legacy_query_ids)
-            all_query_ids.extend(finding.dwh_query_ids)
-            self._print_progress(index, len(insights), finding, options["verbosity"])
+        progress_handle = open(options["progress_path"], "a") if options["progress_path"] else None
+        try:
+            for index, insight in enumerate(insights, start=1):
+                finding = self._process_insight(insight, run_id, options)
+                findings.append(finding)
+                all_query_ids.extend(finding.legacy_query_ids)
+                all_query_ids.extend(finding.dwh_query_ids)
+                if progress_handle is not None:
+                    progress_handle.write(finding_to_json_line(finding) + "\n")
+                    progress_handle.flush()
+                self._print_progress(index, len(insights), finding, options["verbosity"])
+                self._print_heartbeat(index, len(insights), started_at, findings)
+        finally:
+            if progress_handle is not None:
+                progress_handle.close()
 
         if options["clickhouse_stats"] and not options["no_perf"] and all_query_ids:
             self._attach_resource_stats(findings, all_query_ids, options)
+        if options["progress_path"]:
+            # Rewrite with resource stats attached, so a later --resume or report regeneration
+            # does not depend on the query log still retaining this run's rows.
+            save_progress_findings(options["progress_path"], findings)
 
         aggregate = build_perf_aggregate(findings, worst_n=DEFAULT_WORST_N)
         run_meta = self._build_run_meta(findings, options)
@@ -1443,7 +1594,19 @@ class Command(BaseCommand):
         if options["fail_on_mismatch"] and run_meta["counts"]["mismatch"]:
             raise CommandError(f"{run_meta['counts']['mismatch']} insight(s) mismatched between variants")
 
-    def _select_insights(self, options: dict[str, Any]) -> list[Insight]:
+    def _load_progress(self, options: dict[str, Any]) -> list[InsightFinding]:
+        path: Optional[str] = options["progress_path"]
+        if options["resume"] and not path:
+            raise CommandError("--resume requires --progress-path")
+        if options["resume"] and options["sample"]:
+            raise CommandError("--sample picks a random set and cannot resume a sweep")
+        if not path or not os.path.exists(path):
+            return []
+        if not options["resume"]:
+            raise CommandError(f"{path} already exists — pass --resume to continue that run, or remove the file")
+        return load_progress_findings(path)
+
+    def _select_insights(self, options: dict[str, Any], exclude_ids: Optional[set[int]] = None) -> list[Insight]:
         queryset = Insight.objects.filter(saved=True, deleted=False, query__source__kind="RetentionQuery")
         if options["team_id"]:
             queryset = queryset.filter(team_id__in=options["team_id"])
@@ -1451,10 +1614,16 @@ class Command(BaseCommand):
             queryset = queryset.filter(id__in=options["insight_id"])
         if options["short_id"]:
             queryset = queryset.filter(short_id__in=options["short_id"])
+        if exclude_ids:
+            queryset = queryset.exclude(id__in=exclude_ids)
         queryset = queryset.select_related("team")
         if options["sample"]:
             return list(queryset.order_by("?")[: options["sample"]])
-        return list(queryset.order_by("created_at")[: options["limit"]])
+        # The id tiebreaker keeps the order stable across runs when created_at values collide.
+        queryset = queryset.order_by("created_at", "id")
+        if options["all"]:
+            return list(queryset)
+        return list(queryset[: options["limit"]])
 
     def _process_insight(self, insight: Insight, run_id: str, options: dict[str, Any]) -> InsightFinding:
         base_url = options["base_url"].rstrip("/")
@@ -1659,7 +1828,10 @@ class Command(BaseCommand):
             "insight_id",
             "short_id",
             "limit",
+            "all",
             "sample",
+            "progress_path",
+            "resume",
             "perf_iterations",
             "warmup",
             "no_perf",
@@ -1688,6 +1860,20 @@ class Command(BaseCommand):
         }
         with open(path, "w") as handle:
             json.dump(payload, handle, indent=2, default=str)
+
+    def _print_heartbeat(self, index: int, total: int, started_at: float, findings: list[InsightFinding]) -> None:
+        """Elapsed/ETA line every HEARTBEAT_EVERY insights, so a long run with quiet (all-OK)
+        stretches still shows liveness. Counts are cumulative — on --resume they include loaded findings."""
+        if index != total and index % HEARTBEAT_EVERY:
+            return
+        elapsed = perf_counter() - started_at
+        eta = (elapsed / index) * (total - index)
+        counts: Counter[str] = Counter(f.status for f in findings)
+        errors = sum(count for status, count in counts.items() if status.startswith("ERROR"))
+        self.stdout.write(
+            f"[{index}/{total}] elapsed={_fmt_duration(elapsed)} eta={_fmt_duration(eta)} — "
+            f"ok={counts['OK']} mismatch={counts['MISMATCH']} errors={errors} skipped={counts['SKIPPED']}"
+        )
 
     def _print_progress(self, index: int, total: int, finding: InsightFinding, verbosity: int) -> None:
         if verbosity < 2 and finding.status in ("OK", "SKIPPED"):

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -1,0 +1,92 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from posthog.management.commands.compare_retention_correctness import (
+    ProgressState,
+    Row,
+    merge_progress_state,
+    scope_signature,
+)
+
+
+def _row(insight_id, status, detail=""):
+    return Row(
+        id=insight_id, short_id=f"s{insight_id}", team_id=1, url=f"url{insight_id}", status=status, detail=detail
+    )
+
+
+class TestMergeProgressState(TestCase):
+    def test_accumulates_counts_and_findings_across_batches(self):
+        first = merge_progress_state(
+            None, [_row(1, "OK"), _row(2, "MISMATCH", "d2")], next_cursor=2, limit=2, scope="S"
+        )
+        second = merge_progress_state(first, [_row(3, "ERROR", "e3"), _row(4, "OK")], next_cursor=4, limit=2, scope="S")
+        self.assertEqual(second.processed, 4)
+        self.assertEqual(second.counts, {"OK": 2, "MISMATCH": 1, "ERROR": 1, "SKIPPED": 0})
+        self.assertEqual([m["id"] for m in second.mismatches], [2])
+        self.assertEqual([e["id"] for e in second.errors], [3])
+        self.assertEqual(second.cursor, 4)
+
+    def test_does_not_mutate_previous_state(self):
+        first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, limit=10, scope="S")
+        merge_progress_state(first, [_row(2, "MISMATCH")], next_cursor=2, limit=10, scope="S")
+        self.assertEqual(first.processed, 1)
+        self.assertEqual(len(first.mismatches), 1)
+
+    def test_cursor_never_regresses(self):
+        first = merge_progress_state(None, [_row(5, "OK")], next_cursor=5, limit=1, scope="S")
+        rewound = merge_progress_state(first, [_row(2, "OK")], next_cursor=2, limit=10, scope="S")
+        self.assertEqual(rewound.cursor, 5)
+
+
+class TestSweepCompletion(TestCase):
+    @parameterized.expand(
+        [
+            ("full_batch_keeps_going", 3, 3, False),
+            ("short_batch_completes", 2, 3, True),
+            ("empty_batch_completes", 0, 3, True),
+        ]
+    )
+    def test_complete_iff_batch_smaller_than_limit(self, _name, batch_size, limit, expected):
+        rows = [_row(i, "OK") for i in range(1, batch_size + 1)]
+        state = merge_progress_state(None, rows, next_cursor=batch_size or None, limit=limit, scope="S")
+        self.assertEqual(state.complete, expected)
+
+    def test_empty_batch_leaves_cursor_in_place(self):
+        first = merge_progress_state(None, [_row(1, "OK"), _row(2, "OK")], next_cursor=2, limit=2, scope="S")
+        self.assertFalse(first.complete)
+        done = merge_progress_state(first, [], next_cursor=None, limit=2, scope="S")
+        self.assertTrue(done.complete)
+        self.assertEqual(done.cursor, 2)
+        self.assertEqual(done.processed, 2)
+
+
+class TestProgressStateRoundTrip(TestCase):
+    def test_to_dict_from_dict_preserves_state(self):
+        state = merge_progress_state(
+            None, [_row(1, "OK"), _row(2, "MISMATCH", "d")], next_cursor=2, limit=2, scope="SC"
+        )
+        self.assertEqual(ProgressState.from_dict(state.to_dict()), state)
+
+    def test_from_dict_tolerates_missing_keys(self):
+        restored = ProgressState.from_dict({"cursor": 7})
+        self.assertEqual(restored.cursor, 7)
+        self.assertEqual(restored.counts, {"OK": 0, "MISMATCH": 0, "ERROR": 0, "SKIPPED": 0})
+        self.assertEqual(restored.mismatches, [])
+        self.assertFalse(restored.complete)
+
+
+class TestScopeSignature(TestCase):
+    def test_order_insensitive_and_defaults_for_missing_keys(self):
+        explicit = scope_signature(
+            {"team_id": [2, 1], "insight_id": [], "short_id": ["b", "a"], "freeze_window": False}
+        )
+        reordered = scope_signature({"team_id": [1, 2], "short_id": ["a", "b"]})
+        self.assertEqual(explicit, reordered)
+
+    def test_distinguishes_freeze_window(self):
+        self.assertNotEqual(scope_signature({"freeze_window": True}), scope_signature({"freeze_window": False}))
+
+    def test_distinguishes_team_filter(self):
+        self.assertNotEqual(scope_signature({"team_id": [1]}), scope_signature({"team_id": [2]}))

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -21,12 +21,22 @@ class TestMergeProgressState(TestCase):
         first = merge_progress_state(
             None, [_row(1, "OK"), _row(2, "MISMATCH", "d2")], next_cursor=2, limit=2, scope="S"
         )
-        second = merge_progress_state(first, [_row(3, "ERROR", "e3"), _row(4, "OK")], next_cursor=4, limit=2, scope="S")
-        self.assertEqual(second.processed, 4)
-        self.assertEqual(second.counts, {"OK": 2, "MISMATCH": 1, "ERROR": 1, "SKIPPED": 0})
+        second = merge_progress_state(
+            first,
+            [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5")],
+            next_cursor=5,
+            limit=3,
+            scope="S",
+        )
+        self.assertEqual(second.processed, 5)
+        self.assertEqual(second.counts["OK"], 2)
+        self.assertEqual(second.counts["MISMATCH"], 1)
+        self.assertEqual(second.counts["ERROR"], 1)
+        self.assertEqual(second.counts["ERROR_DWH"], 1)
         self.assertEqual([m["id"] for m in second.mismatches], [2])
-        self.assertEqual([e["id"] for e in second.errors], [3])
-        self.assertEqual(second.cursor, 4)
+        # Attributed errors accumulate alongside plain ones, keeping their status in the record.
+        self.assertEqual([(e["id"], e["status"]) for e in second.errors], [(3, "ERROR"), (5, "ERROR_DWH")])
+        self.assertEqual(second.cursor, 5)
 
     def test_does_not_mutate_previous_state(self):
         first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, limit=10, scope="S")
@@ -70,9 +80,12 @@ class TestProgressStateRoundTrip(TestCase):
         self.assertEqual(ProgressState.from_dict(state.to_dict()), state)
 
     def test_from_dict_tolerates_missing_keys(self):
-        restored = ProgressState.from_dict({"cursor": 7})
+        # A state file written before the attributed ERROR_* statuses existed must still load.
+        restored = ProgressState.from_dict({"cursor": 7, "counts": {"OK": 3, "ERROR": 1}})
         self.assertEqual(restored.cursor, 7)
-        self.assertEqual(restored.counts, {"OK": 0, "MISMATCH": 0, "ERROR": 0, "SKIPPED": 0})
+        self.assertEqual(restored.counts["OK"], 3)
+        self.assertEqual(restored.counts["ERROR"], 1)
+        self.assertEqual(restored.counts["ERROR_DWH"], 0)
         self.assertEqual(restored.mismatches, [])
         self.assertFalse(restored.complete)
 
@@ -90,3 +103,9 @@ class TestScopeSignature(TestCase):
 
     def test_distinguishes_team_filter(self):
         self.assertNotEqual(scope_signature({"team_id": [1]}), scope_signature({"team_id": [2]}))
+
+    def test_distinguishes_recheck_mismatches(self):
+        # Stability-filtered and raw MISMATCH verdicts must not accumulate into one sweep.
+        self.assertNotEqual(
+            scope_signature({"recheck_mismatches": True}), scope_signature({"recheck_mismatches": False})
+        )

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -13,6 +13,7 @@ from posthog.management.commands.compare_retention_correctness import (
     ProgressState,
     Row,
     _check_one,
+    format_cell_sample,
     journal_line,
     merge_progress_state,
     parse_journal_lines,
@@ -20,6 +21,7 @@ from posthog.management.commands.compare_retention_correctness import (
     scope_signature,
     unabsorbed_journal_rows,
 )
+from posthog.management.commands.compare_retention_legacy_vs_dwh import CellDiff
 from posthog.management.commands.test.test_compare_retention_legacy_vs_dwh import FakeObjectStorage
 from posthog.models import Team
 
@@ -241,6 +243,48 @@ class TestRevalidateMismatches(TestCase):
         self.assertEqual(kept, [record])
         self.assertEqual(resolved, [])
         self.assertEqual(new_counts["MISMATCH"], 1)
+
+
+class TestFormatCellSample(TestCase):
+    # Cell dumps steer prod triage; printing dwh where legacy belongs would invert every
+    # conclusion, and a dropped overflow marker would pass off a sample as the full diff.
+    def test_order_prefix_and_overflow(self):
+        cells = [
+            CellDiff(
+                breakdown_value=None,
+                row_label="Day 2",
+                value_label="Day 1-5",
+                field="count",
+                legacy=12.0,
+                dwh=11.0,
+                abs_diff=1.0,
+                rel_diff=None,
+            ),
+            CellDiff(
+                breakdown_value="Chrome",
+                row_label="Day 0",
+                value_label="Day 0",
+                field="aggregation_value",
+                legacy=3.5,
+                dwh=4.0,
+                abs_diff=0.5,
+                rel_diff=None,
+            ),
+            CellDiff(
+                breakdown_value=None,
+                row_label="Day 3",
+                value_label="Day 6-10",
+                field="count",
+                legacy=2.0,
+                dwh=0.0,
+                abs_diff=2.0,
+                rel_diff=None,
+            ),
+        ]
+        self.assertEqual(
+            format_cell_sample(cells, 2),
+            "Day 2/Day 1-5 12≠11; [Chrome] Day 0/Day 0 agg 3.5≠4 (+1 more)",
+        )
 
 
 def _retention_insight():

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -73,6 +73,16 @@ class TestMergeProgressState(TestCase):
         self.assertEqual(done.cursor, 2)
         self.assertEqual(done.processed, 2)
 
+    def test_start_of_run_claim_folds_like_no_checkpoint(self):
+        # The claim written at run start must stay a neutral element: if it ever carried counts
+        # or a cursor, a resumed sweep would double-count (or drop) the journal-recovered rows.
+        claim = ProgressState(scope="S", writer="pod-a", updated_at="2026-08-04T00:00:00+00:00")
+        rows = [_row(1, "OK"), _row(2, "MISMATCH", "d2")]
+        self.assertEqual(
+            merge_progress_state(claim, rows, next_cursor=2, complete=True, scope="S"),
+            merge_progress_state(None, rows, next_cursor=2, complete=True, scope="S"),
+        )
+
 
 class TestJournal(TestCase):
     def test_recovers_rows_dropping_a_line_torn_by_the_interrupt(self):
@@ -134,6 +144,12 @@ class TestUnabsorbedJournalRows(TestCase):
     def test_without_a_checkpoint_every_row_is_pending(self):
         rows = [_row(5, "OK")]
         self.assertEqual(unabsorbed_journal_rows(rows, None), rows)
+
+    def test_start_of_run_claim_absorbs_nothing(self):
+        # The claim's cursor is 0: were it ever written with a real cursor (say --after-id),
+        # journal rows at or below it would be treated as absorbed and their results dropped.
+        rows = [_row(1, "OK"), _row(7, "OK")]
+        self.assertEqual(unabsorbed_journal_rows(rows, 0), rows)
 
 
 class TestProgressStateRoundTrip(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -18,7 +18,9 @@ from posthog.management.commands.compare_retention_correctness import (
     parse_journal_lines,
     revalidate_mismatches,
     scope_signature,
+    unabsorbed_journal_rows,
 )
+from posthog.management.commands.test.test_compare_retention_legacy_vs_dwh import FakeObjectStorage
 from posthog.models import Team
 
 from products.product_analytics.backend.models.insight import Insight
@@ -89,17 +91,49 @@ class TestJournal(TestCase):
         cmd = Command(stdout=StringIO())
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "sweep.json.journal")
-            handle = cmd._open_journal(path, scope="S")
-            assert handle is not None
-            handle.write(journal_line(_row(1, "OK")) + "\n")
-            handle.write('{"id": 2, "sho')
-            handle.close()
-            handle = cmd._open_journal(path, scope="S")
-            assert handle is not None
-            handle.write(journal_line(_row(2, "OK")) + "\n")
-            handle.close()
+            sink = cmd._open_journal(path, scope="S", recovered=[])
+            assert sink is not None
+            sink.append(journal_line(_row(1, "OK")))
+            sink.close()
+            with open(path, "a") as handle:
+                handle.write('{"id": 2, "sho')  # the interrupt tears a write mid-line
+            sink = cmd._open_journal(path, scope="S", recovered=[])
+            assert sink is not None
+            sink.append(journal_line(_row(2, "OK")))
+            sink.close()
             recovered = cmd._load_journal(path, scope="S", restart=False)
             self.assertEqual([r.id for r in recovered], [1, 2])
+
+    def test_remote_journal_reseeds_recovered_rows_on_resume(self):
+        # Each object-storage upload replaces the whole journal, so a resumed run that fails to
+        # seed the recovered rows erases them with its first upload.
+        cmd = Command(stdout=StringIO())
+        path = "s3://retention/sweep.json.journal"
+        fake = FakeObjectStorage()
+        with patch("posthog.management.commands.compare_retention_legacy_vs_dwh.object_storage", fake):
+            sink = cmd._open_journal(path, scope="S", recovered=[])
+            assert sink is not None
+            sink.append(journal_line(_row(1, "OK")))
+            sink.close()  # stands in for the SIGTERM flush of an evicted pod
+            recovered = cmd._load_journal(path, scope="S", restart=False)
+            self.assertEqual([r.id for r in recovered], [1])
+            sink = cmd._open_journal(path, scope="S", recovered=recovered)
+            assert sink is not None
+            sink.append(journal_line(_row(2, "OK")))
+            sink.close()
+            self.assertEqual([r.id for r in cmd._load_journal(path, scope="S", restart=False)], [1, 2])
+
+
+class TestUnabsorbedJournalRows(TestCase):
+    def test_rows_already_folded_into_the_checkpoint_are_dropped(self):
+        # A journal outlives its absorb only when the post-save delete failed; folding those
+        # rows again would double-count every one of them.
+        rows = [_row(5, "OK"), _row(10, "OK"), _row(15, "OK")]
+        self.assertEqual([r.id for r in unabsorbed_journal_rows(rows, 10)], [15])
+
+    def test_without_a_checkpoint_every_row_is_pending(self):
+        rows = [_row(5, "OK")]
+        self.assertEqual(unabsorbed_journal_rows(rows, None), rows)
 
 
 class TestProgressStateRoundTrip(TestCase):
@@ -107,6 +141,8 @@ class TestProgressStateRoundTrip(TestCase):
         state = merge_progress_state(
             None, [_row(1, "OK"), _row(2, "MISMATCH", "d")], next_cursor=2, complete=False, scope="SC"
         )
+        state.writer = "pod-a"
+        state.updated_at = "2026-08-03T00:00:00+00:00"
         self.assertEqual(ProgressState.from_dict(state.to_dict()), state)
 
     def test_from_dict_tolerates_missing_keys(self):

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -1,13 +1,21 @@
+from datetime import UTC, datetime
+
 from unittest import TestCase
+from unittest.mock import patch
 
 from parameterized import parameterized
 
 from posthog.management.commands.compare_retention_correctness import (
     ProgressState,
     Row,
+    _check_one,
     merge_progress_state,
+    revalidate_mismatches,
     scope_signature,
 )
+from posthog.models import Team
+
+from products.product_analytics.backend.models.insight import Insight
 
 
 def _row(insight_id, status, detail=""):
@@ -80,13 +88,15 @@ class TestProgressStateRoundTrip(TestCase):
         self.assertEqual(ProgressState.from_dict(state.to_dict()), state)
 
     def test_from_dict_tolerates_missing_keys(self):
-        # A state file written before the attributed ERROR_* statuses existed must still load.
+        # A state file written before the attributed ERROR_* statuses or resolved_mismatches
+        # existed must still load.
         restored = ProgressState.from_dict({"cursor": 7, "counts": {"OK": 3, "ERROR": 1}})
         self.assertEqual(restored.cursor, 7)
         self.assertEqual(restored.counts["OK"], 3)
         self.assertEqual(restored.counts["ERROR"], 1)
         self.assertEqual(restored.counts["ERROR_DWH"], 0)
         self.assertEqual(restored.mismatches, [])
+        self.assertEqual(restored.resolved_mismatches, [])
         self.assertFalse(restored.complete)
 
 
@@ -109,3 +119,118 @@ class TestScopeSignature(TestCase):
         self.assertNotEqual(
             scope_signature({"recheck_mismatches": True}), scope_signature({"recheck_mismatches": False})
         )
+
+
+def _mismatch_record(insight_id):
+    return {
+        "id": insight_id,
+        "short_id": f"s{insight_id}",
+        "team_id": 1,
+        "url": f"url{insight_id}",
+        "status": "MISMATCH",
+        "detail": "2 stable cell diff(s)",
+    }
+
+
+class TestRevalidateMismatches(TestCase):
+    @parameterized.expand(
+        [
+            ("recheck_ok", _row(1, "OK"), "OK"),
+            ("references_now_deleted", _row(1, "SKIPPED", "action deleted"), "SKIPPED"),
+            ("insight_gone", None, "SKIPPED"),
+        ]
+    )
+    def test_resolves_when_no_longer_reproducing(self, _name, recheck_row, resolved_status):
+        counts = {"MISMATCH": 1, "OK": 5, "SKIPPED": 0}
+        kept, resolved, new_counts = revalidate_mismatches([_mismatch_record(1)], counts, lambda rec: recheck_row)
+        self.assertEqual(kept, [])
+        self.assertEqual(len(resolved), 1)
+        self.assertIn("resolution", resolved[0])
+        self.assertEqual(new_counts["MISMATCH"], 0)
+        self.assertEqual(new_counts[resolved_status], counts[resolved_status] + 1)
+        # Inputs stay untouched so a crash between revalidation and save can't lose findings.
+        self.assertEqual(counts["MISMATCH"], 1)
+
+    def test_keeps_and_refreshes_still_reproducing_mismatch(self):
+        kept, resolved, new_counts = revalidate_mismatches(
+            [_mismatch_record(1)],
+            {"MISMATCH": 1},
+            lambda rec: _row(1, "MISMATCH", "1 stable cell diff(s), values moved (churn)"),
+        )
+        self.assertEqual(resolved, [])
+        self.assertEqual(new_counts["MISMATCH"], 1)
+        self.assertEqual(kept[0]["detail"], "1 stable cell diff(s), values moved (churn)")
+
+    def test_errored_recheck_keeps_record_untouched(self):
+        record = _mismatch_record(1)
+        kept, resolved, new_counts = revalidate_mismatches([record], {"MISMATCH": 1}, lambda rec: _row(1, "ERROR_DWH"))
+        self.assertEqual(kept, [record])
+        self.assertEqual(resolved, [])
+        self.assertEqual(new_counts["MISMATCH"], 1)
+
+
+def _retention_insight():
+    # Unsaved team; personsOnEventsMode pinned so modifier defaulting needs no DB or flag lookups.
+    team = Team(pk=1, timezone="UTC", modifiers={"personsOnEventsMode": "person_id_no_override_properties_on_events"})
+    return Insight(
+        id=42,
+        short_id="abc123",
+        team=team,
+        query={
+            "kind": "InsightVizNode",
+            "source": {
+                "kind": "RetentionQuery",
+                "dateRange": {"date_to": "2023-04-10T00:00:00.000Z", "explicitDate": False},
+                "retentionFilter": {
+                    "period": "Day",
+                    "targetEntity": {"id": "start", "type": "events"},
+                    "returningEntity": {"id": "start", "type": "events"},
+                    "retentionType": "retention_first_time",
+                    "totalIntervals": 3,
+                },
+            },
+        },
+    )
+
+
+def _retention_results(day0_count):
+    return [
+        {
+            "breakdown_value": None,
+            "label": "Day 0",
+            "date": datetime(2023, 4, 8, tzinfo=UTC),
+            "values": [{"count": day0_count, "label": "Day 0"}, {"count": 1, "label": "Day 1"}],
+        }
+    ]
+
+
+class TestRecheckStabilityClassification(TestCase):
+    def _check_with_fake_variants(self, fake):
+        with patch("posthog.management.commands.compare_retention_correctness._try_variant", side_effect=fake):
+            return _check_one(_retention_insight(), "url", freeze=False, recheck=True)
+
+    def test_replica_alternation_is_classified_as_churn_not_deterministic(self):
+        # Divergent replica part-sets serve different data per QUERY, regardless of variant. A strict
+        # legacy→dwh→legacy→dwh cadence phase-locks each variant onto one state, which used to read
+        # as a value-identical "deterministic" difference. The reversed recheck order must classify
+        # this as churn.
+        states = [_retention_results(16), _retention_results(15)]
+        calls = {"n": 0}
+
+        def alternating_replicas(insight, use_dwh, modifiers, override):
+            result = states[calls["n"] % 2]
+            calls["n"] += 1
+            return result, None
+
+        row = self._check_with_fake_variants(alternating_replicas)
+        self.assertEqual(row.status, "MISMATCH")
+        self.assertIn("values moved between passes (churn", row.detail)
+        self.assertNotIn("value-identical", row.detail)
+
+    def test_true_variant_difference_stays_deterministic(self):
+        def variant_dependent(insight, use_dwh, modifiers, override):
+            return _retention_results(15 if use_dwh else 16), None
+
+        row = self._check_with_fake_variants(variant_dependent)
+        self.assertEqual(row.status, "MISMATCH")
+        self.assertIn("value-identical (deterministic)", row.detail)

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -90,10 +90,12 @@ class TestJournal(TestCase):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "sweep.json.journal")
             handle = cmd._open_journal(path, scope="S")
+            assert handle is not None
             handle.write(journal_line(_row(1, "OK")) + "\n")
             handle.write('{"id": 2, "sho')
             handle.close()
             handle = cmd._open_journal(path, scope="S")
+            assert handle is not None
             handle.write(journal_line(_row(2, "OK")) + "\n")
             handle.close()
             recovered = cmd._load_journal(path, scope="S", restart=False)

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -31,20 +31,21 @@ class TestMergeProgressState(TestCase):
         )
         second = merge_progress_state(
             first,
-            [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5")],
-            next_cursor=5,
-            limit=3,
+            [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5"), _row(6, "OK_SINGLE", "24h")],
+            next_cursor=6,
+            limit=4,
             scope="S",
         )
-        self.assertEqual(second.processed, 5)
+        self.assertEqual(second.processed, 6)
         self.assertEqual(second.counts["OK"], 2)
+        self.assertEqual(second.counts["OK_SINGLE"], 1)
         self.assertEqual(second.counts["MISMATCH"], 1)
         self.assertEqual(second.counts["ERROR"], 1)
         self.assertEqual(second.counts["ERROR_DWH"], 1)
         self.assertEqual([m["id"] for m in second.mismatches], [2])
         # Attributed errors accumulate alongside plain ones, keeping their status in the record.
         self.assertEqual([(e["id"], e["status"]) for e in second.errors], [(3, "ERROR"), (5, "ERROR_DWH")])
-        self.assertEqual(second.cursor, 5)
+        self.assertEqual(second.cursor, 6)
 
     def test_does_not_mutate_previous_state(self):
         first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, limit=10, scope="S")
@@ -136,12 +137,13 @@ class TestRevalidateMismatches(TestCase):
     @parameterized.expand(
         [
             ("recheck_ok", _row(1, "OK"), "OK"),
+            ("now_single_path", _row(1, "OK_SINGLE", "24h rolling window"), "OK_SINGLE"),
             ("references_now_deleted", _row(1, "SKIPPED", "action deleted"), "SKIPPED"),
             ("insight_gone", None, "SKIPPED"),
         ]
     )
     def test_resolves_when_no_longer_reproducing(self, _name, recheck_row, resolved_status):
-        counts = {"MISMATCH": 1, "OK": 5, "SKIPPED": 0}
+        counts = {"MISMATCH": 1, "OK": 5, "OK_SINGLE": 0, "SKIPPED": 0}
         kept, resolved, new_counts = revalidate_mismatches([_mismatch_record(1)], counts, lambda rec: recheck_row)
         self.assertEqual(kept, [])
         self.assertEqual(len(resolved), 1)
@@ -234,3 +236,35 @@ class TestRecheckStabilityClassification(TestCase):
         row = self._check_with_fake_variants(variant_dependent)
         self.assertEqual(row.status, "MISMATCH")
         self.assertIn("value-identical (deterministic)", row.detail)
+
+
+class TestCheckOneSinglePath(TestCase):
+    # A 24h insight must cost one query, not a legacy/dwh pair diffed against itself, and a failure
+    # of that one run must come back as an attributed row instead of crashing the team lane.
+    def _rolling_insight(self):
+        insight = _retention_insight()
+        insight.query["source"]["retentionFilter"]["timeWindowMode"] = "24_hour_windows"
+        return insight
+
+    def test_clean_single_run_reports_ok_single(self):
+        calls = []
+
+        def fake(insight, use_dwh, modifiers, override):
+            calls.append(use_dwh)
+            return [], None
+
+        with patch("posthog.management.commands.compare_retention_correctness._try_variant", side_effect=fake):
+            row = _check_one(self._rolling_insight(), "url", freeze=False, recheck=True)
+        self.assertEqual(row.status, "OK_SINGLE")
+        self.assertIn("24h", row.detail)
+        self.assertEqual(len(calls), 1)
+
+    def test_failed_single_run_reports_error(self):
+        with patch(
+            "posthog.management.commands.compare_retention_correctness._try_variant",
+            return_value=(None, ValueError("rejected")),
+        ):
+            row = _check_one(self._rolling_insight(), "url", freeze=False, recheck=True)
+        self.assertEqual(row.status, "ERROR")
+        self.assertIn("single-path", row.detail)
+        self.assertIn("ValueError", row.detail)

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -1,4 +1,7 @@
+import os
+import tempfile
 from datetime import UTC, datetime
+from io import StringIO
 
 from unittest import TestCase
 from unittest.mock import patch
@@ -6,10 +9,13 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from posthog.management.commands.compare_retention_correctness import (
+    Command,
     ProgressState,
     Row,
     _check_one,
+    journal_line,
     merge_progress_state,
+    parse_journal_lines,
     revalidate_mismatches,
     scope_signature,
 )
@@ -27,13 +33,13 @@ def _row(insight_id, status, detail=""):
 class TestMergeProgressState(TestCase):
     def test_accumulates_counts_and_findings_across_batches(self):
         first = merge_progress_state(
-            None, [_row(1, "OK"), _row(2, "MISMATCH", "d2")], next_cursor=2, limit=2, scope="S"
+            None, [_row(1, "OK"), _row(2, "MISMATCH", "d2")], next_cursor=2, complete=False, scope="S"
         )
         second = merge_progress_state(
             first,
             [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5")],
             next_cursor=5,
-            limit=3,
+            complete=False,
             scope="S",
         )
         self.assertEqual(second.processed, 5)
@@ -47,43 +53,57 @@ class TestMergeProgressState(TestCase):
         self.assertEqual(second.cursor, 5)
 
     def test_does_not_mutate_previous_state(self):
-        first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, limit=10, scope="S")
-        merge_progress_state(first, [_row(2, "MISMATCH")], next_cursor=2, limit=10, scope="S")
+        first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, complete=False, scope="S")
+        merge_progress_state(first, [_row(2, "MISMATCH")], next_cursor=2, complete=False, scope="S")
         self.assertEqual(first.processed, 1)
         self.assertEqual(len(first.mismatches), 1)
 
     def test_cursor_never_regresses(self):
-        first = merge_progress_state(None, [_row(5, "OK")], next_cursor=5, limit=1, scope="S")
-        rewound = merge_progress_state(first, [_row(2, "OK")], next_cursor=2, limit=10, scope="S")
+        first = merge_progress_state(None, [_row(5, "OK")], next_cursor=5, complete=False, scope="S")
+        rewound = merge_progress_state(first, [_row(2, "OK")], next_cursor=2, complete=False, scope="S")
         self.assertEqual(rewound.cursor, 5)
 
-
-class TestSweepCompletion(TestCase):
-    @parameterized.expand(
-        [
-            ("full_batch_keeps_going", 3, 3, False),
-            ("short_batch_completes", 2, 3, True),
-            ("empty_batch_completes", 0, 3, True),
-        ]
-    )
-    def test_complete_iff_batch_smaller_than_limit(self, _name, batch_size, limit, expected):
-        rows = [_row(i, "OK") for i in range(1, batch_size + 1)]
-        state = merge_progress_state(None, rows, next_cursor=batch_size or None, limit=limit, scope="S")
-        self.assertEqual(state.complete, expected)
-
     def test_empty_batch_leaves_cursor_in_place(self):
-        first = merge_progress_state(None, [_row(1, "OK"), _row(2, "OK")], next_cursor=2, limit=2, scope="S")
+        first = merge_progress_state(None, [_row(1, "OK"), _row(2, "OK")], next_cursor=2, complete=False, scope="S")
         self.assertFalse(first.complete)
-        done = merge_progress_state(first, [], next_cursor=None, limit=2, scope="S")
+        done = merge_progress_state(first, [], next_cursor=None, complete=True, scope="S")
         self.assertTrue(done.complete)
         self.assertEqual(done.cursor, 2)
         self.assertEqual(done.processed, 2)
 
 
+class TestJournal(TestCase):
+    def test_recovers_rows_dropping_a_line_torn_by_the_interrupt(self):
+        rows = [_row(1, "OK"), _row(2, "MISMATCH", "2 stable cell diff(s)")]
+        lines = ['{"scope": "S"}', *(journal_line(r) for r in rows), '{"id": 3, "short_id": "s3", "tea']
+        self.assertEqual(parse_journal_lines(lines, "S"), rows)
+
+    def test_refuses_journal_from_a_different_filter_set(self):
+        lines = ['{"scope": "S"}', journal_line(_row(1, "OK"))]
+        with self.assertRaises(ValueError):
+            parse_journal_lines(lines, "OTHER")
+
+    def test_append_after_torn_tail_starts_on_a_fresh_line(self):
+        # A plain append would glue the resumed run's first record onto the torn fragment,
+        # silently losing both rows on the next recovery.
+        cmd = Command(stdout=StringIO())
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "sweep.json.journal")
+            handle = cmd._open_journal(path, scope="S")
+            handle.write(journal_line(_row(1, "OK")) + "\n")
+            handle.write('{"id": 2, "sho')
+            handle.close()
+            handle = cmd._open_journal(path, scope="S")
+            handle.write(journal_line(_row(2, "OK")) + "\n")
+            handle.close()
+            recovered = cmd._load_journal(path, scope="S", restart=False)
+            self.assertEqual([r.id for r in recovered], [1, 2])
+
+
 class TestProgressStateRoundTrip(TestCase):
     def test_to_dict_from_dict_preserves_state(self):
         state = merge_progress_state(
-            None, [_row(1, "OK"), _row(2, "MISMATCH", "d")], next_cursor=2, limit=2, scope="SC"
+            None, [_row(1, "OK"), _row(2, "MISMATCH", "d")], next_cursor=2, complete=False, scope="SC"
         )
         self.assertEqual(ProgressState.from_dict(state.to_dict()), state)
 

--- a/posthog/management/commands/test/test_compare_retention_correctness.py
+++ b/posthog/management/commands/test/test_compare_retention_correctness.py
@@ -31,21 +31,20 @@ class TestMergeProgressState(TestCase):
         )
         second = merge_progress_state(
             first,
-            [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5"), _row(6, "OK_SINGLE", "24h")],
-            next_cursor=6,
-            limit=4,
+            [_row(3, "ERROR", "e3"), _row(4, "OK"), _row(5, "ERROR_DWH", "e5")],
+            next_cursor=5,
+            limit=3,
             scope="S",
         )
-        self.assertEqual(second.processed, 6)
+        self.assertEqual(second.processed, 5)
         self.assertEqual(second.counts["OK"], 2)
-        self.assertEqual(second.counts["OK_SINGLE"], 1)
         self.assertEqual(second.counts["MISMATCH"], 1)
         self.assertEqual(second.counts["ERROR"], 1)
         self.assertEqual(second.counts["ERROR_DWH"], 1)
         self.assertEqual([m["id"] for m in second.mismatches], [2])
         # Attributed errors accumulate alongside plain ones, keeping their status in the record.
         self.assertEqual([(e["id"], e["status"]) for e in second.errors], [(3, "ERROR"), (5, "ERROR_DWH")])
-        self.assertEqual(second.cursor, 6)
+        self.assertEqual(second.cursor, 5)
 
     def test_does_not_mutate_previous_state(self):
         first = merge_progress_state(None, [_row(1, "MISMATCH")], next_cursor=1, limit=10, scope="S")
@@ -137,13 +136,12 @@ class TestRevalidateMismatches(TestCase):
     @parameterized.expand(
         [
             ("recheck_ok", _row(1, "OK"), "OK"),
-            ("now_single_path", _row(1, "OK_SINGLE", "24h rolling window"), "OK_SINGLE"),
             ("references_now_deleted", _row(1, "SKIPPED", "action deleted"), "SKIPPED"),
             ("insight_gone", None, "SKIPPED"),
         ]
     )
     def test_resolves_when_no_longer_reproducing(self, _name, recheck_row, resolved_status):
-        counts = {"MISMATCH": 1, "OK": 5, "OK_SINGLE": 0, "SKIPPED": 0}
+        counts = {"MISMATCH": 1, "OK": 5, "SKIPPED": 0}
         kept, resolved, new_counts = revalidate_mismatches([_mismatch_record(1)], counts, lambda rec: recheck_row)
         self.assertEqual(kept, [])
         self.assertEqual(len(resolved), 1)
@@ -236,35 +234,3 @@ class TestRecheckStabilityClassification(TestCase):
         row = self._check_with_fake_variants(variant_dependent)
         self.assertEqual(row.status, "MISMATCH")
         self.assertIn("value-identical (deterministic)", row.detail)
-
-
-class TestCheckOneSinglePath(TestCase):
-    # A 24h insight must cost one query, not a legacy/dwh pair diffed against itself, and a failure
-    # of that one run must come back as an attributed row instead of crashing the team lane.
-    def _rolling_insight(self):
-        insight = _retention_insight()
-        insight.query["source"]["retentionFilter"]["timeWindowMode"] = "24_hour_windows"
-        return insight
-
-    def test_clean_single_run_reports_ok_single(self):
-        calls = []
-
-        def fake(insight, use_dwh, modifiers, override):
-            calls.append(use_dwh)
-            return [], None
-
-        with patch("posthog.management.commands.compare_retention_correctness._try_variant", side_effect=fake):
-            row = _check_one(self._rolling_insight(), "url", freeze=False, recheck=True)
-        self.assertEqual(row.status, "OK_SINGLE")
-        self.assertIn("24h", row.detail)
-        self.assertEqual(len(calls), 1)
-
-    def test_failed_single_run_reports_error(self):
-        with patch(
-            "posthog.management.commands.compare_retention_correctness._try_variant",
-            return_value=(None, ValueError("rejected")),
-        ):
-            row = _check_one(self._rolling_insight(), "url", freeze=False, recheck=True)
-        self.assertEqual(row.status, "ERROR")
-        self.assertIn("single-path", row.detail)
-        self.assertIn("ValueError", row.detail)

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -15,12 +15,14 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     _clickhouse_seconds,
     _frozen_date_range,
     aggregate_resource_stats,
+    attribute_variant_errors,
     build_perf_aggregate,
     classify_insight,
     compute_perf_result,
     diff_retention_results,
     intersect_stable_mismatch,
     parse_query_log_rows,
+    referenced_ids,
     summarize_samples,
 )
 
@@ -74,6 +76,107 @@ class TestClassifyInsight(TestCase):
     def test_error_classification(self, _name, query):
         action, _reason = classify_insight(_insight(query))
         self.assertEqual(action, "error")
+
+
+class TestAttributeVariantErrors(TestCase):
+    # Mislabeling here inverts the sweep's signal: a DWH-only failure read as ERROR_BOTH (or as
+    # legacy's) would hide a rollout blocker behind "broken insight anyway".
+    @parameterized.expand(
+        [
+            ("dwh_only", None, ValueError("boom"), "ERROR_DWH", "ValueError"),
+            ("legacy_only", ValueError("boom"), None, "ERROR_LEGACY", "ValueError"),
+            ("both_identical", ValueError("boom"), ValueError("boom"), "ERROR_BOTH", "ValueError"),
+            ("both_different", ValueError("a"), KeyError("b"), "ERROR_BOTH", "legacy=ValueError, dwh=KeyError"),
+        ]
+    )
+    def test_status_and_type(self, _name, legacy_exc, dwh_exc, expected_status, expected_type):
+        status, error_type, summary = attribute_variant_errors(legacy_exc, dwh_exc)
+        self.assertEqual(status, expected_status)
+        self.assertEqual(error_type, expected_type)
+        self.assertTrue(summary)
+
+    def test_identical_failure_summarized_once(self):
+        _status, _error_type, summary = attribute_variant_errors(ValueError("boom"), ValueError("boom"))
+        self.assertIn("identically", summary)
+        self.assertEqual(summary.count("boom"), 1)
+
+    def test_differing_failures_both_summarized(self):
+        _status, _error_type, summary = attribute_variant_errors(ValueError("legacy msg"), TypeError("dwh msg"))
+        self.assertIn("legacy msg", summary)
+        self.assertIn("dwh msg", summary)
+
+
+class TestReferencedIds(TestCase):
+    # A missed reference site keeps a broken insight erroring instead of skipping; over-collection
+    # (event breakdowns, "all"/0 pseudo-cohort) would wrongly skip healthy insights, silently
+    # shrinking sweep coverage.
+    @parameterized.expand(
+        [
+            (
+                "action_entities",
+                {
+                    "retentionFilter": {
+                        "targetEntity": {"type": "actions", "id": "123"},
+                        "returningEntity": {"type": "actions", "id": 456},
+                    }
+                },
+                {123, 456},
+                set(),
+            ),
+            (
+                "event_entities_have_no_refs",
+                {"retentionFilter": {"targetEntity": {"type": "events", "id": "$pageview"}}},
+                set(),
+                set(),
+            ),
+            (
+                "cohort_in_nested_property_group",
+                {
+                    "properties": {
+                        "type": "AND",
+                        "values": [{"type": "OR", "values": [{"key": "id", "type": "cohort", "value": 27777}]}],
+                    }
+                },
+                set(),
+                {27777},
+            ),
+            (
+                "cohort_on_entity_properties",
+                {
+                    "retentionFilter": {
+                        "targetEntity": {
+                            "type": "events",
+                            "properties": [{"key": "id", "type": "cohort", "value": 18217}],
+                        }
+                    }
+                },
+                set(),
+                {18217},
+            ),
+            (
+                "cohort_breakdown_uses_property_key",
+                {"breakdownFilter": {"breakdowns": [{"type": "cohort", "property": 18217}]}},
+                set(),
+                {18217},
+            ),
+            (
+                "legacy_single_breakdown_with_all_pseudo_cohort",
+                {"breakdownFilter": {"breakdown_type": "cohort", "breakdown": [123, "all", 0]}},
+                set(),
+                {123},
+            ),
+            (
+                "event_breakdown_property_is_not_a_cohort",
+                {"breakdownFilter": {"breakdowns": [{"type": "event", "property": "42"}]}},
+                set(),
+                set(),
+            ),
+        ]
+    )
+    def test_extraction(self, _name, source, expected_actions, expected_cohorts):
+        action_ids, cohort_ids = referenced_ids({"kind": "RetentionQuery", **source})
+        self.assertEqual(action_ids, expected_actions)
+        self.assertEqual(cohort_ids, expected_cohorts)
 
 
 class TestDiffRetentionResults(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -92,6 +92,7 @@ class TestDiffRetentionResults(TestCase):
         self.assertEqual(cell.legacy, 50)
         self.assertEqual(cell.dwh, 40)
         self.assertEqual(cell.abs_diff, 10)
+        assert cell.rel_diff is not None
         self.assertAlmostEqual(cell.rel_diff, -0.2)
 
     def test_aggregation_value_diff_is_mismatch(self):
@@ -168,54 +169,43 @@ class TestSummarizeSamples(TestCase):
 
 
 class TestComputePerfResult(TestCase):
-    def test_regression_needs_both_thresholds(self):
-        result = compute_perf_result(
-            [100, 100, 100],
-            [200, 200, 200],
-            [80, 80, 80],
-            [180, 180, 180],
-            regression_rel=0.10,
-            regression_ms=50.0,
-        )
-        self.assertEqual(result.ratio_median_wall, 2.0)
-        self.assertTrue(result.is_regression)
-        self.assertFalse(result.is_improvement)
-
-    def test_relative_slowdown_below_ms_floor_is_not_regression(self):
-        result = compute_perf_result(
-            [10, 10],
-            [20, 20],
-            [5, 5],
-            [10, 10],
-            regression_rel=0.10,
-            regression_ms=50.0,
-        )
-        self.assertEqual(result.ratio_median_wall, 2.0)
-        self.assertFalse(result.is_regression)
-
-    def test_improvement_detection(self):
-        result = compute_perf_result(
-            [200, 200],
-            [100, 100],
-            [180, 180],
-            [90, 90],
-            regression_rel=0.10,
-            regression_ms=50.0,
-        )
-        self.assertTrue(result.is_improvement)
-        self.assertFalse(result.is_regression)
-
-    def test_zero_legacy_median_yields_no_ratio(self):
-        result = compute_perf_result(
-            [0, 0],
-            [10, 10],
-            [0, 0],
-            [10, 10],
-            regression_rel=0.10,
-            regression_ms=1.0,
-        )
-        self.assertIsNone(result.ratio_median_wall)
-        self.assertFalse(result.is_regression)
+    @parameterized.expand(
+        [
+            # name, wall_legacy, wall_dwh, ch_legacy, ch_dwh, rel, ms, ratio, is_regression, is_improvement
+            (
+                "regression",
+                [100, 100, 100],
+                [200, 200, 200],
+                [80, 80, 80],
+                [180, 180, 180],
+                0.10,
+                50.0,
+                2.0,
+                True,
+                False,
+            ),
+            ("slowdown_below_ms_floor", [10, 10], [20, 20], [5, 5], [10, 10], 0.10, 50.0, 2.0, False, False),
+            ("improvement", [200, 200], [100, 100], [180, 180], [90, 90], 0.10, 50.0, 0.5, False, True),
+            ("zero_legacy_median", [0, 0], [10, 10], [0, 0], [10, 10], 0.10, 1.0, None, False, False),
+        ]
+    )
+    def test_compute_perf_result(
+        self,
+        _name,
+        wall_legacy,
+        wall_dwh,
+        ch_legacy,
+        ch_dwh,
+        rel,
+        ms,
+        expected_ratio,
+        expected_regression,
+        expected_improvement,
+    ):
+        result = compute_perf_result(wall_legacy, wall_dwh, ch_legacy, ch_dwh, regression_rel=rel, regression_ms=ms)
+        self.assertEqual(result.ratio_median_wall, expected_ratio)
+        self.assertEqual(result.is_regression, expected_regression)
+        self.assertEqual(result.is_improvement, expected_improvement)
 
 
 class TestResourceStats(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -125,6 +125,16 @@ class TestDiffRetentionResults(TestCase):
         self.assertEqual(diff.row_count_legacy, 1)
         self.assertEqual(diff.row_count_dwh, 0)
 
+    def test_row_label_mismatch_with_equal_counts_is_flagged(self):
+        # Equal row counts and identical breakdown sets, but a differing row label must not be
+        # silently dropped into an OK verdict.
+        legacy = [_result(None, "Day 0", [_value(10, "Day 0")]), _result(None, "Day 1", [_value(5, "Day 0")])]
+        dwh = [_result(None, "Day 0", [_value(10, "Day 0")]), _result(None, "Day 2", [_value(5, "Day 0")])]
+        diff = diff_retention_results(legacy, dwh)
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertTrue(any("missing in DWH" in note for note in diff.notes))
+        self.assertTrue(any("missing in legacy" in note for note in diff.notes))
+
 
 class TestClickhouseSeconds(TestCase):
     def test_matches_leaf_key(self):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -346,9 +346,10 @@ class TestIntersectStableMismatch(TestCase):
         dwh = [
             _result(None, "Day 0", [_value(5, "Day 0"), _value(10, "Day 1"), _value(10, "Day 2"), _value(7, "Day 3")])
         ]
-        kwargs = {"latest_interval_start": _DT + timedelta(days=3), "interval_delta": timedelta(days=1)}
-        first = diff_retention_results(legacy, dwh, **kwargs)
-        second = diff_retention_results(legacy, dwh, **kwargs)
+        latest = _DT + timedelta(days=3)
+        delta = timedelta(days=1)
+        first = diff_retention_results(legacy, dwh, latest_interval_start=latest, interval_delta=delta)
+        second = diff_retention_results(legacy, dwh, latest_interval_start=latest, interval_delta=delta)
         result = intersect_stable_mismatch(first, second)
         self.assertEqual(result.status, "MISMATCH")
         self.assertEqual(result.trailing_cell_diffs, first.trailing_cell_diffs)

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from unittest import TestCase
@@ -11,12 +11,15 @@ from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRI
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     InsightFinding,
     ResourceStats,
+    _cell_is_trailing,
     _clickhouse_seconds,
+    _frozen_date_range,
     aggregate_resource_stats,
     build_perf_aggregate,
     classify_insight,
     compute_perf_result,
     diff_retention_results,
+    intersect_stable_mismatch,
     parse_query_log_rows,
     summarize_samples,
 )
@@ -134,6 +137,127 @@ class TestDiffRetentionResults(TestCase):
         self.assertEqual(diff.status, "MISMATCH")
         self.assertTrue(any("missing in DWH" in note for note in diff.notes))
         self.assertTrue(any("missing in legacy" in note for note in diff.notes))
+
+
+class TestTrailingClassification(TestCase):
+    def test_trailing_only_diff_is_ok(self):
+        # Cohort interval == latest interval, so every cell in the row is trailing: a count delta is
+        # live-ingest drift, not a mismatch.
+        diff = diff_retention_results(
+            _simple_series([100, 50]),
+            _simple_series([100, 40]),
+            latest_interval_start=_DT,
+            interval_delta=timedelta(days=1),
+        )
+        self.assertEqual(diff.status, "OK")
+        self.assertEqual(diff.cell_diffs, [])
+        self.assertEqual(len(diff.trailing_cell_diffs), 1)
+        self.assertEqual(diff.trailing_cell_diffs[0].value_label, "Day 1")
+
+    def test_returning_offset_routes_per_cell(self):
+        # Cohort at _DT, latest interval three periods later: the offset-3 returning bucket is trailing,
+        # the offset-0 one is not. Each cell is routed independently.
+        legacy = [_result(None, "Day 0", [_value(10, f"Day {i}") for i in range(4)])]
+        dwh = [
+            _result(None, "Day 0", [_value(5, "Day 0"), _value(10, "Day 1"), _value(10, "Day 2"), _value(7, "Day 3")])
+        ]
+        diff = diff_retention_results(
+            legacy, dwh, latest_interval_start=_DT + timedelta(days=3), interval_delta=timedelta(days=1)
+        )
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual([c.value_label for c in diff.cell_diffs], ["Day 0"])
+        self.assertEqual([c.value_label for c in diff.trailing_cell_diffs], ["Day 3"])
+
+    def test_non_trailing_cell_diff_is_mismatch(self):
+        diff = diff_retention_results(
+            _simple_series([100, 50]),
+            _simple_series([100, 40]),
+            latest_interval_start=_DT + timedelta(days=2),
+            interval_delta=timedelta(days=1),
+        )
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(len(diff.cell_diffs), 1)
+        self.assertEqual(diff.trailing_cell_diffs, [])
+
+    def test_classification_disabled_by_default(self):
+        # Without the trailing params, behaviour is identical to before: everything counts.
+        diff = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(len(diff.cell_diffs), 1)
+        self.assertEqual(diff.trailing_cell_diffs, [])
+
+    @parameterized.expand(
+        [
+            ("latest_none", _DT, 0, None, timedelta(days=1), False),
+            ("cohort_none", None, 0, _DT, timedelta(days=1), False),
+            ("cohort_equals_latest", _DT, 2, _DT, timedelta(days=1), True),
+            ("returning_equals_latest", _DT, 3, _DT + timedelta(days=3), timedelta(days=1), True),
+            ("returning_off_by_one", _DT, 2, _DT + timedelta(days=3), timedelta(days=1), False),
+            ("offset_branch_needs_delta", _DT, 3, _DT + timedelta(days=3), None, False),
+        ]
+    )
+    def test_cell_is_trailing(self, _name, cohort_date, offset, latest, delta, expected):
+        self.assertEqual(_cell_is_trailing(cohort_date, offset, latest, delta), expected)
+
+
+class TestIntersectStableMismatch(TestCase):
+    def test_transient_mismatch_dropped(self):
+        first = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        second = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 50]))
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(result.cell_diffs, [])
+
+    def test_reproduced_mismatch_kept(self):
+        first = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        second = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "MISMATCH")
+        self.assertEqual(len(result.cell_diffs), 1)
+        self.assertEqual(result.cell_diffs[0].value_label, "Day 1")
+
+    def test_reproduced_row_count_mismatch_kept(self):
+        first = diff_retention_results(_simple_series([10]), [])
+        second = diff_retention_results(_simple_series([10]), [])
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "MISMATCH")
+
+    def test_transient_breakdown_divergence_dropped(self):
+        first = diff_retention_results(
+            _simple_series([10], breakdown_value="chrome") + _simple_series([5], breakdown_value="firefox"),
+            _simple_series([10], breakdown_value="chrome")
+            + _simple_series([5], breakdown_value=BREAKDOWN_OTHER_STRING_LABEL),
+        )
+        self.assertEqual(first.status, "MISMATCH")
+        second = diff_retention_results(
+            _simple_series([10], breakdown_value="chrome") + _simple_series([5], breakdown_value="firefox"),
+            _simple_series([10], breakdown_value="chrome") + _simple_series([5], breakdown_value="firefox"),
+        )
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "OK")
+        self.assertEqual(result.breakdown_only_dwh, [])
+        self.assertFalse(result.other_bucket_changed)
+
+    def test_trailing_diffs_carried_through(self):
+        legacy = [_result(None, "Day 0", [_value(10, f"Day {i}") for i in range(4)])]
+        dwh = [
+            _result(None, "Day 0", [_value(5, "Day 0"), _value(10, "Day 1"), _value(10, "Day 2"), _value(7, "Day 3")])
+        ]
+        kwargs = {"latest_interval_start": _DT + timedelta(days=3), "interval_delta": timedelta(days=1)}
+        first = diff_retention_results(legacy, dwh, **kwargs)
+        second = diff_retention_results(legacy, dwh, **kwargs)
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "MISMATCH")
+        self.assertEqual(result.trailing_cell_diffs, first.trailing_cell_diffs)
+        self.assertEqual([c.value_label for c in result.trailing_cell_diffs], ["Day 3"])
+
+
+class TestFrozenDateRange(TestCase):
+    def test_excludes_current_period(self):
+        frozen = _frozen_date_range(_DT, _DT + timedelta(days=3), timedelta(days=1))
+        self.assertEqual(frozen["date_from"], _DT.isoformat())
+        self.assertEqual(frozen["date_to"], (_DT + timedelta(days=2)).isoformat())
+        self.assertTrue(frozen["explicitDate"])
 
 
 class TestClickhouseSeconds(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -1,0 +1,276 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from posthog.schema import QueryTiming, RetentionResult, RetentionValue
+
+from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
+from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    InsightFinding,
+    ResourceStats,
+    _clickhouse_seconds,
+    aggregate_resource_stats,
+    build_perf_aggregate,
+    classify_insight,
+    compute_perf_result,
+    diff_retention_results,
+    parse_query_log_rows,
+    summarize_samples,
+)
+
+_DT = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def _value(count, label, aggregation_value=None):
+    return RetentionValue(count=count, label=label, aggregation_value=aggregation_value)
+
+
+def _result(breakdown_value, label, values):
+    return RetentionResult(breakdown_value=breakdown_value, date=_DT, label=label, values=values)
+
+
+def _simple_series(counts, breakdown_value=None):
+    values = [_value(count, f"Day {i}") for i, count in enumerate(counts)]
+    return [_result(breakdown_value, "Day 0", values)]
+
+
+def _insight(query):
+    return SimpleNamespace(query=query)
+
+
+def _retention_query(retention_filter):
+    return {"kind": "InsightVizNode", "source": {"kind": "RetentionQuery", "retentionFilter": retention_filter}}
+
+
+class TestClassifyInsight(TestCase):
+    @parameterized.expand(
+        [
+            ("rolling_24h", {"timeWindowMode": "24_hour_windows"}, "skip", "24h"),
+            ("dwh_target", {"targetEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
+            ("dwh_returning", {"returningEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
+            ("plain_events", {"targetEntity": {"type": "events"}}, "compare", ""),
+            ("empty_filter", {}, "compare", ""),
+        ]
+    )
+    def test_classification(self, _name, retention_filter, expected_action, reason_contains):
+        action, reason = classify_insight(_insight(_retention_query(retention_filter)))
+        self.assertEqual(action, expected_action)
+        self.assertIn(reason_contains, reason)
+
+    @parameterized.expand(
+        [
+            ("query_not_dict", "not a dict"),
+            ("wrong_source_kind", {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}}),
+            ("missing_retention_filter", {"kind": "InsightVizNode", "source": {"kind": "RetentionQuery"}}),
+            ("no_source", {"kind": "InsightVizNode"}),
+        ]
+    )
+    def test_error_classification(self, _name, query):
+        action, _reason = classify_insight(_insight(query))
+        self.assertEqual(action, "error")
+
+
+class TestDiffRetentionResults(TestCase):
+    def test_identical_is_ok(self):
+        diff = diff_retention_results(_simple_series([10, 5, 2]), _simple_series([10, 5, 2]))
+        self.assertEqual(diff.status, "OK")
+        self.assertEqual(diff.cell_diffs, [])
+
+    def test_count_within_relative_tolerance_is_ok(self):
+        diff = diff_retention_results(_simple_series([1000]), _simple_series([1001]), count_tol_rel=0.01)
+        self.assertEqual(diff.status, "OK")
+
+    def test_count_beyond_tolerance_is_mismatch(self):
+        diff = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(len(diff.cell_diffs), 1)
+        cell = diff.cell_diffs[0]
+        self.assertEqual(cell.field, "count")
+        self.assertEqual(cell.legacy, 50)
+        self.assertEqual(cell.dwh, 40)
+        self.assertEqual(cell.abs_diff, 10)
+        self.assertAlmostEqual(cell.rel_diff, -0.2)
+
+    def test_aggregation_value_diff_is_mismatch(self):
+        legacy = [_result(None, "Day 0", [_value(10, "Day 0", aggregation_value=100.0)])]
+        dwh = [_result(None, "Day 0", [_value(10, "Day 0", aggregation_value=130.0)])]
+        diff = diff_retention_results(legacy, dwh)
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(diff.cell_diffs[0].field, "aggregation_value")
+
+    def test_cell_diffs_sorted_by_abs_diff(self):
+        legacy = _simple_series([100, 100, 100])
+        dwh = _simple_series([90, 100, 50])
+        diff = diff_retention_results(legacy, dwh)
+        self.assertEqual([c.abs_diff for c in diff.cell_diffs], [50, 10])
+
+    def test_breakdown_set_diff_and_other_bucket(self):
+        legacy = _simple_series([10], breakdown_value="chrome") + _simple_series([5], breakdown_value="firefox")
+        dwh = _simple_series([10], breakdown_value="chrome") + _simple_series(
+            [5], breakdown_value=BREAKDOWN_OTHER_STRING_LABEL
+        )
+        diff = diff_retention_results(legacy, dwh)
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(diff.breakdown_only_legacy, ["firefox"])
+        self.assertEqual(diff.breakdown_only_dwh, [BREAKDOWN_OTHER_STRING_LABEL])
+        self.assertTrue(diff.other_bucket_changed)
+
+    def test_row_count_mismatch(self):
+        diff = diff_retention_results(_simple_series([10]), [])
+        self.assertEqual(diff.status, "MISMATCH")
+        self.assertEqual(diff.row_count_legacy, 1)
+        self.assertEqual(diff.row_count_dwh, 0)
+
+
+class TestClickhouseSeconds(TestCase):
+    def test_matches_leaf_key(self):
+        timings = [
+            QueryTiming(k="./retention_query/print_ast", t=0.5),
+            QueryTiming(k="./retention_query/.../clickhouse_execute", t=0.12),
+        ]
+        self.assertAlmostEqual(_clickhouse_seconds(timings), 0.12)
+
+    def test_sums_multiple_clickhouse_execute(self):
+        timings = [
+            QueryTiming(k="./a/clickhouse_execute", t=0.1),
+            QueryTiming(k="./b/clickhouse_execute", t=0.2),
+        ]
+        self.assertAlmostEqual(_clickhouse_seconds(timings), 0.3)
+
+    def test_accepts_dicts(self):
+        self.assertAlmostEqual(_clickhouse_seconds([{"k": "x/clickhouse_execute", "t": 0.25}]), 0.25)
+
+    @parameterized.expand([("none", None), ("empty", [])])
+    def test_empty(self, _name, timings):
+        self.assertEqual(_clickhouse_seconds(timings), 0.0)
+
+
+class TestSummarizeSamples(TestCase):
+    def test_known_array(self):
+        timing = summarize_samples([10, 20, 30, 40, 50])
+        self.assertEqual(timing.min_ms, 10)
+        self.assertEqual(timing.median_ms, 30)
+        self.assertAlmostEqual(timing.p95_ms, 48.0)
+        self.assertAlmostEqual(timing.stdev_ms, 15.8113883, places=5)
+
+    def test_single_sample_has_zero_stdev(self):
+        timing = summarize_samples([42.0])
+        self.assertEqual(timing.min_ms, 42.0)
+        self.assertEqual(timing.median_ms, 42.0)
+        self.assertEqual(timing.stdev_ms, 0.0)
+
+    def test_empty(self):
+        timing = summarize_samples([])
+        self.assertEqual(timing.median_ms, 0.0)
+
+
+class TestComputePerfResult(TestCase):
+    def test_regression_needs_both_thresholds(self):
+        result = compute_perf_result(
+            [100, 100, 100],
+            [200, 200, 200],
+            [80, 80, 80],
+            [180, 180, 180],
+            regression_rel=0.10,
+            regression_ms=50.0,
+        )
+        self.assertEqual(result.ratio_median_wall, 2.0)
+        self.assertTrue(result.is_regression)
+        self.assertFalse(result.is_improvement)
+
+    def test_relative_slowdown_below_ms_floor_is_not_regression(self):
+        result = compute_perf_result(
+            [10, 10],
+            [20, 20],
+            [5, 5],
+            [10, 10],
+            regression_rel=0.10,
+            regression_ms=50.0,
+        )
+        self.assertEqual(result.ratio_median_wall, 2.0)
+        self.assertFalse(result.is_regression)
+
+    def test_improvement_detection(self):
+        result = compute_perf_result(
+            [200, 200],
+            [100, 100],
+            [180, 180],
+            [90, 90],
+            regression_rel=0.10,
+            regression_ms=50.0,
+        )
+        self.assertTrue(result.is_improvement)
+        self.assertFalse(result.is_regression)
+
+    def test_zero_legacy_median_yields_no_ratio(self):
+        result = compute_perf_result(
+            [0, 0],
+            [10, 10],
+            [0, 0],
+            [10, 10],
+            regression_rel=0.10,
+            regression_ms=1.0,
+        )
+        self.assertIsNone(result.ratio_median_wall)
+        self.assertFalse(result.is_regression)
+
+
+class TestResourceStats(TestCase):
+    def test_parse_query_log_rows(self):
+        rows = [("42_x_a", 1000, 50, 9000, 12, 1), ("42_x_b", 2000, 80, 7000, 8, 1)]
+        stats = parse_query_log_rows(rows)
+        self.assertEqual(stats["42_x_a"].read_bytes, 1000)
+        self.assertEqual(stats["42_x_b"].read_rows, 80)
+
+    def test_aggregate_sums_bytes_and_rows_max_memory(self):
+        stats_by_id = {
+            "a": ResourceStats(
+                read_bytes=1000, read_rows=50, memory_usage=9000, query_duration_ms=12, ch_query_count=1
+            ),
+            "b": ResourceStats(read_bytes=2000, read_rows=80, memory_usage=7000, query_duration_ms=8, ch_query_count=1),
+        }
+        aggregated = aggregate_resource_stats(["a", "b"], stats_by_id)
+        assert aggregated is not None
+        self.assertEqual(aggregated.read_bytes, 3000)
+        self.assertEqual(aggregated.read_rows, 130)
+        self.assertEqual(aggregated.memory_usage, 9000)
+        self.assertEqual(aggregated.ch_query_count, 2)
+
+    def test_aggregate_returns_none_without_matches(self):
+        self.assertIsNone(aggregate_resource_stats(["missing"], {}))
+
+
+class TestBuildPerfAggregate(TestCase):
+    def _finding_with_perf(self, insight_id, wall_legacy, wall_dwh, read_legacy=None, read_dwh=None):
+        finding = InsightFinding(
+            insight_id=insight_id,
+            short_id=f"s{insight_id}",
+            team_id=1,
+            name="",
+            url="",
+            status="OK",
+        )
+        finding.perf = compute_perf_result(
+            wall_legacy, wall_dwh, wall_legacy, wall_dwh, regression_rel=0.10, regression_ms=50.0
+        )
+        if read_legacy is not None and read_dwh is not None:
+            finding.resource_legacy = ResourceStats(read_legacy, 0, 0, 0, 1)
+            finding.resource_dwh = ResourceStats(read_dwh, 0, 0, 0, 1)
+            finding.bytes_ratio = read_dwh / read_legacy
+        return finding
+
+    def test_distribution_and_regression_counts(self):
+        findings = [
+            self._finding_with_perf(1, [100, 100], [300, 300], read_legacy=1000, read_dwh=3000),  # regression
+            self._finding_with_perf(2, [100, 100], [100, 100], read_legacy=1000, read_dwh=1000),  # even
+            self._finding_with_perf(3, [200, 200], [100, 100], read_legacy=2000, read_dwh=1000),  # improvement
+        ]
+        aggregate = build_perf_aggregate(findings, worst_n=5)
+        self.assertEqual(aggregate.n_compared, 3)
+        self.assertEqual(aggregate.n_regressions, 1)
+        self.assertEqual(aggregate.n_improvements, 1)
+        self.assertEqual(aggregate.wall_ratio_dist["median"], 1.0)
+        self.assertEqual(aggregate.worst_by_rel[0].insight_id, 1)

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -34,6 +34,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     parse_query_log_rows,
     referenced_ids,
     save_progress_findings,
+    shape_fingerprint,
     summarize_samples,
 )
 
@@ -109,6 +110,111 @@ class TestClassifyInsight(TestCase):
     def test_error_classification(self, _name, query):
         action, _reason = classify_insight(_insight(query))
         self.assertEqual(action, "error")
+
+
+class TestShapeFingerprint(TestCase):
+    # The tag drives mismatch triage on prod pods; a misread source silently files a finding under
+    # the wrong query family. The risky reads: display-only entity keys (uuid/name) and explicit
+    # nulls must not flip entities to "diff", and the legacy single-breakdown shape must register.
+    @parameterized.expand(
+        [
+            (
+                "defaults",
+                {"kind": "RetentionQuery", "retentionFilter": {}},
+                "recurring entities=same(events) period=Day intervals=7",
+            ),
+            (
+                "display_only_entity_noise_is_same",
+                {
+                    "kind": "RetentionQuery",
+                    "dateRange": {"date_from": "-7d", "date_to": None},
+                    "retentionFilter": {
+                        "retentionType": "retention_first_time",
+                        "cumulative": True,
+                        "totalIntervals": 11,
+                        "targetEntity": {
+                            "id": None,
+                            "type": "events",
+                            "uuid": "aaaa",
+                            "name": "$pageview",
+                            "properties": [{"key": "$host", "value": ["a"], "operator": "exact", "label": None}],
+                        },
+                        "returningEntity": {
+                            "id": None,
+                            "type": "events",
+                            "uuid": "bbbb",
+                            "order": 0,
+                            "properties": [{"key": "$host", "value": ["a"], "operator": "exact"}],
+                        },
+                    },
+                    "filterTestAccounts": True,
+                },
+                "first_time entities=same(events) period=Day intervals=11 range=-7d..now cumulative test_accounts",
+            ),
+            (
+                "differing_entities_and_types",
+                {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {
+                        "retentionType": "retention_first_ever_occurrence",
+                        "targetEntity": {"id": 12, "type": "actions"},
+                        "returningEntity": {"id": "$pageview", "type": "events"},
+                    },
+                },
+                "first_ever entities=diff(actions/events) period=Day intervals=7",
+            ),
+            (
+                "legacy_single_breakdown",
+                {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {},
+                    "breakdownFilter": {"breakdown": "plan", "breakdown_type": "person"},
+                },
+                "recurring entities=same(events) period=Day intervals=7 bd=person",
+            ),
+            (
+                "multi_cohort_breakdown",
+                {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {},
+                    "breakdownFilter": {
+                        "breakdowns": [{"type": "cohort", "property": 1}, {"type": "cohort", "property": 2}]
+                    },
+                },
+                "recurring entities=same(events) period=Day intervals=7 bd=cohort×2",
+            ),
+            (
+                "all_modifier_flags",
+                {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {
+                        "period": "Week",
+                        "totalIntervals": 4,
+                        "aggregationType": "avg",
+                        "aggregationProperty": "revenue",
+                        "aggregationPropertyType": "person",
+                        "minimumOccurrences": 3,
+                        "retentionCustomBrackets": [1, 2],
+                    },
+                    "samplingFactor": 0.1,
+                    "aggregation_group_type_index": 2,
+                    "properties": {"type": "AND", "values": [{"key": "x"}]},
+                },
+                "recurring entities=same(events) period=Week intervals=4 agg=avg(person) minocc=3 brackets=2 sampling=0.1 groups=2 filters",
+            ),
+            (
+                "empty_property_group_and_bad_minocc",
+                {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {"minimumOccurrences": "nope"},
+                    "properties": {"type": "AND", "values": []},
+                },
+                "recurring entities=same(events) period=Day intervals=7",
+            ),
+        ]
+    )
+    def test_fingerprint(self, _name, source, expected):
+        self.assertEqual(shape_fingerprint(source), expected)
 
 
 class TestAttributeVariantErrors(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -15,6 +16,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     CellDiff,
     CorrectnessDiff,
     InsightFinding,
+    ObjectStorageLineSink,
     ResourceStats,
     _cell_is_trailing,
     _clickhouse_seconds,
@@ -31,8 +33,31 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     load_progress_findings,
     parse_query_log_rows,
     referenced_ids,
+    save_progress_findings,
     summarize_samples,
 )
+
+
+# In-memory stand-in for posthog.storage.object_storage, matching the module-level helper signatures.
+class FakeObjectStorage:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.writes = 0
+
+    def read(self, file_name, missing_ok=False):
+        if file_name not in self.store:
+            if missing_ok:
+                return None
+            raise Exception(f"missing object: {file_name}")
+        return self.store[file_name]
+
+    def write(self, file_name, content, extras=None):
+        self.writes += 1
+        self.store[file_name] = content
+
+    def delete(self, file_name):
+        self.store.pop(file_name, None)
+
 
 _DT = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -603,3 +628,34 @@ class TestProgressState(TestCase):
                     handle.write(finding_to_json_line(finding) + "\n")
             loaded = load_progress_findings(path)
         self.assertEqual({f.insight_id: f.status for f in loaded}, {7: "OK", 8: "OK"})
+
+
+class TestObjectStoragePersistence(TestCase):
+    def test_progress_findings_round_trip_through_object_storage(self):
+        # The s3:// scheme must be stripped from the stored key, or a resuming pod reads a
+        # different object than the one the interrupted run wrote.
+        finding = InsightFinding(insight_id=1, short_id="s1", team_id=1, name="", url="", status="OK")
+        fake = FakeObjectStorage()
+        with patch("posthog.management.commands.compare_retention_legacy_vs_dwh.object_storage", fake):
+            save_progress_findings("s3://retention/progress.jsonl", [finding])
+            self.assertEqual(list(fake.store), ["retention/progress.jsonl"])
+            self.assertEqual(load_progress_findings("s3://retention/progress.jsonl"), [finding])
+
+    def test_sink_batches_uploads_by_time_window_and_keeps_seeded_lines(self):
+        # Uploading on every append re-sends the whole object per insight; never uploading until
+        # close loses everything on a hard kill; dropping the seeded lines erases the work a
+        # resumed run loaded. All three would pass a naive implementation of one of the others.
+        clock = {"now": 0.0}
+        fake = FakeObjectStorage()
+        with patch("posthog.management.commands.compare_retention_legacy_vs_dwh.object_storage", fake):
+            sink = ObjectStorageLineSink("journal", ["seeded"], flush_seconds=30.0, now=lambda: clock["now"])
+            sink.append("row1")
+            self.assertEqual(fake.writes, 0)
+            clock["now"] = 31.0
+            sink.append("row2")
+            self.assertEqual(fake.writes, 1)
+            self.assertEqual(fake.store["journal"], "seeded\nrow1\nrow2\n")
+            sink.append("row3")
+            self.assertEqual(fake.writes, 1)
+            sink.close()
+            self.assertEqual(fake.store["journal"], "seeded\nrow1\nrow2\nrow3\n")

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -318,6 +318,17 @@ class TestIntersectStableMismatch(TestCase):
         self.assertEqual(result.status, "MISMATCH")
         self.assertEqual(len(result.cell_diffs), 1)
         self.assertEqual(result.cell_diffs[0].value_label, "Day 1")
+        self.assertIs(result.cell_diffs[0].values_stable, True)
+
+    def test_moved_values_kept_but_marked_unstable(self):
+        # Same cell differs in both passes but with different values: data churned under the
+        # queries (merges / late ingest), so it must not be reported as a deterministic difference.
+        first = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        second = diff_retention_results(_simple_series([100, 52]), _simple_series([100, 45]))
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "MISMATCH")
+        self.assertEqual(len(result.cell_diffs), 1)
+        self.assertIs(result.cell_diffs[0].values_stable, False)
 
     def test_reproduced_row_count_mismatch_kept(self):
         first = diff_retention_results(_simple_series([10]), [])

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -18,6 +18,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     InsightFinding,
     ObjectStorageLineSink,
     ResourceStats,
+    SampleCandidate,
     _cell_is_trailing,
     _clickhouse_seconds,
     _frozen_date_range,
@@ -34,7 +35,9 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     parse_query_log_rows,
     referenced_ids,
     save_progress_findings,
+    shape_family,
     shape_fingerprint,
+    stratified_sample,
     summarize_samples,
 )
 
@@ -215,6 +218,74 @@ class TestShapeFingerprint(TestCase):
     )
     def test_fingerprint(self, _name, source, expected):
         self.assertEqual(shape_fingerprint(source), expected)
+
+
+class TestShapeFamily(TestCase):
+    # The family key decides what the stratified perf sample covers: keeping a volatile token
+    # (range/intervals) shatters families into near-singletons and the sample balloons, while
+    # dropping a structural one (breakdown, aggregation, period) merges exactly the shapes whose
+    # SQL differs between the builders — they'd silently fall out of the sample.
+    @parameterized.expand(
+        [
+            (
+                "volatile_dropped_parameterized_normalized",
+                {
+                    "kind": "RetentionQuery",
+                    "dateRange": {"date_from": "-7d"},
+                    "retentionFilter": {
+                        "period": "Week",
+                        "totalIntervals": 4,
+                        "aggregationType": "avg",
+                        "aggregationProperty": "revenue",
+                        "aggregationPropertyType": "person",
+                        "minimumOccurrences": 3,
+                        "retentionCustomBrackets": [1, 2],
+                    },
+                    "samplingFactor": 0.1,
+                    "aggregation_group_type_index": 2,
+                    "properties": {"type": "AND", "values": [{"key": "x"}]},
+                    "filterTestAccounts": True,
+                },
+                "recurring entities=same(events) period=Week agg=avg(person) minocc brackets sampling groups",
+            ),
+            (
+                "structural_tokens_kept",
+                {
+                    "kind": "RetentionQuery",
+                    "dateRange": {"date_from": "2025-01-01", "date_to": "now"},
+                    "retentionFilter": {"retentionType": "retention_first_time", "totalIntervals": 11},
+                    "breakdownFilter": {"breakdowns": [{"type": "person", "property": "plan"}]},
+                },
+                "first_time entities=same(events) period=Day bd=person",
+            ),
+        ]
+    )
+    def test_family(self, _name, source, expected):
+        self.assertEqual(shape_family(source), expected)
+
+
+class TestStratifiedSample(TestCase):
+    # The team rotation is what stops one prolific team from filling a family's quota (the sample
+    # would then measure a single dataset), and input-order determinism is the --resume contract —
+    # a re-run must re-derive the same set or resumption draws replacements and the sample drifts.
+    def test_rotates_teams_before_taking_a_teams_second_insight(self):
+        candidates = [
+            SampleCandidate(100, 1, "A"),
+            SampleCandidate(95, 2, "A"),
+            SampleCandidate(90, 1, "A"),
+            SampleCandidate(80, 1, "A"),
+            SampleCandidate(70, 3, "A"),
+            SampleCandidate(60, 1, "B"),
+        ]
+        selected, census = stratified_sample(candidates, per_family=3)
+        self.assertEqual(selected, [100, 95, 70, 60])
+        self.assertEqual(census, [("A", 5, 3), ("B", 1, 1)])
+
+    def test_single_team_family_capped_newest_first(self):
+        candidates = [SampleCandidate(insight_id, 7, "A") for insight_id in (50, 40, 30)]
+        selected, census = stratified_sample(candidates, per_family=2)
+        self.assertEqual(selected, [50, 40])
+        self.assertEqual(census, [("A", 3, 2)])
 
 
 class TestAttributeVariantErrors(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -28,6 +28,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     classify_insight,
     compute_perf_result,
     diff_retention_results,
+    fetch_query_log_stats,
     finding_from_dict,
     finding_to_json_line,
     intersect_stable_mismatch,
@@ -665,6 +666,79 @@ class TestComputePerfResult(TestCase):
         self.assertEqual(result.ratio_median_wall, expected_ratio)
         self.assertEqual(result.is_regression, expected_regression)
         self.assertEqual(result.is_improvement, expected_improvement)
+
+
+_QUERY_LOG_MODULE = "posthog.management.commands.compare_retention_legacy_vs_dwh"
+
+
+class TestFetchQueryLogStats(TestCase):
+    # A sweep's worth of ids in one IN-list scans the distributed archive table and exceeds
+    # max_execution_time, and the lookup used to abandon everything on the first failure — a perf
+    # run losing every resource stat it collected, which is the load-independent half of the report.
+    @staticmethod
+    def _row(query_id):
+        return (query_id, 1000, 50, 9000, 12, 1)
+
+    def test_a_failing_batch_does_not_cost_the_other_batches_their_stats(self):
+        batches = []
+
+        def fake_execute(_query, params):
+            batch = list(params["query_ids"])
+            batches.append(batch)
+            if "b2" in batch:
+                raise Exception("Query has hit the max execution time before completing")
+            return [self._row(query_id) for query_id in batch]
+
+        with patch(f"{_QUERY_LOG_MODULE}.sync_execute", side_effect=fake_execute):
+            found = fetch_query_log_stats(
+                ["a1", "a2", "b1", "b2"], table="query_log_archive", flush=False, wait_seconds=0, batch_size=2
+            )
+
+        self.assertEqual(batches, [["a1", "a2"], ["b1", "b2"]])
+        self.assertEqual(sorted(found), ["a1", "a2"])
+
+    def test_a_wholly_failing_lookup_gives_up_instead_of_polling(self):
+        # Missing table or missing privileges: no amount of waiting produces rows, so the run must
+        # fall through to timing-only immediately rather than burn its whole --query-log-wait budget.
+        batches = []
+
+        def fake_execute(_query, params):
+            batches.append(list(params["query_ids"]))
+            raise Exception("Unknown table query_log_archive")
+
+        with (
+            patch(f"{_QUERY_LOG_MODULE}.sync_execute", side_effect=fake_execute),
+            patch(f"{_QUERY_LOG_MODULE}.time.sleep") as sleep,
+        ):
+            found = fetch_query_log_stats(
+                ["a", "b", "c"], table="query_log_archive", flush=False, wait_seconds=0.05, batch_size=1
+            )
+
+        self.assertEqual(found, {})
+        self.assertEqual(len(batches), 3)
+        sleep.assert_not_called()
+
+    def test_polling_asks_only_for_the_ids_still_missing(self):
+        # Rows reach the log asynchronously, so early passes come back short. Re-asking for ids
+        # already found is what grew the lookup back to sweep size on every resume.
+        batches = []
+
+        def fake_execute(_query, params):
+            batch = list(params["query_ids"])
+            batches.append(batch)
+            flushed = batch if len(batches) > 1 else [query_id for query_id in batch if query_id != "late"]
+            return [self._row(query_id) for query_id in flushed]
+
+        with (
+            patch(f"{_QUERY_LOG_MODULE}.sync_execute", side_effect=fake_execute),
+            patch(f"{_QUERY_LOG_MODULE}.time.sleep"),
+        ):
+            found = fetch_query_log_stats(
+                ["early", "late"], table="query_log", flush=False, wait_seconds=5, batch_size=10
+            )
+
+        self.assertEqual(batches, [["early", "late"], ["late"]])
+        self.assertEqual(sorted(found), ["early", "late"])
 
 
 class TestResourceStats(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -822,6 +822,54 @@ class TestReportDurability(TestCase):
         self.assertIn("# Retention legacy vs DWH-variant comparison", fake.store["retention_compare/perf_report.md"])
 
 
+class TestAttachResourceStats(TestCase):
+    def test_a_resumed_lookup_keeps_the_stats_an_earlier_run_attached(self):
+        # A resumed run only asks the query log for the ids still missing stats, so the attach loop
+        # sees a miss for every finding an earlier run already covered. Assigning those misses wiped
+        # real measurements — leaving a bytes_ratio with n/a byte counts under it in the report — and
+        # the progress file was rewritten with the loss.
+        already = InsightFinding(
+            insight_id=1,
+            short_id="s1",
+            team_id=2,
+            name="",
+            url="",
+            status="OK",
+            legacy_query_ids=["old_legacy"],
+            dwh_query_ids=["old_dwh"],
+            resource_legacy=ResourceStats(1000, 10, 500, 5, 1),
+            resource_dwh=ResourceStats(2000, 20, 700, 6, 1),
+            bytes_ratio=2.0,
+        )
+        still_missing = InsightFinding(
+            insight_id=2,
+            short_id="s2",
+            team_id=2,
+            name="",
+            url="",
+            status="OK",
+            legacy_query_ids=["new_legacy"],
+            dwh_query_ids=["new_dwh"],
+        )
+        command = Command(stdout=StringIO())
+        options = vars(command.create_parser("manage.py", "compare_retention_legacy_vs_dwh").parse_args([]))
+        fresh_stats = {
+            "new_legacy": ResourceStats(400, 4, 100, 2, 1),
+            "new_dwh": ResourceStats(1200, 12, 150, 3, 1),
+        }
+
+        with patch(f"{_QUERY_LOG_MODULE}.fetch_query_log_stats", return_value=fresh_stats):
+            command._attach_resource_stats([already, still_missing], ["new_legacy", "new_dwh"], options)
+
+        assert already.resource_legacy is not None and already.resource_dwh is not None
+        self.assertEqual(already.resource_legacy.read_bytes, 1000)
+        self.assertEqual(already.resource_dwh.read_bytes, 2000)
+        self.assertEqual(already.bytes_ratio, 2.0)
+        assert still_missing.resource_legacy is not None
+        self.assertEqual(still_missing.resource_legacy.read_bytes, 400)
+        self.assertEqual(still_missing.bytes_ratio, 3.0)
+
+
 class TestResourceStats(TestCase):
     def test_parse_query_log_rows(self):
         rows = [("42_x_a", 1000, 50, 9000, 12, 1), ("42_x_b", 2000, 80, 7000, 8, 1)]

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -42,6 +42,7 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     shape_family,
     shape_fingerprint,
     stratified_sample,
+    summarize_regressions_by_shape,
     summarize_samples,
 )
 
@@ -820,6 +821,50 @@ class TestReportDurability(TestCase):
             self._run("s3://retention_compare/perf_report.md")
 
         self.assertIn("# Retention legacy vs DWH-variant comparison", fake.store["retention_compare/perf_report.md"])
+
+
+class TestSummarizeRegressionsByShape(TestCase):
+    @staticmethod
+    def _finding(insight_id, family_period, *, regression, source_json=None):
+        finding = InsightFinding(
+            insight_id=insight_id, short_id=f"s{insight_id}", team_id=1, name="", url="", status="OK"
+        )
+        finding.source_json = (
+            source_json
+            if source_json is not None
+            else json.dumps({"kind": "RetentionQuery", "retentionFilter": {"period": family_period}})
+        )
+        slow = [200.0] if regression else [100.0]
+        finding.perf = compute_perf_result([100.0], slow, [100.0], slow, regression_rel=0.10, regression_ms=50.0)
+        return finding
+
+    def test_only_families_containing_a_regression_are_ranked(self):
+        # The point of grouping is to name the slow builder path; carrying clean families into the
+        # table buries the signal, and ranking that ignores regression count buries broad ones.
+        findings = [
+            self._finding(1, "Day", regression=True),
+            self._finding(2, "Day", regression=True),
+            self._finding(3, "Day", regression=False),
+            self._finding(4, "Week", regression=True),
+            self._finding(5, "Month", regression=False),
+        ]
+
+        rows, omitted = summarize_regressions_by_shape(findings, limit=10)
+
+        self.assertEqual(omitted, 0)
+        self.assertEqual(
+            [(r.family.split()[-1], r.n_compared, r.n_regressions) for r in rows],
+            [("period=Day", 3, 2), ("period=Week", 1, 1)],
+        )
+
+    def test_a_trimmed_query_json_buckets_instead_of_failing_the_report(self):
+        # source_json is trimmed for embedding, so a large query arrives as invalid JSON. This runs
+        # while rendering, so raising here would cost the run its entire report.
+        findings = [self._finding(1, "Day", regression=True, source_json='{"kind": "RetentionQ')]
+
+        rows, _ = summarize_regressions_by_shape(findings, limit=10)
+
+        self.assertEqual([r.family for r in rows], ["(query json trimmed)"])
 
 
 class TestAttachResourceStats(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -2,6 +2,7 @@ import os
 import json
 import tempfile
 from datetime import UTC, datetime, timedelta
+from io import StringIO
 from types import SimpleNamespace
 from typing import Any
 
@@ -15,6 +16,7 @@ from posthog.schema import QueryTiming, RetentionResult, RetentionValue
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     CellDiff,
+    Command,
     CorrectnessDiff,
     InsightFinding,
     ObjectStorageLineSink,
@@ -772,6 +774,52 @@ class TestFetchQueryLogStats(TestCase):
 
         self.assertEqual(batches, [["early", "late"], ["late"]])
         self.assertEqual(sorted(found), ["early", "late"])
+
+
+class TestReportDurability(TestCase):
+    # These runs happen on ephemeral prod pods, and the resource-stats lookup can take minutes:
+    # writing the report only after it meant a pod dying mid-lookup discarded the whole run's
+    # verdict, and a local-only report file dies with the container regardless.
+    @staticmethod
+    def _run(report_path, on_lookup=None):
+        finding = InsightFinding(
+            insight_id=1,
+            short_id="s1",
+            team_id=2,
+            name="",
+            url="",
+            status="OK",
+            legacy_query_ids=["q1"],
+            dwh_query_ids=["q2"],
+        )
+        command = Command(stdout=StringIO())
+        # Parsed rather than hand-built, so the options dict matches what a real invocation passes.
+        options = vars(
+            command.create_parser("manage.py", "compare_retention_legacy_vs_dwh").parse_args(
+                ["--report-path", report_path]
+            )
+        )
+        with (
+            patch.object(Command, "_load_progress", return_value=[finding]),
+            patch.object(Command, "_select_insights", return_value=[]),
+            patch.object(Command, "_attach_resource_stats", side_effect=on_lookup or (lambda *a: None)),
+        ):
+            command.handle(**options)
+
+    def test_report_exists_before_the_resource_stats_lookup_runs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = os.path.join(directory, "report.md")
+            seen: dict[str, Any] = {}
+            self._run(report_path, on_lookup=lambda *a: seen.update(existed=os.path.exists(report_path)))
+
+            self.assertTrue(seen.get("existed"))
+
+    def test_report_can_be_written_to_object_storage(self):
+        fake = FakeObjectStorage()
+        with patch("posthog.management.commands.compare_retention_legacy_vs_dwh.object_storage", fake):
+            self._run("s3://retention_compare/perf_report.md")
+
+        self.assertIn("# Retention legacy vs DWH-variant comparison", fake.store["retention_compare/perf_report.md"])
 
 
 class TestResourceStats(TestCase):

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -3,6 +3,7 @@ import json
 import tempfile
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any
 
 from unittest import TestCase
 from unittest.mock import patch
@@ -678,6 +679,38 @@ class TestFetchQueryLogStats(TestCase):
     @staticmethod
     def _row(query_id):
         return (query_id, 1000, 50, 9000, 12, 1)
+
+    def _capture_query(self, **kwargs):
+        seen: dict[str, Any] = {}
+
+        def fake_execute(query, params):
+            seen["query"] = query
+            seen["params"] = params
+            return []
+
+        with patch(f"{_QUERY_LOG_MODULE}.sync_execute", side_effect=fake_execute):
+            fetch_query_log_stats(["a"], flush=False, wait_seconds=0, **kwargs)
+        return seen
+
+    def test_scopes_the_scan_by_team_and_time_window(self):
+        # query_log_archive is ORDER BY (team_id, event_date, event_time, query_id): filtering on
+        # query_id alone prunes nothing, so the lookup reads the whole retained log and times out.
+        seen = self._capture_query(table="query_log_archive", team_ids=[7, 2, 7], lookback_hours=48)
+
+        self.assertIn("team_id IN %(team_ids)s", seen["query"])
+        self.assertIn("event_date >= toDate(now() - INTERVAL %(lookback_hours)s HOUR)", seen["query"])
+        self.assertIn("event_time > now() - INTERVAL %(lookback_hours)s HOUR", seen["query"])
+        self.assertEqual(seen["params"]["team_ids"], [2, 7])
+        self.assertEqual(seen["params"]["lookback_hours"], 48)
+
+    def test_omits_the_scoping_filters_when_the_table_lacks_those_columns(self):
+        # system.query_log (the local default) has neither team_id nor event_date; emitting them
+        # anyway would fail every local run outright.
+        seen = self._capture_query(table="system.query_log")
+
+        self.assertNotIn("team_id", seen["query"])
+        self.assertNotIn("event_date", seen["query"])
+        self.assertEqual(set(seen["params"]), {"query_ids"})
 
     def test_a_failing_batch_does_not_cost_the_other_batches_their_stats(self):
         batches = []

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from unittest import TestCase
-from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -14,11 +13,9 @@ from posthog.schema import QueryTiming, RetentionResult, RetentionValue
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     CellDiff,
-    Command as CompareCommand,
     CorrectnessDiff,
     InsightFinding,
     ResourceStats,
-    VariantRun,
     _cell_is_trailing,
     _clickhouse_seconds,
     _frozen_date_range,
@@ -36,9 +33,6 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     referenced_ids,
     summarize_samples,
 )
-from posthog.models import Team
-
-from products.product_analytics.backend.models.insight import Insight
 
 _DT = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -67,15 +61,7 @@ def _retention_query(retention_filter):
 class TestClassifyInsight(TestCase):
     @parameterized.expand(
         [
-            ("rolling_24h", {"timeWindowMode": "24_hour_windows"}, "single", "24h"),
-            # The 24h route must win over the data-warehouse skip: a 24h DWH series is the newly
-            # supported shape a sweep should exercise, not classify as fixed-interval new-path-only.
-            (
-                "rolling_24h_dwh_series",
-                {"timeWindowMode": "24_hour_windows", "targetEntity": {"type": "data_warehouse"}},
-                "single",
-                "24h",
-            ),
+            ("rolling_24h", {"timeWindowMode": "24_hour_windows"}, "skip", "24h"),
             ("dwh_target", {"targetEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
             ("dwh_returning", {"returningEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
             ("plain_events", {"targetEntity": {"type": "events"}}, "compare", ""),
@@ -98,65 +84,6 @@ class TestClassifyInsight(TestCase):
     def test_error_classification(self, _name, query):
         action, _reason = classify_insight(_insight(query))
         self.assertEqual(action, "error")
-
-
-def _rolling_24h_insight():
-    # Unsaved team; personsOnEventsMode pinned so modifier defaulting needs no DB or flag lookups.
-    team = Team(pk=1, timezone="UTC", modifiers={"personsOnEventsMode": "person_id_no_override_properties_on_events"})
-    return Insight(
-        id=7,
-        short_id="abc123",
-        team=team,
-        query={
-            "kind": "InsightVizNode",
-            "source": {
-                "kind": "RetentionQuery",
-                "retentionFilter": {
-                    "period": "Day",
-                    "timeWindowMode": "24_hour_windows",
-                    "targetEntity": {"id": "start", "type": "events"},
-                    "returningEntity": {"id": "start", "type": "events"},
-                },
-            },
-        },
-    )
-
-
-_SINGLE_PATH_OPTIONS = {
-    "base_url": "https://us.posthog.com",
-    "max_source_json_chars": 4000,
-    "no_perf": False,
-    "clickhouse_stats": True,
-}
-
-
-class TestProcessInsightSinglePath(TestCase):
-    # A 24h insight misrouted into the A/B comparison doubles its ClickHouse cost for a vacuous
-    # parity verdict; misrouted to skip it loses coverage. The returned status pins the route.
-    def test_clean_run_reports_ok_single(self):
-        run = VariantRun(results=[], hogql="SELECT 1", wall_s=0.1, ch_s=0.05, query_ids=["qid1"])
-        with patch(
-            "posthog.management.commands.compare_retention_legacy_vs_dwh._attempt_variant",
-            return_value=(run, None),
-        ):
-            finding = CompareCommand()._process_insight(_rolling_24h_insight(), "runid", _SINGLE_PATH_OPTIONS)
-        self.assertEqual(finding.status, "OK_SINGLE")
-        self.assertIn("24h", finding.single_path_reason or "")
-        self.assertEqual(finding.dwh_query_ids, ["qid1"])
-        self.assertEqual(finding.legacy_query_ids, [])
-        self.assertIsNone(finding.correctness)
-
-    def test_failed_run_is_error_without_persisted_sql(self):
-        with patch(
-            "posthog.management.commands.compare_retention_legacy_vs_dwh._attempt_variant",
-            return_value=(None, ValueError("rejected by validation")),
-        ):
-            finding = CompareCommand()._process_insight(_rolling_24h_insight(), "runid", _SINGLE_PATH_OPTIONS)
-        self.assertEqual(finding.status, "ERROR")
-        self.assertEqual(finding.error_type, "ValueError")
-        self.assertIn("single-path", finding.error_detail or "")
-        self.assertIsNone(finding.source_json)
-        self.assertIsNone(finding.dwh_hogql)
 
 
 class TestAttributeVariantErrors(TestCase):
@@ -662,23 +589,6 @@ class TestProgressState(TestCase):
             )
         restored = finding_from_dict(json.loads(finding_to_json_line(finding)))
         self.assertEqual(restored, finding)
-
-    def test_single_path_round_trip_and_pre_field_line_still_loads(self):
-        # A progress file written before single_path_reason existed must keep resuming cleanly.
-        finding = InsightFinding(
-            insight_id=9,
-            short_id="s9",
-            team_id=1,
-            name="",
-            url="",
-            status="OK_SINGLE",
-            single_path_reason="24h rolling window",
-            dwh_query_ids=["q1"],
-        )
-        self.assertEqual(finding_from_dict(json.loads(finding_to_json_line(finding))), finding)
-        pre_field_payload = json.loads(finding_to_json_line(finding))
-        del pre_field_payload["single_path_reason"]
-        self.assertIsNone(finding_from_dict(pre_field_payload).single_path_reason)
 
     def test_load_keeps_last_record_per_insight_id(self):
         # A crash between the per-insight append and the end-of-run rewrite leaves an id twice;

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -13,9 +14,11 @@ from posthog.schema import QueryTiming, RetentionResult, RetentionValue
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     CellDiff,
+    Command as CompareCommand,
     CorrectnessDiff,
     InsightFinding,
     ResourceStats,
+    VariantRun,
     _cell_is_trailing,
     _clickhouse_seconds,
     _frozen_date_range,
@@ -33,6 +36,9 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     referenced_ids,
     summarize_samples,
 )
+from posthog.models import Team
+
+from products.product_analytics.backend.models.insight import Insight
 
 _DT = datetime(2024, 1, 1, tzinfo=UTC)
 
@@ -61,7 +67,15 @@ def _retention_query(retention_filter):
 class TestClassifyInsight(TestCase):
     @parameterized.expand(
         [
-            ("rolling_24h", {"timeWindowMode": "24_hour_windows"}, "skip", "24h"),
+            ("rolling_24h", {"timeWindowMode": "24_hour_windows"}, "single", "24h"),
+            # The 24h route must win over the data-warehouse skip: a 24h DWH series is the newly
+            # supported shape a sweep should exercise, not classify as fixed-interval new-path-only.
+            (
+                "rolling_24h_dwh_series",
+                {"timeWindowMode": "24_hour_windows", "targetEntity": {"type": "data_warehouse"}},
+                "single",
+                "24h",
+            ),
             ("dwh_target", {"targetEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
             ("dwh_returning", {"returningEntity": {"type": "data_warehouse"}}, "skip", "data_warehouse"),
             ("plain_events", {"targetEntity": {"type": "events"}}, "compare", ""),
@@ -84,6 +98,65 @@ class TestClassifyInsight(TestCase):
     def test_error_classification(self, _name, query):
         action, _reason = classify_insight(_insight(query))
         self.assertEqual(action, "error")
+
+
+def _rolling_24h_insight():
+    # Unsaved team; personsOnEventsMode pinned so modifier defaulting needs no DB or flag lookups.
+    team = Team(pk=1, timezone="UTC", modifiers={"personsOnEventsMode": "person_id_no_override_properties_on_events"})
+    return Insight(
+        id=7,
+        short_id="abc123",
+        team=team,
+        query={
+            "kind": "InsightVizNode",
+            "source": {
+                "kind": "RetentionQuery",
+                "retentionFilter": {
+                    "period": "Day",
+                    "timeWindowMode": "24_hour_windows",
+                    "targetEntity": {"id": "start", "type": "events"},
+                    "returningEntity": {"id": "start", "type": "events"},
+                },
+            },
+        },
+    )
+
+
+_SINGLE_PATH_OPTIONS = {
+    "base_url": "https://us.posthog.com",
+    "max_source_json_chars": 4000,
+    "no_perf": False,
+    "clickhouse_stats": True,
+}
+
+
+class TestProcessInsightSinglePath(TestCase):
+    # A 24h insight misrouted into the A/B comparison doubles its ClickHouse cost for a vacuous
+    # parity verdict; misrouted to skip it loses coverage. The returned status pins the route.
+    def test_clean_run_reports_ok_single(self):
+        run = VariantRun(results=[], hogql="SELECT 1", wall_s=0.1, ch_s=0.05, query_ids=["qid1"])
+        with patch(
+            "posthog.management.commands.compare_retention_legacy_vs_dwh._attempt_variant",
+            return_value=(run, None),
+        ):
+            finding = CompareCommand()._process_insight(_rolling_24h_insight(), "runid", _SINGLE_PATH_OPTIONS)
+        self.assertEqual(finding.status, "OK_SINGLE")
+        self.assertIn("24h", finding.single_path_reason or "")
+        self.assertEqual(finding.dwh_query_ids, ["qid1"])
+        self.assertEqual(finding.legacy_query_ids, [])
+        self.assertIsNone(finding.correctness)
+
+    def test_failed_run_is_error_without_persisted_sql(self):
+        with patch(
+            "posthog.management.commands.compare_retention_legacy_vs_dwh._attempt_variant",
+            return_value=(None, ValueError("rejected by validation")),
+        ):
+            finding = CompareCommand()._process_insight(_rolling_24h_insight(), "runid", _SINGLE_PATH_OPTIONS)
+        self.assertEqual(finding.status, "ERROR")
+        self.assertEqual(finding.error_type, "ValueError")
+        self.assertIn("single-path", finding.error_detail or "")
+        self.assertIsNone(finding.source_json)
+        self.assertIsNone(finding.dwh_hogql)
 
 
 class TestAttributeVariantErrors(TestCase):
@@ -589,6 +662,23 @@ class TestProgressState(TestCase):
             )
         restored = finding_from_dict(json.loads(finding_to_json_line(finding)))
         self.assertEqual(restored, finding)
+
+    def test_single_path_round_trip_and_pre_field_line_still_loads(self):
+        # A progress file written before single_path_reason existed must keep resuming cleanly.
+        finding = InsightFinding(
+            insight_id=9,
+            short_id="s9",
+            team_id=1,
+            name="",
+            url="",
+            status="OK_SINGLE",
+            single_path_reason="24h rolling window",
+            dwh_query_ids=["q1"],
+        )
+        self.assertEqual(finding_from_dict(json.loads(finding_to_json_line(finding))), finding)
+        pre_field_payload = json.loads(finding_to_json_line(finding))
+        del pre_field_payload["single_path_reason"]
+        self.assertIsNone(finding_from_dict(pre_field_payload).single_path_reason)
 
     def test_load_keeps_last_record_per_insight_id(self):
         # A crash between the per-insight append and the end-of-run rewrite leaves an id twice;

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -1,3 +1,6 @@
+import os
+import json
+import tempfile
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
@@ -9,6 +12,8 @@ from posthog.schema import QueryTiming, RetentionResult, RetentionValue
 
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_OTHER_STRING_LABEL
 from posthog.management.commands.compare_retention_legacy_vs_dwh import (
+    CellDiff,
+    CorrectnessDiff,
     InsightFinding,
     ResourceStats,
     _cell_is_trailing,
@@ -20,7 +25,10 @@ from posthog.management.commands.compare_retention_legacy_vs_dwh import (
     classify_insight,
     compute_perf_result,
     diff_retention_results,
+    finding_from_dict,
+    finding_to_json_line,
     intersect_stable_mismatch,
+    load_progress_findings,
     parse_query_log_rows,
     referenced_ids,
     summarize_samples,
@@ -513,3 +521,85 @@ class TestBuildPerfAggregate(TestCase):
         self.assertEqual(aggregate.n_improvements, 1)
         self.assertEqual(aggregate.wall_ratio_dist["median"], 1.0)
         self.assertEqual(aggregate.worst_by_rel[0].insight_id, 1)
+
+
+class TestProgressState(TestCase):
+    # A field added to any finding dataclass without updating finding_from_dict makes --resume
+    # crash or silently drop recorded work; the full round trip locks the two sides together.
+    def _full_finding(self):
+        finding = InsightFinding(
+            insight_id=7,
+            short_id="abc123",
+            team_id=42,
+            name="Weekly retention",
+            url="https://example.com/insights/abc123",
+            status="MISMATCH",
+            has_breakdown=True,
+            legacy_hogql="SELECT legacy",
+            dwh_hogql="SELECT dwh",
+            legacy_query_ids=["q1", "q2"],
+            dwh_query_ids=["q3"],
+            bytes_ratio=1.5,
+        )
+        cell = CellDiff(
+            breakdown_value="Chrome",
+            row_label="Week 0",
+            value_label="Week 1",
+            field="count",
+            legacy=10.0,
+            dwh=8.0,
+            abs_diff=2.0,
+            rel_diff=-0.2,
+            values_stable=True,
+        )
+        finding.correctness = CorrectnessDiff(
+            status="MISMATCH",
+            row_count_legacy=2,
+            row_count_dwh=1,
+            breakdown_keys_legacy=["Chrome", None],
+            breakdown_keys_dwh=["Chrome"],
+            breakdown_only_legacy=[None],
+            breakdown_only_dwh=[],
+            other_bucket_changed=True,
+            cell_diffs=[cell],
+            notes=["row (breakdown=None, label='Week 1') present in legacy but missing in DWH"],
+            rows_only_legacy=[(None, "Week 1")],
+            rows_only_dwh=[],
+            trailing_cell_diffs=[CellDiff(None, "Week 3", "Week 0", "count", 5.0, 6.0, 1.0, 0.2)],
+        )
+        finding.perf = compute_perf_result(
+            [100.0, 110.0], [150.0, 160.0], [90.0, 95.0], [140.0, 150.0], regression_rel=0.10, regression_ms=50.0
+        )
+        finding.resource_legacy = ResourceStats(1000, 10, 100, 5, 1)
+        finding.resource_dwh = ResourceStats(2000, 20, 200, 10, 2)
+        return finding
+
+    @parameterized.expand(
+        [
+            ("fully_populated", True),
+            ("skipped_all_optionals_none", False),
+        ]
+    )
+    def test_json_line_round_trip(self, _name, full):
+        if full:
+            finding = self._full_finding()
+        else:
+            finding = InsightFinding(
+                insight_id=1, short_id="s1", team_id=1, name="", url="", status="SKIPPED", skip_reason="24h"
+            )
+        restored = finding_from_dict(json.loads(finding_to_json_line(finding)))
+        self.assertEqual(restored, finding)
+
+    def test_load_keeps_last_record_per_insight_id(self):
+        # A crash between the per-insight append and the end-of-run rewrite leaves an id twice;
+        # double-counting it would inflate the report and the resume skip set.
+        stale = self._full_finding()
+        other = InsightFinding(insight_id=8, short_id="def456", team_id=42, name="", url="", status="OK")
+        updated = InsightFinding(insight_id=7, short_id="abc123", team_id=42, name="", url="", status="OK")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "progress.jsonl")
+            with open(path, "w") as handle:
+                for finding in (stale, other, updated):
+                    handle.write(finding_to_json_line(finding) + "\n")
+            loaded = load_progress_findings(path)
+        self.assertEqual({f.insight_id: f.status for f in loaded}, {7: "OK", 8: "OK"})

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/actions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ActionsCreateBody,
     ActionsDestroyParams,
@@ -16,6 +10,10 @@ import {
     ActionsPartialUpdateParams,
     ActionsRetrieveParams,
 } from '@/generated/actions/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ActionCreateSchema = ActionsCreateBody.omit({ _create_in_folder: true }).extend({
     name: ActionsCreateBody.shape['name'].describe('Name of the action (must be unique within the project)'),

--- a/services/mcp/src/tools/generated/agent_platform.ts
+++ b/services/mcp/src/tools/generated/agent_platform.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/agent_platform.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AgentApplicationsCreateBody,
     AgentApplicationsDestroyParams,
@@ -66,6 +63,7 @@ import {
     AgentRevisionsEnvKeysGetParams,
     AgentRevisionsEnvKeysListParams,
 } from '@/generated/agent_platform/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AgentApplicationsCreateSchema = AgentApplicationsCreateBody
 

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/ai_observability/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
-
 import {
     EvaluationRunsCreateBody,
     EvaluationsCreateBody,
@@ -77,6 +72,9 @@ import {
     TaggersListQueryParams,
     TaggersTestHogCreateBody,
 } from '@/generated/ai_observability/api'
+import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LlmaClusteringConfigGetSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/alerts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AlertsCreateBody,
     AlertsDestroyParams,
@@ -16,6 +12,8 @@ import {
     AlertsRetrieveQueryParams,
     AlertsSimulateCreateBody,
 } from '@/generated/alerts/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AlertCreateSchema = AlertsCreateBody
 

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/annotations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     AnnotationsCreateBody,
     AnnotationsDestroyParams,
@@ -15,6 +10,9 @@ import {
     AnnotationsPartialUpdateParams,
     AnnotationsRetrieveParams,
 } from '@/generated/annotations/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AnnotationCreateSchema = AnnotationsCreateBody.omit({
     creation_type: true,

--- a/services/mcp/src/tools/generated/batch_exports.ts
+++ b/services/mcp/src/tools/generated/batch_exports.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/batch_exports/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     BatchExportsCreateBody,
     BatchExportsDestroyParams,
@@ -18,6 +14,8 @@ import {
     FileDownloadBatchExportsCreateBody,
     FileDownloadBatchExportsRetrieveParams,
 } from '@/generated/batch_exports/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BatchExportCreateSchema = BatchExportsCreateBody
 

--- a/services/mcp/src/tools/generated/business_knowledge.ts
+++ b/services/mcp/src/tools/generated/business_knowledge.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/business_knowledge/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
-
 import {
     BusinessKnowledgeDocumentsSearchListQueryParams,
     BusinessKnowledgeDocumentsWindowListParams,
@@ -17,6 +12,9 @@ import {
     BusinessKnowledgeSourcesPartialUpdateParams,
     BusinessKnowledgeSourcesRetrieveParams,
 } from '@/generated/business_knowledge/api'
+import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BusinessKnowledgeDocumentWindowRetrieveSchema = BusinessKnowledgeDocumentsWindowListParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/cdp_function_templates.ts
+++ b/services/mcp/src/tools/generated/cdp_function_templates.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_function_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionTemplatesListQueryParams,
     HogFunctionTemplatesRetrieveParams,
 } from '@/generated/cdp_function_templates/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionTemplatesListSchema = HogFunctionTemplatesListQueryParams
 

--- a/services/mcp/src/tools/generated/cdp_functions.ts
+++ b/services/mcp/src/tools/generated/cdp_functions.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_functions.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -21,6 +17,8 @@ import {
     HogFunctionsRearrangePartialUpdateBody,
     HogFunctionsRetrieveParams,
 } from '@/generated/cdp_functions/api'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/cohorts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     CohortsAddPersonsToStaticCohortPartialUpdateBody,
     CohortsAddPersonsToStaticCohortPartialUpdateParams,
@@ -19,6 +13,10 @@ import {
     CohortsRemovePersonFromStaticCohortPartialUpdateParams,
     CohortsRetrieveParams,
 } from '@/generated/cohorts/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CohortsAddPersonsToStaticCohortPartialUpdateSchema = CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/conversations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ConversationsTicketsListQueryParams,
     ConversationsTicketsMessagesListParams,
@@ -17,6 +13,8 @@ import {
     ConversationsTicketsRetrieveParams,
     ConversationsViewsListQueryParams,
 } from '@/generated/conversations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ConversationsTicketsListSchema = ConversationsTicketsListQueryParams
 

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/core.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DesktopFileSystemCanvasPartialUpdateBody,
     DesktopFileSystemCanvasPartialUpdateParams,
@@ -23,6 +18,9 @@ import {
     UsersPartialUpdateParams,
     UsersRetrieveParams,
 } from '@/generated/core/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
     .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/customer_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
-
 import {
     AccountRelationshipDefinitionsCreateBody,
     AccountRelationshipDefinitionsDestroyParams,
@@ -59,6 +54,9 @@ import {
     GroupsTypesMetricsPartialUpdateParams,
     GroupsTypesMetricsRetrieveParams,
 } from '@/generated/customer_analytics/api'
+import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AccountRelationshipDefinitionsCreateSchema = AccountRelationshipDefinitionsCreateBody
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -1,18 +1,7 @@
 // AUTO-GENERATED from products/dashboards/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    omitResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DashboardTemplatesListQueryParams,
     DashboardTemplatesRetrieveParams,
@@ -46,6 +35,15 @@ import {
     DashboardsWidgetsBatchCreateBody,
     DashboardsWidgetsBatchCreateParams,
 } from '@/generated/dashboards/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import {
+    withPostHogUrl,
+    omitResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DashboardCreateSchema = DashboardsCreateQueryParams.omit({ format: true }).extend(DashboardsCreateBody.shape)
 

--- a/services/mcp/src/tools/generated/data_catalog.ts
+++ b/services/mcp/src/tools/generated/data_catalog.ts
@@ -1,16 +1,7 @@
 // AUTO-GENERATED from products/data_catalog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     DataCatalogCertificationsCertifyCreateParams,
     DataCatalogCertificationsCreateBody,
@@ -27,6 +18,13 @@ import {
     DataCatalogRelationshipProposalsRejectCreateBody,
     DataCatalogRelationshipProposalsRejectCreateParams,
 } from '@/generated/data_catalog/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataCatalogCertificationCertifySchema = DataCatalogCertificationsCertifyCreateParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/data_management.ts
+++ b/services/mcp/src/tools/generated/data_management.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/data_management.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { IngestionWarningsV2ListQueryParams } from '@/generated/data_management/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IngestionWarningsListSchema = IngestionWarningsV2ListQueryParams
 

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/data_warehouse/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     InsightVariablesCreateBody,
     InsightVariablesDestroyParams,
@@ -32,6 +28,8 @@ import {
     WarehouseSavedQueriesRunHistoryRetrieveParams,
     WarehouseTablesRefreshSchemaCreateParams,
 } from '@/generated/data_warehouse/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SavedQueryColumnAnnotationsCreateSchema = SavedQueryColumnAnnotationsCreateBody.extend({
     column_name: SavedQueryColumnAnnotationsCreateBody.shape['column_name'].describe(

--- a/services/mcp/src/tools/generated/docs.ts
+++ b/services/mcp/src/tools/generated/docs.ts
@@ -1,11 +1,9 @@
 // AUTO-GENERATED from services/mcp/definitions/docs.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import { DocsSearchBody } from '@/generated/docs/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DocsSearchSchema = DocsSearchBody
 

--- a/services/mcp/src/tools/generated/early_access_features.ts
+++ b/services/mcp/src/tools/generated/early_access_features.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/early_access_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EarlyAccessFeatureCreateBody,
     EarlyAccessFeatureDestroyParams,
@@ -14,6 +10,8 @@ import {
     EarlyAccessFeaturePartialUpdateParams,
     EarlyAccessFeatureRetrieveParams,
 } from '@/generated/early_access_features/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EarlyAccessFeatureCreateSchema = EarlyAccessFeatureCreateBody.omit({ _create_in_folder: true })
 

--- a/services/mcp/src/tools/generated/email_templates.ts
+++ b/services/mcp/src/tools/generated/email_templates.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/email_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
-
 import {
     MessagingTemplatesCreateBody,
     MessagingTemplatesListQueryParams,
@@ -15,6 +9,10 @@ import {
     MessagingTemplatesPartialUpdateParams,
     MessagingTemplatesRetrieveParams,
 } from '@/generated/email_templates/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateEmailTemplateSchema = MessagingTemplatesCreateBody
 

--- a/services/mcp/src/tools/generated/endpoints.ts
+++ b/services/mcp/src/tools/generated/endpoints.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/endpoints/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EndpointsCreateBody,
     EndpointsDestroyParams,
@@ -28,6 +24,8 @@ import {
     EndpointsVersionsListParams,
     EndpointsVersionsListQueryParams,
 } from '@/generated/endpoints/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EndpointCreateSchema = EndpointsCreateBody.omit({
     is_active: true,

--- a/services/mcp/src/tools/generated/engineering_analytics.ts
+++ b/services/mcp/src/tools/generated/engineering_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/engineering_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EngineeringAnalyticsBrokenTestsQueryParams,
     EngineeringAnalyticsCiFailureLogsQueryParams,
@@ -19,6 +15,8 @@ import {
     EngineeringAnalyticsWorkflowJobsQueryParams,
     EngineeringAnalyticsWorkflowRunnerCostsQueryParams,
 } from '@/generated/engineering_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EngineeringAnalyticsBrokenTestsSchema = EngineeringAnalyticsBrokenTestsQueryParams
 

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     ErrorTrackingAssignmentRulesCreateBody,
     ErrorTrackingAssignmentRulesListQueryParams,
@@ -37,6 +32,9 @@ import {
     ErrorTrackingSymbolSetsListQueryParams,
     ErrorTrackingSymbolSetsRetrieveParams,
 } from '@/generated/error_tracking/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAssignmentRulesCreateSchema = ErrorTrackingAssignmentRulesCreateBody
 

--- a/services/mcp/src/tools/generated/error_tracking_alerts.ts
+++ b/services/mcp/src/tools/generated/error_tracking_alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/error_tracking_alerts.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -13,6 +9,8 @@ import {
     HogFunctionsPartialUpdateBody,
     HogFunctionsPartialUpdateParams,
 } from '@/generated/error_tracking_alerts/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAlertsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/experiments/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ExperimentHoldoutsCreateBody,
     ExperimentHoldoutsDestroyParams,
@@ -49,6 +42,11 @@ import {
     ExperimentsUnarchiveCreateParams,
     ExperimentsUnfreezeExposureCreateParams,
 } from '@/generated/experiments/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ExperimentArchiveSchema = ExperimentsArchiveCreateParams.omit({ project_id: true })
     .extend(ExperimentsArchiveCreateBody.shape)

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/feature_flags/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     FeatureFlagsActivityRetrieveParams,
     FeatureFlagsActivityRetrieveQueryParams,
@@ -36,6 +29,11 @@ import {
     ScheduledChangesPartialUpdateParams,
     ScheduledChangesRetrieveParams,
 } from '@/generated/feature_flags/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CreateFeatureFlagSchema = FeatureFlagsCreateBody.omit({ archived: true }).extend({
     is_remote_configuration: FeatureFlagsCreateBody.shape['is_remote_configuration'].describe(

--- a/services/mcp/src/tools/generated/field_notes.ts
+++ b/services/mcp/src/tools/generated/field_notes.ts
@@ -1,17 +1,15 @@
 // AUTO-GENERATED from products/field_notes/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     FieldNotesListQueryParams,
     FieldNotesPartialUpdateBody,
     FieldNotesPartialUpdateParams,
     FieldNotesRetrieveParams,
 } from '@/generated/field_notes/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const FieldNotesGetSchema = FieldNotesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/health_issues.ts
+++ b/services/mcp/src/tools/generated/health_issues.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/health_issues.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { HealthIssuesListQueryParams, HealthIssuesRetrieveParams } from '@/generated/health_issues/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HealthIssuesGetSchema = HealthIssuesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/integrations.ts
+++ b/services/mcp/src/tools/generated/integrations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/integrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     IntegrationsChannelsRetrieveParams,
     IntegrationsChannelsRetrieveQueryParams,
@@ -17,6 +13,8 @@ import {
     IntegrationsListQueryParams,
     IntegrationsRetrieveParams,
 } from '@/generated/integrations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IntegrationDeleteSchema = IntegrationsDestroyParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/logs/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LogsAlertsCreateBody,
     LogsAlertsDestinationsCreateBody,
@@ -31,6 +27,8 @@ import {
     LogsSparklineCreateBody,
     LogsValuesRetrieveQueryParams,
 } from '@/generated/logs/api'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LogsAlertsCreateSchema = LogsAlertsCreateBody
 

--- a/services/mcp/src/tools/generated/managed_migrations.ts
+++ b/services/mcp/src/tools/generated/managed_migrations.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/managed_migrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ManagedMigrationsSupportListQueryParams,
     ManagedMigrationsSupportRetrieveParams,
 } from '@/generated/managed_migrations/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ManagedMigrationsSupportGetSchema = ManagedMigrationsSupportRetrieveParams
 

--- a/services/mcp/src/tools/generated/marketing_analytics.ts
+++ b/services/mcp/src/tools/generated/marketing_analytics.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/marketing_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MarketingAnalyticsDataSourcesRetrieveQueryParams,
     MarketingAnalyticsDiagnoseRetrieveQueryParams,
@@ -13,6 +10,7 @@ import {
     MarketingAnalyticsSuggestUtmMappingsRetrieveQueryParams,
     MarketingAnalyticsUtmAuditRetrieveQueryParams,
 } from '@/generated/marketing_analytics/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const MarketingAnalyticsConversionGoalsSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/mcp_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     McpAnalyticsFeedbackCreateBody,
     McpAnalyticsMissingCapabilitiesCreateBody,
@@ -16,6 +11,9 @@ import {
     McpAnalyticsSessionsToolCallsParams,
     McpAnalyticsSessionsToolCallsQueryParams,
 } from '@/generated/mcp_analytics/api'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpAnalyticsIntentClustersRecomputeSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_store.ts
+++ b/services/mcp/src/tools/generated/mcp_store.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/mcp_store/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     McpServerInstallationsListQueryParams,
     McpServerInstallationsToolsRetrieveParams,
 } from '@/generated/mcp_store/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpConnectionToolsListSchema = McpServerInstallationsToolsRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/metrics.ts
+++ b/services/mcp/src/tools/generated/metrics.ts
@@ -1,16 +1,14 @@
 // AUTO-GENERATED from products/metrics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MetricsCharacterizeCreateBody,
     MetricsQueryCreateBody,
     MetricsValuesRetrieveQueryParams,
 } from '@/generated/metrics/api'
+import { pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CharacterizeMetricAnomalySchema = MetricsCharacterizeCreateBody
 

--- a/services/mcp/src/tools/generated/notebooks.ts
+++ b/services/mcp/src/tools/generated/notebooks.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/notebooks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     NotebooksCreateBody,
     NotebooksDestroyParams,
@@ -14,6 +10,8 @@ import {
     NotebooksPartialUpdateParams,
     NotebooksRetrieveParams,
 } from '@/generated/notebooks/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const NotebooksCreateSchema = NotebooksCreateBody
 

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/persons/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     PersonsBulkDeleteCreateBody,
     PersonsCohortsRetrieveQueryParams,
@@ -18,6 +13,9 @@ import {
     PersonsUpdatePropertyCreateParams,
     PersonsValuesRetrieveQueryParams,
 } from '@/generated/persons/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PersonsBulkDeleteSchema = PersonsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -1,23 +1,7 @@
 // AUTO-GENERATED from products/platform_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     AdvancedActivityLogsListQueryParams,
     ApprovalPoliciesListQueryParams,
@@ -45,6 +29,20 @@ import {
     UserHomeSettingsPartialUpdateParams,
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import {
+    withPostHogUrl,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AdvancedActivityLogsFiltersSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/product_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
-
 import {
     ElementsStatsRetrieveQueryParams,
     InsightsActivityRetrieveParams,
@@ -21,6 +16,9 @@ import {
     InsightsRetrieveQueryParams,
     InsightsTrendingRetrieveQueryParams,
 } from '@/generated/product_analytics/api'
+import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AssistantInsightVizNode = z.object({
     kind: z.literal('InsightVizNode').default('InsightVizNode'),

--- a/services/mcp/src/tools/generated/proxy-records.ts
+++ b/services/mcp/src/tools/generated/proxy-records.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/proxy-records.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ProxyRecordsCreateBody,
     ProxyRecordsDestroyParams,
@@ -13,6 +9,8 @@ import {
     ProxyRecordsRetrieveParams,
     ProxyRecordsRetryCreateParams,
 } from '@/generated/proxy-records/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ProxyCreateSchema = ProxyRecordsCreateBody
 

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1,8 +1,8 @@
 // AUTO-GENERATED from services/mcp/definitions/query-wrappers.yaml + schema.json — do not edit
 import { z } from 'zod'
 
-import type { ZodObjectAny } from '@/tools/types'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import type { ZodObjectAny } from '@/tools/types'
 
 // --- Shared Zod schemas generated from schema.json ---
 

--- a/services/mcp/src/tools/generated/reminders.ts
+++ b/services/mcp/src/tools/generated/reminders.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/reminders/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     RemindersCreateBody,
     RemindersDestroyParams,
@@ -14,6 +10,8 @@ import {
     RemindersPartialUpdateParams,
     RemindersRetrieveParams,
 } from '@/generated/reminders/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ReminderCreateSchema = RemindersCreateBody
 

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/replay/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     SessionRecordingPlaylistsCreateBody,
     SessionRecordingPlaylistsListQueryParams,
@@ -20,6 +14,10 @@ import {
     SingleSessionSummariesListQueryParams,
     SingleSessionSummariesRetrieveParams,
 } from '@/generated/replay/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SessionRecordingBulkDeleteSchema = SessionRecordingsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/replay_vision/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     VisionActionsListQueryParams,
     VisionActionsRetrieveParams,
@@ -43,6 +39,8 @@ import {
     VisionScannersPromptSuggestionsGenerateCreateParams,
     VisionScannersRetrieveParams,
 } from '@/generated/replay_vision/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisionActionsListSchema = VisionActionsListQueryParams
 

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -1,19 +1,7 @@
 // AUTO-GENERATED from products/signals/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    withAgentNote,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithAgentNote,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     SignalsReportArtefactsCreateBody,
     SignalsReportArtefactsCreateParams,
@@ -62,6 +50,16 @@ import {
     SignalsSourceConfigsUpdateBody,
     SignalsSourceConfigsUpdateParams,
 } from '@/generated/signals/api'
+import {
+    withPostHogUrl,
+    withAgentNote,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithAgentNote,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const InboxReportArtefactsCreateSchema = SignalsReportArtefactsCreateParams.omit({ project_id: true }).extend(
     SignalsReportArtefactsCreateBody.shape

--- a/services/mcp/src/tools/generated/skills.ts
+++ b/services/mcp/src/tools/generated/skills.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/skills/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LlmSkillsCreateBody,
     LlmSkillsListQueryParams,
@@ -25,6 +22,7 @@ import {
     LlmSkillsNameRetrieveParams,
     LlmSkillsNameRetrieveQueryParams,
 } from '@/generated/skills/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SkillArchiveSchema = LlmSkillsNameArchiveCreateParams.omit({ project_id: true }).extend({
     skill_name: LlmSkillsNameArchiveCreateParams.shape['skill_name'].describe(

--- a/services/mcp/src/tools/generated/stamphog.ts
+++ b/services/mcp/src/tools/generated/stamphog.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/stamphog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     StamphogDigestChannelsCreateBody,
     StamphogDigestChannelsDestroyParams,
@@ -19,6 +15,8 @@ import {
     StamphogReviewRunsListQueryParams,
     StamphogReviewRunsRetrieveParams,
 } from '@/generated/stamphog/api'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const StamphogDigestChannelsCreateSchema = StamphogDigestChannelsCreateBody
 

--- a/services/mcp/src/tools/generated/subscriptions.ts
+++ b/services/mcp/src/tools/generated/subscriptions.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/subscriptions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     SubscriptionsCreateBody,
     SubscriptionsDeliveriesListParams,
@@ -19,6 +14,9 @@ import {
     SubscriptionsRetrieveParams,
     SubscriptionsTestDeliveryCreateParams,
 } from '@/generated/subscriptions/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SubscriptionsCreateSchema = SubscriptionsCreateBody
 

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/surveys/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     SurveysCreateBody,
     SurveysDestroyParams,
@@ -25,6 +20,9 @@ import {
     SurveysSummarizeResponsesCreateParams,
     SurveysSummarizeResponsesCreateQueryParams,
 } from '@/generated/surveys/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SurveyCreateSchema = SurveysCreateBody.omit({
     linked_insight_id: true,

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -1,17 +1,7 @@
 // AUTO-GENERATED from products/tasks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     LoopsCreateBody,
     LoopsDestroyParams,
@@ -33,6 +23,14 @@ import {
     TasksRunsSessionLogsRetrieveParams,
     TasksRunsSessionLogsRetrieveQueryParams,
 } from '@/generated/tasks/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LoopsCreateSchema = LoopsCreateBody
 

--- a/services/mcp/src/tools/generated/tracing.ts
+++ b/services/mcp/src/tools/generated/tracing.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/tracing/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     TracingSpansAggregateCreateBody,
     TracingSpansAttributeBreakdownCreateBody,
@@ -22,6 +17,9 @@ import {
     TracingSpansTreeCreateBody,
     TracingSpansValuesRetrieveQueryParams,
 } from '@/generated/tracing/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ApmAttributeBreakdownSchema = TracingSpansAttributeBreakdownCreateBody
 

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/user_interviews/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     UserInterviewTopicsAddIntervieweeCreateBody,
     UserInterviewTopicsAddIntervieweeCreateParams,
@@ -38,6 +33,9 @@ import {
     UserInterviewsRetrieveParams,
     UserInterviewsSearchCreateBody,
 } from '@/generated/user_interviews/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const UserInterviewTopicsAddIntervieweeSchema = UserInterviewTopicsAddIntervieweeCreateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/visual_review.ts
+++ b/services/mcp/src/tools/generated/visual_review.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/visual_review/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     VisualReviewReposListQueryParams,
     VisualReviewReposRetrieveParams,
@@ -25,6 +20,9 @@ import {
     VisualReviewRunsToleratedHashesListParams,
     VisualReviewRunsToleratedHashesListQueryParams,
 } from '@/generated/visual_review/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisualReviewReposListSchema = VisualReviewReposListQueryParams
 

--- a/services/mcp/src/tools/generated/warehouse_sources.ts
+++ b/services/mcp/src/tools/generated/warehouse_sources.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/warehouse_sources/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
-
 import {
     ExternalDataSchemasCancelCreateParams,
     ExternalDataSchemasDeleteDataDestroyParams,
@@ -43,6 +38,9 @@ import {
     ExternalDataSourcesWebhookInfoRetrieveParams,
     ExternalDataSourcesWizardRetrieveQueryParams,
 } from '@/generated/warehouse_sources/api'
+import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataWarehouseSourceConnectLinkSchema = ExternalDataSourcesConnectLinkRetrieveQueryParams.extend({
     source_type: ExternalDataSourceTypeSchema,

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/web_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HeatmapsEventsRetrieveQueryParams,
     HeatmapsListQueryParams,
@@ -17,6 +13,8 @@ import {
     SavedRetrieveParams,
     WebAnalyticsWeeklyDigestQueryParams,
 } from '@/generated/web_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HeatmapsEventsSchema = HeatmapsEventsRetrieveQueryParams
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
-
 import {
     HogFlowsBatchJobsListParams,
     HogFlowsCreateBody,
@@ -36,6 +30,10 @@ import {
     HogFlowsSchedulesPartialUpdateBody,
     HogFlowsSchedulesPartialUpdateParams,
 } from '@/generated/workflows/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateSchema = HogFlowsCreateBody
 


### PR DESCRIPTION
## TL;DR

Retention has an old (legacy) query and a new "DWH variant" behind a flag. These read-only commands run both variants on real saved insights, check the results match, and compare speed and ClickHouse cost, so we know flipping the flag is safe. Not for merging: the files get copied onto a prod pod and run by hand.

## Problem

The retention fixed-interval base query has two implementations: the legacy single-pass query and a new "DWH variant" (a drop-in replacement that also supports data-warehouse series), gated behind the `retention-fixed-interval-base-query-dwh-variant` flag. Before rolling the flag out broadly we want confidence that the new path returns identical results to legacy across real insights and doesn't regress performance. There was no tooling to check this at scale.

## Changes

A new read-only management command, `compare_retention_legacy_vs_dwh`, that for each affected retention insight:

- Runs the query twice with the variant toggle patched off (legacy) and on (new), then **diffs results** — keyed by `(breakdown_value, label)`, reporting per-cell count/aggregation differences and breakdown-set / "Other"-bucket membership changes. Breakdown retention (a known parity gap) is surfaced rather than skipped, since that's where regressions are most likely.
- **Benchmarks performance** with an interleaved multi-iteration protocol: per-insight min/median/p95 plus a new/legacy ratio, a cross-insight ratio distribution, and a ranked regression list. It also reads per-query `read_bytes` / `read_rows` / `memory_usage` back from the query log (`system.query_log` locally, `query_log_archive` on prod clusters) — a load-independent cost signal that doesn't depend on cache or cluster state.
- Emits a self-contained Markdown report — each finding carries the insight URL, the query JSON, and both generated HogQL variants, so a single block can be pasted into another tool to diagnose a regression — plus optional JSON.

Insights the toggle can't affect — data-warehouse retention (always new-path) and the 24h rolling window (a different builder with no legacy/new split) — are detected and skipped. The command never mutates anything.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated checks only:

- 86 unit tests across both commands' pure helpers (result diffing, timing stats, insight classification, progress-state round-trips, query-log row parsing/aggregation) — all passing.
- `ruff check` and `ruff format` — clean.
- Verified the module imports and the argument parser builds and parses under Django, including the `--clickhouse-stats` / `--no-clickhouse-stats` boolean toggles and the repeatable `--insight-id`.

I did **not** run it end-to-end against ClickHouse — that needs an environment with retention data and query-log access, which wasn't available here. The live execution and query-log lookup path is therefore unverified and should be smoke-tested by a human (an events insight should classify `OK` with `read_bytes` captured; a data-warehouse insight should be skipped).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal validation tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8), directed by the assignee. Codebase research and design were done with Explore and Plan subagents, then implemented directly.

No mandatory skills applied — this is a standalone management command, not a DRF endpoint, migration, or frontend API consumer. Notable decisions:

- Reused the existing `RETENTION_BASE_QUERY_VARIANT_PATCH_PATH` constant as the patch target so the comparison can't drift from the real toggle, and confirmed the variant test mixin already treats breakdown retention as a known parity gap (hence surfacing, not skipping, breakdowns).
- Correlate each `.calculate()` to its query-log rows by capturing the generated ClickHouse `query_id`s and filtering `is_initial_query = 1`, which avoids double-counting distributed sub-queries on a cluster.
- Chose `read_bytes`/memory from the query log as the primary performance signal over wall-clock (which varies with cache and load); wall-clock and ClickHouse-execute time are kept as cross-checks, and the report header documents the warm-cache caveat.


---

## Update 2026-07-29: recheck hardened against replica-skew false positives

A prod sweep reported two insights as MISMATCH with "value-identical (deterministic)" cell diffs. Root-causing them showed no query bug: the exact executed query pairs (pulled from `system.query_log`) returned identical results once the data settled, and the WHERE shapes are boolean-equivalent. The differences came from replicas serving divergent part sets while a merge campaign rewrote old partitions; the tool's fixed legacy→dwh→legacy→dwh cadence phase-locked each variant onto one replica state, so the skew reproduced value-identically across the recheck and looked deterministic.

Changes:

- The recheck now runs the variants in reversed order (dwh first). Replica skew then surfaces as moved values → classified as churn; a genuine query difference still reproduces value-identically → classified as deterministic.
- Sweeps with `--state-file` re-verify all previously accumulated mismatches at the start of each run (typically hours later, after data settles). Records that stop reproducing move to a `resolved_mismatches` list and counts shift from MISMATCH to the settled status. Re-running an already-complete sweep performs just this revalidation pass.

---

## Update 2026-07-30: full-sweep progress state

For running the comparison over *all* retention insights: `--all` processes every matching insight (the default `--limit 100` silently capped a sweep at the 100 oldest). `--progress-path file.jsonl` appends each finding the moment its insight finishes, and `--resume` continues an interrupted sweep, folding the recorded findings into the final report. A heartbeat line every 10 insights shows elapsed time and ETA.

24h rolling window insights stay skipped: they have no legacy/new split to A/B (their builder routes by series type, not by the flag), so running them would add query cost without any parity signal. A single-path health-check run for them was added and then reverted on the branch.



`compare_retention_correctness` now takes the same `--all` flag: every matching insight in one run, ignoring `--limit`. With `--state-file` it drains everything past the cursor and marks the sweep complete. It also gets the same heartbeat: an elapsed/ETA line with running counts every 10 insights, since per-row output stays quiet on OK.

Interrupted `compare_retention_correctness` runs now resume: with `--state-file`, every finished insight is appended to `<state-file>.journal` the moment it completes, and the next run skips journaled insights and folds their results back in (the concurrent per-team lanes leave completed ids scattered, so the keyset cursor alone can't describe an interrupt point). Re-running the same command continues where it stopped; the journal is absorbed into the state file when the batch finishes. `--all --state-file sweep.json` is therefore a single Ctrl-C-safe run.


