### PR TITLE
fix(signals): use report's selected repo for inbox Create PR

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5122,8 +5122,11 @@ const api = {
         async get(id: SignalReport['id']): Promise<SignalReport> {
             return await new ApiRequest().signalReport(id).get()
         },
-        async artefacts(id: SignalReport['id']): Promise<SignalReportArtefactResponse> {
-            return await new ApiRequest().signalReport(id).withAction('artefacts').get()
+        async artefacts(
+            id: SignalReport['id'],
+            params: { limit?: number } = {}
+        ): Promise<SignalReportArtefactResponse> {
+            return await new ApiRequest().signalReport(id).withAction('artefacts').withQueryString(params).get()
         },
         async getReportSignals(reportId: string): Promise<{ report: SignalReport | null; signals: SignalNode[] }> {
             return await new ApiRequest().signalReport(reportId).withAction('signals').get()

--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -54,7 +54,10 @@ async function createReportTask(
         const { results } = await api.signalReports.artefacts(report.id)
         const selected = results.find((a) => a.type === 'repo_selection')?.content?.repository
         repository = typeof selected === 'string' && selected ? selected : undefined
-    } catch {
+    } catch (e) {
+        if (requireRepository) {
+            throw e
+        }
         repository = undefined
     }
 

--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -42,15 +42,27 @@ async function createReportTask(
     report: SignalReport,
     relationship: SignalReportTaskRelationship,
     prompt: string,
-    fallbackTitle: string
+    fallbackTitle: string,
+    requireRepository = false
 ): Promise<void> {
-    // Pick a default repository (mirrors desktop resolving lastUsedCloudRepository → first repo).
+    // Use the repository the signals pipeline already selected for this report (its
+    // `repo_selection` artefact), matching the desktop app and the auto-start flow. Never fall
+    // back to an arbitrary project repo — `repositories[0]` previously leaked whichever repo
+    // sorted first (e.g. a personal repo) and pinned the task to the wrong codebase.
     let repository: string | undefined
     try {
-        const { repositories } = await api.tasks.repositories()
-        repository = repositories[0]
+        const { results } = await api.signalReports.artefacts(report.id)
+        const selected = results.find((a) => a.type === 'repo_selection')?.content?.repository
+        repository = typeof selected === 'string' && selected ? selected : undefined
     } catch {
         repository = undefined
+    }
+
+    // Opening a PR needs a concrete target repo. If selection hasn't resolved one (e.g. a
+    // pending-input report), fail with a clear message instead of creating a task pinned to no
+    // repository that can never open a PR. Discuss doesn't require one, so it stays lenient.
+    if (requireRepository && !repository) {
+        throw new Error('No repository has been selected for this report yet — try again once analysis finishes.')
     }
 
     const task = await api.tasks.create({
@@ -113,7 +125,8 @@ export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
                     report,
                     SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP,
                     buildCreatePrReportPrompt(report),
-                    'Implement report fix'
+                    'Implement report fix',
+                    true
                 )
                 actions.createPrSuccess()
             } catch (error: any) {

--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -16,6 +16,11 @@ import { SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP, SignalReport, SignalRep
 // NOT a live chat surface. The created task carries the SignalReport linkage so the
 // backend's agent pipeline can pick it up.
 
+// Report artefacts are paginated newest-first (default page size 100); `repo_selection` is
+// written early in a research run, so a generous limit keeps it on the fetched page even for
+// reports with many findings.
+const REPO_SELECTION_ARTEFACT_FETCH_LIMIT = 1000
+
 function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
     const base = `Act on PostHog Inbox report "${report.title ?? report.id}" (id ${report.id}). Investigate the root cause using the report's contributing findings, implement the fix, and open a PR.${
         report.summary ? `\n\nReport summary:\n${report.summary}` : ''
@@ -49,12 +54,16 @@ async function createReportTask(
     // `repo_selection` artefact), matching the desktop app and the auto-start flow. Never fall
     // back to an arbitrary project repo — `repositories[0]` previously leaked whichever repo
     // sorted first (e.g. a personal repo) and pinned the task to the wrong codebase.
+    // Artefacts are paginated newest-first and `repo_selection` is written early in the run, so
+    // fetch a high limit to keep it on the page even for reports with many findings.
     let repository: string | undefined
     try {
-        const { results } = await api.signalReports.artefacts(report.id)
+        const { results } = await api.signalReports.artefacts(report.id, { limit: REPO_SELECTION_ARTEFACT_FETCH_LIMIT })
         const selected = results.find((a) => a.type === 'repo_selection')?.content?.repository
         repository = typeof selected === 'string' && selected ? selected : undefined
     } catch (e) {
+        // A genuine fetch failure must not masquerade as "no repository selected" — when a repo
+        // is required, surface the real error so the user retries instead of waiting on analysis.
         if (requireRepository) {
             throw e
         }
@@ -63,7 +72,7 @@ async function createReportTask(
 
     // Opening a PR needs a concrete target repo. If selection hasn't resolved one (e.g. a
     // pending-input report), fail with a clear message instead of creating a task pinned to no
-    // repository that can never open a PR. Discuss doesn't require one, so it stays lenient.
+    // repository that can never open a PR. Discuss doesn't require a repo.
     if (requireRepository && !repository) {
         throw new Error('No repository has been selected for this report yet — try again once analysis finishes.')
     }


### PR DESCRIPTION
## Problem

Clicking **Create PR** (or **Discuss**) on a Signals inbox report in the web app could open the task against the wrong repository — including a personal repo such as `andrewm4894/emoji-hero` — instead of the repo the signals pipeline already selected for the report (`posthog/posthog`).

Root cause: `inboxTaskKickoffLogic.ts` `createReportTask` defaulted the task `repository` to the first entry of `api.tasks.repositories()`, which returns the distinct repos already referenced by tasks in the project, **sorted alphabetically**. So `andrewm4894/...` sorted ahead of `posthog/...` and won. It never consulted the report's `repo_selection` artefact. Worse, it was self-perpetuating: once one personal-repo task existed in the project, it stayed the alphabetical default for everyone's next Create PR.

For contrast, the desktop app and the signals auto-start flow already resolve the repo from the report's `repo_selection` artefact, so they were unaffected — this gap was specific to the web inbox port.

## Changes

- `createReportTask` now resolves `repository` from the report's `repo_selection` artefact (`api.signalReports.artefacts` → `type === 'repo_selection'` → `content.repository`), matching the desktop app and the auto-start flow.
- It never falls back to an arbitrary project repo. If no selection is resolved, **Create PR** fails with a clear message rather than creating a task pinned to no/wrong repository that can never open a PR. **Discuss** stays lenient (it does not require a repo).

Net effect: all three surfaces (web inbox, desktop app, auto-start) now read the same selected repo.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran locally on the changed file:

- `tsgo --noEmit` (frontend typecheck) — passed.
- `oxlint` on the changed file — 0 warnings / 0 errors.
- `oxfmt` — no formatting changes.

No manual UI testing performed. The root cause and the corrected behavior were verified against production data (read-only): the two affected reports' `repo_selection` artefacts both correctly held `posthog/posthog`, while the manually-created tasks were pinned to `andrewm4894/emoji-hero`; the signals auto-start tasks for the same reports were correctly on `posthog/posthog`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the investigation and fix.

- Investigated a report from Andy that the inbox "make PR" button used a personal repo. Traced it end-to-end: confirmed signals repo selection was correct, ruled out two earlier hypotheses (a stale "repository: null" reading, and a suspected server-side fallback to a personal GitHub integration), and isolated the actual cause to the web inbox's `repositories[0]` default via read-only prod inspection.
- Considered a server-side guard in `TaskSerializer.create` (reject a repo not in the team install's repo set) as a general backstop, but kept this PR scoped to the actual client bug; the server guard would require a tasks→signals dependency (signals already imports tasks) and is better as a separate follow-up.
- Tools: Claude Code. No repo skills were required for this change.
