### PR TITLE
feat(data-warehouse): add DuckgresServerTeam model and table_suffix

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -162,6 +162,7 @@ def get_scoped_models() -> tuple[dict[str, set[str]], set[str], set[str], set[st
         "DuckLakeBackfill",
         "DuckLakeCatalog",
         "DuckgresServer",
+        "DuckgresServerTeam",
         "EvaluationConfig",
         "RemoteConfig",
         "TeamConversationsSlackConfig",

--- a/posthog/admin/admins/duckgres_server_team_admin.py
+++ b/posthog/admin/admins/duckgres_server_team_admin.py
@@ -1,0 +1,32 @@
+from django.contrib import admin
+
+from posthog.models import DuckgresServerTeam
+
+
+@admin.register(DuckgresServerTeam)
+class DuckgresServerTeamAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "server_id",
+        "team_id",
+        "created_at",
+        "updated_at",
+    )
+    search_fields = ("=team__id", "=server__id")
+    readonly_fields = ("id", "created_at", "updated_at")
+    raw_id_fields = ("server", "team")
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": ("id", "server", "team"),
+            },
+        ),
+        (
+            "Metadata",
+            {
+                "fields": ("created_at", "updated_at"),
+            },
+        ),
+    )

--- a/posthog/admin/admins/ducklake_backfill_admin.py
+++ b/posthog/admin/admins/ducklake_backfill_admin.py
@@ -11,12 +11,13 @@ class DuckLakeBackfillAdmin(admin.ModelAdmin):
         "id",
         "team_id",
         "enabled",
+        "table_suffix",
         "created_by",
         "created_at",
         "updated_at",
     )
     list_filter = ("enabled",)
-    search_fields = ("=team__id",)
+    search_fields = ("=team__id", "table_suffix")
     readonly_fields = ("id", "created_at", "updated_at")
     raw_id_fields = ("team", "created_by")
     actions = ("make_enabled", "make_disabled")
@@ -38,7 +39,7 @@ class DuckLakeBackfillAdmin(admin.ModelAdmin):
         (
             None,
             {
-                "fields": ("id", "team", "enabled"),
+                "fields": ("id", "team", "enabled", "table_suffix"),
             },
         ),
         (

--- a/posthog/ducklake/models.py
+++ b/posthog/ducklake/models.py
@@ -101,6 +101,31 @@ class DuckgresServer(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
         verbose_name_plural = "Duckgres servers"
 
 
+class DuckgresServerTeam(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
+    """Per-team membership of an org's Duckgres warehouse.
+
+    A DuckgresServer is org-scoped and can host many teams (1->n). This model
+    records which teams live in a given server, and is the home for any future
+    team-specific server config.
+    """
+
+    server = models.ForeignKey(
+        "posthog.DuckgresServer",
+        on_delete=models.CASCADE,
+        related_name="teams",
+    )
+    team = models.OneToOneField(
+        "posthog.Team",
+        on_delete=models.CASCADE,
+        related_name="duckgres_server_team",
+    )
+
+    class Meta:
+        db_table = "posthog_duckgresserverteam"
+        verbose_name = "Duckgres server team"
+        verbose_name_plural = "Duckgres server teams"
+
+
 class DuckLakeBackfill(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     """Per-team enablement of DuckLake warehouse backfills.
 
@@ -117,6 +142,13 @@ class DuckLakeBackfill(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     enabled = models.BooleanField(
         default=True,
         help_text="Whether warehouse backfills are enabled for this team",
+    )
+    table_suffix = models.CharField(
+        max_length=63,
+        null=True,
+        blank=True,
+        help_text="Suffix for this team's warehouse tables in the duckling (events_<suffix>, persons_<suffix>). "
+        "User-supplied; falls back to the shared tables when unset.",
     )
 
     class Meta:

--- a/posthog/migrations/1231_duckgresserverteam.py
+++ b/posthog/migrations/1231_duckgresserverteam.py
@@ -1,0 +1,70 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1230_duckgresserver_bucket"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DuckgresServerTeam",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="posthog.user",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, null=True, blank=True)),
+                (
+                    "server",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="teams",
+                        to="posthog.duckgresserver",
+                    ),
+                ),
+                (
+                    "team",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="duckgres_server_team",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_duckgresserverteam",
+                "verbose_name": "Duckgres server team",
+                "verbose_name_plural": "Duckgres server teams",
+            },
+        ),
+        migrations.AddField(
+            model_name="ducklakebackfill",
+            name="table_suffix",
+            field=models.CharField(
+                blank=True,
+                help_text="Suffix for this team's warehouse tables in the duckling (events_<suffix>, persons_<suffix>). "
+                "User-supplied; falls back to the shared tables when unset.",
+                max_length=63,
+                null=True,
+            ),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1230_duckgresserver_bucket
+1231_duckgresserverteam

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -15,7 +15,7 @@ from .comment import Comment
 from .core_event import CoreEvent
 from .data_deletion_request import DataDeletionRequest
 from .data_color_theme import DataColorTheme
-from ..ducklake.models import DuckgresServer, DuckLakeBackfill, DuckLakeCatalog
+from ..ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill, DuckLakeCatalog
 from .element import Element
 from .element_group import ElementGroup
 from .entity import Entity
@@ -105,6 +105,7 @@ __all__ = [
     "DataColorTheme",
     "DeletionType",
     "DuckgresServer",
+    "DuckgresServerTeam",
     "DuckLakeBackfill",
     "DuckLakeCatalog",
     "Element",


### PR DESCRIPTION
> **Stack 1/4** (safe rollout: schema → DAG → writes → UI). Base `master`. Followed by the DAG PR, then the provision/enable PR, then the UI PR.

## Problem

Two teams in one org share a single org-scoped duckling warehouse, but there's no first-class record of which teams belong to it, and the backfill DAG writes every team into the same hardcoded `posthog.events`/`posthog.persons` tables. This PR lays the additive schema groundwork for fixing both.

## Changes

- **`DuckgresServerTeam`** (`posthog/ducklake/models.py`) — join model (`server` FK + `team` `OneToOne`) recording team↔duckling membership.
- **`DuckLakeBackfill.table_suffix`** — nullable column for a team's per-environment events-table name.
- Django admin for `DuckgresServerTeam`; `table_suffix` surfaced on the existing `DuckLakeBackfill` admin; IDOR coverage entry.
- Migration `1231_duckgresserverteam` (CreateModel + AddField).

**Additive only — no runtime code reads or writes these yet, so this deploys with zero behavior change.** That's deliberate: landing the schema first de-risks everything stacked on top.

## How did you test this code?

Agent (Claude Code), human-directed. `makemigrations --check` reports no drift; `check-idor-model-coverage.py` passes; ruff clean. New table + nullable column on a non-hot table — low lock risk.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Skills: `/django-migrations`. First of a 4-PR split re-decomposed from earlier combined PRs (#64924/#64941, now superseded) for a safer phased rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)