### PR TITLE
fix(hubspot): retry token refresh while portal migration is in progress

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -16,7 +16,7 @@ _FALLBACK_WAIT = wait_exponential_jitter(initial=1, max=30)
 
 
 class HubspotRetryableError(Exception):
-    """Transient HubSpot API failure (429 rate limit or 5xx) that should be retried with backoff."""
+    """Transient HubSpot API failure (429 rate limit, 5xx, or portal migration) that should be retried with backoff."""
 
     def __init__(self, message: str, retry_after: float | None = None) -> None:
         super().__init__(message)

--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -81,6 +81,11 @@ def hubspot_refresh_access_token(refresh_token: str, source_id: str | None = Non
         if res.status_code == 429 or res.status_code >= 500:
             retry_after = _parse_retry_after(res) if res.status_code == 429 else None
             raise HubspotRetryableError(err_message, retry_after=retry_after)
+        # HubSpot briefly returns this (on a non-5xx) while a portal is migrated between data
+        # centers; the portal becomes reachable again once the migration finishes, so back off
+        # and retry rather than failing the sync (and disabling the schema) on a transient state.
+        if "migration in progress" in err_message.lower():
+            raise HubspotRetryableError(err_message)
         raise Exception(err_message)
 
     access_token = res.json()["access_token"]

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_hubspot_auth.py
@@ -69,6 +69,25 @@ def test_non_transient_status_raises_plain_exception(status: int, message: str) 
         assert message in str(exc_info.value)
 
 
+@pytest.mark.parametrize("status", [400, 403, 423])
+def test_portal_migration_in_progress_is_retryable(status: int) -> None:
+    # A portal mid-migration is a transient HubSpot state on a non-5xx status; it must back off
+    # and retry instead of failing the sync and disabling the schema.
+    message = "Migration in progress and the portal is not available for access."
+    session = MagicMock()
+    session.post.side_effect = [
+        _make_response(status, {"message": message}),
+        _make_response(status, {"message": message}),
+        _make_response(200, {"access_token": "new-token"}),
+    ]
+    with patch(
+        "posthog.temporal.data_imports.sources.hubspot.auth.make_tracked_session",
+        return_value=session,
+    ):
+        assert hubspot_refresh_access_token("refresh-token") == "new-token"
+    assert session.post.call_count == 3
+
+
 def test_transient_status_with_non_json_body_still_retryable() -> None:
     response = MagicMock()
     response.status_code = 429


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring failure in the HubSpot data-warehouse import: [`Migration in progress and the portal is not available for access.`](https://us.posthog.com/project/2/error_tracking/019ee249-c714-75a1-8a26-309dd3d18bcf)

It's raised in `hubspot_refresh_access_token` (`posthog/temporal/data_imports/sources/hubspot/auth.py:84`) when HubSpot's OAuth token endpoint returns a non-200, non-429, non-5xx response whose body message is "Migration in progress and the portal is not available for access." HubSpot returns this while a portal is being migrated between data centers — the portal becomes reachable again once the migration finishes.

The signal looks transient and self-resolving: a tight cluster of occurrences across several portals within roughly a minute, then nothing.

## Changes

Recognize the "migration in progress" message and raise `HubspotRetryableError` instead of a bare `Exception`, mirroring how the function already handles 429/5xx.

Why retry rather than treat as non-retryable:

- The portal recovers on its own once HubSpot finishes the migration, so the right behavior is to back off and retry, not to give up.
- Adding it to `get_non_retryable_errors` would classify the failure as non-retryable, which calls `update_should_sync(should_sync=False)` and **disables the schema** — leaving the user's sync stopped until they manually re-enable it, for a condition that heals itself. That's the wrong outcome here.

Raising `HubspotRetryableError` lets the existing `tenacity` backoff retry the refresh in-process (catching short migration windows transparently) and keeps the error out of the non-retryable path, so the schema stays enabled and resumes on its own.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_portal_migration_in_progress_is_retryable`) asserting that a non-5xx response carrying the migration message backs off, retries, and succeeds once HubSpot stops returning it. I could not execute the test suite in this environment (no test runner installed); I verified both changed files compile, pass `ruff check`, and are `ruff format`-clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's stack trace and sampled events via the PostHog error-tracking MCP tools, confirmed the failure originates in `hubspot/auth.py`, then traced the call path (`import_data_activity_sync` → `source_for_pipeline` → `hubspot_refresh_access_token`) and read `external_data_job.py` to confirm that the non-retryable path disables the schema.

Decision: transient upstream condition, not a credential/config error — so a code fix (retry) rather than extending `NonRetryableErrors`. Checked open PRs (including the HubSpot maintainer's) for duplicates; none address this error.