### PR TITLE
fix(replay): exclude properties_group_* from recording export event query

### DIFF
--- a/posthog/temporal/session_replay/export_recording/activities.py
+++ b/posthog/temporal/session_replay/export_recording/activities.py
@@ -98,8 +98,13 @@ async def export_event_clickhouse_rows(input: ExportContext) -> None:
     logger = LOGGER.bind()
     logger.info(f"Exporting event ClickHouse rows for session {input.session_id}")
 
+    # Exclude internal materialized columns: mat_/dmat_ materialized properties and the
+    # properties_group_* map columns. The latter churn (added/dropped by migrations, e.g.
+    # properties_group_ai_large), and a bare SELECT * breaks with "no column ... in table
+    # 'sharded_events'" whenever the distributed and sharded schemas are briefly out of step.
+    # They duplicate data already in `properties`, so an export never needs them.
     query: str = """
-        SELECT * EXCEPT('mat_.*|dmat_.*')
+        SELECT * EXCEPT('mat_.*|dmat_.*|properties_group_.*')
         FROM events
         WHERE
             team_id = %(team_id)s AND

--- a/posthog/temporal/tests/session_replay/export_recording/test_activities.py
+++ b/posthog/temporal/tests/session_replay/export_recording/test_activities.py
@@ -162,6 +162,12 @@ async def test_export_event_clickhouse_rows_success():
         await export_event_clickhouse_rows(export_context)
 
         mock_client.aget_query.assert_called_once()
+        # the events SELECT * must exclude the internal materialized columns, including the
+        # churny properties_group_* maps, otherwise the query breaks whenever the distributed
+        # and sharded schemas are briefly out of step (e.g. dropping properties_group_ai_large)
+        executed_query = mock_client.aget_query.call_args.kwargs["query"]
+        assert "properties_group_.*" in executed_query
+
         mock_redis.setex.assert_called_once()
         call_args = mock_redis.setex.call_args
         assert call_args[0][0] == _redis_key(export_id, "events")


### PR DESCRIPTION
## Problem

Session recording exports (Django admin → S3, the `export-recording` Temporal workflow) have been failing for everyone — large and small recordings alike. Error tracking shows hundreds of occurrences of:

> `Code: 47. DB::Exception: There's no column 'sharded_events.properties_group_ai_large' in table 'sharded_events'` / `... '__table1.properties_group_ai_large' cannot be resolved`

sourced from `export_recording/workflow.py`, firing on every export.

The cause is in `export_event_clickhouse_rows`, which ran `SELECT * EXCEPT('mat_.*|dmat_.*') FROM events`. The bare `SELECT *` expands to include the internal `properties_group_*` map columns. Those columns churn as migrations add and drop them (a migration is currently dropping `properties_group_ai_large`), and whenever the distributed `events` table and the underlying `sharded_events` are briefly out of step, `SELECT *` references a column that no longer exists on the shard → ClickHouse code 47 → the activity fails, the `asyncio.TaskGroup` cancels its siblings, and the whole export errors.

## Changes

Extend the `EXCEPT` to also drop `properties_group_*`, alongside the existing `mat_`/`dmat_` exclusions:

```
SELECT * EXCEPT('mat_.*|dmat_.*|properties_group_.*') FROM events
```

These are internal materialized columns that duplicate data already present in `properties`, so an export never needs them — and excluding them makes the query resilient to property-group column churn rather than breaking on every schema transition.

Note: this is the immediate blocker. A companion PR adds a failure handler to the workflow so failed exports are marked `failed` instead of sitting in `running` forever (which is why these failures were invisible until now).

## How did you test this code?

I'm an agent (PostHog Code), human-directed. Added a regression assertion to `test_export_event_clickhouse_rows_success` that the executed query excludes `properties_group_.*`, and ran it:

```
posthog/temporal/tests/session_replay/export_recording/test_activities.py::test_export_event_clickhouse_rows_success — 1 passed
```

No manual end-to-end export run (the worker is still broken on the stuck-`running` side until the companion PR lands).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code, directed by Paul. Root-caused by inspecting the `export-recording` Temporal workflow/activities and corroborating against PostHog's own error tracking (the `properties_group_ai_large` ClickHouse exception, firing on every export with timestamps matching live export attempts). Chose to exclude the `properties_group_*` family by regex rather than enumerate explicit event columns — it's the minimal change, matches the intent of the pre-existing `mat_`/`dmat_` exclusions, and is durable against future group-column additions. No skills were required (query-string change, no migration/endpoint).

Requires human review; do not self-merge.
