### PR TITLE
feat(signals): add per-team daily run budget and daily seed cadence

### DIFF
--- a/products/signals/backend/scout_harness/config_registry.py
+++ b/products/signals/backend/scout_harness/config_registry.py
@@ -142,9 +142,11 @@ def register_missing_configs(team_id: int, seed_config_layers: list[dict] | None
         seed_enabled = in_allowlist and not at_cap
 
         defaults: dict = {} if seed_enabled else {"enabled": False}
-        # The launch cadence applies to scouts enabled via the allowlist; custom scouts keep
-        # the model default so a user's own scout isn't forced onto the fleet's schedule.
-        if seed_enabled and gated and enabled_interval is not None:
+        # The launch cadence is stamped on every canonical (gated) scout — whether it seeds
+        # enabled now or stays disabled for the user to switch on later — so a specialist a user
+        # toggles on runs at the daily launch cadence, not the 3h model default. Custom scouts
+        # keep the model default so a user's own scout isn't forced onto the fleet's schedule.
+        if gated and enabled_interval is not None:
             defaults["run_interval_minutes"] = enabled_interval
 
         # `team_id` must be passed as a kwarg: `get_or_create` builds the created row from

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -243,7 +243,12 @@ def _collect_planned_runs(
     if not due:
         return []
 
-    runs_today = _runs_today_by_team({d.team_id for d in due}, now - DAILY_BUDGET_WINDOW)
+    # Only count runs for teams that actually have a resolved daily budget — for the default
+    # rollout (no `max_runs_per_day` set anywhere) this skips the aggregate query entirely.
+    capped_team_ids = {
+        d.team_id for d in due if _resolve_max_runs_per_day(d.team_id, team_configs, default_team_config) is not None
+    }
+    runs_today = _runs_today_by_team(capped_team_ids, now - DAILY_BUDGET_WINDOW)
     selected = _allocate_tick_budget(due, team_configs, default_team_config, runs_today)
     planned = [PlannedRun(team_id=d.team_id, skill_name=d.skill_name) for d in selected]
     # Stable order for predictable child-workflow ids within the tick.
@@ -293,12 +298,22 @@ def _allocate_tick_budget(
         runs.sort(key=lambda d: (-d.overdue_s, d.skill_name))
         cap = _team_cap(team_id)
         if len(runs) > cap:
-            logger.warning(
-                "signals_scout coordinator: team over effective per-team cap, deferring overflow",
-                team_id=team_id,
-                due=len(runs),
-                cap=cap,
-            )
+            if cap == 0:
+                # The expected steady state once a team has spent its daily budget — info, not a
+                # warning, so it doesn't read as a misconfiguration in alerting (it would otherwise
+                # fire every tick for the rest of the 24h window).
+                logger.info(
+                    "signals_scout coordinator: team daily budget spent, deferring all due scouts",
+                    team_id=team_id,
+                    deferred=len(runs),
+                )
+            else:
+                logger.warning(
+                    "signals_scout coordinator: team over effective per-team cap, deferring overflow",
+                    team_id=team_id,
+                    due=len(runs),
+                    cap=cap,
+                )
             del runs[cap:]
 
     # Drop teams trimmed to zero (e.g. daily budget spent) so the round-robin's most-overdue-team

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.utils import timezone
 
 import structlog
@@ -21,7 +21,7 @@ from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
 
-from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.models import SignalScoutConfig, SignalScoutRun
 from products.signals.backend.scout_harness.config_registry import register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import sync_canonical_skills
 from products.signals.backend.temporal.agentic.scout_scheduler import RunSignalsScoutInput, RunSignalsScoutWorkflow
@@ -65,6 +65,25 @@ MAX_RUNS_PER_TEAM_PER_TICK = 50
 # override bag — so add more per-team-tunable settings here and each consumer reads + validates
 # the key it cares about.
 TEAM_CONFIG_MAX_RUNS_PER_TICK = "max_runs_per_tick"
+
+# Per-team DAILY run budget — the cost guarantee the per-tick cap can't express. The tick cap
+# bounds bursts (≤ cap per 30-min tick → ≤ cap × 48/day); this bounds the day directly, so a
+# launch team that enables many scouts (or cranks their intervals down) still runs at most N
+# times a day. Counted over a rolling 24h window of dispatched runs and folded into the per-team
+# tick cap (the tighter of the two binds each tick — see `_allocate_tick_budget`).
+#
+# `None` = no daily cap (the historical behaviour; the per-tick cap stays the only bound). Like
+# the tick cap, the effective value resolves most-specific-first (see `_resolve_max_runs_per_day`):
+# a team's `team_configs` entry → the fleet-wide `default_team_config` → this code constant. Left
+# `None` so existing teams are unchanged; the launch posture sets a small N on
+# `default_team_config` in the flag, no deploy.
+MAX_RUNS_PER_TEAM_PER_DAY: int | None = None
+
+# Key inside `team_configs` / `default_team_config` that overrides `MAX_RUNS_PER_TEAM_PER_DAY`.
+TEAM_CONFIG_MAX_RUNS_PER_DAY = "max_runs_per_day"
+
+# Rolling window the per-team daily budget is counted over.
+DAILY_BUDGET_WINDOW = timedelta(hours=24)
 
 # Coordinator tick cadence. Per-scout schedules are enforced via the due-check, so this is
 # just the polling granularity — the floor on how often any scout can run.
@@ -224,7 +243,8 @@ def _collect_planned_runs(
     if not due:
         return []
 
-    selected = _allocate_tick_budget(due, team_configs, default_team_config)
+    runs_today = _runs_today_by_team({d.team_id for d in due}, now - DAILY_BUDGET_WINDOW)
+    selected = _allocate_tick_budget(due, team_configs, default_team_config, runs_today)
     planned = [PlannedRun(team_id=d.team_id, skill_name=d.skill_name) for d in selected]
     # Stable order for predictable child-workflow ids within the tick.
     planned.sort(key=lambda p: (p.team_id, p.skill_name))
@@ -235,21 +255,36 @@ def _allocate_tick_budget(
     due: list[_DueRun],
     team_configs: dict[int, dict] | None = None,
     default_team_config: dict | None = None,
+    runs_today: dict[int, int] | None = None,
 ) -> list[_DueRun]:
     """Apply the per-team and global tick caps fairly. Deterministic — no sampling.
 
-    Each team's due runs are ordered most-overdue-first and trimmed to its per-team cap,
-    resolved per `_resolve_max_runs_per_tick` (team override → fleet default → code constant);
-    the global `MAX_RUNS_PER_TICK` budget is then filled round-robin across teams (one run per
-    team per round) so a single team with many due scouts can't monopolize the tick. Deferred
+    Each team's due runs are ordered most-overdue-first and trimmed to its effective per-team
+    cap, then the global `MAX_RUNS_PER_TICK` budget is filled round-robin across teams (one run
+    per team per round) so a single team with many due scouts can't monopolize the tick. Deferred
     runs stay unstamped, so they're the most overdue next tick — a poor-man's queue, same
     catch-up semantics as before.
+
+    The effective per-team cap is the tighter of two bounds: the per-tick cap
+    (`_resolve_max_runs_per_tick`) and the day's remaining headroom under the per-team daily
+    budget (`_resolve_max_runs_per_day` minus `runs_today`). The daily budget is what bounds a
+    team to N runs/day regardless of how many scouts it enables or how short their intervals —
+    the per-tick cap alone can only bound bursts (≤ cap × ticks/day).
     """
     team_configs = team_configs or {}
     default_team_config = default_team_config or {}
+    runs_today = runs_today or {}
 
     def _team_cap(team_id: int) -> int:
-        return _resolve_max_runs_per_tick(team_id, team_configs, default_team_config)
+        per_tick = _resolve_max_runs_per_tick(team_id, team_configs, default_team_config)
+        per_day = _resolve_max_runs_per_day(team_id, team_configs, default_team_config)
+        if per_day is None:
+            return per_tick
+        # Day's remaining headroom caps this tick too: a team that's spent its daily budget gets
+        # 0 this tick, no matter how many scouts are due. Counted runs exclude this tick's
+        # not-yet-started dispatches; the per-tick cap bounds that brief window.
+        remaining_today = max(0, per_day - runs_today.get(team_id, 0))
+        return min(per_tick, remaining_today)
 
     by_team: dict[int, list[_DueRun]] = {}
     for d in due:
@@ -259,12 +294,16 @@ def _allocate_tick_budget(
         cap = _team_cap(team_id)
         if len(runs) > cap:
             logger.warning(
-                "signals_scout coordinator: team over per-tick cap, deferring overflow",
+                "signals_scout coordinator: team over effective per-team cap, deferring overflow",
                 team_id=team_id,
                 due=len(runs),
                 cap=cap,
             )
             del runs[cap:]
+
+    # Drop teams trimmed to zero (e.g. daily budget spent) so the round-robin's most-overdue-team
+    # sort never indexes into an empty list.
+    by_team = {team_id: runs for team_id, runs in by_team.items() if runs}
 
     # Count after per-team trimming — that's the real candidate pool the global cap defers
     # against, so the warning doesn't fire on runs already dropped by the per-team caps.
@@ -308,6 +347,40 @@ def _resolve_max_runs_per_tick(team_id: int, team_configs: dict[int, dict], defa
         if isinstance(override, int) and not isinstance(override, bool) and override > 0:
             return override
     return MAX_RUNS_PER_TEAM_PER_TICK
+
+
+def _resolve_max_runs_per_day(team_id: int, team_configs: dict[int, dict], default_team_config: dict) -> int | None:
+    """Effective per-team daily run budget, most-specific layer first.
+
+    `team_configs[team_id]` (per-team override) → `default_team_config` (fleet-wide default) →
+    `MAX_RUNS_PER_TEAM_PER_DAY` (code constant, `None` = unbounded). Same per-layer fallback and
+    validation (positive int, not bool) as `_resolve_max_runs_per_tick`: a malformed value at one
+    layer falls through to the next rather than failing the tick. `None` means no daily cap — only
+    the per-tick cap binds, the historical behaviour.
+    """
+    for source in ((team_configs.get(team_id) or {}), default_team_config):
+        override = source.get(TEAM_CONFIG_MAX_RUNS_PER_DAY)
+        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
+            return override
+    return MAX_RUNS_PER_TEAM_PER_DAY
+
+
+def _runs_today_by_team(team_ids: set[int], window_start: datetime) -> dict[int, int]:
+    """Scout runs dispatched per team within the trailing daily-budget window.
+
+    Counts `SignalScoutRun` bridge rows (created at run start), so the budget tracks runs that
+    actually happened — the durable, cost-relevant signal. Uses the unscoped `all_teams` manager,
+    matching the coordinator's other cross-team reads. A run dispatched this tick but not yet
+    started isn't counted until its row lands; the per-tick cap bounds that brief window.
+    """
+    if not team_ids:
+        return {}
+    rows = (
+        SignalScoutRun.all_teams.filter(team_id__in=team_ids, created_at__gte=window_start)
+        .values("team_id")
+        .annotate(n=Count("id"))
+    )
+    return {row["team_id"]: row["n"] for row in rows}
 
 
 def _participating_teams(enrolled: set[int]) -> list[Team]:

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -795,29 +795,29 @@ def _due_run(team_id: int, skill_name: str, overdue_s: float) -> _DueRun:
     return _DueRun(overdue_s=overdue_s, config_pk=skill_name, team_id=team_id, skill_name=skill_name)
 
 
-def test_daily_budget_trims_to_remaining_headroom():
-    # Three due scouts, fleet daily budget 3, team already ran twice today → only 1 slot left, so
-    # just the most-overdue dispatches even though the per-tick cap (50) is nowhere near binding.
-    due = [
-        _due_run(7, "signals-scout-most", 10 * 3600),
-        _due_run(7, "signals-scout-mid", 5 * 3600),
-        _due_run(7, "signals-scout-least", 2 * 3600),
-    ]
-    selected = _allocate_tick_budget(due, {}, {"max_runs_per_day": 3}, {7: 2})
-    assert [d.skill_name for d in selected] == ["signals-scout-most"]
-
-
-def test_daily_budget_exhausted_dispatches_nothing():
-    # Budget fully spent → 0 runs this tick, and the empty team must not crash the round-robin.
-    due = [_due_run(7, "signals-scout-most", 10 * 3600)]
-    assert _allocate_tick_budget(due, {}, {"max_runs_per_day": 3}, {7: 3}) == []
-
-
-def test_daily_budget_none_leaves_only_the_tick_cap():
-    # No daily budget set → historical behaviour: every due run (within the per-tick cap) goes.
-    due = [_due_run(7, "signals-scout-a", 3600), _due_run(7, "signals-scout-b", 2 * 3600)]
-    selected = _allocate_tick_budget(due, {}, {}, {7: 999})
-    assert sorted(d.skill_name for d in selected) == ["signals-scout-a", "signals-scout-b"]
+@pytest.mark.parametrize(
+    "default_cfg,runs_today,due_skills,expected",
+    [
+        # Budget 3, 2 already run today → 1 slot left, so only the most-overdue dispatches (the
+        # per-tick cap of 50 is nowhere near binding).
+        (
+            {"max_runs_per_day": 3},
+            {7: 2},
+            [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)],
+            ["signals-scout-most"],
+        ),
+        # Budget fully spent → 0 runs this tick; the empty team must not crash the round-robin.
+        ({"max_runs_per_day": 3}, {7: 3}, [("signals-scout-most", 10)], []),
+        # Pre-existing over-run (runs_today > budget) → still 0, no negative cap.
+        ({"max_runs_per_day": 3}, {7: 5}, [("signals-scout-most", 10)], []),
+        # No daily budget set → historical behaviour: every due run (within the per-tick cap) goes.
+        ({}, {7: 999}, [("signals-scout-a", 1), ("signals-scout-b", 2)], ["signals-scout-a", "signals-scout-b"]),
+    ],
+)
+def test_daily_budget_allocation(default_cfg, runs_today, due_skills, expected):
+    due = [_due_run(7, name, hours * 3600) for name, hours in due_skills]
+    selected = _allocate_tick_budget(due, {}, default_cfg, runs_today)
+    assert sorted(d.skill_name for d in selected) == sorted(expected)
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -30,9 +30,12 @@ from products.signals.backend.temporal.agentic.scout_coordinator import (
     PlannedRun,
     SignalsScoutCoordinatorWorkflow,
     StampDispatchedRunsInput,
+    _allocate_tick_budget,
     _default_team_config,
+    _DueRun,
     _enrolled_team_ids,
     _read_flag_payload,
+    _resolve_max_runs_per_day,
     _team_configs,
     fetch_enabled_signals_scout_runs_activity,
     stamp_dispatched_signals_scout_runs_activity,
@@ -736,6 +739,116 @@ async def test_seed_enabled_interval_validates_bounds(ateam, interval, expected)
     else:
         # Unchanged from the model default (not the out-of-range value).
         assert general.run_interval_minutes != interval
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_seed_launch_cadence_stamped_on_disabled_canonical(ateam):
+    # Option B: a canonical scout that seeds DISABLED under the allowlist still gets the launch
+    # cadence stamped, so when the user later toggles it on it runs at the daily cadence, not the
+    # 3h model default. general is allowlisted (enabled); error-tracking is gated (disabled).
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-general")
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-error-tracking")
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {
+                "enabled_skills": ["signals-scout-general"],
+                "enabled_interval_minutes": 1440,
+            },
+        }
+
+    with patch(_PAYLOAD_PATH, side_effect=_payload):
+        await _run_activity()
+
+    rows = await database_sync_to_async(
+        lambda: {
+            c.skill_name: (c.enabled, c.run_interval_minutes)
+            for c in SignalScoutConfig.all_teams.filter(team_id=ateam.id)
+        }
+    )()
+    assert rows["signals-scout-general"] == (True, 1440)
+    # Disabled, but already on the daily cadence — so enabling it later doesn't run it every 3h.
+    assert rows["signals-scout-error-tracking"] == (False, 1440)
+
+
+# ── Per-team daily run budget (max_runs_per_day) ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "team_configs,default_cfg,expected",
+    [
+        ({}, {}, None),  # nothing set → unbounded (only the per-tick cap binds)
+        ({}, {"max_runs_per_day": 3}, 3),  # fleet default binds
+        ({7: {"max_runs_per_day": 10}}, {"max_runs_per_day": 3}, 10),  # per-team override wins
+        ({7: {"max_runs_per_day": "nope"}}, {"max_runs_per_day": 3}, 3),  # malformed team → fleet default
+        ({}, {"max_runs_per_day": 0}, None),  # non-positive → falls through to the constant (None)
+        ({}, {"max_runs_per_day": True}, None),  # bool rejected
+    ],
+)
+def test_resolve_max_runs_per_day(team_configs, default_cfg, expected):
+    assert _resolve_max_runs_per_day(7, team_configs, default_cfg) == expected
+
+
+def _due_run(team_id: int, skill_name: str, overdue_s: float) -> _DueRun:
+    return _DueRun(overdue_s=overdue_s, config_pk=skill_name, team_id=team_id, skill_name=skill_name)
+
+
+def test_daily_budget_trims_to_remaining_headroom():
+    # Three due scouts, fleet daily budget 3, team already ran twice today → only 1 slot left, so
+    # just the most-overdue dispatches even though the per-tick cap (50) is nowhere near binding.
+    due = [
+        _due_run(7, "signals-scout-most", 10 * 3600),
+        _due_run(7, "signals-scout-mid", 5 * 3600),
+        _due_run(7, "signals-scout-least", 2 * 3600),
+    ]
+    selected = _allocate_tick_budget(due, {}, {"max_runs_per_day": 3}, {7: 2})
+    assert [d.skill_name for d in selected] == ["signals-scout-most"]
+
+
+def test_daily_budget_exhausted_dispatches_nothing():
+    # Budget fully spent → 0 runs this tick, and the empty team must not crash the round-robin.
+    due = [_due_run(7, "signals-scout-most", 10 * 3600)]
+    assert _allocate_tick_budget(due, {}, {"max_runs_per_day": 3}, {7: 3}) == []
+
+
+def test_daily_budget_none_leaves_only_the_tick_cap():
+    # No daily budget set → historical behaviour: every due run (within the per-tick cap) goes.
+    due = [_due_run(7, "signals-scout-a", 3600), _due_run(7, "signals-scout-b", 2 * 3600)]
+    selected = _allocate_tick_budget(due, {}, {}, {7: 999})
+    assert sorted(d.skill_name for d in selected) == ["signals-scout-a", "signals-scout-b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_daily_budget_bounds_dispatch_end_to_end(ateam):
+    # End-to-end through the activity: fleet daily budget 2, team already ran once today (the
+    # trailing-24h count is stubbed to 1) → only 1 slot left, so the single most-overdue scout
+    # dispatches regardless of the per-tick cap.
+    now = timezone.now()
+    for name, hours in [("signals-scout-most", 10), ("signals-scout-mid", 5), ("signals-scout-least", 2)]:
+        await database_sync_to_async(_create_skill)(ateam, name)
+        await database_sync_to_async(_create_config)(
+            ateam, name, enabled=True, run_interval_minutes=60, last_run_at=now - timedelta(hours=hours)
+        )
+
+    def _payload(*_a, **_k):
+        return {
+            "guaranteed_team_ids": [int(t) for t in _FLAGGED_TEAM_IDS],
+            "default_team_config": {"max_runs_per_day": 2},
+        }
+
+    with (
+        patch(_PAYLOAD_PATH, side_effect=_payload),
+        patch(
+            "products.signals.backend.temporal.agentic.scout_coordinator._runs_today_by_team",
+            return_value={ateam.id: 1},
+        ),
+    ):
+        planned = await _run_activity()
+
+    assert [p.skill_name for p in planned] == ["signals-scout-most"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

We're launching scouts to dogfooder teams next week and want a cheap, predictable default: the general scout runs once a day, users can freely toggle other scouts to explore, but a team's spend stays bounded no matter what they do.

The Phase 1 backstop (`max_runs_per_tick`, [#64821](https://github.com/PostHog/posthog/pull/64821)) only bounds *bursts* — at 1 run/tick it still permits ~48 runs/day (~$71/day). It structurally can't express "one run a day." And once a user toggles on a scout that seeded disabled, it runs at the 3h model default (~8×/day), so "explore freely" gets expensive fast.

This adds the missing primitive and makes free exploration cheap by default.

## Changes

**1. Per-team daily run budget (`max_runs_per_day`).** A new flag-resolved budget that bounds a team's runs over a rolling 24h window, regardless of how many scouts it enables or how short their intervals.

- Resolves through the same three layers as `max_runs_per_tick`, most-specific first: `team_configs[team]` → `default_team_config` → code constant. The constant defaults to `None` (unbounded), so existing teams are unchanged until the flag sets a value.
- Folded into the per-team tick cap as the tighter of the two bounds: `min(per_tick_cap, max(0, per_day − runs_today))`. A team that's spent its daily budget gets 0 runs that tick. Counted off `SignalScoutRun` rows (runs that actually happened) in the trailing 24h.
- Teams trimmed to zero are dropped before the round-robin so the allocator never indexes an empty team list.

**2. Daily seed cadence on disabled canonical scouts.** `register_missing_configs` now stamps the launch `enabled_interval_minutes` on every canonical (gated) scout — including the ones that seed disabled — not just the enabled ones. So a specialist a user later toggles on runs at the daily launch cadence, not the 3h model default. Custom scouts still keep the model default.

Together: a launch team defaults to general once a day; a curious user can enable anything and it stays proportional and bounded (`# enabled × ~daily`, hard-capped by `max_runs_per_day`). Both knobs are flag-tunable with no deploy; both are forward-only (shape new teams, leave the pinned dogfood teams untouched).

No model/schema change — `max_runs_per_day` lives in the flag payload, like `max_runs_per_tick`. The launch posture (e.g. `default_team_config.max_runs_per_day = 3`) is armed in the `signals-scout` flag after deploy.

## How did you test this code?

I'm an agent (Claude Code); Andy directed the work. Automated tests only — I did not manually exercise the coordinator. Added to `test_scout_coordinator.py` and ran the full file (72 passed):

- `test_resolve_max_runs_per_day` — three-layer resolution + validation (malformed/non-positive/bool fall through).
- `test_daily_budget_trims_to_remaining_headroom` — budget 3, 2 already run today → only the most-overdue dispatches.
- `test_daily_budget_exhausted_dispatches_nothing` — budget spent → 0 runs, empty team doesn't crash the round-robin.
- `test_daily_budget_none_leaves_only_the_tick_cap` — no budget set → unchanged behaviour.
- `test_daily_budget_bounds_dispatch_end_to_end` — through the activity with the trailing-24h count stubbed.
- `test_seed_launch_cadence_stamped_on_disabled_canonical` — disabled specialist seeds at the daily cadence.

`ruff check` + `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy is the DRI.

Built with Claude Code while working through the scouts dogfooding cost-guardrails effort (issues 17/20/23). Andy walked through the launch UX and we landed on this two-part approach over a hard UI lock: the daily budget is the real "N runs/day" guarantee the tick cap can't give, and the daily seed cadence makes free toggling cheap-by-default instead of needing to block enabling. Rejected a hard lock + "coming soon" UX for launch (more code across two repos) since the budget bounds cost regardless of what a user enables. No mandatory skills applied — no DRF serializer, migration, or generated-types changes (the budget is flag-only).

Follow-up after this deploys: arm `default_team_config.max_runs_per_day` (suggest a small N like 3 so general stays guaranteed without extra slot-priority logic) in the `signals-scout` flag, and stand up the per-team scout-spend alert.
