### PR TITLE
fix(endpoints): avoid "Unknown table" in materialization preview

### DIFF
--- a/products/endpoints/backend/services/materialization.py
+++ b/products/endpoints/backend/services/materialization.py
@@ -393,8 +393,23 @@ class EndpointMaterializationService:
                     )
                 return q
 
-            # Each call builds a fresh SelectQuery, so WHERE mutations don't leak between calls
-            execution_query_str = to_printed_hogql(_build_exec_preview(version.materialized_view_name), team=self.team)
+            # Each call builds a fresh SelectQuery, so WHERE mutations don't leak between calls.
+            # Type resolution (to_printed_hogql) needs the materialized table to exist in the
+            # database, which only holds once materialization has completed. Previewing a
+            # not-yet-materialized version means that table is absent, so we'd otherwise hit
+            # "Unknown table". Fall back to printing without type resolution in that case — the
+            # frontend uses execution_query only as a presence flag and renders the display variant.
+            if version.is_materialized:
+                execution_query_str = to_printed_hogql(
+                    _build_exec_preview(version.materialized_view_name), team=self.team
+                )
+            else:
+                execution_query_str = print_prepared_ast(
+                    node=_build_exec_preview(version.materialized_view_name),
+                    context=HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+                    dialect="hogql",
+                    pretty=True,
+                )
 
             # Display variant uses the friendly endpoint name — printed without type resolution
             # since the friendly name isn't a real table in the database

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1297,6 +1297,12 @@ class TestMaterializationPreview(ClickhouseTestMixin, APIBaseTest):
         assert data["range_pairs"][0]["column"] == "timestamp"
         assert set(data["range_pairs"][0]["variables"]) == {"start_ts", "end_ts"}
 
+        # The endpoint isn't materialized yet, so its backing table doesn't exist in the database.
+        # The execution-query preview must still be produced (printed without type resolution)
+        # rather than failing with "Unknown table".
+        assert data["execution_query"] is not None
+        assert data["display_execution_query"] is not None
+
     def test_preview_with_bucket_override(self):
         self._create_endpoint_with_variables()
 


### PR DESCRIPTION
## Problem

The endpoint materialization preview ("Query we run" panel) crashed with `ResolutionError: Unknown table` → `QueryError` whenever it previewed a version that wasn't materialized yet. The preview type-resolved the execution query against the version's materialized table name (e.g. `feedback_csat_v1`), but that table only exists in the HogQL database once materialization has *completed*. Since preview is explicitly meant to run *before* enabling materialization, the table was usually absent.

The `try/except` swallowed the error for the response but still called `capture_exception`, so this kept flooding error tracking as a recurring, expected-but-noisy error.

## Changes

Gate the type-resolved print on `version.is_materialized`:

- Materialized → table exists, keep using `to_printed_hogql` (full type resolution).
- Not materialized → print the same AST with `print_prepared_ast(..., dialect="hogql")` **without** type resolution — exactly what the adjacent `display_execution_query` already does for the friendly endpoint name.

The frontend is unaffected: it uses `execution_query` only as a presence flag and renders `display_execution_query` for the actual content, which is now correctly populated for non-materialized previews too.

## How did you test this code?

Extended `test_preview_returns_transform` (which already previews a non-materialized endpoint — the exact bug scenario) to assert `execution_query` and `display_execution_query` are both non-null, locking in that the preview succeeds instead of raising "Unknown table".

I'm an agent — I did **not** run the suite manually: this environment has no Django/pytest installed. Both changed files pass `py_compile` and all referenced symbols were already imported/available. CI runs the tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from an error-tracking stack trace. Traced the failure to `EndpointMaterializationService.preview`, confirmed `to_printed_hogql` does type resolution (needs the real table) while the sibling display variant already prints without it, and confirmed via the frontend that `execution_query` is only a presence flag. Chose to gate on `version.is_materialized` and fall back to a non-type-resolved print rather than just suppressing the `capture_exception` — fixes the root cause instead of hiding it. No skills were applicable to this change.
