### PR TITLE
feat(inbox): link task id to its run on scout signal card

### DIFF
--- a/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
@@ -203,6 +203,7 @@ export function SignalsScoutSignalCard({ signal }: SignalCardProps): JSX.Element
             <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
                 <MonoId label="Finding" value={extra.finding_id} />
                 <MonoId label="Scout run" value={extra.scout_run_id} />
+                {extra.task_id && <MonoId label="Task" value={extra.task_id} to={taskRunUrl} />}
                 <MonoId label="Task run" value={extra.task_run_id} to={taskRunUrl} />
                 {extra.mcp_trace_id && (
                     <>


### PR DESCRIPTION
## Problem

When you open a report with a scout signal in the inbox, the scout signal card shows a few identifiers in its footer — `Finding`, `Scout run`, and `Task run`. The `Task run` id already deep-links into the Tasks UI, but the underlying **task id** (`task_id` on the signal payload) was never surfaced. So there was no way to jump from a card straight to the task it came from.

## Changes

Added a `Task` entry to the scout signal card footer that renders `extra.task_id` as a clickable link to its run (`/tasks/{task_id}?runId={task_run_id}`), reusing the existing `taskRunUrl`. It's gated on `task_id` being present — older scout emissions don't carry it, so there's nothing to link in that case and the entry is simply omitted.

## How did you test this code?

I'm an agent (Claude Code). I ran the oxfmt formatter over the changed file. No automated tests were added — this is a one-line, presentational change reusing an already-tested link path (`MonoId` + `taskRunUrl`). I did not perform manual testing in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this work — the ask was to make the task id on the inbox scout signal card a clickable link to the task run. Built with Claude Code ([session](https://claude.ai/code/session_01NNH2RGg3NC1attcYUVf8Ph)).

The card already had the plumbing: `taskRunUrl` was being computed and used for the `Task run` id. The only real decision was that `task_id` wasn't displayed at all, so I added a new `Task` `MonoId` pointing at the same run URL rather than introducing a separate task-detail link — that keeps both ids resolving to the run the signal actually came from. No repo skills were needed for a change this small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNH2RGg3NC1attcYUVf8Ph