### PR TITLE
feat(signals): fleet-wide default_team_config for scout tick caps

### DIFF
--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -50,15 +50,20 @@ MAX_RUNS_PER_TICK = 1000
 # per day: cap × ticks/day), so a team registering many scouts degrades its own cadence,
 # not everyone else's. Sized well above the canonical fleet (~16 scouts) so a fully-enrolled
 # team is never trimmed; round-robin allocation still keeps any one team from starving the
-# others even when this is close to the global cap. This is the DEFAULT — a per-team override
-# takes precedence when set in the `signals-scout` flag payload under `team_configs` (see
-# `_team_configs`), to give an important dogfooder more headroom or hold a noisy one lower,
-# no deploy.
+# others even when this is close to the global cap.
+#
+# This is the LAST-RESORT default. Effective per-team cap resolves through three layers,
+# most specific first (see `_resolve_max_runs_per_tick`): a team's own `team_configs` entry →
+# the fleet-wide `default_team_config` → this code constant. The two flag layers are read
+# fresh each tick, so the launch posture (e.g. cap every enrolled team at 1 run/tick via
+# `default_team_config`, then hand a close partner more headroom via `team_configs`) is
+# tunable in the flag UI with no deploy.
 MAX_RUNS_PER_TEAM_PER_TICK = 50
 
-# Key inside a team's `team_configs` entry that overrides `MAX_RUNS_PER_TEAM_PER_TICK` for that
-# team. `team_configs` is a forward-looking per-team override bag — add more keys here as other
-# settings become per-team-tunable; each consumer reads + validates the key it cares about.
+# Key inside a `team_configs` entry (or the `default_team_config` blob) that overrides
+# `MAX_RUNS_PER_TEAM_PER_TICK`. Both blobs share the same inner shape — a forward-looking
+# override bag — so add more per-team-tunable settings here and each consumer reads + validates
+# the key it cares about.
 TEAM_CONFIG_MAX_RUNS_PER_TICK = "max_runs_per_tick"
 
 # Coordinator tick cadence. Per-scout schedules are enforced via the due-check, so this is
