### PR TITLE
feat(data-warehouse): add lookback window for Google Ads incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -1289,6 +1289,9 @@ class GoogleAdManagerSourceConfig(config.Config):
 class GoogleAdsSourceConfig(config.Config):
     customer_id: str
     google_ads_integration_id: int = config.value(converter=config.str_to_int)
+    conversion_lookback_days: int | None = config.value(
+        converter=config.str_to_optional_int, default_factory=lambda: None
+    )
     is_mcc_account: GoogleAdsIsMccAccountConfig | None = None
 
 

--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -401,7 +401,17 @@ def google_ads_source(
             else:
                 last_value = db_incremental_field_last_value
 
-            if isinstance(last_value, dt.datetime) or isinstance(last_value, dt.date):
+            # Google Ads revises conversions/conversion value for days after the click. A strict
+            # `date >= cursor` would freeze those days once the cursor passes them, so roll the
+            # cursor back by the configured lookback to re-fetch and merge the recent window on
+            # every run. Merge over `primary_keys` (which includes `segments.date`) updates the
+            # re-fetched rows in place rather than duplicating them. Date cursors only; the legacy
+            # service-account config doesn't expose the field, so it stays on the strict cursor.
+            lookback_days = config.conversion_lookback_days if isinstance(config, GoogleAdsSourceConfig) else None
+            if lookback_days and lookback_days > 0 and isinstance(last_value, (dt.datetime, dt.date)):
+                last_value = last_value - dt.timedelta(days=lookback_days)
+
+            if isinstance(last_value, (dt.datetime, dt.date)):
                 last_value = f"'{last_value.isoformat()}'"
 
             query += f" WHERE {incremental_field} >= {last_value}"

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -173,8 +173,8 @@ class GoogleAdsSource(
                             "Google Ads keeps updating conversions and conversion value for days after the "
                             "original click. On each sync we re-fetch the most recent N days of stats so those "
                             "delayed updates are merged in — set this to match your Google Ads conversion window "
-                            "(e.g. 30 days). **A larger window re-syncs more rows every run and increases sync cost.** "
-                            "Leave blank to disable (only rows for newly seen dates are synced)."
+                            "(e.g. 30 days, max 90). **A larger window re-syncs more rows every run and increases "
+                            "sync cost.** Leave blank to disable (only rows for newly seen dates are synced)."
                         ),
                         secret=False,
                     ),
