### PR TITLE
feat(logs): make the facet rail config-driven

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -4,46 +4,39 @@ import { useCallback, useMemo, useRef } from 'react'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 
-import { LogSeverityLevel } from '~/queries/schema/schema-general'
-
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { serviceFilterLogic } from 'products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic'
-import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 
 import { Facet, FacetOption } from './Facet'
 import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
+import { FacetConfig, FacetFilterKey, FacetField, facetsByGroup } from './facets'
 
 const DEFAULT_WIDTH_PX = 240
 const COLLAPSE_THRESHOLD_PX = 120
-
-// Colors mirror the severity bar in the log rows (SEVERITY_BAR_COLORS) so the rail matches the viewer.
-const SEVERITY_OPTIONS: FacetOption[] = (
-    [
-        ['trace', 'Trace'],
-        ['debug', 'Debug'],
-        ['info', 'Info'],
-        ['warn', 'Warn'],
-        ['error', 'Error'],
-        ['fatal', 'Fatal'],
-    ] as const
-).map(([value, label]) => ({ value, label, color: SEVERITY_BAR_COLORS[value] }))
 
 export interface FacetRailProps {
     id: string
 }
 
-/** Resizable left-hand facet rail. Level + Service today; more facets and counts land in follow-up work. */
+/** Resizable left-hand facet rail, rendered entirely from the FACETS config (see facets.ts). */
 export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
     const { severityLevels, serviceNames, utcDateRange } = useValues(logsViewerFiltersLogic)
     const { levelCounts, serviceCounts } = useValues(facetCountsLogic({ id }))
     const { collapsedFacets } = useValues(facetRailLogic({ id }))
