### PR TITLE
fix(insights): hide tile freshness clock when no date is shown

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4837,13 +4837,13 @@ snapshots:
     scenes-app-customer-analytics-journeys-nodes-profileflownode--optional-not-completed--light:
         hash: v1.k794b7964.165b884e9e737c00707811f9efa7d348927a432402c544b41495eac9722a1fca.wqLWQTzb1O7RBTeeyTR5l_hUeX0IpJXkgexpAQbuNWs
     scenes-app-dashboards--access-control-dashboard--dark:
-        hash: v1.k794b7964.5a2070ced40d9a7283b60d208aef3315f684f2586db52f79337f82ca4f80ae49.eOeTlC4JZNhfDx_aXctKeV6HL1TQKugnpDyf1l-NFX0
+        hash: v1.k794b7964.72e46fa2edde8a213313ed3683e99beab5dbce9f6ba0068bfd147800fc33a01b.d5e1MmICfNadPNGril9i7LXuLz3UeJ3MQcShG9j9ysk
     scenes-app-dashboards--access-control-dashboard--light:
-        hash: v1.k794b7964.8750e411634aabaec37428088a6c2ff338b30103628b3358ec1aa9303e7bc6a4.QHf7vvPUacMgAWbJiWSEEWZ5xEhNe-apEwxD59eg29o
+        hash: v1.k794b7964.2cb1dc53e388e2ba2f1ba027db19970b5c836420c212719646cc6e01df3eb532.3JJd9GmozBQFNT4B9WyN_CM7iuWaWKL1u3Fq6SXTnhI
     scenes-app-dashboards--edit--dark:
-        hash: v1.k794b7964.77a03f7c6aef36f12b2eff445c072046a811be333172a731bb86ae353e047544.YlLoJRLu6tNMUvkmYZH8wVJzRVUqWFZtV-BhpSz5aTo
+        hash: v1.k794b7964.083587fcf5cb279b32adeda05783970f3e222dc33a17ad5686f5196be865a8ab.A-1zzLAHX5TOyD8dvQYlCNH2xD4FZiiDW7CXMovArYM
     scenes-app-dashboards--edit--light:
-        hash: v1.k794b7964.3b2874181e936c6709d7c67db69bba087f600c2bd33835bce8e0e3a73964e948.pJ537ZFActzJzjSYe4aRQKCKH1DFgA32qSl7v9VUWIQ
+        hash: v1.k794b7964.a2f42d94fac861654f447f332cd513eaa9bd81f3c108967e6745f695f12c2546.mV7i91ApKabQ_d_YjjU0K5OMYpM7el5LmffL9XWr8M8
     scenes-app-dashboards--erroring--dark:
         hash: v1.k794b7964.a356bf2ce40e53018919ebc890579c0ad6e493385f546d26b1f70471bf99f726.UER3Vv5UUZ1POzJv4_TuxrLBcLfLa8WTZ_hyUX9t72s
     scenes-app-dashboards--erroring--light:
@@ -4865,9 +4865,9 @@ snapshots:
     scenes-app-dashboards--not-found--light:
         hash: v1.k794b7964.1ce58559d0a7f0fdec75dc0cd2230c29bf6dcc25cb275a8eccd9a5c2a0a928b6.j9xKwNlmX3cJs2iIEJw1NuA6vMsMRIvFsNdfSYwmYN4
     scenes-app-dashboards--view-only-dashboard--dark:
-        hash: v1.k794b7964.21152e91717a6fc5140d8f3aa7a814ba91e1cc23fb0bbfdbeb84a23cb175a562.Nm0X90U2YpPaxYuelhuNFzaQ3mixWrNcL8mcKbwHPXk
+        hash: v1.k794b7964.316dfbc4e36a5fc42de0437536475f5f96fe42bba8d90ac0bae231ac537a350e.vXEOGysbaIc9cFvql1OJbrMfDUuMJX0OgQtvFpFiR2M
     scenes-app-dashboards--view-only-dashboard--light:
