### PR TITLE
fix(web-analytics): add padding to web vitals metric cards

### DIFF
--- a/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
@@ -28,7 +28,7 @@ export function WebVitalsTab({ value, metric, isActive, setTab, isLoading }: Web
         <div
             onClick={setTab}
             className={clsx(
-                'flex-1 gap-2 border p-2 bg-surface-primary rounded items-center sm:items-start flex flex-col justify-between cursor-pointer',
+                'flex-1 gap-2 border p-4 bg-surface-primary rounded items-center sm:items-start flex flex-col justify-between cursor-pointer',
                 isActive && 'border-accent border-2'
             )}
         >


### PR DESCRIPTION
## Problem

The Web vitals tile's inner metric cards (INP, LCP, FCP, CLS) used tighter padding (`p-2`) than the surrounding cards in the same tile (`p-4`), making them look cramped and visually inconsistent.

## Changes

Bumped the inner `WebVitalsTab` card padding from `p-2` to `p-4` so it matches the content and chart panels in the same tile.

## How did you test this code?

I'm an agent — I made a single Tailwind class change and did not run the app or manual visual testing. No automated tests were run for this CSS-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Arthur reported the Web vitals first card's inner cards looked odd due to missing padding. Traced the rendering to `frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx`, where each metric card used `p-2` while the sibling content (`WebVitalsContent.tsx`) and chart panels used `p-4`. Changed the one class to align them. No skills were needed for this CSS-only change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BBRQJLS69/p1781901311800549)*
