### PR TITLE
fix(stripe): stop echoing the rejected key in the credentials error

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -336,15 +336,18 @@ If automatic creation failed due to a permissions error and you're using a restr
                 return True, None
             else:
                 return False, "Invalid Stripe credentials"
-        except StripeAuthenticationError as e:
+        except StripeAuthenticationError:
             if config.auth_method.selection == "oauth":
                 return (
                     False,
                     "Your Stripe OAuth connection has expired or been revoked. Please reconnect your Stripe account.",
                 )
+            # Stripe's 401 body echoes the rejected key verbatim, so interpolating `e.stripe_message`
+            # leaks whatever the user pasted (often a password) into the toast and the
+            # `warehouse credentials invalid` analytics event. The guidance below stands on its own.
             return (
                 False,
-                f"Stripe rejected the API key: {e.stripe_message}. Double-check that you pasted a restricted key (rk_live_...) for the same Stripe account, with no extra whitespace, and that it has not been revoked.",
+                "Stripe rejected the API key. Double-check that you pasted a restricted key (rk_live_...) for the same Stripe account, with no extra whitespace, and that it has not been revoked.",
             )
         except StripePermissionError as e:
             # 403s are self-explanatory — the resource name tells the customer which Stripe scope

--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,7 +1,9 @@
 import pytest
+from unittest import mock
 
 from posthog.temporal.data_imports.sources.generated_configs import StripeAuthMethodConfig, StripeSourceConfig
 from posthog.temporal.data_imports.sources.stripe.source import StripeSource
+from posthog.temporal.data_imports.sources.stripe.stripe import StripeAuthenticationError
 
 
 class TestStripeSource:
@@ -64,3 +66,22 @@ class TestStripeSource:
 
         assert ok is False
         assert message == expected_message
+
+    def test_validate_credentials_does_not_echo_rejected_key(self):
+        # Stripe's 401 body echoes the submitted key verbatim; here the user pasted a password into
+        # the key field. The validation message must not leak it into the toast or analytics event.
+        pasted_secret = "Ammgad1979@"
+        config = StripeSourceConfig(
+            auth_method=StripeAuthMethodConfig(selection="api_key", stripe_secret_key=pasted_secret)
+        )
+
+        with mock.patch(
+            "posthog.temporal.data_imports.sources.stripe.source.validate_stripe_credentials",
+            side_effect=StripeAuthenticationError(f"Invalid API Key provided: {pasted_secret}"),
+        ):
+            ok, message = self.source.validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert message is not None
+        assert pasted_secret not in message
+        assert message.startswith("Stripe rejected the API key.")


### PR DESCRIPTION
## Problem

When Stripe rejects an API key on source creation, its 401 response body echoes the submitted key value verbatim (e.g. `Invalid API Key provided: <whatever-was-pasted>`). Our `validate_credentials` interpolated that string into the user-facing error via `e.stripe_message`. Users frequently paste the wrong value into the API key field — including passwords — so the rejected secret ended up in two places it shouldn't:

- the validation toast, and
- the `warehouse credentials invalid` product-analytics event (`errorMessage` is read from the server's response `message`).

## Changes

Drop the `{e.stripe_message}` interpolation in the `StripeAuthenticationError` (api-key) branch and surface a fixed message. The surrounding guidance already tells the user exactly what to check (paste a restricted `rk_live_...` key for the same account, no whitespace, not revoked), so nothing actionable is lost by not echoing Stripe's raw rejection.

The OAuth and permission/validation branches are unchanged — they don't echo the key.

## How did you test this code?

I'm an agent. I added an automated regression test (`test_validate_credentials_does_not_echo_rejected_key`) asserting the pasted value never appears in the returned message, and ran the Stripe source test suite:

```
uv run python -m pytest posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
# 13 passed
```

Ruff check + format pass on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over data-warehouse source-creation failures. This one was classified as an internal/sensitive leak: the message bubbled a user-entered secret into analytics. Considered redacting just the key substring out of Stripe's message, but that's fragile (Stripe's wording varies and the echoed value isn't always key-shaped) — dropping the echo entirely is simpler and strictly safer. No sync behavior or schemas changed.

Safe error-message-only change.
