### PR TITLE
fix(endpoints): reject OR/multi-column variables before materializing

### DIFF
--- a/products/endpoints/backend/materialization_transforms.py
+++ b/products/endpoints/backend/materialization_transforms.py
@@ -23,7 +23,15 @@ from posthog.models.team import Team
 ENDPOINT_BREAKDOWN_LIMIT = 10_000
 
 
-class VariableInHavingClauseError(ValueError):
+class MaterializationNotSupportedError(ValueError):
+    """Raised when a query uses a construct materialization can't transform.
+
+    This is a user-input limitation (a 400), not a server fault — callers should surface
+    it as a validation error rather than letting it bubble up as an unhandled exception.
+    """
+
+
+class VariableInHavingClauseError(MaterializationNotSupportedError):
     """Raised when a variable is used in a HAVING clause, which is not supported for materialization."""
 
 
@@ -124,6 +132,7 @@ class VariableUsageInWhere:
     operator: ast.CompareOperationOp
     column_ast: Optional[ast.Expr] = None
     value_wrapper_fns: Optional[list[str]] = None
+    in_or: bool = False  # True when this usage sits inside an OR within the WHERE clause
 
 
 RANGE_OPS = frozenset(
@@ -275,6 +284,19 @@ def analyze_variables_for_materialization(
 
         if not all_usages:
             return False, "Variable not used in WHERE clause", []
+
+        # A variable nested in an OR can't be lifted into a single materialized key column:
+        # removing its predicate (as the transform does) would change the result set.
+        if any(usage.in_or for _, usage in all_usages):
+            return False, "Variables in OR conditions are not supported for materialization", []
+
+        # A variable compared against more than one column has no single bucket key to
+        # materialize on (the transform would silently keep only the first usage).
+        distinct_columns = {
+            tuple(usage.column_chain) if usage.column_chain else usage.column_expression for _, usage in all_usages
+        }
+        if len(distinct_columns) > 1:
+            return False, "Variable compared against multiple columns is not supported for materialization", []
 
         # Determine CTE context for this variable
         cte_names = {cte_name for cte_name, _ in all_usages}
@@ -868,6 +890,7 @@ class VariableInWhereFinder(TraversingVisitor):
         self.target = target_placeholder
         self.all_results: list[tuple[Optional[str], VariableUsageInWhere]] = []
         self.in_where = False
+        self._or_depth = 0
         self._current_cte_name: Optional[str] = None
 
     @property
@@ -891,9 +914,20 @@ class VariableInWhereFinder(TraversingVisitor):
                 self._current_cte_name = prev_cte
 
         if node.where:
-            self.in_where = True
+            prev_in_where, prev_or_depth = self.in_where, self._or_depth
+            self.in_where, self._or_depth = True, 0
             self.visit(node.where)
-            self.in_where = False
+            self.in_where, self._or_depth = prev_in_where, prev_or_depth
+
+    def visit_or(self, node: ast.Or):
+        # Only OR nesting within a WHERE clause matters for materialization.
+        track = self.in_where
+        if track:
+            self._or_depth += 1
+        for expr in node.exprs:
+            self.visit(expr)
+        if track:
+            self._or_depth -= 1
 
     def visit_compare_operation(self, node: ast.CompareOperation):
         if not self.in_where:
@@ -923,6 +957,7 @@ class VariableInWhereFinder(TraversingVisitor):
                         column_expression=".".join(column_chain),
                         operator=node.op,
                         value_wrapper_fns=wrapper_fns,
+                        in_or=self._or_depth > 0,
                     ),
                 )
             )
@@ -937,6 +972,7 @@ class VariableInWhereFinder(TraversingVisitor):
                         operator=node.op,
                         column_ast=field_side if not column_chain else None,
                         value_wrapper_fns=wrapper_fns,
+                        in_or=self._or_depth > 0,
                     ),
                 )
             )
@@ -1400,7 +1436,7 @@ class MaterializationTransformer(CloningVisitor):
             return ast.And(exprs=filtered_exprs)
 
         if isinstance(where_node, ast.Or):
