### PR TITLE
fix(llma): limit sentiment onnx runtime threads

### DIFF
--- a/posthog/temporal/ai_observability/sentiment/README.md
+++ b/posthog/temporal/ai_observability/sentiment/README.md
@@ -60,6 +60,18 @@ uv run --group sentiment bin/download-sentiment-model
 
 This is a no-op if the model already exists.
 
+### Runtime CPU controls
+
+The ONNX Runtime session defaults to one intra-op and one inter-op thread to
+avoid CPU oversubscription when Temporal runs multiple
+sentiment activities concurrently.
+Override these only for a dedicated worker with measured headroom:
+
+```bash
+POSTHOG_SENTIMENT_ONNX_INTRA_OP_NUM_THREADS=2
+POSTHOG_SENTIMENT_ONNX_INTER_OP_NUM_THREADS=1
+```
+
 ## Running tests
 
 ```bash

--- a/posthog/temporal/ai_observability/sentiment/constants.py
+++ b/posthog/temporal/ai_observability/sentiment/constants.py
@@ -3,11 +3,22 @@
 import os
 from pathlib import Path
 
+
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.environ.get(name, default))
+    except ValueError:
+        return default
+    return max(1, value)
+
+
 # Model
 MODEL_NAME = "cardiffnlp/twitter-roberta-base-sentiment-latest"
 MODEL_MAX_TOKENS = 512  # context window for the cardiffnlp model
 LABELS = ["negative", "neutral", "positive"]
 ONNX_CACHE_DIR = Path(os.environ.get("POSTHOG_SENTIMENT_MODEL_CACHE", "/tmp/posthog-sentiment-onnx-cache"))
+ONNX_INTRA_OP_NUM_THREADS = _positive_int_env("POSTHOG_SENTIMENT_ONNX_INTRA_OP_NUM_THREADS", 1)
+ONNX_INTER_OP_NUM_THREADS = _positive_int_env("POSTHOG_SENTIMENT_ONNX_INTER_OP_NUM_THREADS", 1)
 
 # Extraction bounds
 MAX_USER_MESSAGES = 50

--- a/posthog/temporal/ai_observability/sentiment/model.py
+++ b/posthog/temporal/ai_observability/sentiment/model.py
@@ -20,6 +20,8 @@ from posthog.temporal.ai_observability.sentiment.constants import (
     MODEL_MAX_TOKENS,
     MODEL_NAME,
     ONNX_CACHE_DIR,
+    ONNX_INTER_OP_NUM_THREADS,
+    ONNX_INTRA_OP_NUM_THREADS,
 )
 from posthog.temporal.ai_observability.sentiment.schema import SentimentResult
 
@@ -57,12 +59,22 @@ def _load_pipeline():
                 f"Ensure Dockerfile.llm-analytics bakes the model into {ONNX_CACHE_DIR}."
             )
 
+        from onnxruntime import SessionOptions
         from optimum.onnxruntime import ORTModelForSequenceClassification
         from transformers import AutoTokenizer, pipeline
 
-        logger.info("Loading sentiment model from ONNX cache", cache_dir=cache_dir)
+        session_options = SessionOptions()
+        session_options.intra_op_num_threads = ONNX_INTRA_OP_NUM_THREADS
+        session_options.inter_op_num_threads = ONNX_INTER_OP_NUM_THREADS
+
+        logger.info(
+            "Loading sentiment model from ONNX cache",
+            cache_dir=cache_dir,
+            onnx_intra_op_threads=ONNX_INTRA_OP_NUM_THREADS,
+            onnx_inter_op_threads=ONNX_INTER_OP_NUM_THREADS,
+        )
         tokenizer = AutoTokenizer.from_pretrained(cache_dir)
-        model = ORTModelForSequenceClassification.from_pretrained(cache_dir)
+        model = ORTModelForSequenceClassification.from_pretrained(cache_dir, session_options=session_options)
 
         _pipeline_cache["pipe"] = pipeline(
             "sentiment-analysis",


### PR DESCRIPTION
## Problem

Sentiment evaluations run local ONNX inference inside Temporal workers. ONNX Runtime can choose its own CPU thread pools, which can oversubscribe CPU when several sentiment activities run concurrently.

## Changes

- Add configurable ONNX Runtime intra-op and inter-op thread counts for sentiment inference, defaulting to 1/1.
- Pass those values through `SessionOptions` when loading the ONNX sentiment model.
- Document the runtime tuning knobs in the sentiment README.

## How did you test this code?

Automated tests for sentiment model and extraction behavior. Ruff checks on touched Python files.

Not run: DB-backed sentiment data tests locally; local Postgres was unavailable.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Runtime README updated. No public docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this small runtime tuning change after reviewing sentiment evaluation CPU behavior. Skills invoked: /improving-drf-endpoints for initial API audit context and /create-pr for PR creation. A cache-sharing optimization was considered and dropped; this PR only constrains ONNX Runtime threading and documents the tuning knobs.