### PR TITLE
feat(subscriptions): email owner when a scheduled delivery fails

### DIFF
--- a/ee/tasks/subscriptions/failure_notifications.py
+++ b/ee/tasks/subscriptions/failure_notifications.py
@@ -57,7 +57,10 @@ def failure_target_label(subscription: Subscription) -> str | None:
     if not target_value:
         return None
     if subscription.target_type == Subscription.SubscriptionTarget.SLACK:
-        channel_name = target_value.split("|")[-1].strip()
+        # Stored as `channel_id|channel_name`; show the name, not the raw id. With no name
+        # part we have nothing human-readable, so omit the target rather than print an id.
+        _, _, channel_name = target_value.partition("|")
+        channel_name = channel_name.strip()
         if not channel_name:
             return None
         return channel_name if channel_name.startswith("#") else f"#{channel_name}"
@@ -68,6 +71,7 @@ def send_notification_for_failed_subscription(
     subscription: Subscription,
     reason: FailureReason,
     error_type: str | None,
+    delivery_id: uuid.UUID,
     targets: list[str],
 ) -> None:
     logger.info(
@@ -82,10 +86,10 @@ def send_notification_for_failed_subscription(
         if subscription.title
         else "Your PostHog subscription failed to send"
     )
-    # uuid4 campaign key: re-send suppression is handled upstream (we only notify on the
-    # transition into failure), so MessagingRecord must not also collapse the distinct
-    # failure emails a subscription legitimately sends over its lifetime.
-    campaign_key = f"subscription-failed-notification-{subscription.id}-{uuid.uuid4()}"
+    # Keyed on the failed delivery, not a fresh uuid: a Temporal activity retry (worker
+    # crash/timeout) then reuses the same key, so MessagingRecord dedups the duplicate
+    # send. Distinct failures still differ — each delivery attempt has its own id.
+    campaign_key = f"subscription-failed-notification-{delivery_id}"
 
     message = EmailMessage(
         campaign_key=campaign_key,

--- a/ee/tasks/subscriptions/failure_notifications.py
+++ b/ee/tasks/subscriptions/failure_notifications.py
@@ -1,0 +1,106 @@
+import uuid
+from typing import NamedTuple
+
+import structlog
+
+from posthog.email import EmailMessage
+
+from products.exports.backend.models.subscription import Subscription
+
+logger = structlog.get_logger(__name__)
+
+
+class FailureReason(NamedTuple):
+    # One-line, user-facing description of what went wrong.
+    summary: str
+    # Concrete next step the subscription owner can take. May be empty.
+    suggestion: str
+
+
+GENERIC_FAILURE_REASON = FailureReason(
+    summary="PostHog hit an unexpected error while preparing or sending this report.",
+    suggestion="We'll automatically retry on the next scheduled run. If it keeps failing, reach out to support and we'll dig in.",
+)
+
+SLACK_FAILURE_REASON = FailureReason(
+    summary="PostHog couldn't post this report to Slack.",
+    suggestion="This is usually a temporary Slack issue, and we'll retry on the next scheduled run. If it keeps failing, check that the PostHog app is still installed in your Slack workspace and is a member of the target channel.",
+)
+
+EMAIL_FAILURE_REASON = FailureReason(
+    summary="PostHog couldn't deliver this report by email.",
+    suggestion="We'll retry on the next scheduled run. If it keeps failing, double-check the recipient email addresses on the subscription.",
+)
+
+
+def classify_delivery_failure(target_type: str | None) -> FailureReason:
+    """Map a failed delivery to a user-facing reason + suggestion.
+
+    Deliberately coarse and keyed off the delivery channel: the underlying exception is
+    often redacted (it can carry Slack tokens or recipient PII), so we describe what we
+    can say honestly rather than surfacing a raw error string to the subscription owner.
+    """
+    if target_type == Subscription.SubscriptionTarget.SLACK:
+        return SLACK_FAILURE_REASON
+    if target_type == Subscription.SubscriptionTarget.EMAIL:
+        return EMAIL_FAILURE_REASON
+    return GENERIC_FAILURE_REASON
+
+
+def failure_target_label(subscription: Subscription) -> str | None:
+    """A human-friendly rendering of where the subscription delivers, for the email body.
+
+    Slack target_value is stored as `channel_id|channel_name`; email target_value is a
+    comma-separated list of addresses (which the owner set themselves, so it's safe to echo).
+    """
+    target_value = (subscription.target_value or "").strip()
+    if not target_value:
+        return None
+    if subscription.target_type == Subscription.SubscriptionTarget.SLACK:
+        channel_name = target_value.split("|")[-1].strip()
+        if not channel_name:
+            return None
+        return channel_name if channel_name.startswith("#") else f"#{channel_name}"
+    return target_value
+
+
+def send_notification_for_failed_subscription(
+    subscription: Subscription,
+    reason: FailureReason,
+    error_type: str | None,
+    targets: list[str],
+) -> None:
+    logger.info(
+        "subscription.send_failed_notification",
+        subscription_id=subscription.id,
+        recipient_count=len(targets),
+    )
+
+    display_name = subscription.title or "your subscription"
+    subject = (
+        f'PostHog subscription "{subscription.title}" failed to send'
+        if subscription.title
+        else "Your PostHog subscription failed to send"
+    )
+    # uuid4 campaign key: re-send suppression is handled upstream (we only notify on the
+    # transition into failure), so MessagingRecord must not also collapse the distinct
+    # failure emails a subscription legitimately sends over its lifetime.
+    campaign_key = f"subscription-failed-notification-{subscription.id}-{uuid.uuid4()}"
+
+    message = EmailMessage(
+        campaign_key=campaign_key,
+        subject=subject,
+        template_name="subscription_failed",
+        template_context={
+            "subscription_url": subscription.url,
+            "subscription_title": display_name,
+            "target_label": failure_target_label(subscription),
+            "failure_summary": reason.summary,
+            "failure_suggestion": reason.suggestion,
+            "error_type": error_type,
+        },
+    )
+    for target in targets:
+        message.add_recipient(email=target)
+
+    message.send()

--- a/ee/tasks/subscriptions/test_failure_notifications.py
+++ b/ee/tasks/subscriptions/test_failure_notifications.py
@@ -1,0 +1,122 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from products.exports.backend.models.subscription import Subscription
+
+from ee.tasks.subscriptions.failure_notifications import (
+    EMAIL_FAILURE_REASON,
+    GENERIC_FAILURE_REASON,
+    SLACK_FAILURE_REASON,
+    classify_delivery_failure,
+    failure_target_label,
+    send_notification_for_failed_subscription,
+)
+
+
+class TestClassifyDeliveryFailure:
+    @parameterized.expand(
+        [
+            ("slack", "slack", SLACK_FAILURE_REASON),
+            ("email", "email", EMAIL_FAILURE_REASON),
+            ("unknown_target", "webhook", GENERIC_FAILURE_REASON),
+            ("none_target", None, GENERIC_FAILURE_REASON),
+        ]
+    )
+    def test_classify_delivery_failure(self, _label, target_type, expected):
+        reason = classify_delivery_failure(target_type)
+        assert reason == expected
+        # Every reason carries an actionable suggestion so the email is never a dead end.
+        assert reason.summary
+        assert reason.suggestion
+
+
+class TestFailureTargetLabel(APIBaseTest):
+    def _make_subscription(self, **overrides) -> Subscription:
+        defaults = {
+            "team": self.team,
+            "target_type": "slack",
+            "target_value": "C12345|#alerts",
+            "frequency": "daily",
+            "start_date": timezone.now(),
+            "insight": None,
+            "title": "t",
+            "created_by": self.user,
+        }
+        defaults.update(overrides)
+        return Subscription.objects.create(**defaults)
+
+    @parameterized.expand(
+        [
+            ("slack_id_and_name", "slack", "C12345|#alerts", "#alerts"),
+            ("slack_name_without_hash", "slack", "C12345|alerts", "#alerts"),
+            ("slack_id_only", "slack", "C12345", "#C12345"),
+            ("email_single", "email", "a@b.com", "a@b.com"),
+            ("email_multiple", "email", "a@b.com,c@d.com", "a@b.com,c@d.com"),
+            ("empty", "slack", "", None),
+        ]
+    )
+    def test_failure_target_label(self, _label, target_type, target_value, expected):
+        sub = self._make_subscription(target_type=target_type, target_value=target_value)
+        assert failure_target_label(sub) == expected
+
+
+class TestSendNotificationForFailedSubscription(APIBaseTest):
+    def _make_subscription(self, **overrides) -> Subscription:
+        defaults = {
+            "team": self.team,
+            "target_type": "slack",
+            "target_value": "C12345|#alerts",
+            "frequency": "daily",
+            "start_date": timezone.now(),
+            "insight": None,
+            "title": "Daily metrics",
+            "created_by": self.user,
+        }
+        defaults.update(overrides)
+        return Subscription.objects.create(**defaults)
+
+    def test_builds_email_with_failure_context(self):
+        sub = self._make_subscription()
+
+        with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, "SlackApiError", [self.user.email])
+
+        kwargs = email_cls.call_args.kwargs
+        assert kwargs["template_name"] == "subscription_failed"
+        assert "Daily metrics" in kwargs["subject"]
+        ctx = kwargs["template_context"]
+        assert ctx["subscription_title"] == "Daily metrics"
+        assert ctx["target_label"] == "#alerts"
+        assert ctx["failure_summary"] == SLACK_FAILURE_REASON.summary
+        assert ctx["failure_suggestion"] == SLACK_FAILURE_REASON.suggestion
+        assert ctx["error_type"] == "SlackApiError"
+        email_cls.return_value.add_recipient.assert_called_once_with(email=self.user.email)
+        email_cls.return_value.send.assert_called_once()
+
+    def test_untitled_subscription_uses_generic_copy(self):
+        sub = self._make_subscription(title=None)
+
+        with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
+            send_notification_for_failed_subscription(sub, GENERIC_FAILURE_REASON, None, [self.user.email])
+
+        kwargs = email_cls.call_args.kwargs
+        assert kwargs["subject"] == "Your PostHog subscription failed to send"
+        assert kwargs["template_context"]["subscription_title"] == "your subscription"
+
+    def test_unique_campaign_key_per_call(self):
+        sub = self._make_subscription()
+
+        with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, [self.user.email])
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, [self.user.email])
+
+        first_key = email_cls.call_args_list[0].kwargs["campaign_key"]
+        second_key = email_cls.call_args_list[1].kwargs["campaign_key"]
+        assert first_key != second_key
+        prefix = f"subscription-failed-notification-{sub.id}-"
+        assert first_key.startswith(prefix)
+        assert second_key.startswith(prefix)

