### PR TITLE
feat(billing): handle collections access commands

### DIFF
--- a/ee/billing/queue/BillingConsumer.py
+++ b/ee/billing/queue/BillingConsumer.py
@@ -256,13 +256,9 @@ class BillingConsumer(SQSConsumer):
 
         if desired_state == "blocked":
             if (
-                organization.is_active is not False
-                or organization.is_not_active_reason == BILLING_COLLECTIONS_INACTIVE_REASON
+                organization.is_active is False
+                and organization.is_not_active_reason != BILLING_COLLECTIONS_INACTIVE_REASON
             ):
-                organization.is_active = False
-                organization.is_not_active_reason = BILLING_COLLECTIONS_INACTIVE_REASON
-                organization.save(update_fields=["is_active", "is_not_active_reason", "updated_at"])
-            else:
                 logger.info(
                     "Skipping Billing collections block because organization is already inactive for another reason",
                     extra={
@@ -273,6 +269,11 @@ class BillingConsumer(SQSConsumer):
                         "is_not_active_reason": organization.is_not_active_reason,
                     },
                 )
+                return
+
+            organization.is_active = False
+            organization.is_not_active_reason = BILLING_COLLECTIONS_INACTIVE_REASON
+            organization.save(update_fields=["is_active", "is_not_active_reason", "updated_at"])
         else:
             if (
                 organization.is_active is False

--- a/ee/billing/queue/BillingConsumer.py
+++ b/ee/billing/queue/BillingConsumer.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 # PostHog's own team on Cloud US — owns the Customer-analytics accounts that inbound billing
 # usage-spike events resolve against. Billing emits these spike messages to the US queue.
 POSTHOG_SELF_TEAM_ID = 2
+BILLING_COLLECTIONS_ACCESS_BLOCK_REASON = "collections_failed_payment"
+BILLING_COLLECTIONS_INACTIVE_REASON = "Billing collections: payment failed"
 
 
 class BillingConsumer(SQSConsumer):
@@ -52,6 +54,8 @@ class BillingConsumer(SQSConsumer):
                 self._process_billing_customer_update(body)
             elif message_type == "usage_spike_detected":
                 self._process_usage_spike_detected(body)
+            elif message_type == "billing_collections_access_state_changed":
+                self._process_collections_access_state_changed(body)
             # Add more message types as needed
             # elif message_type == "invoice_created":
             #     self._process_invoice_created(body)
@@ -174,3 +178,106 @@ class BillingConsumer(SQSConsumer):
             stripe_customer_id=data.get("stripe_customer_id"),
             detected_at=data.get("detected_at"),
         )
+
+    def _process_collections_access_state_changed(self, body: dict[str, Any]) -> None:
+        """Apply a Billing collections org access block/unblock command."""
+        data = body.get("data", {})
+        organization_id = body.get("organization_id") or data.get("organization_id")
+        billing_customer_id = (
+            body.get("billing_customer_id")
+            or body.get("customer_id")
+            or data.get("billing_customer_id")
+            or data.get("customer_id")
+        )
+        stripe_customer_id = body.get("stripe_customer_id") or data.get("stripe_customer_id")
+        desired_state = body.get("desired_state") or data.get("desired_state")
+        reason = body.get("reason") or data.get("reason")
+
+        if not all([organization_id, billing_customer_id, stripe_customer_id, desired_state, reason]):
+            logger.error(
+                "Billing collections access state message is missing required fields",
+                extra={
+                    "organization_id": organization_id,
+                    "billing_customer_id": billing_customer_id,
+                    "stripe_customer_id": stripe_customer_id,
+                    "desired_state": desired_state,
+                    "reason": reason,
+                },
+            )
+            capture_exception(Exception("Billing collections access state message is missing required fields"))
+            return
+
+        if reason != BILLING_COLLECTIONS_ACCESS_BLOCK_REASON:
+            logger.error("Unsupported Billing collections access block reason", extra={"reason": reason})
+            capture_exception(Exception("Unsupported Billing collections access block reason"), {"reason": reason})
+            return
+
+        if desired_state not in {"blocked", "unblocked"}:
+            logger.error(
+                "Unsupported Billing collections access desired state",
+                extra={"desired_state": desired_state},
+            )
+            capture_exception(
+                Exception("Unsupported Billing collections access desired state"),
+                {"desired_state": desired_state},
+            )
+            return
+
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            logger.exception(f"Organization {organization_id} does not exist")
+            capture_exception(
+                Exception("Organization for Billing collections access state does not exist"),
+                {"organization_id": organization_id},
+            )
+            return
+
+        if organization.customer_id != str(billing_customer_id):
+            logger.error(
+                "Billing collections access state customer mismatch",
+                extra={
+                    "organization_id": organization_id,
+                    "organization_customer_id": organization.customer_id,
+                    "billing_customer_id": billing_customer_id,
+                    "stripe_customer_id": stripe_customer_id,
+                },
+            )
+            capture_exception(
+                Exception("Billing collections access state customer mismatch"),
+                {
+                    "organization_id": organization_id,
+                    "organization_customer_id": organization.customer_id,
+                    "billing_customer_id": billing_customer_id,
+                    "stripe_customer_id": stripe_customer_id,
+                },
+            )
+            return
+
+        if desired_state == "blocked":
+            if (
+                organization.is_active is not False
+                or organization.is_not_active_reason == BILLING_COLLECTIONS_INACTIVE_REASON
+            ):
+                organization.is_active = False
+                organization.is_not_active_reason = BILLING_COLLECTIONS_INACTIVE_REASON
+                organization.save(update_fields=["is_active", "is_not_active_reason", "updated_at"])
+            else:
+                logger.info(
+                    "Skipping Billing collections block because organization is already inactive for another reason",
+                    extra={
+                        "organization_id": organization_id,
+                        "organization_customer_id": organization.customer_id,
+                        "billing_customer_id": billing_customer_id,
+                        "stripe_customer_id": stripe_customer_id,
+                        "is_not_active_reason": organization.is_not_active_reason,
+                    },
+                )
+        else:
+            if (
+                organization.is_active is False
+                and organization.is_not_active_reason == BILLING_COLLECTIONS_INACTIVE_REASON
+            ):
+                organization.is_active = True
+                organization.is_not_active_reason = None
+                organization.save(update_fields=["is_active", "is_not_active_reason", "updated_at"])

