### PR TITLE
fix(ducklake): make get_instance_region a lazy import in common helpers

### DIFF
--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -25,8 +25,6 @@ import duckdb
 import psycopg
 from psycopg import sql
 
-from posthog.utils import get_instance_region
-
 if TYPE_CHECKING:
     from posthog.ducklake.models import DuckgresServer, DuckLakeCatalog
 
@@ -285,6 +283,10 @@ def _duckling_env_suffix() -> str:
     enabled yet, so that path is a no-op (raises rather than fabricating a bucket name);
     everything that isn't prod-US — hosted dev/staging, local dev — maps to "dev".
     """
+    # Lazy import so this module can be loaded standalone (see bin/check_ducklake_up)
+    # without the full posthog package on sys.path.
+    from posthog.utils import get_instance_region  # noqa: PLC0415
+
     region = (get_instance_region() or "").upper()
     if region == "EU":
         raise NotImplementedError("Managed warehouse is not enabled in the EU region")

--- a/posthog/ducklake/test_common.py
+++ b/posthog/ducklake/test_common.py
@@ -25,11 +25,11 @@ class TestDeriveDucklingBucket:
     )
     def test_derives_bucket_from_region(self, _name: str, region: str | None, expected_bucket: str):
         # Mirrors the duckgres Crossplane composition: posthog-duckling-{org}-{suffix}.
-        with patch("posthog.ducklake.common.get_instance_region", return_value=region):
+        with patch("posthog.utils.get_instance_region", return_value=region):
             assert derive_duckling_bucket("org-abc") == (expected_bucket, "us-east-1")
 
     def test_eu_is_not_enabled(self):
-        with patch("posthog.ducklake.common.get_instance_region", return_value="EU"):
+        with patch("posthog.utils.get_instance_region", return_value="EU"):
             with pytest.raises(NotImplementedError, match="EU"):
                 derive_duckling_bucket("org-1")
 


### PR DESCRIPTION
## Problem

Running `temporal-worker` locally crashed on startup with:

```
File "/Users/.../posthog/ducklake/common.py", line 28, in <module>
    from posthog.utils import get_instance_region
ModuleNotFoundError: No module named 'posthog'
```

`bin/check_ducklake_up` (part of the local startup health check) loads `posthog/ducklake/common.py` directly via `spec_from_file_location`, deliberately without the `posthog` package on `sys.path` so it doesn't depend on an editable install. The rest of the module respects this with lazy, fallback-guarded imports (e.g. `is_dev_mode`), but a recently-added top-level `from posthog.utils import get_instance_region` broke the contract and the whole module failed to load.

## Changes

Move the `get_instance_region` import into `_duckling_env_suffix()` as a lazy import, mirroring the existing pattern in `is_dev_mode()`. The module now loads standalone again, and the import still resolves normally everywhere `common.py` runs inside the full app.

## How did you test this code?

I'm an agent (PostHog Slack app). I reproduced the failure mode by loading `common.py` via `spec_from_file_location` with the `posthog` package absent from `sys.path` (C deps stubbed) — it failed before the change and loads cleanly after, with `posthog` never entering `sys.modules`. No automated test suite was run for this one-line import relocation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ross reported the `temporal-worker` startup crash from a Slack thread. Root cause was a top-level import added to a module that's intentionally loaded standalone by the local startup health check. Fix follows the file's established lazy-import convention rather than adding `sys.path` hacks to `bin/check_ducklake_up`, keeping the standalone-loadability contract intact. No skills were invoked.
