### PR TITLE
fix(rbac): identify materialized backing tables by storage path

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1185,10 +1185,15 @@ class Database(BaseModel):
                 except Exception as e:
                     capture_exception(e)
 
-        # A materialized view's backing table shares the view's name. Exclude every backing table so the
-        # view owns the access decision - otherwise the backing table would shadow the view and stay
-        # queryable even when the view is denied.
-        backing_table_ids = {sq.table_id for sq in (*saved_queries, *endpoint_saved_queries) if sq.table_id is not None}
+        # Materialized views store their backing table under the saved-query-specific S3 path.
+        # Exclude that private storage table so the view owns access control, even after a rename.
+        backing_table_ids = {
+            sq.table_id
+            for sq in (*saved_queries, *endpoint_saved_queries)
+            if sq.table_id is not None
+            and sq.table is not None
+            and f"team_{team.pk}_model_{sq.id.hex}/modeling" in sq.table.url_pattern
+        }
 
         with timings.measure("data_warehouse_tables", emit_span=True):
             with timings.measure("select", emit_span=True):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1190,9 +1190,7 @@ class Database(BaseModel):
         backing_table_ids = {
             sq.table_id
             for sq in (*saved_queries, *endpoint_saved_queries)
-            if sq.table_id is not None
-            and sq.table is not None
-            and f"team_{team.pk}_model_{sq.id.hex}/modeling" in sq.table.url_pattern
+            if sq.table_id is not None and sq.table is not None and sq.folder_path in sq.table.url_pattern
         }
 
         with timings.measure("data_warehouse_tables", emit_span=True):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -355,11 +355,6 @@
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND NOT ("posthog_datawarehousetable"."id" IN ('00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid))
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
   ORDER BY "posthog_datawarehousetable"."created_at" DESC
@@ -691,16 +686,6 @@
                   AND "posthog_datawarehousetable"."deleted" IS NOT NULL)
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND NOT ("posthog_datawarehousetable"."id" IN ('00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid,
-                                                        '00000000000000000000000000000000'::uuid))
          AND NOT ("posthog_externaldatasource"."access_method" = 'direct'
                   AND "posthog_externaldatasource"."access_method" IS NOT NULL))
   ORDER BY "posthog_datawarehousetable"."created_at" DESC

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -811,22 +811,23 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 credential=credential,
                 url_pattern="",
             )
+            saved_query = DataWarehouseSavedQuery.objects.create(
+                team=self.team,
+                name=f"whatever_view{i}",
+                query={"query": f"SELECT id FROM whatever{i}"},
+                columns={"id": "String"},
+                status=DataWarehouseSavedQuery.Status.COMPLETED,
+            )
             # Give the view a materialized backing table so the build exercises that path with no IO
             backing_table = DataWarehouseTable.objects.create(
                 name=f"whatever_view{i}",
                 team=self.team,
                 columns={"id": "String"},
                 credential=credential,
-                url_pattern="",
+                url_pattern=saved_query.url_pattern,
             )
-            DataWarehouseSavedQuery.objects.create(
-                team=self.team,
-                name=f"whatever_view{i}",
-                query={"query": f"SELECT id FROM whatever{i}"},
-                columns={"id": "String"},
-                table=backing_table,
-                status=DataWarehouseSavedQuery.Status.COMPLETED,
-            )
+            saved_query.table = backing_table
+            saved_query.save(update_fields=["table"])
         # Endpoint-origin saved query so the endpoint build loop is exercised under assertNumQueries(0).
         DataWarehouseSavedQuery.objects.create(
             team=self.team,
@@ -872,6 +873,52 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         assert db.has_table("whatever_endpoint")
         assert "some_field" in db.get_table("events").fields
         assert "timestamp" in db.get_table("whatever0").fields
+
+    def test_materialized_backing_filter_keeps_source_tables_but_hides_backing_tables(self):
+        credential = DataWarehouseCredential.objects.create(
+            team=self.team, access_key="_accesskey", access_secret="_secret"
+        )
+        source_table = DataWarehouseTable.objects.create(
+            name="stripe_charge",
+            team=self.team,
+            columns={"id": "String"},
+            credential=credential,
+            url_pattern="s3://source/stripe_charge/*",
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="charges_view",
+            query={"query": "SELECT id FROM stripe_charge"},
+            columns={"id": "String"},
+            table=source_table,
+            is_materialized=True,
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+        )
+
+        renamed_view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="renamed_view",
+            query={"query": "SELECT id FROM stripe_charge"},
+            columns={"id": "String"},
+            is_materialized=True,
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+        )
+        backing_table = DataWarehouseTable.objects.create(
+            name="old_view_name",
+            team=self.team,
+            columns={"id": "String"},
+            credential=credential,
+            url_pattern=renamed_view.url_pattern,
+        )
+        renamed_view.table = backing_table
+        renamed_view.save(update_fields=["table"])
+
+        database = Database.create_for(team=self.team, bypass_warehouse_access_control=True)
+
+        assert database.has_table("stripe_charge")
+        assert database.has_table("charges_view")
+        assert database.has_table("renamed_view")
+        assert not database.has_table("old_view_name")
 
     @patch("posthog.hogql.query.sync_execute", return_value=([], []))
     def test_build_from_sources_performs_no_io_for_direct_postgres(self, patch_execute):

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -617,7 +617,7 @@ class TestWarehouseViewAccessControl(BaseTest):
             format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
             team=self.team,
             credential=credential,
-            url_pattern=f"s3://bucket/{view.name}/*",
+            url_pattern=view.url_pattern,
             columns={"id": "String"},
         )
         view.table = backing_table

--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -310,7 +310,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
 
     @property
     def folder_path(self):
-        return f"team_{self.team.pk}_model_{self.id.hex}/modeling"
+        return f"team_{self.team_id}_model_{self.id.hex}/modeling"
 
     @property
     def normalized_name(self):


### PR DESCRIPTION
## Problem

Error: 
https://us.posthog.com/project/2/error_tracking/019e8a1b-6689-7471-aa1d-5902f4c0483f
https://us.posthog.com/project/2/error_tracking/019d1c2c-7cfd-7bc3-bec6-c41b0c791d03
https://us.posthog.com/project/2/error_tracking/019ee0e8-47f7-73d3-ad0e-1437d885484f

The previous warehouse access-control change (#61686) hid every `DataWarehouseTable` referenced by a saved query `table_id`. That was intentional for materialized views: their private backing table can otherwise shadow the view and bypass the view access-control decision, including after a view is renamed.

The issue is that `table_id` is broader than private materialized backing table. Some saved queries point at a normal warehouse source table with a different storage path. The broad exclusion removed those source tables from the HogQL schema, so existing dashboard tiles and SQL queries that selected the source table by name started failing with `Unknown table`, even when warehouse RBAC was disabled.

## Changes

- Identify private materialized backing tables by the saved-query-specific materialization storage path instead of excluding every saved-query `table_id`.
- Preserve the rename hardening: a renamed materialized view old backing table is still hidden if it lives under that saved query materialization path.
- Keep normal warehouse source tables visible when they are referenced by a saved query but are not that query private backing storage.
- Add regression coverage for both cases: source tables remain queryable, and renamed backing tables stay hidden.

## How did you test this code?

Tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No