-        hash: v1.k794b7964.1375536ea1ec87463a36ff8387073e3502d5127e68837fee3474b11d52684155.BobnrxAcdpL_nNICNKf2aqg_CXhq38fCWTgceozBTcY
+        hash: v1.k794b7964.8d8565dfb737034f8415ede3db773dc555f73a43c618218c1a12cd0d83a0a217.BpLcmQ8sF7wQ1KIfd09rJf_Elm5nWz51vY8uKfG--_Q
     scenes-app-dashboards-add-insight-to-dashboard-modal--default--dark:
         hash: v1.k794b7964.9e274692c8e4c207d502de8e74ecb4ad848c351a69dc19185ddc3d52616e9c6f.JXi4RnJ4pej3Q4xhfMDQUlzqxMhz31nwrjmt1U-Fwbo
     scenes-app-dashboards-add-insight-to-dashboard-modal--default--light:

--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -68,6 +68,7 @@ export function TopHeading({
             query == undefined || isInsightQueryNode(query) || isInsightVizNode(query) ? 'Last 7 days' : null
         dateText = dateFilterToText(date_from, date_to, defaultDateRange)
     }
+    const dateLabel = showDate ? dateText : null
 
     const insightQueryNode = isInsightVizNode(query) ? query.source : isInsightQueryNode(query) ? query : null
     const interval = insightQueryNode ? getInterval(insightQueryNode) : null
@@ -78,10 +79,11 @@ export function TopHeading({
             typeLabel={insightType?.name}
             typeTitle={insightType?.description}
             showTypeLabel={showInsightType}
-            dateText={showDate ? dateText : null}
+            dateText={dateLabel}
             dateTooltip={resolvedDateTooltip}
         >
-            {lastRefresh ? <InsightFreshness lastRefresh={lastRefresh} /> : null}
+            {/* Freshness clock lives in the date row — without a date it would hold the row open on its own. */}
+            {dateLabel && lastRefresh ? <InsightFreshness lastRefresh={lastRefresh} /> : null}
             {hasTileOverrides ? <TileOverridesWarning /> : null}
         </CardTopHeadingRow>
     )


### PR DESCRIPTION
## Problem

A recent change (#64855) suppressed the redundant date label on compact dashboard tiles, but the freshness clock icon lived in that same heading row. With the date gone, the lone clock held the row open, pushing the tile title down onto its own line instead of sitting inline with the `…` menu — most visible on big-number metric tiles.

## Changes

- In `TopHeading`, gate the `InsightFreshness` clock on whether a date label is actually being rendered (`dateLabel`), not just on `lastRefresh`.
- When no date is shown the heading row is now empty and collapses, so the title sits inline with the more menu.
- Placements that still show a date (info popover, saved-insights list) keep the clock; Retention insights — which have no date label — no longer show a lone clock.
-
Before
<img width="950" height="103" alt="Screenshot 2026-06-20 at 09 02 55" src="https://github.com/user-attachments/assets/3584f465-e908-4ad1-9aed-6c12e75cb5b4" />
After
<img width="940" height="77" alt="Screenshot 2026-06-20 at 09 01 27" src="https://github.com/user-attachments/assets/a11a9a72-66ab-4342-866b-68c66210a12b" />

## How did you test this code?

I'm an agent (directed by the PR author). No automated test suites were run. I verified the rendering with the `/look` skill driving Playwright against a local dashboard — confirmed the big-number tiles ("Pageview count", etc.) show the title inline with the `…` menu, with no clock row and no date label.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the author's direction, as a follow-up to #64855. The author noticed the suppressed date left a clock icon occupying the header row and pushing the title down.

- First traced it to `InsightFreshness` rendering as a child of the heading row in `TopHeading`; on tiles wide enough for `.CardMeta__heading` to become `display: contents`, the clock becomes a flex item that holds `CardMeta__top` open.
- Initially threaded a `showFreshness` prop from `InsightMeta`, then simplified per author feedback to a single self-contained rule in `TopHeading`: no date label → no clock.
- No skills shaped the code beyond `/look` for visual verification.