### PR TITLE
chore(llma): stop tagging AI observability on automated cost PRs

### DIFF
--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -21,6 +21,9 @@ const CONFIG = {
         '**/*.lock',
         '**/*.snap',
         '**/*.ambr',
+        // Regenerated wholesale by `pnpm update-ai-costs` from the OpenRouter API.
+        'nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts',
+        'nodejs/src/ingestion/ai/costs/providers/llm-costs.json',
     ],
     // An owner is formally requested for review only if their footprint clears
     // one of these bars; otherwise they are demoted to the explanation comment

--- a/.github/scripts/assign-reviewers.test.js
+++ b/.github/scripts/assign-reviewers.test.js
@@ -30,6 +30,9 @@ describe('assign-reviewers', () => {
             ['uv.lock', true],
             ['posthog/api/test/__snapshots__/test_survey.ambr', true],
             ['frontend/src/scenes/x/Component.test.tsx.snap', true],
+            ['nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts', true],
+            ['nodejs/src/ingestion/ai/costs/providers/llm-costs.json', true],
+            ['nodejs/src/ingestion/ai/costs/providers/manual-providers.ts', false],
             ['posthog/api/survey.py', false],
             ['frontend/src/scenes/surveys/Survey.tsx', false],
         ])('%s -> %s', (filename, expected) => {

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -149,7 +149,7 @@ jobs:
                   )" \
                     --base master \
                     --head chore/llma-update-ai-costs \
-                    --label "automated" --label "llm-analytics" \
+                    --label "automated" \
                     --reviewer "PostHog/team-ai-gateway")
                   echo "Created $new_pr_url"
 


### PR DESCRIPTION
## Problem

Cost update PRs still tag AIObs

## Changes

Remove the files from codeowners tracking

## How did you test this code?

I'm an agent. I didn't run the full Jest suite (the `.github/scripts` test uses Jest globals and isn't wired to a local runner here). I validated the behavior change directly against the real soft-owner rules by calling the exported `isExcludedFile` and `computeOwnerFootprints` in Node:

- `isExcludedFile` returns `true` for both generated files and `false` for `manual-providers.ts` / `input-costs.ts`.
- Simulating the cost PR (both generated files changed) against the actual `ai/`, `ai/costs/`, and `ai/costs/providers/` rules: before the change the assigner resolved `[team-ai-observability, team-ai-gateway]`; after, it resolves `[]`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Carlos asked to stop the automated LLM cost-update PRs from tagging AI observability. Investigated with PostHog Code (Claude Opus): traced the title to `update-ai-costs.yml`, then found the real tagging path was `auto-assign-reviewers.yml` → `assign-reviewers.js`, whose `computeOwnerFootprints` aggregates every matching `CODEOWNERS-soft` rule rather than honoring last-match-wins.

First attempt removed the `--reviewer` line outright; Carlos clarified gateway owns it and should stay, only AI observability should go. Considered narrowing the broad `nodejs/src/ingestion/ai/` soft-owner rule, but CODEOWNERS has no negation so that would be brittle. Chose the assigner `excludedPatterns` route instead since both cost files are machine-generated, which matches the list's stated purpose and keeps gateway's explicit reviewer request intact. No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
