### PR TITLE
feat(data-warehouse): per-environment events/persons tables for ducklings

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -187,6 +187,23 @@ class DucklingTarget:
     organization_id: str
     bucket: str
     bucket_region: str
+    events_table: str
+    persons_table: str
+
+
+def _resolve_table_names(team_id: int) -> tuple[str, str]:
+    """Resolve this team's per-environment events/persons table names.
+
+    A team's `DuckLakeBackfill.events_table_suffix` (when set) isolates its data into
+    dedicated `events_<suffix>` / `persons_<suffix>` tables so multiple teams sharing one
+    org-scoped duckling don't merge into the shared `posthog.events` / `posthog.persons`.
+    An unset suffix (legacy single-team ducklings) keeps the shared table names.
+    """
+    suffix = DuckLakeBackfill.objects.filter(team_id=team_id).values_list("events_table_suffix", flat=True).first()
+    if not suffix:
+        return "events", "persons"
+    _validate_identifier(suffix)
+    return f"events_{suffix}", f"persons_{suffix}"
 
 
 def _resolve_duckling_target(team_id: int) -> DucklingTarget:
@@ -196,19 +213,35 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
     resolves the duckgres server itself) and the S3 bucket. The bucket name is read from a
     stored source of truth — the org's DuckLakeCatalog (hand-entered, older orgs) or its
     DuckgresServer (written at provision time, newer orgs) — and only falls back to the
-    deterministic derivation when neither carries one (e.g. dev mode).
+    deterministic derivation when neither carries one (e.g. dev mode). The table names carry
+    the team's per-environment suffix (or the shared defaults).
     """
     org_id = _get_org_id_for_team(team_id)
+    events_table, persons_table = _resolve_table_names(team_id)
 
     catalog = get_ducklake_catalog_for_organization(org_id)
     if catalog is not None and catalog.bucket:
         bucket, bucket_region = catalog.bucket, catalog.bucket_region
-        return DucklingTarget(team_id=team_id, organization_id=org_id, bucket=bucket, bucket_region=bucket_region)
+        return DucklingTarget(
+            team_id=team_id,
+            organization_id=org_id,
+            bucket=bucket,
+            bucket_region=bucket_region,
+            events_table=events_table,
+            persons_table=persons_table,
+        )
 
     server = get_duckgres_server_for_organization(org_id)
     if server is not None and server.bucket:
         bucket, bucket_region = server.bucket, server.bucket_region
-        return DucklingTarget(team_id=team_id, organization_id=org_id, bucket=bucket, bucket_region=bucket_region)
+        return DucklingTarget(
+            team_id=team_id,
+            organization_id=org_id,
+            bucket=bucket,
+            bucket_region=bucket_region,
+            events_table=events_table,
+            persons_table=persons_table,
+        )
 
     # No stored bucket anywhere (dev mode, or a pre-existing row from before the bucket was
     # persisted): the derived name is an unverified guess at the provisioned bucket. Log it
@@ -220,7 +253,14 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
         organization_id=org_id,
         bucket=bucket,
     )
-    return DucklingTarget(team_id=team_id, organization_id=org_id, bucket=bucket, bucket_region=bucket_region)
+    return DucklingTarget(
+        team_id=team_id,
+        organization_id=org_id,
+        bucket=bucket,
+        bucket_region=bucket_region,
+        events_table=events_table,
+        persons_table=persons_table,
+    )
 
 
 @retry(
@@ -532,7 +572,7 @@ duckling_persons_partitions_def = DynamicPartitionsDefinition(name="duckling_per
 # SQL for creating the events table in DuckLake if it doesn't exist
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
 EVENTS_TABLE_DDL = """