--- a/ee/tasks/subscriptions/test_failure_notifications.py
+++ b/ee/tasks/subscriptions/test_failure_notifications.py
@@ -1,3 +1,5 @@
+import uuid
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -53,7 +55,7 @@ class TestFailureTargetLabel(APIBaseTest):
         [
             ("slack_id_and_name", "slack", "C12345|#alerts", "#alerts"),
             ("slack_name_without_hash", "slack", "C12345|alerts", "#alerts"),
-            ("slack_id_only", "slack", "C12345", "#C12345"),
+            ("slack_id_only", "slack", "C12345", None),
             ("email_single", "email", "a@b.com", "a@b.com"),
             ("email_multiple", "email", "a@b.com,c@d.com", "a@b.com,c@d.com"),
             ("empty", "slack", "", None),
@@ -83,7 +85,9 @@ class TestSendNotificationForFailedSubscription(APIBaseTest):
         sub = self._make_subscription()
 
         with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
-            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, "SlackApiError", [self.user.email])
+            send_notification_for_failed_subscription(
+                sub, SLACK_FAILURE_REASON, "SlackApiError", uuid.uuid4(), [self.user.email]
+            )
 
         kwargs = email_cls.call_args.kwargs
         assert kwargs["template_name"] == "subscription_failed"
