### PR TITLE
feat(logs): facet values on resource attributes

### DIFF
--- a/products/logs/backend/log_facet_values_query_runner.py
+++ b/products/logs/backend/log_facet_values_query_runner.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import cast
 
 from posthog.schema import CachedLogsQueryResponse, LogsQuery
 
@@ -25,24 +26,44 @@ DEFAULT_FACET_LIMIT = 100
 
 
 class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
-    """Per-value counts for a single facet field, cross-filtered.
+    """Per-value counts for a single facet, cross-filtered.
 
-    Every active filter is applied except the one belonging to `facet_field`, so selecting a value
-    in a facet re-scopes the *other* facets without zeroing out the facet's own siblings — the
-    standard faceted-search behaviour.
+    The facet is either a top-level column (severity_text/service_name) or a resource attribute map
+    key (e.g. k8s.namespace.name). Every active filter is applied except the one belonging to this
+    facet, so selecting a value re-scopes the *other* facets without zeroing out its own siblings —
+    the standard faceted-search behaviour.
     """
 
     query: LogsQuery
     cached_response: CachedLogsQueryResponse
 
-    def __init__(self, query: LogsQuery, facet_field: str, *args, facet_search: str | None = None, **kwargs):
+    def __init__(
+        self,
+        query: LogsQuery,
+        *args,
+        facet_field: str | None = None,
+        facet_resource_attribute: str | None = None,
+        facet_search: str | None = None,
+        **kwargs,
+    ):
         super().__init__(query, *args, **kwargs)
-        if facet_field not in FACET_FIELDS:
+        # A facet targets either a top-level column (severity_text/service_name) or a resource
+        # attribute map key (e.g. k8s.namespace.name). Exactly one must be supplied.
+        if bool(facet_field) == bool(facet_resource_attribute):
+            raise ValueError("Provide exactly one of facet_field or facet_resource_attribute")
+        if facet_field is not None and facet_field not in FACET_FIELDS:
             raise ValueError(f"Unsupported facet field: {facet_field!r}")
         self.facet_field = facet_field
+        self.facet_resource_attribute = facet_resource_attribute
         # Type-ahead over the facet's *own* values (e.g. service name contains "kafka"), distinct from
         # query.searchTerm which searches log bodies. Lets a dynamic facet search past the LIMIT window.
         self.facet_search = (facet_search or "").strip() or None
+
+    def _facet_expr(self) -> ast.Expr:
+        """The expression a facet groups by: a top-level column or a resource_attributes map lookup."""
+        if self.facet_field is not None:
+            return ast.Field(chain=[self.facet_field])
+        return ast.Field(chain=["resource_attributes", cast(str, self.facet_resource_attribute)])
 
     @cached_property
     def settings(self) -> HogQLGlobalSettings:
@@ -70,10 +91,15 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
     def to_query(self) -> ast.SelectQuery:
         # The day-precision time_bucket prune in where() is widened to exact timestamp bounds so the
         # counts match the requested window (same half-open pattern as CountQueryRunner).
+        filter_builder = LogsFilterBuilder(
+            self.query,
+            self.team,
+            self.query_date_range,
+            exclude_facet_field=self.facet_field,
+            exclude_resource_attribute=self.facet_resource_attribute,
+        )
         exprs = [
-            LogsFilterBuilder(
-                self.query, self.team, self.query_date_range, exclude_facet_field=self.facet_field
-            ).where(),
+            filter_builder.where(),
             parse_expr(
                 "timestamp >= {date_from} AND timestamp < {date_to}",
                 placeholders={
@@ -82,12 +108,16 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
                 },
             ),
         ]
+        if self.facet_resource_attribute is not None:
+            # A missing map key reads back as '' in ClickHouse — exclude it so the facet doesn't show a
+            # blank value counting every log that lacks the attribute.
+            exprs.append(parse_expr("{facet} != ''", placeholders={"facet": self._facet_expr()}))
         if self.facet_search:
             exprs.append(
                 parse_expr(
-                    "{facet_field} ILIKE {pattern}",
+                    "{facet} ILIKE {pattern}",
                     placeholders={
-                        "facet_field": ast.Field(chain=[self.facet_field]),
+                        "facet": self._facet_expr(),
                         # Escape %, _ and \ so user input matches literally instead of as wildcards.
                         "pattern": ast.Constant(value=ilike_pattern(self.facet_search)),
                     },
@@ -96,15 +126,15 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
         where = ast.And(exprs=exprs)
         query = parse_select(
             """
