### PR TITLE
fix(quill): hide DataTable pager when there are no rows

### DIFF
--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -35,7 +35,7 @@ Rules:
 - Column defs are standard TanStack `ColumnDef`s; quill-specific options go in `meta`: `align: 'left' | 'center' | 'right'` (header + cells) and `expand: true` (absorb leftover width).
 - `fullWidth` needs exactly one column with `meta: { expand: true }` to decide which column stretches.
 - Sorting is client-side and on by default — click header toggles asc → desc → off. Opt out per column with `enableSorting: false`.
-- Pagination is opt-in via `pageSize`; the component owns page state and resets to page 0 when `pageSize` changes.
+- Pagination is opt-in via `pageSize`; the component owns page state and resets to page 0 when `pageSize` changes. The pager is suppressed when the table has no rows — an empty table shows only its empty state, never a "0–0 of 0" pager.
 - Custom empty state via the `empty` prop (ReactNode); default is a minimal "No results".
 - Don't rebuild tables from `Table` primitives when the data is row/column shaped and needs sorting or pagination — that's what DataTable is for. Drop to the `Table` primitive only for fully custom layouts.
 

--- a/packages/quill/packages/components/src/data-table.stories.tsx
+++ b/packages/quill/packages/components/src/data-table.stories.tsx
@@ -192,6 +192,20 @@ export const Empty: Story = {
     ),
 }
 
+// Empty + paginated — the pager is suppressed when there are no rows, so only
+// the empty state shows (no "0–0 of 0" pager).
+export const EmptyPaginated: Story = {
+    render: () => (
+        <DataTable
+            columns={columns}
+            data={[]}
+            pageSize={10}
+            pageSizeOptions={[10, 25, 50]}
+            className="max-w-2xl rounded-md border border-[var(--border)]"
+        />
+    ),
+}
+
 // Override the empty slot with app-specific copy and actions.
 export const EmptyCustom: Story = {
     render: () => (

--- a/packages/quill/packages/components/src/data-table.tsx
+++ b/packages/quill/packages/components/src/data-table.tsx
@@ -293,7 +293,9 @@ function DataTable<TData, TValue>({
         </Table>
     )
 
-    if (!paginated) {
+    // Nothing to paginate when the table is empty — the empty state already
+    // signals the absence of data, so a "0–0 of 0" pager is just noise.
+    if (!paginated || table.getFilteredRowModel().rows.length === 0) {
         return tableElement
     }
 


### PR DESCRIPTION
## Problem

When an MCP App table renders zero entries, it still shows a pagination control reading `0–0 of 0` beneath the empty state. There's nothing to paginate, so the pager is pure noise. MCP App tables page through quill's `DataTable` (via the `@posthog/mcp-ui` adapter), so the root cause lives in quill — and it affects every quill `DataTable` consumer, not just MCP Apps.

## Changes

Suppress the pager in quill's `DataTable` when the filtered row count is zero. An empty table now shows only its empty state. The fix is in the shared component rather than the MCP adapter so all consumers benefit and the "0–0 of 0" pager never renders on an empty table.

- `packages/quill/packages/components/src/data-table.tsx` — guard the pager render on a non-zero row count.
- Added an `EmptyPaginated` story demonstrating an empty + paginated table renders no pager.
- Updated the components `AGENTS.md` pagination rule.

## How did you test this code?

I'm an agent. I did not run manual testing — `node_modules` isn't installed in this environment, so I couldn't run the build/typecheck or Storybook locally. The change reuses the exact expression (`table.getFilteredRowModel().rows.length`) already used inside the pager component, and the new `EmptyPaginated` Storybook story covers the empty + paginated case for visual verification in CI/review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Rafael, who asked whether the fix belonged in quill or in MCP Apps. I traced the render path: MCP App tables (`services/mcp/src/ui-apps/lib/DataTable.tsx`) are a thin adapter over quill's `DataTable`, which unconditionally renders its pager whenever `pageSize` is set — regardless of row count. Fixing it at the quill root is strictly better than special-casing the adapter: it's the actual source of the noise and every `DataTable` consumer (not just MCP Apps) gets the cleaner empty state. Scoped the guard to zero rows only — single-page tables still show their `1–N of N` count, which some consumers rely on.

Tools: Claude Code (Opus 4.8). No repo skills were applicable to this quill-only change.
