### PR TITLE
fix(intercom): retry transient companies scroll 5xx inline

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -50,6 +50,16 @@ def _is_scroll_exists(exc: HTTPError) -> bool:
     return any(isinstance(e, dict) and e.get("code") == "scroll_exists" for e in errors or [])
 
 
+def _is_server_error(exc: HTTPError) -> bool:
+    """Intercom's companies Scroll API intermittently returns a 5xx mid-walk —
+    a transient backend blip, not a poisoned cursor. Retrying the identical
+    scroll request clears it, so back off and retry inline rather than failing
+    the whole sync. Distinct from the short transport-level retry: this gives
+    the flaky endpoint a wider window before a Temporal activity retry."""
+    resp = exc.response
+    return resp is not None and 500 <= resp.status_code < 600
+
+
 def _default_headers() -> dict[str, str]:
     return {
         "Accept": "application/json",
@@ -285,6 +295,39 @@ def _conversation_parts_generator(
 _SCROLL_EXISTS_BACKOFF_SECONDS = 60
 _SCROLL_EXISTS_MAX_RETRIES = 2
 
+# Transient 5xx from the companies Scroll API (see `_is_server_error`). Retry the
+# identical request inline with exponential backoff, then let it surface so
+# Temporal retries the activity (which re-opens a fresh scroll).
+_SCROLL_SERVER_ERROR_BACKOFF_SECONDS = 2.0
+_SCROLL_SERVER_ERROR_MAX_RETRIES = 3
+
+
+def _scroll_companies_get(session: Session, scroll_param: str | None = None) -> dict[str, Any]:
+    """Fetch one `/companies/scroll` page, retrying a transient 5xx inline.
+
+    `scroll_param` is None to open the scroll, or the cursor from the prior page
+    to continue it. Retrying the same request is safe — the cursor doesn't
+    advance until a page is returned, so a retried call yields the same page
+    without duplicating or skipping rows."""
+    params = {"scroll_param": scroll_param} if scroll_param is not None else None
+    for attempt in range(_SCROLL_SERVER_ERROR_MAX_RETRIES + 1):
+        try:
+            return _intercom_get(session, "/companies/scroll", params=params)
+        except HTTPError as exc:
+            if _is_server_error(exc) and attempt < _SCROLL_SERVER_ERROR_MAX_RETRIES:
+                wait = _SCROLL_SERVER_ERROR_BACKOFF_SECONDS * (2**attempt)
+                logger.warning(
+                    "intercom_companies_scroll_server_error_retry",
+                    attempt=attempt + 1,
+                    backoff_seconds=wait,
+                    status_code=exc.response.status_code if exc.response is not None else None,
+                )
+                time.sleep(wait)
+                continue
+            raise
+    # Unreachable: the final attempt either returns or re-raises above.
+    raise AssertionError("unreachable")
+
 
 def _open_companies_scroll(session: Session) -> dict[str, Any]:
     """Open a fresh companies scroll, waiting out a stale `scroll_exists` lock.
@@ -297,7 +340,7 @@ def _open_companies_scroll(session: Session) -> dict[str, Any]:
     yet at this stage)."""
     for attempt in range(_SCROLL_EXISTS_MAX_RETRIES + 1):
         try:
-            return _intercom_get(session, "/companies/scroll")
+            return _scroll_companies_get(session)
         except HTTPError as exc:
             if _is_scroll_exists(exc) and attempt < _SCROLL_EXISTS_MAX_RETRIES:
                 logger.warning(
@@ -327,7 +370,7 @@ def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
         if scroll_param is None:
             payload = _open_companies_scroll(session)
         else:
-            payload = _intercom_get(session, "/companies/scroll", params={"scroll_param": scroll_param})
+            payload = _scroll_companies_get(session, scroll_param)
         data = payload.get("data") or []
         if not data:
             return

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -486,7 +486,7 @@ class TestCompaniesScrollServerError:
             companies = list(_iter_companies(mock_session))
 
         assert [c["id"] for c in companies] == ["co1", "co2"]
-        sleep.assert_called_once()
+        sleep.assert_called_once_with(intercom_module._SCROLL_SERVER_ERROR_BACKOFF_SECONDS)
         # The retried continuation reuses the same scroll_param — the cursor only
         # advances once a page is returned.
         assert mock_session.get.call_args_list[2].kwargs["params"] == {"scroll_param": "s1"}

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -22,6 +22,7 @@ from posthog.temporal.data_imports.sources.intercom.intercom import (
     _company_segments_generator,
     _conversation_parts_generator,
     _is_scroll_exists,
+    _is_server_error,
     _iter_companies,
     _make_intercom_session,
     get_resource,
@@ -450,6 +451,77 @@ class TestCompaniesScrollExists:
 
         sleep.assert_not_called()
         assert mock_session.get.call_count == 1
+
+
+class TestCompaniesScrollServerError:
+    @pytest.mark.parametrize(
+        "status_code,expected",
+        [
+            (500, True),
+            (502, True),
+            (503, True),
+            (504, True),
+            (400, False),
+            (404, False),
+            (429, False),
+            (200, False),
+        ],
+    )
+    def test_is_server_error(self, status_code: int, expected: bool):
+        assert _is_server_error(_http_error(None, status_code=status_code, text="boom")) is expected
+
+    def test_iter_companies_retries_continuation_server_error(self):
+        # A transient 5xx mid-walk (the observed error: 500 on
+        # `/companies/scroll?scroll_param=...`) is retried inline against the same
+        # scroll_param, so the walk continues without re-opening or duplicating rows.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response(None, status_code=500, text="Server Error"),
+            _make_response({"data": [{"id": "co2"}], "scroll_param": "s2"}),
+            _make_response({"data": []}),
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep") as sleep:
+            companies = list(_iter_companies(mock_session))
+
+        assert [c["id"] for c in companies] == ["co1", "co2"]
+        sleep.assert_called_once()
+        # The retried continuation reuses the same scroll_param — the cursor only
+        # advances once a page is returned.
+        assert mock_session.get.call_args_list[2].kwargs["params"] == {"scroll_param": "s1"}
+
+    def test_iter_companies_retries_open_server_error(self):
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=503, text="Service Unavailable"),
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": []}),
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep"):
+            companies = list(_iter_companies(mock_session))
+
+        assert [c["id"] for c in companies] == ["co1"]
+        # The retried open carries no scroll_param.
+        assert mock_session.get.call_args_list[1].kwargs["params"] is None
+
+    def test_iter_companies_reraises_server_error_after_max_retries(self):
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            *[
+                _make_response(None, status_code=500, text="Server Error")
+                for _ in range(intercom_module._SCROLL_SERVER_ERROR_MAX_RETRIES + 1)
+            ],
+        ]
+
+        with mock.patch.object(intercom_module.time, "sleep"):
+            with pytest.raises(HTTPError):
+                list(_iter_companies(mock_session))
+
+        # One open + every continuation attempt (initial + retries) before surfacing.
+        assert mock_session.get.call_count == intercom_module._SCROLL_SERVER_ERROR_MAX_RETRIES + 2
 
 
 class TestSubstreamSessionRetries:


### PR DESCRIPTION
## Problem

Intercom's companies Scroll API intermittently returns a 5xx mid-walk. When this happens on a scroll *continuation* (`GET /companies/scroll?scroll_param=...`), the raised `HTTPError` was unhandled and aborted the entire companies / company_segments sync.

Surfaced by error tracking: `HTTPError: 500 Server Error: Internal Server Error for url: https://api.intercom.io/companies/scroll?scroll_param=...`, raised in `_iter_companies` → `_intercom_get`. The walk had already yielded several company pages before the continuation 500'd. It fired once and self-healed via a full activity retry, but it shouldn't cost a wasted activity attempt + full re-walk for a known-flaky endpoint.

## Changes

- Add `_is_server_error` (classifies any 5xx) and `_scroll_companies_get`, which retries the scroll fetch inline with exponential backoff on a transient 5xx, then re-raises if it never clears.
- Route both the scroll open and the continuation through it.

Retrying the *identical* scroll request is safe: the cursor only advances once a page is returned, so a retried call yields the same page without duplicating or skipping rows — unlike re-opening the scroll mid-walk, which would re-emit already-yielded companies.

A 5xx is a transient upstream error and stays retryable — it is **not** added to `NonRetryableErrors`. If the inline retries are exhausted, the `HTTPError` surfaces so Temporal retries the activity, which re-opens a fresh scroll (the existing `scroll_exists` backoff bridges the still-open stale scroll during that re-open). This mirrors the existing inline-retry handling for transient 5xx in the Google Analytics source.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `_is_server_error` classification across 5xx / 4xx / 2xx.
- Inline retry on a transient 5xx during a scroll continuation (reuses the same `scroll_param`) and during the initial open.
- Re-raise after exhausting the retry budget.

`pytest posthog/temporal/data_imports/sources/intercom/tests/` — 101 passed (`test_intercom.py` 82, `test_intercom_source.py` 19). `ruff check` and `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Intercom data-warehouse import source. Decision: a 500 from Intercom's notoriously-flaky companies Scroll API is a transient upstream error, so it must stay retryable (adding it to `NonRetryableErrors` would wrongly stop retrying on every blip). Considered relying solely on the existing Temporal-level activity retry (no change) and rejected it — the established pattern in this source family is to retry transient 5xx inline before falling back to a full activity re-walk. Also considered re-opening the scroll mid-walk and rejected it: that would re-yield already-emitted companies and risk duplicate rows; retrying the same `scroll_param` avoids that entirely.

Tools: Claude Code, PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`). No repo skills were applicable to this change.
