### PR TITLE
fix(llma): trace url opens a generation instead of the trace

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4557,9 +4557,9 @@ snapshots:
     scenes-app-ai-observability-skills--skill-detail-stacked-below-2-xl-breakpoint--wide--light:
         hash: v1.k794b7964.ef580d47a394f197ebb785c2cac8156ae7e76b62d3220ea7f7b6f2a0609803e6.8rGPQkHXBXwGCatN1swSo0VYg_ZFgpa2fksd77fzWjM
     scenes-app-ai-observability-trace--full--dark:
-        hash: v1.k794b7964.c96ac17075c438842f6c9cba3108ad203ac5c6f5b2623e9eb6cee27850f4121a.cLPI-cVw9u_9N1Zrt8FTQs9NzQ7VCNiXUHUdMVbN9qM
+        hash: v1.k794b7964.296994af982eb0b096056e11cc548d5791b42341cd327c1180c6d1fc23c9c720.pPgjmtw4EdGMKMSIHvGQvnlFjAWDprUj7Z0jknbgqjk
     scenes-app-ai-observability-trace--full--light:
-        hash: v1.k794b7964.b361829cf7d87f44cbe435c630a53d23ad9c8af9db114bafaa23bff6fbf0a7e4.olin-_LNlWRvmiXuuiNcUhhOx-MCJxFMRs3-bucQMSI
+        hash: v1.k794b7964.0398131af102984194753213ba780df939fbac0ed16332dfcdf9b3f1d669039f.cBBkp-j7nvJSLV9qCgvrbHaPBDIpSTENFUTv_eY6URk
     scenes-app-ai-observability-trace--full-specific-event--dark:
         hash: v1.k794b7964.4de8815628861bb8b08d047d21715c4092708765ad0fd33e0e1579f2a33001b3.AEqiNKEtRaO1aI9cnGWv8PLtlutECNuaoqqxFCW9XP0
     scenes-app-ai-observability-trace--full-specific-event--light:

