### PR TITLE
feat(data-warehouse): provision/enable per-team warehouse backfill with named tables

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
@@ -100,9 +100,21 @@ export function SettingsTab(): JSX.Element {
         initialPassword,
         isResettingPassword,
         warehouseDomain,
+        tableName,
+        isValidTableName,
+        isEnablingBackfill,
+        backfillTableSuffix,
+        hasBackfill,
     } = useValues(warehouseProvisioningLogic)
-    const { provisionWarehouse, deprovisionWarehouse, setDatabaseName, clearInitialPassword, resetPassword } =
-        useActions(warehouseProvisioningLogic)
+    const {
+        provisionWarehouse,
+        deprovisionWarehouse,
+        setDatabaseName,
+        clearInitialPassword,
+        resetPassword,
+        setTableName,
+        enableBackfill,
+    } = useActions(warehouseProvisioningLogic)
     const deprovisionRestrictionReason = useRestrictedArea({
         scope: RestrictionScope.Organization,
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
@@ -203,16 +215,31 @@ export function SettingsTab(): JSX.Element {
                             </p>
                         ) : null}
                     </div>
+                    <div>
+                        <LemonLabel>Table name</LemonLabel>
+                        <LemonInput value={tableName} onChange={setTableName} placeholder="my_project" fullWidth />
+                        {tableName && !isValidTableName ? (
+                            <p className="text-danger text-xs mt-1">
+                                Use lowercase letters, numbers, and underscores only (max 63 characters).
+                            </p>
+                        ) : (
+                            <p className="text-muted text-xs mt-1">
+                                This project's data lands in its own warehouse tables, suffixed with this name (e.g.{' '}
+                                <code>events_&lt;name&gt;</code>, <code>persons_&lt;name&gt;</code>). Other projects
+                                pick their own when they join.
+                            </p>
+                        )}
+                    </div>
                     <LemonButton
                         type="primary"
                         loading={isProvisioning}
                         disabledReason={
                             isFailed
                                 ? !canRetryProvision
-                                    ? 'Enter a valid database name'
+                                    ? 'Enter a valid database name and table name'
                                     : undefined
                                 : !canProvision
-                                  ? 'Enter an available database name'
+                                  ? 'Enter an available database name and table name'
                                   : undefined
                         }
                         onClick={() => {
@@ -224,7 +251,7 @@ export function SettingsTab(): JSX.Element {
                                     'This will create a managed warehouse for your organization, shared by every project in it. Should take less than 5 minutes.',
                                 primaryButton: {
                                     children: isFailed ? 'Retry provisioning' : 'Provision',
-                                    onClick: () => provisionWarehouse({ databaseName: retryDatabaseName }),
+                                    onClick: () => provisionWarehouse({ databaseName: retryDatabaseName, tableName }),
                                 },
                                 secondaryButton: {
                                     children: 'Cancel',
@@ -268,6 +295,67 @@ export function SettingsTab(): JSX.Element {
 
                     {isReady && warehouseStatus?.connection && (
                         <ConnectionDetails connection={warehouseStatus.connection} />
+                    )}
+
+                    {isReady && (
+                        <div className="border rounded p-4 space-y-3">
+                            <h3 className="mb-0">Warehouse tables for this project</h3>
+                            {hasBackfill ? (
+                                // A backfill already exists — the table name is fixed (immutable), so show
+                                // read-only state rather than re-offering the form.
+                                backfillTableSuffix ? (
+                                    <p className="text-muted text-xs mb-0">
+                                        This project writes to its own tables <code>events_{backfillTableSuffix}</code>{' '}
+                                        / <code>persons_{backfillTableSuffix}</code>. The table name is fixed once a
+                                        backfill is running.
+                                    </p>
+                                ) : (
+                                    <p className="text-muted text-xs mb-0">
+                                        This project writes to the shared <code>events</code> / <code>persons</code>{' '}
+                                        tables. Changing it would split existing data, so it's fixed.
+                                    </p>
+                                )
+                            ) : (
+                                <>
+                                    <p className="text-muted text-xs mb-0">
+                                        Each project writes its data into its own tables in the shared warehouse so they
+                                        don't merge. Choose a name for this project's warehouse tables — lowercase
+                                        letters, numbers, and underscores only; it's used as the suffix (e.g.{' '}
+                                        <code>events_&lt;name&gt;</code>). This can't be changed once a backfill runs.
+                                    </p>
+                                    <div>
+                                        <div className="flex items-end gap-2">
+                                            <div className="flex-1">
+                                                <LemonLabel>Table name</LemonLabel>
+                                                <LemonInput
+                                                    value={tableName}
+                                                    onChange={setTableName}
+                                                    placeholder="my_project"
+                                                    fullWidth
+                                                />
+                                            </div>
+                                            <LemonButton
+                                                type="primary"
+                                                loading={isEnablingBackfill}
+                                                disabledReason={
+                                                    !isValidTableName ? 'Enter a valid table name' : undefined
+                                                }
+                                                onClick={() => enableBackfill({ tableName })}
+                                                data-attr="enable-warehouse-backfill"
+                                            >
+                                                Enable backfill
+                                            </LemonButton>
+                                        </div>
+                                        {tableName && !isValidTableName && (
+                                            <p className="text-danger text-xs mt-1">
+                                                Use lowercase letters, numbers, and underscores only (max 63
+                                                characters).
+                                            </p>
+                                        )}
+                                    </div>
+                                </>
+                            )}
+                        </div>
                     )}
 
                     <div className="flex gap-2">

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.test.ts
@@ -71,7 +71,7 @@ describe('warehouseProvisioningLogic', () => {
         logic.mount()
 
         await expectLogic(logic, () => {
-            logic.actions.provisionWarehouse({ databaseName: 'shared-warehouse' })
+            logic.actions.provisionWarehouse({ databaseName: 'shared-warehouse', tableName: 'shared' })
         }).toDispatchActions(['provisionWarehouse', 'loadWarehouseStatus', 'provisionWarehouseComplete'])
 
         expect(infoToast).toHaveBeenCalledTimes(1)

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
@@ -10,6 +10,7 @@ import { Region } from '~/types'
 import {
     dataWarehouseCheckDatabaseNameRetrieve,
     dataWarehouseDeprovisionCreate,
+    dataWarehouseEnableBackfillCreate,
     dataWarehouseProvisionCreate,
     dataWarehouseResetPasswordCreate,
     dataWarehouseWarehouseStatusRetrieve,
@@ -31,6 +32,10 @@ const MANAGED_WAREHOUSE_DOMAINS: Partial<Record<Region, string>> = {
     [Region.DEV]: 'dev.postwh.com',
 }
 
+// The table name is used verbatim as the suffix in events_<suffix> / persons_<suffix>, so it
+// must already be a safe SQL identifier. Mirrors validate_table_suffix in posthog/ducklake/common.py.
+const TABLE_NAME_REGEX = /^[a-z0-9_]{1,63}$/
+
 const databaseNameStorageKey = (teamId: number | null): string =>
     `warehouse-provisioning-database-name-${teamId ?? 'unknown'}`
 
@@ -44,7 +49,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
     })),
 
     actions({
-        provisionWarehouse: (params: { databaseName: string }) => params,
+        provisionWarehouse: (params: { databaseName: string; tableName: string }) => params,
         provisionWarehouseComplete: true,
         deprovisionWarehouse: true,
         deprovisionWarehouseComplete: true,
@@ -59,6 +64,9 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
         checkDatabaseName: (name: string) => ({ name }),
         setDatabaseNameAvailable: (available: boolean | null) => ({ available }),
         setDatabaseNameChecking: (checking: boolean) => ({ checking }),
+        setTableName: (name: string) => ({ name }),
+        enableBackfill: (params: { tableName: string }) => params,
+        enableBackfillComplete: (suffix: string | null) => ({ suffix }),
     }),
 
     loaders({
@@ -144,6 +152,37 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 resetPasswordComplete: () => false,
             },
         ],
+        tableName: [
+            '',
+            {
+                setTableName: (_, { name }) => name,
+            },
+        ],
+        isEnablingBackfill: [
+            false,
+            {
+                enableBackfill: () => true,
+                enableBackfillComplete: () => false,
+            },
+        ],
+        backfillTableSuffix: [
+            null as string | null,
+            {
+                loadWarehouseStatusSuccess: (_, { warehouseStatus }) => warehouseStatus?.table_suffix ?? null,
+                enableBackfillComplete: (state, { suffix }) => suffix ?? state,
+                deprovisionWarehouse: () => null,
+            },
+        ],
+        // Whether this project already has a backfill configured. When true, the table name is
+        // fixed (immutable), so we show a read-only state instead of re-offering the enable form.
+        hasBackfill: [
+            false,
+            {
+                loadWarehouseStatusSuccess: (_, { warehouseStatus }) => warehouseStatus?.has_backfill ?? false,
+                enableBackfillComplete: (state, { suffix }) => (suffix ? true : state),
+                deprovisionWarehouse: () => false,
+            },
+        ],
     }),
 
     selectors({
@@ -178,13 +217,17 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
             (s) => [s.databaseName, s.lastRequestedDatabaseName],
             (databaseName, lastRequestedDatabaseName): string => databaseName || lastRequestedDatabaseName || '',
         ],
+        // The table name is used verbatim as the table suffix, so it must already be a valid
+        // identifier (mirrors the backend validator) — we reject rather than silently rewrite.
+        isValidTableName: [(s) => [s.tableName], (name): boolean => TABLE_NAME_REGEX.test(name)],
         canProvision: [
-            (s) => [s.isValidDatabaseName, s.databaseNameAvailable],
-            (valid, available): boolean => valid && available === true,
+            (s) => [s.isValidDatabaseName, s.databaseNameAvailable, s.isValidTableName],
+            (valid, available, validEvents): boolean => valid && available === true && validEvents,
         ],
         canRetryProvision: [
-            (s) => [s.retryDatabaseName],
-            (retryDatabaseName): boolean => !!retryDatabaseName && WAREHOUSE_NAME_REGEX.test(retryDatabaseName),
+            (s) => [s.retryDatabaseName, s.isValidTableName],
+            (retryDatabaseName, validEvents): boolean =>
+                !!retryDatabaseName && WAREHOUSE_NAME_REGEX.test(retryDatabaseName) && validEvents,
         ],
     }),
 
@@ -216,12 +259,13 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 actions.setDatabaseNameChecking(false)
             },
 
