### PR TITLE
feat(signals): seed scouts from flag enabled_skills allowlist

### DIFF
--- a/products/signals/backend/scout_harness/config_registry.py
+++ b/products/signals/backend/scout_harness/config_registry.py
@@ -127,8 +127,10 @@ def register_missing_configs(team_id: int, seed_config_layers: list[dict] | None
     for name in missing:
         at_cap = enabled >= MAX_ENABLED_SCOUTS_PER_TEAM
         # A canonical scout is gated by the allowlist (when one is set); a custom scout never is.
+        # The explicit `is not None` keeps the membership check well-typed (mypy can't carry the
+        # narrowing through `gated`).
         gated = enabled_skills is not None and name in canonical_names
-        in_allowlist = (not gated) or name in enabled_skills
+        in_allowlist = (not gated) or (enabled_skills is not None and name in enabled_skills)
         seed_enabled = in_allowlist and not at_cap
 
         defaults: dict = {} if seed_enabled else {"enabled": False}

--- a/products/signals/backend/scout_harness/config_registry.py
+++ b/products/signals/backend/scout_harness/config_registry.py
@@ -12,11 +12,19 @@ from __future__ import annotations
 import structlog
 
 from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY
 from products.signals.backend.scout_harness.limits import MAX_ENABLED_SCOUTS_PER_TEAM
 from products.signals.backend.scout_harness.skill_loader import SIGNALS_SCOUT_SKILL_PREFIX
 from products.skills.backend.models.skills import LLMSkill
 
 logger = structlog.get_logger(__name__)
+
+# Mirror the `SignalScoutConfig.run_interval_minutes` model + serializer bounds (10–43200). A
+# seed interval comes from arbitrary flag JSON and is written via `get_or_create`, which bypasses
+# model validators — so an out-of-range value is validated here and treated as absent rather than
+# persisted (a large enough int would otherwise raise a DB error and abort the coordinator tick).
+MIN_RUN_INTERVAL_MINUTES = 10
+MAX_RUN_INTERVAL_MINUTES = 43200
 
 
 def enabled_scout_count(team_id: int, *, exclude_skill: str | None = None) -> int:
@@ -31,36 +39,45 @@ def enabled_scout_count(team_id: int, *, exclude_skill: str | None = None) -> in
     return queryset.count()
 
 
-def _resolve_seed_posture(seed_config: dict | None) -> tuple[set[str] | None, int | None]:
-    """Parse the optional seed posture from a resolved per-team config blob.
+def _resolve_seed_posture(seed_config_layers: list[dict] | None) -> tuple[set[str] | None, int | None]:
+    """Resolve the seed posture across ordered config layers, most-specific first.
+
+    Each field is resolved independently: the first layer carrying a VALID value for that key
+    wins; a layer whose value is absent or malformed falls through to the next — the same per-key
+    fallback as `_resolve_max_runs_per_tick` does for the tick cap, so a typo'd per-team override
+    doesn't silently drop the fleet default (e.g. a team passing `enabled_skills` as a string
+    still inherits the fleet allowlist rather than enabling everything).
 
     Returns `(enabled_skills, enabled_interval_minutes)`:
-    - `enabled_skills`: the allowlist of canonical scouts that auto-enable on seed; everything
-      else registers disabled. `None` means "no allowlist" — every scout enables, the historical
-      behaviour.
-    - `enabled_interval_minutes`: cadence stamped on the auto-enabled rows, or `None` to keep the
-      model default.
-
-    The blob is arbitrary flag JSON, so both keys are validated; a malformed value is treated as
-    absent (falls back to historical behaviour) rather than failing the seed.
+    - `enabled_skills`: allowlist of canonical scouts that auto-enable on seed; the rest register
+      disabled. `None` (no valid layer) means "no allowlist" — every scout enables, historical.
+    - `enabled_interval_minutes`: cadence stamped on the auto-enabled rows, validated against the
+      model's 10–43200 bounds; `None` keeps the model default.
     """
-    if not seed_config:
-        return None, None
+    layers = [layer for layer in (seed_config_layers or []) if isinstance(layer, dict)]
 
     enabled_skills: set[str] | None = None
-    raw_skills = seed_config.get("enabled_skills")
-    if isinstance(raw_skills, list) and all(isinstance(s, str) for s in raw_skills):
-        enabled_skills = {str(s) for s in raw_skills}
+    for layer in layers:
+        raw_skills = layer.get("enabled_skills")
+        if isinstance(raw_skills, list) and all(isinstance(s, str) for s in raw_skills):
+            enabled_skills = {str(s) for s in raw_skills}
+            break
 
     enabled_interval: int | None = None
-    raw_interval = seed_config.get("enabled_interval_minutes")
-    if isinstance(raw_interval, int) and not isinstance(raw_interval, bool) and raw_interval > 0:
-        enabled_interval = raw_interval
+    for layer in layers:
+        raw_interval = layer.get("enabled_interval_minutes")
+        if (
+            isinstance(raw_interval, int)
+            and not isinstance(raw_interval, bool)
+            and MIN_RUN_INTERVAL_MINUTES <= raw_interval <= MAX_RUN_INTERVAL_MINUTES
+        ):
+            enabled_interval = raw_interval
+            break
 
     return enabled_skills, enabled_interval
 
 
-def register_missing_configs(team_id: int, seed_config: dict | None = None) -> set[str]:
+def register_missing_configs(team_id: int, seed_config_layers: list[dict] | None = None) -> set[str]:
     """Auto-create a config for each scout skill lacking a row, honouring an optional seed posture.
 
     Idempotent — `get_or_create` keyed on the `(team, skill_name)` unique constraint, so
@@ -68,12 +85,14 @@ def register_missing_configs(team_id: int, seed_config: dict | None = None) -> s
     the set of live `signals-scout-*` skill names for the team, so the caller can skip
     dispatching configs whose skill is gone.
 
