### PR TITLE
feat(logs): add facet source discriminator (column vs resource attribute)

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -10,7 +10,7 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 import { Facet, FacetOption } from './Facet'
 import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
-import { FacetConfig, FacetField, FacetFilterKey, facetsByGroup } from './facets'
+import { FacetConfig, FacetField, FacetFilterKey, facetsByGroup, resourceAttributeValues } from './facets'
 
 const DEFAULT_WIDTH_PX = 240
 const COLLAPSE_THRESHOLD_PX = 120
@@ -23,7 +23,7 @@ export interface FacetRailProps {
 export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
-    const { severityLevels, serviceNames } = useValues(logsViewerFiltersLogic)
+    const { severityLevels, serviceNames, filterGroup } = useValues(logsViewerFiltersLogic)
     const { levelValues, levelValuesLoading, serviceValues, serviceValuesLoading, facetSearch } = useValues(
         facetCountsLogic({ id })
     )
@@ -63,9 +63,18 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
 
     const renderFacet = (facet: FacetConfig): JSX.Element => {
-        const selected = selectedByKey[facet.filterKey]
-        const fetched = valuesByField[facet.facetField]
-        const onToggle = (value: string): void => toggleFacetValue(facet.filterKey, value)
+        const { source } = facet
+        // Selection: column facets read their dedicated filter field; resource-attribute facets read
+        // their log_resource_attribute filter out of the group.
+        const selected =
+            source.type === 'resourceAttribute'
+                ? resourceAttributeValues(filterGroup, source.key)
+                : selectedByKey[source.filterKey]
+        // Counts/values + search are still keyed by FacetField (column facets only today); resource
+        // attribute facets get their own per-facet fetch in a follow-up.
+        const field: FacetField | null = source.type === 'column' ? source.column : null
+        const fetched = field ? valuesByField[field] : []
+        const onToggle = (value: string): void => toggleFacetValue(source, value)
         const onToggleCollapsed = (): void => toggleFacetCollapsed(facet.key)
         const collapsed = collapsedFacets.includes(facet.key)
 
@@ -83,7 +92,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                     options={options}
                     selected={selected}
                     onToggle={onToggle}
-                    loading={loadingByField[facet.facetField]}
+                    loading={field ? loadingByField[field] : false}
                     collapsed={collapsed}
                     onToggleCollapsed={onToggleCollapsed}
                     dimZeroCounts
@@ -99,10 +108,10 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 options={fetched}
                 selected={selected}
                 onToggle={onToggle}
-                loading={loadingByField[facet.facetField]}
+                loading={field ? loadingByField[field] : false}
                 emptyLabel={facet.emptyLabel}
-                searchValue={facet.searchable ? (facetSearch[facet.facetField] ?? '') : undefined}
-                onSearchChange={facet.searchable ? (value) => setFacetSearch(facet.facetField, value) : undefined}
+                searchValue={facet.searchable && field ? (facetSearch[field] ?? '') : undefined}
+                onSearchChange={facet.searchable && field ? (value) => setFacetSearch(field, value) : undefined}
                 searchPlaceholder={facet.searchPlaceholder}
                 collapsed={collapsed}
                 onToggleCollapsed={onToggleCollapsed}

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.test.ts
@@ -1,9 +1,15 @@
 import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
+import { UniversalFiltersGroup } from '~/types'
 
 import { logsViewerFiltersLogic } from '../Filters/logsViewerFiltersLogic'
 import { facetRailLogic } from './facetRailLogic'
+import { FacetSource, resourceAttributeValues } from './facets'
+
+const LEVEL_SOURCE: FacetSource = { type: 'column', column: 'severity_text', filterKey: 'severityLevels' }
+const SERVICE_SOURCE: FacetSource = { type: 'column', column: 'service_name', filterKey: 'serviceNames' }
+const NAMESPACE_SOURCE: FacetSource = { type: 'resourceAttribute', key: 'k8s.namespace.name' }
 
 describe('facetRailLogic', () => {
     let filtersLogic: ReturnType<typeof logsViewerFiltersLogic.build>
@@ -24,19 +30,13 @@ describe('facetRailLogic', () => {
 
     describe('severity level toggling', () => {
         it('adds, accumulates (OR), and removes levels on the shared filters logic', async () => {
-            await expectLogic(logic, () =>
-                logic.actions.toggleFacetValue('severityLevels', 'error')
-            ).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(LEVEL_SOURCE, 'error')).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['error'])
 
-            await expectLogic(logic, () =>
-                logic.actions.toggleFacetValue('severityLevels', 'warn')
-            ).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(LEVEL_SOURCE, 'warn')).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['error', 'warn'])
 
-            await expectLogic(logic, () =>
-                logic.actions.toggleFacetValue('severityLevels', 'error')
-            ).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(LEVEL_SOURCE, 'error')).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['warn'])
         })
 
@@ -44,12 +44,12 @@ describe('facetRailLogic', () => {
             'toggling %s on then off round-trips to empty',
             async (level) => {
                 await expectLogic(logic, () =>
-                    logic.actions.toggleFacetValue('severityLevels', level)
+                    logic.actions.toggleFacetValue(LEVEL_SOURCE, level)
                 ).toFinishAllListeners()
                 expect(filtersLogic.values.severityLevels).toEqual([level])
 
                 await expectLogic(logic, () =>
-                    logic.actions.toggleFacetValue('severityLevels', level)
+                    logic.actions.toggleFacetValue(LEVEL_SOURCE, level)
                 ).toFinishAllListeners()
                 expect(filtersLogic.values.severityLevels).toEqual([])
             }
@@ -72,10 +72,10 @@ describe('facetRailLogic', () => {
 
     describe('service name toggling', () => {
         it('adds then removes a service on the shared filters logic', async () => {
-            await expectLogic(logic, () => logic.actions.toggleFacetValue('serviceNames', 'api')).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(SERVICE_SOURCE, 'api')).toFinishAllListeners()
             expect(filtersLogic.values.serviceNames).toEqual(['api'])
 
-            await expectLogic(logic, () => logic.actions.toggleFacetValue('serviceNames', 'api')).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(SERVICE_SOURCE, 'api')).toFinishAllListeners()
             expect(filtersLogic.values.serviceNames).toEqual([])
         })
     })
@@ -85,10 +85,43 @@ describe('facetRailLogic', () => {
             filtersLogic.actions.setSeverityLevels(['info'])
             await expectLogic(filtersLogic).toFinishAllListeners()
 
-            await expectLogic(logic, () =>
-                logic.actions.toggleFacetValue('severityLevels', 'error')
-            ).toFinishAllListeners()
+            await expectLogic(logic, () => logic.actions.toggleFacetValue(LEVEL_SOURCE, 'error')).toFinishAllListeners()
             expect(filtersLogic.values.severityLevels).toEqual(['info', 'error'])
+        })
+    })
+
+    describe('resource attribute toggling', () => {
+        const read = (): string[] => resourceAttributeValues(filtersLogic.values.filterGroup, 'k8s.namespace.name')
+
+        it('adds, accumulates (OR), and removes values as a log_resource_attribute filter in the group', async () => {
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue(NAMESPACE_SOURCE, 'argocd')
+            ).toFinishAllListeners()
+            expect(read()).toEqual(['argocd'])
+
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue(NAMESPACE_SOURCE, 'kube-system')
+            ).toFinishAllListeners()
+            expect(read()).toEqual(['argocd', 'kube-system'])
+
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue(NAMESPACE_SOURCE, 'argocd')
+            ).toFinishAllListeners()
+            expect(read()).toEqual(['kube-system'])
+        })
+
+        it('removing the last value drops the filter from the group entirely', async () => {
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue(NAMESPACE_SOURCE, 'argocd')
+            ).toFinishAllListeners()
+            expect(read()).toEqual(['argocd'])
+
+            await expectLogic(logic, () =>
+                logic.actions.toggleFacetValue(NAMESPACE_SOURCE, 'argocd')
+            ).toFinishAllListeners()
+            expect(read()).toEqual([])
+            // the single inner group holds no filters once the last value is removed
+            expect((filtersLogic.values.filterGroup.values[0] as UniversalFiltersGroup).values).toEqual([])
         })
     })
 })

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
@@ -5,7 +5,7 @@ import { LogSeverityLevel } from '~/queries/schema/schema-general'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
 import type { facetRailLogicType } from './facetRailLogicType'