--- a/products/ai_observability/frontend/aiObservabilityTraceDataLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceDataLogic.test.ts
@@ -10,6 +10,7 @@ import {
     reportTraceNormalizationFailures,
     resolveTraceEventById,
     restoreTree,
+    traceHasRootContent,
 } from './aiObservabilityTraceDataLogic'
 
 describe('aiObservabilityTraceDataLogic: restoreTree', () => {
@@ -212,162 +213,84 @@ describe('aiObservabilityTraceDataLogic: restoreTree', () => {
 })
 
 describe('getInitialFocusEventId', () => {
-    it('returns $ai_trace event id when present', () => {
-        const events: LLMTraceEvent[] = [
-            {
-                id: 'span-1',
-                event: '$ai_span',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-            {
-                id: 'trace-event-1',
-                event: '$ai_trace',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-        ]
-
-        const tree: TraceTreeNode[] = [{ event: events[0] }]
-
-        expect(getInitialFocusEventId(events, tree, null)).toBe('trace-event-1')
+    const makeTrace = (overrides: Partial<LLMTrace> = {}): LLMTrace => ({
+        id: 'trace-1',
+        createdAt: '2024-01-01T00:00:00Z',
+        distinctId: 'user-1',
+        events: [],
+        ...overrides,
     })
 
-    it('returns first $ai_generation event id when no $ai_trace event exists', () => {
-        const events: LLMTraceEvent[] = [
-            {
-                id: 'span-1',
-                event: '$ai_span',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-            {
-                id: 'generation-1',
-                event: '$ai_generation',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-        ]
-
-        const tree: TraceTreeNode[] = [{ event: events[0] }, { event: events[1] }]
-
-        expect(getInitialFocusEventId(events, tree, null)).toBe('generation-1')
+    const node = (id: string, event: LLMTraceEvent['event']): TraceTreeNode => ({
+        event: { id, event, properties: {}, createdAt: '2024-01-01T00:00:00Z' },
     })
 
-    it('returns first tree event id when no $ai_trace or $ai_generation events exist', () => {
-        const events: LLMTraceEvent[] = [
-            {
-                id: 'span-1',
-                event: '$ai_span',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-            {
-                id: 'span-2',
-                event: '$ai_span',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-        ]
+    it('focuses the trace root (null) when the trace has its own content', () => {
+        // The $ai_trace event is folded into the trace by the runner, surfacing as inputState.
+        const trace = makeTrace({ inputState: { messages: [] } })
+        const tree = [node('span-1', '$ai_span'), node('generation-1', '$ai_generation')]
 
-        const tree: TraceTreeNode[] = [{ event: events[0] }, { event: events[1] }]
-
-        expect(getInitialFocusEventId(events, tree, null)).toBe('span-1')
+        expect(getInitialFocusEventId(trace, tree, null)).toBeNull()
     })
 
-    it('returns null when no events exist', () => {
-        expect(getInitialFocusEventId([], [], null)).toBeNull()
+    it('focuses the trace root even when only outputState is present', () => {
+        const trace = makeTrace({ outputState: { result: 'ok' } })
+
+        expect(getInitialFocusEventId(trace, [node('generation-1', '$ai_generation')], null)).toBeNull()
     })
 
-    it('prioritizes $ai_trace over $ai_generation and tree order', () => {
-        const generationEvent: LLMTraceEvent = {
-            id: 'generation-1',
-            event: '$ai_generation',
-            properties: {},
-            createdAt: '2024-01-01T00:00:00Z',
-        }
+    it('stays at the trace root for a real trace whose only children are spans (reported bug)', () => {
+        // 5a3f404d: real $ai_trace (folded into inputState), spans, zero generations.
+        // Previously fell through to the first span; must now stay at the trace root.
+        const trace = makeTrace({ inputState: { messages: [] } })
+        const tree = [node('title_generator', '$ai_span'), node('slash_command_handler', '$ai_span')]
 
-        const traceEvent: LLMTraceEvent = {
-            id: 'trace-event-1',
-            event: '$ai_trace',
-            properties: {},
-            createdAt: '2024-01-01T00:00:00Z',
-        }
-
-        const events: LLMTraceEvent[] = [generationEvent, traceEvent]
-
-        // Tree has generation first, but $ai_trace should still be selected
-        const tree: TraceTreeNode[] = [{ event: generationEvent }]
-
-        expect(getInitialFocusEventId(events, tree, null)).toBe('trace-event-1')
+        expect(getInitialFocusEventId(trace, tree, null)).toBeNull()
     })
 
-    it('skips $ai_generation events not in filtered tree', () => {
-        const spanEvent: LLMTraceEvent = {
-            id: 'span-1',
-            event: '$ai_span',
-            properties: {},
-            createdAt: '2024-01-01T00:00:00Z',
-        }
+    it('returns first $ai_generation event id for a pseudo-trace without root content', () => {
+        const trace = makeTrace()
+        const tree = [node('span-1', '$ai_span'), node('generation-1', '$ai_generation')]
 
-        const generationEvent: LLMTraceEvent = {
-            id: 'generation-1',
-            event: '$ai_generation',
-            properties: {},
-            createdAt: '2024-01-01T00:00:00Z',
-        }
-
-        const events: LLMTraceEvent[] = [spanEvent, generationEvent]
-
-        // Tree only has span (e.g., generation was filtered out by search)
-        const tree: TraceTreeNode[] = [{ event: spanEvent }]
-
-        // Should return first tree event since generation is not in tree
-        expect(getInitialFocusEventId(events, tree, null)).toBe('span-1')
+        expect(getInitialFocusEventId(trace, tree, null)).toBe('generation-1')
     })
 
-    it('returns null when initialTab is summary on pseudo-trace to stay at trace level', () => {
-        const events: LLMTraceEvent[] = [
-            {
-                id: 'span-1',
-                event: '$ai_span',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-            {
-                id: 'generation-1',
-                event: '$ai_generation',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-        ]
+    it('returns first tree event id when no root content and no $ai_generation exists', () => {
+        const trace = makeTrace()
+        const tree = [node('span-1', '$ai_span'), node('span-2', '$ai_span')]
 
-        const tree: TraceTreeNode[] = [{ event: events[0] }, { event: events[1] }]
-
-        // When tab=summary is specified, should return null to stay at trace level
-        expect(getInitialFocusEventId(events, tree, 'summary')).toBeNull()
+        expect(getInitialFocusEventId(trace, tree, null)).toBe('span-1')
     })
 
-    it('returns $ai_trace event id even when initialTab is summary', () => {
-        const events: LLMTraceEvent[] = [
-            {
-                id: 'trace-event-1',
-                event: '$ai_trace',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-            {
-                id: 'generation-1',
-                event: '$ai_generation',
-                properties: {},
-                createdAt: '2024-01-01T00:00:00Z',
-            },
-        ]
+    it('returns null when the trace is missing and the tree is empty', () => {
+        expect(getInitialFocusEventId(undefined, [], null)).toBeNull()
+    })
 
-        const tree: TraceTreeNode[] = [{ event: events[1] }]
+    it('returns null when initialTab is summary on a pseudo-trace to stay at trace level', () => {
+        const trace = makeTrace()
+        const tree = [node('span-1', '$ai_span'), node('generation-1', '$ai_generation')]
 
-        // When $ai_trace exists, it should be returned regardless of initialTab
-        expect(getInitialFocusEventId(events, tree, 'summary')).toBe('trace-event-1')
+        expect(getInitialFocusEventId(trace, tree, 'summary')).toBeNull()
+    })
+})
+
+describe('traceHasRootContent', () => {
+    const makeTrace = (overrides: Partial<LLMTrace> = {}): LLMTrace => ({
+        id: 'trace-1',
+        createdAt: '2024-01-01T00:00:00Z',
+        distinctId: 'user-1',
+        events: [],
+        ...overrides,
+    })
+
+    it('is true when inputState or outputState is populated', () => {
+        expect(traceHasRootContent(makeTrace({ inputState: { messages: [] } }))).toBe(true)
+        expect(traceHasRootContent(makeTrace({ outputState: { result: 'ok' } }))).toBe(true)
+    })
+
+    it('is false for a pseudo-trace with no folded-in $ai_trace content', () => {
+        expect(traceHasRootContent(makeTrace())).toBe(false)
+        expect(traceHasRootContent(undefined)).toBe(false)
     })
 })
 

--- a/products/ai_observability/frontend/aiObservabilityTraceDataLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceDataLogic.ts
@@ -358,12 +358,9 @@ export const aiObservabilityTraceDataLogic = kea<aiObservabilityTraceDataLogicTy
                 })),
         ],
         initialFocusEventId: [
-            (s) => [s.showableEvents, s.filteredTree, s.initialTab],
-            (
-                showableEvents: LLMTraceEvent[],
-                filteredTree: TraceTreeNode[],
-                initialTab: string | null
-            ): string | null => getInitialFocusEventId(showableEvents, filteredTree, initialTab),
+            (s) => [s.trace, s.filteredTree, s.initialTab],
+            (trace: LLMTrace | undefined, filteredTree: TraceTreeNode[], initialTab: string | null): string | null =>
+                getInitialFocusEventId(trace, filteredTree, initialTab),
         ],
         effectiveEventId: [
             (s) => [s.eventId, s.initialFocusEventId],
@@ -641,39 +638,38 @@ export function findNodeForEvent(tree: EnrichedTraceTreeNode[], eventId: string)
     return null
 }
 
+// The trace query runner folds the $ai_trace event into the trace itself (its
+// `inputState`/`outputState`) and drops it from `events`, so populated state is the
+// only signal left that a real $ai_trace event existed. Mirrors the scene's
+// `isTopLevelTraceWithoutContent` so the focus decision and the rendered root agree.
+export function traceHasRootContent(trace: LLMTrace | undefined): boolean {
+    return !!trace && (!!trace.inputState || !!trace.outputState)
+}
+
 export function getInitialFocusEventId(
-    showableEvents: LLMTraceEvent[],
+    trace: LLMTrace | undefined,
     filteredTree: TraceTreeNode[],
     initialTab: string | null
 ): string | null {
-    // First, look for an $ai_trace event
-    const aiTraceEvent = showableEvents.find((event) => event.event === '$ai_trace')
-
-    if (aiTraceEvent) {
-        return aiTraceEvent.id
+    // A real trace renders its whole conversation at the root, so focus the root
+    // (null) instead of diving into a child node.
+    if (traceHasRootContent(trace)) {
+        return null
     }
 
-    // If tab=summary is specified, user wants to stay at the trace level (e.g., from clusters view)
-    // Don't skip to first generation event in this case
+    // tab=summary means the user explicitly asked to stay at the trace level (e.g. from clusters view).
     if (initialTab === 'summary') {
         return null
     }
 
-    // If no $ai_trace event, look for the first $ai_generation event
-    // This provides a better default for pseudo-traces where the generation
-    // is typically what users want to see
+    // Pseudo-trace: bare generations grouped by trace_id with no $ai_trace event.
+    // The first generation is the most useful default here.
     const firstGenerationNode = filteredTree.find((node) => node.event.event === '$ai_generation')
-
     if (firstGenerationNode) {
         return firstGenerationNode.event.id
     }
 
-    // Fall back to first event in tree
-    if (filteredTree.length > 0) {
-        return filteredTree[0].event.id
-    }
-
-    return null
+    return filteredTree[0]?.event.id ?? null
 }
 
 export function getEffectiveEventId(eventId: string | null, initialFocusEventId: string | null): string | null {


### PR DESCRIPTION
## Problem

Opening a trace focuses to the last event in the trace even when there's an actual trace event that we ingested. This is because we check for an `$ai_trace` event in the frontend to decide whether it's a real or synthetic trace, but the trace query runner actually never added the root trace event to the list, it just folds its properties into the synthetic trace event.

## Changes

Check for input and output on the root trace event instead to decide whether to auto focus.

## How did you test this code?

I'm an agent (PostHog Code) — no manual UI testing was performed; the items below are what I actually ran.

- Verified the root cause empirically by pulling the reported trace and its full conversation from production ClickHouse (via the `query-clickhouse-via-metabase` skill). This confirmed the traces carry a folded-in `$ai_trace` event and were landing on a child node — and overturned an initial (wrong) "pseudo-trace" hypothesis.
- Updated and extended the unit tests in `aiObservabilityTraceDataLogic.test.ts` (30 passing), including a regression test for the exact reported trace shape: a real `$ai_trace` (folded into `inputState`) plus spans and zero generations → now stays at the trace root.
- TypeScript-clean for the edited functions (remaining `tsgo` noise in the worktree is pre-existing, from kea-typegen not running locally).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Carlos directed the work; assign him as the DRI.

- Tooling: PostHog Code (Claude Opus). Skills invoked: `query-clickhouse-via-metabase` (empirical trace pull), `pr-link` (this link).
- Investigation started static, then Carlos pushed for empirical verification. Pulling the real trace revealed the runner-fold root cause and corrected the initial hypothesis.
- Chose a frontend fix (detect trace content) over changing the runner to stop stripping `$ai_trace`: the latter would re-introduce a duplicate root node into the tree and ripple through downstream tree/aggregation logic for no user benefit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