@@ -101,22 +105,25 @@ class TestSendNotificationForFailedSubscription(APIBaseTest):
         sub = self._make_subscription(title=None)
 
         with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
-            send_notification_for_failed_subscription(sub, GENERIC_FAILURE_REASON, None, [self.user.email])
+            send_notification_for_failed_subscription(
+                sub, GENERIC_FAILURE_REASON, None, uuid.uuid4(), [self.user.email]
+            )
 
         kwargs = email_cls.call_args.kwargs
         assert kwargs["subject"] == "Your PostHog subscription failed to send"
         assert kwargs["template_context"]["subscription_title"] == "your subscription"
 
-    def test_unique_campaign_key_per_call(self):
+    def test_campaign_key_is_idempotent_per_delivery(self):
+        # Keyed on the delivery id so a Temporal activity retry reuses the key (and
+        # MessagingRecord dedups), while distinct deliveries still get distinct keys.
         sub = self._make_subscription()
+        delivery_id = uuid.uuid4()
 
         with patch("ee.tasks.subscriptions.failure_notifications.EmailMessage") as email_cls:
-            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, [self.user.email])
-            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, [self.user.email])
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, delivery_id, [self.user.email])
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, delivery_id, [self.user.email])
+            send_notification_for_failed_subscription(sub, SLACK_FAILURE_REASON, None, uuid.uuid4(), [self.user.email])
 
-        first_key = email_cls.call_args_list[0].kwargs["campaign_key"]
-        second_key = email_cls.call_args_list[1].kwargs["campaign_key"]
-        assert first_key != second_key
-        prefix = f"subscription-failed-notification-{sub.id}-"
-        assert first_key.startswith(prefix)
-        assert second_key.startswith(prefix)
+        keys = [c.kwargs["campaign_key"] for c in email_cls.call_args_list]
+        assert keys[0] == keys[1] == f"subscription-failed-notification-{delivery_id}"
+        assert keys[2] != keys[0]

--- a/posthog/templates/email/subscription_failed.html
+++ b/posthog/templates/email/subscription_failed.html
@@ -1,0 +1,25 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block preheader %}We couldn't deliver your scheduled PostHog subscription "{{ subscription_title }}".{% endblock %}
+{% block heading %}Your subscription didn't send{% endblock %}
+{% block section %}
+    <p>
+        PostHog couldn't deliver your subscription <strong>{{ subscription_title }}</strong>{% if target_label %} to
+        <strong>{{ target_label }}</strong>{% endif %} on its last scheduled run.
+    </p>
+    <p><strong>What happened:</strong> {{ failure_summary }}</p>
+    {% if failure_suggestion %}
+    <p><strong>What you can do:</strong> {{ failure_suggestion }}</p>
+    {% endif %}
+    <p class="muted">
+        This subscription is still active — we'll automatically try again on its next scheduled run. You'll only get
+        another email if it fails again after a successful delivery.
+    </p>
+    {% if subscription_url %}
+    <div class="mb mt text-center">
+        <a class="button" href="{% absolute_uri subscription_url %}">View subscription</a>
+    </div>
+    {% endif %}
+    {% if error_type %}
+    <p class="muted">Reference for support: {{ error_type }}</p>
+    {% endif %}
+{% endblock %}

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -41,6 +41,7 @@ from products.exports.backend.temporal.subscriptions.activities import (
     create_export_assets,
     deliver_subscription,
     fetch_due_subscriptions_activity,
+    notify_subscription_failure,
     update_delivery_record,
     validate_subscription_for_delivery,
 )