@@ -129,8 +134,9 @@ async def fetch_enabled_signals_scout_runs_activity(
         payload = await asyncio.to_thread(_read_flag_payload)
         enrolled_team_ids = _enrolled_team_ids(payload)
         team_configs = _team_configs(payload)
+        default_team_config = _default_team_config(payload)
         planned = await database_sync_to_async(_collect_planned_runs, thread_sensitive=False)(
-            enrolled_team_ids, team_configs
+            enrolled_team_ids, team_configs, default_team_config
         )
     logger.info("signals_scout coordinator: planned runs", count=len(planned))
     return FetchEnabledRunsOutput(planned_runs=planned)
@@ -172,11 +178,15 @@ class _DueRun:
     skill_name: str
 
 
-def _collect_planned_runs(enrolled_team_ids: set[int], team_configs: dict[int, dict] | None = None) -> list[PlannedRun]:
+def _collect_planned_runs(
+    enrolled_team_ids: set[int],
+    team_configs: dict[int, dict] | None = None,
+    default_team_config: dict | None = None,
+) -> list[PlannedRun]:
     """Sync DB scan. Runs in a worker thread via Django's per-thread connection mgmt.
 
-    Takes the already-resolved enrolled team ids (and optional per-team config overrides) so
-    the flag reads stay off this DB pool.
+    Takes the already-resolved enrolled team ids, the optional per-team config overrides, and
+    the fleet-wide default config so the flag reads stay off this DB pool.
     """
     now = timezone.now()
     team_configs = _canonicalize_team_config_keys(team_configs or {})
@@ -208,32 +218,32 @@ def _collect_planned_runs(enrolled_team_ids: set[int], team_configs: dict[int, d
     if not due:
         return []
 
-    selected = _allocate_tick_budget(due, team_configs)
+    selected = _allocate_tick_budget(due, team_configs, default_team_config)
     planned = [PlannedRun(team_id=d.team_id, skill_name=d.skill_name) for d in selected]
     # Stable order for predictable child-workflow ids within the tick.
     planned.sort(key=lambda p: (p.team_id, p.skill_name))
     return planned
 
 
-def _allocate_tick_budget(due: list[_DueRun], team_configs: dict[int, dict] | None = None) -> list[_DueRun]:
+def _allocate_tick_budget(
+    due: list[_DueRun],
+    team_configs: dict[int, dict] | None = None,
+    default_team_config: dict | None = None,
+) -> list[_DueRun]:
     """Apply the per-team and global tick caps fairly. Deterministic — no sampling.
 
-    Each team's due runs are ordered most-overdue-first and trimmed to its per-team cap — the
-    `max_runs_per_tick` from its `team_configs` flag override if set, else
-    `MAX_RUNS_PER_TEAM_PER_TICK`; the global `MAX_RUNS_PER_TICK` budget is then filled
-    round-robin across teams (one run per team per round) so a single team with many due scouts
-    can't monopolize the tick. Deferred runs stay unstamped, so they're the most overdue next
-    tick — a poor-man's queue, same catch-up semantics as before.
+    Each team's due runs are ordered most-overdue-first and trimmed to its per-team cap,
+    resolved per `_resolve_max_runs_per_tick` (team override → fleet default → code constant);
+    the global `MAX_RUNS_PER_TICK` budget is then filled round-robin across teams (one run per
+    team per round) so a single team with many due scouts can't monopolize the tick. Deferred
+    runs stay unstamped, so they're the most overdue next tick — a poor-man's queue, same
+    catch-up semantics as before.
     """
     team_configs = team_configs or {}
+    default_team_config = default_team_config or {}
 
     def _team_cap(team_id: int) -> int:
-        # Per-team override takes precedence; validate the value here (the config blob is
-        # arbitrary flag JSON) and fall back to the global default if absent or invalid.
-        override = (team_configs.get(team_id) or {}).get(TEAM_CONFIG_MAX_RUNS_PER_TICK)
-        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
-            return override
-        return MAX_RUNS_PER_TEAM_PER_TICK
+        return _resolve_max_runs_per_tick(team_id, team_configs, default_team_config)
 
     by_team: dict[int, list[_DueRun]] = {}
     for d in due:
@@ -277,6 +287,21 @@ def _allocate_tick_budget(due: list[_DueRun], team_configs: dict[int, dict] | No
             if len(selected) >= MAX_RUNS_PER_TICK:
                 break
     return selected
+
+
+def _resolve_max_runs_per_tick(team_id: int, team_configs: dict[int, dict], default_team_config: dict) -> int:
+    """Effective per-tick cap for a team, most-specific layer first.
+
+    `team_configs[team_id]` (per-team override) → `default_team_config` (fleet-wide default) →
+    `MAX_RUNS_PER_TEAM_PER_TICK` (code constant). Both flag blobs are arbitrary JSON, so the
+    `max_runs_per_tick` value is validated at each layer (positive int, not bool); an absent or
+    malformed value falls through to the next layer rather than failing the tick.
+    """
+    for source in ((team_configs.get(team_id) or {}), default_team_config):
+        override = source.get(TEAM_CONFIG_MAX_RUNS_PER_TICK)
+        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
+            return override
+    return MAX_RUNS_PER_TEAM_PER_TICK
 
 
 def _participating_teams(enrolled: set[int]) -> list[Team]:
@@ -406,6 +431,23 @@ def _team_configs(payload: dict | None) -> dict[int, dict]:
             continue
         configs[team_id] = value
     return configs
+
+
+def _default_team_config(payload: dict | None) -> dict:
+    """Fleet-wide default config applied to every enrolled team, parsed from the `signals-scout`
+    flag payload key `default_team_config`.
+
+    Same inner shape as a `team_configs` entry (today: `max_runs_per_tick`). It sits between a
+    per-team `team_configs` override and the code constant in `_resolve_max_runs_per_tick`, so a
+    single fleet-wide cost guardrail (e.g. cap every enrolled team at 1 run/tick for launch) can
+    be set in the flag UI with no deploy, while specific teams still get more headroom via
+    `team_configs`. Absent/malformed (`None` payload included) → `{}` (everyone falls back to the
+    code constants — unchanged behaviour).
+    """
+    if payload is None:
+        return {}
+    raw = payload.get("default_team_config", {})
+    return raw if isinstance(raw, dict) else {}
 
 
 def _overdue_seconds(config: SignalScoutConfig, now: datetime) -> float | None:

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -30,6 +30,7 @@ from products.signals.backend.temporal.agentic.scout_coordinator import (
     PlannedRun,
     SignalsScoutCoordinatorWorkflow,
     StampDispatchedRunsInput,
+    _default_team_config,
     _enrolled_team_ids,
     _read_flag_payload,
     _team_configs,
@@ -542,6 +543,80 @@ async def test_per_team_config_override_keyed_by_child_env_applies_to_parent(ate
     assert [p.skill_name for p in planned] == ["signals-scout-most"]
 
     await sync_to_async(child.delete)()
+
+
+# ── Fleet-wide default config via the flag payload (default_team_config) ──────────
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"default_team_config": {"max_runs_per_tick": 1}}, {"max_runs_per_tick": 1}),
+        ('{"default_team_config": {"max_runs_per_tick": 2}}', {"max_runs_per_tick": 2}),  # JSON string payload
+        ({"default_team_config": "nope"}, {}),  # wrong type → empty
+        ({}, {}),  # absent key → no fleet default
+        (None, {}),  # no payload → no fleet default
+    ],
+)
+@pytest.mark.flag_off
+def test_default_team_config_parses_payload(payload, expected):
+    with patch(_PAYLOAD_PATH, return_value=payload):
+        assert _default_team_config(_read_flag_payload()) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_default_team_config_caps_team_without_override(ateam):
+    # The launch posture: a fleet-wide `default_team_config` caps EVERY enrolled team at 1/tick,
+    # with no per-team entry. Three due scouts → only the most-overdue dispatches, proving the
+    # default layer applies when a team has no `team_configs` override of its own.
+    now = timezone.now()
+    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+        await database_sync_to_async(_create_config)(
+            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
+        )
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"max_runs_per_tick": 1},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    assert [p.skill_name for p in planned] == ["signals-scout-most"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_per_team_override_beats_default_team_config(ateam):
+    # A per-team `team_configs` entry takes precedence over the fleet-wide `default_team_config`:
+    # the default would cap this team at 1/tick, but its own override raises it to 3, so all three
+    # due scouts dispatch.
+    now = timezone.now()
+    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+        await database_sync_to_async(_create_config)(
+            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
+        )
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"max_runs_per_tick": 1},
+            "team_configs": {str(ateam.id): {"max_runs_per_tick": 3}},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    assert sorted(p.skill_name for p in planned) == [
+        "signals-scout-least",
+        "signals-scout-mid",
+        "signals-scout-most",
+    ]
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -566,10 +566,21 @@ def test_default_team_config_parses_payload(payload, expected):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_default_team_config_caps_team_without_override(ateam):
-    # The launch posture: a fleet-wide `default_team_config` caps EVERY enrolled team at 1/tick,
-    # with no per-team entry. Three due scouts → only the most-overdue dispatches, proving the
-    # default layer applies when a team has no `team_configs` override of its own.
+@pytest.mark.parametrize(
+    "team_override_cap,expected_names",
+    [
+        # No per-team entry → the fleet-wide default_team_config (cap 1) binds.
+        (None, ["signals-scout-most"]),
+        # A valid per-team override beats the fleet default, so all three dispatch.
+        (3, ["signals-scout-least", "signals-scout-mid", "signals-scout-most"]),
+        # An invalid per-team override falls through to the fleet default (cap 1).
+        ("nope", ["signals-scout-most"]),
+    ],
+)
+async def test_default_team_config_resolution(ateam, team_override_cap, expected_names):
+    # A fleet-wide `default_team_config` caps every enrolled team at 1/tick; a per-team
+    # `team_configs` override takes precedence when present and valid, else the fleet default
+    # still binds. Three scouts due (10h/5h/2h overdue) make the resolved cap observable.
     now = timezone.now()
     for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
         await database_sync_to_async(_create_skill)(ateam, name)
@@ -578,45 +589,18 @@ async def test_default_team_config_caps_team_without_override(ateam):
         )
 
     def _payload(*_a, **_k):
