### PR TITLE
fix(llma): point AI trace tools to ai_events for input/output content

### DIFF
--- a/ee/hogai/tools/execute_sql/prompts.py
+++ b/ee/hogai/tools/execute_sql/prompts.py
@@ -25,6 +25,22 @@ Use this tool to generate a HogQL query, which is PostHog's variant of SQL that 
 # Events and properties
 Standardized events/properties such as pageview or screen start with `$`. Custom events/properties start with any other character.
 
+# LLM / AI observability events
+For LLM events ($ai_generation, $ai_trace, $ai_span, $ai_embedding, etc.) the heavy content keys are NOT stored on `events.properties` — they live as native columns on a dedicated table, referenced as `posthog.ai_events` (a bare `FROM ai_events` errors with "Unknown table"):
+
+| `events` property    | `posthog.ai_events` column |
+| -------------------- | -------------------------- |
+| $ai_input            | input                      |
+| $ai_output           | output                     |
+| $ai_output_choices   | output_choices             |
+| $ai_input_state      | input_state                |
+| $ai_output_state     | output_state               |
+| $ai_tools            | tools                      |
+
+Metadata (token counts, costs, model, $ai_trace_id, latency, error flags) stays on `events` and is safe to query there. `posthog.ai_events` is `ORDER BY (team_id, trace_id, timestamp)`, so anchor on `trace_id`, never scan by timestamp. Rows are dropped after the retention period (30 days by default), so an empty result means the content aged out, not that nothing happened.
+- Single trace: `SELECT input, output_choices FROM posthog.ai_events WHERE trace_id = '<id>' ORDER BY timestamp`
+- Batch: filter the timestamp-indexed `events` table for trace IDs first, then fetch content from `posthog.ai_events` anchored on `trace_id`.
+
 # Linked tables
 `virtual_table` and `lazy_table` fields are connections to linked tables, e.g. the virtual table field `person` allows accessing person properties like so: `person.properties.foo`.
 

--- a/ee/hogai/tools/search_traces.py
+++ b/ee/hogai/tools/search_traces.py
@@ -27,6 +27,14 @@ Search for LLM traces based on criteria like date range, model, error status, an
 A formatted list of matching traces with their name, timestamp, latency, cost, token counts, and error count.
 If more results are available, a cursor will be provided for pagination.
 All timestamps are in UTC timezone.
+
+# What this tool does NOT return:
+This is metadata only. It does NOT include prompt/response content ($ai_input, $ai_output, $ai_output_choices, $ai_tools).
+That content is retained for 30 days by default.
+
+# Do not infer bugs or "no problems" from this list alone:
+- To inspect what actually happened in a trace (the prompt, the model output, the tools called), use `read_data` with kind="llm_trace" and the trace's ID from this list.
+- A trace older than the 30-day retention window still shows metadata here but has no content left to read — that is aged-out data, not evidence that nothing went wrong.
 """.strip()
 
 SEARCH_TRACES_QUERY_DESCRIPTION = """
@@ -128,6 +136,12 @@ class SearchLLMTracesTool(MaxTool):
 
         for i, trace in enumerate(results, 1):
             content += self._format_trace(i, trace)
+
+        content += (
+            "\nThis list is metadata only — prompt/response content ($ai_input, $ai_output, $ai_output_choices) "
+            'is not included. To inspect a trace\'s content, read it with read_data (kind="llm_trace") using the '
+            "trace's ID above (content is retained 30 days; older traces show metadata but no content)."
+        )
 
         if has_more and next_cursor:
             content += f'\nMore traces are available. Pass cursor="{next_cursor}" to see the next page.'


### PR DESCRIPTION
## Problem

Sometimes PostHog AI is still not aware that heavy event data only lives in the dedicated AI events table

## Changes

Surface the fact where the assistant reasons, scoped to the two relevant tool prompts

## How did you test this code?

I'm an agent — no manual testing. Automated tests I ran, all green:

- `ee/hogai/tools/test/test_search_traces.py` — 8 passed
- `ee/hogai/tools/execute_sql/test/test_tool.py` — 6 passed
- `ee/hogai/core/agent_modes/presets/test/test_ai_observability_preset.py` + `test_sql_preset.py` — 6 passed
- `ruff check` / `ruff format` clean; lint-staged `ty` check passed at commit time.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — this only affects the in-product assistant's tool prompts. The retention behavior itself is already documented at `/docs/ai-observability/data-retention`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). The change itself needed no special repo skill; the work was investigation-led — mapping which prompts and tool descriptions the assistant loads at reasoning time versus the sub-docs it never reaches, then checking tool availability per agent mode.

Key decision: the first pass pointed users at `execute_sql` on `posthog.ai_events`, but `execute_sql` isn't in the AI observability mode's toolkit (it's exclusive to SQL mode). Switched the trace-search guidance to `read_data` (`kind="llm_trace"`), which is in `DEFAULT_TOOLS` and already does the `ai_events`→`events` fallback. Kept the `execute_sql` prompt addition for SQL mode. Deliberately left the core system prompt untouched to avoid loading AI-observability-specific context into every assistant turn.

Note: the fact is now stated in three places (these two prompts, plus the existing MCP template and skill reference). There's no shared include across the Python prompt / TS MCP template / markdown skill, so they're kept as concise consistent copies.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*