@@ -234,6 +234,22 @@ class GoogleAdsSource(
                 errors.append(
                     "Please enter a valid Google Ads manager customer ID — the 10-digit number from "
                     "your manager account (dashes optional)."
+                )
+                is_valid = False
+
+        # Cap the lookback at the longest Google Ads conversion window (90-day click-through);
+        # beyond that there's nothing left to recover, only wasted re-syncing. Reject out-of-range
+        # values at setup so a fat-fingered entry surfaces here instead of bloating every sync.
+        raw_lookback = job_inputs.get("conversion_lookback_days")
+        if raw_lookback is not None and raw_lookback != "":
+            try:
+                lookback_days = int(raw_lookback)
+            except (TypeError, ValueError):
+                lookback_days = None
+            if lookback_days is None or not (0 <= lookback_days <= 90):
+                errors.append(
+                    "Conversion lookback window must be a whole number of days between 0 and 90 "
+                    "(the longest Google Ads conversion window)."
                 )
                 is_valid = False
 

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -163,6 +163,21 @@ class GoogleAdsSource(
                     SourceFieldOauthConfig(
                         name="google_ads_integration_id", label="Google Ads account", required=True, kind="google-ads"
                     ),
+                    SourceFieldInputConfig(
+                        name="conversion_lookback_days",
+                        label="Conversion lookback window (days)",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=False,
+                        placeholder="30",
+                        caption=(
+                            "Google Ads keeps updating conversions and conversion value for days after the "
+                            "original click. On each sync we re-fetch the most recent N days of stats so those "
+                            "delayed updates are merged in — set this to match your Google Ads conversion window "
+                            "(e.g. 30 days). **A larger window re-syncs more rows every run and increases sync cost.** "
+                            "Leave blank to disable (only rows for newly seen dates are synced)."
+                        ),
+                        secret=False,
+                    ),
                     SourceFieldSwitchGroupConfig(
                         name="is_mcc_account",
                         label="Using MCC account?",

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from types import SimpleNamespace
 
 import pytest
@@ -10,14 +11,21 @@ from google.ads.googleads.v23.errors.types.request_error import RequestErrorEnum
 
 from posthog.models.integration import Integration
 from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
-from posthog.temporal.data_imports.sources.google_ads.configs import GoogleAdsResumeConfig, clean_customer_id
+from posthog.temporal.data_imports.sources.google_ads.configs import (
+    GoogleAdsResumeConfig,
+    GoogleAdsServiceAccountSourceConfig,
+    clean_customer_id,
+)
 from posthog.temporal.data_imports.sources.google_ads.google_ads import (
     GoogleAdsColumn,
     GoogleAdsTable,
     _is_invalid_page_token_error,
     _search_as_arrow_tables,
+    google_ads_source,
 )
 from posthog.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
+
+from products.data_warehouse.backend.types import IncrementalFieldType
 
 _CUSTOMER_ID_ERROR = "valid Google Ads customer ID"
 _MANAGER_ID_ERROR = "valid Google Ads manager customer ID"
@@ -357,6 +365,90 @@ class _FakeResumableManager:
 
     def save_state(self, data: GoogleAdsResumeConfig) -> None:
         self.saved_states.append(data.page_token)
+
+
+def _stats_table() -> GoogleAdsTable:
+    return GoogleAdsTable(
+        name="campaign_stats",
+        alias="campaign_stats",
+        columns=[_string_column("segments.date"), _string_column("metrics.conversions_value")],
+        parents=None,
+        requires_filter=True,
+        primary_key=["campaign.id", "segments.date"],
+        should_sync_default=True,
+        description=None,
+        partition_keys=["segments.date"],
+    )
+
+
+def _capture_incremental_query(config, db_incremental_field_last_value: dt.date) -> str:
+    """Build a stats-table source response and return the query its fetch loop issues.
+
+    Mocks out the SDK (`get_schemas`, `google_ads_client`) and intercepts
+    `_search_as_arrow_tables` so we can assert on the WHERE clause without a live API.
+    """
+    captured: dict[str, str] = {}
+
+    def _capture(*, query: str, **_kwargs):
+        captured["query"] = query
+        return iter(())
+
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_ads.google_ads.get_schemas",
+            return_value={"campaign_stats": _stats_table()},
+        ),
+        mock.patch("posthog.temporal.data_imports.sources.google_ads.google_ads.google_ads_client"),
+        mock.patch(
+            "posthog.temporal.data_imports.sources.google_ads.google_ads._search_as_arrow_tables",
+            side_effect=_capture,
+        ),
+    ):
+        response = google_ads_source(
+            config=config,
+            resource_name="campaign_stats",
+            team_id=1,
+            resumable_source_manager=mock.MagicMock(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field="segments.date",
+            incremental_field_type=IncrementalFieldType.Date,
+        )
+        list(response.items())
+
+    return captured["query"]
+
+
+class TestConversionLookback:
+    @pytest.mark.parametrize(
+        "lookback_days, expected_lower_bound",
+        [
+            (None, "2026-06-01"),  # unset → strict cursor, backwards compatible
+            (0, "2026-06-01"),  # zero / negative are treated as disabled
+            (1, "2026-05-31"),
+            (30, "2026-05-02"),
+        ],
+    )
+    def test_lookback_rolls_cursor_back(self, lookback_days, expected_lower_bound):
+        config = GoogleAdsSourceConfig(
+            customer_id="1234567890",
+            google_ads_integration_id=1,
+            conversion_lookback_days=lookback_days,
+        )
+
+        query = _capture_incremental_query(config, db_incremental_field_last_value=dt.date(2026, 6, 1))
+
+        assert f"segments.date >= '{expected_lower_bound}'" in query
+        assert "segments.date < '2100-01-01'" in query
+
+    def test_legacy_service_account_config_is_unaffected(self):
+        # The legacy service-account config has no `conversion_lookback_days` field; the
+        # `getattr` fallback must leave the strict cursor untouched rather than raising.
+        config = GoogleAdsServiceAccountSourceConfig(customer_id="1234567890")
+
+        query = _capture_incremental_query(config, db_incremental_field_last_value=dt.date(2026, 6, 1))
+
+        assert "segments.date >= '2026-06-01'" in query
 
 
 class TestInvalidPageTokenDetection:

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -29,6 +29,7 @@ from products.data_warehouse.backend.types import IncrementalFieldType
 
 _CUSTOMER_ID_ERROR = "valid Google Ads customer ID"
 _MANAGER_ID_ERROR = "valid Google Ads manager customer ID"
+_LOOKBACK_ERROR = "Conversion lookback window must be"
 
 
 class TestCleanCustomerId:
@@ -58,6 +59,19 @@ class TestGoogleAdsValidateConfig:
     def _manager_id_errors(self, job_inputs: dict) -> list[str]:
         _, errors = self.source.validate_config(job_inputs)
         return [e for e in errors if _MANAGER_ID_ERROR in e]
+
+    def _lookback_errors(self, lookback) -> list[str]:
+        job_inputs = {"customer_id": "1234567890", "conversion_lookback_days": lookback}
+        _, errors = self.source.validate_config(job_inputs)
+        return [e for e in errors if _LOOKBACK_ERROR in e]
+
+    @pytest.mark.parametrize("lookback", [None, "", 0, 1, 30, 90, "30"])
+    def test_accepts_valid_conversion_lookback(self, lookback):
+        assert self._lookback_errors(lookback) == []
+
+    @pytest.mark.parametrize("lookback", [-1, 91, 365, "abc", "12.5"])
+    def test_rejects_out_of_range_conversion_lookback(self, lookback):
+        assert len(self._lookback_errors(lookback)) == 1
 
     @pytest.mark.parametrize(
         "customer_id",
@@ -414,7 +428,7 @@ def _capture_incremental_query(config, db_incremental_field_last_value: dt.date)
             incremental_field="segments.date",
             incremental_field_type=IncrementalFieldType.Date,
         )
-        list(response.items())
+        list(response.items())  # type: ignore[arg-type]
 
     return captured["query"]
 
@@ -424,7 +438,8 @@ class TestConversionLookback:
         "lookback_days, expected_lower_bound",
         [
             (None, "2026-06-01"),  # unset → strict cursor, backwards compatible
-            (0, "2026-06-01"),  # zero / negative are treated as disabled
+            (0, "2026-06-01"),  # zero → disabled
+            (-1, "2026-06-01"),  # negative → disabled (defensive; validation rejects it at setup)
             (1, "2026-05-31"),
             (30, "2026-05-02"),
         ],
@@ -442,8 +457,8 @@ class TestConversionLookback:
         assert "segments.date < '2100-01-01'" in query
 
     def test_legacy_service_account_config_is_unaffected(self):
-        # The legacy service-account config has no `conversion_lookback_days` field; the
-        # `getattr` fallback must leave the strict cursor untouched rather than raising.
+        # The legacy service-account config is not a GoogleAdsSourceConfig; the
+        # isinstance guard must leave the strict cursor untouched.
         config = GoogleAdsServiceAccountSourceConfig(customer_id="1234567890")
 
         query = _capture_incremental_query(config, db_incremental_field_last_value=dt.date(2026, 6, 1))


### PR DESCRIPTION
## Problem

A [user reported](https://posthoghelp.zendesk.com/agent/tickets/60361) that their Google Ads conversion data was too low, suspecting it's because Google Ads updates data after the fact. We use `segments.date` for incremental syncs, and therefore never refresh this updated data.

For customers with lots of data, doing full refreshes can get expensive.

## Changes

Add a new 'lookback window' config option on the Google Ads source, which lets customers configure how many days before their most recent sync they want to refresh. The idea is that this aligns with their conversion window in Google Ads (typically 30 days).

I considered using the API to look up the conversion window, but I think it can vary per campaign, which would make this quite complicated.

Obviously this will result in lots more rows getting synced, so we make this clear in the UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Yes

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). The work started as a sense-check of a customer report — Google Ads conversion values in the warehouse drifting below the Google Ads UI while cost matched perfectly — and turned into this fix once the cause was confirmed.

**What's going on:** the Google Ads source syncs the `*_stats` tables incrementally on a strict `segments.date >= cursor` cursor. Google revises conversions and conversion value for days *after* the original click (the attribution/conversion window), but once the cursor advances past a day, that day is frozen and never re-fetched. So delayed conversion updates are silently lost, leaving conversion totals low. The customer confirmed a full-table refresh reconciles the numbers, which pinned staleness as the root cause.

**The fix:** a configurable `conversion_lookback_days` field on the Google Ads source. When set, the incremental cursor is rolled back by N days (`WHERE segments.date >= cursor − N`) so the recent window is re-fetched on every run. The existing Delta merge is an upsert on a primary key that already includes `segments.date`, so re-fetched rows update in place rather than duplicating — no new merge logic needed.

**Decisions made along the way:**
- **Naming.** Deliberately *not* called `sync_lookback_days` to avoid confusion with the Meta Ads field of that name, which does a different thing (it seeds the initial backfill window; this rolls the ongoing incremental cursor back). Named for the customer's mental model — their Google Ads conversion window.
- **Config vs. auto-detect.** We can read per-conversion-action lookback windows from the already-synced `conversion_action` table, but auto-deriving a single value risks a stray 90-day action forcing a runaway re-sync. Shipped a simple configurable field as v1 so the user owns the cost/accuracy trade-off; auto-suggesting a default is a possible follow-up.
- **Scope.** The lookback is gated to the incremental date-cursor path, which is exactly the 12 `*_stats`/performance tables — all of which carry `metrics.conversions`. Full-refresh entity tables (`campaign`, `ad`, `conversion_action`, …) are excluded automatically. No explicit table allowlist was added since the structural gating already hits all and only the tables that benefit.
- **Backward compatibility.** Field defaults to `None`; `None`/`0`/negative are no-ops, so existing sources keep the strict cursor unchanged. The legacy service-account config doesn't expose the field, and the cursor logic narrows on `isinstance(config, GoogleAdsSourceConfig)` (consistent with how the rest of the module branches the config union) so that path stays untouched.
- **UI cost warning.** The field's caption flags that a larger window re-syncs more rows per run and costs more.

**Skills invoked:** `/implementing-warehouse-sources` (source/config conventions, the `generate:source-configs` workflow), and `/simplify` (a 4-agent cleanup pass that replaced a stringly-typed `getattr` with `isinstance` narrowing and stripped unrelated formatting churn from `generated_configs.py`).

**Testing (agent-run, automated only):** added parameterized tests asserting the cursor lower bound for lookback values `None`/`0`/`1`/`30`, plus a legacy-service-account no-op case. The full `test_google_ads_source.py` suite (64 tests) passes; `ruff check`/`format` clean. `generated_configs.py` was produced by `pnpm generate:source-configs` (verified reproducible from a clean regenerate), not hand-edited. No manual end-to-end sync against the live Google Ads API was performed.
