### PR TITLE
feat(inbox): make scout findings linkable

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -95,6 +95,7 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
     const { emissionRows, emissionsLoading, emissionsLoadFailed, runsWindowLoadedOnce, runsWindowComplete } = useValues(
         scoutDetailLogic({ skillName })
     )
+    const { selectedScoutFindingId } = useValues(inboxSceneLogic)
 
     // "Loading" until the fleet's runs window has settled once AND this scout's emissions have
     // resolved — otherwise a fresh deep-link would flash the empty state before we know the
@@ -123,7 +124,14 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
             ) : (
                 <>
                     {emissionRows.map(({ emission, run, report }) => (
-                        <ScoutEmissionCard key={emission.id} emission={emission} run={run} report={report} />
+                        <ScoutEmissionCard
+                            key={emission.id}
+                            skillName={skillName}
+                            emission={emission}
+                            run={run}
+                            report={report}
+                            isDeepLinked={selectedScoutFindingId === emission.finding_id}
+                        />
                     ))}
                     {!runsWindowComplete && (
                         <span className="text-xs text-muted">

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -103,6 +103,10 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
     // quiet-scout empty state from flickering to a skeleton every 60s poll.
     const loading = !runsWindowLoadedOnce || emissionsLoading
     const hasRows = emissionRows.length > 0
+    // The unique emission the deep-link resolves to: the newest row whose finding matches.
+    const deepLinkedEmissionId = selectedScoutFindingId
+        ? (emissionRows.find(({ emission }) => emission.finding_id === selectedScoutFindingId)?.emission.id ?? null)
+        : null
 
     return (
         <div className="flex flex-col gap-2">
@@ -130,7 +134,10 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
                             emission={emission}
                             run={run}
                             report={report}
-                            isDeepLinked={selectedScoutFindingId === emission.finding_id}
+                            // `finding_id` repeats across runs (it's a dedup trace id, not unique), so only
+                            // mark the newest matching emission — rows are newest-first — to keep the
+                            // highlight/scroll deterministic for a single shared link.
+                            isDeepLinked={emission.id === deepLinkedEmissionId}
                         />
                     ))}
                     {!runsWindowComplete && (

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -1,10 +1,13 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { IconArrowRight, IconChevronDown, IconExternal } from '@posthog/icons'
-import { Link } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 
+import { IconLink } from 'lib/lemon-ui/icons'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { addProjectIdIfMissing } from 'lib/utils/kea-router'
 import { urls } from 'scenes/urls'
 
 import { LinkedSignalReport, SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
@@ -24,40 +27,81 @@ function MonoId({ label, value }: { label: string; value: string }): JSX.Element
  * One emitted finding in the scout detail Signals section. Shares the collapse/expand grammar of
  * the run rows: a header (chevron · severity · confidence · timestamp) that stays visible, a 2-line
  * markdown preview when collapsed, and the full markdown plus an id/task-run footer when expanded.
+ *
+ * `isDeepLinked` marks the finding the current `/inbox/scouts/<skill>/<finding>` URL points at — it
+ * auto-expands, highlights, and scrolls itself into view so a shared link lands on the right card.
  */
 export function ScoutEmissionCard({
+    skillName,
     emission,
     run,
     report,
+    isDeepLinked = false,
 }: {
+    skillName: string
     emission: SignalScoutEmission
     run: SignalScoutRunSummary
     /** The inbox report this finding grouped into, if resolved — renders the "In report" deep-link chip. */
     report: LinkedSignalReport | null
+    /** True when this finding is the one the current URL deep-links to. */
+    isDeepLinked?: boolean
 }): JSX.Element {
-    const [expanded, setExpanded] = useState(false)
+    const [expanded, setExpanded] = useState(isDeepLinked)
     const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
+    const cardRef = useRef<HTMLDivElement>(null)
+
+    // A deep-linked finding may mount after the URL is already settled (emissions load async), so
+    // bring it into view and open it once it appears. Keyed on the finding id so re-selecting a
+    // different finding in the same list re-triggers, not on every render.
+    useEffect(() => {
+        if (isDeepLinked) {
+            setExpanded(true)
+            cardRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isDeepLinked, emission.finding_id])
+
+    const copyFindingLink = (): void => {
+        void copyToClipboard(
+            `${window.location.origin}${addProjectIdIfMissing(urls.inboxScout(skillName, emission.finding_id))}`,
+            'finding link'
+        )
+    }
 
     return (
-        <div className="flex flex-col rounded border border-primary bg-bg-light">
-            <button
-                type="button"
-                onClick={() => setExpanded((value) => !value)}
-                className="flex items-center gap-2 px-3 py-2 text-left"
-                aria-expanded={expanded}
-            >
-                <IconChevronDown
-                    className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
+        <div
+            ref={cardRef}
+            className={`flex flex-col rounded border bg-bg-light ${
+                isDeepLinked ? 'border-accent bg-accent-highlight-secondary' : 'border-primary'
+            }`}
+        >
+            <div className="flex items-center">
+                <button
+                    type="button"
+                    onClick={() => setExpanded((value) => !value)}
+                    className="flex flex-1 items-center gap-2 px-3 py-2 text-left"
+                    aria-expanded={expanded}
+                >
+                    <IconChevronDown
+                        className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
+                    />
+                    <SignalReportPriorityBadge priority={emission.severity} />
+                    <span className="whitespace-nowrap text-[11px] text-muted tabular-nums">
+                        {confidencePercent}% confidence
+                    </span>
+                    <span className="flex-1" />
+                    <span className="whitespace-nowrap text-[11px] text-muted">
+                        {humanFriendlyDetailedTime(emission.emitted_at)}
+                    </span>
+                </button>
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconLink />}
+                    tooltip="Copy a link to this finding"
+                    className="mr-2 shrink-0"
+                    onClick={copyFindingLink}
                 />
-                <SignalReportPriorityBadge priority={emission.severity} />
-                <span className="whitespace-nowrap text-[11px] text-muted tabular-nums">
-                    {confidencePercent}% confidence
-                </span>
-                <span className="flex-1" />
-                <span className="whitespace-nowrap text-[11px] text-muted">
-                    {humanFriendlyDetailedTime(emission.emitted_at)}
-                </span>
-            </button>
+            </div>
 
             <div className="px-3 pb-2 pl-9">
                 <LemonMarkdown

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -71,8 +71,13 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         // detail renders without a spinner while the authoritative fetch runs in the background.
         seedSelectedReport: (report: SignalReport | null) => ({ report }),
         setActiveTab: (tab: InboxTabKey) => ({ tab }),
-        // Scout detail surface: selecting a scout opens its full-width detail over the list.
-        setSelectedScoutSkillName: (skillName: string | null) => ({ skillName }),
+        // Scout detail surface: selecting a scout opens its full-width detail over the list. An
+        // optional finding id deep-links to one emitted finding within that scout (highlighted +
+        // scrolled into view if it's still in the recent window).
+        setSelectedScoutSkillName: (skillName: string | null, findingId: string | null = null) => ({
+            skillName,
+            findingId,
+        }),
         runSessionAnalysis: true,
         runSessionAnalysisSuccess: true,
         runSessionAnalysisFailure: (error: string) => ({ error }),
@@ -128,6 +133,14 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             null as string | null,
             {
                 setSelectedScoutSkillName: (_, { skillName }) => skillName,
+            },
+        ],
+        // The finding deep-linked within the selected scout, if any. Cleared whenever a scout is
+        // (re)selected without a finding — navigating to a scout from the fleet drops any prior finding.
+        selectedScoutFindingId: [
+            null as string | null,
+            {
+                setSelectedScoutSkillName: (_, { findingId }) => findingId,
             },
         ],
         isRunningSessionAnalysis: [
@@ -240,7 +253,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             values.selectedReportId
                 ? urls.inboxReport(values.activeTab, values.selectedReportId)
                 : values.selectedScoutSkillName
-                  ? urls.inboxScout(values.selectedScoutSkillName)
+                  ? urls.inboxScout(values.selectedScoutSkillName, values.selectedScoutFindingId ?? undefined)
                   : urls.inbox(values.activeTab),
             router.values.searchParams,
             router.values.hashParams,
@@ -248,7 +261,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         ],
         setSelectedScoutSkillName: () => [
             values.selectedScoutSkillName
-                ? urls.inboxScout(values.selectedScoutSkillName)
+                ? urls.inboxScout(values.selectedScoutSkillName, values.selectedScoutFindingId ?? undefined)
                 : values.selectedReportId
                   ? urls.inboxReport(values.activeTab, values.selectedReportId)
                   : urls.inbox(values.activeTab),
@@ -294,8 +307,22 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         },
         [urls.inboxScout(':skillName')]: ({ skillName }: { skillName?: string }) => {
             const name = skillName ?? null
-            if (values.selectedScoutSkillName !== name) {
+            // Also reset the finding when landing on the bare scout URL after a finding deep-link.
+            if (values.selectedScoutSkillName !== name || values.selectedScoutFindingId !== null) {
                 actions.setSelectedScoutSkillName(name)
+            }
+        },
+        [urls.inboxScout(':skillName', ':findingId')]: ({
+            skillName,
+            findingId,
+        }: {
+            skillName?: string
+            findingId?: string
+        }) => {
+            const name = skillName ?? null
+            const finding = findingId ?? null
+            if (values.selectedScoutSkillName !== name || values.selectedScoutFindingId !== finding) {
+                actions.setSelectedScoutSkillName(name, finding)
             }
         },
         [urls.inboxReport(':tab', ':reportId')]: ({ tab, reportId }: { tab?: string; reportId?: string }) => {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -932,6 +932,8 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.inbox(':tab')]: [Scene.Inbox, 'inbox'],
     // Registered before the generic report route: both are two-segment `/inbox/x/y` shapes.
     [urls.inboxScout(':skillName')]: [Scene.Inbox, 'inbox'],
+    // Deep-link to a single scout finding: three-segment `/inbox/scouts/<skill>/<finding>`.
+    [urls.inboxScout(':skillName', ':findingId')]: [Scene.Inbox, 'inbox'],
     [urls.inboxReport(':tab', ':reportId')]: [Scene.Inbox, 'inbox'],
     [urls.pipelineStatus()]: [Scene.PipelineStatus, 'pipelineStatus'],
     [urls.sdkHealth()]: [Scene.SdkHealth, 'sdkHealth'],

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -932,7 +932,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.inbox(':tab')]: [Scene.Inbox, 'inbox'],
     // Registered before the generic report route: both are two-segment `/inbox/x/y` shapes.
     [urls.inboxScout(':skillName')]: [Scene.Inbox, 'inbox'],
-    // Deep-link to a single scout finding: three-segment `/inbox/scouts/<skill>/<finding>`.
+    // Deep-link to a single scout finding: the bare scout route plus a trailing `/<finding>` segment.
     [urls.inboxScout(':skillName', ':findingId')]: [Scene.Inbox, 'inbox'],
     [urls.inboxReport(':tab', ':reportId')]: [Scene.Inbox, 'inbox'],
     [urls.pipelineStatus()]: [Scene.PipelineStatus, 'pipelineStatus'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -300,7 +300,10 @@ export const urls = {
     inbox: (tab?: InboxTabKey | ':tab'): string => `/inbox${tab ? `/${tab}` : ''}`,
     inboxReport: (tab: InboxTabKey | ':tab', reportId: string | ':reportId'): string => `/inbox/${tab}/${reportId}`,
     // Scout detail surface, full-width over the inbox list (the fleet section lives in the Configuration tab).
-    inboxScout: (skillName: string | ':skillName'): string => `/inbox/scouts/${skillName}`,
+    // An optional finding id deep-links straight to one emitted finding (best-effort: only resolves while
+    // that finding is still in the scout's recent runs window).
+    inboxScout: (skillName: string | ':skillName', findingId?: string | ':findingId'): string =>
+        `/inbox/scouts/${skillName}${findingId ? `/${findingId}` : ''}`,
     webAnalyticsBotAnalytics: (): string => '/web/bots',
     webAnalyticsHealth: (): string => '/web/health',
     pipelineStatus: (): string => '/health/pipeline-status',

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -302,8 +302,10 @@ export const urls = {
     // Scout detail surface, full-width over the inbox list (the fleet section lives in the Configuration tab).
     // An optional finding id deep-links straight to one emitted finding (best-effort: only resolves while
     // that finding is still in the scout's recent runs window).
-    inboxScout: (skillName: string | ':skillName', findingId?: string | ':findingId'): string =>
-        `/inbox/scouts/${skillName}${findingId ? `/${findingId}` : ''}`,
+    inboxScout: (skillName: string | ':skillName', findingId?: string | ':findingId'): string => {
+        const segment = findingId ? `/${findingId === ':findingId' ? findingId : encodeURIComponent(findingId)}` : ''
+        return `/inbox/scouts/${skillName}${segment}`
+    },
     webAnalyticsBotAnalytics: (): string => '/web/bots',
     webAnalyticsHealth: (): string => '/web/health',
     pipelineStatus: (): string => '/health/pipeline-status',


### PR DESCRIPTION
## Problem

When you're looking at a finding from a scout in the inbox, there's no way to grab a link to that specific finding and share it with a teammate. You can link to the scout, but not to the one finding you actually want to point someone at.

## Changes

Adds a per-finding deep link in the scout detail view. The finding id now sits one segment below the scout URL: `/inbox/scouts/<skillName>/<findingId>`.

- Each emitted finding card (`ScoutEmissionCard`) gets a copy-link button (tooltip: "Copy a link to this finding") that copies the absolute, project-prefixed URL — mirroring the existing "Copy link" affordance on report detail headers.
- Opening that URL routes to the Inbox scene, opens the right scout, and the matching finding **auto-expands, highlights** (accent border + tint, reusing the product's existing selected-row styling), and **scrolls into view**. Because emissions load asynchronously, the highlight/scroll fires once the card actually mounts.
- **Best-effort by design:** the link only resolves while the finding is still in the scout's recent runs window (the window the detail view already loads). Once it ages out, the scout detail opens normally with nothing highlighted — no error, no broken page.

Touched files:
- `frontend/src/scenes/urls.ts` — `inboxScout()` takes an optional `findingId`.
- `frontend/src/scenes/scenes.ts` — registers the three-segment route to the Inbox scene.
- `frontend/src/scenes/inbox/inboxSceneLogic.ts` — new `selectedScoutFindingId` state plus URL ↔ state sync; clears the finding when navigating to a bare scout URL.
- `ScoutDetailView.tsx` / `ScoutEmissionCard.tsx` — thread the selected finding through; render the copy button and deep-link behavior.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run manual testing or add automated tests for this change.

The environment's frontend `node_modules` and Python/`hogli` venv weren't provisioned, so I couldn't run `tsgo` typecheck, kea typegen, or jest locally. I relied on CI to regenerate kea types and run the full typecheck. The routing follows the existing report/scout deep-link patterns already in `inboxSceneLogic.ts`.

I deliberately skipped adding a logic test: mounting `inboxSceneLogic` pulls in `signalSourcesLogic`/`userLogic` side effects that need mocks I couldn't execute in this environment, so I avoided pushing an unverifiable test that could turn CI red.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Directed by the PR assignee, who asked to make scout findings shareable and suggested putting the finding id under the individual scout URL.

Key decisions:
- **Path segment over query param:** chose `/inbox/scouts/<skill>/<finding>` to match the assignee's suggestion and the existing two-segment inbox URL grammar. The three-segment shape doesn't collide with the two-segment report route, so routing stays unambiguous.
- **Match on `finding_id`:** used the human-meaningful finding id (already shown in the card footer) rather than the internal emission row id, so a shared link reads sensibly. First match wins if a finding id recurs across runs — acceptable for a best-effort link.
- **Reused existing primitives:** `copyToClipboard` + `addProjectIdIfMissing` (same as report-detail copy link) and the `border-accent bg-accent-highlight-secondary` selected styling already used elsewhere in the inbox, rather than introducing new patterns.

No repo skills were applicable to this change, so none were invoked.

Agent-authored code — requires human review; not self-merged.