### PR TITLE
feat(logs): search facet values server-side

### DIFF
--- a/products/logs/backend/log_facet_values_query_runner.py
+++ b/products/logs/backend/log_facet_values_query_runner.py
@@ -10,7 +10,12 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
-from products.logs.backend.logs_query_runner import LogsFilterBuilder, LogsQueryResponse, LogsQueryRunnerMixin
+from products.logs.backend.logs_query_runner import (
+    LogsFilterBuilder,
+    LogsQueryResponse,
+    LogsQueryRunnerMixin,
+    ilike_pattern,
+)
 
 # Columns a facet may group by. Each value is also the WHERE clause that gets omitted, so a facet's
 # counts reflect every *other* active filter rather than its own selection.
@@ -30,11 +35,14 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
     query: LogsQuery
     cached_response: CachedLogsQueryResponse
 
-    def __init__(self, query: LogsQuery, facet_field: str, *args, **kwargs):
+    def __init__(self, query: LogsQuery, facet_field: str, *args, facet_search: str | None = None, **kwargs):
         super().__init__(query, *args, **kwargs)
         if facet_field not in FACET_FIELDS:
             raise ValueError(f"Unsupported facet field: {facet_field!r}")
         self.facet_field = facet_field
+        # Type-ahead over the facet's *own* values (e.g. service name contains "kafka"), distinct from
+        # query.searchTerm which searches log bodies. Lets a dynamic facet search past the LIMIT window.
+        self.facet_search = (facet_search or "").strip() or None
 
     @cached_property
     def settings(self) -> HogQLGlobalSettings:
@@ -62,20 +70,30 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
     def to_query(self) -> ast.SelectQuery:
         # The day-precision time_bucket prune in where() is widened to exact timestamp bounds so the
         # counts match the requested window (same half-open pattern as CountQueryRunner).
