### PR TITLE
refactor(customer-analytics): Thin external account API behind facade

### DIFF
--- a/products/customer_analytics/backend/constants.py
+++ b/products/customer_analytics/backend/constants.py
@@ -3,6 +3,10 @@ DEFAULT_ACTIVITY_EVENT = {"kind": "EventsNode", "event": "$pageview", "name": "$
 # Mirrors frontend `FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP`.
 CUSTOMER_ANALYTICS_CSP_FLAG = "customer-analytics-csp"
 
+# Account assignment roles, each assignable to a user. Shared by the external account API's
+# request validation and the facade write path so the set is defined once.
+ACCOUNT_ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
+
 # Mirrors frontend `BILLING_INSIGHT_SHORT_IDS` in accountBillingLogic.ts. These saved insights read
 # warehouse-synced billing data to report an account's PostHog consumption (events ingested, rows
 # synced, recordings, etc.) and spend (MRR, per-product cost). PostHog-internal: they only resolve

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -28,6 +28,7 @@ from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
 
 from products.customer_analytics.backend.account_urls import build_account_deeplink as build_account_deeplink
+from products.customer_analytics.backend.constants import ACCOUNT_ASSIGNMENT_ROLE_FIELDS
 from products.customer_analytics.backend.logic.usage_spike_notifications import (
     notify_managers_of_usage_spike as notify_managers_of_usage_spike,
 )
@@ -210,8 +211,6 @@ def get_account(
 # endpoint. The view keeps only HTTP concerns (auth, throttles, the flag gate,
 # request validation) and maps the results below to responses.
 
-_EXTERNAL_ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
-
 
 def _to_external_account(account: Account) -> contracts.ExternalAccount:
     """Map an account to the verbatim external wire shape.
@@ -231,7 +230,7 @@ def _to_external_account(account: Account) -> contracts.ExternalAccount:
 
 def _get_external_account_by_external_id(team_id: int, external_id: str) -> Account | None:
     try:
-        return Account.objects.for_team(team_id).get(external_id=external_id)
+        return Account.objects.for_team(team_id).select_related("team").get(external_id=external_id)
     except Account.DoesNotExist:
         return None
 
@@ -270,7 +269,7 @@ def _apply_external_role_assignments(
     properties = dict(account._properties or {})
     changed = False
 
-    for field in _EXTERNAL_ASSIGNMENT_ROLE_FIELDS:
+    for field in ACCOUNT_ASSIGNMENT_ROLE_FIELDS:
         if field not in role_assignments:
             continue
         user_id = role_assignments[field]

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -18,8 +18,13 @@ Do NOT:
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.db.models import Q
 
+from posthog.api.tagged_item import set_tags_on_object
+from posthog.exceptions_capture import capture_exception
+from posthog.models import OrganizationMembership, Tag
+from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
 
 from products.customer_analytics.backend.account_urls import build_account_deeplink as build_account_deeplink
@@ -196,3 +201,137 @@ def get_account(
         properties=_to_account_properties(account.properties),
         created_at=account.created_at,
     )
+
+
+# --- External (CDP worker) account API ---
+#
+# The data access, transactional write, org-membership resolution, tag
+# application, and exception capture for the Bearer-authed external account
+# endpoint. The view keeps only HTTP concerns (auth, throttles, the flag gate,
+# request validation) and maps the results below to responses.
+
+_EXTERNAL_ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
+
+
+def _to_external_account(account: Account) -> contracts.ExternalAccount:
+    """Map an account to the verbatim external wire shape.
+
+    ``properties`` is the exact ``model_dump(mode="json")`` of the validated
+    pydantic properties and ``tags`` the sorted tag names — byte-identical to
+    what the CDP worker consumed before this moved behind the facade.
+    """
+    return contracts.ExternalAccount(
+        id=str(account.id),
+        external_id=account.external_id,
+        name=account.name,
+        properties=account.properties.model_dump(mode="json"),
+        tags=sorted(account.tagged_items.values_list("tag__name", flat=True)),
+    )
+
+
+def _get_external_account_by_external_id(team_id: int, external_id: str) -> Account | None:
+    try:
+        return Account.objects.for_team(team_id).get(external_id=external_id)
+    except Account.DoesNotExist:
+        return None
+
+
+def get_external_account(team_id: int, external_id: str) -> contracts.ExternalAccount | None:
+    """Fetch the team's account by external id for the external API, or None."""
+    account = _get_external_account_by_external_id(team_id, external_id)
+    if account is None:
+        return None
+    return _to_external_account(account)
+
+
+def _apply_external_tags(account: Account, tags: list[str], mode: str) -> None:
+    normalized = list({tagify(t) for t in tags})
+    if mode == "remove":
+        account.tagged_items.filter(tag__name__in=normalized).delete()
+    elif mode == "set":
+        set_tags_on_object(normalized, account)
+    else:
+        for tag_name in normalized:
+            tag, _ = Tag.objects.get_or_create(name=tag_name, team_id=account.team_id)
+            account.tagged_items.get_or_create(tag_id=tag.id)
+
+
+def _apply_external_role_assignments(
+    account: Account, role_assignments: dict[str, int | None]
+) -> contracts.ExternalAccountUpdateResult | None:
+    """Apply provided role assignments to the account's properties.
+
+    ``role_assignments`` holds only the roles present in the request (None
+    clears a role). Each non-None user id is resolved against an
+    ``OrganizationMembership`` in the account's org so the stored ``{id, email}``
+    is always trusted. Returns an error result (membership missing / invalid
+    properties) or None on success.
+    """
+    properties = dict(account._properties or {})
+    changed = False
+
+    for field in _EXTERNAL_ASSIGNMENT_ROLE_FIELDS:
+        if field not in role_assignments:
+            continue
+        user_id = role_assignments[field]
+        if user_id is None:
+            properties[field] = None
+        else:
+            membership = (
+                OrganizationMembership.objects.select_related("user")
+                .filter(organization_id=account.team.organization_id, user_id=user_id)
+                .first()
+            )
+            if membership is None:
+                return contracts.ExternalAccountUpdateResult(
+                    error=contracts.ExternalAccountUpdateError.USER_NOT_IN_ORGANIZATION,
+                    error_field=field,
+                )
+            properties[field] = {"id": membership.user.id, "email": membership.user.email}
+        changed = True
+
+    if not changed:
+        return None
+
+    try:
+        account.properties = _ModelAccountProperties.model_validate(properties)
+    except Exception as e:
+        capture_exception(e, {"account_id": str(account.id)})
+        return contracts.ExternalAccountUpdateResult(error=contracts.ExternalAccountUpdateError.INVALID_PROPERTIES)
+
+    account.save(update_fields=["_properties", "updated_at"])
+    return None
+
+
+def update_external_account(
+    team_id: int,
+    external_id: str,
+    *,
+    role_assignments: dict[str, int | None],
+    tags: list[str] | None,
+    tags_mode: str,
+) -> contracts.ExternalAccountUpdateResult:
+    """Apply role assignments and tags to an account, transactionally, for the external API.
+
+    Role assignments and tags are all-or-nothing — a tag failure must not leave the
+    role-contact changes committed. Returns a result the view maps to the exact HTTP
+    status/body: not found, a per-role org-membership failure, invalid properties, a
+    generic write failure, or success carrying the re-serialized account.
+    """
+    account = _get_external_account_by_external_id(team_id, external_id)
+    if account is None:
+        return contracts.ExternalAccountUpdateResult(error=contracts.ExternalAccountUpdateError.NOT_FOUND)
+
+    try:
+        with transaction.atomic():
+            error_result = _apply_external_role_assignments(account, role_assignments)
+            if error_result is not None:
+                return error_result
+            if tags is not None:
+                _apply_external_tags(account, tags, tags_mode)
+    except Exception as e:
+        capture_exception(e, {"account_id": str(account.id)})
+        return contracts.ExternalAccountUpdateResult(error=contracts.ExternalAccountUpdateError.UPDATE_FAILED)
+
+    account.refresh_from_db()
+    return contracts.ExternalAccountUpdateResult(account=_to_external_account(account))

--- a/products/customer_analytics/backend/facade/constants.py
+++ b/products/customer_analytics/backend/facade/constants.py
@@ -6,6 +6,7 @@ stays as the source of truth.
 """
 
 from products.customer_analytics.backend.constants import (
+    ACCOUNT_ASSIGNMENT_ROLE_FIELDS,
     BILLING_SPEND_INSIGHT_SHORT_IDS,
     BILLING_USAGE_INSIGHT_SHORT_IDS,
     CUSTOMER_ANALYTICS_CSP_FLAG,
@@ -13,6 +14,7 @@ from products.customer_analytics.backend.constants import (
 )
 
 __all__ = [
+    "ACCOUNT_ASSIGNMENT_ROLE_FIELDS",
     "BILLING_SPEND_INSIGHT_SHORT_IDS",
     "BILLING_USAGE_INSIGHT_SHORT_IDS",
     "CUSTOMER_ANALYTICS_CSP_FLAG",

--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -12,6 +12,7 @@ instead of producing a malformed payload deeper in a caller.
 
 from dataclasses import field
 from datetime import datetime
+from enum import Enum
 from uuid import UUID
 
 from pydantic.dataclasses import dataclass
@@ -93,3 +94,46 @@ class AccountContextData:
     properties: AccountProperties
     tags: list[str] = field(default_factory=list)
     notes: list[AccountNote] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ExternalAccount:
+    """The account shape the external (CDP worker) API serializes verbatim.
+
+    ``properties`` is carried as a plain dict set to exactly
+    ``account.properties.model_dump(mode="json")`` so the JSON the CDP worker
+    consumes stays byte-identical to the pre-facade response — a validated
+    pydantic pass-through, not a re-typed projection. ``id`` is the stringified
+    UUID, matching the wire shape.
+    """
+
+    id: str
+    external_id: str | None
+    name: str
+    properties: dict
+    tags: list[str] = field(default_factory=list)
+
+
+class ExternalAccountUpdateError(Enum):
+    """Failure modes of the external account write, each mapping to a distinct
+    HTTP response in the view."""
+
+    NOT_FOUND = "not_found"
+    USER_NOT_IN_ORGANIZATION = "user_not_in_organization"
+    INVALID_PROPERTIES = "invalid_properties"
+    UPDATE_FAILED = "update_failed"
+
+
+@dataclass(frozen=True)
+class ExternalAccountUpdateResult:
+    """Outcome of the external account write, modeled so the view can map each
+    case to its exact HTTP status and error string without holding write logic.
+
+    Exactly one of ``account`` / ``error`` is set. ``error_field`` carries the
+    role field name for a ``USER_NOT_IN_ORGANIZATION`` failure (so the view can
+    keep the ``"{field}: ..."`` message shape); it is None otherwise.
+    """
+
+    account: ExternalAccount | None = None
+    error: ExternalAccountUpdateError | None = None
+    error_field: str | None = None

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -30,9 +30,10 @@ from products.customer_analytics.backend.facade import (
     api as facade,
     contracts,
 )
-from products.customer_analytics.backend.facade.constants import CUSTOMER_ANALYTICS_CSP_FLAG
-
-ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
+from products.customer_analytics.backend.facade.constants import (
+    ACCOUNT_ASSIGNMENT_ROLE_FIELDS,
+    CUSTOMER_ANALYTICS_CSP_FLAG,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -139,7 +140,7 @@ class ExternalAccountUpdateSerializer(serializers.Serializer):
     tags_mode = serializers.ChoiceField(choices=["add", "set", "remove"], required=False, default="add")
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        for field in ASSIGNMENT_ROLE_FIELDS:
+        for field in ACCOUNT_ASSIGNMENT_ROLE_FIELDS:
             if field in attrs and attrs[field] is not None:
                 attrs[field] = self._normalize_assignee(field, attrs[field])
         return attrs
@@ -203,7 +204,7 @@ class ExternalAccountView(APIView):
         if not external_id:
             return Response({"error": "external_id is required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        role_assignments = {field: data[field] for field in ASSIGNMENT_ROLE_FIELDS if field in data}
+        role_assignments = {field: data[field] for field in ACCOUNT_ASSIGNMENT_ROLE_FIELDS if field in data}
         result = facade.update_external_account(
             team.id,
             external_id,

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -3,12 +3,16 @@ External API endpoints for the Customer analytics product.
 
 These endpoints are used by the CDP worker for workflow actions. Authenticated
 via the team secret API token passed as a Bearer token in the Authorization header.
+
+The view holds only HTTP concerns — Bearer auth, throttles, the feature-flag gate,
+request validation, and mapping facade results to responses. Data access, the
+transactional write, org-membership resolution, tag application, and exception
+capture live behind ``facade.api``.
 """
 
 import hashlib
 from typing import Any
 
-from django.db import transaction
 from django.db.models import Q
 
 import structlog
@@ -20,14 +24,13 @@ from rest_framework.response import Response
 from rest_framework.throttling import SimpleRateThrottle
 from rest_framework.views import APIView
 
-from posthog.api.tagged_item import set_tags_on_object
-from posthog.exceptions_capture import capture_exception
-from posthog.models import OrganizationMembership, Tag, Team
-from posthog.models.tag import tagify
+from posthog.models import Team
 
-from products.customer_analytics.backend.constants import CUSTOMER_ANALYTICS_CSP_FLAG
-from products.customer_analytics.backend.models import Account
-from products.customer_analytics.backend.models.account import AccountProperties
+from products.customer_analytics.backend.facade import (
+    api as facade,
+    contracts,
+)
+from products.customer_analytics.backend.facade.constants import CUSTOMER_ANALYTICS_CSP_FLAG
 
 ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
 
@@ -92,28 +95,42 @@ def _authenticate_team(request: Request) -> tuple[Team, None] | tuple[None, Resp
     return team, None
 
 
-def _serialize_account(account: Account) -> dict[str, Any]:
+def _external_account_body(account: contracts.ExternalAccount) -> dict[str, Any]:
     return {
-        "id": str(account.id),
+        "id": account.id,
         "external_id": account.external_id,
         "name": account.name,
-        "properties": account.properties.model_dump(mode="json"),
-        "tags": sorted(account.tagged_items.values_list("tag__name", flat=True)),
+        "properties": account.properties,
+        "tags": account.tags,
     }
 
 
-def _get_account_by_external_id(team: Team, external_id: str) -> Account | None:
-    try:
-        return Account.objects.for_team(team.id).get(external_id=external_id)
-    except Account.DoesNotExist:
-        return None
+_UPDATE_ERROR_RESPONSES = {
+    contracts.ExternalAccountUpdateError.NOT_FOUND: ("Account not found", status.HTTP_404_NOT_FOUND),
+    contracts.ExternalAccountUpdateError.INVALID_PROPERTIES: (
+        "Invalid account properties",
+        status.HTTP_400_BAD_REQUEST,
+    ),
+    contracts.ExternalAccountUpdateError.UPDATE_FAILED: ("Failed to update account", status.HTTP_400_BAD_REQUEST),
+}
+
+
+def _update_error_response(result: contracts.ExternalAccountUpdateResult) -> Response:
+    if result.error == contracts.ExternalAccountUpdateError.USER_NOT_IN_ORGANIZATION:
+        return Response(
+            {"error": f"{result.error_field}: user is not a member of this organization"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    assert result.error is not None
+    message, code = _UPDATE_ERROR_RESPONSES[result.error]
+    return Response({"error": message}, status=code)
 
 
 class ExternalAccountUpdateSerializer(serializers.Serializer):
     external_id = serializers.CharField(max_length=400)
     # Each role accepts a `posthog_assignee` value `{type, id}`, `null` to clear, or is
     # omitted to leave unchanged. Roles (RBAC) are rejected — accounts assign users only.
-    # `validate` normalizes a provided assignment down to the user id; the view resolves
+    # `validate` normalizes a provided assignment down to the user id; the facade resolves
     # the email against an org membership so the stored `{id, email}` is always trusted.
     csm = serializers.JSONField(required=False, allow_null=True)
     account_executive = serializers.JSONField(required=False, allow_null=True)
@@ -141,18 +158,6 @@ class ExternalAccountUpdateSerializer(serializers.Serializer):
             raise serializers.ValidationError({field: "Assignee id must be a user id"})
 
 
-def _apply_tags(account: Account, tags: list[str], mode: str) -> None:
-    normalized = list({tagify(t) for t in tags})
-    if mode == "remove":
-        account.tagged_items.filter(tag__name__in=normalized).delete()
-    elif mode == "set":
-        set_tags_on_object(normalized, account)
-    else:
-        for tag_name in normalized:
-            tag, _ = Tag.objects.get_or_create(name=tag_name, team_id=account.team_id)
-            account.tagged_items.get_or_create(tag_id=tag.id)
-
-
 class ExternalAccountView(APIView):
     """
     GET /api/customer_analytics/external/account?external_id=<external_id> — Fetch account data
@@ -176,11 +181,11 @@ class ExternalAccountView(APIView):
         if not external_id:
             return Response({"error": "external_id is required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        account = _get_account_by_external_id(team, external_id)
+        account = facade.get_external_account(team.id, external_id)
         if account is None:
             return Response({"error": "Account not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        return Response(_serialize_account(account))
+        return Response(_external_account_body(account))
 
     def patch(self, request: Request) -> Response:
         team, error = _authenticate_team(request)
@@ -198,58 +203,15 @@ class ExternalAccountView(APIView):
         if not external_id:
             return Response({"error": "external_id is required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        account = _get_account_by_external_id(team, external_id)
-        if account is None:
-            return Response({"error": "Account not found"}, status=status.HTTP_404_NOT_FOUND)
+        role_assignments = {field: data[field] for field in ASSIGNMENT_ROLE_FIELDS if field in data}
+        result = facade.update_external_account(
+            team.id,
+            external_id,
+            role_assignments=role_assignments,
+            tags=data["tags"] if "tags" in data else None,
+            tags_mode=data.get("tags_mode", "add"),
+        )
+        if result.account is None:
+            return _update_error_response(result)
 
-        # Role assignments and tags must be all-or-nothing — a tag failure must not leave the
-        # role-contact changes committed. Validation errors return before any write happens.
-        try:
-            with transaction.atomic():
-                error = self._apply_role_assignments(team, account, data)
-                if error:
-                    return error
-                if "tags" in data:
-                    _apply_tags(account, data["tags"], data.get("tags_mode", "add"))
-        except Exception as e:
-            capture_exception(e, {"account_id": str(account.id)})
-            return Response({"error": "Failed to update account"}, status=status.HTTP_400_BAD_REQUEST)
-
-        account.refresh_from_db()
-        return Response(_serialize_account(account))
-
-    def _apply_role_assignments(self, team: Team, account: Account, data: dict[str, Any]) -> Response | None:
-        properties = dict(account._properties or {})
-        changed = False
-
-        for field in ASSIGNMENT_ROLE_FIELDS:
-            if field not in data:
-                continue
-            user_id = data[field]
-            if user_id is None:
-                properties[field] = None
-            else:
-                membership = (
-                    OrganizationMembership.objects.select_related("user")
-                    .filter(organization_id=team.organization_id, user_id=user_id)
-                    .first()
-                )
-                if membership is None:
-                    return Response(
-                        {"error": f"{field}: user is not a member of this organization"},
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-                properties[field] = {"id": membership.user.id, "email": membership.user.email}
-            changed = True
-
-        if not changed:
-            return None
-
-        try:
-            account.properties = AccountProperties.model_validate(properties)
-        except Exception as e:
-            capture_exception(e, {"account_id": str(account.id)})
-            return Response({"error": "Invalid account properties"}, status=status.HTTP_400_BAD_REQUEST)
-
-        account.save(update_fields=["_properties", "updated_at"])
-        return None
+        return Response(_external_account_body(result.account))

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -197,7 +197,7 @@ class TestExternalAccountAPI(APIBaseTest):
 
     def test_patch_rolls_back_role_assignment_when_tags_fail(self):
         with patch(
-            "products.customer_analytics.backend.presentation.views.external._apply_tags",
+            "products.customer_analytics.backend.facade.api._apply_external_tags",
             side_effect=Exception("boom"),
         ):
             response = self._patch(

--- a/products/customer_analytics/backend/test/test_facade.py
+++ b/products/customer_analytics/backend/test/test_facade.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from posthog.models import Organization, User
 from posthog.models.tag import Tag
 from posthog.models.tagged_item import TaggedItem
 from posthog.rbac.user_access_control import UserAccessControl
@@ -112,3 +113,161 @@ class TestCustomerAnalyticsFacade(BaseTest):
 
         assert count == 2
         assert {r.name for r in rows} == {"First", "Second"}
+
+    # -- External account API (CDP worker) --------------------------------
+
+    def test_get_external_account_returns_verbatim_shape(self):
+        account = create_account(
+            team_id=self.team.id,
+            name="Acme Corp",
+            external_id="acme-1",
+            _properties=AccountProperties(
+                csm=AccountAssignment(id=self.user.id, email=self.user.email),
+            ).model_dump(mode="json"),
+        )
+        tag = Tag.objects.create(name="enterprise", team_id=self.team.id)
+        TaggedItem.objects.create(tag=tag, account=account)
+
+        result = facade.get_external_account(self.team.id, "acme-1")
+
+        assert isinstance(result, contracts.ExternalAccount)
+        assert result.id == str(account.id)
+        assert result.external_id == "acme-1"
+        assert result.name == "Acme Corp"
+        assert result.tags == ["enterprise"]
+        assert result.properties == account.properties.model_dump(mode="json")
+        assert result.properties["csm"] == {"id": self.user.id, "email": self.user.email}
+
+    def test_get_external_account_missing_and_other_team(self):
+        create_account(team_id=self.team.id, name="Acme Corp", external_id="acme-1")
+        other_team = Organization.objects.bootstrap(None, name="Other")[2]
+
+        assert facade.get_external_account(self.team.id, "nope") is None
+        assert facade.get_external_account(other_team.id, "acme-1") is None
+
+    def test_update_external_account_not_found_returns_not_found(self):
+        result = facade.update_external_account(
+            self.team.id, "missing", role_assignments={}, tags=None, tags_mode="add"
+        )
+        assert result.account is None
+        assert result.error == contracts.ExternalAccountUpdateError.NOT_FOUND
+
+    def test_update_external_account_assigns_role_and_resolves_email(self):
+        account = create_account(team_id=self.team.id, name="Acme Corp", external_id="acme-1")
+
+        result = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={"csm": self.user.id}, tags=None, tags_mode="add"
+        )
+
+        assert result.error is None
+        assert result.account is not None
+        assert result.account.properties["csm"] == {"id": self.user.id, "email": self.user.email}
+        account.refresh_from_db()
+        assert account.properties.csm == AccountAssignment(id=self.user.id, email=self.user.email)
+
+    def test_update_external_account_clears_role_with_none(self):
+        account = create_account(
+            team_id=self.team.id,
+            name="Acme Corp",
+            external_id="acme-1",
+            _properties=AccountProperties(
+                csm=AccountAssignment(id=self.user.id, email=self.user.email),
+            ).model_dump(mode="json"),
+        )
+
+        result = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={"csm": None}, tags=None, tags_mode="add"
+        )
+
+        assert result.account is not None
+        assert result.account.properties["csm"] is None
+        account.refresh_from_db()
+        assert account.properties.csm is None
+
+    def test_update_external_account_preserves_unmentioned_properties(self):
+        account = create_account(
+            team_id=self.team.id,
+            name="Acme Corp",
+            external_id="acme-1",
+            _properties=AccountProperties(stripe_customer_id="cus_123").model_dump(mode="json"),
+        )
+
+        facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={"csm": self.user.id}, tags=None, tags_mode="add"
+        )
+
+        account.refresh_from_db()
+        assert account.properties.stripe_customer_id == "cus_123"
+        assert account.properties.csm == AccountAssignment(id=self.user.id, email=self.user.email)
+
+    def test_update_external_account_rejects_non_member(self):
+        account = create_account(team_id=self.team.id, name="Acme Corp", external_id="acme-1")
+        outsider = User.objects.create_and_join(Organization.objects.create(name="Outsiders"), "out@example.com", None)
+
+        result = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={"csm": outsider.id}, tags=None, tags_mode="add"
+        )
+
+        assert result.account is None
+        assert result.error == contracts.ExternalAccountUpdateError.USER_NOT_IN_ORGANIZATION
+        assert result.error_field == "csm"
+        account.refresh_from_db()
+        assert account.properties.csm is None
+
+    def test_update_external_account_invalid_properties(self):
+        create_account(
+            team_id=self.team.id,
+            name="Acme Corp",
+            external_id="acme-1",
+            _properties={"not_a_real_property": "x"},
+        )
+
+        result = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={"csm": self.user.id}, tags=None, tags_mode="add"
+        )
+
+        assert result.account is None
+        assert result.error == contracts.ExternalAccountUpdateError.INVALID_PROPERTIES
+
+    def test_update_external_account_tag_modes(self):
+        create_account(team_id=self.team.id, name="Acme Corp", external_id="acme-1")
+
+        added = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={}, tags=["enterprise"], tags_mode="add"
+        )
+        assert added.account is not None and added.account.tags == ["enterprise"]
+
+        added_more = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={}, tags=["priority"], tags_mode="add"
+        )
+        assert added_more.account is not None and added_more.account.tags == ["enterprise", "priority"]
+
+        replaced = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={}, tags=["only"], tags_mode="set"
+        )
+        assert replaced.account is not None and replaced.account.tags == ["only"]
+
+        removed = facade.update_external_account(
+            self.team.id, "acme-1", role_assignments={}, tags=["only"], tags_mode="remove"
+        )
+        assert removed.account is not None and removed.account.tags == []
+
+    def test_update_external_account_rolls_back_role_when_tags_fail(self):
+        account = create_account(team_id=self.team.id, name="Acme Corp", external_id="acme-1")
+
+        with patch(
+            "products.customer_analytics.backend.facade.api._apply_external_tags",
+            side_effect=Exception("boom"),
+        ):
+            result = facade.update_external_account(
+                self.team.id,
+                "acme-1",
+                role_assignments={"csm": self.user.id},
+                tags=["enterprise"],
+                tags_mode="add",
+            )
+
+        assert result.account is None
+        assert result.error == contracts.ExternalAccountUpdateError.UPDATE_FAILED
+        account.refresh_from_db()
+        assert account.properties.csm is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -572,9 +572,6 @@ ignore_imports = [
     # TODO: customer_analytics presentation wave — these views still reach internals directly.
     # Thin each view to parse -> facade -> serialize and delete its entry. backend:contract-check
     # stays off until this list is empty.
-    "products.customer_analytics.backend.presentation.views.external -> products.customer_analytics.backend.constants",
-    "products.customer_analytics.backend.presentation.views.external -> products.customer_analytics.backend.models",
-    "products.customer_analytics.backend.presentation.views.external -> products.customer_analytics.backend.models.account",
     "products.customer_analytics.backend.presentation.views.organization_members -> products.customer_analytics.backend.constants",
     "products.customer_analytics.backend.presentation.views.serializers -> products.customer_analytics.backend.models",
     "products.customer_analytics.backend.presentation.views.utils -> products.customer_analytics.backend.models",


### PR DESCRIPTION
## Problem

The external account API (`ExternalAccountView`, consumed by the CDP worker) still reached `customer_analytics` internals — `backend.models`, `backend.models.account`, and `backend.constants` — directly from the presentation layer, so it carried temporary `ignore_imports` allowlist entries that keep the product's CI skip off.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add `ExternalAccount` contract (carries `properties` as the verbatim `model_dump(mode="json")` dict for byte-identical JSON), plus `ExternalAccountUpdateError` / `ExternalAccountUpdateResult` to model write outcomes.
- Add `get_external_account` and `update_external_account` to `facade/api.py`; move the transactional write, org-membership resolution (`{id, email}`), tag application, `AccountProperties` validation, and `capture_exception` behind the facade.
- Thin `external.py` to parse → facade → serialize: it keeps only Bearer auth, throttles, the feature-flag gate, request validation, the empty-`external_id` guard, and result→`Response` mapping.
- Route the CSP flag constant through `facade.constants` instead of `backend.constants`.
- Remove the three `external` `ignore_imports` entries from `pyproject.toml`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests: `test_external.py` (existing assertions unchanged, they pin the wire contract) and new facade parity tests in `test_facade.py` covering get + update happy paths and each error case (not found, non-member, invalid properties, tag-failure rollback). Full `products/customer_analytics/backend/test` suite green (217 passed). `lint-imports`, `tach check --dependencies --interfaces`, and `hogli product:lint customer_analytics` all pass; `build:openapi` produced no diff.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Fully autonomous

One slice of the `customer_analytics` presentation-wave isolation migration (after #64336). Authored with PostHog Code; invoked the `/isolating-product-facade-contracts` and `/improving-drf-endpoints` skills.

Behavior parity was the priority — the external API has zero in-process importers but is consumed over HTTP by the CDP worker, so the JSON must stay byte-identical. Key decisions:

- `ExternalAccount.properties` carries the raw `model_dump(mode="json")` dict (a validated-pydantic pass-through) rather than the typed `AccountProperties` contract, to guarantee identical JSON without re-projection risk.
- The all-or-nothing write semantics are preserved: the transaction lives in the facade, and a tag failure still rolls back already-applied role assignments (covered by a facade-level test that mocks the tag helper to raise).
- Org-membership failures, invalid properties, and generic write failures are returned as a typed result the thin view maps to the exact existing status codes and error strings; `capture_exception` moved to the facade where the write happens, while the flag check (`posthoganalytics`) stays in the view.
- The `_apply_tags` test patch was repointed to its new facade location; the `feature_enabled` patch stays on the view.

This PR intentionally does **not** enable `backend:contract-check` — three sibling presentation-wave entries remain (`product:lint` reports 4 bypasses still open, down from 7); a later PR flips the skip on once the allowlist is empty.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