-            provisionWarehouse: async ({ databaseName }) => {
+            provisionWarehouse: async ({ databaseName, tableName }) => {
                 actions.setLastRequestedDatabaseName(databaseName)
                 window.localStorage.setItem(databaseNameStorageKey(teamLogic.values.currentTeamId), databaseName)
                 try {
                     const result = await dataWarehouseProvisionCreate(currentProjectId(), {
                         database_name: databaseName,
+                        table_name: tableName,
                     })
                     if (result.password) {
                         actions.setInitialPassword(result.password)
@@ -240,6 +284,21 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                     }
                 }
                 actions.provisionWarehouseComplete()
+            },
+
+            enableBackfill: async ({ tableName }) => {
+                try {
+                    const result = await dataWarehouseEnableBackfillCreate(currentProjectId(), {
+                        table_name: tableName,
+                    })
+                    lemonToast.success('Warehouse backfill enabled for this project')
+                    actions.enableBackfillComplete(result.table_suffix ?? null)
+                    // Refresh from the server so the read-only state reflects the now-fixed table.
+                    actions.loadWarehouseStatus()
+                } catch (e: any) {
+                    lemonToast.error(`Failed to enable backfill: ${e.detail || e.message || 'Unknown error'}`)
+                    actions.enableBackfillComplete(null)
+                }
             },
 
             resetPassword: async () => {
@@ -301,6 +360,18 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
         )
         if (persistedDatabaseName) {
             actions.setLastRequestedDatabaseName(persistedDatabaseName)
+        }
+        // Prefill the table name with a valid default derived from the project name (lowercased,
+        // non-identifier chars collapsed to underscores). It's only a starting point — the user
+        // edits/confirms it, and the input is validated verbatim from there.
+        const projectName = teamLogic.values.currentTeam?.name
+        const defaultTableName = projectName
+            ?.toLowerCase()
+            .replace(/[^a-z0-9_]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .slice(0, 63)
+        if (defaultTableName) {
+            actions.setTableName(defaultTableName)
         }
         actions.loadWarehouseStatus()
     }),

--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -550,8 +550,109 @@ def sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
     return cleaned[:63]
 
 
