### PR TITLE
feat(signals): link scout findings to their inbox report

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,7 @@ import {
     SignalScoutConfig,
     SignalScoutConfigUpdate,
     SignalScoutEmission,
+    SignalScoutEmissionReportLink,
     SignalScoutRunSummary,
     SignalSourceConfig,
     SignalTeamConfig,
@@ -5191,6 +5192,11 @@ const api = {
             },
             async emissions(runId: string): Promise<SignalScoutEmission[]> {
                 return await new ApiRequest().signalScoutRun(runId).withAction('emissions').get()
+            },
+            // Per-finding reverse lookup: which inbox report each emitted finding grouped into.
+            // `report` is null when a finding hasn't grouped, was deduped, or its signal was deleted.
+            async emissionReports(runId: string): Promise<SignalScoutEmissionReportLink[]> {
+                return await new ApiRequest().signalScoutRun(runId).withAction('emissions/reports').get()
             },
         },
         configs: {

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -122,8 +122,8 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
                 </div>
             ) : (
                 <>
-                    {emissionRows.map(({ emission, run }) => (
-                        <ScoutEmissionCard key={emission.id} emission={emission} run={run} />
+                    {emissionRows.map(({ emission, run, report }) => (
+                        <ScoutEmissionCard key={emission.id} emission={emission} run={run} report={report} />
                     ))}
                     {!runsWindowComplete && (
                         <span className="text-xs text-muted">

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 
-import { IconChevronDown, IconExternal } from '@posthog/icons'
+import { IconArrowRight, IconChevronDown, IconExternal } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { urls } from 'scenes/urls'
 
-import { SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
+import { LinkedSignalReport, SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
 import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
 
 /** Truncated mono identifier rendering for the footer finding id. */
@@ -27,9 +28,12 @@ function MonoId({ label, value }: { label: string; value: string }): JSX.Element
 export function ScoutEmissionCard({
     emission,
     run,
+    report,
 }: {
     emission: SignalScoutEmission
     run: SignalScoutRunSummary
+    /** The inbox report this finding grouped into, if resolved — renders the "In report" deep-link chip. */
+    report: LinkedSignalReport | null
 }): JSX.Element {
     const [expanded, setExpanded] = useState(false)
     const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
@@ -62,6 +66,17 @@ export function ScoutEmissionCard({
                 >
                     {emission.description || '_No description._'}
                 </LemonMarkdown>
+
+                {report && (
+                    <Link
+                        to={urls.inboxReport('reports', report.id)}
+                        className="mt-2 inline-flex max-w-full items-center gap-1 rounded bg-primary-highlight px-2 py-0.5 text-xs font-medium text-primary"
+                    >
+                        <span className="shrink-0 text-muted">In report:</span>
+                        <span className="truncate">{report.title || 'Untitled report'}</span>
+                        <IconArrowRight className="size-3 shrink-0" />
+                    </Link>
+                )}
 
                 {expanded && (
                     <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -4,7 +4,7 @@ import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 
-import { SignalScoutEmission, SignalScoutRunSummary } from '../types'
+import { LinkedSignalReport, SignalScoutEmission, SignalScoutEmissionReportLink, SignalScoutRunSummary } from '../types'
 import type { scoutDetailLogicType } from './scoutDetailLogicType'
 import { scoutFleetLogic } from './scoutFleetLogic'
 
@@ -18,10 +18,12 @@ export interface ScoutDetailLogicProps {
 // findings live on in the inbox reports they produced.
 const MAX_EMITTED_RUNS = 50
 
-/** An emitted finding paired with the run that produced it (for the run-level task link). */
+/** An emitted finding paired with the run that produced it (for the run-level task link) and the
+ * inbox report its signal grouped into, if any (for the "In report" deep-link chip). */
 export interface ScoutEmissionRow {
     emission: SignalScoutEmission
     run: SignalScoutRunSummary
+    report: LinkedSignalReport | null
 }
 
 /**
@@ -68,6 +70,30 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                 },
             },
         ],
+        // The reverse "which inbox report did this finding land in" lookup, fetched per emitted run
+        // off the same window as the emissions themselves. Best-effort and non-blocking: a finding
+        // with no resolved report (not yet grouped, deduped, deleted) simply gets no chip, and a
+        // failed fetch leaves the cards as-is rather than erroring the whole section.
+        emissionReports: [
+            [] as SignalScoutEmissionReportLink[],
+            {
+                loadEmissionReports: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissionReports(run.run_id))
+                    )
+                    return settled
+                        .filter(
+                            (result): result is PromiseFulfilledResult<SignalScoutEmissionReportLink[]> =>
+                                result.status === 'fulfilled'
+                        )
+                        .flatMap((result) => result.value)
+                },
+            },
+        ],
     })),
 
     reducers({
@@ -107,15 +133,28 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                     .sort()
                     .join(','),
         ],
-        // Join fetched emissions back to their run (for the per-row task-run link), newest first.
+        // source_id -> linked inbox report, for findings that resolved to one. Keyed on source_id
+        // (the deterministic `run:<run_id>:finding:<id>` join), which is unique per emission and the
+        // exact field the backend reverse-lookup keys on. Findings with a null report are skipped.
+        reportBySourceId: [
+            (s) => [s.emissionReports],
+            (emissionReports): Map<string, LinkedSignalReport> =>
+                new Map(
+                    emissionReports
+                        .filter((link) => link.report !== null)
+                        .map((link) => [link.source_id, link.report as LinkedSignalReport])
+                ),
+        ],
+        // Join fetched emissions back to their run (for the per-row task-run link) and to the inbox
+        // report they grouped into (for the "In report" chip), newest first.
         emissionRows: [
-            (s) => [s.emissions, s.emittedRuns],
-            (emissions, emittedRuns): ScoutEmissionRow[] => {
+            (s) => [s.emissions, s.emittedRuns, s.reportBySourceId],
+            (emissions, emittedRuns, reportBySourceId): ScoutEmissionRow[] => {
                 const runsById = new Map(emittedRuns.map((run) => [run.run_id, run]))
                 return emissions
                     .map((emission) => {
                         const run = runsById.get(emission.run_id)
-                        return run ? { emission, run } : null
+                        return run ? { emission, run, report: reportBySourceId.get(emission.source_id) ?? null } : null
                     })
                     .filter((row): row is ScoutEmissionRow => row !== null)
                     .sort((a, b) => (b.emission.emitted_at ?? '').localeCompare(a.emission.emitted_at ?? ''))
@@ -128,6 +167,7 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
         // emitted runs changes; the string key holds equal across no-op polls so we don't refetch.
         emittedRunsKey: () => {
             actions.loadEmissions()
+            actions.loadEmissionReports()
         },
     })),
 ])

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -92,15 +92,23 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                     if (runs.length === 0) {
                         return []
                     }
+                    // Retains the prior round's links per run on failure: this loader is re-run by the
+                    // runs-window poll, so blindly keeping only the fulfilled responses would drop a
+                    // failed run's already-resolved chips (and an all-rejected retry would clear them
+                    // all). source_id is `run:<run_id>:finding:<id>`, so prior links for a run are the
+                    // ones prefixed with its run_id.
+                    const previous = values.emissionReports
                     const settled = await Promise.allSettled(
                         runs.map((run) => api.signalScout.runs.emissionReports(run.run_id))
                     )
-                    return settled
-                        .filter(
-                            (result): result is PromiseFulfilledResult<SignalScoutEmissionReportLink[]> =>
-                                result.status === 'fulfilled'
-                        )
-                        .flatMap((result) => result.value)
+                    return runs.flatMap((run, index) => {
+                        const result = settled[index]
+                        if (result.status === 'fulfilled') {
+                            return result.value
+                        }
+                        const prefix = `run:${run.run_id}:`
+                        return previous.filter((link) => link.source_id.startsWith(prefix))
+                    })
                 },
             },
         ],

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -1,8 +1,9 @@
-import { connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 
 import { LinkedSignalReport, SignalScoutEmission, SignalScoutEmissionReportLink, SignalScoutRunSummary } from '../types'
 import type { scoutDetailLogicType } from './scoutDetailLogicType'
@@ -17,6 +18,15 @@ export interface ScoutDetailLogicProps {
 // render hundreds of markdown cards. Bound both to the most recent N emitted runs — older
 // findings live on in the inbox reports they produced.
 const MAX_EMITTED_RUNS = 50
+
+// Report linkage is eventually consistent: a finding's signal is grouped into a report asynchronously
+// after the run emits it, so the reverse lookup can return `report: null` right after emission and
+// resolve minutes later. The emissions themselves are stable once a run completes, so the
+// `emittedRunsKey` subscription never refires for them — but the report links need to keep retrying.
+// We re-fetch them on the fleet's existing 60s runs-window poll, but only while a *recent* finding is
+// still unlinked. Past this window the remaining nulls are findings that will never group (deduped,
+// deleted, or below the report threshold), so we stop polling for them.
+const REPORT_LINK_RETRY_WINDOW_MINUTES = 30
 
 /** An emitted finding paired with the run that produced it (for the run-level task link) and the
  * inbox report its signal grouped into, if any (for the "In report" deep-link chip). */
@@ -168,6 +178,23 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
         emittedRunsKey: () => {
             actions.loadEmissions()
             actions.loadEmissionReports()
+        },
+    })),
+
+    listeners(({ actions, values }) => ({
+        // Report grouping resolves asynchronously after emission, so ride the fleet's 60s runs-window
+        // poll to keep refetching the links — but only while a recently-emitted finding is still
+        // unlinked. Computed fresh here (not a memoized selector) so the recency cutoff advances with
+        // wall-clock time and a never-grouping finding stops the poll once it ages out of the window.
+        [scoutFleetLogic.actionTypes.loadRunsWindowSuccess]: () => {
+            const cutoff = dayjs().subtract(REPORT_LINK_RETRY_WINDOW_MINUTES, 'minute')
+            const hasRecentUnlinked = values.emissionRows.some(
+                (row) =>
+                    row.report === null && row.emission.emitted_at && dayjs(row.emission.emitted_at).isAfter(cutoff)
+            )
+            if (hasRecentUnlinked) {
+                actions.loadEmissionReports()
+            }
         },
     })),
 ])

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -251,7 +251,6 @@ export interface SignalScoutEmission {
 export interface LinkedSignalReport {
     id: string
     title: string | null
-    status: string
 }
 
 /** One finding a run emitted, paired with the inbox report (if any) its signal grouped into. */

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -247,6 +247,22 @@ export interface SignalScoutEmission {
     emitted_at: string
 }
 
+/** Minimal projection of the inbox report a scout finding grouped into (for the linked chip). */
+export interface LinkedSignalReport {
+    id: string
+    title: string | null
+    status: string
+}
+
+/** One finding a run emitted, paired with the inbox report (if any) its signal grouped into. */
+export interface SignalScoutEmissionReportLink {
+    finding_id: string
+    /** Deterministic `run:<run_id>:finding:<finding_id>` join key — the stable key into the emission set. */
+    source_id: string
+    /** The inbox report this finding linked to, or null if none could be resolved (not yet grouped, deduped, deleted). */
+    report: LinkedSignalReport | null
+}
+
 // ── Report state transitions (backend `state` action: dismiss / snooze) ──────
 
 export interface SignalReportStateRequest {


### PR DESCRIPTION
## Problem

On the web scout detail page (`/inbox/scouts/:skillName`), the Signals section shows every finding a scout emitted, but there's no way to jump from a finding to the inbox report it actually landed in. The desktop PostHog Code app has had this for a while; this closes the gap (parity item W4).

## Changes

Surface the inbox report each scout finding grouped into, as a deep-link chip on the emission card.

- **API wiring** — `api.signalScout.runs.emissionReports(runId)` wraps the existing backend `emissions/reports` reverse-lookup action (per-finding `{ finding_id, source_id, report | null }`).
- **`scoutDetailLogic`** — a new `emissionReports` loader fetches the links per emitted run (same window + `allSettled` posture as the emissions loader, fired off the same `emittedRunsKey` so it refetches only when the run set changes), a `reportBySourceId` map, and the resolved report joined into each `emissionRows` entry.
- **`ScoutEmissionCard`** — an always-visible "In report: \<title\> →" chip linking to `/inbox/reports/<id>`. The chip is absent when a finding hasn't grouped into a report yet, was deduped away, or its signal was deleted (backend returns `report: null`).

Frontend-only; rides the existing per-scout detail surface and the already-shipped backend endpoint — no new logic state machine, no backend change.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran on the five changed files:

- `oxlint` — clean (0 warnings, 0 errors)
- `oxfmt` — formatted
- `tsc` typecheck — no new errors in the changed files (only a pre-existing unrelated error in `TaxonomicFilterMenu.tsx`)
- `kea-typegen write` — regenerated; new `emissionReports` loader + `reportBySourceId` selector picked up

No manual/browser verification was done in this session. The chip only renders for findings whose signal resolved to a non-deleted, non-suppressed report, so exercising it live needs a scout finding that grouped into a report.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by Andy. Implements the "emission → report linked chip" item (W4) from the scouts-ui workstream (tracked via the `/phs scouts-ui` skill), bringing the web scout detail surface to parity with the desktop app's `listScoutEmissionReports` chip.

Decisions:
- Joined links to emissions on `source_id` (the deterministic `run:<run_id>:finding:<id>` key the backend reverse-lookup keys on) rather than `finding_id`, since `source_id` is unique per emission.
- Report links are fetched in a separate non-blocking loader rather than folded into the emissions load — a failed/empty links fetch leaves the cards intact (just no chip) instead of erroring the section.
- Chip targets the Reports tab (`/inbox/reports/<id>`); scout `cross_source_issue` findings group into reports that live there. The report detail opens regardless of background-list tab via the existing `urlToAction`.

Skills invoked: `/phs scouts-ui` (workstream context), `/phs make-pr`.