-        return {
+        payload: dict[str, Any] = {
             "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
             "default_team_config": {"max_runs_per_tick": 1},
         }
+        if team_override_cap is not None:
+            payload["team_configs"] = {str(ateam.id): {"max_runs_per_tick": team_override_cap}}
+        return payload
 
     with patch(_PAYLOAD_PATH, side_effect=_payload):
         planned = await _run_activity()
 
-    assert [p.skill_name for p in planned] == ["signals-scout-most"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.django_db
-async def test_per_team_override_beats_default_team_config(ateam):
-    # A per-team `team_configs` entry takes precedence over the fleet-wide `default_team_config`:
-    # the default would cap this team at 1/tick, but its own override raises it to 3, so all three
-    # due scouts dispatch.
-    now = timezone.now()
-    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
-        await database_sync_to_async(_create_skill)(ateam, name)
-        await database_sync_to_async(_create_config)(
-            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
-        )
-
-    def _payload(*_a, **_k):
-        return {
-            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
-            "default_team_config": {"max_runs_per_tick": 1},
-            "team_configs": {str(ateam.id): {"max_runs_per_tick": 3}},
-        }
-
-    with patch(_PAYLOAD_PATH, side_effect=_payload):
-        planned = await _run_activity()
-
-    assert sorted(p.skill_name for p in planned) == [
-        "signals-scout-least",
-        "signals-scout-mid",
-        "signals-scout-most",
-    ]
+    assert sorted(p.skill_name for p in planned) == sorted(expected_names)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

We're rolling Signals scouts out to dogfooders next week and want a cost guardrail that bounds per-team scout spend without a deploy each time we tune it.

Today the per-team tick cap (`MAX_RUNS_PER_TEAM_PER_TICK`, which bounds per-team runs/day and therefore spend) resolves as: a team's own `team_configs` override in the `signals-scout` flag payload, else a hardcoded global constant. There's no fleet-wide default in between — so "cap *every* enrolled team unless told otherwise" can only be done by listing every team individually under `team_configs`, or by changing the constant and redeploying.

## Changes

Adds a `default_team_config` layer to the `signals-scout` flag payload. The effective per-team cap now resolves through three layers, most specific first:

`team_configs[team]` (per-team override) → `default_team_config` (fleet-wide default) → `MAX_RUNS_PER_TEAM_PER_TICK` (code constant)

- `_default_team_config(payload)` — parses the new payload key (sibling to `_team_configs`; absent/malformed → `{}`, i.e. unchanged behaviour).
- `_resolve_max_runs_per_tick(team_id, team_configs, default_team_config)` — one home for the precedence + per-layer value validation (positive int, not bool), threaded into `_allocate_tick_budget`.

Both flag layers are read fresh each tick, so the launch posture (e.g. cap every enrolled team at 1 run/tick fleet-wide, then hand a close partner more headroom via `team_configs`) is tunable in the flag UI with no deploy. This is purely additive — with no `default_team_config` key set, behaviour is identical to today.

This is the blunt fleet-wide backstop. A follow-up will extend enrollment seeding (`register_missing_configs`) to read the same resolved config for which scouts auto-enable and at what cadence (the "general scout only, once a day" launch posture).

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Added `test_default_team_config_parses_payload` (parametrized), `test_default_team_config_caps_team_without_override`, and `test_per_team_override_beats_default_team_config`.
- Full coordinator suite green: `hogli test products/signals/backend/test/test_scout_coordinator.py` → 51 passed. `ruff` clean; pre-commit `ty check` passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this while planning the scouts launch cost posture. We explored the economics (≈$1.49/scout run, all internal/non-billable, full hourly fleet ≈$570/team/day) and landed on a layered, no-deploy-tunable design rather than baking launch caps into constants.

Scoped deliberately to Phase 1 (the live per-tick backstop) so it's small and low-risk; the seed-side "general scout only" change (Phase 2) is intentionally a separate PR. The resolver centralizes validation that previously lived inline in `_allocate_tick_budget`, so the per-team and fleet-default layers validate identically.

Tools: Claude Code. No repo skills with their own codegen were invoked for the code change.
