### PR TITLE
feat(data-warehouse): add per-project events-table-name onboarding UI

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
@@ -99,9 +99,20 @@ export function SettingsTab(): JSX.Element {
         retryDatabaseName,
         initialPassword,
         isResettingPassword,
+        eventsTableName,
+        isValidEventsTableName,
+        isEnablingBackfill,
+        backfillEventsTableSuffix,
     } = useValues(warehouseProvisioningLogic)
-    const { provisionWarehouse, deprovisionWarehouse, setDatabaseName, clearInitialPassword, resetPassword } =
-        useActions(warehouseProvisioningLogic)
+    const {
+        provisionWarehouse,
+        deprovisionWarehouse,
+        setDatabaseName,
+        clearInitialPassword,
+        resetPassword,
+        setEventsTableName,
+        enableBackfill,
+    } = useActions(warehouseProvisioningLogic)
     const deprovisionRestrictionReason = useRestrictedArea({
         scope: RestrictionScope.Organization,
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
@@ -255,6 +266,46 @@ export function SettingsTab(): JSX.Element {
 
                     {isReady && warehouseStatus?.connection && (
                         <ConnectionDetails connection={warehouseStatus.connection} />
+                    )}
+
+                    {isReady && (
+                        <div className="border rounded p-4 space-y-3">
+                            <h3 className="mb-0">Events table for this project</h3>
+                            <p className="text-muted text-xs mb-0">
+                                Each project writes its events into its own table in the shared warehouse so they don't
+                                merge. Choose a name for this project's events table — it's normalized to a safe
+                                identifier (e.g. <code>events_&lt;name&gt;</code>).
+                            </p>
+                            {backfillEventsTableSuffix ? (
+                                <LemonBanner type="success">
+                                    Backfill enabled. This project writes to{' '}
+                                    <code>events_{backfillEventsTableSuffix}</code>.
+                                </LemonBanner>
+                            ) : (
+                                <div className="flex items-end gap-2">
+                                    <div className="flex-1">
+                                        <LemonLabel>Events table name</LemonLabel>
+                                        <LemonInput
+                                            value={eventsTableName}
+                                            onChange={setEventsTableName}
+                                            placeholder="my-project"
+                                            fullWidth
+                                        />
+                                    </div>
+                                    <LemonButton
+                                        type="primary"
+                                        loading={isEnablingBackfill}
+                                        disabledReason={
+                                            !isValidEventsTableName ? 'Enter an events table name' : undefined
+                                        }
+                                        onClick={() => enableBackfill({ eventsTableName })}
+                                        data-attr="enable-warehouse-backfill"
+                                    >
+                                        Enable backfill
+                                    </LemonButton>
+                                </div>
+                            )}
+                        </div>
                     )}
 
                     <div className="flex gap-2">

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
@@ -7,6 +7,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import {
     dataWarehouseCheckDatabaseNameRetrieve,
     dataWarehouseDeprovisionCreate,
+    dataWarehouseEnableBackfillCreate,
     dataWarehouseProvisionCreate,
     dataWarehouseResetPasswordCreate,
     dataWarehouseWarehouseStatusRetrieve,
@@ -44,6 +45,9 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
         checkDatabaseName: (name: string) => ({ name }),
         setDatabaseNameAvailable: (available: boolean | null) => ({ available }),
         setDatabaseNameChecking: (checking: boolean) => ({ checking }),
+        setEventsTableName: (name: string) => ({ name }),
+        enableBackfill: (params: { eventsTableName: string }) => params,
+        enableBackfillComplete: (suffix: string | null) => ({ suffix }),
     }),
 
     loaders({
@@ -129,6 +133,26 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 resetPasswordComplete: () => false,
             },
         ],
+        eventsTableName: [
+            '',
+            {
+                setEventsTableName: (_, { name }) => name,
+            },
+        ],
+        isEnablingBackfill: [
+            false,
+            {
+                enableBackfill: () => true,
+                enableBackfillComplete: () => false,
+            },
+        ],
+        backfillEventsTableSuffix: [
+            null as string | null,
+            {
+                enableBackfillComplete: (state, { suffix }) => suffix ?? state,
+                deprovisionWarehouse: () => null,
+            },
+        ],
     }),
 
     selectors({
@@ -163,6 +187,9 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
             (s) => [s.retryDatabaseName],
             (retryDatabaseName): boolean => !!retryDatabaseName && WAREHOUSE_NAME_REGEX.test(retryDatabaseName),
         ],
+        // The backend normalizes the events table name into a safe identifier, so the only
+        // client-side requirement is a non-empty value.
+        isValidEventsTableName: [(s) => [s.eventsTableName], (name): boolean => name.trim().length > 0],
     }),
 
     listeners(({ actions, values }) => {
@@ -217,6 +244,19 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                     }
                 }
                 actions.provisionWarehouseComplete()
+            },
+
+            enableBackfill: async ({ eventsTableName }) => {
+                try {
+                    const result = await dataWarehouseEnableBackfillCreate(currentProjectId(), {
+                        events_table_name: eventsTableName,
+                    })
+                    lemonToast.success('Warehouse backfill enabled for this project')
+                    actions.enableBackfillComplete(result.events_table_suffix ?? null)
+                } catch (e: any) {
+                    lemonToast.error(`Failed to enable backfill: ${e.detail || e.message || 'Unknown error'}`)
+                    actions.enableBackfillComplete(null)
+                }
             },
 
             resetPassword: async () => {
@@ -278,6 +318,11 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
         )
         if (persistedDatabaseName) {
             actions.setLastRequestedDatabaseName(persistedDatabaseName)
+        }
+        // Prefill the events table name with the project name; the backend normalizes it.
+        const projectName = teamLogic.values.currentTeam?.name
+        if (projectName) {
+            actions.setEventsTableName(projectName)
         }
         actions.loadWarehouseStatus()
     }),


### PR DESCRIPTION
> **Stack 4/4** (schema → DAG → writes → **UI**). Base is the provision/enable PR (#64939). Lowest-risk, ships last.

## Changes

The managed-warehouse settings tab gains an editable "events table name" field (prefilled from the project name, normalized server-side), wired through `warehouseProvisioningLogic` to the `enable_backfill` API added in the provision/enable PR.

## How did you test this code?

Agent (Claude Code), human-directed. `warehouseProvisioningLogic.test.ts` green; `typescript:check` clean after kea typegen.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). 4th of a 4-PR safe-rollout split. Depends on the `enable_backfill` generated client from the provision/enable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
