### PR TITLE
fix(ducklake): lazy-import get_instance_region for standalone load

### DIFF
--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -25,8 +25,6 @@ import duckdb
 import psycopg
 from psycopg import sql
 
-from posthog.utils import get_instance_region
-
 if TYPE_CHECKING:
     from posthog.ducklake.models import DuckgresServer, DuckLakeCatalog
 
@@ -285,6 +283,10 @@ def _duckling_env_suffix() -> str:
     enabled yet, so that path is a no-op (raises rather than fabricating a bucket name);
     everything that isn't prod-US — hosted dev/staging, local dev — maps to "dev".
     """
+    # deferred so bin/check_ducklake_up can load this module standalone, without the posthog
+    # package importable — only the managed-bucket path below needs get_instance_region
+    from posthog.utils import get_instance_region  # noqa: PLC0415
+
     region = (get_instance_region() or "").upper()
     if region == "EU":
         raise NotImplementedError("Managed warehouse is not enabled in the EU region")


### PR DESCRIPTION
## Problem

`bin/check_ducklake_up` (run during `./bin/start`) loads `posthog/ducklake/common.py` as a standalone module — deliberately, "without relying on editable installs," so the repo root is not on `sys.path`. A top-level `from posthog.utils import get_instance_region` (added in #63834) breaks that contract: the module now fails to import with `ModuleNotFoundError: No module named 'posthog'`, the DuckLake health check crashes, and local startup fails.

## Changes

Move the `get_instance_region` import into `_duckling_env_suffix()`, its only caller. The module loads standalone again, and the managed-bucket path that actually needs the region is unaffected (in the real app the `posthog` package is importable).

## How did you test this code?

I'm an agent. Checks I actually ran:

- Loaded `common.py` via the same `importlib.spec_from_file_location` path `bin/check_ducklake_up` uses, with the repo root removed from `sys.path` (the exact condition that triggered the regression) — it imports cleanly and exposes `get_config` / `attach_catalog`.
- `ruff check` + `ruff format` clean.

## Docs update

No docs impact (local dev tooling).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the user's direction while investigating the DuckLake data-modeling stack. Root-caused with `git log -S` on `common.py`, confirming the regression came from #63834 — a master change, not the working branch. Chose the lazy import over adding the repo root to `sys.path` in the script: the script's explicit contract is to load the module *without* the posthog package importable, so deferring the one import keeps that contract intact and is the smaller change. No repo skills were invoked.