@@ -59,6 +60,7 @@ from products.exports.backend.temporal.subscriptions.types import (
     DeliveryStatus,
     FetchDueSubscriptionsActivityInputs,
     GenerateAIReportInputs,
+    NotifySubscriptionFailureInputs,
     ProcessSubscriptionWorkflowInputs,
     ScheduleAllSubscriptionsWorkflowInputs,
     SubscriptionTriggerType,
@@ -99,6 +101,7 @@ SUBSCRIPTION_SCHEDULE_ACTIVITIES: Sequence[Callable[..., Any]] = cast(
         generate_ai_subscription_report,
         update_delivery_record,
         advance_next_delivery_date,
+        notify_subscription_failure,
     ],
 )
 
@@ -113,6 +116,7 @@ SUBSCRIPTION_PROCESS_ACTIVITIES: Sequence[Callable[..., Any]] = cast(
         generate_ai_subscription_report,
         update_delivery_record,
         advance_next_delivery_date,
+        notify_subscription_failure,
     ],
 )
 
@@ -2489,3 +2493,122 @@ async def test_fetch_due_subscriptions_includes_ai_with_resource_type(team, user
     match = next((s for s in fetched if s.subscription_id == sub.id), None)
     assert match is not None, "due AI subscription must be picked up by the shared scheduler fetch"
     assert match.resource_type == Subscription.ResourceType.AI_PROMPT
+
+
+_NOTIFY_SEND = "products.exports.backend.temporal.subscriptions.activities.send_notification_for_failed_subscription"
+
+
+def _make_delivery(subscription, status, *, finished=True, key_suffix=""):
+    return SubscriptionDelivery.objects.create(
+        subscription=subscription,
+        team=subscription.team,
+        temporal_workflow_id="wf-test",
+        idempotency_key=f"idem-{subscription.id}-{status}-{key_suffix}-{uuid.uuid4()}",
+        trigger_type=SubscriptionTriggerType.SCHEDULED,
+        target_type=subscription.target_type,
+        target_value=subscription.target_value,
+        status=status,
+        finished_at=timezone.now() if finished else None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case_label, prior_statuses",
+    [
+        ("no_prior_delivery", []),
+        ("prior_completed", [SubscriptionDelivery.Status.COMPLETED]),
+        ("prior_skipped", [SubscriptionDelivery.Status.SKIPPED]),
+    ],
+)
+async def test_notify_subscription_failure_emails_owner_on_transition(team, user, case_label, prior_statuses):
+    """The owner is emailed when a scheduled delivery newly fails (no prior failure)."""
+    subscription = await sync_to_async(create_subscription)(
+        team=team, created_by=user, target_type="slack", target_value="C123|#alerts", title="Daily metrics"
+    )
+    for i, status in enumerate(prior_statuses):
+        await sync_to_async(_make_delivery)(subscription, status, key_suffix=f"prior{i}")
+    failed = await sync_to_async(_make_delivery)(subscription, SubscriptionDelivery.Status.FAILED, key_suffix="current")
+
+    with patch(_NOTIFY_SEND) as send_mock:
+        await ActivityEnvironment().run(
+            notify_subscription_failure,
+            NotifySubscriptionFailureInputs(
+                subscription_id=subscription.id, delivery_id=failed.id, error_type="SlackApiError"
+            ),
+        )
+
+    send_mock.assert_called_once()
+    args = send_mock.call_args.args
+    assert args[0].id == subscription.id  # subscription
+    assert args[2] == "SlackApiError"  # error_type
+    assert args[3] == [user.email]  # targets
+
+
+@pytest.mark.asyncio
+async def test_notify_subscription_failure_silent_during_failure_streak(team, user):
+    """A second consecutive failure does not re-email — the owner was told on the first."""
+    subscription = await sync_to_async(create_subscription)(team=team, created_by=user, target_type="slack")
+    await sync_to_async(_make_delivery)(subscription, SubscriptionDelivery.Status.FAILED, key_suffix="prior")
+    current = await sync_to_async(_make_delivery)(
+        subscription, SubscriptionDelivery.Status.FAILED, key_suffix="current"
+    )
+
+    with patch(_NOTIFY_SEND) as send_mock:
+        await ActivityEnvironment().run(
+            notify_subscription_failure,
+            NotifySubscriptionFailureInputs(subscription_id=subscription.id, delivery_id=current.id),
+        )
+
+    send_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case_label, disabled, clear_author",
+    [
+        ("disabled_subscription", True, False),
+        ("no_author", False, True),
+    ],
+)
+async def test_notify_subscription_failure_skips_when_unreachable(team, user, case_label, disabled, clear_author):
+    """Auto-disabled subs get the dedicated 'disabled' email, and an author-less sub has nobody to notify."""
+    subscription = await sync_to_async(create_subscription)(
+        team=team,
+        created_by=None if clear_author else user,
+        enabled=not disabled,
+        target_type="slack",
+    )
+    current = await sync_to_async(_make_delivery)(
+        subscription, SubscriptionDelivery.Status.FAILED, key_suffix="current"
+    )
+
+    with patch(_NOTIFY_SEND) as send_mock:
+        await ActivityEnvironment().run(
+            notify_subscription_failure,
+            NotifySubscriptionFailureInputs(subscription_id=subscription.id, delivery_id=current.id),
+        )
+
+    send_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_subscription_failure_swallows_send_errors(team, user):
+    """A broken email send must not turn the already-failed delivery into a hard workflow failure."""
+    subscription = await sync_to_async(create_subscription)(team=team, created_by=user, target_type="slack")
+    current = await sync_to_async(_make_delivery)(
+        subscription, SubscriptionDelivery.Status.FAILED, key_suffix="current"
+    )
+
+    with (
+        patch(_NOTIFY_SEND, side_effect=RuntimeError("smtp down")) as send_mock,
+        patch("products.exports.backend.temporal.subscriptions.activities.capture_exception") as capture_mock,
+    ):
+        # Must not raise.
+        await ActivityEnvironment().run(
+            notify_subscription_failure,
+            NotifySubscriptionFailureInputs(subscription_id=subscription.id, delivery_id=current.id),
+        )
+
+    send_mock.assert_called_once()
+    capture_mock.assert_called_once()

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -2542,7 +2542,8 @@ async def test_notify_subscription_failure_emails_owner_on_transition(team, user
     args = send_mock.call_args.args
     assert args[0].id == subscription.id  # subscription
     assert args[2] == "SlackApiError"  # error_type
-    assert args[3] == [user.email]  # targets
+    assert args[3] == failed.id  # delivery_id
+    assert args[4] == [user.email]  # targets
 
 
 @pytest.mark.asyncio

--- a/products/exports/backend/temporal/subscriptions/__init__.py
+++ b/products/exports/backend/temporal/subscriptions/__init__.py
@@ -4,6 +4,7 @@ from products.exports.backend.temporal.subscriptions.activities import (
     create_export_assets,
     deliver_subscription,
     fetch_due_subscriptions_activity,
+    notify_subscription_failure,
     update_delivery_record,
     validate_subscription_for_delivery,
 )
@@ -33,4 +34,5 @@ ACTIVITIES = [
     create_delivery_record,
     update_delivery_record,
     snapshot_subscription_insights,
+    notify_subscription_failure,
 ]

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -530,16 +530,20 @@ async def notify_subscription_failure(inputs: NotifySubscriptionFailureInputs) -
             LOGGER.info("notify_subscription_failure.skipped_no_author_email", subscription_id=inputs.subscription_id)
             return
 
-        # Notify only on the transition into failure. The just-failed delivery row is
-        # excluded; if the most recent prior finished delivery also failed, we already
-        # notified for this streak.
+        # Notify only on the transition into failure. Look at the most recent prior
+        # delivery that actually attempted to send (COMPLETED or FAILED) — SKIPPED runs
+        # (no assets, over-budget) sent nothing, so they neither start nor break a streak.
+        # If that prior attempt already failed, we notified then and stay quiet.
+        # Order by -created_at (not -finished_at): deliveries for one subscription never
+        # overlap, so the two orderings agree, and -created_at is covered by the existing
+        # (subscription, -created_at) index — no post-sort.
         previous_status = (
             SubscriptionDelivery.objects.filter(
                 subscription_id=inputs.subscription_id,
-                finished_at__isnull=False,
+                status__in=[SubscriptionDelivery.Status.COMPLETED, SubscriptionDelivery.Status.FAILED],
             )
             .exclude(pk=inputs.delivery_id)
-            .order_by("-finished_at")
+            .order_by("-created_at")
             .values_list("status", flat=True)
             .first()
         )
@@ -552,6 +556,7 @@ async def notify_subscription_failure(inputs: NotifySubscriptionFailureInputs) -
             subscription,
             reason,
             inputs.error_type,
+            inputs.delivery_id,
             [subscription.created_by.email],
         )
 

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -11,6 +11,7 @@ import temporalio.activity
 from structlog import get_logger
 from temporalio.exceptions import ApplicationError
 
