### PR TITLE
fix(dev): open Storybook browser from outside the sandbox

### DIFF
--- a/bin/dev-open-when-ready
+++ b/bin/dev-open-when-ready
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Open a URL in the browser once its server is listening — from OUTSIDE the dev
+# sandbox.
+#
+# Storybook (and other web procs) auto-open via `open`, but the macOS Seatbelt
+# sandbox blocks that: the open → LaunchServices path reads $HOME, which the
+# profile denies. Rather than widen the profile (which would hand untrusted
+# dependency code a general app/URL launcher), the devenv generator peels this
+# helper out to run unsandboxed (see _SANDBOX_UNSANDBOXED_PREFIXES). It backgrounds
+# a poller and returns immediately, so the sandboxed server starts right after,
+# then the poller fires a single fixed `open <url>` once the port answers.
+#
+# Usage: bin/dev-open-when-ready <url>     # e.g. http://localhost:6006
+#
+# No-op (exit 0) in CI / under PostHog Code, or when no opener is available.
+
+set -euo pipefail
+
+url="${1:?bin/dev-open-when-ready: expected a URL as the first argument}"
+
+# Don't pop a browser in automated/headless contexts.
+if [[ -n "${CI:-}" || -n "${POSTHOG_CODE:-}" ]]; then
+    exit 0
+fi
+
+# Pick a platform opener; bail quietly if none (e.g. headless Linux).
+if [[ "$(uname -s)" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
+    opener="open"
+elif command -v xdg-open >/dev/null 2>&1; then
+    opener="xdg-open"
+else
+    exit 0
+fi
+
+# Derive host:port from the URL (strip scheme + path; default by scheme).
+case "$url" in
+    https://*) _defport=443 ;;
+    *) _defport=80 ;;
+esac
+_hostport="${url#*://}"
+_hostport="${_hostport%%/*}"
+host="${_hostport%%:*}"
+port="${_hostport##*:}"
+[[ "$port" == "$host" ]] && port="$_defport" # no explicit port in the URL
+
+# Background poller: wait (bounded) for the port to accept a connection, then open
+# once. Detached so the caller returns immediately (the sandboxed server starts
+# right after); the deadline keeps it from lingering if the server never comes up.
+(
+    deadline=$(($(date +%s) + 180))
+    until (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null; do
+        if (($(date +%s) >= deadline)); then exit 0; fi
+        sleep 0.5
+    done
+    "$opener" "$url" >/dev/null 2>&1 || true
+) &
+disown 2>/dev/null || true
+
+exit 0

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -610,7 +610,9 @@ procs:
 
     storybook:
         sandbox: true
-        shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'
+        # dev-open-when-ready is peeled out to run unsandboxed (it opens the browser
+        # once :6006 is up — a path the sandbox denies); the rest stays sandboxed.
+        shell: 'bin/dev-open-when-ready http://localhost:6006 && pnpm --filter=@posthog/storybook install && pnpm run storybook'
         autostart: false
         ready_pattern: 'Storybook *'
         groups:

--- a/common/storybook/package.json
+++ b/common/storybook/package.json
@@ -3,7 +3,7 @@
     "scripts": {
         "build:products": "pnpm --filter=@posthog/frontend build:products",
         "build": "pnpm build:products && DEBUG=0 NODE_OPTIONS=--max-old-space-size=6144 storybook build -o dist",
-        "start": "pnpm build:products && DEBUG=0 NODE_OPTIONS=--max-old-space-size=8192 storybook dev -p 6006",
+        "start": "pnpm build:products && DEBUG=0 NODE_OPTIONS=--max-old-space-size=8192 storybook dev -p 6006 --no-open",
         "test:visual:ci:update": "test-storybook -u --junit --no-index-json --maxWorkers=1",
         "test:visual:ci:verify": "test-storybook --ci --junit --no-index-json --maxWorkers=1",
         "test:visual:debug": "pnpm build:products && PWDEBUG=1 NODE_OPTIONS=--max-old-space-size=16384 test-storybook --browsers chromium webkit --no-index-json",

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1079,3 +1079,7 @@ environment:
         bin_script: setup-gateway-e2e
         description: 'Provision the local ai-gateway e2e: enable the team, mint a phs_, publish the credential blob, fund the ledger'
         hidden: true
+    dev:open:when:ready:
+        bin_script: dev-open-when-ready
+        description: 'Open a URL in the browser once its server is listening (internal; runs unsandboxed so sandboxed procs can auto-open)'
+        hidden: true

--- a/tools/hogli-commands/hogli_commands/devenv/generator.py
+++ b/tools/hogli-commands/hogli_commands/devenv/generator.py
@@ -396,6 +396,15 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
     # code, so running them unsandboxed doesn't widen the untrusted attack surface.
     _SANDBOX_DOCKER_GATES = ("bin/wait-for-docker", "bin/wait-for-postgres-tables")
 
+    # Trusted helpers peeled out to run OUTSIDE the sandbox for a reason other than
+    # the docker socket. bin/dev-open-when-ready backgrounds a poller and opens the
+    # browser once a server is up — the OS browser-open path (open → LaunchServices)
+    # reads $HOME, which the sandbox denies. It self-backgrounds and returns 0
+    # immediately, so hoisting it to the front is safe. It takes a fixed URL from the
+    # proc def (never dependency input) and lives in $PROJECT/bin, which the profile
+    # write-denies, so a compromised dep can't tamper with it.
+    _SANDBOX_UNSANDBOXED_PREFIXES = ("bin/dev-open-when-ready",)
+
     # Procs excluded from the sandbox by default: they need the docker socket the
     # profile denies (e.g. temporal-worker running PostHog Code tasks with
     # SANDBOX_PROVIDER=docker). POSTHOG_DEV_SANDBOX_EXCLUDE adds more on top.
@@ -424,6 +433,11 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         unsandboxed, since it needs the very socket the sandbox denies; the actual
         server (which reaches infra over TCP) is what gets sandboxed. bin/dev-sandbox
         is a no-op passthrough on non-macOS, so the generated config stays portable.
+
+        bin/dev-open-when-ready (``_SANDBOX_UNSANDBOXED_PREFIXES``) is peeled out the
+        same way so a proc can auto-open its browser once it's listening — the OS
+        browser-open path the sandbox denies runs outside it, not by widening the
+        profile.
         """
         # `sandbox` is a registry-only selector; pop it so it never leaks into the
         # emitted proc config (which phrocs/mprocs would otherwise see).
@@ -445,9 +459,11 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         # in place: _add_startup_message and _add_uv_groups prepend echo/uv-sync
         # preambles, so a gate is never the leading segment (a leading-run scan would
         # wrongly sandbox it). Hoisting reorders segments, which is safe because the
-        # only gates (wait-for-docker, wait-for-postgres-tables) just block until
-        # infra is ready and are order-independent w.r.t. install/echo/server steps.
-        # A future order-sensitive gate would need interleaving instead of hoisting.
+        # peeled-out helpers (wait-for-docker / wait-for-postgres-tables block until
+        # infra is ready; dev-open-when-ready self-backgrounds and returns at once)
+        # are all order-independent w.r.t. install/echo/server steps. A future
+        # order-sensitive helper would need interleaving instead of hoisting.
+        unsandboxed_prefixes = self._SANDBOX_DOCKER_GATES + self._SANDBOX_UNSANDBOXED_PREFIXES
         normalized = re.sub(r"\\\n\s*", " ", shell)
         gates: list[str] = []
         rest: list[str] = []
@@ -456,7 +472,7 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
             if not stripped:
                 continue
             first_token = stripped.split(maxsplit=1)[0]
-            (gates if first_token in self._SANDBOX_DOCKER_GATES else rest).append(stripped)
+            (gates if first_token in unsandboxed_prefixes else rest).append(stripped)
 
         rest_cmd = " && ".join(rest)
         if not rest_cmd:

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -176,6 +176,21 @@ class TestSandboxWrapper:
         result = self._wrap({"shell": "bin/wait-for-docker && ./bin/start-backend", "sandbox": True})
         assert result["shell"] == "bin/wait-for-docker && bin/dev-sandbox ./bin/start-backend"
 
+    def test_open_when_ready_runs_outside_sandbox(self, monkeypatch: Any) -> None:
+        # The browser-opener is peeled out to run unsandboxed (the OS open path the
+        # sandbox denies), and the rest stays sandboxed.
+        monkeypatch.delenv("POSTHOG_DEV_SANDBOX", raising=False)
+        result = self._wrap(
+            {
+                "shell": "bin/dev-open-when-ready http://localhost:6006 && pnpm install && pnpm run storybook",
+                "sandbox": True,
+            }
+        )
+        assert result["shell"] == (
+            "bin/dev-open-when-ready http://localhost:6006 && bin/dev-sandbox "
+            + shlex.quote("pnpm install && pnpm run storybook")
+        )
+
     def test_gate_hoisted_from_middle_of_chain(self, monkeypatch: Any) -> None:
         # echo/uv-sync preambles are prepended before the gate, so it is never the
         # leading segment; it must still be peeled out to run unsandboxed.


### PR DESCRIPTION
## Problem

The `storybook` proc is sandboxed (`sandbox: true`), and `storybook dev` auto-opens the browser via `open` → LaunchServices — a path that reads `~/Library/Preferences/com.apple.LaunchServices…`, which the Seatbelt profile's `$HOME` read-deny blocks. Storybook errors out on launch; the only workaround today is `POSTHOG_DEV_SANDBOX=0`, which throws away the sandbox entirely.

## Changes

Keep auto-open, but do it from **outside** the sandbox instead of widening the profile:

- New `bin/dev-open-when-ready <url>`: backgrounds a bounded poller (bash `/dev/tcp`, 180s deadline) and returns immediately; fires a single fixed `open <url>` once the port answers. No-ops under `CI`/`POSTHOG_CODE`; uses `open` (macOS) or `xdg-open` (Linux).
- The devenv generator peels it out to run unsandboxed (new `_SANDBOX_UNSANDBOXED_PREFIXES`), the same mechanism already used for `bin/wait-for-docker`. The storybook proc becomes `bin/dev-open-when-ready http://localhost:6006 && bin/dev-sandbox 'pnpm … install && pnpm run storybook'`.
- `storybook dev … --no-open` so the sandboxed process never attempts the open itself.

**Why not allow `open` inside the profile:** that hands untrusted dependency code a general app/URL launcher (`open -a …`, `open ~/secret.pdf` → an unsandboxed app then reads denied files) — a real partial escape. This change leaves `bin/dev-sandbox.sb` untouched: the only `open` that runs is a hardcoded localhost URL from a helper in `$PROJECT/bin`, which the profile already write-protects.

Trade-off: a manual `pnpm storybook` outside the dev stack now prints a clickable URL instead of auto-opening.

## How did you test this code?

I'm an agent (Claude Code), human-driven. Verification run:

- 69 generator unit tests pass, incl. the new `test_open_when_ready_runs_outside_sandbox` (opener hoisted unsandboxed, rest wrapped); ruff + `ty` clean.
- Runtime smoke test (fake `open` on PATH + throwaway listener): the helper returns in 0s without opening early, fires the opener with the correct URL once the port comes up, and no-ops under `CI=1`.
- `bin/dev-sandbox.sb` confirmed unchanged.

Not run: a full live `storybook` proc under the dev stack on macOS.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the sandbox-on-by-default work (#64392). The core decision was to move the browser-open outside the sandbox rather than poke a hole in the profile for `open`/LaunchServices — keeping the deny-by-default `$HOME` model intact. The helper is generic, so wiring it into other web procs later is trivial.
