### PR TITLE
fix(bigquery): surface a clear error when the dataset is not found

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -58,8 +58,10 @@ from posthog.temporal.data_imports.sources.generated_configs import BigQuerySour
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
 
 __all__ = [
+    "BIGQUERY_DATASET_NOT_FOUND_ERROR",
     "BIGQUERY_TOKEN_RESPONSE_ERROR",
     "BigQueryCredentialsRejectedError",
+    "BigQueryDatasetNotFoundError",
     "BigQueryImplementation",
     "BigQueryTokenRefreshError",
     "bigquery_client",
@@ -79,6 +81,24 @@ BIGQUERY_STORAGE_HOST = "bigquerystorage.googleapis.com"
 # Used both when raising below and when matching in `BigQuerySource.get_non_retryable_errors`,
 # so it must stay free of volatile data (urls, ids, timestamps).
 BIGQUERY_TOKEN_RESPONSE_ERROR = "BigQuery OAuth token endpoint returned an unexpected response"
+
+# User-facing message for a missing dataset/table during schema discovery. Raised below and matched
+# in `BigQuerySource.get_non_retryable_errors`, so it must stay free of volatile data (ids, regions).
+BIGQUERY_DATASET_NOT_FOUND_ERROR = (
+    "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or "
+    "it may live in a different region — verify your dataset and table names, and set the dataset "
+    "region in your source configuration if it isn't in the US."
+)
+
+
+class BigQueryDatasetNotFoundError(Exception):
+    """Raised when schema discovery queries a dataset/table that doesn't exist in the queried region.
+
+    `client.query()` raises a `google.api_core.exceptions.NotFound` whose `str()` is a raw
+    "404 Not found: Dataset ... was not found in location US ... Job ID: ..." — BigQuery job
+    internals the user can't act on, which would otherwise leak straight to the create/validate
+    response. We re-raise it with the same actionable wording we map this condition to during syncs.
+    """
 
 
 class BigQueryTokenRefreshError(Exception):
@@ -714,6 +734,11 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                 config.dataset_id,
             )
             return {}
+        except NotFound as e:
+            structlog.get_logger().warning(
+                "BigQuery dataset '%s' not found during schema discovery: %s", config.dataset_id, e
+            )
+            raise BigQueryDatasetNotFoundError(BIGQUERY_DATASET_NOT_FOUND_ERROR) from e
         except TypeError as e:
             # See `BigQueryTokenRefreshError`: google-auth raises an opaque
             # `TypeError: string indices must be integers` when the OAuth token endpoint

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -12,6 +12,7 @@ from posthog.schema import (
 )
 
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
+    BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryImplementation,
     build_destination_table_prefix,
@@ -89,13 +90,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # grant the missing permission (e.g. the BigQuery Read Session User role). Matched on the
             # stable permission name rather than the volatile project id.
             "bigquery.readsessions.create": "BigQuery denied access to the Storage Read API: your service account is missing the bigquery.readsessions.create permission. Please grant it (for example via the BigQuery Read Session User role) on the project you're syncing, then reconnect the source.",
-            # Raised from schema discovery (`get_columns`) and query jobs when the configured
-            # dataset/table doesn't exist in the location we query — the dataset was deleted or
-            # renamed, or it lives in a different region than the one we run against. The google
-            # exception stringifies as "404 Not found: Dataset ... was not found in location US",
-            # so match the stable phrasing here. Retrying can't recover — the user must fix the
-            # dataset or set the correct region.
-            "was not found in location": "BigQuery couldn't find the configured dataset or table. It may have been deleted or renamed, or it may live in a different region — verify your dataset and table names, and set the dataset region in your source configuration if it isn't in the US.",
+            # Raised from query jobs when the configured dataset/table doesn't exist in the location
+            # we query — the dataset was deleted or renamed, or it lives in a different region than the
+            # one we run against. The google exception stringifies as "404 Not found: Dataset ... was
+            # not found in location US", so match the stable phrasing here. Retrying can't recover —
+            # the user must fix the dataset or set the correct region.
+            "was not found in location": BIGQUERY_DATASET_NOT_FOUND_ERROR,
+            # Schema discovery (`get_columns`) re-raises the same 404 as `BigQueryDatasetNotFoundError`
+            # carrying this exact wording (so the create/validate path shows it instead of the raw
+            # 404). Match it here too so the discovery activity treats it as non-retryable.
+            BIGQUERY_DATASET_NOT_FOUND_ERROR: BIGQUERY_DATASET_NOT_FOUND_ERROR,
             # Raised from `bq_client.get_table(...)` in `_build_source_response` when the table being
             # synced no longer exists at sync time — it was deleted or renamed in BigQuery (common with
             # dbt-managed datasets) after schema discovery selected it. The google exception stringifies

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -11,8 +11,10 @@ from google.auth.exceptions import RefreshError
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery import bigquery as bq_module
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
+    BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryCredentialsRejectedError,
+    BigQueryDatasetNotFoundError,
     BigQueryImplementation,
     BigQueryTokenRefreshError,
     _bq_select_clause,
