### PR TITLE
fix(llma): render openai responses image and text content parts

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -128,6 +128,42 @@ describe('LLMMessageDisplay', () => {
         expect(container.querySelector('img')?.getAttribute('src')).toBe(expectedSrc)
     })
 
+    it('renders OpenAI Responses input_text/input_image content parts as text and an image', () => {
+        const dataUri = 'data:image/jpeg;base64,/9j/4AAQSkZ'
+        const message: CompatMessage = {
+            role: 'user',
+            content: [
+                { type: 'input_text', text: 'what is in this photo?' },
+                { type: 'input_image', image_url: dataUri },
+            ],
+        }
+        const { container } = render(
+            <Provider>
+                <LLMMessageDisplay message={message} show />
+            </Provider>
+        )
+
+        expect(container.textContent).toContain('what is in this photo?')
+        expect(container.textContent).not.toContain('input_image')
+        expect(container.textContent).not.toContain('base64')
+        expect(container.querySelector('img')?.getAttribute('src')).toBe(dataUri)
+    })
+
+    it('renders an OpenAI Responses output_text content part as plain text', () => {
+        const message: CompatMessage = {
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'it is a photo of a cat' }],
+        }
+        const { container } = render(
+            <Provider>
+                <LLMMessageDisplay message={message} show />
+            </Provider>
+        )
+
+        expect(container.textContent).toContain('it is a photo of a cat')
+        expect(container.textContent).not.toContain('output_text')
+    })
+
     it('renders content[].type=function with object arguments as a tool-call block', async () => {
         const message: CompatMessage = {
             role: 'assistant',

--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -404,7 +404,11 @@ function renderContentItem(item: MultiModalContentItem, searchQuery?: string): J
         return <HighlightedJSONViewer src={item} name={null} collapsed={5} searchQuery={searchQuery} />
     }
 
-    if (item.type === 'text' && 'text' in item && typeof item.text === 'string') {
+    if (
+        (item.type === 'text' || item.type === 'input_text' || item.type === 'output_text') &&
+        'text' in item &&
+        typeof item.text === 'string'
+    ) {
         return searchQuery?.trim() ? (
             <SearchHighlight string={item.text} substring={searchQuery} className="whitespace-pre-wrap" />
         ) : (
@@ -414,6 +418,10 @@ function renderContentItem(item: MultiModalContentItem, searchQuery?: string): J
 
     if (item.type === 'image' && 'image' in item && typeof item.image === 'string') {
         return <ImageMessageDisplay message={{ content: { type: 'image', image: item.image } }} />
+    }
+
+    if (item.type === 'input_image' && typeof item.image_url === 'string') {
+        return <ImageMessageDisplay message={{ content: { type: 'image', image: item.image_url } }} />
     }
 
     if (isOpenAIImageURLMessage(item)) {

--- a/products/ai_observability/frontend/types.ts
+++ b/products/ai_observability/frontend/types.ts
@@ -262,6 +262,11 @@ export interface TextContentItem {
     text: string
 }
 
+export interface OutputTextContentItem {
+    type: 'output_text'
+    text: string
+}
+
 export interface ImageContentItem {
     type: 'image'
     image: string
@@ -279,8 +284,11 @@ export interface FunctionContentItem {
 export type MultiModalContentItem =
     | string
     | TextContentItem
+    | OutputTextContentItem
     | ImageContentItem
     | FunctionContentItem
+    | VercelSDKInputTextMessage
+    | VercelSDKInputImageMessage
     | OpenAIImageURLMessage
     | OpenAIFileMessage
     | OpenAIAudioMessage


### PR DESCRIPTION
## Problem

Multimodal display for OpenAI responses fails for image inputs (a user was doing manual capture + sending small images so they were neither hitting the redaction at the SDKs nor the size limit at capture).

## Changes

Fix it to include input images. Fix an unrelated latent bug for output text format.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual UI testing.

- Added jest cases in `ConversationMessagesDisplay.test.tsx` covering array content with `input_text` + `input_image` (asserts the image renders and no base64/`input_image` JSON leaks) and with `output_text` (asserts prose renders, no `output_text` JSON). Full file passes (26/26).
- Typecheck clean on the touched files.

Validation against production (US `ai_events`, last 2 days): the reported event's `input` is the exact `input_text` + `input_image` data-URI shape; `output_text` appears in 174k events across 63 teams, with the confirmed `{ role, content: [{ type: "output_text", text, … }] }` shape. Ran both real shapes through the actual `RecipeNormalizer` to confirm they arrive at the renderer raw.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Carlos Marchal triaging a user feedback ticket. Tooling: PostHog Code (Claude). Validated the data shapes by querying production ClickHouse `ai_events` via the `query-clickhouse-via-metabase` skill, and confirmed normalizer behavior with throwaway tests against the real recipes (deleted before commit).

Decision worth flagging for review: the fix lives in the renderer, not the normalizer. The alternative — canonicalizing `input_image`/`input_text`/`output_text` into `image`/`text` inside `compat_array` — was rejected because the renderer is already the established home for raw provider content-part shapes, and canonicalizing only these would diverge them from their allowlist siblings (`image_url`, `audio`, `file`, `document`). The original pass covered only the two reported input-side types; `output_text` was added after confirming it's the higher-volume output-side instance of the same bug, not a guess. Not in scope: a defensive truncation of data-URIs/oversized strings in the JSON-viewer fallback, which would cap any future unrecognized base64 part.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
