### PR TITLE
fix(replay): reap stale recording exports when a new one starts

### DIFF
--- a/posthog/temporal/session_replay/export_recording/activities.py
+++ b/posthog/temporal/session_replay/export_recording/activities.py
@@ -33,9 +33,11 @@ from products.replay.backend.models.exported_recording import ExportedRecording
 
 LOGGER = get_write_only_logger()
 
-# A real export never runs this long; anything still unfinished is wedged (e.g. a worker died
-# before its failure handler ran). We reap these opportunistically when a new export starts.
-STALE_EXPORT_AFTER = timedelta(hours=12)
+# Set safely beyond the export workflow's maximum legitimate lifetime (build 3h + parallel export
+# 6h + store 6h + cleanup 3h, which a workflow-level retry can roughly double) so an actively
+# running export is never reaped. Anything older is wedged (e.g. a worker died before its failure
+# handler ran). We reap these opportunistically when a new export starts.
+STALE_EXPORT_AFTER = timedelta(hours=48)
 
 
 def _redis_url(config: RedisConfig) -> str:

--- a/posthog/temporal/session_replay/export_recording/activities.py
+++ b/posthog/temporal/session_replay/export_recording/activities.py
@@ -2,11 +2,12 @@ import json
 import uuid
 import base64
 import shutil
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 from django.conf import settings
+from django.utils import timezone
 
 import pytz
 from temporalio import activity
@@ -32,6 +33,10 @@ from products.replay.backend.models.exported_recording import ExportedRecording
 
 LOGGER = get_write_only_logger()
 
+# A real export never runs this long; anything still unfinished is wedged (e.g. a worker died
+# before its failure handler ran). We reap these opportunistically when a new export starts.
+STALE_EXPORT_AFTER = timedelta(hours=12)
+
 
 def _redis_url(config: RedisConfig) -> str:
     return config.redis_url or settings.SESSION_RECORDING_REDIS_URL
@@ -46,6 +51,8 @@ def _redis_key(export_id: uuid.UUID, key_type: str, suffix: str = "") -> str:
 async def build_recording_export_context(input: ExportRecordingInput) -> ExportContext:
     logger = LOGGER.bind()
     logger.info(f"Building export context for recording {input.exported_recording_id}")
