### PR TITLE
fix(endpoints): classify ClickHouse query-cost failures separately from system errors

### DIFF
--- a/products/endpoints/backend/exceptions.py
+++ b/products/endpoints/backend/exceptions.py
@@ -1,0 +1,30 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class EndpointQueryTooExpensive(APIException):
+    """A customer query hit a ClickHouse cost guardrail (execution time, memory, or size).
+
+    Deterministic: the query keeps failing until the customer narrows its scope or
+    materializes the endpoint, so we answer 400 (rather than a 5xx that invites blind
+    retries) with an actionable `code` the client can branch on.
+    """
+
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "query_performance_limit"
+    default_detail = "This query is too expensive to run inline. Narrow its scope or materialize the endpoint."
+
+
+class EndpointAtCapacity(APIException):
+    """The shared ClickHouse query pool was momentarily at capacity.
+
+    Transient and retryable, but materializing moves the endpoint onto dedicated endpoint
+    compute that isn't affected by shared-pool load — so we recommend it as the durable fix.
+    """
+
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_code = "query_capacity"
+    default_detail = (
+        "Queries are momentarily at capacity — please retry shortly. For consistently heavy "
+        "endpoints, materialize to run on dedicated endpoint compute that isn't affected by shared query load."
+    )

--- a/products/endpoints/backend/exceptions.py
+++ b/products/endpoints/backend/exceptions.py
@@ -3,12 +3,7 @@ from rest_framework.exceptions import APIException
 
 
 class EndpointQueryTooExpensive(APIException):
-    """A customer query hit a ClickHouse cost guardrail (execution time, memory, or size).
-
-    Deterministic: the query keeps failing until the customer narrows its scope or
-    materializes the endpoint, so we answer 400 (rather than a 5xx that invites blind
-    retries) with an actionable `code` the client can branch on.
-    """
+    """A customer query hit a ClickHouse cost guardrail — deterministic, so 400 (not a retry-inviting 5xx)."""
 
     status_code = status.HTTP_400_BAD_REQUEST
     default_code = "query_performance_limit"
@@ -16,11 +11,7 @@ class EndpointQueryTooExpensive(APIException):
 
 
 class EndpointAtCapacity(APIException):
-    """The shared ClickHouse query pool was momentarily at capacity.
-
-    Transient and retryable, but materializing moves the endpoint onto dedicated endpoint
-    compute that isn't affected by shared-pool load — so we recommend it as the durable fix.
-    """
+    """Shared ClickHouse pool momentarily at capacity — transient; materializing gives isolated compute."""
 
     status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     default_code = "query_capacity"

--- a/products/endpoints/backend/metrics.py
+++ b/products/endpoints/backend/metrics.py
@@ -10,7 +10,10 @@ def query_kind_label(query: dict | None) -> str:
 ENDPOINT_EXECUTION_TOTAL = Counter(
     "posthog_endpoint_execution_total",
     "Endpoint executions that reached query execution (excludes concurrency rejections; see posthog_endpoint_concurrency_rejected_total). "
-    "status is success, user_error (invalid query/variables in the user's endpoint, returned as 4xx), or error (unexpected system failure)",
+    "status is success; user_error (invalid query/variables in the user's endpoint, returned as 4xx); "
+    "query_performance (the query hit a ClickHouse cost guardrail — timeout/memory/size/estimated-too-slow — returned as 400); "
+    "capacity (shared ClickHouse pool momentarily saturated, returned as 503); "
+    'or error (unexpected system failure). Only error is a system fault — alert on status="error"',
     labelnames=["execution_type", "query_kind", "status"],
 )
 

--- a/products/endpoints/backend/openapi.py
+++ b/products/endpoints/backend/openapi.py
@@ -82,9 +82,25 @@ def generate_openapi_spec(
                                 }
                             },
                         },
-                        "400": {"description": "Invalid request"},
+                        "400": {
+                            "description": (
+                                "Invalid request, or the query is too expensive to run inline. "
+                                "Query-cost failures carry a stable `code`: `query_timeout`, "
+                                "`query_memory_limit`, `query_too_large`, or `query_estimated_too_slow` — "
+                                "narrow the query's scope (e.g. a smaller date range) or materialize the endpoint."
+                            ),
+                            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}},
+                        },
                         "401": {"description": "Authentication required"},
                         "404": {"description": "Endpoint not found"},
