### PR TITLE
chore(feature-flags): disable auth-flow-variant in local flag sync

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -22,6 +22,7 @@ INACTIVE_FLAGS = [
     "halloween-override",
     "christmas-override",
     "control_support_login",
+    "auth-flow-variant",
     "person-property-incident-annotation-jan-2026",
     "replay-exclude-from-hide-recordings-menu",
     "webhooks-denylist",


### PR DESCRIPTION
## Problem

The local `sync_feature_flags` command creates every flag from `constants.tsx` enabled, and for multivariate flags it sets the last variant to 100%. For `auth-flow-variant` the last variant is `redesign-2026-06-02`, which currently renders a placeholder login (`"Redesigned sign-in — coming soon."`) with no form. So after a fresh local sync, sign-in is broken.

## Changes

Add `auth-flow-variant` to `INACTIVE_FLAGS` so the sync command creates/undeletes it disabled. With the flag off, `resolveAuthFlowVariant()` falls back to the working `legacy` login. This is exactly what `INACTIVE_FLAGS` is for — the header comment already calls out "authentication changes, big UI changes" as the intended use.

This only affects local developer environments (the `sync_feature_flags` management command); no production behavior changes.

## How did you test this code?

I'm an agent (Claude Code) — no manual UI testing claimed, and there are no automated tests for this command. I verified the code path locally: forced the flag into a `deleted=True, active=True` state, ran `sync_feature_flags`, and confirmed it was undeleted back to `active=False` (legacy login restored). Without the change it would have come back `active=True`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code. The human reported local login was broken by the redesigned sign-in placeholder; traced it to `auth-flow-variant` being synced on with `redesign-2026-06-02` at 100%.
- No repo-provided skills were invoked for this change.
- Considered flipping the variant rollout to `legacy` 100% instead, but disabling via `INACTIVE_FLAGS` is the established pattern for auth/UI flags and keeps the flag dormant rather than steering a live rollout.