-    const { toggleSeverityLevel, toggleServiceName, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
+    const { toggleFacetValue, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
 
-    const levelOptions = SEVERITY_OPTIONS.map((option) => ({ ...option, count: levelCounts[option.value] }))
+    const selectedByKey: Record<FacetFilterKey, string[]> = {
+        severityLevels: severityLevels ?? [],
+        serviceNames: serviceNames ?? [],
+    }
+    const countsByField: Record<FacetField, Record<string, number>> = {
+        severity_text: levelCounts,
+        service_name: serviceCounts,
+    }
 
     const onToggleClosed = useCallback(
         (shouldBeClosed: boolean) => setFacetRailCollapsed(shouldBeClosed),
@@ -63,6 +56,27 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     )
     const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
 
+    const renderFacet = (facet: FacetConfig): JSX.Element => {
+        const selected = selectedByKey[facet.filterKey]
+        const counts = countsByField[facet.facetField] ?? {}
+        const shared = {
+            facet,
+            selected,
+            counts,
+            collapsed: collapsedFacets.includes(facet.key),
+            onToggle: (value: string) => toggleFacetValue(facet.filterKey, value),
+            onToggleCollapsed: () => toggleFacetCollapsed(facet.key),
+        }
+        if (facet.kind === 'dynamic') {
+            return (
+                <BindLogic key={facet.key} logic={serviceFilterLogic} props={{ dateRange: utcDateRange }}>
+                    <DynamicFacet {...shared} />
+                </BindLogic>
+            )
+        }
+        return <FixedFacet key={facet.key} {...shared} />
+    }
+
     return (
         <div
             ref={railRef}
@@ -75,45 +89,63 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 <span className="text-xs font-semibold text-secondary uppercase tracking-wide">Filters</span>
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto p-2">
-                <div className="px-1 pb-1 mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted border-b border-primary">
-                    Standard
-                </div>
-                <Facet
-                    title="Level"
-                    options={levelOptions}
-                    selected={severityLevels ?? []}
-                    onToggle={(value) => toggleSeverityLevel(value as LogSeverityLevel)}
-                    collapsed={collapsedFacets.includes('level')}
-                    onToggleCollapsed={() => toggleFacetCollapsed('level')}
-                />
-                <BindLogic logic={serviceFilterLogic} props={{ dateRange: utcDateRange }}>
-                    <ServiceFacet
-                        selected={serviceNames ?? []}
-                        onToggle={toggleServiceName}
-                        counts={serviceCounts}
-                        collapsed={collapsedFacets.includes('service')}
-                        onToggleCollapsed={() => toggleFacetCollapsed('service')}
-                    />
-                </BindLogic>
+                {facetsByGroup().map(([group, facets]) => (
+                    <div key={group}>
+                        <div className="px-1 pb-1 mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted border-b border-primary">
+                            {group}
+                        </div>
+                        {facets.map(renderFacet)}
+                    </div>
+                ))}
             </div>
             <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
         </div>
     )
 }
 
-function ServiceFacet({
-    selected,
-    onToggle,
-    counts,
-    collapsed,
-    onToggleCollapsed,
-}: {
+interface FacetRenderProps {
+    facet: FacetConfig
     selected: string[]
-    onToggle: (name: string) => void
     counts: Record<string, number>
     collapsed: boolean
+    onToggle: (value: string) => void
     onToggleCollapsed: () => void
-}): JSX.Element {
+}
+
+/** Fixed facet: the closed value set from config, with counts overlaid. */
+function FixedFacet({
+    facet,
+    selected,
+    counts,
+    collapsed,
+    onToggle,
+    onToggleCollapsed,
+}: FacetRenderProps): JSX.Element {
+    const options: FacetOption[] = (facet.fixedOptions ?? []).map((option) => ({
+        ...option,
+        count: counts[option.value],
+    }))
+    return (
+        <Facet
+            title={facet.title}
+            options={options}
+            selected={selected}
+            onToggle={onToggle}
+            collapsed={collapsed}
+            onToggleCollapsed={onToggleCollapsed}
+        />
+    )
+}
+
+/** Dynamic facet: values discovered from the data. PR1 keeps the service list/search on serviceFilterLogic. */
+function DynamicFacet({
+    facet,
+    selected,
+    counts,
+    collapsed,
+    onToggle,
+    onToggleCollapsed,
+}: FacetRenderProps): JSX.Element {
     const { serviceNames, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
     const { setSearch } = useActions(serviceFilterLogic)
 
@@ -121,18 +153,18 @@ function ServiceFacet({
 
     return (
         <Facet
-            title="Service"
+            title={facet.title}
             options={options}
             selected={selected}
             onToggle={onToggle}
             loading={allServiceNamesLoading}
-            emptyLabel="No services"
-            searchValue={search}
-            onSearchChange={setSearch}
-            searchPlaceholder="Search services…"
+            emptyLabel={facet.emptyLabel}
+            searchValue={facet.searchable ? search : undefined}
+            onSearchChange={facet.searchable ? setSearch : undefined}
+            searchPlaceholder={facet.searchPlaceholder}
             collapsed={collapsed}
             onToggleCollapsed={onToggleCollapsed}
-            maxHeight={300}
+            maxHeight={facet.maxHeight}
         />
     )
 }

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.test.ts
@@ -24,23 +24,33 @@ describe('facetRailLogic', () => {
 
     describe('severity level toggling', () => {
         it('adds, accumulates (OR), and removes levels on the shared filters logic', async () => {
-            await expectLogic(logic, () => logic.actions.toggleSeverityLevel('error')).toFinishAllListeners()
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue('severityLevels', 'error')
+            ).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['error'])
 
-            await expectLogic(logic, () => logic.actions.toggleSeverityLevel('warn')).toFinishAllListeners()
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue('severityLevels', 'warn')
+            ).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['error', 'warn'])
 
-            await expectLogic(logic, () => logic.actions.toggleSeverityLevel('error')).toFinishAllListeners()
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue('severityLevels', 'error')
+            ).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['warn'])
         })
 
         it.each(['trace', 'info', 'error', 'fatal'] as const)(
             'toggling %s on then off round-trips to empty',
             async (level) => {
-                await expectLogic(logic, () => logic.actions.toggleSeverityLevel(level)).toFinishAllListeners()
+                await expectLogic(logic, () =>
+                    logic.actions.toggleFacetValue('severityLevels', level)
+                ).toFinishAllListeners()
                 expect(filtersLogic.values.severityLevels).toEqual([level])
 
-                await expectLogic(logic, () => logic.actions.toggleSeverityLevel(level)).toFinishAllListeners()
+                await expectLogic(logic, () =>
+                    logic.actions.toggleFacetValue('severityLevels', level)
+                ).toFinishAllListeners()
                 expect(filtersLogic.values.severityLevels).toEqual([])
             }
         )
@@ -62,10 +72,10 @@ describe('facetRailLogic', () => {
 
     describe('service name toggling', () => {
         it('adds then removes a service on the shared filters logic', async () => {
-            await expectLogic(logic, () => logic.actions.toggleServiceName('api')).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue('serviceNames', 'api')).toFinishAllListeners()
             expect(filtersLogic.values.serviceNames).toEqual(['api'])
 
-            await expectLogic(logic, () => logic.actions.toggleServiceName('api')).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue('serviceNames', 'api')).toFinishAllListeners()
             expect(filtersLogic.values.serviceNames).toEqual([])
         })
     })
@@ -75,7 +85,9 @@ describe('facetRailLogic', () => {
             filtersLogic.actions.setSeverityLevels(['info'])
             await expectLogic(filtersLogic).toFinishAllListeners()
 
-            await expectLogic(logic, () => logic.actions.toggleSeverityLevel('error')).toFinishAllListeners()
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue('severityLevels', 'error')
+            ).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['info', 'error'])
         })
     })

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
@@ -5,6 +5,7 @@ import { LogSeverityLevel } from '~/queries/schema/schema-general'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 import type { facetRailLogicType } from './facetRailLogicType'
+import { FacetFilterKey } from './facets'
 
 export interface FacetRailLogicProps {
     id: string
@@ -27,8 +28,9 @@ export const facetRailLogic = kea<facetRailLogicType>([
     })),
 
     actions({
-        toggleSeverityLevel: (level: LogSeverityLevel) => ({ level }),
-        toggleServiceName: (name: string) => ({ name }),
+        // Generic toggle: the rail is config-driven, so a single action writes a value into whichever
+        // filter field the facet maps to (see FacetConfig.filterKey).
+        toggleFacetValue: (filterKey: FacetFilterKey, value: string) => ({ filterKey, value }),
         toggleFacetCollapsed: (facetKey: string) => ({ facetKey }),
     }),
 