-            raise ValueError("Variables in OR conditions not supported")
+            raise MaterializationNotSupportedError("Variables in OR conditions not supported")
 
         return where_node
 

--- a/products/endpoints/backend/services/materialization.py
+++ b/products/endpoints/backend/services/materialization.py
@@ -30,6 +30,7 @@ from products.data_modeling.backend.models.datawarehouse_saved_query import Data
 from products.data_modeling.backend.services.saved_query_dag_sync import delete_node_from_dag, sync_saved_query_to_dag
 from products.endpoints.backend.constants import DATA_FRESHNESS_BUCKETS
 from products.endpoints.backend.materialization_transforms import (
+    MaterializationNotSupportedError,
     _extract_aggregate_name,
     analyze_variables_for_materialization,
     build_endpoint_hogql,
@@ -149,8 +150,9 @@ class EndpointMaterializationService:
         except ValidationError:
             ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="validation_error").inc()
             raise
-        except ExposedHogQLError as e:
-            # A bad user query, not a system fault — surface as a 400.
+        except (ExposedHogQLError, MaterializationNotSupportedError) as e:
+            # A bad user query, not a system fault — surface as a 400. Pre-flight validation
+            # (can_materialize) normally catches these, so reaching here is a backstop.
             ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="validation_error").inc()
             raise ValidationError(f"Cannot materialize endpoint. Reason: {e}")
         except Exception:

--- a/products/endpoints/backend/tests/test_variable_materialization.py
+++ b/products/endpoints/backend/tests/test_variable_materialization.py
@@ -10,6 +10,8 @@ from posthog.hogql.parser import parse_select
 
 from products.endpoints.backend.materialization_transforms import (
     DownstreamCTEShape,
+    MaterializableVariable,
+    MaterializationNotSupportedError,
     _build_cte_read_graph,
     _classify_downstream_cte,
     _downstream_ctes,
@@ -236,9 +238,57 @@ class TestVariableAnalysis(APIBaseTest):
 
         can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
 
-        if can_materialize and var_infos:
-            with pytest.raises(ValueError, match="OR conditions not supported"):
-                transform_query_for_materialization(query, var_infos, self.team)
+        # Pre-flight analysis must reject so this never reaches (and blows up in) the transform.
+        assert can_materialize is False
+        assert "OR conditions" in reason
+        assert var_infos == []
+
+    def test_variable_in_or_with_multiple_columns_blocked(self):
+        # Reproduction of a real materialization failure: the variable appears in two OR
+        # branches against two different columns, with one branch using ILIKE.
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "SELECT count() FROM events\n"
+                "WHERE (event = '$pageview' AND properties.$current_url ILIKE CONCAT('%/refer?p_ref=', {variables.playeruuid}, '%'))\n"
+                "   OR (event = 'referral-impression' AND properties.referrer_uuid = {variables.playeruuid})"
+            ),
+            "variables": {"var-1": {"code_name": "playeruuid", "value": "191e674e"}},
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "OR conditions" in reason
+        assert var_infos == []
+
+    def test_variable_compared_against_multiple_columns_blocked(self):
+        # Same variable, two AND'd branches, but two different columns — no single bucket key.
+        query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT count() FROM events WHERE properties.a = {variables.v} AND properties.b = {variables.v}",
+            "variables": {"var-1": {"code_name": "v", "value": "x"}},
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is False
+        assert "multiple columns" in reason
+        assert var_infos == []
+
+    def test_or_condition_without_variable_still_materializes(self):
+        # An OR that doesn't contain the variable must not trip the OR guard.
+        query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT count() FROM events WHERE event = {variables.event_name} AND (properties.a = '1' OR properties.b = '2')",
+            "variables": {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+
+        assert can_materialize is True
+        assert reason == "OK"
+        assert len(var_infos) == 1
 
     def test_variable_with_parentheses(self):
         query = {
@@ -1229,10 +1279,18 @@ class TestQueryTransformation(APIBaseTest):
             },
         }
 