-    `seed_config` is the team's resolved flag config (`default_team_config` merged with its
-    `team_configs` override). When it carries an `enabled_skills` allowlist, only those scouts
-    auto-enable (at `enabled_interval_minutes` if set) and the rest register disabled — the
-    launch posture (e.g. general-only, once a day). With no allowlist the historical behaviour
-    holds: every scout enables at the model-default schedule. Either way, a scout disabled at seed
-    stays visible and tunable but adds no spend.
+    `seed_config_layers` are the team's flag config layers, most-specific first (its `team_configs`
+    override, then the fleet `default_team_config`); `_resolve_seed_posture` resolves them per key.
+    When an `enabled_skills` allowlist is in force, only those **canonical** (harness-seeded)
+    scouts auto-enable (at `enabled_interval_minutes` if set) and the rest register disabled — the
+    launch posture (e.g. general-only, once a day). Hand-authored **custom** scouts are never gated
+    by the allowlist: "author a skill, get a scout" still auto-enables them, so a launch team's own
+    scout isn't silently muted. With no allowlist, every scout enables at the model-default
+    schedule. Either way, a scout disabled at seed stays visible and tunable but adds no spend.
 
     Posture only shapes rows at creation (forward-only) — existing configs are never re-stamped,
     so flipping the flag later doesn't disturb teams already seeded, and a user enabling a scout
@@ -84,15 +103,20 @@ def register_missing_configs(team_id: int, seed_config: dict | None = None) -> s
     (count + create, no lock) — a race can briefly overshoot by one, which the coordinator's
     per-tick caps still bound.
     """
-    enabled_skills, enabled_interval = _resolve_seed_posture(seed_config)
-    skill_names = set(
+    enabled_skills, enabled_interval = _resolve_seed_posture(seed_config_layers)
+    rows = list(
         LLMSkill.objects.filter(
             team_id=team_id,
             name__startswith=SIGNALS_SCOUT_SKILL_PREFIX,
             is_latest=True,
             deleted=False,
-        ).values_list("name", flat=True)
+        ).values_list("name", "metadata")
     )
+    skill_names = {name for name, _ in rows}
+    # The allowlist governs the canonical fleet only; custom (hand-authored) scouts always
+    # auto-enable. `seeded_by` is the canonical marker stamped by lazy_seed.
+    canonical_names = {name for name, metadata in rows if (metadata or {}).get("seeded_by") == HARNESS_SEEDED_BY}
+
     configs = SignalScoutConfig.objects.for_team(team_id)
     existing = set(configs.values_list("skill_name", flat=True))
     missing = sorted(skill_names - existing)
@@ -102,11 +126,15 @@ def register_missing_configs(team_id: int, seed_config: dict | None = None) -> s
     enabled = enabled_scout_count(team_id)
     for name in missing:
         at_cap = enabled >= MAX_ENABLED_SCOUTS_PER_TEAM
-        in_allowlist = enabled_skills is None or name in enabled_skills
+        # A canonical scout is gated by the allowlist (when one is set); a custom scout never is.
+        gated = enabled_skills is not None and name in canonical_names
+        in_allowlist = (not gated) or name in enabled_skills
         seed_enabled = in_allowlist and not at_cap
 
         defaults: dict = {} if seed_enabled else {"enabled": False}
-        if seed_enabled and enabled_interval is not None:
+        # The launch cadence applies to scouts enabled via the allowlist; custom scouts keep
+        # the model default so a user's own scout isn't forced onto the fleet's schedule.
+        if seed_enabled and gated and enabled_interval is not None:
             defaults["run_interval_minutes"] = enabled_interval
 
         # `team_id` must be passed as a kwarg: `get_or_create` builds the created row from

--- a/products/signals/backend/scout_harness/config_registry.py
+++ b/products/signals/backend/scout_harness/config_registry.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import structlog
 
 from products.signals.backend.models import SignalScoutConfig
-from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY
+from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY, canonical_skill_names
 from products.signals.backend.scout_harness.limits import MAX_ENABLED_SCOUTS_PER_TEAM
 from products.signals.backend.scout_harness.skill_loader import SIGNALS_SCOUT_SKILL_PREFIX
 from products.skills.backend.models.skills import LLMSkill
@@ -113,9 +113,17 @@ def register_missing_configs(team_id: int, seed_config_layers: list[dict] | None
         ).values_list("name", "metadata")
     )
     skill_names = {name for name, _ in rows}
-    # The allowlist governs the canonical fleet only; custom (hand-authored) scouts always
-    # auto-enable. `seeded_by` is the canonical marker stamped by lazy_seed.
-    canonical_names = {name for name, metadata in rows if (metadata or {}).get("seeded_by") == HARNESS_SEEDED_BY}
+    # The allowlist governs the canonical fleet only; custom (hand-authored or duplicated) scouts
+    # always auto-enable. A scout is canonical iff it BOTH carries the harness `seeded_by` tag AND
+    # matches an on-disk canonical name — same dual check as `views._scout_origin`. The tag alone
+    # isn't enough: `duplicate_skill` copies metadata verbatim, so a user's duplicate of a
+    # canonical scout keeps the tag under a new, non-canonical name and must not be gated.
+    on_disk_canonical = canonical_skill_names()
+    canonical_names = {
+        name
+        for name, metadata in rows
+        if (metadata or {}).get("seeded_by") == HARNESS_SEEDED_BY and name in on_disk_canonical
+    }
 
     configs = SignalScoutConfig.objects.for_team(team_id)
     existing = set(configs.values_list("skill_name", flat=True))

--- a/products/signals/backend/scout_harness/config_registry.py
+++ b/products/signals/backend/scout_harness/config_registry.py
@@ -31,19 +31,60 @@ def enabled_scout_count(team_id: int, *, exclude_skill: str | None = None) -> in
     return queryset.count()
 
 
-def register_missing_configs(team_id: int) -> set[str]:
-    """Auto-create a default-schedule config for each scout skill lacking a row.
+def _resolve_seed_posture(seed_config: dict | None) -> tuple[set[str] | None, int | None]:
+    """Parse the optional seed posture from a resolved per-team config blob.
+
+    Returns `(enabled_skills, enabled_interval_minutes)`:
+    - `enabled_skills`: the allowlist of canonical scouts that auto-enable on seed; everything
+      else registers disabled. `None` means "no allowlist" — every scout enables, the historical
+      behaviour.
+    - `enabled_interval_minutes`: cadence stamped on the auto-enabled rows, or `None` to keep the
+      model default.
+
+    The blob is arbitrary flag JSON, so both keys are validated; a malformed value is treated as
+    absent (falls back to historical behaviour) rather than failing the seed.
+    """
+    if not seed_config:
+        return None, None
+
+    enabled_skills: set[str] | None = None
+    raw_skills = seed_config.get("enabled_skills")
+    if isinstance(raw_skills, list) and all(isinstance(s, str) for s in raw_skills):
+        enabled_skills = {str(s) for s in raw_skills}
+
+    enabled_interval: int | None = None
+    raw_interval = seed_config.get("enabled_interval_minutes")
+    if isinstance(raw_interval, int) and not isinstance(raw_interval, bool) and raw_interval > 0:
+        enabled_interval = raw_interval
+
+    return enabled_skills, enabled_interval
+
+
+def register_missing_configs(team_id: int, seed_config: dict | None = None) -> set[str]:
+    """Auto-create a config for each scout skill lacking a row, honouring an optional seed posture.
 
     Idempotent — `get_or_create` keyed on the `(team, skill_name)` unique constraint, so
     concurrent callers (coordinator tick racing an API call) converge on one row. Returns
     the set of live `signals-scout-*` skill names for the team, so the caller can skip
     dispatching configs whose skill is gone.
 
-    New rows default to enabled until the team hits `MAX_ENABLED_SCOUTS_PER_TEAM`; past
-    the cap they register disabled, so the scout is still visible and tunable but never
-    silently adds spend. The check is best-effort (count + create, no lock) — a race can
-    briefly overshoot by one, which the coordinator's per-tick caps still bound.
+    `seed_config` is the team's resolved flag config (`default_team_config` merged with its
+    `team_configs` override). When it carries an `enabled_skills` allowlist, only those scouts
+    auto-enable (at `enabled_interval_minutes` if set) and the rest register disabled — the
+    launch posture (e.g. general-only, once a day). With no allowlist the historical behaviour
+    holds: every scout enables at the model-default schedule. Either way, a scout disabled at seed
+    stays visible and tunable but adds no spend.
+
+    Posture only shapes rows at creation (forward-only) — existing configs are never re-stamped,
+    so flipping the flag later doesn't disturb teams already seeded, and a user enabling a scout
+    won't be reverted on the next tick.
+
+    The per-team `MAX_ENABLED_SCOUTS_PER_TEAM` cap is an independent second gate: even an
+    allowlisted scout registers disabled once the team is at the cap. Both checks are best-effort
+    (count + create, no lock) — a race can briefly overshoot by one, which the coordinator's
+    per-tick caps still bound.
     """
