### PR TITLE
test: verify agent-services-only PR skips frontend & storybook CI

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -31,8 +31,12 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run frontend checks
         outputs:
-            frontend: ${{ steps.filter.outputs.frontend || 'true' }}
-            frontend_code: ${{ steps.filter.outputs.frontend_code || 'true' }}
+            # AND the broad filter with `exclude` (below): a PR that touches only
+            # the Node-only agent-platform services/packages must not trigger
+            # frontend CI — they have their own suite (ci-agents.yml) and are
+            # excluded from jest (frontend/jest.config.ts) and the bundle.
+            frontend: ${{ (steps.filter.outputs.frontend || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
+            frontend_code: ${{ (steps.filter.outputs.frontend_code || 'true') == 'true' && (steps.exclude.outputs.outside_agent_services || 'true') == 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -107,6 +111,25 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
+
+            # dorny's default `some` quantifier OR-matches patterns, so a plain
+            # `!products/agent_platform/services/**` negation in the filter above
+            # would be silently ignored — the broad `products/**/*.ts` rule still
+            # matches (same gotcha documented in
+            # ci-migrations-service-separation-check.yml). With
+            # `predicate-quantifier: every` this filter is true only when some
+            # changed file lives OUTSIDE the agent-platform Node services/packages;
+            # AND-ed into the outputs above so a services-only PR skips frontend CI.
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: exclude
+              if: github.event_name != 'push'
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  predicate-quantifier: 'every'
+                  filters: |
+                      outside_agent_services:
+                        - '!products/agent_platform/services/**'
+                        - '!products/agent_platform/packages/**'
 
     # Pick which jest tests to run on draft PRs by passing changed files to
     # `jest --findRelatedTests` (jest's resolver walks the import graph for us).

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -41,6 +41,7 @@ jobs:
                 ${{
                     github.event_name == 'push'
                     || (steps.filter.outputs.frontend == 'true'
+                        && steps.exclude.outputs.outside_agent_services == 'true'
                         && fromJSON(steps.filter.outputs.frontend_count || '0')
                            > fromJSON(steps.filter.outputs.frontend_generated_count || '0')
                         && !(github.event_name == 'pull_request'
@@ -81,6 +82,24 @@ jobs:
                         - 'products/**/frontend/generated/**'
                       snapshots:
                         - 'frontend/snapshots.yml'
+
+            # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
+            # Node-only agent-platform services/packages, which contain no stories
+            # and aren't in the bundle. dorny's default `some` quantifier ignores a
+            # plain `!` negation (see the output comment above), so we use a second
+            # `predicate-quantifier: every` filter: true only when some changed file
+            # lives OUTSIDE those dirs. AND-ed into the `frontend` output so a
+            # services-only PR skips the visual-regression suite.
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: exclude
+              if: github.event_name != 'push'
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  predicate-quantifier: 'every'
+                  filters: |
+                      outside_agent_services:
+                        - '!products/agent_platform/services/**'
+                        - '!products/agent_platform/packages/**'
 
             # Build the visual-regression matrix.
             # On PRs, only run chromium shards — no story currently opts into webkit snapshots

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -85,11 +85,13 @@ jobs:
 
             # The `frontend` filter's `products/**/*.{ts,tsx}` rule matches the
             # Node-only agent-platform services/packages, which contain no stories
-            # and aren't in the bundle. dorny's default `some` quantifier ignores a
-            # plain `!` negation (see the output comment above), so we use a second
-            # `predicate-quantifier: every` filter: true only when some changed file
-            # lives OUTSIDE those dirs. AND-ed into the `frontend` output so a
-            # services-only PR skips the visual-regression suite.
+            # and aren't in the bundle. We can't just add a `!` negation to that
+            # filter: under dorny's default `some` quantifier a `!path` predicate
+            # matches every file NOT under `path`, so the filter would stay true for
+            # almost any PR (the over-match described in the output comment above).
+            # Instead use a second `predicate-quantifier: every` filter: true only
+            # when some changed file lives OUTSIDE those dirs. AND-ed into the
+            # `frontend` output so a services-only PR skips the visual-regression suite.
             - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
               id: exclude
               if: github.event_name != 'push'

--- a/products/agent_platform/services/agent-shared/src/index.ts
+++ b/products/agent_platform/services/agent-shared/src/index.ts
@@ -65,3 +65,6 @@ export * from './runtime/secret-resolver'
 export * from './config/platform'
 
 export * from './memory'
+
+// CI no-op: verifying that a services-only change skips frontend & storybook CI.
+// Remove before merge.


### PR DESCRIPTION
**Do not merge — verification only for #64887.**

Stacked on `ci/skip-frontend-storybook-for-agent-services` (#64887) so the diff against this PR's base is a single agent-service file, while HEAD carries the fixed workflows. This reproduces the #64868 scenario (services-only change) with the fix applied.

Expected with the fix:
- Frontend CI jest / typecheck / bundle-size / formatting → **skipped**
- Storybook visual-regression → **skipped**
- `ci-agents.yml` (`@posthog/agent-*` jobs) → **runs**

If frontend/storybook still run here, the path-filter fix isn't working.