### PR TITLE
feat(phai): render inline file diffs in sandbox tool cards

### DIFF
--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -32,6 +32,7 @@ import { IconRobot } from 'lib/lemon-ui/icons'
 import type { McpToolCallMessage } from './maxTypes'
 import { CreateInsightWidget } from './messages/adapters/CreateInsightWidget'
 import { CreateNotebookWidget } from './messages/adapters/CreateNotebookWidget'
+import { EditDiffRenderer } from './messages/adapters/EditDiffRenderer'
 import { ErrorTrackingWidget } from './messages/adapters/ErrorTrackingWidget'
 import { QueryWidget } from './messages/adapters/QueryWidget'
 import { SearchSessionRecordingsWidget } from './messages/adapters/SearchSessionRecordingsWidget'
@@ -175,11 +176,11 @@ for (const { key, displayName, icon } of QUERY_WRAPPER_TOOLS) {
 // Keyed by the stable SDK tool name (reachable via `_meta.claudeCode.toolName`). All reuse the
 // fallback card — the goal is a friendly title + icon, not a bespoke widget. The fallback header
 // already prefers Twig's rich `title` (e.g. "Edit `foo.ts`"), so these supply the icon and a stable
-// `displayName` for any frame whose title is empty. `MultiEdit`/`Skill` are registered speculatively
-// (not enumerated in Twig's tools.ts) — zero cost if never emitted.
+// `displayName` for any frame whose title is empty. `Skill` is registered speculatively (not
+// enumerated in Twig's tools.ts) — zero cost if never emitted. File-editing built-ins are split out
+// below into a dedicated diff renderer.
 const BUILTIN_TOOLS: { keys: string[]; displayName: string; icon: JSX.Element }[] = [
     { keys: ['Read', 'NotebookRead'], displayName: 'Read', icon: <IconEye /> },
-    { keys: ['Edit', 'Write', 'NotebookEdit', 'MultiEdit'], displayName: 'Edit', icon: <IconPencil /> },
     { keys: ['Grep', 'Glob', 'LS'], displayName: 'Search', icon: <IconSearch /> },
     { keys: ['Bash', 'BashOutput', 'KillShell'], displayName: 'Terminal', icon: <IconTerminal /> },
     { keys: ['WebSearch', 'WebFetch'], displayName: 'Web', icon: <IconGlobe /> },
@@ -197,6 +198,12 @@ for (const { keys, displayName, icon } of BUILTIN_TOOLS) {
     for (const key of keys) {
         mcpToolRegistry.register({ key, displayName, icon, Renderer: FallbackMcpToolRenderer })
     }
+}
+
+// File-editing built-ins render an inline visual diff when the agent attaches `type: "diff"` content
+// blocks; EditDiffRenderer falls back to the same fallback card when none are present.
+for (const key of ['Edit', 'Write', 'NotebookEdit', 'MultiEdit']) {
+    mcpToolRegistry.register({ key, displayName: 'Edit', icon: <IconPencil />, Renderer: EditDiffRenderer })
 }
 
 // AskUserQuestion (the agent asking the user to pick between options) gets a bespoke renderer that

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
@@ -8,14 +8,38 @@ import { EditDiffRenderer } from './EditDiffRenderer'
 // Monaco can't render in jsdom — stand it in for a marker that echoes the diff props we care about.
 jest.mock('lib/components/MonacoDiffEditor', () => ({
     __esModule: true,
-    default: ({ original, modified, language }: { original?: string; modified?: string; language?: string }) => (
-        <div data-attr="monaco-diff" data-original={original} data-modified={modified} data-language={language} />
+    default: ({
+        original,
+        modified,
+        language,
+        theme,
+    }: {
+        original?: string
+        modified?: string
+        language?: string
+        theme?: string
+    }) => (
+        <div
+            data-attr="monaco-diff"
+            data-original={original}
+            data-modified={modified}
+            data-language={language}
+            data-theme={theme}
+        />
     ),
 }))
 
 // Force the lazy-mount gate open so the editor instantiates.
 jest.mock('react-intersection-observer', () => ({
     useInView: () => ({ ref: () => {}, inView: true }),
+}))
+
+// Drive the app theme without mounting themeLogic (and its scene/user deps). The arrow reads
+// `mockDarkMode` lazily at render time, so flipping it per test works.
+let mockDarkMode = false
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: () => ({ isDarkModeOn: mockDarkMode }),
 }))
 
 function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMessage {
@@ -32,7 +56,10 @@ function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMe
 }
 
 describe('EditDiffRenderer', () => {
-    afterEach(cleanup)
+    afterEach(() => {
+        cleanup()
+        mockDarkMode = false
+    })
 
     it('renders an inline diff with +/- stats for an Edit with a diff block', () => {
         const message = makeMessage({
@@ -46,6 +73,7 @@ describe('EditDiffRenderer', () => {
         expect(editor).toHaveAttribute('data-original', 'a\nb')
         expect(editor).toHaveAttribute('data-modified', 'a\nb\nc')
         expect(editor).toHaveAttribute('data-language', 'typescript')
+        expect(editor).toHaveAttribute('data-theme', 'vs')
         expect(screen.getByText('foo.ts')).toBeInTheDocument()
         expect(screen.getByText('+1')).toBeInTheDocument()
         expect(screen.getByText('-0')).toBeInTheDocument()
@@ -84,5 +112,13 @@ describe('EditDiffRenderer', () => {
         expect(screen.queryByTestId('monaco-diff')).not.toBeInTheDocument()
         // The standard tool card still renders its header.
         expect(screen.getByText('Edit `foo.ts`')).toBeInTheDocument()
+    })
+
+    it('uses the dark Monaco theme when the app is in dark mode', () => {
+        mockDarkMode = true
+        const message = makeMessage({ content: [{ type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' }] })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-theme', 'vs-dark')
     })
 })

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
@@ -105,6 +105,17 @@ describe('EditDiffRenderer', () => {
         expect(screen.getByText('+2')).toBeInTheDocument()
     })
 
+    it('resolves filename and language from rawInput.file_path when the diff block has no path', () => {
+        const message = makeMessage({
+            content: [{ type: 'diff', oldText: 'a', newText: 'b' }],
+            rawInput: { file_path: 'main.go' },
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        expect(screen.getByText('main.go')).toBeInTheDocument()
+        expect(screen.getByTestId('monaco-diff')).toHaveAttribute('data-language', 'go')
+    })
+
     it('falls back to the plain tool card (no editor) when there is no diff block', () => {
         const message = makeMessage({ title: 'Edit `foo.ts`', content: [{ type: 'text', text: 'no diff yet' }] })
         render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import type { McpToolCallMessage } from '../../maxTypes'
+import { EditDiffRenderer } from './EditDiffRenderer'
+
+// Monaco can't render in jsdom — stand it in for a marker that echoes the diff props we care about.
+jest.mock('lib/components/MonacoDiffEditor', () => ({
+    __esModule: true,
+    default: ({ original, modified, language }: { original?: string; modified?: string; language?: string }) => (
+        <div data-attr="monaco-diff" data-original={original} data-modified={modified} data-language={language} />
+    ),
+}))
+
+// Force the lazy-mount gate open so the editor instantiates.
+jest.mock('react-intersection-observer', () => ({
+    useInView: () => ({ ref: () => {}, inView: true }),
+}))
+
+function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Edit',
+        rawServerName: 'posthog',
+        rawToolName: 'Edit',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
+
+describe('EditDiffRenderer', () => {
+    afterEach(cleanup)
+
+    it('renders an inline diff with +/- stats for an Edit with a diff block', () => {
+        const message = makeMessage({
+            title: 'Edit `foo.ts`',
+            content: [{ type: 'diff', path: 'foo.ts', oldText: 'a\nb', newText: 'a\nb\nc' }],
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        const editor = screen.getByTestId('monaco-diff')
+        expect(editor).toBeInTheDocument()
+        expect(editor).toHaveAttribute('data-original', 'a\nb')
+        expect(editor).toHaveAttribute('data-modified', 'a\nb\nc')
+        expect(editor).toHaveAttribute('data-language', 'typescript')
+        expect(screen.getByText('foo.ts')).toBeInTheDocument()
+        expect(screen.getByText('+1')).toBeInTheDocument()
+        expect(screen.getByText('-0')).toBeInTheDocument()
+    })
+
+    it('renders one editor per diff block for a MultiEdit', () => {
+        const message = makeMessage({
+            resolvedKey: 'MultiEdit',
+            content: [
+                { type: 'diff', path: 'foo.ts', oldText: 'a', newText: 'b' },
+                { type: 'content', content: { type: 'diff', path: 'foo.ts', oldText: 'b', newText: 'c' } },
+            ],
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        expect(screen.getAllByTestId('monaco-diff')).toHaveLength(2)
+    })
+
+    it('shows all-added stats and an empty original for a new file (Write)', () => {
+        const message = makeMessage({
+            resolvedKey: 'Write',
+            content: [{ type: 'diff', path: 'new.py', oldText: null, newText: 'print(1)\nprint(2)' }],
+        })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        const editor = screen.getByTestId('monaco-diff')
+        expect(editor).toHaveAttribute('data-original', '')
+        expect(editor).toHaveAttribute('data-language', 'python')
+        expect(screen.getByText('+2')).toBeInTheDocument()
+    })
+
+    it('falls back to the plain tool card (no editor) when there is no diff block', () => {
+        const message = makeMessage({ title: 'Edit `foo.ts`', content: [{ type: 'text', text: 'no diff yet' }] })
+        render(<EditDiffRenderer message={message} displayName="Edit" isLastInGroup />)
+
+        expect(screen.queryByTestId('monaco-diff')).not.toBeInTheDocument()
+        // The standard tool card still renders its header.
+        expect(screen.getByText('Edit `foo.ts`')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
@@ -1,0 +1,75 @@
+import type { editor } from 'monaco-editor'
+import { useInView } from 'react-intersection-observer'
+
+import MonacoDiffEditor from 'lib/components/MonacoDiffEditor'
+
+import { SandboxToolActivity } from '../../components/Activity'
+import type { McpToolRendererProps } from '../../mcpToolRegistry'
+import { findAllDiffContent, getDiffStats, languageFromPath, type ToolCallDiffContent } from '../../toolDiffContent'
+
+// Module-level so the object identity is stable across renders — MonacoDiffEditor calls
+// `updateOptions` whenever this prop changes, and a fresh literal each render would thrash it
+// during streaming.
+const DIFF_EDITOR_OPTIONS: editor.IDiffEditorConstructionOptions = {
+    hideUnchangedRegions: { enabled: true },
+    readOnly: true,
+    renderSideBySide: true,
+}
+
+function EditDiffBody({ diff, fallbackPath }: { diff: ToolCallDiffContent; fallbackPath?: string }): JSX.Element {
+    // Lazy-mount: render the cheap stat line always, but only instantiate the Monaco diff editor once
+    // the card scrolls near the viewport. This bounds the number of live editors to what's on screen.
+    const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
+    const path = diff.path ?? fallbackPath
+    const { added, removed } = getDiffStats(diff.oldText, diff.newText)
+
+    return (
+        <div ref={ref} className="flex flex-col gap-1 w-full min-w-0">
+            <div className="flex items-center gap-2 min-w-0">
+                {path && <span className="font-mono text-xs text-muted truncate">{path}</span>}
+                <span className="font-mono text-xs shrink-0">
+                    <span className="text-success">+{added}</span> <span className="text-danger">-{removed}</span>
+                </span>
+            </div>
+            {inView ? (
+                <MonacoDiffEditor
+                    original={diff.oldText ?? ''}
+                    value={diff.newText ?? ''}
+                    modified={diff.newText ?? ''}
+                    language={languageFromPath(path)}
+                    options={DIFF_EDITOR_OPTIONS}
+                />
+            ) : (
+                <div className="h-24 rounded border border-border-secondary" />
+            )}
+        </div>
+    )
+}
+
+/**
+ * Renderer for Edit/Write/MultiEdit/NotebookEdit tool calls. When the agent attached `type: "diff"`
+ * content blocks (full-file old/new text), it shows an inline visual diff with +/- line stats inside
+ * the standard tool card. Otherwise it degrades to the plain `SandboxToolActivity` card — this
+ * renderer is a strict superset of `FallbackMcpToolRenderer`, so non-diff edits and not-yet-streamed
+ * content render exactly as before.
+ */
+export function EditDiffRenderer(props: McpToolRendererProps): JSX.Element {
+    const { message, icon, displayName } = props
+    const diffs = findAllDiffContent(message.content)
+
+    if (diffs.length === 0) {
+        return <SandboxToolActivity message={message} icon={icon} displayName={displayName} />
+    }
+
+    const fallbackPath = typeof message.rawInput.file_path === 'string' ? message.rawInput.file_path : undefined
+
+    return (
+        <SandboxToolActivity message={message} icon={icon} displayName={displayName}>
+            <div className="flex flex-col gap-3 w-full min-w-0">
+                {diffs.map((diff, index) => (
+                    <EditDiffBody key={index} diff={diff} fallbackPath={fallbackPath} />
+                ))}
+            </div>
+        </SandboxToolActivity>
+    )
+}

--- a/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
+++ b/frontend/src/scenes/max/messages/adapters/EditDiffRenderer.tsx
@@ -1,25 +1,51 @@
+import { useValues } from 'kea'
 import type { editor } from 'monaco-editor'
 import { useInView } from 'react-intersection-observer'
 
 import MonacoDiffEditor from 'lib/components/MonacoDiffEditor'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
 import { SandboxToolActivity } from '../../components/Activity'
 import type { McpToolRendererProps } from '../../mcpToolRegistry'
 import { findAllDiffContent, getDiffStats, languageFromPath, type ToolCallDiffContent } from '../../toolDiffContent'
 
-// Module-level so the object identity is stable across renders — MonacoDiffEditor calls
-// `updateOptions` whenever this prop changes, and a fresh literal each render would thrash it
-// during streaming.
+// A stripped-down, unified diff that reads cleanly embedded in a chat card — mirrors the look of the
+// sandbox agent's own diff UI (unified style, soft-wrapped, compact font, no editor chrome). Module-level
+// so the object identity is stable across renders: MonacoDiffEditor calls `updateOptions` whenever this
+// prop changes, and a fresh literal each render would thrash it during streaming.
 const DIFF_EDITOR_OPTIONS: editor.IDiffEditorConstructionOptions = {
-    hideUnchangedRegions: { enabled: true },
     readOnly: true,
-    renderSideBySide: true,
+    renderSideBySide: false,
+    hideUnchangedRegions: { enabled: true },
+    diffAlgorithm: 'advanced',
+    wordWrap: 'on',
+    diffWordWrap: 'inherit',
+    fontSize: 12,
+    lineNumbers: 'on',
+    minimap: { enabled: false },
+    renderOverviewRuler: false,
+    overviewRulerLanes: 0,
+    overviewRulerBorder: false,
+    hideCursorInOverviewRuler: true,
+    scrollBeyondLastLine: false,
+    folding: false,
+    glyphMargin: false,
+    renderLineHighlight: 'none',
+    renderGutterMenu: false,
+    guides: { indentation: false },
+    padding: { top: 4, bottom: 4 },
+    // Don't trap the thread's scroll when the cursor is over the diff.
+    scrollbar: { alwaysConsumeMouseWheel: false, vertical: 'auto', horizontal: 'auto' },
 }
 
 function EditDiffBody({ diff, fallbackPath }: { diff: ToolCallDiffContent; fallbackPath?: string }): JSX.Element {
     // Lazy-mount: render the cheap stat line always, but only instantiate the Monaco diff editor once
     // the card scrolls near the viewport. This bounds the number of live editors to what's on screen.
     const { ref, inView } = useInView({ rootMargin: '500px', triggerOnce: true })
+    // Match the surrounding app theme — without this Monaco falls back to its default `vs` (white) theme,
+    // which looks broken on a dark card. Same wiring CodeEditorImpl uses.
+    const { isDarkModeOn } = useValues(themeLogic)
     const path = diff.path ?? fallbackPath
     const { added, removed } = getDiffStats(diff.oldText, diff.newText)
 
@@ -37,6 +63,7 @@ function EditDiffBody({ diff, fallbackPath }: { diff: ToolCallDiffContent; fallb
                     value={diff.newText ?? ''}
                     modified={diff.newText ?? ''}
                     language={languageFromPath(path)}
+                    theme={isDarkModeOn ? 'vs-dark' : 'vs'}
                     options={DIFF_EDITOR_OPTIONS}
                 />
             ) : (

--- a/frontend/src/scenes/max/toolDiffContent.test.ts
+++ b/frontend/src/scenes/max/toolDiffContent.test.ts
@@ -1,0 +1,77 @@
+import { Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+import { findAllDiffContent, findDiffContent, getDiffStats, languageFromPath } from './toolDiffContent'
+
+const flatDiff = { type: 'diff', path: 'a.ts', oldText: 'old', newText: 'new' }
+const nestedDiff = { type: 'content', content: { type: 'diff', path: 'b.py', oldText: null, newText: 'print(1)' } }
+const textBlock = { type: 'text', text: 'hello' }
+
+describe('toolDiffContent', () => {
+    describe('findDiffContent', () => {
+        it.each([
+            ['flat diff block', [textBlock, flatDiff], { path: 'a.ts', oldText: 'old', newText: 'new' }],
+            ['ACP-nested diff block', [textBlock, nestedDiff], { path: 'b.py', oldText: null, newText: 'print(1)' }],
+        ])('extracts the first %s', (_label, content, expected) => {
+            expect(findDiffContent(content)).toEqual({ type: 'diff', ...expected })
+        })
+
+        it.each([
+            ['no diff blocks', [textBlock, { type: 'content', content: textBlock }]],
+            ['empty content', []],
+            ['non-object members', [null, undefined, 'string', 42]],
+        ])('returns null for %s', (_label, content) => {
+            expect(findDiffContent(content as unknown[])).toBeNull()
+        })
+    })
+
+    describe('findAllDiffContent', () => {
+        it('collects every diff block (flat + nested), in order — MultiEdit emits one per edit', () => {
+            const second = { type: 'diff', path: 'a.ts', oldText: 'b', newText: 'c' }
+            expect(findAllDiffContent([flatDiff, textBlock, nestedDiff, second])).toEqual([
+                { type: 'diff', path: 'a.ts', oldText: 'old', newText: 'new' },
+                { type: 'diff', path: 'b.py', oldText: null, newText: 'print(1)' },
+                { type: 'diff', path: 'a.ts', oldText: 'b', newText: 'c' },
+            ])
+        })
+
+        it('returns an empty array when there are no diff blocks', () => {
+            expect(findAllDiffContent([textBlock])).toEqual([])
+        })
+    })
+
+    describe('getDiffStats', () => {
+        it.each([
+            ['pure addition', 'a\nb', 'a\nb\nc', { added: 1, removed: 0 }],
+            ['pure removal', 'a\nb\nc', 'a\nb', { added: 0, removed: 1 }],
+            ['changed line', 'a\nb\nc', 'a\nB\nc', { added: 1, removed: 1 }],
+            ['new file (null old)', null, 'a\nb\nc', { added: 3, removed: 0 }],
+            ['new file (empty old)', '', 'a\nb', { added: 2, removed: 0 }],
+            ['no change', 'a\nb', 'a\nb', { added: 0, removed: 0 }],
+        ])('counts %s', (_label, oldText, newText, expected) => {
+            expect(getDiffStats(oldText, newText)).toEqual(expected)
+        })
+    })
+
+    describe('languageFromPath', () => {
+        it.each([
+            ['foo.ts', Language.TypeScript],
+            ['foo.tsx', Language.TypeScript],
+            ['foo.py', Language.Python],
+            ['foo.js', Language.JavaScript],
+            ['foo.jsx', Language.JavaScript],
+            ['foo.json', Language.JSON],
+            ['foo.sql', Language.SQL],
+            ['foo.go', Language.Go],
+            ['foo.yaml', Language.YAML],
+            ['foo.yml', Language.YAML],
+            ['foo.sh', Language.Bash],
+            ['foo.rb', Language.Ruby],
+            ['nested/dir/Component.TSX', Language.TypeScript],
+            ['Dockerfile', Language.Text],
+            ['foo.unknownext', Language.Text],
+            [undefined, Language.Text],
+        ])('maps %s to the expected language', (path, expected) => {
+            expect(languageFromPath(path)).toBe(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/max/toolDiffContent.test.ts
+++ b/frontend/src/scenes/max/toolDiffContent.test.ts
@@ -1,29 +1,12 @@
 import { Language } from 'lib/components/CodeSnippet/CodeSnippet'
 
-import { findAllDiffContent, findDiffContent, getDiffStats, languageFromPath } from './toolDiffContent'
+import { findAllDiffContent, getDiffStats, languageFromPath } from './toolDiffContent'
 
 const flatDiff = { type: 'diff', path: 'a.ts', oldText: 'old', newText: 'new' }
 const nestedDiff = { type: 'content', content: { type: 'diff', path: 'b.py', oldText: null, newText: 'print(1)' } }
 const textBlock = { type: 'text', text: 'hello' }
 
 describe('toolDiffContent', () => {
-    describe('findDiffContent', () => {
-        it.each([
-            ['flat diff block', [textBlock, flatDiff], { path: 'a.ts', oldText: 'old', newText: 'new' }],
-            ['ACP-nested diff block', [textBlock, nestedDiff], { path: 'b.py', oldText: null, newText: 'print(1)' }],
-        ])('extracts the first %s', (_label, content, expected) => {
-            expect(findDiffContent(content)).toEqual({ type: 'diff', ...expected })
-        })
-
-        it.each([
-            ['no diff blocks', [textBlock, { type: 'content', content: textBlock }]],
-            ['empty content', []],
-            ['non-object members', [null, undefined, 'string', 42]],
-        ])('returns null for %s', (_label, content) => {
-            expect(findDiffContent(content as unknown[])).toBeNull()
-        })
-    })
-
     describe('findAllDiffContent', () => {
         it('collects every diff block (flat + nested), in order — MultiEdit emits one per edit', () => {
             const second = { type: 'diff', path: 'a.ts', oldText: 'b', newText: 'c' }
@@ -34,8 +17,12 @@ describe('toolDiffContent', () => {
             ])
         })
 
-        it('returns an empty array when there are no diff blocks', () => {
-            expect(findAllDiffContent([textBlock])).toEqual([])
+        it.each([
+            ['non-diff blocks', [textBlock, { type: 'content', content: textBlock }]],
+            ['empty content', []],
+            ['non-object members', [null, undefined, 'string', 42]],
+        ])('returns an empty array for %s', (_label, content) => {
+            expect(findAllDiffContent(content as unknown[])).toEqual([])
         })
     })
 

--- a/frontend/src/scenes/max/toolDiffContent.ts
+++ b/frontend/src/scenes/max/toolDiffContent.ts
@@ -1,0 +1,146 @@
+import { Language } from 'lib/components/CodeSnippet/CodeSnippet'
+
+/**
+ * A normalized `type: "diff"` tool-call content block, as emitted by the sandbox agent's Claude
+ * adapter for Edit/Write/MultiEdit/NotebookEdit calls. `oldText` is `null` for a brand-new file.
+ */
+export interface ToolCallDiffContent {
+    type: 'diff'
+    path?: string
+    oldText?: string | null
+    newText?: string
+}
+
+/**
+ * Unwraps the ACP `{ type: 'content', content: {...} }` envelope, mirroring `contentBlockText` in
+ * SandboxActivity — diff blocks may arrive flat or nested under that wrapper.
+ */
+function unwrapBlock(block: unknown): unknown {
+    if (!block || typeof block !== 'object') {
+        return block
+    }
+    if ((block as { type?: unknown }).type === 'content' && 'content' in block) {
+        return (block as { content: unknown }).content
+    }
+    return block
+}
+
+function asDiffContent(block: unknown): ToolCallDiffContent | null {
+    const inner = unwrapBlock(block)
+    if (!inner || typeof inner !== 'object' || (inner as { type?: unknown }).type !== 'diff') {
+        return null
+    }
+    const { path, oldText, newText } = inner as { path?: unknown; oldText?: unknown; newText?: unknown }
+    return {
+        type: 'diff',
+        path: typeof path === 'string' ? path : undefined,
+        oldText: oldText === null ? null : typeof oldText === 'string' ? oldText : undefined,
+        newText: typeof newText === 'string' ? newText : undefined,
+    }
+}
+
+/** First `type: "diff"` block in the content array, or null. */
+export function findDiffContent(content: unknown[]): ToolCallDiffContent | null {
+    for (const block of content) {
+        const diff = asDiffContent(block)
+        if (diff) {
+            return diff
+        }
+    }
+    return null
+}
+
+/** Every `type: "diff"` block — MultiEdit emits one per edit. */
+export function findAllDiffContent(content: unknown[]): ToolCallDiffContent[] {
+    const diffs: ToolCallDiffContent[] = []
+    for (const block of content) {
+        const diff = asDiffContent(block)
+        if (diff) {
+            diffs.push(diff)
+        }
+    }
+    return diffs
+}
+
+/**
+ * Line-level +added/-removed counts via a line-frequency diff. Ported from the ../code EditToolView:
+ * a missing/empty `oldText` means a new file, so every line is an addition.
+ */
+export function getDiffStats(
+    oldText: string | null | undefined,
+    newText: string | null | undefined
+): { added: number; removed: number } {
+    const oldLines = oldText ? oldText.split('\n') : []
+    const newLines = newText ? newText.split('\n') : []
+
+    if (!oldText) {
+        return { added: newLines.length, removed: 0 }
+    }
+
+    const oldCounts = new Map<string, number>()
+    for (const line of oldLines) {
+        oldCounts.set(line, (oldCounts.get(line) ?? 0) + 1)
+    }
+
+    const newCounts = new Map<string, number>()
+    for (const line of newLines) {
+        newCounts.set(line, (newCounts.get(line) ?? 0) + 1)
+    }
+
+    let added = 0
+    let removed = 0
+
+    for (const [line, count] of newCounts) {
+        const oldCount = oldCounts.get(line) ?? 0
+        if (count > oldCount) {
+            added += count - oldCount
+        }
+    }
+
+    for (const [line, count] of oldCounts) {
+        const newCount = newCounts.get(line) ?? 0
+        if (count > newCount) {
+            removed += count - newCount
+        }
+    }
+
+    return { added, removed }
+}
+
+// The Language enum string values double as valid Monaco language ids, which is what
+// MonacoDiffEditor.language wants.
+const EXTENSION_LANGUAGE_MAP: Record<string, Language> = {
+    ts: Language.TypeScript,
+    tsx: Language.TypeScript,
+    mts: Language.TypeScript,
+    cts: Language.TypeScript,
+    js: Language.JavaScript,
+    jsx: Language.JavaScript,
+    mjs: Language.JavaScript,
+    cjs: Language.JavaScript,
+    py: Language.Python,
+    json: Language.JSON,
+    sql: Language.SQL,
+    go: Language.Go,
+    yaml: Language.YAML,
+    yml: Language.YAML,
+    sh: Language.Bash,
+    bash: Language.Bash,
+    rb: Language.Ruby,
+    java: Language.Java,
+    kt: Language.Kotlin,
+    php: Language.PHP,
+    cs: Language.CSharp,
+    swift: Language.Swift,
+    html: Language.HTML,
+    xml: Language.XML,
+}
+
+/** Maps a file path's extension to a Monaco language id, defaulting to plain text. */
+export function languageFromPath(path?: string): Language {
+    const ext = path?.split('.').pop()?.toLowerCase()
+    if (!ext) {
+        return Language.Text
+    }
+    return EXTENSION_LANGUAGE_MAP[ext] ?? Language.Text
+}

--- a/frontend/src/scenes/max/toolDiffContent.ts
+++ b/frontend/src/scenes/max/toolDiffContent.ts
@@ -39,18 +39,7 @@ function asDiffContent(block: unknown): ToolCallDiffContent | null {
     }
 }
 
-/** First `type: "diff"` block in the content array, or null. */
-export function findDiffContent(content: unknown[]): ToolCallDiffContent | null {
-    for (const block of content) {
-        const diff = asDiffContent(block)
-        if (diff) {
-            return diff
-        }
-    }
-    return null
-}
-
-/** Every `type: "diff"` block — MultiEdit emits one per edit. */
+/** Every `type: "diff"` block — MultiEdit emits one per edit; the single-edit case is `[0]`. */
 export function findAllDiffContent(content: unknown[]): ToolCallDiffContent[] {
     const diffs: ToolCallDiffContent[] = []
     for (const block of content) {


### PR DESCRIPTION
## Problem

When Max runs the coding agent inside a sandbox, its `Edit` / `Write` / `MultiEdit` / `NotebookEdit` tool calls already carry full-file `type: "diff"` content blocks (old + new text) over the SSE stream. But those tools were wired to the generic fallback renderer, which just pretty-prints the block as JSON — so users saw a wall of escaped text instead of the change the agent actually made.

## Changes

File-editing tool cards now render a real visual diff inline:

- New `toolDiffContent.ts` helpers: `findDiffContent` / `findAllDiffContent` (handle both flat and ACP-nested `{ type: "content", content }` blocks), a line-frequency `getDiffStats` (`+added` / `-removed`), and `languageFromPath` (extension → Monaco language id, reusing the `CodeSnippet` `Language` enum).
- New `EditDiffRenderer` composes the existing `SandboxToolActivity` card with a diff body: a file-path chip + `+/-` stat line, plus a `MonacoDiffEditor` (zero new deps). The editor is **lazy-mounted** via `useInView`, so only on-screen diffs hold a live Monaco instance and long threads stay performant. `MultiEdit` renders one editor per edit.
- `Edit` / `Write` / `MultiEdit` / `NotebookEdit` are split out of the fallback loop in `mcpToolRegistry` and pointed at `EditDiffRenderer` (same icon and display name as before).

`EditDiffRenderer` is a strict superset of the fallback: when a call has no diff block (a non-diff edit, or content not yet streamed) it renders exactly the previous card, so nothing regresses.

Stacks on #60860 — the sandbox-thread infrastructure this builds on lives there, not on master.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated only — I did not run the live stack:

- `toolDiffContent.test.ts` — parameterized unit tests for `findDiffContent` / `findAllDiffContent` (flat, ACP-nested, none), `getDiffStats` (add / remove / change / new-file), and `languageFromPath`.
- `EditDiffRenderer.test.tsx` — renders an Edit with a diff block (asserts the diff body, `+N/-N` stats, language), a MultiEdit (one editor per block), a new-file Write (all-added, empty original), and the no-diff fallback path. `MonacoDiffEditor` and `react-intersection-observer` are mocked.
- Existing `mcpToolRegistry.test.tsx` stays green (Edit / Write / etc. keep their display name and icon).
- `pnpm typescript:check` reports no errors in the changed files (the pre-existing kea-typegen staleness on this branch is unrelated).

86 tests pass across the three suites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal Max sandbox rendering only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). Georgiy directed the work from a written plan to bring the sandbox coding agent's diff rendering into the Max thread. I first confirmed the wire already carries `type: "diff"` blocks end to end (agent adapter → `sandboxStreamLogic` → `Thread`), then made the frontend-only change.
- No repo skills were required: frontend-only, with no DRF / migration / generated-API-type surface, so no `build:openapi` run.
- Decisions: reused PostHog's `MonacoDiffEditor` instead of adding a diff library (zero new deps); lazy-mounted via `useInView` (mirroring `InsightCard`) to bound the number of live editors; kept `renderSideBySide` on to match the approved preview; made the renderer a strict superset of the fallback so streaming/partial and non-diff calls never regress.