+    enabled_skills, enabled_interval = _resolve_seed_posture(seed_config)
     skill_names = set(
         LLMSkill.objects.filter(
             team_id=team_id,
@@ -61,20 +102,25 @@ def register_missing_configs(team_id: int) -> set[str]:
     enabled = enabled_scout_count(team_id)
     for name in missing:
         at_cap = enabled >= MAX_ENABLED_SCOUTS_PER_TEAM
+        in_allowlist = enabled_skills is None or name in enabled_skills
+        seed_enabled = in_allowlist and not at_cap
+
+        defaults: dict = {} if seed_enabled else {"enabled": False}
+        if seed_enabled and enabled_interval is not None:
+            defaults["run_interval_minutes"] = enabled_interval
+
         # `team_id` must be passed as a kwarg: `get_or_create` builds the created row from
         # kwargs/defaults only — the queryset's team filter does not propagate into `create`.
-        _, created = configs.get_or_create(
-            team_id=team_id,
-            skill_name=name,
-            defaults={"enabled": False} if at_cap else {},
-        )
-        if created and at_cap:
+        _, created = configs.get_or_create(team_id=team_id, skill_name=name, defaults=defaults)
+        if not created:
+            continue
+        if seed_enabled:
+            enabled += 1
+        elif in_allowlist and at_cap:
             logger.info(
                 "signals_scout: enabled-scout cap reached, auto-registered config disabled",
                 team_id=team_id,
                 skill_name=name,
                 cap=MAX_ENABLED_SCOUTS_PER_TEAM,
             )
-        elif created:
-            enabled += 1
     return skill_names

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -206,11 +206,12 @@ def _collect_planned_runs(
                 "signals_scout coordinator: canonical skill sync failed for team; continuing",
                 team_id=team.id,
             )
-        # Resolve this team's seed posture the same way as the tick cap: its own `team_configs`
-        # override layered over the fleet-wide `default_team_config`. Drives which scouts
-        # auto-enable (and at what cadence) when the team is first seeded.
-        seed_config = {**default_team_config, **(team_configs.get(team.id) or {})}
-        live_skills = register_missing_configs(team.id, seed_config)
+        # This team's seed posture resolves like the tick cap: its own `team_configs` override
+        # layered over the fleet-wide `default_team_config`, most-specific first. Passing the
+        # layers (not a shallow merge) lets `_resolve_seed_posture` fall back per key, so a
+        # malformed per-team value doesn't clobber a valid fleet default.
+        seed_config_layers = [team_configs.get(team.id) or {}, default_team_config]
+        live_skills = register_missing_configs(team.id, seed_config_layers)
         # Skip enabled configs whose `signals-scout-*` skill was deleted or is no longer the
         # latest version: dispatching them would spawn a child workflow that fails fast in
         # load_skill_for_run on every tick.

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -50,15 +50,20 @@ MAX_RUNS_PER_TICK = 1000
 # per day: cap × ticks/day), so a team registering many scouts degrades its own cadence,
 # not everyone else's. Sized well above the canonical fleet (~16 scouts) so a fully-enrolled
 # team is never trimmed; round-robin allocation still keeps any one team from starving the
-# others even when this is close to the global cap. This is the DEFAULT — a per-team override
-# takes precedence when set in the `signals-scout` flag payload under `team_configs` (see
-# `_team_configs`), to give an important dogfooder more headroom or hold a noisy one lower,
-# no deploy.
+# others even when this is close to the global cap.
+#
+# This is the LAST-RESORT default. Effective per-team cap resolves through three layers,
+# most specific first (see `_resolve_max_runs_per_tick`): a team's own `team_configs` entry →
+# the fleet-wide `default_team_config` → this code constant. The two flag layers are read
+# fresh each tick, so the launch posture (e.g. cap every enrolled team at 1 run/tick via
+# `default_team_config`, then hand a close partner more headroom via `team_configs`) is
+# tunable in the flag UI with no deploy.
 MAX_RUNS_PER_TEAM_PER_TICK = 50
 
-# Key inside a team's `team_configs` entry that overrides `MAX_RUNS_PER_TEAM_PER_TICK` for that
-# team. `team_configs` is a forward-looking per-team override bag — add more keys here as other
-# settings become per-team-tunable; each consumer reads + validates the key it cares about.
+# Key inside a `team_configs` entry (or the `default_team_config` blob) that overrides
+# `MAX_RUNS_PER_TEAM_PER_TICK`. Both blobs share the same inner shape — a forward-looking
+# override bag — so add more per-team-tunable settings here and each consumer reads + validates
+# the key it cares about.
 TEAM_CONFIG_MAX_RUNS_PER_TICK = "max_runs_per_tick"
 
 # Coordinator tick cadence. Per-scout schedules are enforced via the due-check, so this is
@@ -129,8 +134,9 @@ async def fetch_enabled_signals_scout_runs_activity(
         payload = await asyncio.to_thread(_read_flag_payload)
         enrolled_team_ids = _enrolled_team_ids(payload)
         team_configs = _team_configs(payload)
+        default_team_config = _default_team_config(payload)
         planned = await database_sync_to_async(_collect_planned_runs, thread_sensitive=False)(
-            enrolled_team_ids, team_configs
+            enrolled_team_ids, team_configs, default_team_config
         )
     logger.info("signals_scout coordinator: planned runs", count=len(planned))
     return FetchEnabledRunsOutput(planned_runs=planned)
@@ -172,11 +178,15 @@ class _DueRun:
     skill_name: str
 
 
-def _collect_planned_runs(enrolled_team_ids: set[int], team_configs: dict[int, dict] | None = None) -> list[PlannedRun]:
+def _collect_planned_runs(
+    enrolled_team_ids: set[int],
+    team_configs: dict[int, dict] | None = None,
+    default_team_config: dict | None = None,
+) -> list[PlannedRun]:
     """Sync DB scan. Runs in a worker thread via Django's per-thread connection mgmt.
 
-    Takes the already-resolved enrolled team ids (and optional per-team config overrides) so
-    the flag reads stay off this DB pool.
+    Takes the already-resolved enrolled team ids, the optional per-team config overrides, and
+    the fleet-wide default config so the flag reads stay off this DB pool.
     """
     now = timezone.now()
     team_configs = _canonicalize_team_config_keys(team_configs or {})
@@ -208,32 +218,32 @@ def _collect_planned_runs(enrolled_team_ids: set[int], team_configs: dict[int, d
     if not due:
         return []
 
-    selected = _allocate_tick_budget(due, team_configs)
+    selected = _allocate_tick_budget(due, team_configs, default_team_config)
     planned = [PlannedRun(team_id=d.team_id, skill_name=d.skill_name) for d in selected]
     # Stable order for predictable child-workflow ids within the tick.
     planned.sort(key=lambda p: (p.team_id, p.skill_name))
     return planned
 
 
-def _allocate_tick_budget(due: list[_DueRun], team_configs: dict[int, dict] | None = None) -> list[_DueRun]:
+def _allocate_tick_budget(
+    due: list[_DueRun],
+    team_configs: dict[int, dict] | None = None,
+    default_team_config: dict | None = None,
+) -> list[_DueRun]:
     """Apply the per-team and global tick caps fairly. Deterministic — no sampling.
 
-    Each team's due runs are ordered most-overdue-first and trimmed to its per-team cap — the
-    `max_runs_per_tick` from its `team_configs` flag override if set, else
-    `MAX_RUNS_PER_TEAM_PER_TICK`; the global `MAX_RUNS_PER_TICK` budget is then filled
-    round-robin across teams (one run per team per round) so a single team with many due scouts
-    can't monopolize the tick. Deferred runs stay unstamped, so they're the most overdue next
-    tick — a poor-man's queue, same catch-up semantics as before.
+    Each team's due runs are ordered most-overdue-first and trimmed to its per-team cap,
+    resolved per `_resolve_max_runs_per_tick` (team override → fleet default → code constant);
+    the global `MAX_RUNS_PER_TICK` budget is then filled round-robin across teams (one run per
+    team per round) so a single team with many due scouts can't monopolize the tick. Deferred
+    runs stay unstamped, so they're the most overdue next tick — a poor-man's queue, same
+    catch-up semantics as before.
     """
     team_configs = team_configs or {}
+    default_team_config = default_team_config or {}
 
     def _team_cap(team_id: int) -> int:
-        # Per-team override takes precedence; validate the value here (the config blob is
-        # arbitrary flag JSON) and fall back to the global default if absent or invalid.
-        override = (team_configs.get(team_id) or {}).get(TEAM_CONFIG_MAX_RUNS_PER_TICK)
-        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
-            return override
-        return MAX_RUNS_PER_TEAM_PER_TICK
+        return _resolve_max_runs_per_tick(team_id, team_configs, default_team_config)
 
     by_team: dict[int, list[_DueRun]] = {}
     for d in due:
@@ -277,6 +287,21 @@ def _allocate_tick_budget(due: list[_DueRun], team_configs: dict[int, dict] | No
             if len(selected) >= MAX_RUNS_PER_TICK:
                 break
     return selected
+
+
+def _resolve_max_runs_per_tick(team_id: int, team_configs: dict[int, dict], default_team_config: dict) -> int:
+    """Effective per-tick cap for a team, most-specific layer first.
+
+    `team_configs[team_id]` (per-team override) → `default_team_config` (fleet-wide default) →
+    `MAX_RUNS_PER_TEAM_PER_TICK` (code constant). Both flag blobs are arbitrary JSON, so the
+    `max_runs_per_tick` value is validated at each layer (positive int, not bool); an absent or
+    malformed value falls through to the next layer rather than failing the tick.
+    """
+    for source in ((team_configs.get(team_id) or {}), default_team_config):
+        override = source.get(TEAM_CONFIG_MAX_RUNS_PER_TICK)
+        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
+            return override
+    return MAX_RUNS_PER_TEAM_PER_TICK
 
 
 def _participating_teams(enrolled: set[int]) -> list[Team]:
@@ -406,6 +431,23 @@ def _team_configs(payload: dict | None) -> dict[int, dict]:
             continue
         configs[team_id] = value
     return configs
+
+
+def _default_team_config(payload: dict | None) -> dict:
+    """Fleet-wide default config applied to every enrolled team, parsed from the `signals-scout`
+    flag payload key `default_team_config`.
+
+    Same inner shape as a `team_configs` entry (today: `max_runs_per_tick`). It sits between a
+    per-team `team_configs` override and the code constant in `_resolve_max_runs_per_tick`, so a
+    single fleet-wide cost guardrail (e.g. cap every enrolled team at 1 run/tick for launch) can
+    be set in the flag UI with no deploy, while specific teams still get more headroom via
+    `team_configs`. Absent/malformed (`None` payload included) → `{}` (everyone falls back to the
+    code constants — unchanged behaviour).
+    """
+    if payload is None:
+        return {}
+    raw = payload.get("default_team_config", {})
+    return raw if isinstance(raw, dict) else {}
 
 
 def _overdue_seconds(config: SignalScoutConfig, now: datetime) -> float | None:

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -190,6 +190,7 @@ def _collect_planned_runs(
     """
     now = timezone.now()
     team_configs = _canonicalize_team_config_keys(team_configs or {})
+    default_team_config = default_team_config or {}
     due: list[_DueRun] = []
     for team in _participating_teams(enrolled_team_ids):
         # Sync canonical scouts so a freshly-enrolled team has skills to register on.
@@ -205,7 +206,11 @@ def _collect_planned_runs(
                 "signals_scout coordinator: canonical skill sync failed for team; continuing",
                 team_id=team.id,
             )
-        live_skills = register_missing_configs(team.id)
+        # Resolve this team's seed posture the same way as the tick cap: its own `team_configs`
+        # override layered over the fleet-wide `default_team_config`. Drives which scouts
+        # auto-enable (and at what cadence) when the team is first seeded.
+        seed_config = {**default_team_config, **(team_configs.get(team.id) or {})}
+        live_skills = register_missing_configs(team.id, seed_config)
         # Skip enabled configs whose `signals-scout-*` skill was deleted or is no longer the
         # latest version: dispatching them would spawn a child workflow that fails fast in
         # load_skill_for_run on every tick.

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -622,6 +622,93 @@ async def test_auto_register_past_enabled_cap_creates_disabled_config(ateam):
     assert sorted(p.skill_name for p in planned) == ["signals-scout-existing"]
 
 
+# ── Seed posture via the flag (enabled_skills allowlist + interval) ───────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_seed_enabled_skills_allowlist_enables_only_listed(ateam):
+    # default_team_config.enabled_skills allowlists one scout: only it seeds enabled, the rest
+    # register disabled (visible, no spend), and only the enabled one is planned this tick.
+    for name in ["signals-scout-general", "signals-scout-errors", "signals-scout-surveys"]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"enabled_skills": ["signals-scout-general"]},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    rows = await database_sync_to_async(
+        lambda: {c.skill_name: c.enabled for c in SignalScoutConfig.all_teams.filter(team_id=ateam.id)}
+    )()
+    assert rows == {
+        "signals-scout-general": True,
+        "signals-scout-errors": False,
+        "signals-scout-surveys": False,
+    }
+    assert [p.skill_name for p in planned] == ["signals-scout-general"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_seed_enabled_interval_stamps_listed_scout(ateam):
+    # enabled_interval_minutes sets the cadence on auto-enabled rows (e.g. daily for launch).
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-general")
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"enabled_skills": ["signals-scout-general"], "enabled_interval_minutes": 1440},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        await _run_activity()
+
+    general = await database_sync_to_async(
+        lambda: SignalScoutConfig.all_teams.get(team_id=ateam.id, skill_name="signals-scout-general")
+    )()
+    assert general.enabled is True
+    assert general.run_interval_minutes == 1440
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_no_seed_config_enables_all_scouts(ateam):
+    # Back-compat: with no enabled_skills allowlist (autouse payload has none), every authored
+    # scout seeds enabled — unchanged from before the seed posture existed.
+    for name in ["signals-scout-general", "signals-scout-errors"]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+
+    planned = await _run_activity()
+
+    assert sorted(p.skill_name for p in planned) == ["signals-scout-errors", "signals-scout-general"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_per_team_seed_config_overrides_default_allowlist(ateam):
+    # A per-team team_configs.enabled_skills widens the fleet default for one team (the
+    # close-partner case): general plus error-tracking enable, surveys stays disabled.
+    for name in ["signals-scout-general", "signals-scout-errors", "signals-scout-surveys"]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"enabled_skills": ["signals-scout-general"]},
+            "team_configs": {str(ateam.id): {"enabled_skills": ["signals-scout-general", "signals-scout-errors"]}},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    assert sorted(p.skill_name for p in planned) == ["signals-scout-errors", "signals-scout-general"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_planned_runs_sorted_by_team_then_skill(ateam, aother_team):

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -20,7 +20,7 @@ from posthog.models.scoping import team_scope
 from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalScoutConfig
-from products.signals.backend.scout_harness.lazy_seed import sync_canonical_skills
+from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY, sync_canonical_skills
 from products.signals.backend.temporal.agentic.scout_coordinator import (
     DEFAULT_ENROLLED_TEAM_IDS,
     SIGNALS_SCOUT_DISCOVERY_DISTINCT_ID,
@@ -92,8 +92,11 @@ async def aother_team(aorganization):
     await sync_to_async(team.delete)()
 
 
-def _create_skill(team: Team, name: str) -> LLMSkill:
-    return LLMSkill.objects.create(team=team, name=name, description="d", body="b")
+def _create_skill(team: Team, name: str, *, seeded: bool = True) -> LLMSkill:
+    # Default to a canonical (harness-seeded) skill — the realistic case; pass seeded=False for a
+    # hand-authored custom scout (no `seeded_by` tag), which the seed allowlist must not gate.
+    metadata = {"seeded_by": HARNESS_SEEDED_BY} if seeded else {}
+    return LLMSkill.objects.create(team=team, name=name, description="d", body="b", metadata=metadata)
 
 
 def _create_config(team: Team, skill_name: str, **kwargs: Any) -> SignalScoutConfig:
@@ -627,42 +630,88 @@ async def test_auto_register_past_enabled_cap_creates_disabled_config(ateam):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_seed_enabled_skills_allowlist_enables_only_listed(ateam):
-    # default_team_config.enabled_skills allowlists one scout: only it seeds enabled, the rest
-    # register disabled (visible, no spend), and only the enabled one is planned this tick.
-    for name in ["signals-scout-general", "signals-scout-errors", "signals-scout-surveys"]:
-        await database_sync_to_async(_create_skill)(ateam, name)
+@pytest.mark.parametrize(
+    "default_cfg,team_cfg,skills,expected_enabled",
+    [
+        # An allowlist enables only the listed canonical scout; the rest seed disabled.
+        (
+            {"enabled_skills": ["signals-scout-general"]},
+            None,
+            [("signals-scout-general", True), ("signals-scout-errors", True), ("signals-scout-surveys", True)],
+            {"signals-scout-general": True, "signals-scout-errors": False, "signals-scout-surveys": False},
+        ),
+        # No allowlist → every scout enables (back-compat, unchanged from before seed posture).
+        (
+            {},
+            None,
+            [("signals-scout-general", True), ("signals-scout-errors", True)],
+            {"signals-scout-general": True, "signals-scout-errors": True},
+        ),
+        # A per-team override widens the fleet default for one team (close-partner case).
+        (
+            {"enabled_skills": ["signals-scout-general"]},
+            {"enabled_skills": ["signals-scout-general", "signals-scout-errors"]},
+            [("signals-scout-general", True), ("signals-scout-errors", True), ("signals-scout-surveys", True)],
+            {"signals-scout-general": True, "signals-scout-errors": True, "signals-scout-surveys": False},
+        ),
+        # A malformed per-team override falls back to the fleet default, not "no allowlist".
+        (
+            {"enabled_skills": ["signals-scout-general"]},
+            {"enabled_skills": "signals-scout-general"},
+            [("signals-scout-general", True), ("signals-scout-errors", True)],
+            {"signals-scout-general": True, "signals-scout-errors": False},
+        ),
+        # A hand-authored custom scout (no seeded_by tag) auto-enables even under an allowlist.
+        (
+            {"enabled_skills": ["signals-scout-general"]},
+            None,
+            [("signals-scout-general", True), ("signals-scout-custom", False)],
+            {"signals-scout-general": True, "signals-scout-custom": True},
+        ),
+    ],
+)
+async def test_seed_posture_enabled_map(ateam, default_cfg, team_cfg, skills, expected_enabled):
+    # Which scouts seed enabled vs disabled, across allowlist / no-allowlist / per-team-override /
+    # malformed-override / custom-scout scenarios. `skills` is (name, seeded_as_canonical) pairs.
+    for name, seeded in skills:
+        await database_sync_to_async(_create_skill)(ateam, name, seeded=seeded)
 
     def _payload(*_a, **_k):
-        return {
-            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
-            "default_team_config": {"enabled_skills": ["signals-scout-general"]},
-        }
+        payload: dict[str, Any] = {"guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS]}
+        if default_cfg:
+            payload["default_team_config"] = default_cfg
+        if team_cfg is not None:
+            payload["team_configs"] = {str(ateam.id): team_cfg}
+        return payload
 
     with patch(_PAYLOAD_PATH, side_effect=_payload):
-        planned = await _run_activity()
+        await _run_activity()
 
     rows = await database_sync_to_async(
         lambda: {c.skill_name: c.enabled for c in SignalScoutConfig.all_teams.filter(team_id=ateam.id)}
     )()
-    assert rows == {
-        "signals-scout-general": True,
-        "signals-scout-errors": False,
-        "signals-scout-surveys": False,
-    }
-    assert [p.skill_name for p in planned] == ["signals-scout-general"]
+    assert rows == expected_enabled
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_seed_enabled_interval_stamps_listed_scout(ateam):
-    # enabled_interval_minutes sets the cadence on auto-enabled rows (e.g. daily for launch).
+@pytest.mark.parametrize(
+    "interval,expected",
+    [
+        (1440, 1440),  # in-bounds cadence is stamped on the auto-enabled scout
+        (5, None),  # below the 10-min model floor → ignored, model default kept
+        (99999, None),  # above the 43200-min ceiling → ignored, model default kept
+    ],
+)
+async def test_seed_enabled_interval_validates_bounds(ateam, interval, expected):
+    # enabled_interval_minutes sets the cadence on allowlisted scouts, but only within the model's
+    # 10–43200 bounds (get_or_create bypasses validators); out-of-range falls back to the default.
     await database_sync_to_async(_create_skill)(ateam, "signals-scout-general")
 
     def _payload(*_a, **_k):
         return {
             "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
-            "default_team_config": {"enabled_skills": ["signals-scout-general"], "enabled_interval_minutes": 1440},
+            "default_team_config": {"enabled_skills": ["signals-scout-general"], "enabled_interval_minutes": interval},
         }
 
     with patch(_PAYLOAD_PATH, side_effect=_payload):
@@ -672,41 +721,11 @@ async def test_seed_enabled_interval_stamps_listed_scout(ateam):
         lambda: SignalScoutConfig.all_teams.get(team_id=ateam.id, skill_name="signals-scout-general")
     )()
     assert general.enabled is True
-    assert general.run_interval_minutes == 1440
-
-
-@pytest.mark.asyncio
-@pytest.mark.django_db
-async def test_no_seed_config_enables_all_scouts(ateam):
-    # Back-compat: with no enabled_skills allowlist (autouse payload has none), every authored
-    # scout seeds enabled — unchanged from before the seed posture existed.
-    for name in ["signals-scout-general", "signals-scout-errors"]:
-        await database_sync_to_async(_create_skill)(ateam, name)
-
-    planned = await _run_activity()
-
-    assert sorted(p.skill_name for p in planned) == ["signals-scout-errors", "signals-scout-general"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.django_db
-async def test_per_team_seed_config_overrides_default_allowlist(ateam):
-    # A per-team team_configs.enabled_skills widens the fleet default for one team (the
-    # close-partner case): general plus error-tracking enable, surveys stays disabled.
-    for name in ["signals-scout-general", "signals-scout-errors", "signals-scout-surveys"]:
-        await database_sync_to_async(_create_skill)(ateam, name)
-
-    def _payload(*_a, **_k):
-        return {
-            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
-            "default_team_config": {"enabled_skills": ["signals-scout-general"]},
-            "team_configs": {str(ateam.id): {"enabled_skills": ["signals-scout-general", "signals-scout-errors"]}},
-        }
-
-    with patch(_PAYLOAD_PATH, side_effect=_payload):
-        planned = await _run_activity()
-
-    assert sorted(p.skill_name for p in planned) == ["signals-scout-errors", "signals-scout-general"]
+    if expected is not None:
+        assert general.run_interval_minutes == expected
+    else:
+        # Unchanged from the model default (not the out-of-range value).
+        assert general.run_interval_minutes != interval
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -634,32 +634,33 @@ async def test_auto_register_past_enabled_cap_creates_disabled_config(ateam):
     "default_cfg,team_cfg,skills,expected_enabled",
     [
         # An allowlist enables only the listed canonical scout; the rest seed disabled.
+        # (error-tracking / surveys are real on-disk canonical names, so the tag gates them.)
         (
             {"enabled_skills": ["signals-scout-general"]},
             None,
-            [("signals-scout-general", True), ("signals-scout-errors", True), ("signals-scout-surveys", True)],
-            {"signals-scout-general": True, "signals-scout-errors": False, "signals-scout-surveys": False},
+            [("signals-scout-general", True), ("signals-scout-error-tracking", True), ("signals-scout-surveys", True)],
+            {"signals-scout-general": True, "signals-scout-error-tracking": False, "signals-scout-surveys": False},
         ),
         # No allowlist → every scout enables (back-compat, unchanged from before seed posture).
         (
             {},
             None,
-            [("signals-scout-general", True), ("signals-scout-errors", True)],
-            {"signals-scout-general": True, "signals-scout-errors": True},
+            [("signals-scout-general", True), ("signals-scout-error-tracking", True)],
+            {"signals-scout-general": True, "signals-scout-error-tracking": True},
         ),
         # A per-team override widens the fleet default for one team (close-partner case).
         (
             {"enabled_skills": ["signals-scout-general"]},
-            {"enabled_skills": ["signals-scout-general", "signals-scout-errors"]},
-            [("signals-scout-general", True), ("signals-scout-errors", True), ("signals-scout-surveys", True)],
-            {"signals-scout-general": True, "signals-scout-errors": True, "signals-scout-surveys": False},
+            {"enabled_skills": ["signals-scout-general", "signals-scout-error-tracking"]},
+            [("signals-scout-general", True), ("signals-scout-error-tracking", True), ("signals-scout-surveys", True)],
+            {"signals-scout-general": True, "signals-scout-error-tracking": True, "signals-scout-surveys": False},
         ),
         # A malformed per-team override falls back to the fleet default, not "no allowlist".
         (
             {"enabled_skills": ["signals-scout-general"]},
             {"enabled_skills": "signals-scout-general"},
-            [("signals-scout-general", True), ("signals-scout-errors", True)],
-            {"signals-scout-general": True, "signals-scout-errors": False},
+            [("signals-scout-general", True), ("signals-scout-error-tracking", True)],
+            {"signals-scout-general": True, "signals-scout-error-tracking": False},
         ),
         # A hand-authored custom scout (no seeded_by tag) auto-enables even under an allowlist.
         (
@@ -668,11 +669,20 @@ async def test_auto_register_past_enabled_cap_creates_disabled_config(ateam):
             [("signals-scout-general", True), ("signals-scout-custom", False)],
             {"signals-scout-general": True, "signals-scout-custom": True},
         ),
+        # A duplicated canonical scout keeps the seeded_by tag but on a non-canonical name, so it's
+        # treated as custom and still auto-enables (not gated by the allowlist).
+        (
+            {"enabled_skills": ["signals-scout-general"]},
+            None,
+            [("signals-scout-general", True), ("signals-scout-general-copy", True)],
+            {"signals-scout-general": True, "signals-scout-general-copy": True},
+        ),
     ],
 )
 async def test_seed_posture_enabled_map(ateam, default_cfg, team_cfg, skills, expected_enabled):
     # Which scouts seed enabled vs disabled, across allowlist / no-allowlist / per-team-override /
-    # malformed-override / custom-scout scenarios. `skills` is (name, seeded_as_canonical) pairs.
+    # malformed-override / custom-scout / duplicated-scout scenarios. `skills` is
+    # (name, seeded_with_harness_tag) pairs; only a tag AND an on-disk canonical name = gated.
     for name, seeded in skills:
         await database_sync_to_async(_create_skill)(ateam, name, seeded=seeded)
 

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -30,6 +30,7 @@ from products.signals.backend.temporal.agentic.scout_coordinator import (
     PlannedRun,
     SignalsScoutCoordinatorWorkflow,
     StampDispatchedRunsInput,
+    _default_team_config,
     _enrolled_team_ids,
     _read_flag_payload,
     _team_configs,
@@ -542,6 +543,80 @@ async def test_per_team_config_override_keyed_by_child_env_applies_to_parent(ate
     assert [p.skill_name for p in planned] == ["signals-scout-most"]
 
     await sync_to_async(child.delete)()
+
+
+# ── Fleet-wide default config via the flag payload (default_team_config) ──────────
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"default_team_config": {"max_runs_per_tick": 1}}, {"max_runs_per_tick": 1}),
+        ('{"default_team_config": {"max_runs_per_tick": 2}}', {"max_runs_per_tick": 2}),  # JSON string payload
+        ({"default_team_config": "nope"}, {}),  # wrong type → empty
+        ({}, {}),  # absent key → no fleet default
+        (None, {}),  # no payload → no fleet default
+    ],
+)
+@pytest.mark.flag_off
+def test_default_team_config_parses_payload(payload, expected):
+    with patch(_PAYLOAD_PATH, return_value=payload):
+        assert _default_team_config(_read_flag_payload()) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_default_team_config_caps_team_without_override(ateam):
+    # The launch posture: a fleet-wide `default_team_config` caps EVERY enrolled team at 1/tick,
+    # with no per-team entry. Three due scouts → only the most-overdue dispatches, proving the
+    # default layer applies when a team has no `team_configs` override of its own.
+    now = timezone.now()
+    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+        await database_sync_to_async(_create_config)(
+            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
+        )
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"max_runs_per_tick": 1},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    assert [p.skill_name for p in planned] == ["signals-scout-most"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_per_team_override_beats_default_team_config(ateam):
+    # A per-team `team_configs` entry takes precedence over the fleet-wide `default_team_config`:
+    # the default would cap this team at 1/tick, but its own override raises it to 3, so all three
+    # due scouts dispatch.
+    now = timezone.now()
+    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+        await database_sync_to_async(_create_config)(
+            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
+        )
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"max_runs_per_tick": 1},
+            "team_configs": {str(ateam.id): {"max_runs_per_tick": 3}},
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        planned = await _run_activity()
+
+    assert sorted(p.skill_name for p in planned) == [
+        "signals-scout-least",
+        "signals-scout-mid",
+        "signals-scout-most",
+    ]
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -566,10 +566,21 @@ def test_default_team_config_parses_payload(payload, expected):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_default_team_config_caps_team_without_override(ateam):
-    # The launch posture: a fleet-wide `default_team_config` caps EVERY enrolled team at 1/tick,
-    # with no per-team entry. Three due scouts → only the most-overdue dispatches, proving the
-    # default layer applies when a team has no `team_configs` override of its own.
+@pytest.mark.parametrize(
+    "team_override_cap,expected_names",
+    [
+        # No per-team entry → the fleet-wide default_team_config (cap 1) binds.
+        (None, ["signals-scout-most"]),
+        # A valid per-team override beats the fleet default, so all three dispatch.
+        (3, ["signals-scout-least", "signals-scout-mid", "signals-scout-most"]),
+        # An invalid per-team override falls through to the fleet default (cap 1).
+        ("nope", ["signals-scout-most"]),
+    ],
+)
+async def test_default_team_config_resolution(ateam, team_override_cap, expected_names):
+    # A fleet-wide `default_team_config` caps every enrolled team at 1/tick; a per-team
+    # `team_configs` override takes precedence when present and valid, else the fleet default
+    # still binds. Three scouts due (10h/5h/2h overdue) make the resolved cap observable.
     now = timezone.now()
     for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
         await database_sync_to_async(_create_skill)(ateam, name)
@@ -578,45 +589,18 @@ async def test_default_team_config_caps_team_without_override(ateam):
         )
 
     def _payload(*_a, **_k):
-        return {
+        payload: dict[str, Any] = {
             "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
             "default_team_config": {"max_runs_per_tick": 1},
         }
+        if team_override_cap is not None:
+            payload["team_configs"] = {str(ateam.id): {"max_runs_per_tick": team_override_cap}}
+        return payload
 
     with patch(_PAYLOAD_PATH, side_effect=_payload):
         planned = await _run_activity()
 
-    assert [p.skill_name for p in planned] == ["signals-scout-most"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.django_db
-async def test_per_team_override_beats_default_team_config(ateam):
-    # A per-team `team_configs` entry takes precedence over the fleet-wide `default_team_config`:
-    # the default would cap this team at 1/tick, but its own override raises it to 3, so all three
-    # due scouts dispatch.
-    now = timezone.now()
-    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
-        await database_sync_to_async(_create_skill)(ateam, name)
-        await database_sync_to_async(_create_config)(
-            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
-        )
-
-    def _payload(*_a, **_k):
-        return {
-            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
-            "default_team_config": {"max_runs_per_tick": 1},
-            "team_configs": {str(ateam.id): {"max_runs_per_tick": 3}},
-        }
-
-    with patch(_PAYLOAD_PATH, side_effect=_payload):
-        planned = await _run_activity()
-
-    assert sorted(p.skill_name for p in planned) == [
-        "signals-scout-least",
-        "signals-scout-mid",
-        "signals-scout-most",
-    ]
+    assert sorted(p.skill_name for p in planned) == sorted(expected_names)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Launching Signals scouts to dogfooders next week, we want new teams to start with a minimal, cheap posture — one general scout, once a day — rather than the full ~16-scout canonical fleet running hourly (~$570/team/day). Today enrollment seeds *every* `signals-scout-*` skill enabled at the model-default schedule, so there's no way to start a team small without manually trimming each config after the fact.

Stacked on #64821, which added the fleet-wide `default_team_config` layer (this PR reads the same resolved config).

## Changes

Teaches `register_missing_configs` to honour an optional seed posture carried in the resolved flag config (`default_team_config` merged with a team's `team_configs` override):

- `enabled_skills` — allowlist of canonical scouts that auto-enable on seed. Everything else registers **disabled** (still visible and tunable, no spend). Absent → every scout enables, unchanged from today.
- `enabled_interval_minutes` — cadence stamped on the auto-enabled rows (e.g. `1440` for daily). Absent → model default.

The coordinator builds the per-team seed config (`{**default_team_config, **team_configs[team]}`) and passes it through. Resolution mirrors the tick-cap precedence from #64821: a team's own override layers over the fleet default.

Two properties worth calling out:

- **Forward-only.** Posture only shapes rows at creation (`get_or_create`). Existing configs are never re-stamped, so flipping the flag doesn't disturb already-seeded teams, and a user enabling a scout won't be reverted on the next tick.
- **Additive / no behaviour change until used.** With no `enabled_skills` in the flag (today's state, including the armed `default_team_config: {max_runs_per_tick: 1}`), seeding behaves exactly as before. The launch posture is opt-in per the flag payload, no deploy.

The per-team `MAX_ENABLED_SCOUTS_PER_TEAM` cap stays an independent second gate.

To arm the launch posture once this is live, set in the `signals-scout` flag:

```json
"default_team_config": { "max_runs_per_tick": 1, "enabled_skills": ["signals-scout-general"], "enabled_interval_minutes": 1440 }
```

Throttling (rather than disabling) the non-general scouts is a deliberate follow-up — it slots in as an `others_posture` key on the same blob without a redesign.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Added coordinator-level integration tests: allowlist enables only listed scouts (rest disabled), `enabled_interval_minutes` stamps the cadence, no-config back-compat enables all, and a per-team override widening the fleet default.
- Full coordinator suite green: `hogli test products/signals/backend/test/test_scout_coordinator.py` → 56 passed. `ruff` clean; pre-commit `ty check` passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this as Phase 2 of the scouts launch cost posture (Phase 1 = #64821, the `default_team_config` cap layer). Deliberately stacked on #64821 because it reuses that PR's resolved-config plumbing.

Scope kept tight: the allowlist + interval are enough to deliver "general-only, once a day"; the "throttle the rest" posture is left as a follow-up key rather than built now, to keep the diff reviewable. Resolution intentionally mirrors the existing tick-cap precedence so the two knobs behave consistently.

Tools: Claude Code. No codegen skills were invoked.
