### PR TITLE
fix(mcp-analytics): restore test-account toggle accent in dashboard

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -49,8 +49,8 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
     const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
 
     return (
-        <div className="flex flex-col gap-4" data-quill>
-            <div className="flex flex-wrap items-center justify-between gap-3" data-not-quill>
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-wrap items-center gap-3">
                     <McpDateFilter
                         dateFrom={dateFilter.dateFrom}
@@ -78,11 +78,11 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                     data-attr="mcp-dashboard-test-account-filter"
                 />
             </div>
-            <section>
+            <section data-quill>
                 <h2 className="mb-4 text-xl font-semibold text-primary">Key metrics</h2>
                 <KpiTiles kpis={kpis} intentClusterCount={intentClusterCount} kpisLoading={kpisLoading} theme={theme} />
             </section>
-            <section>
+            <section data-quill>
                 <h2 className="mb-4 text-xl font-semibold text-primary">Usage</h2>
                 <div className="flex flex-col gap-[22px]">
                     <div className="grid grid-cols-1 gap-[22px] lg:grid-cols-3">

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -50,7 +50,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-4" data-quill>
-            <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3" data-not-quill>
                 <div className="flex flex-wrap items-center gap-3">
                     <McpDateFilter
                         dateFrom={dateFilter.dateFrom}

--- a/products/mcp_analytics/frontend/components/McpDateFilter.tsx
+++ b/products/mcp_analytics/frontend/components/McpDateFilter.tsx
@@ -81,7 +81,7 @@ export function McpDateFilter({ dateFrom, dateTo, onChange, dataAttr }: McpDateF
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger
                 render={
-                    <Button variant="outline" data-attr={dataAttr}>
+                    <Button variant="outline" data-attr={dataAttr} data-quill>
                         <IconCalendar />
                         {formatTriggerLabel(value)}
                     </Button>


### PR DESCRIPTION
## Problem

In the MCP analytics dashboard, toggling **Filter out internal and test users** rendered the switch with no accent colour — its checked track looked broken/transparent.



https://github.com/user-attachments/assets/c9b6e048-74f0-4a5f-9e21-f8d2b23c2f9e


## Changes

The dashboard wrapped everything in a single root `[data-quill]` so the charts could read Quill's design tokens. But that also pulled the LemonUI controls (property filters, test-account switch) into the Quill subtree, where the bridge rebinds `--color-accent` to a Quill token. `LemonSwitch`'s checked track (`background-color: var(--color-accent)`) then resolved to nothing.

Rather than patch it with the `data-not-quill` escape hatch, this scopes `data-quill` to the actual Quill subtrees:

- The date picker trigger (`McpDateFilter` owns its own `data-quill`; its popover already self-scopes via the Quill portal).
- The two chart `<section>`s.

The LemonUI controls are now never inside a Quill subtree, so `--color-accent` keeps PostHog's value and the toggle renders correctly — no escape hatch needed. This matches the guidance to add `data-quill` only to subtrees that render Quill primitives.

## How did you test this code?

I'm an agent. No automated tests added — this is CSS-scoping only. Verified the mechanism against `frontend/src/styles/quill-bridge.scss`, Quill's `tokens.scoped.css` (tokens gated behind `:is([data-quill], [data-quill] *)`), and `popover.tsx` (popover content self-applies `data-quill`). Recommend a quick visual check that the date picker, charts, and the toggle's on-state all render correctly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with Claude Code: the root `data-quill` rebinds `--color-accent` to an undefined Quill token, breaking the Lemon switch's checked accent. Initial fix used the `data-not-quill` escape hatch; on review we moved to scoping `data-quill` per Quill island instead, which removes the escape hatch and keeps Lemon and Quill subtrees cleanly separated. No repo skills were required.
