### PR TITLE
feat(data-warehouse): backfill DuckgresServerTeam for existing ducklings

### DIFF
--- a/posthog/ducklake/test_backfill_duckgresserverteam_migration.py
+++ b/posthog/ducklake/test_backfill_duckgresserverteam_migration.py
@@ -1,0 +1,55 @@
+import importlib
+
+import pytest
+
+from django.apps import apps as global_apps
+
+from posthog.ducklake.models import DuckgresServer, DuckgresServerTeam, DuckLakeBackfill
+from posthog.models import Organization, Team
+
+# The migration module name starts with a digit, so it can't be imported with a plain `import`.
+_migration = importlib.import_module("posthog.migrations.1233_backfill_duckgresserverteam")
+backfill_duckgres_server_teams = _migration.backfill_duckgres_server_teams
+
+
+def _server(org: Organization) -> DuckgresServer:
+    return DuckgresServer.objects.create(
+        organization=org, host="h", port=5432, database="ducklake", username="root", password="x"
+    )
+
+
+@pytest.mark.django_db
+class TestBackfillDuckgresServerTeams:
+    def test_links_existing_backfill_teams_to_their_org_server(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        server = _server(org)
+        DuckLakeBackfill.objects.create(team=team, table_suffix=None)
+
+        backfill_duckgres_server_teams(global_apps, None)
+
+        link = DuckgresServerTeam.objects.get(team_id=team.id)
+        assert link.server_id == server.id
+        # Legacy rows keep writing to the shared tables — the backfill never sets a suffix.
+        assert DuckLakeBackfill.objects.get(team_id=team.id).table_suffix is None
+
+    def test_skips_teams_whose_org_has_no_server(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        DuckLakeBackfill.objects.create(team=team)
+
+        backfill_duckgres_server_teams(global_apps, None)
+
+        assert not DuckgresServerTeam.objects.filter(team_id=team.id).exists()
+
+    def test_is_idempotent_and_preserves_existing_membership(self):
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+        server = _server(org)
+        DuckLakeBackfill.objects.create(team=team)
+        DuckgresServerTeam.objects.create(server=server, team=team)
+
+        backfill_duckgres_server_teams(global_apps, None)
+        backfill_duckgres_server_teams(global_apps, None)
+
+        assert DuckgresServerTeam.objects.filter(team_id=team.id).count() == 1

--- a/posthog/migrations/1233_backfill_duckgresserverteam.py
+++ b/posthog/migrations/1233_backfill_duckgresserverteam.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def backfill_duckgres_server_teams(apps, schema_editor):
+    """Record team↔duckling membership for orgs provisioned before DuckgresServerTeam existed.
+
+    A team's DuckLakeBackfill row is the signal that it uses the org's duckling, so link each
+    such team to its org's DuckgresServer. Idempotent (get_or_create on the team OneToOne) and
+    leaves table_suffix untouched — legacy teams keep writing to the shared tables. Skips a team
+    whose org has no DuckgresServer (nothing to link to).
+    """
+    DuckLakeBackfill = apps.get_model("posthog", "DuckLakeBackfill")
+    DuckgresServer = apps.get_model("posthog", "DuckgresServer")
+    DuckgresServerTeam = apps.get_model("posthog", "DuckgresServerTeam")
+
+    servers_by_org = {server.organization_id: server for server in DuckgresServer.objects.all()}
+    if not servers_by_org:
+        return
+
+    for row in DuckLakeBackfill.objects.values("team_id", "team__organization_id").iterator():
+        server = servers_by_org.get(row["team__organization_id"])
+        if server is None:
+            continue
+        DuckgresServerTeam.objects.get_or_create(team_id=row["team_id"], defaults={"server": server})
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1232_alter_duckgresserver_bucket_region")]
+
+    operations = [
+        migrations.RunPython(backfill_duckgres_server_teams, migrations.RunPython.noop),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1232_alter_duckgresserver_bucket_region
+1233_backfill_duckgresserverteam


### PR DESCRIPTION
> **Stack 1/3** (backfill → DAG → provision/enable/UI). Base `master`. The schema PR (#64950) — which added `DuckgresServerTeam` + `DuckLakeBackfill.table_suffix` — is already merged.

## Problem

`DuckgresServerTeam` (added in the merged #64950) records team↔duckling membership, but it's only populated for *new* provisions / enables. Every org provisioned **before** this work has `DuckgresServer` and `DuckLakeBackfill` rows but **no membership row** — so the table that's meant to be the authoritative "which teams belong to this duckling?" map starts empty for the existing install base, and you'd still have to infer membership from `DuckLakeBackfill` (the situation this whole effort was meant to replace).

## Changes

Data migration `1232_backfill_duckgresserverteam`: for every existing `DuckLakeBackfill`, link its team to the org's `DuckgresServer` via `DuckgresServerTeam`.

- **Idempotent** — `get_or_create` on the team (the `team` OneToOne); an existing membership row is left as-is.
- **Non-destructive** — `table_suffix` is left `NULL`, so legacy teams keep writing to the **shared** tables. This only records membership; it does **not** move any data.
- Skips a team whose org has no `DuckgresServer` (nothing to link to).
- Reverse is a no-op (additive backfill).

## How did you test this code?

Agent (Claude Code), human-directed. `posthog/ducklake/test_backfill_duckgresserverteam_migration.py` (3 tests): links existing backfill teams to their org's server without setting a suffix; skips teams whose org has no server; idempotent + preserves an existing membership row. `makemigrations --check` clean; linear graph `1231 → 1232`; the migration applies in the test DB.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Skills: `/django-migrations`. Bottom of a 3-PR stack (the schema PR merged separately); populates membership before the DAG behavior change ships above. Small data update (`DuckLakeBackfill` is a tiny per-team table) → low risk; reverse is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
