### PR TITLE
feat(session-replay): show event triggers on mobile replay settings tab

### DIFF
--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -64,7 +64,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                         {dedent`
                             \`nativeCrashes\` captures native iOS and Android crashes that the JavaScript layer can't see. Beyond the config above, it needs:
 
-                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). This is the same plugin that powers session replay (renamed from \`posthog-react-native-session-replay\` in 4.47.0+), so you may already have it. If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
+                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
                             2. Your project's **Enable exception autocapture** setting enabled in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture) — the same server-side setting that gates JavaScript autocapture.
                             3. Native debug symbols uploaded at build time, so crash stack traces are readable. See [native crash symbolication](https://posthog.com/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication).
                         `}

--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -39,6 +39,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     uncaughtExceptions: true,
                                     unhandledRejections: true,
                                     console: ['error', 'warn'],
+                                    nativeCrashes: true, // native iOS/Android crashes (see below)
                                   },
                                 },
                               })
@@ -55,8 +56,20 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                         | \`uncaughtExceptions\` | Captures Uncaught exceptions (\`ReactNativeGlobal.ErrorUtils.setGlobalHandler\`) |
                         | \`unhandledRejections\` | Captures Unhandled rejections (\`ReactNativeGlobal.onunhandledrejection\`) |
                         | \`console\` | Captures console logs as errors according to the reported \`LogLevel\` |
+                        | \`nativeCrashes\` | Captures native iOS/Android crashes. Requires \`@posthog/react-native-plugin\` and uploaded native symbols (see below) |
                     `}
                 </Markdown>
+                <CalloutBox type="fyi" title="Capturing native crashes">
+                    <Markdown>
+                        {dedent`
+                            \`nativeCrashes\` captures native iOS and Android crashes that the JavaScript layer can't see. Beyond the config above, it needs:
+
+                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). This is the same plugin that powers session replay (renamed from \`posthog-react-native-session-replay\` in 4.47.0+), so you may already have it. If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
+                            2. Your project's **Enable exception autocapture** setting enabled in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture) — the same server-side setting that gates JavaScript autocapture.
+                            3. Native debug symbols uploaded at build time, so crash stack traces are readable. See [native crash symbolication](https://posthog.com/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication).
+                        `}
+                    </Markdown>
+                </CalloutBox>
             </>
         ),
     }
@@ -181,10 +194,9 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                 {dedent`
                     We currently don't support the following features:
 
-                    - No native Android and iOS exception capture
                     - No automatic source map uploads on React Native web
 
-                    These features will be added in future releases. We recommend you stay up to date with the latest version of the PostHog React Native SDK.
+                    This will be added in a future release. We recommend you stay up to date with the latest version of the PostHog React Native SDK.
                 `}
             </Markdown>
         ),

--- a/docs/onboarding/session-replay/react-native.tsx
+++ b/docs/onboarding/session-replay/react-native.tsx
@@ -21,14 +21,14 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Expo',
                                 code: dedent`
-                                    npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization posthog-react-native-session-replay
+                                    npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization @posthog/react-native-plugin
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'yarn',
                                 code: dedent`
-                                    yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize posthog-react-native-session-replay
+                                    yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize @posthog/react-native-plugin
 
                                     # for iOS
                                     cd ios && pod install
@@ -38,7 +38,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'npm',
                                 code: dedent`
-                                    npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize posthog-react-native-session-replay
+                                    npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize @posthog/react-native-plugin
 
                                     # for iOS
                                     cd ios && pod install
@@ -46,6 +46,13 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                             },
                         ]}
                     />
+                    <CalloutBox type="fyi" title="Plugin renamed in 4.47.0+">
+                        <Markdown>
+                            {dedent`
+                                \`@posthog/react-native-plugin\` (\`>= 2.0.1\`) is the renamed \`posthog-react-native-session-replay\` plugin — it was renamed in \`posthog-react-native\` 4.47.0+ and now also powers [native error tracking](https://posthog.com/docs/error-tracking/installation/react-native). If you're on a \`posthog-react-native\` version earlier than 4.47.0, install \`posthog-react-native-session-replay\` instead.
+                            `}
+                        </Markdown>
+                    </CalloutBox>
                     <CalloutBox type="fyi" title="SDK version">
                         <Markdown>
                             Session replay requires PostHog React Native SDK version 3.2.0 or higher. We recommend

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -294,6 +294,36 @@ function MobileSampling(): JSX.Element {
     )
 }
 
+function MobileEventTriggers(): JSX.Element {
+    const { eventTriggerConfig } = useValues(replayTriggersLogic)
+
+    const eventCount = eventTriggerConfig?.length ?? 0
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-row items-center gap-2">
+                <LemonLabel className="text-base">
+                    Event emitted{' '}
+                    <Since
+                        ios={{ version: '3.48.0' }}
+                        android={{ version: '3.40.1' }}
+                        flutter={{ version: '5.25.0' }}
+                    />
+                </LemonLabel>
+                <Tooltip title="Event triggers are shared across web and mobile. Change them on the Web tab.">
+                    <span className="text-muted font-semibold">
+                        {eventCount > 0 ? pluralize(eventCount, 'event') : 'Not configured'}
+                    </span>
+                </Tooltip>
+            </div>
+            <p className="text-muted-alt">
+                Event triggers are shared across Web, iOS, Android, and Flutter.{' '}
+                <span className="font-semibold">Change this setting on the Web tab.</span>
+            </p>
+        </div>
+    )
+}
+
 function MobileMinimumDuration(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
 
@@ -574,6 +604,7 @@ export function ReplayTriggers(): JSX.Element {
                         <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />
                     )}
                     <IngestionControls.MatchTypeSelect lockedToAllReason="Mobile only supports trigger matching of type 'all'." />
+                    <MobileEventTriggers />
                     <LinkedFlagSelector />
                     <MobileSampling />
                     <MobileMinimumDuration />
@@ -678,6 +709,11 @@ const useTriggers = (currentTeam: TeamType | TeamPublicType, selectedPlatform: '
     }
 
     return [
+        {
+            type: TriggerType.EVENT,
+            enabled: hasEventTriggers,
+            events: eventTriggerConfig,
+        },
         flagTrigger,
         {
             type: TriggerType.SAMPLING,


### PR DESCRIPTION
## Problem

The replay triggers settings page (Replay → Settings → Triggers) only surfaced event triggers on the **Web** tab, even though event triggers are now supported on mobile SDKs. A user looking at the **Mobile** tab had no indication that event triggers apply to their iOS/Android/Flutter apps, nor which SDK versions they need.

## Changes

On the **Mobile** tab of the replay triggers settings:

- Added an **Event emitted** row (read-only) showing how many event triggers are configured, with a `Since` badge listing the minimum mobile SDK versions: **iOS 3.48.0+**, **Android 3.40.1+**, **Flutter 5.25.0+**. This mirrors the existing read-only Sampling and Minimum duration rows — the underlying config is a single team-level list shared across web and mobile, so it points the user to the Web tab to edit.
- Included event triggers in the mobile recording-conditions summary banner at the top of the tab.

## How did you test this code?

I'm an agent (Claude Code). I ran `pnpm --filter=@posthog/frontend typescript:check`, which passed with no errors. No manual UI testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the user's direction. The mobile SDK version numbers were sourced from the companion posthog.com docs work on the same feature (the "Event triggers are supported on the following SDKs" list). The config is shared web/mobile, so I followed the existing read-only "change on the Web tab" pattern used by Sampling and Minimum duration rather than adding a separate mobile editor.