@@ -44,13 +46,16 @@ export const facetRailLogic = kea<facetRailLogicType>([
     }),
 
     listeners(({ props, actions }) => ({
-        toggleSeverityLevel: ({ level }) => {
-            const { severityLevels } = logsViewerFiltersLogic({ id: props.id }).values
-            actions.setSeverityLevels(toggleMembership(severityLevels, level))
-        },
-        toggleServiceName: ({ name }) => {
-            const { serviceNames } = logsViewerFiltersLogic({ id: props.id }).values
-            actions.setServiceNames(toggleMembership(serviceNames, name))
+        toggleFacetValue: ({ filterKey, value }) => {
+            const { severityLevels, serviceNames } = logsViewerFiltersLogic({ id: props.id }).values
+            if (filterKey === 'severityLevels') {
+                actions.setSeverityLevels(toggleMembership(severityLevels, value as LogSeverityLevel))
+            } else if (filterKey === 'serviceNames') {
+                actions.setServiceNames(toggleMembership(serviceNames, value))
+            } else {
+                // Adding a new FacetFilterKey without wiring its setter here is a compile error.
+                filterKey satisfies never
+            }
         },
     })),
 ])

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
@@ -1,0 +1,91 @@
+import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
+
+import { FacetOption } from './Facet'
+
+/**
+ * Whether a facet's value set is known ahead of time or discovered from the data.
+ *
+ * - `fixed`: a closed enum defined here in code (e.g. severity levels). The full list is rendered
+ *   regardless of the data; values with a zero count show dimmed rather than disappearing.
+ * - `dynamic`: values come back from the data at query time (e.g. service names) and change with
+ *   the active filters. Only values present in the current scope appear — zeros never show.
+ */
+export type FacetKind = 'fixed' | 'dynamic'
+
+/** The `logsViewerFiltersLogic` field a facet's selection is written to. */
+export type FacetFilterKey = 'severityLevels' | 'serviceNames'
+
+/** The ClickHouse column a facet's values + counts are computed over (matches the backend FACET_FIELDS). */
+export type FacetField = 'severity_text' | 'service_name'
+
+export interface FacetConfig {
+    /** Stable id used for collapse state and data-attrs. */
+    key: string
+    /** User-facing field name shown as the facet header. */
+    title: string
+    /** Header the facet is grouped under in the rail (e.g. "Standard"). */
+    group: string
+    kind: FacetKind
+    filterKey: FacetFilterKey
+    facetField: FacetField
+    /** Required for `fixed` facets: the closed value set, with labels + colors. */
+    fixedOptions?: FacetOption[]
+    /** Renders a search box and virtualizes the list — for `dynamic` facets with many values. */
+    searchable?: boolean
+    searchPlaceholder?: string
+    emptyLabel?: string
+    /** Max pixel height before the value list virtualizes and scrolls. */
+    maxHeight?: number
+}
+
+// Colors mirror the severity bar in the log rows (SEVERITY_BAR_COLORS) so the rail matches the viewer.
+const SEVERITY_OPTIONS: FacetOption[] = (
+    [
+        ['trace', 'Trace'],
+        ['debug', 'Debug'],
+        ['info', 'Info'],
+        ['warn', 'Warn'],
+        ['error', 'Error'],
+        ['fatal', 'Fatal'],
+    ] as const
+).map(([value, label]) => ({ value, label, color: SEVERITY_BAR_COLORS[value] }))
+
+const LEVEL_FACET: FacetConfig = {
+    key: 'level',
+    title: 'Level',
+    group: 'Standard',
+    kind: 'fixed',
+    filterKey: 'severityLevels',
+    facetField: 'severity_text',
+    fixedOptions: SEVERITY_OPTIONS,
+}
+
+const SERVICE_FACET: FacetConfig = {
+    key: 'service',
+    title: 'Service',
+    group: 'Standard',
+    kind: 'dynamic',
+    filterKey: 'serviceNames',
+    facetField: 'service_name',
+    searchable: true,
+    searchPlaceholder: 'Search services…',
+    emptyLabel: 'No services',
+    maxHeight: 300,
+}
+
+/** The rail is rendered entirely from this list — append a config to add a facet (or a new group). */
+export const FACETS: FacetConfig[] = [LEVEL_FACET, SERVICE_FACET]
+
+/** `FACETS` grouped by `group`, preserving first-appearance order of both groups and facets. */
+export function facetsByGroup(): [string, FacetConfig[]][] {
+    const groups: [string, FacetConfig[]][] = []
+    for (const facet of FACETS) {
+        const existing = groups.find(([group]) => group === facet.group)
+        if (existing) {
+            existing[1].push(facet)
+        } else {
+            groups.push([facet.group, [facet]])
+        }
+    }
+    return groups
+}

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -47,15 +47,11 @@ const taxonomicGroupTypes = [
 ]
 
 export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