+
+    await _reap_stale_exports(logger)
 
     export_record = (
         await ExportedRecording.objects.select_related("team")
@@ -312,6 +319,25 @@ async def mark_export_failed(input: MarkExportFailedInput) -> None:
     await database_sync_to_async(export_record.save)(update_fields=["status", "error_message"])
 
     logger.info(f"Marked ExportedRecording {input.exported_recording_id} as failed")
+
+
+def _mark_stale_exports_failed() -> int:
+    cutoff = timezone.now() - STALE_EXPORT_AFTER
+    return ExportedRecording.objects.filter(
+        status__in=[ExportedRecording.Status.PENDING, ExportedRecording.Status.RUNNING],
+        created_at__lt=cutoff,
+    ).update(status=ExportedRecording.Status.FAILED, error_message="timed out")
+
+
+async def _reap_stale_exports(logger) -> None:
+    # best-effort fallback: a worker can die before its failure handler runs, leaving a row stuck
+    # in RUNNING. We have no scheduled sweep, so reap on the next export. Never let this block one.
+    try:
+        count = await database_sync_to_async(_mark_stale_exports_failed)()
+        if count:
+            logger.warning(f"Reaped {count} stale recording export(s) before starting this one")
+    except Exception:
+        logger.warning("Failed to reap stale exports; continuing with this export", exc_info=True)
 
 
 @activity.defn

--- a/posthog/temporal/tests/session_replay/export_recording/test_activities.py
+++ b/posthog/temporal/tests/session_replay/export_recording/test_activities.py
@@ -623,12 +623,13 @@ async def test_cleanup_export_data_no_manifest():
 @pytest.mark.parametrize(
     "status,age_hours,expect_swept",
     [
-        (ExportedRecording.Status.RUNNING, 13, True),
-        (ExportedRecording.Status.PENDING, 13, True),
-        (ExportedRecording.Status.RUNNING, 1, False),
+        (ExportedRecording.Status.RUNNING, 49, True),
+        (ExportedRecording.Status.PENDING, 49, True),
+        # still within the export workflow's max legitimate lifetime - must not be reaped
+        (ExportedRecording.Status.RUNNING, 13, False),
         (ExportedRecording.Status.PENDING, 1, False),
-        (ExportedRecording.Status.COMPLETE, 13, False),
-        (ExportedRecording.Status.FAILED, 13, False),
+        (ExportedRecording.Status.COMPLETE, 49, False),
+        (ExportedRecording.Status.FAILED, 49, False),
     ],
 )
 def test_mark_stale_exports_failed_only_sweeps_old_unfinished(team, status, age_hours, expect_swept):

--- a/posthog/temporal/tests/session_replay/export_recording/test_activities.py
+++ b/posthog/temporal/tests/session_replay/export_recording/test_activities.py
@@ -1,13 +1,17 @@
 import json
 import base64
+from datetime import timedelta
 from uuid import UUID, uuid4
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.utils import timezone
+
 from posthog.session_recordings.recordings.errors import BlockFetchError
 from posthog.session_recordings.session_recording_v2_service import RecordingBlock
 from posthog.temporal.session_replay.export_recording.activities import (
+    _mark_stale_exports_failed,
     _redis_key,
     _redis_url,
     build_recording_export_context,
@@ -89,6 +93,8 @@ async def test_build_recording_export_context_success():
     mock_qs.select_related.assert_called_once_with("team")
     mock_qs.select_related.return_value.only.assert_called_once_with("status", "session_id", "team__id")
     mock_qs.select_related.return_value.only.return_value.aget.assert_called_once_with(id=TEST_RECORDING_ID)
+    # stale exports are reaped opportunistically when a new export starts
+    mock_qs.filter.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -611,3 +617,31 @@ async def test_cleanup_export_data_no_manifest():
         mock_redis.delete.assert_called_once()
         delete_args = mock_redis.delete.call_args[0]
         assert len(delete_args) == 4
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status,age_hours,expect_swept",
+    [
+        (ExportedRecording.Status.RUNNING, 13, True),
+        (ExportedRecording.Status.PENDING, 13, True),
+        (ExportedRecording.Status.RUNNING, 1, False),
+        (ExportedRecording.Status.PENDING, 1, False),
+        (ExportedRecording.Status.COMPLETE, 13, False),
+        (ExportedRecording.Status.FAILED, 13, False),
+    ],
+)
+def test_mark_stale_exports_failed_only_sweeps_old_unfinished(team, status, age_hours, expect_swept):
+    record = ExportedRecording.objects.create(team=team, session_id="s", reason="r", status=status)
+    ExportedRecording.objects.filter(pk=record.pk).update(created_at=timezone.now() - timedelta(hours=age_hours))
+
+    swept = _mark_stale_exports_failed()
+    record.refresh_from_db()
+
+    if expect_swept:
+        assert swept == 1
+        assert record.status == ExportedRecording.Status.FAILED
+        assert record.error_message == "timed out"
+    else:
+        assert swept == 0
+        assert record.status == status


### PR DESCRIPTION
## Problem

Recording exports that never reach `COMPLETE` are left in `RUNNING` indefinitely, so a wedged export is indistinguishable from one still in progress. The in-workflow failure handler (separate PR) marks a *new* run failed when its workflow raises, but it cannot help two cases:

- exports whose worker crashed or was hard-terminated mid-run — no workflow code is left running to catch anything;
- the backlog of rows already stuck in `RUNNING` from before that handler existed.

## Changes

Reap stale exports opportunistically instead of on a schedule. When a new export starts (`build_recording_export_context`), mark any `ExportedRecording` still `PENDING` or `RUNNING` past the stale cutoff as `FAILED` with `error_message = "timed out"`.

- **Cutoff is 48h**, set safely beyond the export workflow's maximum legitimate lifetime (build 3h + parallel export 6h + store 6h + cleanup 3h, which a workflow-level retry can roughly double) so an actively-running export is never reaped.
- This is a best-effort fallback — a reap failure is logged and never blocks the export that triggered it.
- Exports run often enough to keep the backlog clear, so no scheduled-sweep / cron infrastructure is needed.
- Stacked on the failure-handler PR because both extend the same `export_recording` package.

Between the in-workflow handler (immediate, accurate error for graceful activity failures) and this fallback reap (covers orphans + backlog on the next export), an export can no longer be stuck in `RUNNING` forever.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests:

- `test_mark_stale_exports_failed_only_sweeps_old_unfinished` — parameterized over status x age, asserts only `PENDING`/`RUNNING` rows past the 48h cutoff are flipped to `FAILED` ("timed out"); `COMPLETE`/`FAILED`/recent rows (including a 13h-old `RUNNING` one, still within the legitimate workflow lifetime) are untouched.
- Extended `test_build_recording_export_context_success` to assert the reap runs when a new export starts.

I did not exercise the orphan path against a live Temporal worker; relying on CI for the full suite.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) at Paul's direction. Root-causing exports stuck in `RUNNING` surfaced two independent issues plus the need to clear the backlog; this is the third of three PRs (ClickHouse query fix, in-workflow failure handler, and this fallback reap). Originally a scheduled Temporal sweep mirroring `gemini_cleanup_sweep`; simplified to an opportunistic check at export start since it is only a fallback and avoids standing up cron infrastructure. Cutoff raised from 12h to 48h after review flagged it could otherwise reap a still-running export.

No repo skills were required (Temporal activity change; no DRF/migration/ClickHouse-migration surface).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