--- a/ee/billing/test/test_billing_consumer.py
+++ b/ee/billing/test/test_billing_consumer.py
@@ -1,7 +1,16 @@
+import gzip
+import json
+import base64
+
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
-from ee.billing.queue.BillingConsumer import POSTHOG_SELF_TEAM_ID, BillingConsumer
+from ee.billing.queue.BillingConsumer import (
+    BILLING_COLLECTIONS_ACCESS_BLOCK_REASON,
+    BILLING_COLLECTIONS_INACTIVE_REASON,
+    POSTHOG_SELF_TEAM_ID,
+    BillingConsumer,
+)
 
 CONSUMER = "ee.billing.queue.BillingConsumer"
 
@@ -40,3 +49,130 @@ class TestBillingConsumerUsageSpike(BaseTest):
         self._build_consumer()._process_usage_spike_detected({"data": {"organization_id": "org-1"}})
         mock_notify.assert_not_called()
         mock_capture.assert_called_once()
+
+
+class TestBillingConsumerCollectionsAccess(BaseTest):
+    def _build_consumer(self) -> BillingConsumer:
+        with patch("ee.sqs.SQSConsumer.boto3"):
+            return BillingConsumer(queue_url="http://example/queue", region_name="us-east-1")
+
+    def _message(self, desired_state: str = "blocked", **overrides):
+        body = {
+            "type": "billing_collections_access_state_changed",
+            "organization_id": str(self.organization.id),
+            "customer_id": "cus_billing_123",
+            "data": {
+                "stripe_customer_id": "cus_stripe_123",
+                "desired_state": desired_state,
+                "reason": BILLING_COLLECTIONS_ACCESS_BLOCK_REASON,
+            },
+        }
+        body.update(overrides)
+        return body
+
+    def test_block_active_org(self):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.save()
+
+        self._build_consumer()._process_collections_access_state_changed(self._message())
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is False
+        assert self.organization.is_not_active_reason == BILLING_COLLECTIONS_INACTIVE_REASON
+
+    def test_duplicate_block_is_idempotent(self):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.save()
+
+        consumer = self._build_consumer()
+        consumer._process_collections_access_state_changed(self._message())
+        consumer._process_collections_access_state_changed(self._message())
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is False
+        assert self.organization.is_not_active_reason == BILLING_COLLECTIONS_INACTIVE_REASON
+
+    def test_unblock_billing_collections_org(self):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.is_active = False
+        self.organization.is_not_active_reason = BILLING_COLLECTIONS_INACTIVE_REASON
+        self.organization.save()
+
+        self._build_consumer()._process_collections_access_state_changed(self._message("unblocked"))
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is True
+        assert self.organization.is_not_active_reason is None
+
+    def test_block_leaves_manual_inactive_org_inactive(self):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.is_active = False
+        self.organization.is_not_active_reason = "Manual deactivation"
+        self.organization.save()
+
+        self._build_consumer()._process_collections_access_state_changed(self._message("blocked"))
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is False
+        assert self.organization.is_not_active_reason == "Manual deactivation"
+
+    def test_unblock_leaves_manual_inactive_org_inactive(self):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.is_active = False
+        self.organization.is_not_active_reason = "Manual deactivation"
+        self.organization.save()
+
+        self._build_consumer()._process_collections_access_state_changed(self._message("unblocked"))
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is False
+        assert self.organization.is_not_active_reason == "Manual deactivation"
+
+    @patch(f"{CONSUMER}.capture_exception")
+    def test_customer_mismatch_is_ignored(self, mock_capture):
+        self.organization.customer_id = "different_customer"
+        self.organization.save()
+
+        self._build_consumer()._process_collections_access_state_changed(self._message())
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is True
+        mock_capture.assert_called_once()
+
+    @patch(f"{CONSUMER}.capture_exception")
+    def test_missing_required_fields_are_ignored(self, mock_capture):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.save()
+
+        message = self._message()
+        del message["data"]["reason"]
+
+        self._build_consumer()._process_collections_access_state_changed(message)
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is True
+        mock_capture.assert_called_once()
+
+    @patch(f"{CONSUMER}.close_old_connections")
+    @patch.object(BillingConsumer, "delete_message", return_value=True)
+    def test_process_message_dispatches_collections_access_state_change(self, mock_delete_message, mock_close):
+        self.organization.customer_id = "cus_billing_123"
+        self.organization.save()
+        body = json.dumps(self._message()).encode("utf-8")
+        compressed_body = base64.b64encode(gzip.compress(body)).decode("ascii")
+
+        self._build_consumer().process_message(
+            {
+                "Body": compressed_body,
+                "MessageId": "msg-1",
+                "ReceiptHandle": "receipt-1",
+                "MessageAttributes": {
+                    "content_encoding": {"StringValue": "gzip"},
+                    "content_type": {"StringValue": "application/json"},
+                },
+            }
+        )
+
+        self.organization.refresh_from_db()
+        assert self.organization.is_active is False
+        mock_delete_message.assert_called_once_with("receipt-1")