-        where = ast.And(
-            exprs=[
-                LogsFilterBuilder(
-                    self.query, self.team, self.query_date_range, exclude_facet_field=self.facet_field
-                ).where(),
+        exprs = [
+            LogsFilterBuilder(
+                self.query, self.team, self.query_date_range, exclude_facet_field=self.facet_field
+            ).where(),
+            parse_expr(
+                "timestamp >= {date_from} AND timestamp < {date_to}",
+                placeholders={
+                    "date_from": ast.Constant(value=self.query_date_range.date_from()),
+                    "date_to": ast.Constant(value=self.query_date_range.date_to()),
+                },
+            ),
+        ]
+        if self.facet_search:
+            exprs.append(
                 parse_expr(
-                    "timestamp >= {date_from} AND timestamp < {date_to}",
+                    "{facet_field} ILIKE {pattern}",
                     placeholders={
-                        "date_from": ast.Constant(value=self.query_date_range.date_from()),
-                        "date_to": ast.Constant(value=self.query_date_range.date_to()),
+                        "facet_field": ast.Field(chain=[self.facet_field]),
+                        # Escape %, _ and \ so user input matches literally instead of as wildcards.
+                        "pattern": ast.Constant(value=ilike_pattern(self.facet_search)),
                     },
-                ),
-            ]
-        )
+                )
+            )
+        where = ast.And(exprs=exprs)
         query = parse_select(
             """
             SELECT {facet_field} AS value, count() AS count

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -353,6 +353,11 @@ class _LogsFacetValuesBodySerializer(serializers.Serializer):
         help_text="Filter by service names (ignored when faceting on service_name).",
     )
     searchTerm = serializers.CharField(required=False, help_text="Full-text search term to filter log bodies.")
+    facetSearch = serializers.CharField(
+        required=False,
+        help_text="Type-ahead filter over the faceted field's own values (case-insensitive substring match). "
+        "Distinct from searchTerm, which searches log bodies.",
+    )
     filterGroup = serializers.ListField(
         child=_LogPropertyFilterSerializer(),
         required=False,
@@ -846,7 +851,9 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             filterGroup=self._normalize_filter_group(query_data.get("filterGroup", None)),
         )
 
-        runner = LogFacetValuesQueryRunner(team=self.team, query=query, facet_field=facet_field)
+        runner = LogFacetValuesQueryRunner(
+            team=self.team, query=query, facet_field=facet_field, facet_search=query_data.get("facetSearch")
+        )
         response = runner.run(
             ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
             analytics_props=get_request_analytics_properties(request),

--- a/products/logs/backend/test/test_log_facet_values.py
+++ b/products/logs/backend/test/test_log_facet_values.py
@@ -69,6 +69,31 @@ class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
             f"{other_filter_key} should re-scope {facet_field} counts",
         )
 
+    @parameterized.expand(
+        [
+            ("service_name", "aws"),
+            ("service_name", "AWS"),
+        ]
+    )
+    def test_facet_search_narrows_values_case_insensitively(self, facet_field, term):
+        """facetSearch keeps only values containing the term (case-insensitive), independent of count."""
+        base = self._facet(facet_field)
+        searched = self._facet(facet_field, facetSearch=term)
+
+        self.assertGreater(len(searched), 0)
+        self.assertTrue(set(searched).issubset(set(base)))
+        self.assertTrue(all(term.lower() in value.lower() for value in searched))
+
+    def test_facet_search_with_no_matches_returns_empty(self):
+        self.assertEqual(self._facet("service_name", facetSearch="no-such-service-xyz"), {})
+
+    @parameterized.expand([("%",), ("_",)])
+    def test_facet_search_treats_ilike_wildcards_literally(self, wildcard):
+        """ILIKE metacharacters are escaped, so a wildcard-only search matches literally (no match-all)."""
+        # No fixture service contains a literal % or _, so an escaped search returns nothing —
+        # whereas an unescaped wildcard would match every service.
+        self.assertEqual(self._facet("service_name", facetSearch=wildcard), {})
+
     def test_invalid_facet_field_is_rejected(self):
         body = {"query": {"facetField": "body", "dateRange": self.DATE_RANGE}}
         response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1014,6 +1014,8 @@ export interface _LogsFacetValuesBodyApi {
     serviceNames?: string[]
     /** Full-text search term to filter log bodies. */
     searchTerm?: string
+    /** Type-ahead filter over the faceted field's own values (case-insensitive substring match). Distinct from searchTerm, which searches log bodies. */
+    facetSearch?: string
     /** Property filters for the query. */
     filterGroup?: _LogPropertyFilterApi[]
 }

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -640,6 +640,12 @@ export const LogsFacetValuesCreateBody = /* @__PURE__ */ zod.object({
                 .optional()
                 .describe('Filter by service names (ignored when faceting on service_name).'),
             searchTerm: zod.string().optional().describe('Full-text search term to filter log bodies.'),
+            facetSearch: zod
+                .string()
+                .optional()
+                .describe(
+                    "Type-ahead filter over the faceted field's own values (case-insensitive substring match). Distinct from searchTerm, which searches log bodies."
+                ),
             filterGroup: zod
                 .array(
                     zod.object({

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50300,6 +50300,8 @@ export namespace Schemas {
       serviceNames?: string[];
       /** Full-text search term to filter log bodies. */
       searchTerm?: string;
+      /** Type-ahead filter over the faceted field's own values (case-insensitive substring match). Distinct from searchTerm, which searches log bodies. */
+      facetSearch?: string;
       /** Property filters for the query. */
       filterGroup?: _LogPropertyFilter[];
     }


### PR DESCRIPTION
## Problem

When a facet panel (e.g. service names) has many distinct values, users have no way to narrow the list without it being cut off by the query `LIMIT`. A type-ahead search over the facet's own values — separate from the full-text `searchTerm` that searches log bodies — lets users find specific facet values even when they fall outside the top-N window.

## Changes

Adds a `facetSearch` parameter to the facet values API that performs a case-insensitive substring match (`ILIKE '%term%'`) against the faceted field itself. When provided, an additional `WHERE` clause is injected into the HogQL query before aggregation, so only matching values are counted and returned.

- `LogFacetValuesQueryRunner` accepts an optional `facet_search` kwarg and appends the `ILIKE` predicate when set
- The API view reads `facetSearch` from the request body and forwards it to the runner
- Frontend TypeScript types and Zod schemas are updated to expose the new optional field

## How did you test this code?

Two new automated tests cover the main cases:

- `test_facet_search_narrows_values_case_insensitively` — parameterized with both lowercase and uppercase variants of the search term, asserts results are a non-empty subset of the unfiltered facet and that every returned value contains the term (case-insensitively)
- `test_facet_search_with_no_matches_returns_empty` — asserts an empty dict is returned when the term matches nothing

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent added the `facet_search` parameter end-to-end: backend runner, API serializer/view, and generated frontend schemas. The `ILIKE` predicate approach was chosen over a post-filter because it keeps the result set meaningful within the `LIMIT` window — filtering after aggregation would still miss values ranked below the cutoff. Tests were written to validate both case-insensitivity and the no-match empty-result path.