+from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async
 
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
@@ -33,6 +34,7 @@ from products.exports.backend.temporal.subscriptions.types import (
     DeliverSubscriptionInputs,
     DeliverSubscriptionResult,
     FetchDueSubscriptionsActivityInputs,
+    NotifySubscriptionFailureInputs,
     RecipientResult,
     SubscriptionAbortInfo,
     SubscriptionInfo,
@@ -47,6 +49,10 @@ from ee.tasks.subscriptions.auto_disable import (
     get_subscription_disable_reason,
 )
 from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
+from ee.tasks.subscriptions.failure_notifications import (
+    classify_delivery_failure,
+    send_notification_for_failed_subscription,
+)
 from ee.tasks.subscriptions.slack_subscriptions import send_slack_message_with_integration_async
 
 LOGGER = get_logger(__name__)
@@ -499,3 +505,63 @@ async def advance_next_delivery_date(subscription_id: int) -> None:
         subscription_id=subscription_id,
         next_delivery_date=subscription.next_delivery_date,
     )
+
+
+@temporalio.activity.defn
+async def notify_subscription_failure(inputs: NotifySubscriptionFailureInputs) -> None:
+    """Best-effort email to the subscription owner when a scheduled delivery failed without
+    auto-disabling (a transient or unexpected error that will be retried, not a permanently
+    broken target — those get the dedicated "disabled" email instead).
+
+    Sends once per failure streak: if the most recent *prior* finished delivery already
+    failed, the owner has been told, so staying quiet avoids a daily inbox of the same alert.
+    Never raises — a notification problem must not turn a recoverable delivery failure into
+    a hard workflow failure.
+    """
+
+    @database_sync_to_async(thread_sensitive=False)
+    def _notify() -> None:
+        subscription = Subscription.objects.select_related("created_by").get(pk=inputs.subscription_id)
+
+        # Auto-disabled subs already receive the dedicated "disabled" email — don't double up.
+        if not subscription.enabled:
+            return
+        if not (subscription.created_by and subscription.created_by.email):
+            LOGGER.info("notify_subscription_failure.skipped_no_author_email", subscription_id=inputs.subscription_id)
+            return
+
+        # Notify only on the transition into failure. The just-failed delivery row is
+        # excluded; if the most recent prior finished delivery also failed, we already
+        # notified for this streak.
+        previous_status = (
+            SubscriptionDelivery.objects.filter(
+                subscription_id=inputs.subscription_id,
+                finished_at__isnull=False,
+            )
+            .exclude(pk=inputs.delivery_id)
+            .order_by("-finished_at")
+            .values_list("status", flat=True)
+            .first()
+        )
+        if previous_status == SubscriptionDelivery.Status.FAILED:
+            LOGGER.info("notify_subscription_failure.skipped_failure_streak", subscription_id=inputs.subscription_id)
+            return
+
+        reason = classify_delivery_failure(subscription.target_type)
+        send_notification_for_failed_subscription(
+            subscription,
+            reason,
+            inputs.error_type,
+            [subscription.created_by.email],
+        )
+
+    try:
+        await _notify()
+    except Exception as e:
+        # Notification is best-effort; swallow so it can't fail the (already-failed) workflow.
+        capture_exception(e)
+        await LOGGER.awarning(
+            "notify_subscription_failure.failed",
+            subscription_id=inputs.subscription_id,
+            exc_info=True,
+        )

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -212,6 +212,19 @@ class UpdateDeliveryRecordInputs:
 
 
 @dataclasses.dataclass