+                        "503": {
+                            "description": (
+                                "The shared ClickHouse query pool is momentarily at capacity (`code`: "
+                                "`query_capacity`). Retry shortly; materialize the endpoint to run on dedicated "
+                                "compute that isn't affected by shared query load."
+                            ),
+                            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}},
+                        },
                     },
                 }
             }
@@ -108,6 +124,24 @@ def _build_component_schemas(endpoint: Endpoint, version: EndpointVersion, team_
     is_materialized = bool(version and version.is_materialized and version.saved_query)
 
     schemas: dict = {
+        "Error": {
+            "type": "object",
+            "description": "Error response body.",
+            "properties": {
+                "type": {"type": "string", "description": "Error category, e.g. 'validation_error'."},
+                "code": {
+                    "type": "string",
+                    "description": "Stable machine-readable error code, e.g. 'query_timeout' or 'query_capacity'.",
+                },
+                "detail": {"type": "string", "description": "Human-readable explanation and remediation."},
+                "attr": {
+                    "type": "string",
+                    "nullable": True,
+                    "description": "The request field that caused the error, when applicable.",
+                },
+            },
+            "required": ["type", "code", "detail"],
+        },
         "EndpointRunRequest": {
             "type": "object",
             "properties": {

--- a/products/endpoints/backend/openapi.py
+++ b/products/endpoints/backend/openapi.py
@@ -128,10 +128,13 @@ def _build_component_schemas(endpoint: Endpoint, version: EndpointVersion, team_
             "type": "object",
             "description": "Error response body.",
             "properties": {
-                "type": {"type": "string", "description": "Error category, e.g. 'validation_error'."},
+                "type": {
+                    "type": "string",
+                    "description": "Coarse error category (e.g. 'validation_error', 'server_error'). Branch on `code`, not `type`.",
+                },
                 "code": {
                     "type": "string",
-                    "description": "Stable machine-readable error code, e.g. 'query_timeout' or 'query_capacity'.",
+                    "description": "Stable machine-readable error code to branch on, e.g. 'query_timeout' or 'query_capacity'.",
                 },
                 "detail": {"type": "string", "description": "Human-readable explanation and remediation."},
                 "attr": {

--- a/products/endpoints/backend/services/execution.py
+++ b/products/endpoints/backend/services/execution.py
@@ -54,6 +54,13 @@ from posthog.clickhouse.query_tagging import (
 from posthog.ducklake.common import get_duckgres_server_for_organization
 from posthog.errors import ExposedCHQueryError
 from posthog.event_usage import get_request_analytics_properties, report_user_action
+from posthog.exceptions import (
+    ClickHouseAtCapacity,
+    ClickHouseEstimatedQueryExecutionTimeTooLong,
+    ClickHouseQueryMemoryLimitExceeded,
+    ClickHouseQuerySizeExceeded,
+    ClickHouseQueryTimeOut,
+)
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
 from posthog.permissions import is_authenticated_via_project_secret_api_key
@@ -61,6 +68,7 @@ from posthog.synthetic_user import SyntheticUser
 
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.data_load.saved_query_service import trigger_saved_query_schedule
+from products.endpoints.backend.exceptions import EndpointAtCapacity, EndpointQueryTooExpensive
 from products.endpoints.backend.insight_transformers import MaterializedSeriesMismatchError
 from products.endpoints.backend.logs import build_execution_message, log_endpoint_execution
 from products.endpoints.backend.metrics import (
@@ -85,6 +93,40 @@ logger = structlog.get_logger(__name__)
 LAST_EXECUTED_THROTTLE = timedelta(minutes=30)
 
 ExecutionType = Literal["materialized", "materialized_fallback", "inline", "ducklake", "ducklake_fallback"]
+
+# ClickHouse cost guardrails. These are deterministic, customer-caused query-performance
+# failures (the query won't succeed until its scope shrinks or the endpoint is materialized),
+# not PostHog system faults — so they get their own metric status and an actionable 400
+# (code + remediation) instead of falling through to status="error" and paging on-call.
+# Each maps the wrapped CH exception to a stable client-facing `code` and message.
+_QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
+    ClickHouseQueryTimeOut: (
+        "query_timeout",
+        "This query exceeded the execution time limit. Narrow its scope (e.g. a smaller date range) "
+        "or materialize the endpoint for dedicated compute. See https://posthog.com/docs/api/endpoints.",
+    ),
+    ClickHouseQueryMemoryLimitExceeded: (
+        "query_memory_limit",
+        "This query exceeded the memory limit. Narrow its scope (e.g. a smaller date range) "
+        "or materialize the endpoint. See https://posthog.com/docs/api/endpoints.",
+    ),
+    ClickHouseQuerySizeExceeded: (
+        "query_too_large",
+        "The query text is too large to execute. Simplify the query or materialize the endpoint. "
+        "See https://posthog.com/docs/api/endpoints.",
+    ),
+    ClickHouseEstimatedQueryExecutionTimeTooLong: (
+        "query_estimated_too_slow",
+        "This query is estimated to run too long. Reduce its scope by narrowing the time range "
+        "or materialize the endpoint. See https://posthog.com/docs/api/endpoints.",
+    ),
+}
+
+
+def _is_query_capacity_error(error: BaseException) -> bool:
+    """True for ClickHouse cost-guardrail and capacity errors — customer query-performance
+    problems, not system faults, so they skip error-tracking capture and failure signals."""
+    return isinstance(error, (*_QUERY_PERFORMANCE_ERRORS, ClickHouseAtCapacity))
 
 
 def _emit_endpoint_failure_signal(
@@ -499,6 +541,17 @@ class EndpointExecutionService(PydanticModelMixin):
         except ConcurrencyLimitExceeded:
             ENDPOINT_CONCURRENCY_REJECTED_TOTAL.labels(team_id=str(self.team.pk)).inc()
             raise Throttled(detail="Too many concurrent requests. Please try again later.")
+        except tuple(_QUERY_PERFORMANCE_ERRORS) as e:
+            execution_status = "query_performance"
+            error_label = type(e).__name__
+            code, detail = _QUERY_PERFORMANCE_ERRORS[type(e)]
+            logger.warning("Endpoint query hit a performance limit", endpoint_name=endpoint.name, reason=error_label)
+            raise EndpointQueryTooExpensive(detail, code=code)
+        except ClickHouseAtCapacity:
+            execution_status = "capacity"
+            error_label = "ClickHouseAtCapacity"
+            logger.warning("Endpoint query hit shared ClickHouse capacity", endpoint_name=endpoint.name)
+            raise EndpointAtCapacity()
         except Exception as e:
             execution_status = "error"
             error_label = type(e).__name__
@@ -709,6 +762,15 @@ class EndpointExecutionService(PydanticModelMixin):
 
             return result
         except Exception as e:
+            # Query cost/capacity guardrails are customer-caused, not system faults: skip
+            # error-tracking capture and the failure signal, and let execute() classify them.
+            if _is_query_capacity_error(e):
+                logger.warning(
+                    "Materialized endpoint query hit a performance/capacity limit",
+                    endpoint_name=endpoint.name,
+                    reason=type(e).__name__,
+                )
+                raise
             logger.exception(
                 "Materialized endpoint execution failed",
                 endpoint_name=endpoint.name,
@@ -814,6 +876,15 @@ class EndpointExecutionService(PydanticModelMixin):
 
         except Exception as e:
             self.handle_column_ch_error(e)
+            # Query cost/capacity guardrails are customer-caused, not system faults: skip
+            # error-tracking capture and the failure signal, and let execute() classify them.
+            if _is_query_capacity_error(e):
+                logger.warning(
+                    "Inline endpoint query hit a performance/capacity limit",
+                    endpoint_name=endpoint.name,
+                    reason=type(e).__name__,
+                )
+                raise
             logger.exception(
                 "Inline endpoint execution failed",
                 endpoint_name=endpoint.name,

--- a/products/endpoints/backend/services/execution.py
+++ b/products/endpoints/backend/services/execution.py
@@ -100,22 +100,22 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ClickHouseQueryTimeOut: (
         "query_timeout",
         "This query exceeded the execution time limit. Narrow its scope (e.g. a smaller date range) "
-        "or materialize the endpoint for dedicated compute. See https://posthog.com/docs/api/endpoints.",
+        "or materialize the endpoint for dedicated compute.",
     ),
     ClickHouseQueryMemoryLimitExceeded: (
         "query_memory_limit",
         "This query exceeded the memory limit. Narrow its scope (e.g. a smaller date range) "
-        "or materialize the endpoint. See https://posthog.com/docs/api/endpoints.",
+        "or materialize the endpoint.",
     ),
     ClickHouseQuerySizeExceeded: (
         "query_too_large",
         # No materialize hint: it re-parses the same SQL, so it can't shrink an oversized query.
-        "The query text is too large to execute. Simplify the query. See https://posthog.com/docs/api/endpoints.",
+        "The query text is too large to execute. Simplify the query.",
     ),
     ClickHouseEstimatedQueryExecutionTimeTooLong: (
         "query_estimated_too_slow",
         "This query is estimated to run too long. Reduce its scope by narrowing the time range "
-        "or materialize the endpoint. See https://posthog.com/docs/api/endpoints.",
+        "or materialize the endpoint.",
     ),
 }
 

--- a/products/endpoints/backend/services/execution.py
+++ b/products/endpoints/backend/services/execution.py
@@ -112,8 +112,9 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ),
     ClickHouseQuerySizeExceeded: (
         "query_too_large",
-        "The query text is too large to execute. Simplify the query or materialize the endpoint. "
-        "See https://posthog.com/docs/api/endpoints.",
+        # Materialization re-parses the same SQL text, so it doesn't help an oversized query —
+        # simplification is the only fix here, unlike the time/memory guardrails below.
+        "The query text is too large to execute. Simplify the query. See https://posthog.com/docs/api/endpoints.",
     ),
     ClickHouseEstimatedQueryExecutionTimeTooLong: (
         "query_estimated_too_slow",
@@ -122,11 +123,25 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ),
 }
 
+# Single source of truth for "customer query-performance problem, not a system fault": the
+# deterministic cost guardrails plus the transient shared-pool capacity error. Used both to
+# skip error-tracking capture and to re-raise past the materialized/ducklake inline fallback.
+_QUERY_GUARDRAIL_ERRORS: tuple[type[Exception], ...] = (*_QUERY_PERFORMANCE_ERRORS, ClickHouseAtCapacity)
 
-def _is_query_capacity_error(error: BaseException) -> bool:
+
+def _is_query_guardrail_error(error: BaseException) -> bool:
     """True for ClickHouse cost-guardrail and capacity errors — customer query-performance
     problems, not system faults, so they skip error-tracking capture and failure signals."""
-    return isinstance(error, (*_QUERY_PERFORMANCE_ERRORS, ClickHouseAtCapacity))
+    return isinstance(error, _QUERY_GUARDRAIL_ERRORS)
+
+
+def _query_performance_code_and_detail(error: BaseException) -> tuple[str, str]:
+    """Resolve the client-facing code + message for a cost-guardrail error by isinstance, so a
+    future exception subclass caught by the handler can't KeyError into an unhandled 500."""
+    for exc_type, code_and_detail in _QUERY_PERFORMANCE_ERRORS.items():
+        if isinstance(error, exc_type):
+            return code_and_detail
+    raise error  # not a known cost guardrail — let the caller's generic handling take it
 
 
 def _emit_endpoint_failure_signal(
@@ -481,7 +496,12 @@ class EndpointExecutionService(PydanticModelMixin):
                     )
                 except ConcurrencyLimitExceeded:
                     raise
-                except Exception:
+                except Exception as e:
+                    # A query-cost/capacity trip won't be fixed by re-running the (heavier) original
+                    # query inline — and retrying amplifies load exactly when the cluster is saturated.
+                    # Let execute()'s guardrail handlers classify it instead of falling back.
+                    if _is_query_guardrail_error(e):
+                        raise
                     # Already logged/captured/signaled inside the materialized path. Serve the
                     # request from the original query instead of failing — stale tables and
                     # series drift self-heal on the next materialization run.
@@ -493,7 +513,11 @@ class EndpointExecutionService(PydanticModelMixin):
                         endpoint, data, version_obj, version_obj.query.copy(), debug=debug
                     )
                     execution_type = "ducklake"
-                except Exception:
+                except Exception as e:
+                    # As with the materialized path: a cost/capacity guardrail trip shouldn't fall
+                    # back to a heavier inline retry — let execute() classify it.
+                    if _is_query_guardrail_error(e):
+                        raise
                     logger.warning(
                         "DuckLake execution failed, falling back to inline",
                         endpoint_name=endpoint.name,
@@ -544,7 +568,7 @@ class EndpointExecutionService(PydanticModelMixin):
         except tuple(_QUERY_PERFORMANCE_ERRORS) as e:
             execution_status = "query_performance"
             error_label = type(e).__name__
-            code, detail = _QUERY_PERFORMANCE_ERRORS[type(e)]
+            code, detail = _query_performance_code_and_detail(e)
             logger.warning("Endpoint query hit a performance limit", endpoint_name=endpoint.name, reason=error_label)
             raise EndpointQueryTooExpensive(detail, code=code)
         except ClickHouseAtCapacity:
@@ -764,7 +788,7 @@ class EndpointExecutionService(PydanticModelMixin):
         except Exception as e:
             # Query cost/capacity guardrails are customer-caused, not system faults: skip
             # error-tracking capture and the failure signal, and let execute() classify them.
-            if _is_query_capacity_error(e):
+            if _is_query_guardrail_error(e):
                 logger.warning(
                     "Materialized endpoint query hit a performance/capacity limit",
                     endpoint_name=endpoint.name,
@@ -878,7 +902,7 @@ class EndpointExecutionService(PydanticModelMixin):
             self.handle_column_ch_error(e)
             # Query cost/capacity guardrails are customer-caused, not system faults: skip
             # error-tracking capture and the failure signal, and let execute() classify them.
-            if _is_query_capacity_error(e):
+            if _is_query_guardrail_error(e):
                 logger.warning(
                     "Inline endpoint query hit a performance/capacity limit",
                     endpoint_name=endpoint.name,

--- a/products/endpoints/backend/services/execution.py
+++ b/products/endpoints/backend/services/execution.py
@@ -94,11 +94,8 @@ LAST_EXECUTED_THROTTLE = timedelta(minutes=30)
 
 ExecutionType = Literal["materialized", "materialized_fallback", "inline", "ducklake", "ducklake_fallback"]
 
-# ClickHouse cost guardrails. These are deterministic, customer-caused query-performance
-# failures (the query won't succeed until its scope shrinks or the endpoint is materialized),
-# not PostHog system faults — so they get their own metric status and an actionable 400
-# (code + remediation) instead of falling through to status="error" and paging on-call.
-# Each maps the wrapped CH exception to a stable client-facing `code` and message.
+# Deterministic, customer-caused ClickHouse cost guardrails → stable client `code` + remediation.
+# Kept out of status="error" so they don't page on-call; surfaced as an actionable 400.
 _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ClickHouseQueryTimeOut: (
         "query_timeout",
@@ -112,8 +109,7 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ),
     ClickHouseQuerySizeExceeded: (
         "query_too_large",
-        # Materialization re-parses the same SQL text, so it doesn't help an oversized query —
-        # simplification is the only fix here, unlike the time/memory guardrails below.
+        # No materialize hint: it re-parses the same SQL, so it can't shrink an oversized query.
         "The query text is too large to execute. Simplify the query. See https://posthog.com/docs/api/endpoints.",
     ),
     ClickHouseEstimatedQueryExecutionTimeTooLong: (
@@ -123,25 +119,21 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ),
 }
 
-# Single source of truth for "customer query-performance problem, not a system fault": the
-# deterministic cost guardrails plus the transient shared-pool capacity error. Used both to
-# skip error-tracking capture and to re-raise past the materialized/ducklake inline fallback.
+# Cost guardrails + transient capacity: customer problems, not faults. Skipped from capture and
+# re-raised past the materialized/ducklake inline fallback.
 _QUERY_GUARDRAIL_ERRORS: tuple[type[Exception], ...] = (*_QUERY_PERFORMANCE_ERRORS, ClickHouseAtCapacity)
 
 
 def _is_query_guardrail_error(error: BaseException) -> bool:
-    """True for ClickHouse cost-guardrail and capacity errors — customer query-performance
-    problems, not system faults, so they skip error-tracking capture and failure signals."""
     return isinstance(error, _QUERY_GUARDRAIL_ERRORS)
 
 
 def _query_performance_code_and_detail(error: BaseException) -> tuple[str, str]:
-    """Resolve the client-facing code + message for a cost-guardrail error by isinstance, so a
-    future exception subclass caught by the handler can't KeyError into an unhandled 500."""
+    # isinstance, not dict[type(e)], so a future subclass can't KeyError into a 500.
     for exc_type, code_and_detail in _QUERY_PERFORMANCE_ERRORS.items():
         if isinstance(error, exc_type):
             return code_and_detail
-    raise error  # not a known cost guardrail — let the caller's generic handling take it
+    raise error
 
 
 def _emit_endpoint_failure_signal(
@@ -497,9 +489,7 @@ class EndpointExecutionService(PydanticModelMixin):
                 except ConcurrencyLimitExceeded:
                     raise
                 except Exception as e:
-                    # A query-cost/capacity trip won't be fixed by re-running the (heavier) original
-                    # query inline — and retrying amplifies load exactly when the cluster is saturated.
-                    # Let execute()'s guardrail handlers classify it instead of falling back.
+                    # Don't fall back to a heavier inline retry on a guardrail trip — execute() classifies it.
                     if _is_query_guardrail_error(e):
                         raise
                     # Already logged/captured/signaled inside the materialized path. Serve the
@@ -514,8 +504,7 @@ class EndpointExecutionService(PydanticModelMixin):
                     )
                     execution_type = "ducklake"
                 except Exception as e:
-                    # As with the materialized path: a cost/capacity guardrail trip shouldn't fall
-                    # back to a heavier inline retry — let execute() classify it.
+                    # Same as the materialized path: a guardrail trip shouldn't fall back to inline.
                     if _is_query_guardrail_error(e):
                         raise
                     logger.warning(
@@ -589,7 +578,7 @@ class EndpointExecutionService(PydanticModelMixin):
                 ENDPOINT_EXECUTION_TOTAL.labels(
                     execution_type=execution_type, query_kind=query_kind_metric, status=execution_status
                 ).inc()
-            if execution_status in ("error", "user_error"):
+            if execution_status in ("error", "user_error", "query_performance", "capacity"):
                 log_endpoint_execution(
                     team_id=self.team.pk,
                     endpoint_id=str(endpoint.id),
@@ -786,14 +775,8 @@ class EndpointExecutionService(PydanticModelMixin):
 
             return result
         except Exception as e:
-            # Query cost/capacity guardrails are customer-caused, not system faults: skip
-            # error-tracking capture and the failure signal, and let execute() classify them.
+            # Guardrail errors are customer-caused, not faults: skip capture and let execute() classify them.
             if _is_query_guardrail_error(e):
-                logger.warning(
-                    "Materialized endpoint query hit a performance/capacity limit",
-                    endpoint_name=endpoint.name,
-                    reason=type(e).__name__,
-                )
                 raise
             logger.exception(
                 "Materialized endpoint execution failed",
@@ -900,14 +883,8 @@ class EndpointExecutionService(PydanticModelMixin):
 
         except Exception as e:
             self.handle_column_ch_error(e)
-            # Query cost/capacity guardrails are customer-caused, not system faults: skip
-            # error-tracking capture and the failure signal, and let execute() classify them.
+            # Guardrail errors are customer-caused, not faults: skip capture and let execute() classify them.
             if _is_query_guardrail_error(e):
-                logger.warning(
-                    "Inline endpoint query hit a performance/capacity limit",
-                    endpoint_name=endpoint.name,
-                    reason=type(e).__name__,
-                )
                 raise
             logger.exception(
                 "Inline endpoint execution failed",

--- a/products/endpoints/backend/services/execution.py
+++ b/products/endpoints/backend/services/execution.py
@@ -488,10 +488,7 @@ class EndpointExecutionService(PydanticModelMixin):
                     )
                 except ConcurrencyLimitExceeded:
                     raise
-                except Exception as e:
-                    # Don't fall back to a heavier inline retry on a guardrail trip — execute() classifies it.
-                    if _is_query_guardrail_error(e):
-                        raise
+                except Exception:
                     # Already logged/captured/signaled inside the materialized path. Serve the
                     # request from the original query instead of failing — stale tables and
                     # series drift self-heal on the next materialization run.
@@ -503,10 +500,7 @@ class EndpointExecutionService(PydanticModelMixin):
                         endpoint, data, version_obj, version_obj.query.copy(), debug=debug
                     )
                     execution_type = "ducklake"
-                except Exception as e:
-                    # Same as the materialized path: a guardrail trip shouldn't fall back to inline.
-                    if _is_query_guardrail_error(e):
-                        raise
+                except Exception:
                     logger.warning(
                         "DuckLake execution failed, falling back to inline",
                         endpoint_name=endpoint.name,


### PR DESCRIPTION
## Problem

Endpoint execution emits a Prometheus counter labelled `status`, and our alerting treats `status="error"` as "unexpected PostHog system fault" — deliberately excluding `status="user_error"` (customer query mistakes) so on-call isn't paged for things they can't action.

That split has a hole. When a customer's query hits a ClickHouse guardrail — execution-time limit, memory limit, query-text size, or the estimated-time cap — `wrap_clickhouse_query_error` turns it into a `ClickHouse*` exception that subclasses DRF `APIException` (to hide internals), **not** `ExposedCHQueryError`. The endpoint execution service only maps `ExposedHogQLError`/`ExposedCHQueryError` to `user_error`, so these guardrail failures fall through to the catch-all and get counted as `status="error"`. The same happens for transient shared-pool capacity errors.

Net effect: a too-slow customer query (the kind whose fix is "narrow the query or materialize the endpoint") inflates the endpoint execution error rate and pages the owning team — exactly the false positive the alert was built to avoid. The customer also gets an inconsistent response (a 5xx that reads like our fault, or a bare 500 for the query-size case).

## Changes

- New execution statuses on the endpoint execution counter: `query_performance` (deterministic query-cost guardrails: timeout, memory, size, estimated-too-slow) and `capacity` (transient shared-pool). These are excluded from the `status="error"` numerator, so they no longer page, while still counting toward the denominator — the error rate gets *more* accurate, no alert-config change needed.
- These failures no longer hit `capture_exception` / the failure signal — they're customer-caused, not faults, so they stop polluting error tracking.
- The caller now gets an actionable response instead of a bare 5xx:
  - **400** with a stable, machine-readable `code` (`query_timeout`, `query_memory_limit`, `query_too_large`, `query_estimated_too_slow`) and a message telling them to narrow the query's scope or materialize the endpoint.
  - **503** for capacity that also recommends materializing — materialized endpoints serve from dedicated endpoint compute that isn't affected by shared-pool load, so it's the durable fix, not just "retry later".
- The generated per-endpoint OpenAPI spec documents both responses plus a reusable `Error` schema, so generated SDK clients can branch on the code.

## How did you test this code?

I'm an agent (Claude Code). Automated only — I did not perform manual testing:

- `products/endpoints/backend/tests/test_endpoint_execution.py` — 83 passed (regression check; the new `except` branches sit ahead of the existing catch-all).
- `products/endpoints/backend/tests/test_openapi_spec.py` — 12 passed (the spec additions are additive).
- `ruff check` / `ruff format` clean on all three changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a consistently-firing endpoint execution error-rate alert with Claude Code, using the Grafana MCP (Prometheus alert-expression evaluation) and PostHog's own logs (`query-logs`) to confirm the firing `status="error"` volume was dominated by ClickHouse query timeouts on a couple of heavy unmaterialised endpoints — i.e. customer query-performance problems, not system faults. Traced the misclassification to the `APIException`-vs-`ExposedCHQueryError` split in `wrap_clickhouse_query_error`.

Design decisions made with the human in the loop: split into two metric categories (deterministic cost vs transient capacity) rather than one; return a 400 (query won't succeed on blind retry) rather than keeping the existing 504/512; and surface materialisation as the remediation in **both** the cost and capacity messages, since materialised serving runs on isolated compute.

No new test was added at the human's request; existing suites cover regression. No skills were invoked for the code itself.
