### PR TITLE
feat(batch-exports): Tracking bytes streamed from internal stage

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -2,6 +2,8 @@ import time
 import typing
 import asyncio
 import datetime as dt
+import functools
+import collections.abc
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -477,3 +479,78 @@ class SLAWaiter:
             batch_export_id=self.batch_export_id,
             sla_seconds=self.sla.total_seconds(),
         )
+
+
+def get_or_create_counter(name: str, description: str, *, prefix: str = "batch_exports", **attributes) -> MetricCounter:
+    """Create a metric counter, or return a cached one if arguments match.
+
+    The underlying cached function requires hashable arguments, so this function
+    serves as an entrypoint that handles making arguments hashable.
+    """
+    default_attributes = {}
+
+    if activity.in_activity():
+        context = "activity"
+
+        default_attributes["workflow_type"] = activity.info().workflow_type
+        default_attributes["activity_type"] = activity.info().activity_type
+    elif workflow.in_workflow():
+        context = "workflow"
+
+        default_attributes["workflow_type"] = activity.info().workflow_type
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+    full_name = _normalize_name(name, prefix)
+
+    full_attributes = {**default_attributes, **attributes}
+    attribute_pairs = tuple(sorted((k, v) for k, v in full_attributes.items() if v is not None))
+
+    return _get_or_create_counter_cached(full_name, description, attribute_pairs, context)
+
+
+def _normalize_name(name: str, prefix: str) -> str:
+    return "_".join((prefix, *name.lower().split(" ")))
+
+
+@functools.lru_cache
+def _get_or_create_counter_cached(
+    full_name: str,
+    description: str,
+    attribute_pairs: tuple[tuple[str, str | int | float | bool]],
+    # Needed so that we don't cache workflow and activity meters with same args
+    # under the same key.
+    _context: typing.Literal["activity", "workflow"],
+) -> MetricCounter:
+    """Cached function to return a counter."""
+    meter = get_metric_meter(dict(attribute_pairs))
+    return meter.create_counter(full_name, description)
+
+
+class IteratorBytesTracker:
+    """A tracker for async byte iterators.
+
+    Bytes yielded are tracked in a prometheus counter, created using name,
+    description, prefix, and any additional attributes.
+    """
+
+    def __init__(
+        self,
+        it: collections.abc.AsyncIterator[bytes],
+        *,
+        name: str,
+        description: str,
+        prefix: str = "batch_exports",
+        **attributes,
+    ) -> None:
+        self.it = it
+        self.counter = get_or_create_counter(name, description, prefix=prefix, **attributes)
+
+    def __aiter__(self) -> typing.Self:
+        return self
+
+    async def __anext__(self) -> bytes:
+        """Track bytes length and return them."""
+        chunk = await self.it.__anext__()
+        self.counter.add(len(chunk))
+        return chunk

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -8,6 +8,7 @@ from aiobotocore.response import StreamingBody
 import posthog.temporal.common.asyncpa as asyncpa
 from posthog.temporal.common.logger import get_write_only_logger
 
+from products.batch_exports.backend.temporal.metrics import IteratorBytesTracker
 from products.batch_exports.backend.temporal.pipeline.internal_stage import get_base_s3_staging_folder, get_s3_client
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, slice_record_batch
 from products.batch_exports.backend.temporal.utils import make_retryable_with_exponential_backoff
@@ -111,7 +112,13 @@ class Producer:
             assert "Body" in s3_ob, "Body not found in S3 object"
             stream: StreamingBody = s3_ob["Body"]
             # read in 128KB chunks of data from S3
-            reader = asyncpa.AsyncRecordBatchReader(stream.iter_chunks(chunk_size=128 * 1024))
+            reader = asyncpa.AsyncRecordBatchReader(
+                IteratorBytesTracker(
+                    stream.iter_chunks(chunk_size=128 * 1024),
+                    name="bytes_streamed_from_internal_stage",
+                    description="Counter tracking bytes streamed from internal stage",
+                )
+            )
 
             async for batch in reader:
                 for record_batch_slice in slice_record_batch(batch, max_record_batch_size_bytes, min_records_per_batch):

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -10,6 +10,7 @@ from django.conf import settings
 import psycopg
 import pytest_asyncio
 import temporalio.client
+import temporalio.activity
 from structlog.testing import capture_logs
 from temporalio.common import RetryPolicy
 
@@ -17,7 +18,12 @@ from posthog.temporal.tests.utils.models import acreate_batch_export, adelete_ba
 
 from products.batch_exports.backend.service import BatchExportModel
 from products.batch_exports.backend.temporal.destinations.postgres_batch_export import PostgresBatchExportInputs
-from products.batch_exports.backend.temporal.metrics import SLAWaiter
+from products.batch_exports.backend.temporal.metrics import (
+    IteratorBytesTracker,
+    SLAWaiter,
+    _normalize_name,
+    get_or_create_counter,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -163,3 +169,47 @@ async def test_sla_waiter():
             assert detector.is_over_sla() is False
 
     assert not cap_logs
+
+
+@pytest.mark.parametrize(
+    "name,description,prefix",
+    [
+        ("test", "Wow a test", "test_test"),
+        ("A not normalized name", "Wow a test", "test_test"),
+    ],
+)
+async def test_get_or_create_counter_in_activity(activity_environment, name: str, description: str, prefix: str):
+    @temporalio.activity.defn
+    async def test_activity():
+        return get_or_create_counter(name, description, prefix=prefix)
+
+    result = await activity_environment.run(test_activity)
+
+    assert result.name == _normalize_name(name, prefix)
+    assert result.description == description
+
+    another = await activity_environment.run(test_activity)
+
+    assert result is another
+
+
+async def test_iterator_bytes_tracker_activity(activity_environment):
+    chunks = [b"abc", b"def", b"12345", b"0"]
+    # Temporal returns a NoOp counter, so we need our own thing to ensure
+    # we are calling it.
+    magic_mock = mock.MagicMock()
+
+    @temporalio.activity.defn
+    async def test_activity():
+        async def iter_chunks():
+            for chunk in chunks:
+                yield chunk
+
+        tracked = IteratorBytesTracker(iter_chunks(), name="test", description="Test")
+        tracked.counter = magic_mock
+        return [chunk async for chunk in tracked]
+
+    result = await activity_environment.run(test_activity)
+
+    assert result == chunks
+    assert magic_mock.add.mock_calls == [mock.call(len(chunk)) for chunk in chunks]


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

We need more observability into the batch exports pipeline.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This implements throughput tracking for the first stage of the batch exports pipeline: streaming from the S3 internal stage.

It is a new small utility to track bytes as they come through using a prometheus counter. Then, I just wrapped the iter_chunks with it.

The utility is fairly generic, so it can be used in other parts of the pipeline later. It is cached, so spawning all the reading tasks will not cause us to create a counter for each.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added some unit tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Nothing besides reviewing

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