+class NotifySubscriptionFailureInputs:
+    """Drives the best-effort "your subscription failed to send" email to the owner.
+
+    `delivery_id` is the just-failed delivery row — excluded when checking whether the
+    previous delivery already failed (so we only notify on the transition into failure).
+    """
+
+    subscription_id: int
+    delivery_id: uuid.UUID
+    error_type: typing.Optional[str] = None
+
+
+@dataclasses.dataclass
 class SnapshotInsightsInputs:
     subscription_id: int
     team_id: int

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -29,6 +29,7 @@ from products.exports.backend.temporal.subscriptions.activities import (
     create_export_assets,
     deliver_subscription,
     fetch_due_subscriptions_activity,
+    notify_subscription_failure,
     update_delivery_record,
     validate_subscription_for_delivery,
 )
@@ -48,6 +49,7 @@ from products.exports.backend.temporal.subscriptions.types import (
     DeliveryStatus,
     FetchDueSubscriptionsActivityInputs,
     GenerateAIReportInputs,
+    NotifySubscriptionFailureInputs,
     ProcessSubscriptionWorkflowInputs,
     RecipientResult,
     ScheduleAllSubscriptionsWorkflowInputs,
@@ -57,6 +59,18 @@ from products.exports.backend.temporal.subscriptions.types import (
     TrackedSubscriptionInputs,
     UpdateDeliveryRecordInputs,
 )
+
+
+def _terminal_error_type(error: BaseException) -> str:
+    """The original exception class name for the owner-facing failure email.
+
+    A delivery failure surfaces to the workflow wrapped in an ActivityError; Temporal
+    stashes the underlying exception's class name on the ApplicationError cause, so unwrap
+    one level to avoid reporting the unhelpful "ActivityError" to the subscription owner.
+    """
+    if isinstance(error, ActivityError) and isinstance(error.cause, ApplicationError):
+        return error.cause.type or type(error.cause).__name__
+    return type(error).__name__
 
 
 def _to_recipient_dicts(recipient_results: list[RecipientResult]) -> list[dict]:
@@ -399,6 +413,27 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     if caught_error is None:
                         raise
 
+            # Proactively email the owner that their scheduled delivery failed. Auto-disable
+            # paths return normally above (and send their own "disabled" email), so reaching
+            # the except block means a genuine, still-enabled failure that will be retried.
+            # Best-effort and fire-once-per-streak — gated to scheduled runs since manual and
+            # target-change sends already surface their result to the user in the UI.
+            if (
+                caught_error is not None
+                and delivery_id is not None
+                and inputs.trigger_type == SubscriptionTriggerType.SCHEDULED
+            ):
+                await temporalio.workflow.execute_activity(
+                    notify_subscription_failure,
+                    NotifySubscriptionFailureInputs(
+                        subscription_id=inputs.subscription_id,
+                        delivery_id=delivery_id,
+                        error_type=_terminal_error_type(caught_error),
+                    ),
+                    start_to_close_timeout=dt.timedelta(minutes=2),
+                    retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
+                )
+
             # Advance schedule — always for scheduled deliveries, even on failure.
             # The activity itself no-ops when the subscription is disabled, so a
             # just-auto-disabled sub doesn't get a misleading future delivery date.
@@ -564,6 +599,24 @@ class ProcessAISubscriptionWorkflow(PostHogWorkflow):
                     )
                     if caught_error is None:
                         raise