-    const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
     // When the facet rail is on, Level + Service live in the rail instead of this bar.
     const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
-    const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
-    const { zoomDateRange, setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
+    const { setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
     const { filters, utcDateRange, id } = useValues(logsViewerFiltersLogic)
-    const { setDateRange } = useActions(logsViewerFiltersLogic)
-    const { dateRange, severityLevels, serviceNames } = filters
+    const { severityLevels, serviceNames } = filters
 
     return (
         <LogsFilterGroup>
@@ -78,56 +74,7 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
                         <FilterHistoryDropdown />
                         {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
                     </div>
-                    <div className="flex shrink-0 gap-1.5">
-                        <div className="LogsDateButtonGroup">
-                            <LemonButton
-                                size="small"
-                                icon={<IconMinusSquare />}
-                                type="secondary"
-                                tooltip="Zoom out"
-                                onClick={() => zoomDateRange(2)}
-                            />
-
-                            {!newLogsDateRangePicker && <DateRangeFilter />}
-                            {newLogsDateRangePicker && (
-                                <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
-                            )}
-
-                            <LemonButton
-                                size="small"
-                                icon={<IconPlusSquare />}
-                                type="secondary"
-                                tooltip="Zoom in"
-                                onClick={() => zoomDateRange(0.5)}
-                            />
-                        </div>
-
-                        <LemonButton
-                            size="small"
-                            icon={<IconRefresh />}
-                            type="secondary"
-                            onClick={() => runQuery()}
-                            loading={logsLoading || liveTailRunning}
-                            disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
-                        />
-                        <AppShortcut
-                            name="LogsLiveTail"
-                            keybind={[keyBinds.edit]}
-                            intent={liveTailRunning ? 'Stop live tail' : 'Start live tail'}
-                            interaction="click"
-                            scope={Scene.Logs}
-                        >
-                            <LemonButton
-                                size="small"
-                                type={liveTailRunning ? 'primary' : 'secondary'}
-                                icon={liveTailRunning ? <IconPauseCircle /> : <IconPlayCircle />}
-                                onClick={() => setLiveTailRunning(!liveTailRunning)}
-                                disabledReason={liveTailRunning ? undefined : liveTailDisabledReason}
-                            >
-                                Live tail
-                            </LemonButton>
-                        </AppShortcut>
-                    </div>
+                    <LogsQueryControls />
                 </div>
                 <LogsAppliedFilters />
             </div>
@@ -135,7 +82,68 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
     )
 }
 
-const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
+/** Time range, zoom, refresh and live tail — the "execute the query" controls shared by both bars. */
+export const LogsQueryControls = (): JSX.Element => {
+    const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
+    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
+    const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
+    const { zoomDateRange, setDateRange } = useActions(logsViewerFiltersLogic)
+    const { filters } = useValues(logsViewerFiltersLogic)
+    const { dateRange } = filters
+
+    return (
+        <div className="flex shrink-0 gap-1.5">
+            <div className="LogsDateButtonGroup">
+                <LemonButton
+                    size="small"
+                    icon={<IconMinusSquare />}
+                    type="secondary"
+                    tooltip="Zoom out"
+                    onClick={() => zoomDateRange(2)}
+                />
+
+                {!newLogsDateRangePicker && <DateRangeFilter />}
+                {newLogsDateRangePicker && <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />}
+
+                <LemonButton
+                    size="small"
+                    icon={<IconPlusSquare />}
+                    type="secondary"
+                    tooltip="Zoom in"
+                    onClick={() => zoomDateRange(0.5)}
+                />
+            </div>
+
+            <LemonButton
+                size="small"
+                icon={<IconRefresh />}
+                type="secondary"
+                onClick={() => runQuery()}
+                loading={logsLoading || liveTailRunning}
+                disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
+            />
+            <AppShortcut
+                name="LogsLiveTail"
+                keybind={[keyBinds.edit]}
+                intent={liveTailRunning ? 'Stop live tail' : 'Start live tail'}
+                interaction="click"
+                scope={Scene.Logs}
+            >
+                <LemonButton
+                    size="small"
+                    type={liveTailRunning ? 'primary' : 'secondary'}
+                    icon={liveTailRunning ? <IconPauseCircle /> : <IconPlayCircle />}
+                    onClick={() => setLiveTailRunning(!liveTailRunning)}
+                    disabledReason={liveTailRunning ? undefined : liveTailDisabledReason}
+                >
+                    Live tail
+                </LemonButton>
+            </AppShortcut>
+        </div>
+    )
+}
+
+export const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const { filters, id, utcDateRange, queryFilterGroup } = useValues(logsViewerFiltersLogic)
     const { filterGroup, serviceNames } = filters
     const { setFilterGroup } = useActions(logsViewerFiltersLogic)
@@ -165,7 +173,7 @@ const LogsFilterGroup = ({ children }: { children: React.ReactNode }): JSX.Eleme
     )
 }
 