+TABLE_SUFFIX_MAX_LENGTH = 63
+# The table name the user supplies is used verbatim as the suffix in `events_<suffix>` /
+# `persons_<suffix>`, so it must already be a safe SQL identifier — lowercase letters,
+# numbers, and underscores. We validate rather than silently rewrite, so what the user
+# types is exactly what they get.
+TABLE_SUFFIX_PATTERN = re.compile(r"^[a-z0-9_]+$")
+
+
+def validate_table_suffix(name: str | None) -> str | None:
+    """Return a human-readable error if `name` isn't a valid table suffix, else None."""
+    if not name:
+        return "table_name is required"
+    if len(name) > TABLE_SUFFIX_MAX_LENGTH:
+        return f"Table name must be at most {TABLE_SUFFIX_MAX_LENGTH} characters"
+    if not TABLE_SUFFIX_PATTERN.match(name):
+        return "Table name must use only lowercase letters, numbers, and underscores"
+    return None
+
+
+class DucklingBackfillEnableError(Exception):
+    """Raised when a team's warehouse backfill cannot be enabled (no server, name collision)."""
+
+
+def enable_team_backfill(*, team_id: int, organization_id: str | UUID, table_name: str) -> str:
+    """Enable a team's warehouse backfill with a dedicated set of per-environment tables.
+
+    The user-supplied ``table_name`` is used verbatim as the table suffix (validated, not
+    rewritten). Records first-class team↔duckling membership (DuckgresServerTeam) and persists
+    the suffix on the team's DuckLakeBackfill so the Dagster backfill writes to ``events_<suffix>``
+    / ``persons_<suffix>`` instead of the shared tables.
+
+    **Write-once.** The suffix is fixed when the backfill is first created and cannot be changed
+    afterward — including switching a legacy NULL suffix (shared tables) to a real name. Changing
+    it would make the Dagster job write to a different table and split the team's existing data
+    across two tables. Re-calling with the team's current name is an idempotent no-op.
+
+    The org must already have a provisioned DuckgresServer, the name must be a valid identifier,
+    and the suffix must be unique among the org's environments. Returns the suffix, or raises
+    DucklingBackfillEnableError with a user-facing message.
+    """
+    from django.db import transaction
+
+    from posthog.ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill
+
+    error = validate_table_suffix(table_name)
+    if error:
+        raise DucklingBackfillEnableError(error)
+    suffix = table_name
+
+    try:
+        server = DuckgresServer.objects.get(organization_id=organization_id)
+    except DuckgresServer.DoesNotExist:
+        raise DucklingBackfillEnableError(
+            "No managed warehouse is provisioned for this organization. Provision one first."
+        )
+
+    existing = DuckLakeBackfill.objects.filter(team_id=team_id).first()
+    if existing is not None:
+        if existing.table_suffix == suffix:
+            # Same name — ensure membership is recorded, then leave the backfill untouched.
+            DuckgresServerTeam.objects.get_or_create(server=server, team_id=team_id)
+            return suffix
+        current = f"events_{existing.table_suffix}" if existing.table_suffix else "the shared tables"
+        raise DucklingBackfillEnableError(
+            f"This project already writes to {current}, and its warehouse table can't be changed — "
+            "that would split its existing data across two tables."
+        )
+
+    collision = (
+        DuckLakeBackfill.objects.filter(team__organization_id=organization_id, table_suffix=suffix)
+        .exclude(team_id=team_id)
+        .exists()
+    )
+    if collision:
+        raise DucklingBackfillEnableError(
+            f"The table name '{suffix}' is already used by another environment in this organization."
+        )
+
+    with transaction.atomic():
+        DuckgresServerTeam.objects.get_or_create(server=server, team_id=team_id)
+        DuckLakeBackfill.objects.create(team_id=team_id, enabled=True, table_suffix=suffix)
+    return suffix
+
+
+def get_team_backfill_state(team_id: int) -> dict[str, object]:
+    """Return the team's duckling backfill state for the warehouse-status UI.
+
+    ``has_backfill`` distinguishes a team that has never been set up (no row → the enable form is
+    safe to show) from one already backfilling (a row exists → show read-only, since the table is
+    immutable). ``table_suffix`` is None for legacy teams still on the shared tables.
+    """
+    from posthog.ducklake.models import DuckLakeBackfill
+
+    backfill = DuckLakeBackfill.objects.filter(team_id=team_id).values("table_suffix").first()
+    if backfill is None:
+        return {"has_backfill": False, "table_suffix": None}
+    return {"has_backfill": True, "table_suffix": backfill["table_suffix"]}
+
+
 __all__ = [
+    "DucklingBackfillEnableError",
     "attach_catalog",
+    "enable_team_backfill",
     "escape",
     "get_config",
     "get_ducklake_catalog_for_organization",
@@ -570,7 +671,9 @@ __all__ = [
     "is_version_mismatch",
     "parse_postgres_dsn",
     "is_dev_mode",
+    "get_team_backfill_state",
     "reset_ducklake_catalog",
     "run_smoke_check",
     "sanitize_ducklake_identifier",
+    "validate_table_suffix",
 ]

--- a/posthog/ducklake/test_common.py
+++ b/posthog/ducklake/test_common.py
@@ -5,13 +5,16 @@ import duckdb
 from parameterized import parameterized
 
 from posthog.ducklake.common import (
+    DucklingBackfillEnableError,
+    enable_team_backfill,
+    get_team_backfill_state,
     initialize_ducklake,
     is_version_mismatch,
     reset_ducklake_catalog,
     upsert_duckgres_server_for_org,
 )
-from posthog.ducklake.models import DuckgresServer
-from posthog.models import Organization
+from posthog.ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill
+from posthog.models import Organization, Team
 
 
 @pytest.mark.django_db
@@ -34,6 +37,104 @@ class TestUpsertDuckgresServerForOrg:
         assert updated.host == "wh2.dw.us.postwh.com"
         assert updated.port == 6543
         assert updated.password == "pw2"
+
+
+@pytest.mark.django_db
+class TestEnableTeamBackfill:
+    def _server(self, org: Organization) -> DuckgresServer:
+        return DuckgresServer.objects.create(
+            organization=org, host="h", port=5432, database="ducklake", username="root", password="x"
+        )
+
+    def test_creates_membership_and_suffixed_backfill(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        server = self._server(org)
+
+        suffix = enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="my_prod_env")
+
+        assert suffix == "my_prod_env"
+        assert DuckgresServerTeam.objects.filter(server=server, team_id=team.id).exists()
+        backfill = DuckLakeBackfill.objects.get(team_id=team.id)
+        assert backfill.enabled is True
+        assert backfill.table_suffix == "my_prod_env"
+
+    def test_rejects_an_invalid_table_name(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        self._server(org)
+
+        with pytest.raises(DucklingBackfillEnableError):
+            enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="Bad Name!")
+
+    def test_rejects_duplicate_suffix_within_org(self):
+        org = Organization.objects.create(name="Org")
+        team_a = Team.objects.create(organization=org)
+        team_b = Team.objects.create(organization=org)
+        self._server(org)
+        DuckLakeBackfill.objects.create(team=team_a, table_suffix="shared")
+
+        with pytest.raises(DucklingBackfillEnableError):
+            enable_team_backfill(team_id=team_b.id, organization_id=org.id, table_name="shared")
+
+    def test_same_name_is_idempotent(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        self._server(org)
+
+        enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="prod")
+        suffix = enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="prod")
+
+        assert suffix == "prod"
+        assert DuckLakeBackfill.objects.filter(team_id=team.id).count() == 1
+        assert DuckgresServerTeam.objects.filter(team_id=team.id).count() == 1
+
+    def test_refuses_to_change_a_set_suffix(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        self._server(org)
+        enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="first")
+
+        with pytest.raises(DucklingBackfillEnableError):
+            enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="second")
+        assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix == "first"
+
+    def test_refuses_to_set_a_suffix_on_a_legacy_shared_team(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        self._server(org)
+        DuckLakeBackfill.objects.create(team=team, enabled=True, table_suffix=None)
+
+        with pytest.raises(DucklingBackfillEnableError):
+            enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="new_name")
+        assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix is None
+
+    def test_requires_a_provisioned_server(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+
+        with pytest.raises(DucklingBackfillEnableError):
+            enable_team_backfill(team_id=team.id, organization_id=org.id, table_name="events")
+
+
+@pytest.mark.django_db
+class TestGetTeamBackfillState:
+    def test_no_backfill(self):
+        team = Team.objects.create(organization=Organization.objects.create(name="Org"))
+
+        assert get_team_backfill_state(team.id) == {"has_backfill": False, "table_suffix": None}
+
+    def test_legacy_shared_backfill(self):
+        team = Team.objects.create(organization=Organization.objects.create(name="Org"))
+        DuckLakeBackfill.objects.create(team=team, table_suffix=None)
+
+        assert get_team_backfill_state(team.id) == {"has_backfill": True, "table_suffix": None}
+
+    def test_suffixed_backfill(self):
+        team = Team.objects.create(organization=Organization.objects.create(name="Org"))
+        DuckLakeBackfill.objects.create(team=team, table_suffix="prod")
+
+        assert get_team_backfill_state(team.id) == {"has_backfill": True, "table_suffix": "prod"}
 
 
 TEST_CONFIG = {

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -818,7 +818,14 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     @extend_schema(
         request=inline_serializer(
             "ProvisionWarehouseRequest",
-            fields={"database_name": serializers.CharField(help_text="Name for the new database")},
+            fields={
+                "database_name": serializers.CharField(help_text="Name for the new database"),
+                "table_name": serializers.CharField(
+                    help_text="Name for the provisioning project's warehouse tables (events_<name>, persons_<name>, "
+                    "…). Lowercase letters, numbers, and underscores only; used verbatim as the suffix. Required "
+                    "so the first project gets its own per-environment tables."
+                ),
+            },
         ),
         responses={
             202: inline_serializer(
@@ -842,7 +849,51 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         admin_error = self._require_organization_admin(request, "provision")
         if admin_error is not None:
             return admin_error
-        return managed_warehouse.provision(self.team.organization_id, request.data.get("database_name"))
+        return managed_warehouse.provision(
+            self.team.organization_id,
+            request.data.get("database_name"),
+            self.team_id,
+            request.data.get("table_name"),
+        )
+
+    @extend_schema(
+        request=inline_serializer(
+            "EnableWarehouseBackfillRequest",
+            fields={
+                "table_name": serializers.CharField(
+                    help_text="Name for this environment's warehouse tables (events_<name>, persons_<name>, …). "
+                    "Lowercase letters, numbers, and underscores only; used verbatim as the suffix and must be "
+                    "unique across the organization's environments."
+                )
+            },
+        ),
+        responses={
+            200: inline_serializer(
+                "EnableWarehouseBackfillResponse",
+                fields={
+                    "enabled": serializers.BooleanField(help_text="Whether warehouse backfill is now enabled"),
+                    "table_suffix": serializers.CharField(
+                        help_text="Suffix used for this environment's tables (events_<suffix>, persons_<suffix>)"
+                    ),
+                },
+            )
+        },
+    )
+    @action(methods=["POST"], detail=False, required_scopes=["warehouse_view:write"])
+    def enable_backfill(self, request: Request, **kwargs) -> Response:
+        """Enable warehouse backfill for this environment with a dedicated set of tables.
+
+        Requires a table name and records the environment's membership in the
+        organization's managed warehouse. Restricted to organization admins.
+        """
+        admin_error = self._require_organization_admin(request, "enable backfill for")
+        if admin_error is not None:
+            return admin_error
+        return managed_warehouse.enable_backfill(
+            self.team.organization_id,
+            self.team.id,
+            request.data.get("table_name"),
+        )
 
     @extend_schema(
         responses={
@@ -899,14 +950,26 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                         required=False,
                         allow_null=True,
                     ),
+                    "has_backfill": serializers.BooleanField(
+                        help_text="Whether this project already has a warehouse backfill configured. When true, its "
+                        "table name is fixed and the enable form should not be shown."
+                    ),
+                    "table_suffix": serializers.CharField(
+                        allow_null=True,
+                        help_text="This project's per-environment table suffix (events_<suffix>). Null when the "
+                        "project still writes to the shared tables.",
+                    ),
                 },
             )
         },
     )
     @action(methods=["GET"], detail=False)
     def warehouse_status(self, request: Request, **kwargs) -> Response:
-        """Get the current provisioning status of the managed warehouse."""
-        return managed_warehouse.status_for(self.team.organization_id)
+        """Get the current provisioning status of the managed warehouse, with this project's backfill state."""
+        resp = managed_warehouse.status_for(self.team.organization_id)
+        if resp.status_code == 200 and isinstance(resp.data, dict):
+            resp.data.update(managed_warehouse.team_backfill_state(self.team_id))
+        return resp
 
     @extend_schema(
         responses={

--- a/products/data_warehouse/backend/api/managed_warehouse.py
+++ b/products/data_warehouse/backend/api/managed_warehouse.py
@@ -187,10 +187,15 @@ def _request(
     return Response(body, status=resp.status_code)
 
 
-def provision(organization_id: UUID | str, database_name: str | None) -> Response:
+def provision(organization_id: UUID | str, database_name: str | None, team_id: int, table_name: str | None) -> Response:
     name_error = validate_warehouse_name(database_name)
     if name_error:
         return Response({"error": name_error}, status=status.HTTP_400_BAD_REQUEST)
+    # Validate the table name up front: the duckling backfill setup runs best-effort after the
+    # provision call, so a bad name there would be swallowed — catch it before provisioning.
+    table_name_error = _validate_table_name(table_name)
+    if table_name_error or table_name is None:
+        return Response({"error": table_name_error or "table_name is required"}, status=status.HTTP_400_BAD_REQUEST)
     resp = _request(
         "POST",
         organization_id,
@@ -204,6 +209,7 @@ def provision(organization_id: UUID | str, database_name: str | None) -> Respons
     )
     if status.is_success(resp.status_code) and isinstance(resp.data, dict):
         _persist_duckgres_server(organization_id, database_name, resp.data)
+        _register_provisioning_team(organization_id, team_id, table_name)
         # The bucket is internal infra detail, persisted above and consumed by the
         # backfill via cp_bucket_for — not part of the UI-facing ProvisionWarehouseResponse
         # schema. Strip it so the response matches its OpenAPI contract.
@@ -215,6 +221,43 @@ def _strip_bucket_fields(body: dict) -> None:
     """Drop the internal bucket fields from a UI-facing response body, in place."""
     body.pop("bucket", None)
     body.pop("bucket_region", None)
+
+
+def _validate_table_name(name: str | None) -> str | None:
+    """Return an error message if `name` isn't a valid events/persons table suffix, else None."""
+    # Keep ducklake.common (and its duckdb dependency) off the API import path.
+    from posthog.ducklake.common import validate_table_suffix  # noqa: PLC0415
+
+    return validate_table_suffix(name)
+
+
+def team_backfill_state(team_id: int) -> dict:
+    """Return the calling team's duckling backfill state for the warehouse-status response."""
+    # Keep ducklake.common (and its duckdb dependency) off the API import path.
+    from posthog.ducklake.common import get_team_backfill_state  # noqa: PLC0415
+
+    return get_team_backfill_state(team_id)
+
+
+def _register_provisioning_team(organization_id: UUID | str, team_id: int, table_name: str) -> None:
+    """Record the provisioning (calling) team's duckling membership and enable its backfill.
+
+    A managed warehouse is org-scoped, but membership and backfills are per team, so provision
+    registers only the provisioning team: its `DuckgresServerTeam` link (first-class membership)
+    and a `DuckLakeBackfill` enabled with the per-environment table name the admin chose at
+    provision — so a newly provisioned org writes to its own `events_<suffix>` tables. Other teams
+    join later via `enable_backfill`, which runs the same path.
+
+    Best-effort, mirroring `_persist_duckgres_server`: a failure is logged, not raised, so the
+    one-time provision password is never lost to it.
+    """
+    # Keep ducklake.common (and its duckdb dependency) off the API import path.
+    from posthog.ducklake.common import enable_team_backfill  # noqa: PLC0415
+
+    try:
+        enable_team_backfill(team_id=team_id, organization_id=organization_id, table_name=table_name)
+    except Exception:
+        logger.exception("Failed to register provisioning team after provision", team_id=team_id)
 
 
 def _persist_duckgres_server(organization_id: UUID | str, database_name: str | None, body: dict) -> None:
@@ -257,6 +300,34 @@ def _persist_duckgres_server(organization_id: UUID | str, database_name: str | N
         )
     except Exception:
         logger.exception("Failed to persist DuckgresServer after provision", organization_id=str(organization_id))
+
+
+def enable_backfill(organization_id: UUID | str, team_id: int, table_name: str | None) -> Response:
+    """Enable warehouse backfill for a team's environment with dedicated per-environment tables.
+
+    Per-team (not org-wide): persists the per-environment table suffix on the team's
+    DuckLakeBackfill and records team↔duckling membership. Gated on the org's feature flag so
+    a team can't enable a backfill for an org that isn't entitled to the managed warehouse.
+    """
+    if not is_enabled(organization_id):
+        return Response({"error": "This feature is not enabled"}, status=status.HTTP_403_FORBIDDEN)
+    table_name_error = _validate_table_name(table_name)
+    if table_name_error or table_name is None:
+        return Response({"error": table_name_error or "table_name is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+    # Keep ducklake.common (and its duckdb dependency) off the API import path.
+    from posthog.ducklake.common import DucklingBackfillEnableError, enable_team_backfill  # noqa: PLC0415
+
+    try:
+        suffix = enable_team_backfill(
+            team_id=team_id,
+            organization_id=organization_id,
+            table_name=table_name,
+        )
+    except DucklingBackfillEnableError as exc:
+        return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+    return Response({"enabled": True, "table_suffix": suffix}, status=status.HTTP_200_OK)
 
 
 def deprovision(organization_id: UUID | str) -> Response:

--- a/products/data_warehouse/backend/api/test/test_managed_warehouse.py
+++ b/products/data_warehouse/backend/api/test/test_managed_warehouse.py
@@ -7,8 +7,8 @@ from django.test import override_settings
 
 from rest_framework.response import Response
 
-from posthog.ducklake.models import DuckgresServer
-from posthog.models import Organization
+from posthog.ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill
+from posthog.models import Organization, Team
 
 from products.data_warehouse.backend.api import managed_warehouse
 
@@ -35,12 +35,13 @@ def test_is_enabled_uses_data_warehouse_scene_flag(mock_feature_enabled: MagicMo
 @patch("products.data_warehouse.backend.api.managed_warehouse._request")
 def test_provision_persists_duckgres_server_on_success(mock_request: MagicMock) -> None:
     org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
     mock_request.return_value = Response(
         {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
         status=202,
     )
 
-    resp = managed_warehouse.provision(org.id, "my-warehouse")
+    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
 
     assert resp.status_code == 202
     server = DuckgresServer.objects.get(organization_id=org.id)
@@ -63,6 +64,7 @@ def test_provision_persists_bucket_returned_by_control_plane(mock_request: Magic
     # verbatim instead of re-deriving — the CP owns the naming rule (it pins the
     # same name on the Duckling CR), and the local derivation has drifted from it.
     org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
     cp_bucket = "posthog-duckling-0194d6405db400006cde48d6114c0f99-mw-prod-us"
     mock_request.return_value = Response(
         {
@@ -75,7 +77,7 @@ def test_provision_persists_bucket_returned_by_control_plane(mock_request: Magic
         status=202,
     )
 
-    resp = managed_warehouse.provision(org.id, "my-warehouse")
+    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
 
     assert resp.status_code == 202
     server = DuckgresServer.objects.get(organization_id=org.id)
@@ -85,18 +87,45 @@ def test_provision_persists_bucket_returned_by_control_plane(mock_request: Magic
 
 
 @pytest.mark.django_db
+@override_settings(CLOUD_DEPLOYMENT="US", DUCKGRES_PG_PORT=5432)
+@patch("products.data_warehouse.backend.api.managed_warehouse._request")
+def test_provision_enables_backfill_for_calling_team_only(mock_request: MagicMock) -> None:
+    org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
+    other_team = Team.objects.create(organization=org)
+    mock_request.return_value = Response(
+        {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
+        status=202,
+    )
+
+    managed_warehouse.provision(org.id, "my-warehouse", team.id, "prod_events")
+
+    backfill = DuckLakeBackfill.objects.get(team_id=team.id)
+    assert backfill.enabled is True
+    # New provisions set the per-environment suffix from the admin-provided table name.
+    assert backfill.table_suffix == "prod_events"
+    assert not DuckLakeBackfill.objects.filter(team_id=other_team.id).exists()
+
+    # Provision also records first-class duckling membership for the provisioning team only.
+    server = DuckgresServer.objects.get(organization_id=org.id)
+    assert DuckgresServerTeam.objects.filter(server=server, team_id=team.id).exists()
+    assert not DuckgresServerTeam.objects.filter(team_id=other_team.id).exists()
+
+
+@pytest.mark.django_db
 @override_settings(CLOUD_DEPLOYMENT="EU", DUCKGRES_PG_PORT=5432)
 @patch("products.data_warehouse.backend.api.managed_warehouse._request")
 def test_provision_persists_server_without_bucket_when_region_unsupported(mock_request: MagicMock) -> None:
     # EU has no managed-warehouse bucket convention, so bucket derivation raises. The
     # connection row (with the one-time password) must still be persisted.
     org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
     mock_request.return_value = Response(
         {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
         status=202,
     )
 
-    resp = managed_warehouse.provision(org.id, "my-warehouse")
+    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
 
     assert resp.status_code == 202
     server = DuckgresServer.objects.get(organization_id=org.id)
@@ -108,12 +137,14 @@ def test_provision_persists_server_without_bucket_when_region_unsupported(mock_r
 @patch("products.data_warehouse.backend.api.managed_warehouse._request")
 def test_provision_does_not_persist_on_failure(mock_request: MagicMock) -> None:
     org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
     mock_request.return_value = Response({"error": "boom"}, status=500)
 
-    resp = managed_warehouse.provision(org.id, "my-warehouse")
+    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
 
     assert resp.status_code == 500
     assert not DuckgresServer.objects.filter(organization_id=org.id).exists()
+    assert not DuckLakeBackfill.objects.filter(team_id=team.id).exists()
 
 
 @pytest.mark.django_db
@@ -277,6 +308,29 @@ def test_cp_bucket_for_bypasses_feature_gate_and_reconciles(mock_internal: Magic
 
 
 @pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse._request")
+def test_provision_rejects_invalid_table_name(mock_request: MagicMock) -> None:
+    org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org)
+
+    for bad_name in ("", "My Project", "my-project"):
+        resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, bad_name)
+        assert resp.status_code == 400, bad_name
+
+    # Rejected up front, before the duckgres provision call.
+    mock_request.assert_not_called()
+
+
+def _provisioned_org() -> tuple[Organization, Team, DuckgresServer]:
+    org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org, name="Env")
+    server = DuckgresServer.objects.create(
+        organization=org, host="h", port=5432, database="ducklake", username="root", password="x"
+    )
+    return org, team, server
+
+
+@pytest.mark.django_db
 @patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
 @patch("products.data_warehouse.backend.api.managed_warehouse.internal_requests")
 @override_settings(DUCKGRES_API_URL="http://duckgres.invalid", DUCKGRES_INTERNAL_SECRET="s")
@@ -307,3 +361,107 @@ def test_cp_bucket_for_returns_none_when_cp_has_no_bucket(mock_request: MagicMoc
     mock_request.return_value = Response({"org_id": str(org.id), "state": "ready"}, status=200)
 
     assert managed_warehouse.cp_bucket_for(org.id) is None
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_creates_backfill_and_membership(mock_enabled: MagicMock) -> None:
+    org, team, server = _provisioned_org()
+
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "my_events")
+
+    assert resp.status_code == 200
+    assert resp.data == {"enabled": True, "table_suffix": "my_events"}
+
+    backfill = DuckLakeBackfill.objects.get(team_id=team.id)
+    assert backfill.enabled is True
+    assert backfill.table_suffix == "my_events"
+    assert DuckgresServerTeam.objects.filter(server=server, team_id=team.id).exists()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_rejects_invalid_name(mock_enabled: MagicMock) -> None:
+    org, team, _ = _provisioned_org()
+
+    for bad_name in ("", "My Project", "my-project"):
+        resp = managed_warehouse.enable_backfill(org.id, team.id, bad_name)
+        assert resp.status_code == 400, bad_name
+
+    assert not DuckLakeBackfill.objects.filter(team_id=team.id).exists()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_rejects_duplicate_suffix_in_org(mock_enabled: MagicMock) -> None:
+    org, team_a, _ = _provisioned_org()
+    team_b = Team.objects.create(organization=org, name="Env B")
+    DuckLakeBackfill.objects.create(team=team_a, table_suffix="shared")
+
+    resp = managed_warehouse.enable_backfill(org.id, team_b.id, "shared")
+
+    assert resp.status_code == 400
+    assert not DuckLakeBackfill.objects.filter(team_id=team_b.id).exists()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_without_provisioned_server(mock_enabled: MagicMock) -> None:
+    org = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=org, name="Env")
+
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "events")
+
+    assert resp.status_code == 400
+    assert "provision" in resp.data["error"].lower()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=False)
+def test_enable_backfill_gated_on_feature_flag(mock_enabled: MagicMock) -> None:
+    org, team, _ = _provisioned_org()
+
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "events")
+
+    assert resp.status_code == 403
+    assert not DuckLakeBackfill.objects.filter(team_id=team.id).exists()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_same_name_is_idempotent(mock_enabled: MagicMock) -> None:
+    org, team, _ = _provisioned_org()
+
+    managed_warehouse.enable_backfill(org.id, team.id, "first")
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "first")
+
+    assert resp.status_code == 200
+    assert DuckLakeBackfill.objects.filter(team_id=team.id).count() == 1
+    assert DuckgresServerTeam.objects.filter(team_id=team.id).count() == 1
+    assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix == "first"
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_refuses_to_change_an_existing_suffix(mock_enabled: MagicMock) -> None:
+    org, team, _ = _provisioned_org()
+    managed_warehouse.enable_backfill(org.id, team.id, "first")
+
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "second")
+
+    # Changing a set suffix would split the team's data across two tables — rejected, unchanged.
+    assert resp.status_code == 400
+    assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix == "first"
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.api.managed_warehouse.is_enabled", return_value=True)
+def test_enable_backfill_refuses_to_set_a_suffix_on_a_legacy_shared_team(mock_enabled: MagicMock) -> None:
+    org, team, _ = _provisioned_org()
+    # A legacy team already backfilling to the shared tables (NULL suffix), e.g. backfilled by migration.
+    DuckLakeBackfill.objects.create(team=team, enabled=True, table_suffix=None)
+
+    resp = managed_warehouse.enable_backfill(org.id, team.id, "new_name")
+
+    assert resp.status_code == 400
+    assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix is None

--- a/products/data_warehouse/backend/api/test/test_misc_warehouse_viewsets_access_control.py
+++ b/products/data_warehouse/backend/api/test/test_misc_warehouse_viewsets_access_control.py
@@ -136,11 +136,13 @@ class TestDataWarehouseViewSetAccessControl(WarehouseAccessControlTestMixin):
         self.client.force_login(self.editor_user)
 
         response = self.client.post(
-            self._path("provision/"), data={"database_name": "x"}, content_type="application/json"
+            self._path("provision/"),
+            data={"database_name": "x", "table_name": "x"},
+            content_type="application/json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
-        mock_provision.assert_called_once_with(self.team.organization_id, "x")
+        mock_provision.assert_called_once_with(self.team.organization_id, "x", self.team.id, "x")
 
     @patch("products.data_warehouse.backend.api.data_warehouse.managed_warehouse.reset_password")
     def test_reset_password_blocked_for_project_editor_who_is_not_org_admin(self, mock_reset_password):

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -64,9 +64,23 @@ export interface DeprovisionWarehouseResponseApi {
     org: string
 }
 
+export interface EnableWarehouseBackfillRequestApi {
+    /** Name for this environment's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix and must be unique across the organization's environments. */
+    table_name: string
+}
+
+export interface EnableWarehouseBackfillResponseApi {
+    /** Whether warehouse backfill is now enabled */
+    enabled: boolean
+    /** Suffix used for this environment's tables (events_<suffix>, persons_<suffix>) */
+    table_suffix: string
+}
+
 export interface ProvisionWarehouseRequestApi {
     /** Name for the new database */
     database_name: string
+    /** Name for the provisioning project's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix. Required so the first project gets its own per-environment tables. */
+    table_name: string
 }
 
 export interface ProvisionWarehouseResponseApi {
@@ -149,6 +163,13 @@ export interface WarehouseStatusResponseApi {
      */
     failed_at: string | null
     connection?: WarehouseConnectionApi | null
+    /** Whether this project already has a warehouse backfill configured. When true, its table name is fixed and the enable form should not be shown. */
+    has_backfill: boolean
+    /**
+     * This project's per-environment table suffix (events_<suffix>). Null when the project still writes to the shared tables.
+     * @nullable
+     */
+    table_suffix: string | null
 }
 
 /**

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -18,6 +18,8 @@ import type {
     DataWarehouseSavedQueryDraftApi,
     DataWarehouseSavedQueryFolderApi,
     DeprovisionWarehouseResponseApi,
+    EnableWarehouseBackfillRequestApi,
+    EnableWarehouseBackfillResponseApi,
     FixHogqlListParams,
     InsightVariableApi,
     InsightVariablesListParams,
@@ -255,6 +257,29 @@ export const dataWarehouseDeprovisionCreate = async (
     })
 }
 
+export const getDataWarehouseEnableBackfillCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/data_warehouse/enable_backfill/`
+}
+
+/**
+ * Enable warehouse backfill for this environment with a dedicated set of tables.
+ *
+ * Requires a table name and records the environment's membership in the
+ * organization's managed warehouse. Restricted to organization admins.
+ */
+export const dataWarehouseEnableBackfillCreate = async (
+    projectId: string,
+    enableWarehouseBackfillRequestApi: EnableWarehouseBackfillRequestApi,
+    options?: RequestInit
+): Promise<EnableWarehouseBackfillResponseApi> => {
+    return apiMutator<EnableWarehouseBackfillResponseApi>(getDataWarehouseEnableBackfillCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(enableWarehouseBackfillRequestApi),
+    })
+}
+
 export const getDataWarehouseJobStatsRetrieveUrl = (projectId: string) => {
     return `/api/projects/${projectId}/data_warehouse/job_stats/`
 }
@@ -356,7 +381,7 @@ export const getDataWarehouseWarehouseStatusRetrieveUrl = (projectId: string) =>
 }
 
 /**
- * Get the current provisioning status of the managed warehouse.
+ * Get the current provisioning status of the managed warehouse, with this project's backfill state.
  */
 export const dataWarehouseWarehouseStatusRetrieve = async (
     projectId: string,

--- a/products/data_warehouse/frontend/generated/api.zod.ts
+++ b/products/data_warehouse/frontend/generated/api.zod.ts
@@ -10,10 +10,29 @@
 import * as zod from 'zod'
 
 /**
+ * Enable warehouse backfill for this environment with a dedicated set of tables.
+ *
+ * Requires a table name and records the environment's membership in the
+ * organization's managed warehouse. Restricted to organization admins.
+ */
+export const DataWarehouseEnableBackfillCreateBody = /* @__PURE__ */ zod.object({
+    table_name: zod
+        .string()
+        .describe(
+            "Name for this environment's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix and must be unique across the organization's environments."
+        ),
+})
+
+/**
  * Start provisioning a managed warehouse for this organization (shared by all its teams).
  */
 export const DataWarehouseProvisionCreateBody = /* @__PURE__ */ zod.object({
     database_name: zod.string().describe('Name for the new database'),
+    table_name: zod
+        .string()
+        .describe(
+            "Name for the provisioning project's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix. Required so the first project gets its own per-environment tables."
+        ),
 })
 
 export const insightVariablesCreateBodyNameMax = 400

--- a/products/data_warehouse/mcp/tools.yaml
+++ b/products/data_warehouse/mcp/tools.yaml
@@ -50,6 +50,9 @@ tools:
     data-warehouse-deprovision-create:
         operation: data_warehouse_deprovision_create
         enabled: false
+    data-warehouse-enable-backfill-create:
+        operation: data_warehouse_enable_backfill_create
+        enabled: false
     data-warehouse-job-stats-retrieve:
         operation: data_warehouse_job_stats_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17758,6 +17758,18 @@ export namespace Schemas {
       skipped_reason: string | null;
     }
 
+    export interface EnableWarehouseBackfillRequest {
+      /** Name for this environment's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix and must be unique across the organization's environments. */
+      table_name: string;
+    }
+
+    export interface EnableWarehouseBackfillResponse {
+      /** Whether warehouse backfill is now enabled */
+      enabled: boolean;
+      /** Suffix used for this environment's tables (events_<suffix>, persons_<suffix>) */
+      table_suffix: string;
+    }
+
     export interface EndExperiment {
       /** The conclusion of the experiment.
        *
@@ -42139,6 +42151,8 @@ export namespace Schemas {
     export interface ProvisionWarehouseRequest {
       /** Name for the new database */
       database_name: string;
+      /** Name for the provisioning project's warehouse tables (events_<name>, persons_<name>, …). Lowercase letters, numbers, and underscores only; used verbatim as the suffix. Required so the first project gets its own per-environment tables. */
+      table_name: string;
     }
 
     export interface ProvisionWarehouseResponse {
@@ -49653,6 +49667,13 @@ export namespace Schemas {
          */
       failed_at: string | null;
       connection?: WarehouseConnection | null;
+      /** Whether this project already has a warehouse backfill configured. When true, its table name is fixed and the enable form should not be shown. */
+      has_backfill: boolean;
+      /**
+         * This project's per-environment table suffix (events_<suffix>). Null when the project still writes to the shared tables.
+         * @nullable
+         */
+      table_suffix: string | null;
     }
 
     export interface WeeklyDigestResponse {


### PR DESCRIPTION
> **Stack 3/3** (backfill → DAG → **provision+enable+UI**). Base is the DAG PR (#64951). This is the producer: it lets admins/teams set the table name the already-deployed DAG consumer routes on.

## Problem

A managed warehouse is org-scoped and shared, but membership and per-environment tables are per team. Provisioning never recorded which team owns/joined the duckling, and there was no way to choose a team's table name.

## Changes

**Going forward every project writes to its own `events_<suffix>` / `persons_<suffix>` tables** — only pre-existing (NULL-suffix) backfills stay on the shared tables.

- **Provision** now requires a **table name** alongside the warehouse name. It runs the same path as the enable action: validate the name, record the team's `DuckgresServerTeam` membership, and enable a `DuckLakeBackfill` with that `table_suffix`. So a newly provisioned org's first project gets its own tables immediately.
- **`enable_backfill` API** (org-admin): additional teams join the existing duckling by picking their own table name (required, unique within the org).
- **Validate, don't normalize.** The name is used **verbatim** as the suffix — it must be lowercase letters, numbers, and underscores (rejected with a clear error otherwise), so what the user types is exactly the table suffix.
- **Write-once.** Once a backfill exists, its table name is immutable — changing a set suffix, or switching a legacy NULL (shared-table) team to a name, is rejected because it would split the team's existing data across two tables.
- **UI**: the settings tab collects the table name in the provision form (first project) and a per-project enable form (later projects); `warehouse_status` surfaces the team's `table_suffix` / `has_backfill` so an already-configured project shows a read-only "writes to `events_<suffix>`" state instead of re-offering the form.
- Unifies provision and enable on `enable_team_backfill`, removing the interim `enable_backfill_for_team` / `link_team_to_duckling` / `register_provisioning_team` helpers.

Control flow: **first project provisions** → `DuckgresServer` + `DuckgresServerTeam` + suffixed `DuckLakeBackfill`; **other projects enable via UI** → `DuckgresServerTeam` + suffixed `DuckLakeBackfill` (no new server).

## How did you test this code?

Agent (Claude Code), human-directed. Backend (`test_managed_warehouse.py`, `test_common.py`, 44 passing): provision requires a valid table name (400 on empty/spaces/hyphens), sets the suffix verbatim, creates membership for the calling team only; enable rejects duplicate suffix / unprovisioned org; **write-once** — same name is idempotent, changing a set suffix or setting one on a legacy shared team is rejected and unchanged; `get_team_backfill_state` covers no-backfill / legacy-shared / suffixed. Provision access-control wiring updated. Frontend `warehouseProvisioningLogic.test.ts` green; `typescript:check` clean after kea typegen + `build:openapi`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Skills: `/improving-drf-endpoints`, `/adopting-generated-api-types`. 3rd of a 3-PR safe-rollout split; the producer deploys last so the DAG consumer (stack 2/3) is already honoring suffixes when names start being set. Per review, the suffix is write-once and the producer guarantees a team's table only ever goes NULL → set once, never set → different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