-import { FacetFilterKey } from './facets'
+import { FacetSource, toggleResourceAttributeFilter } from './facets'
 
 export interface FacetRailLogicProps {
     id: string
@@ -24,13 +24,13 @@ export const facetRailLogic = kea<facetRailLogicType>([
     key((props) => props.id),
 
     connect((props: FacetRailLogicProps) => ({
-        actions: [logsViewerFiltersLogic({ id: props.id }), ['setSeverityLevels', 'setServiceNames']],
+        actions: [logsViewerFiltersLogic({ id: props.id }), ['setSeverityLevels', 'setServiceNames', 'setFilterGroup']],
     })),
 
     actions({
         // Generic toggle: the rail is config-driven, so a single action writes a value into whichever
-        // filter field the facet maps to (see FacetConfig.filterKey).
-        toggleFacetValue: (filterKey: FacetFilterKey, value: string) => ({ filterKey, value }),
+        // filter field/group the facet's source maps to (see FacetConfig.source).
+        toggleFacetValue: (source: FacetSource, value: string) => ({ source, value }),
         toggleFacetCollapsed: (facetKey: string) => ({ facetKey }),
     }),
 
@@ -46,15 +46,18 @@ export const facetRailLogic = kea<facetRailLogicType>([
     }),
 
     listeners(({ props, actions }) => ({
-        toggleFacetValue: ({ filterKey, value }) => {
-            const { severityLevels, serviceNames } = logsViewerFiltersLogic({ id: props.id }).values
-            if (filterKey === 'severityLevels') {
+        toggleFacetValue: ({ source, value }) => {
+            const { severityLevels, serviceNames, filterGroup } = logsViewerFiltersLogic({ id: props.id }).values
+            if (source.type === 'resourceAttribute') {
+                // Selection lives as a log_resource_attribute filter inside the group.
+                actions.setFilterGroup(toggleResourceAttributeFilter(filterGroup, source.key, value), false)
+            } else if (source.filterKey === 'severityLevels') {
                 actions.setSeverityLevels(toggleMembership(severityLevels, value as LogSeverityLevel))
-            } else if (filterKey === 'serviceNames') {
+            } else if (source.filterKey === 'serviceNames') {
                 actions.setServiceNames(toggleMembership(serviceNames, value))
             } else {
-                // Adding a new FacetFilterKey without wiring its setter here is a compile error.
-                filterKey satisfies never
+                // Adding a new column filterKey without wiring its setter here is a compile error.
+                source.filterKey satisfies never
             }
         },
     })),

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
@@ -1,3 +1,11 @@
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyFilterValue,
+    PropertyOperator,
+    UniversalFiltersGroup,
+} from '~/types'
+
 import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 
 import { FacetOption } from './Facet'
@@ -12,11 +20,22 @@ import { FacetOption } from './Facet'
  */
 export type FacetKind = 'fixed' | 'dynamic'
 
-/** The `logsViewerFiltersLogic` field a facet's selection is written to. */
+/** The `logsViewerFiltersLogic` field a column facet's selection is written to. */
 export type FacetFilterKey = 'severityLevels' | 'serviceNames'
 
-/** The ClickHouse column a facet's values + counts are computed over (matches the backend FACET_FIELDS). */
+/** The ClickHouse column a column facet's values + counts are computed over (matches backend FACET_FIELDS). */
 export type FacetField = 'severity_text' | 'service_name'
+
+/**
+ * Where a facet's field lives, which determines both how it's queried and how its selection is stored.
+ *
+ * - `column`: a top-level logs column. Selection lives in a dedicated filter field (severityLevels/serviceNames).
+ * - `resourceAttribute`: a `resource_attributes` map key (e.g. k8s.namespace.name). No dedicated field —
+ *   selection is stored as a `log_resource_attribute` property filter inside the filterGroup.
+ */
+export type FacetSource =
+    | { type: 'column'; column: FacetField; filterKey: FacetFilterKey }
+    | { type: 'resourceAttribute'; key: string }
 
 export interface FacetConfig {
     /** Stable id used for collapse state and data-attrs. */
@@ -26,8 +45,7 @@ export interface FacetConfig {
     /** Header the facet is grouped under in the rail (e.g. "Standard"). */
     group: string
     kind: FacetKind
-    filterKey: FacetFilterKey
-    facetField: FacetField
+    source: FacetSource
     /** Required for `fixed` facets: the closed value set, with labels + colors. */
     fixedOptions?: FacetOption[]
     /** Renders a search box and virtualizes the list — for `dynamic` facets with many values. */
@@ -36,6 +54,55 @@ export interface FacetConfig {
     emptyLabel?: string
     /** Max pixel height before the value list virtualizes and scrolls. */
     maxHeight?: number
+}
+
+interface LogResourceAttributeFilter {
+    key: string
+    type: PropertyFilterType.LogResourceAttribute
+    operator: PropertyOperator
+    value?: PropertyFilterValue
+}
+
+// The logs filterGroup is always { AND, values: [{ AND, values: [<property filters>] }] } — the
+// editable property filters live in the single inner group.
+function innerFilters(group: UniversalFiltersGroup | undefined): LogResourceAttributeFilter[] {
+    return ((group?.values?.[0] as UniversalFiltersGroup | undefined)?.values ?? []) as LogResourceAttributeFilter[]
+}
+
+function isResourceAttributeFilter(filter: LogResourceAttributeFilter, key: string): boolean {
+    return filter?.type === PropertyFilterType.LogResourceAttribute && filter?.key === key
+}
+
+/** Values currently selected for a resource-attribute facet, read from the log_resource_attribute filter. */
+export function resourceAttributeValues(group: UniversalFiltersGroup | undefined, key: string): string[] {
+    const existing = innerFilters(group).find((f) => isResourceAttributeFilter(f, key))
+    const value = existing?.value
+    if (Array.isArray(value)) {
+        return value as string[]
+    }
+    return value != null && value !== '' ? [String(value)] : []
+}
+
+/**
+ * Add or remove `value` from a resource-attribute facet's selection, returning a new filterGroup.
+ * Multi-select is one log_resource_attribute filter per key with an array value (logs have no `in` operator).
+ */
+export function toggleResourceAttributeFilter(
+    group: UniversalFiltersGroup | undefined,
+    key: string,
+    value: string
+): UniversalFiltersGroup {
+    const current = resourceAttributeValues(group, key)
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value]
+    const others = innerFilters(group).filter((f) => !isResourceAttributeFilter(f, key))
+    const values: LogResourceAttributeFilter[] =
+        next.length > 0
+            ? [
+                  ...others,
+                  { key, type: PropertyFilterType.LogResourceAttribute, operator: PropertyOperator.Exact, value: next },
+              ]
+            : others
+    return { type: FilterLogicalOperator.And, values: [{ type: FilterLogicalOperator.And, values }] }
 }
 
 // Colors mirror the severity bar in the log rows (SEVERITY_BAR_COLORS) so the rail matches the viewer.
@@ -55,8 +122,7 @@ const LEVEL_FACET: FacetConfig = {
     title: 'Level',
     group: 'Standard',
     kind: 'fixed',
-    filterKey: 'severityLevels',
-    facetField: 'severity_text',
+    source: { type: 'column', column: 'severity_text', filterKey: 'severityLevels' },
     fixedOptions: SEVERITY_OPTIONS,
 }
 
@@ -65,8 +131,7 @@ const SERVICE_FACET: FacetConfig = {
     title: 'Service',
     group: 'Standard',
     kind: 'dynamic',
-    filterKey: 'serviceNames',
-    facetField: 'service_name',
+    source: { type: 'column', column: 'service_name', filterKey: 'serviceNames' },
     searchable: true,
     searchPlaceholder: 'Search services…',
     emptyLabel: 'No services',


### PR DESCRIPTION
## Problem

The facet rail previously only supported "column" facets — fields like `severity_text` and `service_name` that map directly to top-level ClickHouse columns and have dedicated filter fields (`severityLevels`, `serviceNames`). There was no way to add facets backed by `resource_attributes` map keys (e.g. `k8s.namespace.name`), which need to store their selection as `log_resource_attribute` property filters inside the `filterGroup` rather than in a dedicated field.

## Changes

Introduces a `FacetSource` discriminated union to `FacetConfig` that replaces the flat `filterKey` + `facetField` pair:

- `{ type: 'column', column: FacetField, filterKey: FacetFilterKey }` — existing behaviour, unchanged.
- `{ type: 'resourceAttribute', key: string }` — new type; selection is stored as a `log_resource_attribute` filter inside the `filterGroup`.

Two new helpers in `facets.ts` manage the `filterGroup` shape for resource-attribute facets:
- `resourceAttributeValues(group, key)` — reads the current selected values for a given attribute key.
- `toggleResourceAttributeFilter(group, key, value)` — adds or removes a value, returning a new `filterGroup`.

`toggleFacetValue` in `facetRailLogic` now accepts a `FacetSource` instead of a `FacetFilterKey`, and dispatches to either the existing `setSeverityLevels`/`setServiceNames` actions or the new `setFilterGroup` action depending on the source type. The exhaustiveness check (`satisfies never`) is preserved for column sources.

The `FacetRail` component reads selection state via `resourceAttributeValues` for resource-attribute facets and falls back gracefully (no loading state, no search) since per-facet value fetching for resource attributes is deferred to a follow-up.

## How did you test this code?

Existing unit tests in `facetRailLogic.test.ts` were updated to pass `FacetSource` objects instead of raw filter key strings. A new test suite covers resource-attribute toggling: add, accumulate (OR), and remove values, verifying the `filterGroup` state via `resourceAttributeValues`.

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The core design decision was replacing the flat `filterKey`/`facetField` pair with a `FacetSource` discriminated union, which keeps the exhaustiveness check intact for column facets while opening the door for resource-attribute facets without requiring a new dedicated filter field per attribute. The `filterGroup` nesting convention (outer AND wrapping a single inner AND containing property filters) was preserved as-is. Per-facet value fetching for resource-attribute facets was intentionally deferred.