--- a/ee/billing/test/test_billing_consumer.py
+++ b/ee/billing/test/test_billing_consumer.py
@@ -104,29 +104,19 @@ class TestBillingConsumerCollectionsAccess(BaseTest):
         assert self.organization.is_active is True
         assert self.organization.is_not_active_reason is None
 
-    def test_block_leaves_manual_inactive_org_inactive(self):
+    def test_access_state_change_leaves_manual_inactive_org_inactive(self):
         self.organization.customer_id = "cus_billing_123"
         self.organization.is_active = False
         self.organization.is_not_active_reason = "Manual deactivation"
         self.organization.save()
 
-        self._build_consumer()._process_collections_access_state_changed(self._message("blocked"))
+        for desired_state in ["blocked", "unblocked"]:
+            with self.subTest(desired_state=desired_state):
+                self._build_consumer()._process_collections_access_state_changed(self._message(desired_state))
 
-        self.organization.refresh_from_db()
-        assert self.organization.is_active is False
-        assert self.organization.is_not_active_reason == "Manual deactivation"
-
-    def test_unblock_leaves_manual_inactive_org_inactive(self):
-        self.organization.customer_id = "cus_billing_123"
-        self.organization.is_active = False
-        self.organization.is_not_active_reason = "Manual deactivation"
-        self.organization.save()
-
-        self._build_consumer()._process_collections_access_state_changed(self._message("unblocked"))
-
-        self.organization.refresh_from_db()
-        assert self.organization.is_active is False
-        assert self.organization.is_not_active_reason == "Manual deactivation"
+                self.organization.refresh_from_db()
+                assert self.organization.is_active is False
+                assert self.organization.is_not_active_reason == "Manual deactivation"
 
     @patch(f"{CONSUMER}.capture_exception")
     def test_customer_mismatch_is_ignored(self, mock_capture):


### PR DESCRIPTION
## Problem

Billing can emit collections access state changes once the calibration MVP is ready, but PostHog needs a safe consumer path before any producer starts sending those commands.

Related draft PRs:

- Billing calibration MVP: https://github.com/PostHog/billing/pull/1962
- PostHog enforcement draft: https://github.com/PostHog/posthog/pull/64837

This PR is intentionally very draft. It should not be merged until the Billing-side calibration has run for a bit, and the message shape/guards here may change based on what we learn from those block/unblock calibration events.

## Changes

- Adds `billing_collections_access_state_changed` handling to the Billing SQS consumer.
- Validates organization, Billing customer, Stripe customer, desired state, and reason before mutating organization access.
- Blocks access by setting the existing organization inactive reason to `Billing collections: payment failed`.
- Unblocks only when the current inactive reason exactly matches that Billing collections reason, leaving manually inactive organizations alone.
- Keeps this as the enforcement MVP without adding a new access-block model or migration. A structured block model can be added later if overlapping block reasons or audit needs outgrow the inactive-reason approach.

## How did you test this code?

Added Billing consumer tests for block, unblock, duplicate block idempotency, manual inactive preservation, customer mismatches, malformed messages, and gzipped SQS dispatch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No product docs update needed. This is internal Billing/PostHog plumbing and remains draft until the Billing producer is ready.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as the second-stage enforcement MVP after the Billing calibration work. The initial structured access-block model was deliberately simplified to use the existing organization inactive fields, with exact-reason unblocking as the guardrail and a structured block model left as future hardening.
