### PR TITLE
fix(data-warehouse): fix schema admin reverse + non-billable CDC resync

### DIFF
--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -55,7 +55,7 @@ async def _is_schedule_paused(client: Client, schedule_id: str) -> bool:
 
 
 def _change_url(schema_id) -> str:
-    return reverse("admin:data_warehouse_externaldataschema_change", args=[schema_id])
+    return reverse("admin:warehouse_sources_externaldataschema_change", args=[schema_id])
 
 
 @admin.register(ExternalDataSchema)
@@ -128,7 +128,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             schema = ExternalDataSchema.objects.select_related("source").get(id=schema_id)
         except ExternalDataSchema.DoesNotExist:
             messages.error(request, f"Schema {schema_id} not found.")
-            return redirect(reverse("admin:data_warehouse_externaldataschema_changelist"))
+            return redirect(reverse("admin:warehouse_sources_externaldataschema_changelist"))
 
         if schema.partition_mode is None:
             messages.error(
@@ -272,7 +272,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             schema = ExternalDataSchema.objects.select_related("source").get(id=schema_id)
         except ExternalDataSchema.DoesNotExist:
             messages.error(request, f"Schema {schema_id} not found.")
-            return redirect(reverse("admin:data_warehouse_externaldataschema_changelist"))
+            return redirect(reverse("admin:warehouse_sources_externaldataschema_changelist"))
 
         # Both checkboxes default to off: an unchecked checkbox isn't sent in the
         # POST body, so .get() returns None, and `None == "on"` is False.
@@ -299,15 +299,28 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         # marker. reset_pipeline goes on sync_type_config rather than the workflow
         # input — the pipeline pops it after the first reset; on the input it
         # would re-fire on every activity retry and wipe progress.
-        sync_type_config_dirty = False
+        update_fields: list[str] = []
         if reset_pipeline:
             schema.sync_type_config["reset_pipeline"] = True
-            sync_type_config_dirty = True
+            update_fields.append("sync_type_config")
+            # A streaming CDC schema no-ops a normal reset — CDCExtractionWorkflow owns it and the
+            # per-schema run raises CDCHandledExternally. Flip it back to snapshot so this run does a
+            # full re-snapshot, mirroring ExternalDataSchemaViewSet.reset. The job below is created
+            # billable=False, and on completion set_initial_sync_complete transitions it back to
+            # streaming, so ongoing CDC stays billable. The save must precede the workflow start so
+            # the source reloads cdc_mode="snapshot" instead of racing on stale "streaming".
+            if schema.is_cdc and schema.cdc_mode == "streaming":
+                schema.sync_type_config["cdc_mode"] = "snapshot"
+                schema.sync_type_config.pop("cdc_last_log_position", None)
+                schema.sync_type_config.pop("cdc_deferred_runs", None)
+                schema.initial_sync_complete = False
+                update_fields.append("initial_sync_complete")
         if admin_paused_now:
             schema.sync_type_config["admin_unpause_schedule_after_run"] = True
-            sync_type_config_dirty = True
-        if sync_type_config_dirty:
-            schema.save(update_fields=["sync_type_config"])
+            if "sync_type_config" not in update_fields:
+                update_fields.append("sync_type_config")
+        if update_fields:
+            schema.save(update_fields=update_fields)
 
         inputs = ExternalDataWorkflowInputs(
             team_id=schema.team_id,

--- a/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
@@ -1,0 +1,78 @@
+import uuid
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.contrib.admin import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from products.warehouse_sources.backend.admin.external_data_schema_admin import ExternalDataSchemaAdmin
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+
+_ADMIN_MODULE = "products.warehouse_sources.backend.admin.external_data_schema_admin"
+
+
+class TestExternalDataSchemaAdmin(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.admin = ExternalDataSchemaAdmin(ExternalDataSchema, AdminSite())
+        self.factory = RequestFactory()
+
+    def _request(self, method: str, data: dict | None = None):
+        request = getattr(self.factory, method)("/", data=data or {})
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def _schema(self, **kwargs) -> ExternalDataSchema:
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+        )
+        return ExternalDataSchema.objects.create(team_id=self.team.pk, source=source, name="public.users", **kwargs)
+
+    def test_trigger_sync_get_redirects_to_change_page(self) -> None:
+        # Guards the admin-app-label reverse: resolving the change URL must not raise NoReverseMatch.
+        schema = self._schema()
+        response = self.admin.trigger_sync_view(self._request("get"), schema.id)
+        assert response.status_code == 302
+        assert str(schema.id) in response.url
+
+    def test_pause_schedule_redirects_to_change_page(self) -> None:
+        schema = self._schema()
+        with patch(f"{_ADMIN_MODULE}.pause_external_data_schedule"):
+            response = self.admin.pause_schedule_view(self._request("post"), schema.id)
+        assert response.status_code == 302
+        assert str(schema.id) in response.url
+
+    def test_reset_streaming_cdc_flips_to_snapshot_non_billable(self) -> None:
+        schema = self._schema(
+            sync_type=ExternalDataSchema.SyncType.CDC,
+            sync_type_config={"cdc_mode": "streaming", "cdc_last_log_position": "0/ABC", "cdc_deferred_runs": [{}]},
+            initial_sync_complete=True,
+        )
+
+        with (
+            patch(f"{_ADMIN_MODULE}.sync_connect"),
+            patch(f"{_ADMIN_MODULE}._is_schedule_paused", return_value=True),
+            patch(f"{_ADMIN_MODULE}._start_external_data_workflow") as mock_start,
+        ):
+            response = self.admin.trigger_sync_view(self._request("post", {"reset_pipeline": "on"}), schema.id)
+
+        assert response.status_code == 302
+        schema.refresh_from_db()
+        assert schema.cdc_mode == "snapshot"
+        assert schema.initial_sync_complete is False
+        assert "cdc_last_log_position" not in schema.sync_type_config
+        assert "cdc_deferred_runs" not in schema.sync_type_config
+
+        # The re-snapshot must persist before the workflow starts (the source reloads cdc_mode), and
+        # the job must be non-billable so the initial full refresh isn't charged to the customer.
+        mock_start.assert_called_once()
+        inputs = mock_start.call_args.args[2]
+        assert inputs.billable is False


### PR DESCRIPTION
## Problem

Two issues in the `ExternalDataSchema` Django admin:

1. **Every custom admin action 500s.** Moving the model admin into the `warehouse_sources` app changed its admin URL names to `warehouse_sources_externaldataschema_*`, but three `reverse()` calls still pointed at the old `data_warehouse_externaldataschema_*` names. Each custom view ends its redirect via those reverses, so trigger-sync, pause, and repartition all raise `NoReverseMatch` and return a 500. Confirmed via internal error tracking — `NoReverseMatch` first seen the day after the admin move.

2. **The "ad-hoc sync + reset" button doesn't re-snapshot a streaming CDC schema.** A streaming CDC schema is owned by `CDCExtractionWorkflow`; a normal reset no-ops because the per-schema run raises `CDCHandledExternally`. So the reset never ran a full refresh for the most common CDC case.

## Changes

- Point the three admin reverses at the correct `warehouse_sources_externaldataschema_*` URL names.
- When resetting a streaming CDC schema, flip it back to snapshot mode (`cdc_mode="snapshot"`, drop `cdc_last_log_position` / `cdc_deferred_runs`, `initial_sync_complete=False`) before starting the job — mirroring the customer-facing `ExternalDataSchemaViewSet.reset`. The save happens before the workflow starts so the source reloads `cdc_mode="snapshot"` instead of racing on stale `"streaming"`.

The admin job is already created with `billable=False`, so the **initial full refresh is non-billable**. On completion, `set_initial_sync_complete` transitions the schema back to streaming, so ongoing CDC continues to bill as normal.

## How did you test this code?

I'm an agent. I added `products/warehouse_sources/backend/tests/test_external_data_schema_admin.py` and ran it locally (3 passing):

- GET trigger-sync redirects (guards the reverse fix against `NoReverseMatch`).
- Pause schedule redirects (same reverse guard).
- Reset on a streaming CDC schema flips it to snapshot, clears CDC log position / deferred runs, sets `initial_sync_complete=False`, and starts a `billable=False` workflow.

No manual testing against a live instance.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 4.8). No mandatory skills triggered (no DRF/serializer or migration changes — the admin is a plain `ModelAdmin`).

Root cause for issue 1 was confirmed against internal error tracking (`NoReverseMatch` in `external_data_schema_admin.py`), not guessed — an earlier hypothesis of a Temporal-client timeout was disproved by that data. For issue 2, the streaming/snapshot/billable mechanics were traced through `import_data_sync.py`, `sources/postgres/source.py`, `cdc/activities.py`, and `pipeline_sync.py`; the fix deliberately mirrors the proven customer-facing reset path rather than introducing new billing plumbing.

Note for the reviewer: the CDC-reset field flip is now duplicated in three places (this admin view, `ExternalDataSchemaViewSet.reset`, and `CDCExtractActivity._reset_schema_to_snapshot`). Left as-is to keep this change surgical and avoid touching the DRF viewset, but it's a candidate for a shared model helper.
