### PR TITLE
fix(dags): read duckling backfill bucket from stored catalog

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -8,8 +8,8 @@ This job targets individual customer "ducklings" - isolated DuckLake instances w
 own RDS catalog and S3 bucket.
 
 Architecture:
-    DuckgresServer (connection) + derived S3 bucket name
-        │ team_id → organization_id → connection; bucket = posthog-duckling-{org}-{suffix}
+    DuckgresServer (connection) + DuckLakeCatalog (S3 bucket name)
+        │ team_id → organization_id → connection; bucket from the stored DuckLakeCatalog row
         ▼
     ClickHouse (events table)
         │ export via s3() - bucket policy allows ClickHouse EC2 role
@@ -176,10 +176,10 @@ def _get_cluster() -> ClickhouseCluster:
 class DucklingTarget:
     """Resolved per-org duckling backfill target: connection identity + S3 storage.
 
-    Replaces DuckLakeCatalog in the backfill path — built once per run from the team's
-    organization id (which drives both the duckgres connection, via make_duckgres_conninfo,
-    and the deterministically derived S3 bucket). Duckgres owns catalog attachment, so no
-    catalog-DB connection is needed here.
+    Built once per run from the team's organization id. The duckgres connection is driven by
+    make_duckgres_conninfo (duckgres owns catalog attachment on the connection); the S3 bucket
+    is read from the org's stored DuckLakeCatalog row — the provisioning source of truth — and
+    only falls back to deterministic derivation when no catalog row exists (e.g. dev mode).
     """
 
     team_id: int

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -67,7 +67,11 @@ from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.ducklake.client import make_duckgres_conninfo
-from posthog.ducklake.common import _get_org_id_for_team, derive_duckling_bucket
+from posthog.ducklake.common import (
+    _get_org_id_for_team,
+    derive_duckling_bucket,
+    get_ducklake_catalog_for_organization,
+)
 from posthog.ducklake.models import DuckLakeBackfill
 
 logger = structlog.get_logger(__name__)
@@ -188,10 +192,19 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
     """Resolve the per-org duckling target for a backfill partition.
 
     The organization id (team → org) drives both the connection (make_duckgres_conninfo
-    resolves the duckgres server itself) and the deterministically derived S3 bucket.
+    resolves the duckgres server itself) and the S3 bucket. The bucket name is read from
+    the org's stored DuckLakeCatalog — the source of truth written at provisioning time —
+    and only falls back to the deterministic derivation for orgs with no catalog row yet
+    (e.g. dev mode, where the catalog lookup returns None).
     """
     org_id = _get_org_id_for_team(team_id)
-    bucket, bucket_region = derive_duckling_bucket(org_id)
+
+    catalog = get_ducklake_catalog_for_organization(org_id)
+    if catalog is not None and catalog.bucket:
+        bucket, bucket_region = catalog.bucket, catalog.bucket_region
+    else:
+        bucket, bucket_region = derive_duckling_bucket(org_id)
+
     return DucklingTarget(team_id=team_id, organization_id=org_id, bucket=bucket, bucket_region=bucket_region)
 
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -67,11 +67,7 @@ from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.ducklake.client import make_duckgres_conninfo
-from posthog.ducklake.common import (
-    _get_org_id_for_team,
-    derive_duckling_bucket,
-    get_ducklake_catalog_for_organization,
-)
+from posthog.ducklake.common import _get_org_id_for_team, derive_duckling_bucket, get_ducklake_catalog_for_organization
 from posthog.ducklake.models import DuckLakeBackfill
 
 logger = structlog.get_logger(__name__)

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -203,7 +203,16 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
     if catalog is not None and catalog.bucket:
         bucket, bucket_region = catalog.bucket, catalog.bucket_region
     else:
+        # No stored catalog row (dev mode, or an org provisioned with only a DuckgresServer):
+        # the derived name is an unverified guess at the provisioned bucket. Log it so the
+        # "bucket does not exist" failure mode is observable rather than silent.
         bucket, bucket_region = derive_duckling_bucket(org_id)
+        logger.warning(
+            "duckling_bucket_derived_no_catalog",
+            team_id=team_id,
+            organization_id=org_id,
+            bucket=bucket,
+        )
 
     return DucklingTarget(team_id=team_id, organization_id=org_id, bucket=bucket, bucket_region=bucket_region)
 


### PR DESCRIPTION
## Problem

The duckling events backfill DAG started failing with a ClickHouse S3 error during the Parquet export step:

```
Code: 499. DB::Exception: The specified bucket does not exist.
```

The regression traces to #63834 (merged the day before this fix). That PR replaced `DuckLakeCatalog` with `DuckgresServer` in the backfill connection path and, as part of it, stopped reading the org's bucket name from the stored `DuckLakeCatalog.bucket` field and instead **recomputed** it deterministically as `posthog-duckling-{org}-{suffix}` via `derive_duckling_bucket`.

`DuckgresServer` has no bucket field, so the new code had nothing to read from and reconstructed the name from the org id. When an org's actually-provisioned bucket name doesn't match that exact pattern (or the env suffix resolves differently than expected in the Dagster runtime), ClickHouse is handed a bucket that doesn't exist and the export blows up — surfacing as a raw ClickHouse 499 deep inside the op rather than a readable error.

## Changes

`_resolve_duckling_target` now reads `bucket` / `bucket_region` from the org's stored `DuckLakeCatalog` row — the source of truth written at provisioning time — and only falls back to the deterministic `derive_duckling_bucket` derivation when there is no catalog row (e.g. dev mode, where the lookup returns `None`).

This restores the pre-#63834 behavior for the bucket while keeping the new duckgres-backed connection path intact. The catalog lookup reuses the existing `get_ducklake_catalog_for_organization` helper.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Automated checks I actually ran:
- isolated `ruff check` and `ruff format --check` (line-length 120) on the modified file — both clean
- `python3 -c "import ast; ast.parse(...)"` syntax check

I did not run the full Python suite locally (the local venv is stale and `hogli`/flox were unavailable). Relying on CI for the full lint + test run. No automated test was added — the change is a narrow source-of-truth swap in an existing resolver; a unit test asserting "stored catalog bucket wins over derived" would be a reasonable follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Debugged from a Dagster stack trace the user pasted. Walked the call chain (`duckling_events_backfill` → `export_events_to_duckling_s3` → `INSERT INTO FUNCTION s3(...)`) to the ClickHouse 499, then used `git log`/`git show` to bisect the bucket-resolution change to #63834. Confirmed `DuckgresServer` carries no bucket field while `DuckLakeCatalog.bucket` is still populated, so the fix reads from the catalog and falls back to the derived name only when no row exists.

No skills were applicable (Dagster DAG / ClickHouse export, not a DRF/migration/frontend surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
