### PR TITLE
ci: skip frontend & storybook CI for agent-platform-services-only PRs

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -31,8 +31,12 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run frontend checks
         outputs:
-            frontend: ${{ steps.filter.outputs.frontend || 'true' }}
-            frontend_code: ${{ steps.filter.outputs.frontend_code || 'true' }}
+            # AND the broad filter with `exclude` (below): a PR that touches only
+            # the Node-only agent-platform services/packages must not trigger
+            # frontend CI — they have their own suite (ci-agents.yml) and are
+            # excluded from jest (frontend/jest.config.ts) and the bundle.
+            frontend: ${{ (steps.filter.outputs.frontend || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
+            frontend_code: ${{ (steps.filter.outputs.frontend_code || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -107,6 +111,25 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
+
+            # dorny's default `some` quantifier OR-matches patterns, so a plain
+            # `!products/agent_platform/services/**` negation in the filter above
+            # would be silently ignored — the broad `products/**/*.ts` rule still
+            # matches (same gotcha documented in
+            # ci-migrations-service-separation-check.yml). With
+            # `predicate-quantifier: every` this filter is true only when some
+            # changed file lives OUTSIDE the agent-platform Node services/packages;
+            # AND-ed into the outputs above so a services-only PR skips frontend CI.
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: exclude
+              if: github.event_name != 'push'
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  predicate-quantifier: 'every'
+                  filters: |
+                      outside_agent_services:
+                        - '!products/agent_platform/services/**'
+                        - '!products/agent_platform/packages/**'
 
     # Pick which jest tests to run on draft PRs by passing changed files to
     # `jest --findRelatedTests` (jest's resolver walks the import graph for us).

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -35,8 +35,8 @@ jobs:
             # the Node-only agent-platform services/packages must not trigger
             # frontend CI — they have their own suite (ci-agents.yml) and are
             # excluded from jest (frontend/jest.config.ts) and the bundle.
-            frontend: ${{ (steps.filter.outputs.frontend || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
-            frontend_code: ${{ (steps.filter.outputs.frontend_code || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
+            frontend: ${{ (steps.filter.outputs.frontend || 'true') == 'true' && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true' }}
+            frontend_code: ${{ (steps.filter.outputs.frontend_code || 'true') == 'true' && (steps.exclude.outputs.outside_non_frontend_ts || 'true') == 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -112,14 +112,18 @@ jobs:
                         - webpack.config.js
                         - stylelint*
 
-            # dorny's default `some` quantifier OR-matches patterns, so a plain
-            # `!products/agent_platform/services/**` negation in the filter above
-            # would be silently ignored — the broad `products/**/*.ts` rule still
-            # matches (same gotcha documented in
-            # ci-migrations-service-separation-check.yml). With
-            # `predicate-quantifier: every` this filter is true only when some
-            # changed file lives OUTSIDE the agent-platform Node services/packages;
-            # AND-ed into the outputs above so a services-only PR skips frontend CI.
+            # Dirs that match the broad `frontend` rules above but aren't frontend
+            # code — Node-only TS that has its own suite (ci-agents.yml) and isn't in
+            # jest or the bundle. Appending a plain `!...` negation to the rules above
+            # wouldn't help: dorny's default `some` quantifier OR-matches predicates,
+            # so the broad `products/**/*.ts` rule still matches and the negation is
+            # neutralized (same gotcha documented in
+            # ci-migrations-service-separation-check.yml). A separate step is required
+            # because `predicate-quantifier` is step-level: with `every`, this filter
+            # is true only when some changed file lives OUTSIDE every excluded dir.
+            # AND-ed into the outputs above so a PR touching only these dirs skips
+            # frontend CI. To exclude another non-frontend dir, add a `!` line below —
+            # the outputs reference this one filter, so they don't need to change.
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: exclude
               if: github.event_name != 'push'
@@ -127,7 +131,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   predicate-quantifier: 'every'
                   filters: |
-                      outside_agent_services:
+                      outside_non_frontend_ts:
                         - '!products/agent_platform/services/**'
                         - '!products/agent_platform/packages/**'
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -41,6 +41,7 @@ jobs:
                 ${{
                     github.event_name == 'push'
                     || (steps.filter.outputs.frontend == 'true'
+                        && steps.exclude.outputs.outside_agent_services == 'true'
                         && fromJSON(steps.filter.outputs.frontend_count || '0')
                            > fromJSON(steps.filter.outputs.frontend_generated_count || '0')
                         && !(github.event_name == 'pull_request'
@@ -81,6 +82,24 @@ jobs:
                         - 'products/**/frontend/generated/**'
                       snapshots:
                         - 'frontend/snapshots.yml'
+
+            # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
+            # Node-only agent-platform services/packages, which contain no stories
+            # and aren't in the bundle. dorny's default `some` quantifier ignores a
+            # plain `!` negation (see the output comment above), so we use a second
+            # `predicate-quantifier: every` filter: true only when some changed file
+            # lives OUTSIDE those dirs. AND-ed into the `frontend` output so a
+            # services-only PR skips the visual-regression suite.
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: exclude
+              if: github.event_name != 'push'
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  predicate-quantifier: 'every'
+                  filters: |
+                      outside_agent_services:
+                        - '!products/agent_platform/services/**'
+                        - '!products/agent_platform/packages/**'
 
             # Build the visual-regression matrix.
             # On PRs, only run chromium shards — no story currently opts into webkit snapshots

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -41,7 +41,7 @@ jobs:
                 ${{
                     github.event_name == 'push'
                     || (steps.filter.outputs.frontend == 'true'
-                        && steps.exclude.outputs.outside_agent_services == 'true'
+                        && steps.exclude.outputs.outside_non_frontend_ts == 'true'
                         && fromJSON(steps.filter.outputs.frontend_count || '0')
                            > fromJSON(steps.filter.outputs.frontend_generated_count || '0')
                         && !(github.event_name == 'pull_request'
@@ -83,18 +83,18 @@ jobs:
                       snapshots:
                         - 'frontend/snapshots.yml'
 
-            # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
-            # Node-only agent-platform services/packages, which contain no stories
-            # and aren't in the bundle. Appending a plain `!products/agent_platform/
-            # services/**` negation to that rule wouldn't help: dorny's default
-            # `some` quantifier OR-matches predicates, so the broad rule still
-            # matches a services file and the negation is effectively neutralized
-            # (same gotcha as the output comment above). Carving the dirs out with
-            # in-glob extglobs is possible but cryptic and would have to be repeated
-            # across every filter, so instead use a second `predicate-quantifier:
-            # every` filter: true only when some changed file lives OUTSIDE those
-            # dirs. AND-ed into the `frontend` output so a services-only PR skips the
-            # visual-regression suite.
+            # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches dirs that
+            # aren't frontend code — Node-only TS (agent-platform services/packages)
+            # with no stories and nothing in the bundle. Appending a plain `!...`
+            # negation to that rule wouldn't help: dorny's default `some` quantifier
+            # OR-matches predicates, so the broad rule still matches and the negation
+            # is neutralized (same gotcha as the output comment above). A separate
+            # step is required because `predicate-quantifier` is step-level: with
+            # `every`, this filter is true only when some changed file lives OUTSIDE
+            # every excluded dir. AND-ed into the `frontend` output so a PR touching
+            # only these dirs skips the visual-regression suite. To exclude another
+            # non-frontend dir, add a `!` line below — the output references this one
+            # filter, so it doesn't need to change.
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: exclude
               if: github.event_name != 'push'
@@ -102,7 +102,7 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   predicate-quantifier: 'every'
                   filters: |
-                      outside_agent_services:
+                      outside_non_frontend_ts:
                         - '!products/agent_platform/services/**'
                         - '!products/agent_platform/packages/**'
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -85,11 +85,13 @@ jobs:
 
             # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
             # Node-only agent-platform services/packages, which contain no stories
-            # and aren't in the bundle. dorny's default `some` quantifier ignores a
-            # plain `!` negation (see the output comment above), so we use a second
-            # `predicate-quantifier: every` filter: true only when some changed file
-            # lives OUTSIDE those dirs. AND-ed into the `frontend` output so a
-            # services-only PR skips the visual-regression suite.
+            # and aren't in the bundle. We can't just add a `!` negation to that
+            # filter: under dorny's default `some` quantifier a `!path` predicate
+            # matches every file NOT under `path`, so the filter would stay true for
+            # almost any PR (the over-match described in the output comment above).
+            # Instead use a second `predicate-quantifier: every` filter: true only
+            # when some changed file lives OUTSIDE those dirs. AND-ed into the
+            # `frontend` output so a services-only PR skips the visual-regression suite.
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: exclude
               if: github.event_name != 'push'

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -85,13 +85,16 @@ jobs:
 
             # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
             # Node-only agent-platform services/packages, which contain no stories
-            # and aren't in the bundle. We can't just add a `!` negation to that
-            # filter: under dorny's default `some` quantifier a `!path` predicate
-            # matches every file NOT under `path`, so the filter would stay true for
-            # almost any PR (the over-match described in the output comment above).
-            # Instead use a second `predicate-quantifier: every` filter: true only
-            # when some changed file lives OUTSIDE those dirs. AND-ed into the
-            # `frontend` output so a services-only PR skips the visual-regression suite.
+            # and aren't in the bundle. Appending a plain `!products/agent_platform/
+            # services/**` negation to that rule wouldn't help: dorny's default
+            # `some` quantifier OR-matches predicates, so the broad rule still
+            # matches a services file and the negation is effectively neutralized
+            # (same gotcha as the output comment above). Carving the dirs out with
+            # in-glob extglobs is possible but cryptic and would have to be repeated
+            # across every filter, so instead use a second `predicate-quantifier:
+            # every` filter: true only when some changed file lives OUTSIDE those
+            # dirs. AND-ed into the `frontend` output so a services-only PR skips the
+            # visual-regression suite.
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: exclude
               if: github.event_name != 'push'

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4895,7 +4895,7 @@ snapshots:
     scenes-app-dashboards-templates-dashboard-template-item--all-versions--dark:
         hash: v1.k794b7964.e9b8ff2046b506e9ea0d6fc7631c9ab733fa2c2a4f0cca7840d06f94210db9ab.s4QfFawRug02evRoMDDO8zl2fXpXkaav0IMq_FGCjtM
     scenes-app-dashboards-templates-dashboard-template-item--all-versions--light:
-        hash: v1.k794b7964.dbfb45bf4f32eed1ead7f2113b41c0c620e231ae19f7a5c0a06bc60475333009.ywACjnuOj9-vd49O4ttNAFemtLiYzV01Spiw9MPg9nM
+        hash: v1.k794b7964.489fcd39fd9a402472ccf4640182ee311ada8843e7cfd18779108a6c96f56be0.WTls6owUdMJZhF0JhBsHei4plrD-EdPYhT2pmZSwVCk
     scenes-app-dashboards-templates-dashboard-templates-table--default--dark:
         hash: v1.k794b7964.4196daeefa23df95ea8a8e0050c7ed33ccbe7eda0826d86f76714fd61d9aee07.ccK2iI3xPtiuBJU88n45tC0Q2UdWu_VKLgSd0dT7Xv0
     scenes-app-dashboards-templates-dashboard-templates-table--default--light:


### PR DESCRIPTION
## Problem

PR #64868 touched only `products/agent_platform/services/**` (Node-only agent services), yet it ran the **full Frontend CI** (jest EE×2 + FOSS×2 at ~9m each, typecheck ~7m, bundle size, formatting) and triggered the **Storybook visual-regression** suite. Django/backend correctly skipped; Playwright E2E correctly skipped.

The waste comes from the Frontend and Storybook `dorny/paths-filter` rules matching `products/**/*.ts(x)` / `products/**/*.{ts,tsx}`. The agent-platform services & packages live under `products/agent_platform/{services,packages}/**` and:

- have their own CI (`ci-agents.yml` → the `@posthog/agent-*` jobs),
- are explicitly ignored by jest (`frontend/jest.config.ts` `testPathIgnorePatterns`),
- aren't imported by the frontend bundle or any Storybook story.

So running those suites for a services-only change executes **zero** relevant tests.

## Why not just add a `!` negation

dorny's default `predicate-quantifier: some` OR-matches patterns, so a `!products/agent_platform/services/**` exclusion in the existing filter is silently ignored — the broad `products/**/*.ts` rule still matches. This exact gotcha is already documented in `ci-migrations-service-separation-check.yml`.

## Fix

Add a second `paths-filter` step (`id: exclude`) with `predicate-quantifier: 'every'` and negation-only patterns. With `every`, a changed file matches only if it is **outside** both dirs, so the filter output is true only when *some* changed file lives outside the agent-platform services/packages. That's AND-ed into the existing `frontend` / `frontend_code` gate outputs.

- services-only PR → `outside_agent_services = false` → frontend/storybook **skip**
- any real frontend change (or mixed PR) → `true` → suites **run** as before
- `master` push → unchanged (filters skipped, defaults to run-everything)
- editing the workflow file itself still re-runs it (self-change rule preserved)

## Verification

A stacked draft PR with a one-line dummy change to an agent service (based on this branch) confirms Frontend CI and Storybook skip while `ci-agents.yml` runs. Link added in a follow-up.