-            SELECT {facet_field} AS value, count() AS count
+            SELECT {facet} AS value, count() AS count
             FROM logs
             WHERE {where}
-            GROUP BY {facet_field}
-            ORDER BY count() DESC, {facet_field} ASC
+            GROUP BY {facet}
+            ORDER BY count() DESC, {facet} ASC
             LIMIT {limit}
             """,
             placeholders={
-                "facet_field": ast.Field(chain=[self.facet_field]),
+                "facet": self._facet_expr(),
                 "where": where,
                 "limit": ast.Constant(value=self.query.limit or DEFAULT_FACET_LIMIT),
             },

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -209,6 +209,7 @@ class LogsFilterBuilder:
         team: "Team",
         query_date_range: QueryDateRange,
         exclude_facet_field: str | None = None,
+        exclude_resource_attribute: str | None = None,
     ):
         self.query = query
         self.team = team
@@ -217,6 +218,9 @@ class LogsFilterBuilder:
         # from the WHERE clause so facet counts reflect every *other* active filter — the standard
         # faceted-search behaviour where selecting a value doesn't zero out its siblings.
         self.exclude_facet_field = exclude_facet_field
+        # The resource-attribute equivalent: when faceting on a resource attribute key, omit that
+        # key's own log_resource_attribute filter so the facet doesn't zero out its own siblings.
+        self.exclude_resource_attribute = exclude_resource_attribute
 
         self.resource_attribute_filters: list[LogPropertyFilter] = []
         self.resource_attribute_negative_filters: list[LogPropertyFilter] = []
@@ -275,6 +279,14 @@ class LogsFilterBuilder:
                     property_filter.key = f"{property_filter.key}__{property_type}"
 
                     self.attribute_filters.insert(0, property_filter)
+
+        if self.exclude_resource_attribute is not None:
+            self.resource_attribute_filters = [
+                f for f in self.resource_attribute_filters if f.key != self.exclude_resource_attribute
+            ]
+            self.resource_attribute_negative_filters = [
+                f for f in self.resource_attribute_negative_filters if f.key != self.exclude_resource_attribute
+            ]
 
     def where(self) -> ast.Expr:
         exprs: list[ast.Expr] = []

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -337,7 +337,17 @@ class _LogsFacetValuesResponseSerializer(serializers.Serializer):
 class _LogsFacetValuesBodySerializer(serializers.Serializer):
     facetField = serializers.ChoiceField(
         choices=["severity_text", "service_name"],
-        help_text="Column to facet on. Its own filter is excluded so counts reflect the other active filters.",
+        required=False,
+        allow_null=True,
+        help_text="Top-level column to facet on. Provide exactly one of facetField or facetResourceAttribute. "
+        "Its own filter is excluded so counts reflect the other active filters.",
+    )
+    facetResourceAttribute = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="Resource attribute key to facet on (e.g. 'k8s.namespace.name'). Provide exactly one of "
+        "facetField or facetResourceAttribute. Its own log_resource_attribute filter is excluded so counts "
+        "reflect the other active filters.",
     )
     dateRange = _DateRangeSerializer(required=False, help_text="Date range. Defaults to last hour.")
     severityLevels = serializers.ListField(
@@ -837,7 +847,10 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         query_data = request.data.get("query", {})
 
         facet_field = query_data.get("facetField")
-        if facet_field not in FACET_FIELDS:
+        facet_resource_attribute = query_data.get("facetResourceAttribute")
+        if bool(facet_field) == bool(facet_resource_attribute):
+            raise ParseError("Provide exactly one of facetField or facetResourceAttribute")
+        if facet_field and facet_field not in FACET_FIELDS:
             raise ParseError(f"facetField must be one of {sorted(FACET_FIELDS)}")
 
         date_range_data = query_data.get("dateRange")
@@ -852,7 +865,11 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         )
 
         runner = LogFacetValuesQueryRunner(
-            team=self.team, query=query, facet_field=facet_field, facet_search=query_data.get("facetSearch")
+            team=self.team,
+            query=query,
+            facet_field=facet_field or None,
+            facet_resource_attribute=facet_resource_attribute or None,
+            facet_search=query_data.get("facetSearch"),
         )
         response = runner.run(
             ExecutionMode.CALCULATE_BLOCKING_ALWAYS,

--- a/products/logs/backend/test/test_log_facet_values.py
+++ b/products/logs/backend/test/test_log_facet_values.py
@@ -36,6 +36,12 @@ class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return {r["value"]: r["count"] for r in response.json()["results"]}
 
+    def _facet_attr(self, key: str, **filters) -> dict[str, int]:
+        body = {"query": {"facetResourceAttribute": key, "dateRange": self.DATE_RANGE, **filters}}
+        response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {r["value"]: r["count"] for r in response.json()["results"]}
+
     @parameterized.expand(
         [
             ("severity_text", "severityLevels"),
@@ -98,3 +104,50 @@ class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
         body = {"query": {"facetField": "body", "dateRange": self.DATE_RANGE}}
         response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand([("k8s.namespace.name",), ("k8s.pod.name",), ("k8s.node.name",)])
+    def test_facet_on_resource_attribute_returns_values(self, key):
+        """A resource attribute key can be faceted and returns its values with counts."""
+        result = self._facet_attr(key)
+        self.assertGreater(len(result), 0)
+        self.assertTrue(all(count > 0 for count in result.values()))
+
+    def test_resource_facet_excludes_blank_for_missing_key(self):
+        """Logs lacking the key read back '' from the map; that bucket must not appear as a facet value."""
+        # k8s.deployment.name is present on only some fixture rows (others carry a daemonset instead).
+        result = self._facet_attr("k8s.deployment.name")
+        self.assertGreater(len(result), 0)
+        self.assertNotIn("", result)
+
+    def test_resource_facet_ignores_its_own_filter(self):
+        """Selecting a value via a log_resource_attribute filter must not change that facet's own counts."""
+        base = self._facet_attr("k8s.namespace.name")
+        own_value = next(iter(base))
+        filter_group = [
+            {"key": "k8s.namespace.name", "type": "log_resource_attribute", "operator": "exact", "value": own_value}
+        ]
+        self.assertEqual(self._facet_attr("k8s.namespace.name", filterGroup=filter_group), base)
+
+    def test_resource_facet_honors_other_filter(self):
+        """A top-level filter re-scopes a resource-attribute facet's counts (strictly fewer)."""
+        base = self._facet_attr("k8s.namespace.name")
+        scoped = self._facet_attr("k8s.namespace.name", severityLevels=["error"])
+        self.assertLess(sum(scoped.values()), sum(base.values()))
+
+    @parameterized.expand([("argo",), ("ARGO",)])
+    def test_resource_facet_search_is_case_insensitive(self, term):
+        searched = self._facet_attr("k8s.namespace.name", facetSearch=term)
+        self.assertGreater(len(searched), 0)
+        self.assertTrue(all(term.lower() in value.lower() for value in searched))
+
+    def test_resource_facet_search_no_match_returns_empty(self):
+        self.assertEqual(self._facet_attr("k8s.namespace.name", facetSearch="no-such-namespace-xyz"), {})
+
+    def test_requires_exactly_one_facet_target(self):
+        for query in (
+            {},  # neither
+            {"facetField": "service_name", "facetResourceAttribute": "k8s.pod.name"},  # both
+        ):
+            body = {"query": {**query, "dateRange": self.DATE_RANGE}}
+            response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1001,11 +1001,16 @@ export const FacetFieldEnumApi = {
 } as const
 
 export interface _LogsFacetValuesBodyApi {
-    /** Column to facet on. Its own filter is excluded so counts reflect the other active filters.
+    /** Top-level column to facet on. Provide exactly one of facetField or facetResourceAttribute. Its own filter is excluded so counts reflect the other active filters.
      *
      * * `severity_text` - severity_text
      * * `service_name` - service_name */
-    facetField: FacetFieldEnumApi
+    facetField?: FacetFieldEnumApi | null
+    /**
+     * Resource attribute key to facet on (e.g. 'k8s.namespace.name'). Provide exactly one of facetField or facetResourceAttribute. Its own log_resource_attribute filter is excluded so counts reflect the other active filters.
+     * @nullable
+     */
+    facetResourceAttribute?: string | null
     /** Date range. Defaults to last hour. */
     dateRange?: _DateRangeApi
     /** Filter by log severity levels (ignored when faceting on severity_text). */

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -605,10 +605,21 @@ export const LogsFacetValuesCreateBody = /* @__PURE__ */ zod.object({
     query: zod
         .object({
             facetField: zod
-                .enum(['severity_text', 'service_name'])
-                .describe('\* `severity_text` - severity_text\n\* `service_name` - service_name')
+                .union([
+                    zod
+                        .enum(['severity_text', 'service_name'])
+                        .describe('\* `severity_text` - severity_text\n\* `service_name` - service_name'),
+                    zod.null(),
+                ])
+                .optional()
                 .describe(
-                    'Column to facet on. Its own filter is excluded so counts reflect the other active filters.\n\n\* `severity_text` - severity_text\n\* `service_name` - service_name'
+                    'Top-level column to facet on. Provide exactly one of facetField or facetResourceAttribute. Its own filter is excluded so counts reflect the other active filters.\n\n\* `severity_text` - severity_text\n\* `service_name` - service_name'
+                ),
+            facetResourceAttribute: zod
+                .string()
+                .nullish()
+                .describe(
+                    "Resource attribute key to facet on (e.g. 'k8s.namespace.name'). Provide exactly one of facetField or facetResourceAttribute. Its own log_resource_attribute filter is excluded so counts reflect the other active filters."
                 ),
             dateRange: zod
                 .object({

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50292,11 +50292,16 @@ export namespace Schemas {
     }
 
     export interface _LogsFacetValuesBody {
-      /** Column to facet on. Its own filter is excluded so counts reflect the other active filters.
+      /** Top-level column to facet on. Provide exactly one of facetField or facetResourceAttribute. Its own filter is excluded so counts reflect the other active filters.
        *
        * * `severity_text` - severity_text
        * * `service_name` - service_name */
-      facetField: FacetFieldEnum;
+      facetField?: FacetFieldEnum | null;
+      /**
+         * Resource attribute key to facet on (e.g. 'k8s.namespace.name'). Provide exactly one of facetField or facetResourceAttribute. Its own log_resource_attribute filter is excluded so counts reflect the other active filters.
+         * @nullable
+         */
+      facetResourceAttribute?: string | null;
       /** Date range. Defaults to last hour. */
       dateRange?: _DateRange;
       /** Filter by log severity levels (ignored when faceting on severity_text). */


### PR DESCRIPTION
## Problem

The logs facet-values endpoint only supported faceting on top-level columns (`severity_text`, `service_name`). There was no way to facet on resource attribute map keys (e.g. `k8s.namespace.name`, `k8s.pod.name`), which are stored in a ClickHouse map column rather than as first-class fields.

## Changes

- `LogFacetValuesQueryRunner` now accepts either `facet_field` (top-level column) or `facet_resource_attribute` (map key) — exactly one must be provided. A `_facet_expr()` helper returns the correct AST expression for whichever is active.
- Blank values from missing map keys (ClickHouse returns `''` for absent map entries) are filtered out so the facet doesn't show an empty bucket counting every log that lacks the attribute.
- `LogsFilterBuilder` gains an `exclude_resource_attribute` parameter that strips the matching `log_resource_attribute` filter from the WHERE clause, preserving the standard faceted-search behaviour where a facet's own filter doesn't zero out its siblings.
- The API view (`facet_values`) validates that exactly one of `facetField` / `facetResourceAttribute` is supplied and routes accordingly.
- Frontend-generated types (`api.schemas.ts`, `api.zod.ts`) and the MCP generated client are updated to reflect `facetField` becoming optional and the new `facetResourceAttribute` field.

## How did you test this code?

New integration tests in `test_log_facet_values.py` cover:

- Resource attribute facets return values with non-zero counts
- Blank values for missing keys are excluded
- A facet's own `log_resource_attribute` filter is ignored (sibling counts unchanged)
- Other active filters (e.g. `severityLevels`) correctly re-scope the facet counts
- Case-insensitive `facetSearch` works for resource attributes
- No-match search returns empty results
- Requests with neither or both facet targets are rejected with HTTP 400

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent extended the existing facet-values infrastructure to support resource attribute map keys alongside the existing top-level column facets. Key decisions:

- Introduced a `_facet_expr()` method to centralise the AST difference between a column reference and a map lookup, keeping the query-building logic DRY.
- Chose to filter `!= ''` at query time rather than post-processing, so the LIMIT applies only to real values.
- Mirrored the `exclude_facet_field` pattern already present in `LogsFilterBuilder` rather than adding a separate code path, keeping the filter-exclusion logic consistent.
- `facet_field` was made positional-optional (keyword-only with `None` default) to avoid breaking the existing call sites while allowing the new `facet_resource_attribute` path.