-CREATE TABLE IF NOT EXISTS {catalog}.posthog.events (
+CREATE TABLE IF NOT EXISTS {catalog}.posthog.{table} (
     uuid VARCHAR,
     event VARCHAR,
     properties VARCHAR,
@@ -565,7 +605,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.events (
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
 # Note: person_version uses UBIGINT to match ClickHouse's UInt64 type.
 PERSONS_TABLE_DDL = """
-CREATE TABLE IF NOT EXISTS {catalog}.posthog.persons (
+CREATE TABLE IF NOT EXISTS {catalog}.posthog.{table} (
     team_id BIGINT,
     distinct_id VARCHAR,
     id VARCHAR,
@@ -867,14 +907,15 @@ def ensure_events_table_exists(
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
     alias = DUCKLAKE_ALIAS
+    table = target.events_table
 
-    if table_exists(conn, alias, "posthog", "events"):
+    if table_exists(conn, alias, "posthog", table):
         context.log.info("Events table already exists in duckling catalog")
         # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
-            "events",
+            table,
             "year(timestamp), month(timestamp), day(timestamp)",
             context,
             target.team_id,
@@ -885,14 +926,14 @@ def ensure_events_table_exists(
     conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
     context.log.info("Creating events table in duckling catalog...")
-    conn.execute(EVENTS_TABLE_DDL.format(catalog=alias))
+    conn.execute(EVENTS_TABLE_DDL.format(catalog=alias, table=table))
     context.log.info("Successfully created events table")
 
     # Set partitioning by year/month/day for efficient querying
     _set_table_partitioning(
         conn,
         alias,
-        "events",
+        table,
         "year(timestamp), month(timestamp), day(timestamp)",
         context,
         target.team_id,
@@ -922,14 +963,15 @@ def ensure_persons_table_exists(
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
     alias = DUCKLAKE_ALIAS
+    table = target.persons_table
 
-    if table_exists(conn, alias, "posthog", "persons"):
+    if table_exists(conn, alias, "posthog", table):
         context.log.info("Persons table already exists in duckling catalog")
         # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
-            "persons",
+            table,
             "year(_timestamp), month(_timestamp)",
             context,
             target.team_id,
@@ -940,14 +982,14 @@ def ensure_persons_table_exists(
     conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
 
     context.log.info("Creating persons table in duckling catalog...")
-    conn.execute(PERSONS_TABLE_DDL.format(catalog=alias))
+    conn.execute(PERSONS_TABLE_DDL.format(catalog=alias, table=table))
     context.log.info("Successfully created persons table")
 
     # Set partitioning by year/month of _timestamp for efficient querying
     _set_table_partitioning(
         conn,
         alias,
-        "persons",
+        table,
         "year(_timestamp), month(_timestamp)",
         context,
         target.team_id,
@@ -974,7 +1016,7 @@ def validate_duckling_schema(
     alias = DUCKLAKE_ALIAS
 
     with conn.cursor() as cur:
-        cur.execute(f"DESCRIBE {alias}.posthog.events")
+        cur.execute(f"DESCRIBE {alias}.posthog.{target.events_table}")
         ducklake_columns = {row[0] for row in cur.fetchall()}
 
     missing_in_ducklake = EXPECTED_DUCKLAKE_EVENTS_COLUMNS - ducklake_columns
@@ -1015,7 +1057,7 @@ def validate_duckling_persons_schema(
     alias = DUCKLAKE_ALIAS
 
     with conn.cursor() as cur:
-        cur.execute(f"DESCRIBE {alias}.posthog.persons")
+        cur.execute(f"DESCRIBE {alias}.posthog.{target.persons_table}")
         ducklake_columns = {row[0] for row in cur.fetchall()}
 
     missing_in_ducklake = EXPECTED_DUCKLAKE_PERSONS_COLUMNS - ducklake_columns
@@ -1099,7 +1141,7 @@ def delete_events_partition_data(
     # to a single day's partition instead of scanning all data files.
     next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
     delete_sql = f"""
-    DELETE FROM {alias}.posthog.events
+    DELETE FROM {alias}.posthog.{target.events_table}
     WHERE team_id = %s
       AND timestamp >= %s
       AND timestamp < %s
@@ -1161,7 +1203,7 @@ def delete_persons_partition_data(
     delete_params: tuple[Any, ...]
     if partition_date is None:
         delete_sql = f"""
-        DELETE FROM {alias}.posthog.persons
+        DELETE FROM {alias}.posthog.{target.persons_table}
         WHERE team_id = %s
         """
         delete_params = (team_id,)
@@ -1169,7 +1211,7 @@ def delete_persons_partition_data(
         date_str = partition_date.strftime("%Y-%m-%d")
         next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
         delete_sql = f"""
-        DELETE FROM {alias}.posthog.persons
+        DELETE FROM {alias}.posthog.{target.persons_table}
         WHERE team_id = %s
           AND _timestamp >= %s
           AND _timestamp < %s
@@ -1335,8 +1377,9 @@ def register_file_with_duckling(
     context.log.info(f"Registering file with DuckLake: {s3_path}")
     try:
         conn.execute(
-            psql.SQL("CALL ducklake_add_data_files({}, 'events', {}, schema => 'posthog')").format(
+            psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => 'posthog')").format(
                 psql.Literal(alias),
+                psql.Literal(target.events_table),
                 psql.Literal(s3_path),
             )
         )
@@ -1532,8 +1575,9 @@ def register_persons_file_with_duckling(
     context.log.info(f"Registering persons file with DuckLake: {s3_path}")
     try:
         conn.execute(
-            psql.SQL("CALL ducklake_add_data_files({}, 'persons', {}, schema => 'posthog')").format(
+            psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => 'posthog')").format(
                 psql.Literal(alias),
+                psql.Literal(target.persons_table),
                 psql.Literal(s3_path),
             )
         )
@@ -1608,7 +1652,7 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
                 try:
                     session.run(
                         "drop events table",
-                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.events"),
+                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.{target.events_table}"),
                     )
                 except Exception:
                     context.log.exception(f"Failed to drop events table for team_id={team_id}")
@@ -1788,7 +1832,7 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
                 try:
                     session.run(
                         "drop persons table",
-                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.persons"),
+                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.{target.persons_table}"),
                     )
                 except Exception:
                     context.log.exception(f"Failed to drop persons table for team_id={team_id}")

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -25,6 +25,7 @@ from posthog.dags.events_backfill_to_duckling import (
     _DuckgresSession,
     _get_cluster,
     _resolve_duckling_target,
+    _resolve_table_names,
     _set_table_partitioning,
     _validate_identifier,
     duckling_events_full_backfill_sensor,
@@ -38,14 +39,57 @@ from posthog.dags.events_backfill_to_duckling import (
 
 
 class TestResolveDucklingTarget:
+    @patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons"))
     @patch("posthog.dags.events_backfill_to_duckling.derive_duckling_bucket", return_value=("bkt", "us-west-2"))
     @patch("posthog.dags.events_backfill_to_duckling._get_org_id_for_team", return_value="org-1")
-    def test_builds_target_from_org_and_derived_bucket(self, mock_org: MagicMock, mock_derive: MagicMock):
+    def test_builds_target_from_org_and_derived_bucket(
+        self, mock_org: MagicMock, mock_derive: MagicMock, mock_tables: MagicMock
+    ):
         target = _resolve_duckling_target(7)
 
-        assert target == DucklingTarget(team_id=7, organization_id="org-1", bucket="bkt", bucket_region="us-west-2")
+        assert target == DucklingTarget(
+            team_id=7,
+            organization_id="org-1",
+            bucket="bkt",
+            bucket_region="us-west-2",
+            events_table="events",
+            persons_table="persons",
+        )
         mock_org.assert_called_once_with(7)
         mock_derive.assert_called_once_with("org-1")
+        mock_tables.assert_called_once_with(7)
+
+
+class TestResolveTableNames:
+    """Resolution of per-environment table names from a team's stored events_table_suffix.
+
+    Kept DB-free (the rest of this file is): the stored suffix is mocked at the ORM boundary.
+    """
+
+    def _patch_suffix(self, suffix: str | None) -> MagicMock:
+        model = MagicMock()
+        model.objects.filter.return_value.values_list.return_value.first.return_value = suffix
+        return model
+
+    def test_set_suffix_yields_dedicated_tables(self):
+        with patch("posthog.dags.events_backfill_to_duckling.DuckLakeBackfill", self._patch_suffix("alpha")):
+            assert _resolve_table_names(1) == ("events_alpha", "persons_alpha")
+
+    def test_distinct_suffixes_isolate_two_teams(self):
+        with patch("posthog.dags.events_backfill_to_duckling.DuckLakeBackfill", self._patch_suffix("alpha")):
+            assert _resolve_table_names(1) == ("events_alpha", "persons_alpha")
+        with patch("posthog.dags.events_backfill_to_duckling.DuckLakeBackfill", self._patch_suffix("beta")):
+            assert _resolve_table_names(2) == ("events_beta", "persons_beta")
+
+    @parameterized.expand([("none", None), ("empty", "")])
+    def test_unset_suffix_falls_back_to_shared_tables(self, _name, suffix):
+        with patch("posthog.dags.events_backfill_to_duckling.DuckLakeBackfill", self._patch_suffix(suffix)):
+            assert _resolve_table_names(1) == ("events", "persons")
+
+    def test_unsafe_suffix_is_rejected(self):
+        with patch("posthog.dags.events_backfill_to_duckling.DuckLakeBackfill", self._patch_suffix("a-b; DROP")):
+            with pytest.raises(ValueError):
+                _resolve_table_names(1)
 
 
 class TestParsePartitionKey:
@@ -165,7 +209,7 @@ class TestEventsDDL:
     def test_events_ddl_is_valid_sql(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = EVENTS_TABLE_DDL.format(catalog="memory")
+        ddl = EVENTS_TABLE_DDL.format(catalog="memory", table="events")
         conn.execute(ddl)
 
         # Verify table was created with expected columns
@@ -178,10 +222,19 @@ class TestEventsDDL:
     def test_events_ddl_is_idempotent(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = EVENTS_TABLE_DDL.format(catalog="memory")
+        ddl = EVENTS_TABLE_DDL.format(catalog="memory", table="events")
         # Should not raise on second execution
         conn.execute(ddl)
         conn.execute(ddl)
+        conn.close()
+
+    def test_events_ddl_honors_suffixed_table_name(self):
+        conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
+        conn.execute(EVENTS_TABLE_DDL.format(catalog="memory", table="events_alpha"))
+
+        result = conn.execute("DESCRIBE memory.posthog.events_alpha").fetchall()
+        assert {row[0] for row in result} == EXPECTED_DUCKLAKE_EVENTS_COLUMNS
         conn.close()
 
 
@@ -189,7 +242,7 @@ class TestPersonsDDL:
     def test_persons_ddl_is_valid_sql(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = PERSONS_TABLE_DDL.format(catalog="memory")
+        ddl = PERSONS_TABLE_DDL.format(catalog="memory", table="persons")
         conn.execute(ddl)
 
         # Verify table was created with expected columns
@@ -202,10 +255,19 @@ class TestPersonsDDL:
     def test_persons_ddl_is_idempotent(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = PERSONS_TABLE_DDL.format(catalog="memory")
+        ddl = PERSONS_TABLE_DDL.format(catalog="memory", table="persons")
         # Should not raise on second execution
         conn.execute(ddl)
         conn.execute(ddl)
+        conn.close()
+
+    def test_persons_ddl_honors_suffixed_table_name(self):
+        conn = duckdb.connect()
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
+        conn.execute(PERSONS_TABLE_DDL.format(catalog="memory", table="persons_beta"))
+
+        result = conn.execute("DESCRIBE memory.posthog.persons_beta").fetchall()
+        assert {row[0] for row in result} == EXPECTED_DUCKLAKE_PERSONS_COLUMNS
         conn.close()
 
 
@@ -617,7 +679,7 @@ class TestDuckLakeAddDataFilesPartitioning:
         conn.execute("LOAD ducklake")
         conn.execute(f"ATTACH 'ducklake:{catalog_path}' AS test_lake (DATA_PATH '{data_path}')")
         conn.execute("CREATE SCHEMA IF NOT EXISTS test_lake.posthog")
-        conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake"))
+        conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake", table="events"))
         conn.execute(
             "ALTER TABLE test_lake.posthog.events "
             "SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))"


### PR DESCRIPTION
> **Stacking:** master → #64939 → #64924 → **this PR**. Rebased onto #64924 (which now sits on #64939). Merge in that order.

## Problem

A `DuckgresServer` (an org's duckling warehouse) is org-scoped and shared by every team in the org, but the backfill DAG writes every team's data into a single hardcoded `posthog.events` (and `posthog.persons`) table. Two teams in one org therefore merge their events, distinguished only by a `team_id` column. We want each environment's data physically isolated into its own table.

This builds on #64924 (the `DuckgresServerTeam` membership model + `DuckLakeBackfill.events_table_suffix` field) and #64939 (auto-enables a `DuckLakeBackfill` for the provisioning team on provision). This PR makes the suffix actually route writes and gives teams a way to set it.

## Changes

**Backfill DAG (`events_backfill_to_duckling.py`)** — `DucklingTarget` now carries resolved `events_table` / `persons_table` names. `_resolve_table_names()` reads the team's `DuckLakeBackfill.events_table_suffix`: unset (legacy single-team ducklings) keeps the shared `events` / `persons` tables; set routes writes to `events_<suffix>` / `persons_<suffix>`. The suffix is `_validate_identifier`-checked before any interpolation. The name is threaded through every site that previously hardcoded the table — DDL, existence check, partitioning, schema `DESCRIBE`, partition `DELETE`, `ducklake_add_data_files` registration, and the `DROP TABLE` path — for both events and persons.

**Membership on provision** — provision now records the provisioning team's first-class `DuckgresServerTeam` membership (via a new `link_team_to_duckling` helper) alongside the `DuckLakeBackfill` that #64939 already creates. So the full control flow is:

- **First team in an org provisions** → `DuckgresServer` + `DuckgresServerTeam` + `DuckLakeBackfill` (writes to the shared tables until it picks a name).
- **Other teams join via the new UI** (`enable_backfill`) → `DuckgresServerTeam` + `DuckLakeBackfill` with a required dedicated events-table name. No new server — they attach to the org's existing duckling.

**Enable flow** — new per-team `enable_backfill` viewset action (org-admin gated, mirrors `provision`) that requires an events-table name. The `enable_team_backfill` helper normalizes the name via the existing `sanitize_ducklake_identifier`, rejects collisions with other environments in the same org, and atomically upserts the `DuckLakeBackfill` row (enabled + suffix) plus the `DuckgresServerTeam` membership link.

**Frontend** — the warehouse settings tab gains a per-project "events table name" form (prefilled from the project name, normalized server-side), wired through `warehouseProvisioningLogic`.

Decisions: suffix collisions reject with a clear error rather than auto-suffixing, since the user is choosing the name in the UI. Legacy single-team ducklings are deliberately left on the shared tables (`NULL` suffix) — no rename migration — while every newly enabled team backfill requires a suffix. The `DuckLakeBackfill` admin already exists on master, so this PR just adds `events_table_suffix` to it rather than registering a new admin.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Automated tests run locally, all passing:

- DAG: `posthog/dags/test_events_backfill_to_duckling.py` — suffix resolution (distinct suffixes isolate two teams, unset/empty falls back to shared, unsafe suffix rejected) and suffixed-table DDL.
- Enable API + provision membership: `products/data_warehouse/backend/api/test/test_managed_warehouse.py` — provision creates `DuckgresServerTeam` + `DuckLakeBackfill` for the calling team only; enable action creates the link + backfill, requires a name (400), rejects duplicate suffix within an org (400), errors when the org has no provisioned server, gates on the feature flag (403), idempotent per team — alongside #64939's provision tests.
- `posthog/ducklake/test_common.py` — `link_team_to_duckling` is idempotent and no-ops without a server.
- Frontend: `warehouseProvisioningLogic.test.ts` green; `typescript:check` clean after kea typegen.
- `makemigrations --check` clean on the rebased migration graph.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked on #64939 → #64924. The reconciliation with #64939 was the notable part: both PRs touch `common.py` / `managed_warehouse.py` / `data_warehouse.py` / `test_managed_warehouse.py`. Resolved by keeping #64939's `provision(team_id)` auto-enable path and layering on the membership link + the explicit `enable_backfill` action. The two `DuckLakeBackfill` helpers (`enable_backfill_for_team` for provision, `enable_team_backfill` for the named-table action) intentionally coexist with different semantics (the former preserves a manual disable; the latter forces enable + sets the suffix). `_resolve_duckling_target` was merged to thread table names through master's newer 3-source bucket resolution.

Skills invoked: `/improving-drf-endpoints` (viewset action + inline serializers), `/adopting-generated-api-types` (`hogli build:openapi` regen), `/django-migrations` (migration renumber during the restack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
