### PR TITLE
fix(error-tracking): preserve integer user assignee id on issue fetch

### DIFF
--- a/products/error_tracking/backend/presentation/views/issues.py
+++ b/products/error_tracking/backend/presentation/views/issues.py
@@ -46,8 +46,15 @@ logger = structlog.get_logger(__name__)
 
 
 class ErrorTrackingIssueAssigneeReadSerializer(serializers.Serializer):
-    id = serializers.CharField(allow_null=True)
+    # User assignees carry an integer id, role assignees a UUID string. `CharField` would
+    # coerce the user id to a string, which the frontend assignee resolver compares with
+    # `===` against the numeric member id — failing to resolve and rendering "Unassigned".
+    id = serializers.SerializerMethodField()
     type = serializers.CharField()
+
+    @extend_schema_field({"oneOf": [{"type": "integer"}, {"type": "string"}], "nullable": True})
+    def get_id(self, obj) -> int | str | None:
+        return obj.id
 
 
 class ErrorTrackingIssueCohortReadSerializer(serializers.Serializer):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -116,6 +116,8 @@ class TestErrorTracking(APIBaseTest):
         # `assignee.id`; if retrieve serializes the user id as a string the issue renders as
         # "Unassigned" despite being assigned. User ids must stay integers, role ids strings.
         issue = self.create_issue(["fingerprint"])
+        expected_id: int | str
+        expected_python_type: type
         if assignee_type == "user":
             ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
             expected_id, expected_python_type = self.user.id, int

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -110,31 +110,26 @@ class TestErrorTracking(APIBaseTest):
             "external_issues": [],
         }
 
-    def test_issue_fetch_user_assignee_id_is_integer(self):
+    @parameterized.expand(["user", "role"])
+    def test_issue_fetch_assignee_id_preserves_type(self, assignee_type):
         # The frontend resolves the assignee by strict-comparing the numeric member id with
         # `assignee.id`; if retrieve serializes the user id as a string the issue renders as
         # "Unassigned" despite being assigned. User ids must stay integers, role ids strings.
         issue = self.create_issue(["fingerprint"])
-        ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
+        if assignee_type == "user":
+            ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
+            expected_id, expected_python_type = self.user.id, int
+        else:
+            role = Role.objects.create(name="Eng role", organization=self.organization)
+            ErrorTrackingIssueAssignment.objects.create(issue=issue, role=role)
+            expected_id, expected_python_type = str(role.id), str
 
         response = self.client.get(f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}")
 
         assert response.status_code == 200
         assignee = response.json()["assignee"]
-        assert assignee == {"id": self.user.id, "type": "user"}
-        assert isinstance(assignee["id"], int)
-
-    def test_issue_fetch_role_assignee_id_is_string(self):
-        issue = self.create_issue(["fingerprint"])
-        role = Role.objects.create(name="Eng role", organization=self.organization)
-        ErrorTrackingIssueAssignment.objects.create(issue=issue, role=role)
-
-        response = self.client.get(f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}")
-
-        assert response.status_code == 200
-        assignee = response.json()["assignee"]
-        assert assignee == {"id": str(role.id), "type": "role"}
-        assert isinstance(assignee["id"], str)
+        assert assignee == {"id": expected_id, "type": assignee_type}
+        assert isinstance(assignee["id"], expected_python_type)
 
     @freeze_time("2025-01-01")
     def test_issue_update(self):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -110,6 +110,32 @@ class TestErrorTracking(APIBaseTest):
             "external_issues": [],
         }
 
+    def test_issue_fetch_user_assignee_id_is_integer(self):
+        # The frontend resolves the assignee by strict-comparing the numeric member id with
+        # `assignee.id`; if retrieve serializes the user id as a string the issue renders as
+        # "Unassigned" despite being assigned. User ids must stay integers, role ids strings.
+        issue = self.create_issue(["fingerprint"])
+        ErrorTrackingIssueAssignment.objects.create(issue=issue, user=self.user)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}")
+
+        assert response.status_code == 200
+        assignee = response.json()["assignee"]
+        assert assignee == {"id": self.user.id, "type": "user"}
+        assert isinstance(assignee["id"], int)
+
+    def test_issue_fetch_role_assignee_id_is_string(self):
+        issue = self.create_issue(["fingerprint"])
+        role = Role.objects.create(name="Eng role", organization=self.organization)
+        ErrorTrackingIssueAssignment.objects.create(issue=issue, role=role)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}")
+
+        assert response.status_code == 200
+        assignee = response.json()["assignee"]
+        assert assignee == {"id": str(role.id), "type": "role"}
+        assert isinstance(assignee["id"], str)
+
     @freeze_time("2025-01-01")
     def test_issue_update(self):
         issue = self.create_issue(["fingerprint"])


### PR DESCRIPTION
## Problem

Assigning a user from the issues list, then opening the issue, showed "Unassigned" even though the assignee was set (you could still remove them).

The issue retrieve endpoint serialized the user assignee `id` through a `CharField`, coercing it to a string. The frontend assignee resolver strict-compares the numeric member id against `assignee.id`, so a string id never matched and the trigger fell back to "Unassigned". The list view (ClickHouse path) returns an integer, so the two views disagreed. Roles were unaffected (their id is a UUID string on both paths).

## Changes

`ErrorTrackingIssueAssigneeReadSerializer.id` now uses a `SerializerMethodField` (`oneOf integer|string`) instead of `CharField`, preserving integer ids for users and string ids for roles — matching the existing `ErrorTrackingIssueAssignmentSerializer`.

## How did you test this code?

I'm an agent. Added two backend regression tests asserting the retrieve endpoint returns an integer id for user assignees and a string id for role assignees; ran the error tracking API test subset (7 passed). No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Invoked the `/improving-drf-endpoints` skill before editing the serializer. Mirrored the existing `ErrorTrackingIssueAssignmentSerializer` (`SerializerMethodField` + `extend_schema_field`) rather than swapping in a less explicit field type. No codegen change needed: `getIssue` uses the handwritten `ErrorTrackingRelationalIssue` type, which already declares `id: integer | string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