+
+            # Proactively email the owner on a genuine (non-auto-disable) scheduled failure.
+            # See ProcessSubscriptionWorkflow for the rationale; kept in sync with it.
+            if (
+                caught_error is not None
+                and delivery_id is not None
+                and inputs.trigger_type == SubscriptionTriggerType.SCHEDULED
+            ):
+                await temporalio.workflow.execute_activity(
+                    notify_subscription_failure,
+                    NotifySubscriptionFailureInputs(
+                        subscription_id=inputs.subscription_id,
+                        delivery_id=delivery_id,
+                        error_type=_terminal_error_type(caught_error),
+                    ),
+                    start_to_close_timeout=dt.timedelta(minutes=2),
+                    retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
+                )
 
             # Advance schedule for scheduled deliveries even on failure — the activity
             # no-ops when the subscription is disabled, so a just-auto-disabled sub

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -13,6 +13,7 @@ from temporalio.exceptions import ActivityError, ApplicationError, WorkflowAlrea
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.errors import resolve_exception_class
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import (
@@ -61,16 +62,39 @@ from products.exports.backend.temporal.subscriptions.types import (
 )
 
 
-def _terminal_error_type(error: BaseException) -> str:
-    """The original exception class name for the owner-facing failure email.
+async def _maybe_notify_owner_of_failure(
+    subscription_id: int,
+    delivery_id: uuid.UUID | None,
+    caught_error: BaseException | None,
+    trigger_type: str,
+) -> None:
+    """Best-effort owner email for a genuine (non-auto-disable) scheduled delivery failure.
 
-    A delivery failure surfaces to the workflow wrapped in an ActivityError; Temporal
-    stashes the underlying exception's class name on the ApplicationError cause, so unwrap
-    one level to avoid reporting the unhelpful "ActivityError" to the subscription owner.
+    Only scheduled runs notify — manual and target-change sends already show their result
+    in the UI. Swallows its own errors so a broken notification can't mask the delivery
+    error or skip the schedule-advance that runs after it (mirrors update_delivery_record).
+    Shared by both workflows' finally blocks, which must stay in sync.
     """
-    if isinstance(error, ActivityError) and isinstance(error.cause, ApplicationError):
-        return error.cause.type or type(error.cause).__name__
-    return type(error).__name__
+    if caught_error is None or delivery_id is None or trigger_type != SubscriptionTriggerType.SCHEDULED:
+        return
+    try:
+        await temporalio.workflow.execute_activity(
+            notify_subscription_failure,
+            NotifySubscriptionFailureInputs(
+                subscription_id=subscription_id,
+                delivery_id=delivery_id,
+                # Same helper the SLO interceptor uses, so the owner's "reference for
+                # support" matches the error_type recorded against this failure.
+                error_type=resolve_exception_class(caught_error),
+            ),
+            start_to_close_timeout=dt.timedelta(minutes=2),
+            retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
+        )
+    except Exception:
+        temporalio.workflow.logger.warning(
+            "notify_subscription_failure failed (owner notification is best-effort)",
+            extra={"subscription_id": subscription_id},
+        )
 
 
 def _to_recipient_dicts(recipient_results: list[RecipientResult]) -> list[dict]:
@@ -413,26 +437,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     if caught_error is None:
                         raise
 
-            # Proactively email the owner that their scheduled delivery failed. Auto-disable
-            # paths return normally above (and send their own "disabled" email), so reaching
-            # the except block means a genuine, still-enabled failure that will be retried.
-            # Best-effort and fire-once-per-streak — gated to scheduled runs since manual and
-            # target-change sends already surface their result to the user in the UI.
-            if (
-                caught_error is not None
-                and delivery_id is not None
-                and inputs.trigger_type == SubscriptionTriggerType.SCHEDULED
-            ):
-                await temporalio.workflow.execute_activity(
-                    notify_subscription_failure,
-                    NotifySubscriptionFailureInputs(
-                        subscription_id=inputs.subscription_id,
-                        delivery_id=delivery_id,
-                        error_type=_terminal_error_type(caught_error),
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=2),
-                    retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
-                )
+            await _maybe_notify_owner_of_failure(inputs.subscription_id, delivery_id, caught_error, inputs.trigger_type)
 
             # Advance schedule — always for scheduled deliveries, even on failure.
             # The activity itself no-ops when the subscription is disabled, so a
@@ -600,23 +605,7 @@ class ProcessAISubscriptionWorkflow(PostHogWorkflow):
                     if caught_error is None:
                         raise
 
-            # Proactively email the owner on a genuine (non-auto-disable) scheduled failure.
-            # See ProcessSubscriptionWorkflow for the rationale; kept in sync with it.
-            if (
-                caught_error is not None
-                and delivery_id is not None
-                and inputs.trigger_type == SubscriptionTriggerType.SCHEDULED
-            ):
-                await temporalio.workflow.execute_activity(
-                    notify_subscription_failure,
-                    NotifySubscriptionFailureInputs(
-                        subscription_id=inputs.subscription_id,
-                        delivery_id=delivery_id,
-                        error_type=_terminal_error_type(caught_error),
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=2),
-                    retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
-                )
+            await _maybe_notify_owner_of_failure(inputs.subscription_id, delivery_id, caught_error, inputs.trigger_type)
 
             # Advance schedule for scheduled deliveries even on failure — the activity
             # no-ops when the subscription is disabled, so a just-auto-disabled sub


### PR DESCRIPTION
## Problem

When a scheduled subscription (insight, dashboard, or AI report) fails to deliver for a reason that **doesn't** auto-disable it — a transient Slack error, an email send failure, an unexpected exception — the delivery is recorded as failed and retried, but the owner is never told. They only find out when they notice a report stopped arriving.

We already email owners when a subscription is *auto-disabled* (permanently broken target). This closes the gap for the failures that stay enabled and keep retrying: tell the owner proactively, explain what broke, and link them straight to the subscription.

## Changes

A new `notify_subscription_failure` Temporal activity, called from the `finally` block of both `ProcessSubscriptionWorkflow` and `ProcessAISubscriptionWorkflow` when a delivery genuinely fails. Key decisions:

- **Only on real, still-enabled failures.** Auto-disable paths return normally and send their own "disabled" email, so they never reach this branch. Gated to `SCHEDULED` triggers — manual and target-change sends already surface their result in the UI.
- **Fire once per failure streak.** It checks the most recent *prior* finished delivery; if that already failed, the owner was told, so it stays quiet. An ongoing outage produces one email, not a daily pile.
- **Best-effort.** The activity swallows its own errors — a notification problem must never turn an already-failed (recoverable) delivery into a hard workflow failure.
- **Honest, channel-specific copy.** The email names the subscription and channel, says what failed in plain language with a suggestion (Slack vs email vs generic), links to the subscription, and notes it's still active. The exact exception is often redacted (it can carry tokens/PII), so the body keys off the delivery channel and surfaces only the exception class name as a support reference.

New `subscription_failed.html` email template (mirrors the existing `subscription_disabled.html`) and a `failure_notifications.py` module with the classification + send helpers.

### Email preview

| Slack delivery failure | Email delivery failure |
| --- | --- |
| ![Slack failure email](https://raw.githubusercontent.com/PostHog/posthog/posthog-code/subscription-failed-email-assets/pr-assets/subscription-failed/slack.png) | ![Email failure email](https://raw.githubusercontent.com/PostHog/posthog/posthog-code/subscription-failed-email-assets/pr-assets/subscription-failed/email.png) |

## How did you test this code?

I'm an agent — I did not run the suite manually (no app runtime in my environment; CI will run it). I added automated tests:

- `ee/tasks/subscriptions/test_failure_notifications.py` — classification per channel, target-label rendering (Slack `channel_id|name` → `#name`, email lists), email context/subject, and unique campaign keys.
- `posthog/temporal/tests/test_subscriptions_workflows.py` — activity tests: emails on the transition into failure (no prior / prior completed / prior skipped), stays silent during a failure streak, skips when the sub is disabled or has no author, and swallows send errors without raising.

Ran `ruff check` and `ruff format` on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @vdekrijger from a Slack thread.

Built with the PostHog Slack app (Claude Code harness). This follows on from the same investigation that produced #64671 (the async-ORM fix for the Slack subscription regression): owners had no visibility when a scheduled delivery failed, so this adds the proactive email.

Design notes for reviewers:
- Hooked into the workflow `finally` (not the per-recipient `deliver_*` helpers) so the email fires once, after Temporal retries are exhausted, rather than on every retry.
- The fire-once-per-streak guard reads the prior `SubscriptionDelivery` row rather than adding a new failure-count field to the model — no migration, and the delivery history is already the source of truth.
- Invoked the repo's `/sending-notifications` skill; it covers in-app real-time notifications, whereas this request was specifically for email, so I followed the existing `subscription_disabled` email convention instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1781804056356249)*
