### PR TITLE
feat(inbox): add Beta tag to Inbox navbar item

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
 import { IconGear } from '@posthog/icons'
+import { LemonTag } from '@posthog/lemon-ui'
 
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -23,6 +24,7 @@ interface NavLinkProps {
     'data-attr'?: string
     onClick?: (e: React.MouseEvent) => void
     sideAction?: NavLinkSideAction
+    tag?: 'alpha' | 'beta' | 'new'
 }
 
 export function NavLink({
@@ -33,6 +35,7 @@ export function NavLink({
     'data-attr': dataAttr,
     onClick,
     sideAction,
+    tag,
 }: NavLinkProps): JSX.Element {
     const { pathname } = useValues(panelLayoutLogic)
 
@@ -77,6 +80,15 @@ export function NavLink({
                     >
                         {label}
                     </span>
+                )}
+                {!isCollapsed && tag && (
+                    <LemonTag
+                        type={tag === 'alpha' ? 'completion' : tag === 'beta' ? 'warning' : 'success'}
+                        size="small"
+                        className="relative top-[-1px]"
+                    >
+                        {tag.toUpperCase()}
+                    </LemonTag>
                 )}
             </Link>
             {hasSideActionRight && sideAction && (

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -229,6 +229,7 @@ export function NavTabBrowse(): JSX.Element {
                             icon={<IconNotification />}
                             isCollapsed={isLayoutNavCollapsed}
                             data-attr="nav-item-inbox"
+                            tag="beta"
                             onClick={() => posthog.capture('nav item clicked', { item: 'inbox' })}
                         />
                     )}


### PR DESCRIPTION
My human summary: Inbox gets [BETA]. It's simple.

## Problem

The Inbox navbar item (shown when the `PRODUCT_AUTONOMY` flag is on) is a new, still-in-beta surface, but unlike other beta features in the nav it carried no maturity indicator. Users had no signal that it's beta.

## Changes

- Added an optional `tag` prop (`'alpha' | 'beta' | 'new'`) to the AI-first `NavLink` component, rendering a small `LemonTag` next to the label — matching the existing tag convention used for products in the project tree (`alpha → completion`, `beta → warning`, else `success`). The tag is hidden when the nav is collapsed.
- Set `tag="beta"` on the Inbox `NavLink`.

## How did you test this code?

I'm an agent. I did not run the app manually. The change reuses the existing `LemonTag` tag-rendering pattern already used elsewhere in the panel layout. `oxfmt` and lint-staged ran clean on the changed files. No automated tests were added — this is a presentational nav change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael directed this: add a Beta label to the Inbox navbar item like other beta nav items. The Inbox item lives in the newer AI-first panel layout (`NavTabBrowse.tsx`) which uses the `NavLink` component rather than the navigation-3000 `tag` system, so `NavLink` had no tag support. Rather than reach into navigation-3000, I extended `NavLink` with the same `tag` shape and reused the panel layout's own `LemonTag` styling (the `warning`-type tag already used for beta products in `ProjectTree`) for visual consistency.

No repo skills were required for this change.