@@ -132,6 +134,24 @@ def test_bigquery_get_columns_typeerror_handling(error_message, expected_type, i
         assert BIGQUERY_TOKEN_RESPONSE_ERROR in BigQuerySource().get_non_retryable_errors()
     else:
         assert error_message in str(exc_info.value)
+
+
+def test_bigquery_get_columns_raises_friendly_error_when_dataset_not_found():
+    """A missing dataset/table surfaces as a raw google `NotFound` from `client.query()`. Schema
+    discovery must re-raise it with actionable wording instead of leaking BigQuery job internals,
+    and that wording must stay registered as non-retryable."""
+    fake_client = mock.MagicMock()
+    fake_client.query.side_effect = NotFound(
+        "404 Not found: Dataset prj:ds was not found in location US Job ID: b3abc342-16a7"
+    )
+
+    with pytest.raises(BigQueryDatasetNotFoundError) as exc_info:
+        BigQueryImplementation().get_columns(fake_client, _make_config(), names=None)
+
+    assert str(exc_info.value) == BIGQUERY_DATASET_NOT_FOUND_ERROR
+    # The raw 404 (job id, location internals) must not survive into the message.
+    assert "Job ID" not in str(exc_info.value)
+    assert BIGQUERY_DATASET_NOT_FOUND_ERROR in BigQuerySource().get_non_retryable_errors()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When a user points a BigQuery source at a dataset/table that doesn't exist in the queried region (deleted, renamed, wrong region, or — as we saw — the project ID pasted into the Dataset ID field), schema discovery's `INFORMATION_SCHEMA.COLUMNS` query raises a `google.api_core.exceptions.NotFound`. The source-creation `database_schema` endpoint returns `str(e)` on any unhandled exception, so the user saw the raw Google error:

```
404 Not found: Dataset prj:prj was not found in location US; reason: notFound,
message: Not found: Dataset ... Location: US Job ID: b3abc342-16a7-435f-...
```

That's BigQuery job plumbing (job id, duplicated text, location internals) the user can't act on. Notably, the source already had a crafted, friendly message for exactly this condition in `get_non_retryable_errors` — but that map is only consulted on the sync/refresh paths, never on initial schema discovery, so the friendly version never reached the create flow.

## Changes

- Catch `NotFound` in `BigQueryImplementation.get_columns` and re-raise it as a new `BigQueryDatasetNotFoundError` carrying the existing actionable wording (verify dataset/table names, set the region if not US). The raw 404 is logged, not surfaced.
- Hoist that wording into a `BIGQUERY_DATASET_NOT_FOUND_ERROR` constant and reuse it as the `get_non_retryable_errors` value, and add an entry keyed on the constant so the discovery activity (`sync_new_schemas`, which classifies on `str(e)`) still treats the re-raised error as non-retryable and skips quietly instead of retrying.
- The existing `"was not found in location"` key stays for the raw `NotFound` that surfaces from query jobs / the Storage Read API during actual syncs — behavior there is unchanged.

No sync behavior or schemas changed beyond this error surfacing.

## How did you test this code?

I'm an agent. Added a regression test (`test_bigquery_get_columns_raises_friendly_error_when_dataset_not_found`) verifying `get_columns` raises the friendly error, that the raw 404 (job id) doesn't survive into the message, and that the wording stays registered as non-retryable. Ran:

```
uv run python -m pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
# 76 passed
```

Ruff check + format pass on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over data-warehouse source-creation failures; this one was classified as an internal error leaking to users (raw API response). Chose to fix it BigQuery-side in `get_columns` rather than wrapping the shared `database_schema` handler, to keep the blast radius to BigQuery and avoid changing the error path for every other source. The friendly wording already existed — the fix is really about routing it to the discovery path while preserving non-retryable classification.

Safe error-surfacing change.
