### PR TITLE
refactor(customer-analytics): Route org-members flag through facade and seal product

### DIFF
--- a/products/customer_analytics/backend/presentation/views/organization_members.py
+++ b/products/customer_analytics/backend/presentation/views/organization_members.py
@@ -10,7 +10,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models import OrganizationMembership
 from posthog.permissions import IsStaffUserOrImpersonating, PostHogFeatureFlagPermission
 
-from products.customer_analytics.backend.constants import CUSTOMER_ANALYTICS_CSP_FLAG
+from products.customer_analytics.backend.facade.constants import CUSTOMER_ANALYTICS_CSP_FLAG
 from products.customer_analytics.backend.presentation.views.serializers import AccountOrganizationMemberSerializer
 
 

--- a/products/customer_analytics/package.json
+++ b/products/customer_analytics/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-customer-analytics",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/customer_analytics/turbo.json
+++ b/products/customer_analytics/turbo.json
@@ -1,0 +1,10 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "backend:contract-check": {
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
+            "outputs": [],
+            "cache": true
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -572,7 +572,6 @@ ignore_imports = [
     # TODO: customer_analytics presentation wave — these views still reach internals directly.
     # Thin each view to parse -> facade -> serialize and delete its entry. backend:contract-check
     # stays off until this list is empty.
-    "products.customer_analytics.backend.presentation.views.organization_members -> products.customer_analytics.backend.constants",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -569,9 +569,6 @@ ignore_imports = [
     "products.logs.backend.presentation.views.api -> products.exports.backend.models.exported_asset",
     "products.logs.backend.presentation.views.alerts_api -> products.cdp.backend.api.hog_function",
     "products.logs.backend.presentation.views.alerts_api -> products.cdp.backend.models.hog_functions.hog_function",
-    # TODO: customer_analytics presentation wave — these views still reach internals directly.
-    # Thin each view to parse -> facade -> serialize and delete its entry. backend:contract-check
-    # stays off until this list is empty.
 ]
 
 [tool.ty.rules]


### PR DESCRIPTION
## Problem

`customer_analytics` was mid-migration to the isolated facade + contracts architecture. Presentation view modules may only reach product internals through `backend/facade/**`; the few that still reached internals directly were temporarily allow-listed in the `ignore_imports` TODO block in `pyproject.toml`. While any entry remained, the product couldn't enable its `backend:contract-check` CI skip, so the full suite kept running.

This PR clears the **last** remaining presentation bypass (`organization_members`). The external account API (#64979) and account-CRUD core (#64982) already merged, so removing this entry empties the allow-list — meaning this PR also completes the migration by sealing the product.

## Changes

**1. Route the org-members flag through the facade.** `OrganizationMembersForAccountViewSet` reached internals through exactly one import — the `CUSTOMER_ANALYTICS_CSP_FLAG` constant from `backend.constants`. The facade already re-exports it (`backend/facade/constants.py`), so this is a one-line import swap, and its `ignore_imports` entry is removed. No behavior change.

**2. Seal the product (the allow-list is now empty).** Because this removes the final entry, `product:lint` flips from *withholding* the skip to *requiring* it. So this PR adds the isolation seal, mirroring `visual_review`:
- `products/customer_analytics/package.json`: add `backend:contract-check`.
- `products/customer_analytics/turbo.json`: narrow `backend:contract-check` inputs to `backend/facade/**`, `backend/presentation/**`, `backend/routes.py` — so the Django suite only re-runs on facade/presentation changes (the CI skip the migration earns).
- `pyproject.toml`: remove the now-empty TODO block.

No serializer/schema changes, so no OpenAPI regeneration.

## How did you test this code?

Agent — automated verification chain only:
- `hogli test products/customer_analytics/backend/test/test_organization_members.py` — 8 passed.
- `lint-imports` — `presentation must use facade` KEPT, 0 broken (with **zero** customer_analytics ignore entries).
- `tach check --dependencies --interfaces` — all modules validated.
- `hogli product:lint customer_analytics` — ✓ all checks passed; isolation chain complete, contract-check enabled, 0 bypasses.
- `ruff` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Final slice of the `customer_analytics` presentation-wave isolation migration (`/isolating-product-facade-contracts`). Originally a one-line import swap, but the external (#64979) and account-CRUD (#64982) slices merged first — so this PR removes the **last** `ignore_imports` entry, which per the skill is where `backend:contract-check` + narrowed `turbo.json` are finally added and the TODO block deleted. The branch was rebased onto current master and the `pyproject.toml` conflict (all customer_analytics presentation entries now resolved away) fixed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*