### PR TITLE
fix(mcp): fall back to mcp session id for $session_id

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -62,9 +62,7 @@ export async function trackInitEvent(state: ResolvedState): Promise<void> {
         const initDurationMs = requestContext.requestStartTime
             ? Date.now() - requestContext.requestStartTime
             : undefined
-        const sessionUuid = requestContext.sessionId
-            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
-            : undefined
+        const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(requestContext)
 
         const { properties, groups } = buildBaseProperties(state, analyticsContext)
 
@@ -129,9 +127,7 @@ export async function trackToolCall(
     try {
         const analyticsContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
         const requestContext = state.requestContext
-        const sessionUuid = requestContext.sessionId
-            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
-            : undefined
+        const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(requestContext)
 
         const { properties, groups } = buildBaseProperties(state, analyticsContext)
 
@@ -196,9 +192,7 @@ export async function trackToolsList(toolNames: string[], state: ResolvedState):
     try {
         const analyticsContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
         const requestContext = state.requestContext
-        const sessionUuid = requestContext.sessionId
-            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
-            : undefined
+        const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(requestContext)
 
         const { properties, groups } = buildBaseProperties(state, analyticsContext)
 

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -120,6 +120,18 @@ export class RequestContext {
         return this.sessionManager.getSessionUuid(sessionId)
     }
 
+    /**
+     * Resolves the UUID emitted as `$session_id`. Prefers the explicit
+     * `?sessionId=` param and falls back to the MCP protocol session id, so
+     * sessions are still attributed for clients that don't pass an explicit
+     * session id. Without the fallback `$session_id` is absent on most events
+     * and the MCP analytics dashboard — which aggregates sessions on
+     * `$session_id` — counts zero.
+     */
+    async getEffectiveSessionUuid(requestContext: MCPRequestContext): Promise<string | undefined> {
+        return this.getSessionUuid(requestContext.sessionId ?? requestContext.mcpSessionId)
+    }
+
     getDistinctId(): Promise<string> {
         if (!this.distinctIdPromise) {
             this.distinctIdPromise = this.resolveDistinctId()
@@ -232,6 +244,7 @@ export class RequestContext {
         try {
             const resolvedDistinctId = distinctId ?? (await this.getDistinctId())
             const clientName = await this.tokenCache.get('clientName')
+            const sessionUuid = await this.getEffectiveSessionUuid(this.requestContext)
             const contextProperties = analyticsContext ? buildMCPContextProperties(analyticsContext) : {}
             const previousContextProperties = previousContext
                 ? buildMCPContextProperties(previousContext, { prefix: 'previous_' })
@@ -244,9 +257,7 @@ export class RequestContext {
                 ...(Object.keys(groups).length > 0 ? { groups } : {}),
                 properties: {
                     ...this.buildClientProperties(),
-                    ...(this.requestContext.sessionId
-                        ? { $session_id: await this.getSessionUuid(this.requestContext.sessionId) }
-                        : {}),
+                    ...(sessionUuid ? { $session_id: sessionUuid } : {}),
                     ...(clientName ? { $mcp_oauth_client_name: clientName } : {}),
                     ...contextProperties,
                     ...previousContextProperties,

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -232,7 +232,7 @@ export class ToolExecutor {
 
             void trackToolCall(tool.name, Date.now() - startMs, true, state, undefined, intentMeta)
 
-            const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
+            const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(state.requestContext)
             return handleToolError(error, tool.name, state.distinctId, sessionUuid)
         }
     }
@@ -294,7 +294,7 @@ export class ToolExecutor {
 
             void trackToolCall('exec', Date.now() - startMs, true, state, undefined, intentMeta)
 
-            const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
+            const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(state.requestContext)
             // Attribute the failure to the inner tool that actually ran (e.g. `query-logs`),
             // not the `exec` wrapper — so the agent-facing `[tool]` label and the 5xx
             // exception fingerprint point at the real source instead of collapsing every
@@ -390,7 +390,7 @@ export class ToolExecutor {
             stop({ status: 'error' })
             classifyToolError(error, 'render-ui')
             void trackToolCall('render-ui', Date.now() - startMs, true, state, undefined, intentMeta)
-            const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
+            const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(state.requestContext)
             return handleToolError(error, 'render-ui', state.distinctId, sessionUuid)
         }
     }

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -23,6 +23,7 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
         reqCtx: {
             safelyGetAnalyticsContext: vi.fn(async () => undefined),
             getSessionUuid: vi.fn(async () => 'session-uuid'),
+            getEffectiveSessionUuid: vi.fn(async () => 'session-uuid'),
         } as any,
         context: {
             stateManager: {},

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -173,6 +173,30 @@ describe('RequestContext', () => {
         })
     })
 
+    describe('getEffectiveSessionUuid', () => {
+        it('prefers the explicit sessionId over the MCP session id', async () => {
+            const ctx = new RequestContext(fakeRedis(), env, makeProps())
+            const effective = await ctx.getEffectiveSessionUuid({ sessionId: 'sess-1', mcpSessionId: 'mcp-1' } as any)
+
+            expect(effective).toBe(await ctx.getSessionUuid('sess-1'))
+        })
+
+        it('falls back to the MCP session id so $session_id is still populated', async () => {
+            const ctx = new RequestContext(fakeRedis(), env, makeProps())
+            const effective = await ctx.getEffectiveSessionUuid({ sessionId: undefined, mcpSessionId: 'mcp-1' } as any)
+
+            expect(effective).toBe(await ctx.getSessionUuid('mcp-1'))
+            expect(effective).toMatch(/^[0-9a-f-]{36}$/)
+        })
+
+        it('returns undefined when neither session id is present', async () => {
+            const ctx = new RequestContext(fakeRedis(), env, makeProps())
+            expect(
+                await ctx.getEffectiveSessionUuid({ sessionId: undefined, mcpSessionId: undefined } as any)
+            ).toBeUndefined()
+        })
+    })
+
     describe('buildClientProperties', () => {
         it('includes all request properties', () => {
             const ctx = new RequestContext(

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -174,27 +174,22 @@ describe('RequestContext', () => {
     })
 
     describe('getEffectiveSessionUuid', () => {
-        it('prefers the explicit sessionId over the MCP session id', async () => {
-            const ctx = new RequestContext(fakeRedis(), env, makeProps())
-            const effective = await ctx.getEffectiveSessionUuid({ sessionId: 'sess-1', mcpSessionId: 'mcp-1' } as any)
+        it.each([
+            { sessionId: 'sess-1', mcpSessionId: 'mcp-1', expectedKey: 'sess-1' },
+            { sessionId: undefined, mcpSessionId: 'mcp-1', expectedKey: 'mcp-1' },
+            { sessionId: undefined, mcpSessionId: undefined, expectedKey: undefined },
+        ])(
+            'sessionId=$sessionId mcpSessionId=$mcpSessionId → resolves via expectedKey=$expectedKey',
+            async ({ sessionId, mcpSessionId, expectedKey }) => {
+                const ctx = new RequestContext(fakeRedis(), env, makeProps())
+                const effective = await ctx.getEffectiveSessionUuid({ sessionId, mcpSessionId } as any)
 
-            expect(effective).toBe(await ctx.getSessionUuid('sess-1'))
-        })
-
-        it('falls back to the MCP session id so $session_id is still populated', async () => {
-            const ctx = new RequestContext(fakeRedis(), env, makeProps())
-            const effective = await ctx.getEffectiveSessionUuid({ sessionId: undefined, mcpSessionId: 'mcp-1' } as any)
-
-            expect(effective).toBe(await ctx.getSessionUuid('mcp-1'))
-            expect(effective).toMatch(/^[0-9a-f-]{36}$/)
-        })
-
-        it('returns undefined when neither session id is present', async () => {
-            const ctx = new RequestContext(fakeRedis(), env, makeProps())
-            expect(
-                await ctx.getEffectiveSessionUuid({ sessionId: undefined, mcpSessionId: undefined } as any)
-            ).toBeUndefined()
-        })
+                expect(effective).toBe(expectedKey ? await ctx.getSessionUuid(expectedKey) : undefined)
+                if (expectedKey) {
+                    expect(effective).toMatch(/^[0-9a-f-]{36}$/)
+                }
+            }
+        )
     })
 
     describe('buildClientProperties', () => {

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -34,6 +34,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
+            getEffectiveSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,
         context: {
             api: {},

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -50,6 +50,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             trackEvent: vi.fn(),
             trackContextSwitchEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
+            getEffectiveSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,
         context: {
             api: {},

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -33,6 +33,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             trackEvent: vi.fn(),
             trackContextSwitchEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
+            getEffectiveSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,
         context: {
             api: {},

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -31,6 +31,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             safelyGetAnalyticsContext: vi.fn().mockResolvedValue(undefined),
             trackEvent: vi.fn(),
             getSessionUuid: vi.fn().mockResolvedValue(undefined),
+            getEffectiveSessionUuid: vi.fn().mockResolvedValue(undefined),
         } as any,
         context: {
             api: {},


### PR DESCRIPTION
## Problem

The MCP analytics dashboard counted ~zero sessions for MCP traffic. MCP events only set `$session_id` when the optional `?sessionId=` query param was provided, which most clients never send. Every event still carried `$mcp_session_id` (the protocol session id), but the dashboard aggregates sessions on `$session_id`, so almost nothing was attributed to a session.

A quick check confirmed it: of recent `mcp tool call` events, only a small fraction had `$session_id` populated.

## Changes

Add `getEffectiveSessionUuid`, which resolves `$session_id` from `sessionId ?? mcpSessionId` — falling back to the MCP protocol session id, mapped to a stable session UUID exactly as the explicit session id already was. It's wired into every emit path: init, tool-call, tools-list, the generic track path, and the three tool-error paths.

`$mcp_session_id` is untouched — this only **adds** `$session_id` so existing session aggregation starts working.

## How did you test this code?

I'm an agent. I added unit tests for the fallback (`getEffectiveSessionUuid` prefers the explicit session id, falls back to the MCP session id, returns undefined when neither is set) and ran the affected suites:

- `tests/hono/request-context.test.ts` ✅
- `tests/hono/analytics.test.ts` ✅

I did not run manual end-to-end testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Georgis from a Slack thread reporting the MCP dashboard showing 0 sessions. The original report pointed at the old `PostHog/mcp` repo, but the server has since moved into the monorepo at `services/mcp`, which is where this fix lands. Grounded the root cause by querying the live `mcp tool call` events before changing code. Chose a single shared resolver (`getEffectiveSessionUuid`) over patching each call site inline so the `sessionId ?? mcpSessionId` precedence lives in one place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1781872889046279?thread_ts=1781872889.046279&cid=C0B3E1Y576X)*
