### PR TITLE
feat(data-warehouse): add DuckgresServerTeam model

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -162,6 +162,7 @@ def get_scoped_models() -> tuple[dict[str, set[str]], set[str], set[str], set[st
         "DuckLakeBackfill",
         "DuckLakeCatalog",
         "DuckgresServer",
+        "DuckgresServerTeam",
         "EvaluationConfig",
         "RemoteConfig",
         "TeamConversationsSlackConfig",

--- a/posthog/admin/admins/duckgres_server_team_admin.py
+++ b/posthog/admin/admins/duckgres_server_team_admin.py
@@ -1,0 +1,32 @@
+from django.contrib import admin
+
+from posthog.models import DuckgresServerTeam
+
+
+@admin.register(DuckgresServerTeam)
+class DuckgresServerTeamAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "server_id",
+        "team_id",
+        "created_at",
+        "updated_at",
+    )
+    search_fields = ("=team__id", "=server__id")
+    readonly_fields = ("id", "created_at", "updated_at")
+    raw_id_fields = ("server", "team")
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": ("id", "server", "team"),
+            },
+        ),
+        (
+            "Metadata",
+            {
+                "fields": ("created_at", "updated_at"),
+            },
+        ),
+    )

--- a/posthog/admin/admins/ducklake_backfill_admin.py
+++ b/posthog/admin/admins/ducklake_backfill_admin.py
@@ -11,12 +11,13 @@ class DuckLakeBackfillAdmin(admin.ModelAdmin):
         "id",
         "team_id",
         "enabled",
+        "events_table_suffix",
         "created_by",
         "created_at",
         "updated_at",
     )
     list_filter = ("enabled",)
-    search_fields = ("=team__id",)
+    search_fields = ("=team__id", "events_table_suffix")
     readonly_fields = ("id", "created_at", "updated_at")
     raw_id_fields = ("team", "created_by")
     actions = ("make_enabled", "make_disabled")