-        _, _, var_infos = analyze_variables_for_materialization(query)
-        assert len(var_infos) >= 1
+        # Analysis now rejects OR up-front, so feed the transform a hand-built var_info to
+        # confirm the transform itself still guards against OR as a backstop.
+        var_infos = [
+            MaterializableVariable(
+                variable_id="var-123",
+                code_name="event_name",
+                column_chain=["event"],
+                column_expression="event",
+            )
+        ]
 
-        with pytest.raises(ValueError, match="OR conditions not supported"):
+        with pytest.raises(MaterializationNotSupportedError, match="OR conditions not supported"):
             transform_query_for_materialization(query, var_infos, self.team)
 
     def test_transform_preserves_specific_columns_in_select(self):
@@ -1831,9 +1889,9 @@ class TestCTEVariableAnalysis(APIBaseTest):
 
         can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
 
-        if can_materialize and var_infos:
-            with pytest.raises(ValueError, match="OR conditions not supported"):
-                transform_query_for_materialization(query, var_infos, self.team)
+        assert can_materialize is False
+        assert "OR conditions" in reason
+        assert var_infos == []
 
     def test_two_ctes_one_variable_each_different_vars_allowed(self):
         query = {

--- a/products/endpoints/backend/tests/test_variable_materialization.py
+++ b/products/endpoints/backend/tests/test_variable_materialization.py
@@ -229,66 +229,59 @@ class TestVariableAnalysis(APIBaseTest):
         assert len(var_infos) == 1
         assert var_infos[0].column_chain == ["event"]
 
-    def test_variable_in_or_condition_blocked(self):
-        query = {
-            "kind": "HogQLQuery",
-            "query": "SELECT count() FROM events WHERE event = {variables.event_name} OR event = '$pageview'",
-            "variables": {"var-1": {"code_name": "event_name", "value": "$identify"}},
-        }
-
-        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
-
-        # Pre-flight analysis must reject so this never reaches (and blows up in) the transform.
-        assert can_materialize is False
-        assert "OR conditions" in reason
-        assert var_infos == []
-
-    def test_variable_in_or_with_multiple_columns_blocked(self):
-        # Reproduction of a real materialization failure: the variable appears in two OR
-        # branches against two different columns, with one branch using ILIKE.
-        query = {
-            "kind": "HogQLQuery",
-            "query": (
+    @parameterized.expand(
+        [
+            # Variable inside an OR can't be lifted into a single materialized key column.
+            (
+                "or_condition",
+                "SELECT count() FROM events WHERE event = {variables.event_name} OR event = '$pageview'",
+                {"var-1": {"code_name": "event_name", "value": "$identify"}},
+                False,
+                "OR conditions",
+                0,
+            ),
+            # Reproduction of a real failure: same variable across two OR branches, two
+            # different columns, one branch using ILIKE.
+            (
+                "or_with_multiple_columns",
                 "SELECT count() FROM events\n"
                 "WHERE (event = '$pageview' AND properties.$current_url ILIKE CONCAT('%/refer?p_ref=', {variables.playeruuid}, '%'))\n"
-                "   OR (event = 'referral-impression' AND properties.referrer_uuid = {variables.playeruuid})"
+                "   OR (event = 'referral-impression' AND properties.referrer_uuid = {variables.playeruuid})",
+                {"var-1": {"code_name": "playeruuid", "value": "191e674e"}},
+                False,
+                "OR conditions",
+                0,
             ),
-            "variables": {"var-1": {"code_name": "playeruuid", "value": "191e674e"}},
-        }
+            # Same variable, two AND'd branches, but two different columns — no single bucket key.
+            (
+                "multiple_columns",
+                "SELECT count() FROM events WHERE properties.a = {variables.v} AND properties.b = {variables.v}",
+                {"var-1": {"code_name": "v", "value": "x"}},
+                False,
+                "multiple columns",
+                0,
+            ),
+            # An OR that doesn't contain the variable must not trip the OR guard.
+            (
+                "or_without_variable_allowed",
+                "SELECT count() FROM events WHERE event = {variables.event_name} AND (properties.a = '1' OR properties.b = '2')",
+                {"var-1": {"code_name": "event_name", "value": "$pageview"}},
+                True,
+                "OK",
+                1,
+            ),
+        ]
+    )
+    def test_or_and_multi_column_variable_analysis(
+        self, _name, query_str, variables, expected_can_materialize, expected_reason, expected_var_count
+    ):
+        query = {"kind": "HogQLQuery", "query": query_str, "variables": variables}
 
         can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
 
-        assert can_materialize is False
-        assert "OR conditions" in reason
-        assert var_infos == []
-
-    def test_variable_compared_against_multiple_columns_blocked(self):
-        # Same variable, two AND'd branches, but two different columns — no single bucket key.
-        query = {
-            "kind": "HogQLQuery",
-            "query": "SELECT count() FROM events WHERE properties.a = {variables.v} AND properties.b = {variables.v}",
-            "variables": {"var-1": {"code_name": "v", "value": "x"}},
-        }
-
-        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
-
-        assert can_materialize is False
-        assert "multiple columns" in reason
-        assert var_infos == []
-
-    def test_or_condition_without_variable_still_materializes(self):
-        # An OR that doesn't contain the variable must not trip the OR guard.
-        query = {
-            "kind": "HogQLQuery",
-            "query": "SELECT count() FROM events WHERE event = {variables.event_name} AND (properties.a = '1' OR properties.b = '2')",
-            "variables": {"var-1": {"code_name": "event_name", "value": "$pageview"}},
-        }
-
-        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
-
-        assert can_materialize is True
-        assert reason == "OK"
-        assert len(var_infos) == 1
+        assert can_materialize is expected_can_materialize
+        assert expected_reason in reason
+        assert len(var_infos) == expected_var_count
 
     def test_variable_with_parentheses(self):
         query = {


### PR DESCRIPTION
## Problem

Materializing an endpoint whose query variable lives inside an `OR` condition raised an unhandled `ValueError("Variables in OR conditions not supported")` deep in the materialization transform. The service wrapped it as a 500 `APIException`, so a legitimate "this query can't be materialized" user error landed in error tracking instead of coming back as a clean validation error.

Root cause: pre-flight analysis (`analyze_variables_for_materialization`) didn't notice the variable was nested in an `OR`, so it passed validation and then the transform blew up. The same gap also let through a variable compared against two different columns — which the transform silently "handled" by keeping only the first usage (a latent correctness bug).

## Changes

- `VariableInWhereFinder` now tracks `OR`-nesting (a `visit_or` override + depth counter scoped to the `WHERE` clause) and records `in_or` on each usage.
- `analyze_variables_for_materialization` rejects up-front, with a readable reason, when a variable is used inside an `OR` or against more than one column — so `can_materialize` returns a clean 400.
- Added `MaterializationNotSupportedError` (with `VariableInHavingClauseError` now subclassing it); the transform's `OR` guard raises it, and `EndpointMaterializationService` maps it to a 400 as a backstop instead of a 500.
- Tests: strengthened the two weak `OR` tests to assert the up-front rejection, added a faithful reproduction (OR + two columns + ILIKE), a pure multi-column case, and a guard that an `OR` not containing the variable still materializes.

## How did you test this code?

I'm an agent and could not run the test suite in this environment. I syntax-checked, `ruff check`/`ruff format`-cleaned the three files, and statically verified no existing test regresses (only the new multi-column tests match that query shape; the CTE-rejection tests reuse the same column, so they keep their original messages). The added/updated unit tests in `test_variable_materialization.py` cover the new behavior and need a CI run to confirm.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from an error-tracking issue (`ValueError: Variables in OR conditions not supported`) pulled via the PostHog MCP. Traced the stack to `_remove_variable_from_where` and found the pre-flight analyzer didn't detect OR-nested variables, so the failure surfaced as a 500 rather than a 400. Chose to fix it at the analysis layer (clean rejection before the transform runs) and add a typed error + 400 mapping as defense in depth, rather than just swallowing the exception at the service boundary. No skills were invoked.