-const LogsFilterSearch = (): JSX.Element => {
+export const LogsFilterSearch = (): JSX.Element => {
     const [visible, setVisible] = useState<boolean>(false)
     const { utcDateRange, filters: logsFilters, queryFilterGroup } = useValues(logsViewerFiltersLogic)
     const { addGroupFilter, setGroupValues } = useActions(universalFiltersLogic)
@@ -267,7 +275,7 @@ const FilterGroupValues = ({ allowInitiallyOpen }: { allowInitiallyOpen: boolean
     )
 }
 
-const LogsAppliedFilters = (): JSX.Element | null => {
+export const LogsAppliedFilters = (): JSX.Element | null => {
     const { filterGroup } = useValues(universalFiltersLogic)
     const [allowInitiallyOpen, setAllowInitiallyOpen] = useState<boolean>(false)
 

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar.tsx
@@ -1,0 +1,36 @@
+import { useValues } from 'kea'
+
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
+
+import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
+import { LogsAppliedFilters, LogsFilterGroup, LogsFilterSearch, LogsQueryControls } from './LogsFilterBar'
+
+/**
+ * Top toolbar for the facet-rail layout — the "ask a question" controls: search, time range, refresh,
+ * live tail, saved views and filter history. Sits above the sparkline (its inputs produce the sparkline
+ * + table). View controls (sort, wrap, export, …) live in LogsDisplayBar below the sparkline.
+ *
+ * Level + Service aren't here — they're facets in the rail. The active-filter chips render under the bar.
+ */
+export const LogsQueryBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
+    const { id } = useValues(logsViewerFiltersLogic)
+
+    return (
+        <LogsFilterGroup>
+            <div className="flex flex-col gap-2 w-full bg-primary">
+                <div className="flex gap-2 flex-wrap w-full justify-between">
+                    <div className="flex shrink-0 flex-1 gap-1.5">
+                        <div className="flex-1 min-w-[300px]">
+                            <LogsFilterSearch />
+                        </div>
+                        <FilterHistoryDropdown />
+                        {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
+                    </div>
+                    <LogsQueryControls />
+                </div>
+                <LogsAppliedFilters />
+            </div>
+        </LogsFilterGroup>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -1,0 +1,33 @@
+import { useActions, useValues } from 'kea'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { logsViewerConfigLogic } from './config/logsViewerConfigLogic'
+import { LogsViewerToolbar, LogsViewerToolbarProps } from './LogsViewerToolbar'
+
+/**
+ * Bottom toolbar for the facet-rail layout — the "operate on the data" controls: the rail toggle plus
+ * the result-view controls (sort, wrap, timezone, export, fullscreen, count). Sits below the sparkline,
+ * next to the table it affects. None of these re-run the query; they only change how results render.
+ */
+export const LogsDisplayBar = (props: LogsViewerToolbarProps): JSX.Element => {
+    const { facetRailCollapsed } = useValues(logsViewerConfigLogic)
+    const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
+
+    return (
+        <div className="flex items-start gap-2">
+            <LemonButton
+                size="small"
+                icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
+                onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
+                aria-label={facetRailCollapsed ? 'Show filters' : 'Hide filters'}
+            >
+                {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
+            </LemonButton>
+            <div className="flex-1 min-w-0">
+                <LogsViewerToolbar {...props} />
+            </div>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -1,9 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useCallback, useEffect, useRef } from 'react'
 
-import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
-
 import { TZLabelProps } from 'lib/components/TZLabel'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
@@ -16,6 +13,7 @@ import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { FacetRail } from 'products/logs/frontend/components/LogsViewer/FacetRail/FacetRail'
 import { LogsFilterBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar'
+import { LogsQueryBar } from 'products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar'
 import { logsFilterHistoryLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterHistoryLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { logsExportLogic } from 'products/logs/frontend/components/LogsViewer/logsExportLogic'
@@ -24,10 +22,11 @@ import { virtualizedLogsListLogic } from 'products/logs/frontend/components/Virt
 
 import { LogDetailsModal } from './LogDetailsModal'
 import { logDetailsModalLogic } from './LogDetailsModal/logDetailsModalLogic'
+import { LogsDisplayBar } from './LogsDisplayBar'
 import { logsViewerLogic } from './logsViewerLogic'
 import { logsViewerModalLogic } from './LogsViewerModal/logsViewerModalLogic'
 import { LogsSparkline } from './LogsViewerSparkline'
-import { LogsViewerToolbar } from './LogsViewerToolbar'
+import { LogsViewerToolbar, LogsViewerToolbarProps } from './LogsViewerToolbar'
 
 const SCROLL_INTERVAL_MS = 16 // ~60fps
 const SCROLL_AMOUNT_PX = 8
@@ -109,8 +108,7 @@ function LogsViewerContent({
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
     const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed } = useValues(logsViewerConfigLogic)
-    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed, setFacetRailCollapsed } =
-        useActions(logsViewerConfigLogic)
+    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
     const { logsLoading, parsedLogs, sparklineData, sparklineLoading, hasMoreLogsToLoad, totalLogsMatchingFilters } =
         useValues(logsViewerDataLogic)
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
@@ -302,14 +300,15 @@ function LogsViewerContent({
 
     const filterBar = showFilterBar ? <LogsFilterBar showSavedViewsButton={showSavedViewsButton} /> : null
 
-    const logBody = (
+    const toolbarProps: LogsViewerToolbarProps = {
+        totalLogsCount: sparklineLoading ? undefined : totalLogsMatchingFilters,
+        orderBy,
+        onChangeOrderBy: (newOrderBy) => setOrderBy(newOrderBy, 'toolbar'),
+        onOpenFullScreen: showFullScreenButton ? () => openLogsViewerModal({ id }) : undefined,
+    }
+
+    const logList = (
         <>
-            <LogsViewerToolbar
-                totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
-                orderBy={orderBy}
-                onChangeOrderBy={(newOrderBy) => setOrderBy(newOrderBy, 'toolbar')}
-                onOpenFullScreen={showFullScreenButton ? () => openLogsViewerModal({ id }) : undefined}
-            />
             {pinnedLogsArray.length > 0 && (
                 <VirtualizedLogsList
                     dataSource={pinnedLogsArray}
@@ -341,28 +340,18 @@ function LogsViewerContent({
         </>
     )
 
-    const railToggle = (
-        <LemonButton
-            size="small"
-            icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
-            onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
-        >
-            {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
-        </LemonButton>
-    )
-
     if (showFacetRail) {
+        // Three-tier layout: query bar (ask a question) above the sparkline, the sparkline, then a
+        // row of [facet rail | display bar (operate on the data) + the log lists].
         return (
             <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
+                <LogsQueryBar showSavedViewsButton={showSavedViewsButton} />
                 {sparklineSection}
                 <div className="flex flex-row gap-2 flex-1 min-h-0">
                     {!facetRailCollapsed && <FacetRail id={id} />}
                     <div className="flex flex-col gap-2 flex-1 min-w-0">
-                        <div className="flex items-start gap-2">
-                            {railToggle}
-                            {filterBar && <div className="flex-1 min-w-0">{filterBar}</div>}
-                        </div>
-                        {logBody}
+                        <LogsDisplayBar {...toolbarProps} />
+                        {logList}
                     </div>
                 </div>
                 <LogDetailsModal timezone={timezone} />
@@ -374,7 +363,8 @@ function LogsViewerContent({
         <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
             {sparklineSection}
             {filterBar}
-            {logBody}
+            <LogsViewerToolbar {...toolbarProps} />
+            {logList}
             <LogDetailsModal timezone={timezone} />
         </div>
     )


### PR DESCRIPTION
## Problem

The facet rail was hardcoded — adding a new facet meant touching the component directly, wiring up a new action, and duplicating rendering logic. The toolbar layout also mixed "ask a question" controls (search, time range, live tail) with "operate on results" controls (sort, wrap, export) in a single bar, making it harder to reason about and reuse.

## Changes

**Config-driven facet rail (`facets.ts`)**

Introduced a `FacetConfig` type and a `FACETS` registry. Each entry declares its `kind` (`fixed` for closed enums like severity, `dynamic` for data-discovered values like services), the `filterKey` it writes to on `logsViewerFiltersLogic`, and the `facetField` counts are computed over. Adding a new facet is now a single object append to `FACETS`.

**Single generic action replaces per-facet actions**

`toggleSeverityLevel` and `toggleServiceName` are replaced by a single `toggleFacetValue(filterKey, value)` action in `facetRailLogic`. The listener dispatches to the correct setter based on `filterKey`. Tests updated accordingly.

**`FacetRail` rendered entirely from config**

The component iterates `facetsByGroup()` and delegates to `FixedFacet` or `DynamicFacet` based on `facet.kind`. All hardcoded option lists, colors, and search props are now read from the config.

**Toolbar split into two focused bars**

- `LogsQueryBar` — search, filter history, saved views, time range, zoom, refresh, live tail. Sits above the sparkline.
- `LogsDisplayBar` — rail toggle + `LogsViewerToolbar` (sort, wrap, export, count). Sits below the sparkline, next to the log list.
- `LogsQueryControls` extracted as a shared component so the classic (non-rail) layout can still use it inline.

`LogsFilterGroup`, `LogsFilterSearch`, `LogsAppliedFilters`, and `LogsQueryControls` are now exported so `LogsQueryBar` can compose them without duplication.

## How did you test this code?

Automated: existing `facetRailLogic` unit tests pass with the updated `toggleFacetValue` action signatures.

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Refactored the facet rail to be config-driven and split the toolbar into query vs. display concerns. The key decision was introducing a `FacetConfig` interface with a `kind` discriminant rather than a union type, keeping the render path simple (`FixedFacet` vs `DynamicFacet`). The generic `toggleFacetValue` action was chosen over a map of per-facet actions to avoid the logic growing linearly with each new facet.