### PR TITLE
feat(logs): source dynamic facet values from endpoint, dim empty levels

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
@@ -33,9 +33,11 @@ interface FacetProps {
     onToggleCollapsed?: () => void
     /** When set, values render in a fixed-height virtualized list capped at this many pixels. */
     maxHeight?: number
+    /** For fixed facets: render zero-count values dimmed, and disabled unless already selected. */
+    dimZeroCounts?: boolean
 }
 
-/** A single rail facet: a collapsible field title and its selectable values (multi-select = OR). No counts yet. */
+/** A single rail facet: a collapsible field title and its selectable values (multi-select = OR), each with a count. */
 export function Facet({
     title,
     options,
@@ -49,12 +51,13 @@ export function Facet({
     collapsed = false,
     onToggleCollapsed,
     maxHeight,
+    dimZeroCounts = false,
 }: FacetProps): JSX.Element {
     const slug = title.toLowerCase().replace(/\s+/g, '-')
 
     const rowProps = useMemo<FacetValueRowProps>(
-        () => ({ options, selected, slug, onToggle }),
-        [options, selected, slug, onToggle]
+        () => ({ options, selected, slug, onToggle, dimZeroCounts }),
+        [options, selected, slug, onToggle, dimZeroCounts]
     )
 
     return (
@@ -109,6 +112,7 @@ export function Facet({
                                         selected={selected.includes(option.value)}
                                         slug={slug}
                                         onToggle={onToggle}
+                                        dimZeroCounts={dimZeroCounts}
                                     />
                                 ))}
                             </div>
@@ -124,6 +128,7 @@ interface FacetValueRowProps {
     selected: string[]
     slug: string
     onToggle: (value: string) => void
+    dimZeroCounts: boolean
 }
 
 function FacetValueRow({
@@ -133,6 +138,7 @@ function FacetValueRow({
     selected,
     slug,
     onToggle,
+    dimZeroCounts,
 }: {
     ariaAttributes: Record<string, unknown>
     index: number
@@ -147,6 +153,7 @@ function FacetValueRow({
                 selected={selected.includes(option.value)}
                 slug={slug}
                 onToggle={onToggle}
+                dimZeroCounts={dimZeroCounts}
             />
         </div>
     )
@@ -157,17 +164,24 @@ function FacetValueButton({
     selected,
     slug,
     onToggle,
+    dimZeroCounts,
 }: {
     option: FacetOption
     selected: boolean
     slug: string
     onToggle: (value: string) => void
+    dimZeroCounts: boolean
 }): JSX.Element {
+    // A fixed facet value with no matches in the current scope: dim it, and disable it unless it's
+    // already selected (so a selected-but-now-empty value can still be toggled off).
+    const isZero = dimZeroCounts && option.count === 0
     return (
         <LemonButton
             type="tertiary"
             size="small"
             fullWidth
+            className={cn(isZero && 'opacity-50')}
+            disabledReason={isZero && !selected ? 'No matching logs for the current filters' : undefined}
             icon={<LemonCheckbox checked={selected} className="pointer-events-none" />}
             onClick={() => onToggle(option.value)}
             data-attr={`logs-facet-${slug}-${option.value}`}

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -1,4 +1,4 @@
-import { BindLogic, useActions, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { useCallback, useMemo, useRef } from 'react'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
@@ -6,12 +6,11 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
-import { serviceFilterLogic } from 'products/logs/frontend/components/LogsViewer/Filters/serviceFilterLogic'
 
 import { Facet, FacetOption } from './Facet'
 import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
-import { FacetConfig, FacetFilterKey, FacetField, facetsByGroup } from './facets'
+import { FacetConfig, FacetField, FacetFilterKey, facetsByGroup } from './facets'
 
 const DEFAULT_WIDTH_PX = 240
 const COLLAPSE_THRESHOLD_PX = 120
@@ -24,8 +23,11 @@ export interface FacetRailProps {
 export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
-    const { severityLevels, serviceNames, utcDateRange } = useValues(logsViewerFiltersLogic)
-    const { levelCounts, serviceCounts } = useValues(facetCountsLogic({ id }))
+    const { severityLevels, serviceNames } = useValues(logsViewerFiltersLogic)
+    const { levelValues, levelValuesLoading, serviceValues, serviceValuesLoading, facetSearch } = useValues(
+        facetCountsLogic({ id })
+    )
+    const { setFacetSearch } = useActions(facetCountsLogic({ id }))
     const { collapsedFacets } = useValues(facetRailLogic({ id }))
     const { toggleFacetValue, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
 
@@ -33,9 +35,13 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
         severityLevels: severityLevels ?? [],
         serviceNames: serviceNames ?? [],
     }
-    const countsByField: Record<FacetField, Record<string, number>> = {
-        severity_text: levelCounts,
-        service_name: serviceCounts,
+    const valuesByField: Record<FacetField, FacetOption[]> = {
+        severity_text: levelValues.map((r) => ({ value: r.value, label: r.value, count: r.count })),
+        service_name: serviceValues.map((r) => ({ value: r.value, label: r.value, count: r.count })),
+    }
+    const loadingByField: Record<FacetField, boolean> = {
+        severity_text: levelValuesLoading,
+        service_name: serviceValuesLoading,
     }
 
     const onToggleClosed = useCallback(
@@ -58,23 +64,51 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
 
     const renderFacet = (facet: FacetConfig): JSX.Element => {
         const selected = selectedByKey[facet.filterKey]
-        const counts = countsByField[facet.facetField] ?? {}
-        const shared = {
-            facet,
-            selected,
-            counts,
-            collapsed: collapsedFacets.includes(facet.key),
-            onToggle: (value: string) => toggleFacetValue(facet.filterKey, value),
-            onToggleCollapsed: () => toggleFacetCollapsed(facet.key),
-        }
-        if (facet.kind === 'dynamic') {
+        const fetched = valuesByField[facet.facetField]
+        const onToggle = (value: string): void => toggleFacetValue(facet.filterKey, value)
+        const onToggleCollapsed = (): void => toggleFacetCollapsed(facet.key)
+        const collapsed = collapsedFacets.includes(facet.key)
+
+        if (facet.kind === 'fixed') {
+            // Fixed value set from config, counts overlaid. Missing values render as a dimmed 0.
+            const countByValue = new Map(fetched.map((option) => [option.value, option.count]))
+            const options: FacetOption[] = (facet.fixedOptions ?? []).map((option) => ({
+                ...option,
+                count: countByValue.get(option.value) ?? 0,
+            }))
             return (
-                <BindLogic key={facet.key} logic={serviceFilterLogic} props={{ dateRange: utcDateRange }}>
-                    <DynamicFacet {...shared} />
-                </BindLogic>
+                <Facet
+                    key={facet.key}
+                    title={facet.title}
+                    options={options}
+                    selected={selected}
+                    onToggle={onToggle}
+                    loading={loadingByField[facet.facetField]}
+                    collapsed={collapsed}
+                    onToggleCollapsed={onToggleCollapsed}
+                    dimZeroCounts
+                />
             )
         }
-        return <FixedFacet key={facet.key} {...shared} />
+
+        // Dynamic facet: values + counts come straight from the cross-filtered endpoint (zeros never appear).
+        return (
+            <Facet
+                key={facet.key}
+                title={facet.title}
+                options={fetched}
+                selected={selected}
+                onToggle={onToggle}
+                loading={loadingByField[facet.facetField]}
+                emptyLabel={facet.emptyLabel}
+                searchValue={facet.searchable ? (facetSearch[facet.facetField] ?? '') : undefined}
+                onSearchChange={facet.searchable ? (value) => setFacetSearch(facet.facetField, value) : undefined}
+                searchPlaceholder={facet.searchPlaceholder}
+                collapsed={collapsed}
+                onToggleCollapsed={onToggleCollapsed}
+                maxHeight={facet.maxHeight}
+            />
+        )
     }
 
     return (
@@ -100,71 +134,5 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
             </div>
             <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
         </div>
-    )
-}
-
-interface FacetRenderProps {
-    facet: FacetConfig
-    selected: string[]
-    counts: Record<string, number>
-    collapsed: boolean
-    onToggle: (value: string) => void
-    onToggleCollapsed: () => void
-}
-
-/** Fixed facet: the closed value set from config, with counts overlaid. */
-function FixedFacet({
-    facet,
-    selected,
-    counts,
-    collapsed,
-    onToggle,
-    onToggleCollapsed,
-}: FacetRenderProps): JSX.Element {
-    const options: FacetOption[] = (facet.fixedOptions ?? []).map((option) => ({
-        ...option,
-        count: counts[option.value],
-    }))
-    return (
-        <Facet
-            title={facet.title}
-            options={options}
-            selected={selected}
-            onToggle={onToggle}
-            collapsed={collapsed}
-            onToggleCollapsed={onToggleCollapsed}
-        />
-    )
-}
-
-/** Dynamic facet: values discovered from the data. PR1 keeps the service list/search on serviceFilterLogic. */
-function DynamicFacet({
-    facet,
-    selected,
-    counts,
-    collapsed,
-    onToggle,
-    onToggleCollapsed,
-}: FacetRenderProps): JSX.Element {
-    const { serviceNames, allServiceNamesLoading, search } = useValues(serviceFilterLogic)
-    const { setSearch } = useActions(serviceFilterLogic)
-
-    const options: FacetOption[] = serviceNames.map((name) => ({ value: name, label: name, count: counts[name] }))
-
-    return (
-        <Facet
-            title={facet.title}
-            options={options}
-            selected={selected}
-            onToggle={onToggle}
-            loading={allServiceNamesLoading}
-            emptyLabel={facet.emptyLabel}
-            searchValue={facet.searchable ? search : undefined}
-            onSearchChange={facet.searchable ? setSearch : undefined}
-            searchPlaceholder={facet.searchPlaceholder}
-            collapsed={collapsed}
-            onToggleCollapsed={onToggleCollapsed}
-            maxHeight={facet.maxHeight}
-        />
     )
 }

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, path, props } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
@@ -11,20 +11,17 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 import { logsFacetValuesCreate } from '../../../generated/api'
 import { _LogFacetValueApi, _LogPropertyFilterApi } from '../../../generated/api.schemas'
 import type { facetCountsLogicType } from './facetCountsLogicType'
+import { FacetField } from './facets'
 
 export interface FacetCountsLogicProps {
     id: string
 }
 
-type FacetField = 'severity_text' | 'service_name'
-
-function toCountMap(results: _LogFacetValueApi[]): Record<string, number> {
-    return Object.fromEntries(results.map((r) => [r.value, r.count]))
-}
-
 /**
- * Per-facet value counts, cross-filtered server-side: each facet's counts reflect every active
- * filter except its own selection. Refetches whenever the filters change.
+ * Per-facet values + counts, cross-filtered server-side: each facet's results reflect every active
+ * filter except its own selection (see the backend's exclude_facet_field). Values come back ordered
+ * by count descending. Dynamic facets (e.g. service) also pass a per-facet type-ahead search so they
+ * can match values beyond the returned window.
  */
 export const facetCountsLogic = kea<facetCountsLogicType>([
     props({ id: 'default' } as FacetCountsLogicProps),
@@ -40,10 +37,23 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
         ],
     })),
 
+    actions({
+        setFacetSearch: (facetField: FacetField, search: string) => ({ facetField, search }),
+    }),
+
+    reducers({
+        facetSearch: [
+            {} as Record<string, string>,
+            {
+                setFacetSearch: (state, { facetField, search }) => ({ ...state, [facetField]: search }),
+            },
+        ],
+    }),
+
     loaders(({ values }) => {
-        const fetchCounts = async (facetField: FacetField): Promise<Record<string, number>> => {
+        const fetchValues = async (facetField: FacetField): Promise<_LogFacetValueApi[]> => {
             if (!values.currentTeamId) {
-                return {}
+                return []
             }
             const group = values.queryFilterGroup as UniversalFiltersGroup
             const filterGroup = ((group?.values?.[0] as UniversalFiltersGroup | undefined)?.values ??
@@ -55,47 +65,60 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                     severityLevels: values.filters.severityLevels ?? [],
                     serviceNames: values.filters.serviceNames ?? [],
                     searchTerm: values.filters.searchTerm || undefined,
+                    facetSearch: values.facetSearch[facetField] || undefined,
                     filterGroup,
                 },
             })
-            return toCountMap(response.results)
+            return response.results
         }
 
         return {
-            levelCounts: [
-                {} as Record<string, number>,
+            levelValues: [
+                [] as _LogFacetValueApi[],
                 {
-                    loadLevelCounts: async (_: null, breakpoint) => {
+                    loadLevelValues: async (_: null, breakpoint) => {
                         await breakpoint(300)
-                        const counts = await fetchCounts('severity_text')
+                        const results = await fetchValues('severity_text')
                         breakpoint()
-                        return counts
+                        return results
                     },
                 },
             ],
-            serviceCounts: [
-                {} as Record<string, number>,
+            serviceValues: [
+                [] as _LogFacetValueApi[],
                 {
-                    loadServiceCounts: async (_: null, breakpoint) => {
+                    loadServiceValues: async (_: null, breakpoint) => {
                         await breakpoint(300)
-                        const counts = await fetchCounts('service_name')
+                        const results = await fetchValues('service_name')
                         breakpoint()
-                        return counts
+                        return results
                     },
                 },
             ],
         }
     }),
 
+    listeners(({ actions }) => {
+        // Re-fetch the facet whose search term changed. Typed by FacetField so adding a field is a
+        // compile error until its loader is wired here (fixed facets just never receive a search).
+        const reloaders: Record<FacetField, () => void> = {
+            severity_text: () => actions.loadLevelValues(null),
+            service_name: () => actions.loadServiceValues(null),
+        }
+        return {
+            setFacetSearch: ({ facetField }) => reloaders[facetField](),
+        }
+    }),
+
     subscriptions(({ actions }) => {
         // Fires on mount (initial load) and on any change. We watch both `filters` (severity,
         // service, search, date, user filterGroup) and `queryFilterGroup` (which folds in
-        // pinnedFilters, e.g. the person-tab distinct_id pin) so counts re-fetch when the pinned
+        // pinnedFilters, e.g. the person-tab distinct_id pin) so values re-fetch when the pinned
         // scope changes too. `filterGroup` feeds both, so a normal edit fires both — the 300ms
         // debounce in each loader collapses that into one request.
         const reload = (): void => {
-            actions.loadLevelCounts(null)
-            actions.loadServiceCounts(null)
+            actions.loadLevelValues(null)
+            actions.loadServiceValues(null)
         }
         return {
             filters: reload,


### PR DESCRIPTION
## Problem

The facet rail was using two separate data shapes — a `Record<string, number>` count map for fixed facets and a separate `serviceFilterLogic` for dynamic facets. This made it hard to unify behavior, and fixed facets (like severity level) didn't handle zero-count values gracefully: they'd show no count at all rather than a dimmed, disabled row.

## Changes

**Unified data model:** `facetCountsLogic` now returns `_LogFacetValueApi[]` arrays (`levelValues`, `serviceValues`) instead of plain count maps. Both fixed and dynamic facets consume the same shape.

**Zero-count dimming for fixed facets:** A new `dimZeroCounts` prop on `Facet` renders values with a count of `0` at reduced opacity and disables them — unless they're already selected, so a user can still deselect a filter that no longer matches the current scope.

**Removed `serviceFilterLogic` dependency from `FacetRail`:** The `DynamicFacet` / `FixedFacet` split and the `BindLogic` wrapper are gone. Both facet kinds now render directly via `<Facet>`, with the distinction handled inline in `renderFacet`.

**Per-facet type-ahead search in logic:** `facetCountsLogic` gains a `facetSearch` reducer and `setFacetSearch` action. When the search changes for a dynamic facet (e.g. `service_name`), only that facet's loader refires. The `facetSearch` value is also forwarded to the API call so the backend can filter beyond the default result window.

## How did you test this code?

This PR was co-authored with an agent. Automated type-checking and existing unit tests were used to verify correctness. Manual verification should confirm:

1. Severity level facet shows all fixed values; values with no matching logs appear dimmed and unclickable (but a selected zero-count value can still be toggled off).
2. Service name facet search still filters results via the API.
3. Changing any filter (date range, search term, pinned filters) causes both facets to refetch counts.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent consolidated the two-path facet rendering approach into a single unified flow, introduced the `dimZeroCounts` behavior for fixed facets, and migrated `facetCountsLogic` from count maps to raw result arrays. The `serviceFilterLogic` `BindLogic` wrapper was removed as part of this consolidation since its only remaining role (search state and loading flag) could be handled directly in `facetCountsLogic`.