@@ -38,7 +39,7 @@ class DuckLakeBackfillAdmin(admin.ModelAdmin):
         (
             None,
             {
-                "fields": ("id", "team", "enabled"),
+                "fields": ("id", "team", "enabled", "events_table_suffix"),
             },
         ),
         (

--- a/posthog/ducklake/models.py
+++ b/posthog/ducklake/models.py
@@ -101,6 +101,31 @@ class DuckgresServer(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
         verbose_name_plural = "Duckgres servers"
 
 
+class DuckgresServerTeam(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
+    """Per-team membership of an org's Duckgres warehouse.
+
+    A DuckgresServer is org-scoped and can host many teams (1->n). This model
+    records which teams live in a given server, and is the home for any future
+    team-specific server config.
+    """
+
+    server = models.ForeignKey(
+        "posthog.DuckgresServer",
+        on_delete=models.CASCADE,
+        related_name="teams",
+    )
+    team = models.OneToOneField(
+        "posthog.Team",
+        on_delete=models.CASCADE,
+        related_name="duckgres_server_team",
+    )
+
+    class Meta:
+        db_table = "posthog_duckgresserverteam"
+        verbose_name = "Duckgres server team"
+        verbose_name_plural = "Duckgres server teams"
+
+
 class DuckLakeBackfill(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     """Per-team enablement of DuckLake warehouse backfills.
 
@@ -117,6 +142,13 @@ class DuckLakeBackfill(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     enabled = models.BooleanField(
         default=True,
         help_text="Whether warehouse backfills are enabled for this team",
+    )
+    events_table_suffix = models.CharField(
+        max_length=63,
+        null=True,
+        blank=True,
+        help_text="Suffix for this team's events table in the duckling (events_<suffix>). "
+        "User-supplied; falls back to the shared events table when unset.",
     )
 
     class Meta:

--- a/posthog/migrations/1231_duckgresserverteam.py
+++ b/posthog/migrations/1231_duckgresserverteam.py
@@ -1,0 +1,70 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1230_duckgresserver_bucket"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DuckgresServerTeam",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="posthog.user",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, null=True, blank=True)),
+                (
+                    "server",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="teams",
+                        to="posthog.duckgresserver",
+                    ),
+                ),
+                (
+                    "team",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="duckgres_server_team",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_duckgresserverteam",
+                "verbose_name": "Duckgres server team",
+                "verbose_name_plural": "Duckgres server teams",
+            },
+        ),
+        migrations.AddField(
+            model_name="ducklakebackfill",
+            name="events_table_suffix",
+            field=models.CharField(
+                blank=True,
+                help_text="Suffix for this team's events table in the duckling (events_<suffix>). "
+                "User-supplied; falls back to the shared events table when unset.",
+                max_length=63,
+                null=True,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1230_duckgresserver_bucket
+1231_duckgresserverteam

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -15,7 +15,7 @@ from .comment import Comment
 from .core_event import CoreEvent
 from .data_deletion_request import DataDeletionRequest
 from .data_color_theme import DataColorTheme
-from ..ducklake.models import DuckgresServer, DuckLakeBackfill, DuckLakeCatalog
+from ..ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill, DuckLakeCatalog
 from .element import Element
 from .element_group import ElementGroup
 from .entity import Entity
@@ -105,6 +105,7 @@ __all__ = [
     "DataColorTheme",
     "DeletionType",
     "DuckgresServer",
+    "DuckgresServerTeam",
     "DuckLakeBackfill",
     "DuckLakeCatalog",
     "Element",


### PR DESCRIPTION
> **Stacking:** this PR now stacks on #64939 (base branch `eric/ducklakebackfill-on-provision`). It was rebased onto that branch and its migration was renumbered `1230_duckgresserverteam` → **`1231_duckgresserverteam`** (re-parented onto master's `1230_duckgresserver_bucket`) to resolve the migration-number collision. `makemigrations --check` confirms no model/migration drift. Merge #64939 first, then this, then #64941.

## Problem

A `DuckgresServer` (an org's duckling warehouse) is org-scoped and can host many teams (1->n), but there's no first-class team relationship on it. Provisioning (`upsert_duckgres_server_for_org`) keys on `organization_id` and never sets the deprecated `team` FK, so a provisioned server has `team=None` — the trigger for this work was a warehouse that came up with no `team_id`.

There's also a latent collision: the backfill DAG writes every team's events into a single hardcoded `posthog.events` table, so two teams in one org would merge their events.

## Changes

- **`DuckgresServerTeam`** (`posthog/ducklake/models.py`) — a join model, many-to-1 with `DuckgresServer`, one row per team (`server` FK + `team` `OneToOne`). This is the first-class team<->duckling membership record and the home for future team-specific server config.
- **`DuckLakeBackfill.events_table_suffix`** — the per-environment events-table suffix lives on the backfill row (the one the Dagster sensors already iterate), nullable. When set, that team's backfill will write to `posthog.events_<suffix>` instead of the shared `posthog.events`; unset rows fall back to the shared table.

Registers a Django admin for `DuckgresServerTeam` and adds it to the IDOR coverage exclusion list next to the sibling ducklake config models.

This is the data-model groundwork. Follow-ups: wiring `events_backfill_to_duckling` to write to `events_<suffix>`, and the onboarding/provision flow that requires the suffix when a new team enables the warehouse.

## How did you test this code?

I'm an agent (PostHog Slack app). No manual testing. Automated checks run locally:

- Django autodetector against the loaded model state — no ducklake/duckgres drift; the migration matches the models (`DuckgresServerTeam` fields + `DuckLakeBackfill.events_table_suffix` all resolve).
- `check-idor-model-coverage.py` — passes (fail-closed baseline unchanged).
- `ruff format` + `ruff check` on all changed files — clean.

`makemigrations` couldn't be run normally (no Postgres in the sandbox); the migration was hand-written to mirror the existing `1088_ducklake_backfill_model` migration and validated via the autodetector.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Eric Duong from a Slack thread with James Greenhill about a duckling that provisioned without a `team_id`. The thread landed on modeling team membership on the duckgres server plus per-environment events tables; the suffix is user-supplied at enable time (no auto-normalization). Per follow-up direction, the suffix field was moved onto `DuckLakeBackfill` (the backfill row the sensors already load per team) rather than `DuckgresServerTeam`.

Skills invoked: `/django-migrations` (migration hand-authored and validated offline against the autodetector since the sandbox has no DB). The new `DuckgresServerTeam` deliberately stays off the fail-closed `TeamScopedManager` and joins the sibling config models in the IDOR exclusion list, because per-environment rows must keep their real team_id (the canonical-team rewrite in `TeamScopedRootMixin` would collapse child environments).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A1M678WCV/p1781890955154899?thread_ts=1781890955.154899&cid=C0A1M678WCV)*