### PR TITLE
fix(flox): set UV_PROJECT_ENVIRONMENT in profile, not [vars]

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -75,8 +75,9 @@ DOTENV_FILE = ".env"
 OPENSSL_INCLUDE_DIR = "$FLOX_ENV/include"
 LDFLAGS="-L$FLOX_ENV/lib"
 CPPFLAGS="-I$FLOX_ENV/include"
-UV_PROJECT_ENVIRONMENT = "$FLOX_ENV_CACHE/venv"
 RUSTC_WRAPPER = "sccache"
+# UV_PROJECT_ENVIRONMENT is set in the [hook]/[profile] scripts, not here: [vars]
+# are added without expanding $FLOX_ENV_CACHE, so flox drops it on fresh activation.
 
 # The `hook.on-activate` script is run by the *bash* shell immediately upon
 # activating an environment, and will not be invoked if Flox detects that the
@@ -107,6 +108,8 @@ bash = '''
   export GOMODCACHE="$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
+  # uv venv path — set here, not in [vars] (which can't expand $FLOX_ENV_CACHE)
+  export UV_PROJECT_ENVIRONMENT="$FLOX_ENV_CACHE/venv"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if [ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]; then
     uv sync
@@ -133,6 +136,8 @@ zsh = '''
   export GOMODCACHE="$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   export PATH="$FLOX_ENV/bin:$PATH"
+  # uv venv path — set here, not in [vars] (which can't expand $FLOX_ENV_CACHE)
+  export UV_PROJECT_ENVIRONMENT="$FLOX_ENV_CACHE/venv"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if [[ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]]; then
     uv sync
@@ -155,6 +160,8 @@ fish = '''
   set -gx GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   fish_add_path -g "$FLOX_ENV/bin"
+  # uv venv path — set here, not in [vars] (which can't expand $FLOX_ENV_CACHE)
+  set -gx UV_PROJECT_ENVIRONMENT "$FLOX_ENV_CACHE/venv"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if not test -f "$UV_PROJECT_ENVIRONMENT/bin/activate.fish"
     uv sync
@@ -172,6 +179,8 @@ tcsh = '''
   setenv GOMODCACHE "$GOPATH/pkg/mod"
   # Ensure flox binaries (especially Node.js) take precedence over system binaries
   setenv PATH "$FLOX_ENV/bin:$PATH"
+  # uv venv path — set here, not in [vars] (which can't expand $FLOX_ENV_CACHE)
+  setenv UV_PROJECT_ENVIRONMENT "$FLOX_ENV_CACHE/venv"
   # Recreate venv if it was deleted (on-activate only runs on first activation)
   if ( ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate.csh" ) then
     uv sync

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -220,6 +220,10 @@ export GOPATH="$FLOX_ENV_CACHE/go"
 export GOCACHE="$FLOX_ENV_CACHE/go-build"
 export GOMODCACHE="$GOPATH/pkg/mod"
 
+# uv-managed venv location (mirrors the [profile] scripts; not in [vars], which
+# can't expand $FLOX_ENV_CACHE). Used below for uv sync + the hogli symlink.
+export UV_PROJECT_ENVIRONMENT="$FLOX_ENV_CACHE/venv"
+
 # ── Direnv first-time setup (interactive only) ─────────────────────
 if [[ "$_interactive" == true ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
   read -p "$(echo -e "${C_BOLD}direnv${C_RESET} recommended for auto-activation. Set up now? (Y/n) ")" -n 1 -r


### PR DESCRIPTION
## Problem

Opening a new shell on macOS can fail flox activation with:

```
error: Project virtual environment directory `.venv` cannot be used ... no Python executable was found
ln: /bin/hogli: Operation not permitted
.../activate.d/profile-zsh:source:20: no such file or directory: /bin/activate
```

Root cause: `UV_PROJECT_ENVIRONMENT` is defined in the manifest's `[vars]` as `"$FLOX_ENV_CACHE/venv"`, but flox does not expand `$FLOX_ENV_CACHE` there — its own docs note `[vars]` are "added without first expanding them" (it does expand `$FLOX_ENV`, just not `$FLOX_ENV_CACHE`). So on a fresh activation the variable comes out **unset**. With it unset, the profile scripts fall back to a stale repo-root `.venv`, try to symlink `hogli` into `/bin`, and `source /bin/activate` — each of which fails with the errors above.

This was latent (the `[vars]` form dates to the original "venv inside flox cache" change) and had been masked by a cached activation render. A recent re-lock regenerated that render and exposed it. It affects every macOS dev the next time their environment re-locks.

## Changes

Move `UV_PROJECT_ENVIRONMENT` out of `[vars]` and set it at the top of the `bash`/`zsh`/`fish`/`tcsh` `[profile]` blocks and in `on-activate.sh`. Those scripts are sourced by the shell with `$FLOX_ENV_CACHE` available, so the path expands reliably. A short comment in `[vars]` explains why it intentionally lives elsewhere.

No change to the resolved path — it still points at `$FLOX_ENV_CACHE/venv`; it just gets set reliably now.

## How did you test this code?

I'm an agent (Claude Code). No automated tests apply to a flox manifest; verification was empirical:

- A fresh `flox activate` now sets `UV_PROJECT_ENVIRONMENT=$FLOX_ENV_CACHE/venv` (it was `<<UNSET>>` before the change).
- Walked the `[profile]` activation path end-to-end: venv detected (no `uv sync`/`.venv` fallback), `hogli` symlinked into the cache venv, `bin/activate` sourced, `VIRTUAL_ENV` set, `hogli` on PATH.
- Confirmed static `[vars]` (`DEBUG`) and `$FLOX_ENV`-referencing vars (`OPENSSL_ROOT_DIR`) were never affected — only the `$FLOX_ENV_CACHE`-referencing var was being dropped.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — dev-environment config only (`skip-inkeep-docs`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus). No repo-provided skills (e.g. `/django-migrations`) were applicable or invoked — this was flox-manifest debugging.
- Decision: set the variable in `[profile]`/`[hook]` rather than hardcoding an absolute path (non-portable) or filing a flox bug (the manifest was relying on undocumented `[vars]` expansion; `[profile]`/`[hook]` are the supported place for references).
- Considered and rejected reverting the commit that triggered the re-lock — it only disturbed a stale lock; the actual flaw is the `[vars]` reliance, so fixing that is the durable solution.
