### PR TITLE
fix(inbox): stop scout row emitted count overlapping sparkline

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -50,7 +50,9 @@ export function ScoutRowCard({
             )}
         >
             <div className="flex items-center gap-4">
-                <div className="flex items-center gap-2 min-w-0 flex-1">
+                {/* overflow-hidden clips the name group so a long name + badges never spill
+                    onto the cadence/emitted column or the sparkline — the name truncates first. */}
+                <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
                     {asHeader ? (
                         // min-w keeps the name from being squeezed to zero width by the
                         // trailing metadata (badges, cadence, emitted count) — truncate
@@ -84,13 +86,13 @@ export function ScoutRowCard({
                     </Tooltip>
                     <ScoutOriginBadge skillName={config.skill_name} />
                     <DryRunBadge config={config} />
-                    <span className="whitespace-nowrap text-[11px] text-muted">
-                        {formatRunIntervalShort(config.run_interval_minutes)}
-                    </span>
+                </div>
+                {/* Cadence + emitted count get their own non-shrinking column so they can't
+                    overlap the sparkline (the name group absorbs any width pressure). */}
+                <div className="flex items-center gap-1 shrink-0 whitespace-nowrap text-[11px] text-muted">
+                    <span>{formatRunIntervalShort(config.run_interval_minutes)}</span>
                     {rollup && rollup.emittedCount > 0 ? (
-                        <span className="whitespace-nowrap text-[11px] text-muted">
-                            · {pluralize(rollup.emittedCount, 'signal')} emitted
-                        </span>
+                        <span>· {pluralize(rollup.emittedCount, 'signal')} emitted</span>
                     ) : null}
                 </div>
                 <div className="shrink-0">


### PR DESCRIPTION
## Problem

In the scouts list (Signals inbox setup modal), the "N signals emitted" text was rendering on top of the run-boxes sparkline, making rows like "Discord feed…" and "Error tracking" look garbled.

## Changes

The row was a three-column flex where the left column (`min-w-0 flex-1`) held the name, badges, cadence **and** the emitted count. That column had no `overflow-hidden`, so once the name truncated to its `min-w`, the `whitespace-nowrap` cadence/emitted text spilled past the column edge and landed on the sparkline.

Fix splits it into two columns:

- **Name group** — now `overflow-hidden`, so a long name truncates cleanly and clips at the edge instead of spilling right.
- **New cadence/emitted column** — `shrink-0`, sits between the metadata and the sparkline. Since both it and the sparkline are non-shrinking, the name group absorbs all width pressure.

Net: the emitted count can no longer overlap the bars.

## How did you test this code?

I'm an agent. I made the layout change and reasoned through the flexbox behavior; I did not run the dev server or take screenshots. No automated tests cover this purely visual component. Frontend `format`/`typescript:check` could not run in the sandbox (node_modules/oxlint absent) — CI will run them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy reported the overlap with a screenshot of the scouts list. I traced it to `ScoutRowCard.tsx`, confirmed the left flex column lacked overflow clipping and bundled the emitted text with the name, and presented four cleanup options. Andy picked "own column + clip", which this implements. No skills were invoked — it's a self-contained CSS/JSX layout fix.
