### PR TITLE
feat(llma): instantiate templated community skills at install

### DIFF
--- a/products/ai_observability/backend/api/community_skill_serializers.py
+++ b/products/ai_observability/backend/api/community_skill_serializers.py
@@ -189,7 +189,9 @@ class CommunitySkillInstallSerializer(serializers.Serializer):
         help_text="Name for the installed skill in your team. Defaults to the community skill's slug.",
     )
     variables = serializers.DictField(
-        child=serializers.CharField(allow_blank=True),
+        # trim_whitespace=False so a value's exact text (multiline snippets, leading/trailing
+        # whitespace meant for the rendered output) survives into the installed skill.
+        child=serializers.CharField(allow_blank=True, trim_whitespace=False),
         required=False,
         help_text=(
             "Values for a template skill's declared variables, as a {name: value} map. Required only when "

--- a/products/ai_observability/backend/api/community_skill_serializers.py
+++ b/products/ai_observability/backend/api/community_skill_serializers.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ..models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier
+from .skill_template_services import parse_template_variables
 
 ALLOWED_LIST_ORDERINGS = frozenset(
     {
@@ -19,6 +20,23 @@ ALLOWED_LIST_ORDERINGS = frozenset(
         "-vote_count",
     }
 )
+
+
+class CommunitySkillTemplateVariableSerializer(serializers.Serializer):
+    """One declared variable of a templated skill — the schema a client renders a form from."""
+
+    name = serializers.CharField(help_text="Variable identifier, substituted for `{{ name }}` in the skill body.")
+    prompt = serializers.CharField(
+        allow_blank=True,
+        help_text="Human-readable question shown when collecting a value for this variable.",
+    )
+    required = serializers.BooleanField(
+        help_text="Whether a value must be supplied at install time (false variables fall back to their default).",
+    )
+    default = serializers.CharField(
+        allow_blank=True,
+        help_text="Value used when none is supplied. Empty when the variable has no default.",
+    )
 
 
 class CommunitySkillFileSerializer(serializers.ModelSerializer):
@@ -60,6 +78,12 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
             "Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint."
         ),
     )
+    template_variables = serializers.SerializerMethodField(
+        help_text=(
+            "Declared template variables, parsed from metadata. Non-empty marks this skill as a template: "
+            "collect a value for each and pass them as `variables` when installing."
+        ),
+    )
     vote_count = serializers.SerializerMethodField(
         help_text="Total number of upvotes this skill has received.",
     )
@@ -84,6 +108,7 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
             "author_handle",
             "github_url",
             "files",
+            "template_variables",
             "install_count",
             "vote_count",
             "has_voted",
@@ -108,6 +133,13 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
     @extend_schema_field(CommunitySkillFileManifestSerializer(many=True))
     def get_files(self, instance: CommunitySkill) -> list[dict[str, Any]]:
         return [dict(row) for row in instance.files.values("path", "content_type")]
+
+    @extend_schema_field(CommunitySkillTemplateVariableSerializer(many=True))
+    def get_template_variables(self, instance: CommunitySkill) -> list[dict[str, Any]]:
+        return [
+            {"name": v.name, "prompt": v.prompt, "required": v.required, "default": v.default}
+            for v in parse_template_variables(instance.metadata)
+        ]
 
     def get_vote_count(self, instance: CommunitySkill) -> int:
         # Provided by the viewset's annotated queryset; fall back to a count for unannotated instances.
@@ -155,6 +187,14 @@ class CommunitySkillInstallSerializer(serializers.Serializer):
         max_length=64,
         required=False,
         help_text="Name for the installed skill in your team. Defaults to the community skill's slug.",
+    )
+    variables = serializers.DictField(
+        child=serializers.CharField(allow_blank=True),
+        required=False,
+        help_text=(
+            "Values for a template skill's declared variables, as a {name: value} map. Required only when "
+            "installing a template (see the skill's `template_variables`); ignored for non-template skills."
+        ),
     )
 
 

--- a/products/ai_observability/backend/api/community_skill_serializers.py
+++ b/products/ai_observability/backend/api/community_skill_serializers.py
@@ -30,8 +30,8 @@ class CommunitySkillTemplateVariableSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Human-readable question shown when collecting a value for this variable.",
     )
-    required = serializers.BooleanField(
-        help_text="Whether a value must be supplied at install time (false variables fall back to their default).",
+    is_required = serializers.BooleanField(
+        help_text="Whether a value must be supplied at install time (otherwise it falls back to the default).",
     )
     default = serializers.CharField(
         allow_blank=True,
@@ -137,7 +137,7 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
     @extend_schema_field(CommunitySkillTemplateVariableSerializer(many=True))
     def get_template_variables(self, instance: CommunitySkill) -> list[dict[str, Any]]:
         return [
-            {"name": v.name, "prompt": v.prompt, "required": v.required, "default": v.default}
+            {"name": v.name, "prompt": v.prompt, "is_required": v.required, "default": v.default}
             for v in parse_template_variables(instance.metadata)
         ]
 

--- a/products/ai_observability/backend/api/community_skill_services.py
+++ b/products/ai_observability/backend/api/community_skill_services.py
@@ -13,7 +13,7 @@ from ..models.community_skills import CommunitySkill, CommunitySkillFile, Commun
 from ..models.skills import LLMSkill
 from .skill_serializers import validate_skill_name_value
 from .skill_services import create_skill
-from .skill_template_services import is_template, render_template_skill
+from .skill_template_services import parse_template_variables, render_template_skill
 
 logger = structlog.get_logger(__name__)
 
@@ -68,9 +68,10 @@ def install_community_skill(
     }
     body = community_skill.body
 
-    if is_template(community_skill.metadata):
+    template_variables = parse_template_variables(community_skill.metadata)
+    if template_variables:
         rendered = render_template_skill(
-            metadata=community_skill.metadata,
+            variables=template_variables,
             body=community_skill.body,
             files=files,
             supplied=variables,

--- a/products/ai_observability/backend/api/community_skill_services.py
+++ b/products/ai_observability/backend/api/community_skill_services.py
@@ -13,6 +13,7 @@ from ..models.community_skills import CommunitySkill, CommunitySkillFile, Commun
 from ..models.skills import LLMSkill
 from .skill_serializers import validate_skill_name_value
 from .skill_services import create_skill
+from .skill_template_services import is_template, render_template_skill
 
 logger = structlog.get_logger(__name__)
 
@@ -38,11 +39,16 @@ def install_community_skill(
     user: User,
     slug: str,
     new_name: str | None = None,
+    variables: dict[str, str] | None = None,
 ) -> LLMSkill:
     """Copy a community skill into a team as a regular LLMSkill and bump its install counter.
 
-    Raises CommunitySkillNotFoundError if the slug is unknown, and
-    LLMSkillDuplicateNameConflictError if the target name already exists in the team.
+    When the community skill is a template (its metadata declares `variables`), the user-supplied
+    `variables` are bound into the body and bundled files before the LLMSkill is created.
+
+    Raises CommunitySkillNotFoundError if the slug is unknown,
+    LLMSkillDuplicateNameConflictError if the target name already exists in the team, and
+    MissingTemplateVariableError / UnknownTemplatePlaceholderError on template render failures.
     """
     community_skill = get_community_skill_by_slug(slug)
     if community_skill is None:
@@ -54,21 +60,39 @@ def install_community_skill(
         {"path": f.path, "content": f.content, "content_type": f.content_type} for f in community_skill.files.all()
     ]
 
+    # Stamp provenance so an installed skill can be traced back to its community source.
+    metadata: dict[str, Any] = {
+        **(community_skill.metadata or {}),
+        "community_skill_slug": community_skill.slug,
+        "community_skill_id": str(community_skill.id),
+    }
+    body = community_skill.body
+
+    if is_template(community_skill.metadata):
+        rendered = render_template_skill(
+            metadata=community_skill.metadata,
+            body=community_skill.body,
+            files=files,
+            supplied=variables,
+        )
+        body = rendered.body
+        files = rendered.files
+        # The instantiated skill is a concrete skill, not a template — drop the variable schema and
+        # record what it was rendered from so a re-render stays deterministic.
+        metadata.pop("variables", None)
+        metadata["instantiated_from"] = f"{community_skill.slug}@{community_skill.source_sha}"
+        metadata["variable_bindings"] = rendered.bindings
+
     installed = create_skill(
         team,
         user=user,
         name=target_name,
         description=community_skill.description,
-        body=community_skill.body,
+        body=body,
         license=community_skill.license,
         compatibility=community_skill.compatibility,
         allowed_tools=community_skill.allowed_tools,
-        # Stamp provenance so an installed skill can be traced back to its community source.
-        metadata={
-            **(community_skill.metadata or {}),
-            "community_skill_slug": community_skill.slug,
-            "community_skill_id": str(community_skill.id),
-        },
+        metadata=metadata,
         files=files or None,
     )
 

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -30,6 +30,7 @@ from .community_skill_serializers import (
 from .community_skill_services import CommunitySkillNotFoundError, install_community_skill, toggle_community_skill_vote
 from .skill_serializers import LLMSkillSerializer
 from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimitError, LLMSkillFilePathConflictError
+from .skill_template_services import MissingTemplateVariableError, UnknownTemplatePlaceholderError
 
 logger = structlog.get_logger(__name__)
 
@@ -162,11 +163,23 @@ class CommunitySkillViewSet(
                 user=cast(User, request.user),
                 slug=slug,
                 new_name=payload.validated_data.get("new_name"),
+                variables=payload.validated_data.get("variables"),
             )
         except CommunitySkillNotFoundError:
             return Response(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+        except MissingTemplateVariableError as err:
+            return Response(
+                {"attr": "variables", "detail": str(err)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except UnknownTemplatePlaceholderError as err:
+            # The synced template body references a variable it never declared — a content-repo bug.
+            return Response(
+                {"detail": str(err)},
+                status=status.HTTP_400_BAD_REQUEST,
             )
         except LLMSkillDuplicateNameConflictError:
             return Response(
@@ -186,6 +199,7 @@ class CommunitySkillViewSet(
             {
                 "community_skill_slug": slug,
                 "installed_skill_name": installed.name,
+                "installed_as_template": "instantiated_from" in (installed.metadata or {}),
             },
             team=self.team,
             request=request,

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -30,7 +30,11 @@ from .community_skill_serializers import (
 from .community_skill_services import CommunitySkillNotFoundError, install_community_skill, toggle_community_skill_vote
 from .skill_serializers import LLMSkillSerializer
 from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimitError, LLMSkillFilePathConflictError
-from .skill_template_services import MissingTemplateVariableError, UnknownTemplatePlaceholderError
+from .skill_template_services import (
+    MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
+    UnknownTemplatePlaceholderError,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -170,16 +174,18 @@ class CommunitySkillViewSet(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except MissingTemplateVariableError as err:
+        except (MissingTemplateVariableError, TemplateRenderTooLargeError) as err:
+            # Both are fixable by the caller (supply the value / shorter values), so they're 400s.
             return Response(
                 {"attr": "variables", "detail": str(err)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except UnknownTemplatePlaceholderError as err:
-            # The synced template body references a variable it never declared — a content-repo bug.
+            # The template body references a variable it never declared — a content-repo bug the
+            # caller can't fix, so surface it as a server-side fault, not a bad request.
             return Response(
                 {"detail": str(err)},
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         except LLMSkillDuplicateNameConflictError:
             return Response(

--- a/products/ai_observability/backend/api/community_skills.py
+++ b/products/ai_observability/backend/api/community_skills.py
@@ -33,6 +33,7 @@ from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimi
 from .skill_template_services import (
     MissingTemplateVariableError,
     TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
     UnknownTemplatePlaceholderError,
 )
 
@@ -174,8 +175,9 @@ class CommunitySkillViewSet(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except (MissingTemplateVariableError, TemplateRenderTooLargeError) as err:
-            # Both are fixable by the caller (supply the value / shorter values), so they're 400s.
+        except (MissingTemplateVariableError, TemplateRenderTooLargeError, UnknownSuppliedVariableError) as err:
+            # All three are fixable by the caller (supply the value / shorter values / fix the key),
+            # so they're 400s.
             return Response(
                 {"attr": "variables", "detail": str(err)},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/products/ai_observability/backend/api/skill_template_services.py
+++ b/products/ai_observability/backend/api/skill_template_services.py
@@ -10,8 +10,13 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from .skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES
+
 # `{{ name }}` with optional surrounding whitespace. Names are Python-identifier-like.
 _PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+# Any residual `{{ ... }}` after substitution — catches placeholders whose declared name isn't a
+# valid identifier (e.g. `{{ repo-name }}`), which the strict pattern above silently skips.
+_LOOSE_PLACEHOLDER_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 
 
 @dataclass(frozen=True)
@@ -40,6 +45,13 @@ class UnknownTemplatePlaceholderError(TemplateRenderError):
     def __init__(self, placeholder: str) -> None:
         self.placeholder = placeholder
         super().__init__(f"Template references undeclared variable '{placeholder}'.")
+
+
+class TemplateRenderTooLargeError(TemplateRenderError):
+    """Rendering expanded the body or a file past the skill size limit."""
+
+    def __init__(self, what: str, limit: int) -> None:
+        super().__init__(f"Rendered {what} exceeds the {limit} byte size limit.")
 
 
 def parse_template_variables(metadata: dict[str, Any] | None) -> list[TemplateVariable]:
@@ -98,7 +110,7 @@ def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str]
 
 
 def render_text(text: str, bindings: dict[str, str]) -> str:
-    """Substitute every `{{ name }}` placeholder, erroring on any undeclared name."""
+    """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name."""
 
     def _replace(match: re.Match[str]) -> str:
         name = match.group(1)
@@ -106,7 +118,13 @@ def render_text(text: str, bindings: dict[str, str]) -> str:
             raise UnknownTemplatePlaceholderError(name)
         return bindings[name]
 
-    return _PLACEHOLDER_RE.sub(_replace, text)
+    rendered = _PLACEHOLDER_RE.sub(_replace, text)
+    # Anything still wrapped in `{{ }}` had a name the strict pattern couldn't match — fail loudly
+    # rather than install a skill with a dangling placeholder.
+    leftover = _LOOSE_PLACEHOLDER_RE.search(rendered)
+    if leftover is not None:
+        raise UnknownTemplatePlaceholderError(leftover.group(0).strip())
+    return rendered
 
 
 @dataclass(frozen=True)
@@ -118,22 +136,29 @@ class RenderedTemplate:
 
 def render_template_skill(
     *,
-    metadata: dict[str, Any] | None,
+    variables: list[TemplateVariable],
     body: str,
     files: list[dict[str, str]],
     supplied: dict[str, str] | None,
 ) -> RenderedTemplate:
     """Resolve user-supplied values against the declared variables and render body + files.
 
-    Raises MissingTemplateVariableError when a required value is absent, and
-    UnknownTemplatePlaceholderError when a placeholder has no matching declared variable.
+    `variables` is the already-parsed schema (see `parse_template_variables`) so the caller can
+    parse once and reuse the result. Raises MissingTemplateVariableError when a required value is
+    absent, UnknownTemplatePlaceholderError when a placeholder has no matching declared variable,
+    and TemplateRenderTooLargeError when a user-supplied value expands output past the size limit.
     """
-    variables = parse_template_variables(metadata)
     bindings = resolve_bindings(variables, supplied)
 
-    rendered_files = [{**file, "content": render_text(file["content"], bindings)} for file in files]
-    return RenderedTemplate(
-        body=render_text(body, bindings),
-        files=rendered_files,
-        bindings=bindings,
-    )
+    rendered_body = render_text(body, bindings)
+    if len(rendered_body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+        raise TemplateRenderTooLargeError("skill body", MAX_SKILL_BODY_BYTES)
+
+    rendered_files: list[dict[str, str]] = []
+    for file in files:
+        content = render_text(file["content"], bindings)
+        if len(content.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+            raise TemplateRenderTooLargeError(f"file '{file['path']}'", MAX_SKILL_FILE_BYTES)
+        rendered_files.append({**file, "content": content})
+
+    return RenderedTemplate(body=rendered_body, files=rendered_files, bindings=bindings)

--- a/products/ai_observability/backend/api/skill_template_services.py
+++ b/products/ai_observability/backend/api/skill_template_services.py
@@ -57,10 +57,11 @@ class TemplateRenderTooLargeError(TemplateRenderError):
 def parse_template_variables(metadata: dict[str, Any] | None) -> list[TemplateVariable]:
     """Read the `variables` schema out of a skill's frontmatter metadata.
 
-    Tolerant of malformed entries from synced/external content: anything without a usable string
-    `name` is skipped rather than raising, so a bad row never breaks discovery or install.
+    Tolerant of malformed entries from synced/external content: a non-dict metadata or anything
+    without a usable string `name` is skipped rather than raising, so a bad row never breaks
+    discovery or install.
     """
-    if not metadata:
+    if not isinstance(metadata, dict):
         return []
     raw = metadata.get("variables")
     if not isinstance(raw, list):
@@ -110,21 +111,22 @@ def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str]
 
 
 def render_text(text: str, bindings: dict[str, str]) -> str:
-    """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name."""
+    """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name.
 
-    def _replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        if name not in bindings:
-            raise UnknownTemplatePlaceholderError(name)
-        return bindings[name]
+    Validation runs against the source `text` only, before substitution — a supplied value may
+    legitimately contain literal `{{ }}` and must not be re-interpreted as a placeholder.
+    """
+    for match in _LOOSE_PLACEHOLDER_RE.finditer(text):
+        token = match.group(0)
+        strict = _PLACEHOLDER_RE.fullmatch(token)
+        if strict is None:
+            # A `{{ ... }}` whose name the strict pattern can't match (e.g. a hyphen) — fail loudly
+            # rather than install a skill with a dangling placeholder.
+            raise UnknownTemplatePlaceholderError(token.strip())
+        if strict.group(1) not in bindings:
+            raise UnknownTemplatePlaceholderError(strict.group(1))
 
-    rendered = _PLACEHOLDER_RE.sub(_replace, text)
-    # Anything still wrapped in `{{ }}` had a name the strict pattern couldn't match — fail loudly
-    # rather than install a skill with a dangling placeholder.
-    leftover = _LOOSE_PLACEHOLDER_RE.search(rendered)
-    if leftover is not None:
-        raise UnknownTemplatePlaceholderError(leftover.group(0).strip())
-    return rendered
+    return _PLACEHOLDER_RE.sub(lambda m: bindings[m.group(1)], text)
 
 
 @dataclass(frozen=True)

--- a/products/ai_observability/backend/api/skill_template_services.py
+++ b/products/ai_observability/backend/api/skill_template_services.py
@@ -54,6 +54,14 @@ class TemplateRenderTooLargeError(TemplateRenderError):
         super().__init__(f"Rendered {what} exceeds the {limit} byte size limit.")
 
 
+class UnknownSuppliedVariableError(TemplateRenderError):
+    """The caller supplied values for variables the template doesn't declare (likely a typo)."""
+
+    def __init__(self, names: list[str]) -> None:
+        self.names = names
+        super().__init__(f"Unknown template variable(s) supplied: {', '.join(names)}.")
+
+
 def parse_template_variables(metadata: dict[str, Any] | None) -> list[TemplateVariable]:
     """Read the `variables` schema out of a skill's frontmatter metadata.
 
@@ -94,18 +102,28 @@ def is_template(metadata: dict[str, Any] | None) -> bool:
 
 
 def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str] | None) -> dict[str, str]:
-    """Build the final {name: value} map, applying defaults and enforcing required variables."""
+    """Build the final {name: value} map, applying defaults and enforcing required variables.
+
+    An explicitly supplied value (including "") is used verbatim — only an absent key falls back to
+    the default. Supplying a value for an undeclared variable is an error (likely a typo).
+    """
     supplied = supplied or {}
+    unknown = sorted(set(supplied) - {v.name for v in variables})
+    if unknown:
+        raise UnknownSuppliedVariableError(unknown)
+
     bindings: dict[str, str] = {}
     for variable in variables:
-        value = supplied.get(variable.name)
-        if value is None or value == "":
-            if variable.default:
-                value = variable.default
-            elif variable.required:
+        if variable.name in supplied:
+            value = supplied[variable.name]
+            if value == "" and variable.required:
                 raise MissingTemplateVariableError(variable)
-            else:
-                value = ""
+        elif variable.default:
+            value = variable.default
+        elif variable.required:
+            raise MissingTemplateVariableError(variable)
+        else:
+            value = ""
         bindings[variable.name] = value
     return bindings
 

--- a/products/ai_observability/backend/api/skill_template_services.py
+++ b/products/ai_observability/backend/api/skill_template_services.py
@@ -1,0 +1,139 @@
+"""Server-side rendering for templated skills.
+
+A skill is a *template* when its `metadata.variables` declares one or more variables. The body and
+bundled files carry `{{ variable }}` placeholders that get bound to user-supplied values when the
+skill is instantiated (installed) into a team. Rendering is deliberately plain string substitution —
+never a template engine — so a community-published template can't execute logic against tenant data.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# `{{ name }}` with optional surrounding whitespace. Names are Python-identifier-like.
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+
+
+@dataclass(frozen=True)
+class TemplateVariable:
+    name: str
+    prompt: str
+    required: bool
+    default: str
+
+
+class TemplateRenderError(Exception):
+    """Base class for failures while rendering a templated skill."""
+
+
+class MissingTemplateVariableError(TemplateRenderError):
+    """A required variable had no supplied value and no default."""
+
+    def __init__(self, variable: TemplateVariable) -> None:
+        self.variable = variable
+        super().__init__(f"Missing required template variable '{variable.name}': {variable.prompt}")
+
+
+class UnknownTemplatePlaceholderError(TemplateRenderError):
+    """The body or a file referenced a `{{ placeholder }}` with no declared variable."""
+
+    def __init__(self, placeholder: str) -> None:
+        self.placeholder = placeholder
+        super().__init__(f"Template references undeclared variable '{placeholder}'.")
+
+
+def parse_template_variables(metadata: dict[str, Any] | None) -> list[TemplateVariable]:
+    """Read the `variables` schema out of a skill's frontmatter metadata.
+
+    Tolerant of malformed entries from synced/external content: anything without a usable string
+    `name` is skipped rather than raising, so a bad row never breaks discovery or install.
+    """
+    if not metadata:
+        return []
+    raw = metadata.get("variables")
+    if not isinstance(raw, list):
+        return []
+
+    variables: list[TemplateVariable] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name or name in seen:
+            continue
+        seen.add(name)
+        default = item.get("default", "")
+        variables.append(
+            TemplateVariable(
+                name=name,
+                prompt=str(item.get("prompt", "")),
+                # Default to required unless a default is supplied or `required` is explicitly false.
+                required=bool(item.get("required", "default" not in item)),
+                default=str(default) if default is not None else "",
+            )
+        )
+    return variables
+
+
+def is_template(metadata: dict[str, Any] | None) -> bool:
+    return len(parse_template_variables(metadata)) > 0
+
+
+def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str] | None) -> dict[str, str]:
+    """Build the final {name: value} map, applying defaults and enforcing required variables."""
+    supplied = supplied or {}
+    bindings: dict[str, str] = {}
+    for variable in variables:
+        value = supplied.get(variable.name)
+        if value is None or value == "":
+            if variable.default:
+                value = variable.default
+            elif variable.required:
+                raise MissingTemplateVariableError(variable)
+            else:
+                value = ""
+        bindings[variable.name] = value
+    return bindings
+
+
+def render_text(text: str, bindings: dict[str, str]) -> str:
+    """Substitute every `{{ name }}` placeholder, erroring on any undeclared name."""
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in bindings:
+            raise UnknownTemplatePlaceholderError(name)
+        return bindings[name]
+
+    return _PLACEHOLDER_RE.sub(_replace, text)
+
+
+@dataclass(frozen=True)
+class RenderedTemplate:
+    body: str
+    files: list[dict[str, str]]
+    bindings: dict[str, str]
+
+
+def render_template_skill(
+    *,
+    metadata: dict[str, Any] | None,
+    body: str,
+    files: list[dict[str, str]],
+    supplied: dict[str, str] | None,
+) -> RenderedTemplate:
+    """Resolve user-supplied values against the declared variables and render body + files.
+
+    Raises MissingTemplateVariableError when a required value is absent, and
+    UnknownTemplatePlaceholderError when a placeholder has no matching declared variable.
+    """
+    variables = parse_template_variables(metadata)
+    bindings = resolve_bindings(variables, supplied)
+
+    rendered_files = [{**file, "content": render_text(file["content"], bindings)} for file in files]
+    return RenderedTemplate(
+        body=render_text(body, bindings),
+        files=rendered_files,
+        bindings=bindings,
+    )

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -9,6 +9,7 @@ from ...models.skills import LLMSkill
 from ..community_skill_services import sync_community_skills_from_github
 from ..skill_template_services import (
     MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
     UnknownTemplatePlaceholderError,
     is_template,
     parse_template_variables,
@@ -281,7 +282,7 @@ class TestSkillTemplateRendering(APIBaseTest):
 
     def test_render_substitutes_and_records_bindings(self) -> None:
         rendered = render_template_skill(
-            metadata={"variables": [{"name": "repo", "required": True}]},
+            variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
             body="watch {{ repo }}",
             files=[{"path": "a.md", "content": "ref {{ repo }}", "content_type": "text/plain"}],
             supplied={"repo": "posthog/posthog"},
@@ -293,7 +294,7 @@ class TestSkillTemplateRendering(APIBaseTest):
     def test_render_missing_required_raises(self) -> None:
         with self.assertRaises(MissingTemplateVariableError):
             render_template_skill(
-                metadata={"variables": [{"name": "repo", "required": True}]},
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
                 body="watch {{ repo }}",
                 files=[],
                 supplied={},
@@ -302,8 +303,27 @@ class TestSkillTemplateRendering(APIBaseTest):
     def test_render_unknown_placeholder_raises(self) -> None:
         with self.assertRaises(UnknownTemplatePlaceholderError):
             render_template_skill(
-                metadata={"variables": [{"name": "repo", "required": True}]},
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
                 body="watch {{ repo }} and {{ undeclared }}",
                 files=[],
                 supplied={"repo": "x"},
+            )
+
+    def test_render_rejects_unrenderable_variable_name(self) -> None:
+        # A declared name the placeholder regex can't match (hyphen) must fail, not install dangling.
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo-name", "required": True}]}),
+                body="watch {{ repo-name }}",
+                files=[],
+                supplied={"repo-name": "x"},
+            )
+
+    def test_render_oversized_output_raises(self) -> None:
+        with self.assertRaises(TemplateRenderTooLargeError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "v", "required": True}]}),
+                body="{{ v }}",
+                files=[],
+                supplied={"v": "x" * 1_000_001},
             )

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -130,9 +130,9 @@ class TestCommunitySkillAPI(APIBaseTest):
         variables = response.json()["template_variables"]
         self.assertEqual([v["name"] for v in variables], ["feed_table", "default_branch"])
         self.assertEqual(
-            variables[0], {"name": "feed_table", "prompt": "Warehouse table", "required": True, "default": ""}
+            variables[0], {"name": "feed_table", "prompt": "Warehouse table", "is_required": True, "default": ""}
         )
-        self.assertFalse(variables[1]["required"])  # has a default
+        self.assertFalse(variables[1]["is_required"])  # has a default
 
     def test_install_template_renders_variables(self, _mock_flag) -> None:
         skill = _create_template_skill(slug="feed-scout")

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -10,6 +10,7 @@ from ..community_skill_services import sync_community_skills_from_github
 from ..skill_template_services import (
     MissingTemplateVariableError,
     TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
     UnknownTemplatePlaceholderError,
     is_template,
     parse_template_variables,
@@ -317,6 +318,33 @@ class TestSkillTemplateRendering(APIBaseTest):
                 body="watch {{ repo-name }}",
                 files=[],
                 supplied={"repo-name": "x"},
+            )
+
+    def test_render_explicit_blank_overrides_default(self) -> None:
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "suffix", "default": "!"}]}),
+            body="hi{{ suffix }}",
+            files=[],
+            supplied={"suffix": ""},
+        )
+        self.assertEqual(rendered.body, "hi")
+
+    def test_render_explicit_blank_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="{{ repo }}",
+                files=[],
+                supplied={"repo": ""},
+            )
+
+    def test_render_unknown_supplied_key_raises(self) -> None:
+        with self.assertRaises(UnknownSuppliedVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "feed_table", "required": True}]}),
+                body="{{ feed_table }}",
+                files=[],
+                supplied={"feed_table": "x", "feedtable": "typo"},
             )
 
     def test_render_allows_braces_inside_supplied_value(self) -> None:

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -1,11 +1,19 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
 from ...models.skills import LLMSkill
 from ..community_skill_services import sync_community_skills_from_github
+from ..skill_template_services import (
+    MissingTemplateVariableError,
+    UnknownTemplatePlaceholderError,
+    is_template,
+    parse_template_variables,
+    render_template_skill,
+)
 
 
 def _create_community_skill(
@@ -25,6 +33,23 @@ def _create_community_skill(
         tags=["web-analytics"],
         install_count=install_count,
         deleted=deleted,
+    )
+
+
+def _create_template_skill(*, slug: str = "feed-scout") -> CommunitySkill:
+    return CommunitySkill.objects.create(
+        slug=slug,
+        name="Feed scout",
+        description="Watch a feed for problems.",
+        body="# Scout\nWatch table {{ feed_table }} on {{ default_branch }}.",
+        trust_tier="official",
+        source_sha="sha123",
+        metadata={
+            "variables": [
+                {"name": "feed_table", "prompt": "Warehouse table", "required": True},
+                {"name": "default_branch", "prompt": "Branch", "default": "main"},
+            ]
+        },
     )
 
 
@@ -98,6 +123,58 @@ class TestCommunitySkillAPI(APIBaseTest):
         response = self.client.post(self._url("does-not-exist/install/"), {})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_retrieve_surfaces_template_variables(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.get(self._url("feed-scout/"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        variables = response.json()["template_variables"]
+        self.assertEqual([v["name"] for v in variables], ["feed_table", "default_branch"])
+        self.assertEqual(
+            variables[0], {"name": "feed_table", "prompt": "Warehouse table", "required": True, "default": ""}
+        )
+        self.assertFalse(variables[1]["required"])  # has a default
+
+    def test_install_template_renders_variables(self, _mock_flag) -> None:
+        skill = _create_template_skill(slug="feed-scout")
+        CommunitySkillFile.objects.create(
+            skill=skill, path="references/notes.md", content="Query {{ feed_table }} carefully."
+        )
+
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc", "default_branch": "develop"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on develop.")
+        self.assertEqual(installed.files.get(path="references/notes.md").content, "Query slack_abc carefully.")
+        # The instantiated skill is concrete, not a template.
+        self.assertNotIn("variables", installed.metadata)
+        self.assertEqual(installed.metadata["instantiated_from"], "feed-scout@sha123")
+        self.assertEqual(
+            installed.metadata["variable_bindings"], {"feed_table": "slack_abc", "default_branch": "develop"}
+        )
+
+    def test_install_template_uses_default_when_omitted(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on main.")
+
+    def test_install_template_missing_required_returns_400(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(self._url("feed-scout/install/"), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "variables")
+        self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
+
     def test_vote_toggles_on_and_off(self, _mock_flag) -> None:
         _create_community_skill(slug="web-analytics-triage")
 
@@ -170,3 +247,63 @@ class TestCommunitySkillSync(APIBaseTest):
         result = sync_community_skills_from_github()
         self.assertEqual(result, {"synced": 0, "skipped": 0, "removed": 0})
         self.assertFalse(CommunitySkill.objects.get(slug="keep-me").deleted)
+
+
+class TestSkillTemplateRendering(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("no metadata", None, False),
+            ("empty", {}, False),
+            ("non-list variables", {"variables": "nope"}, False),
+            ("empty list", {"variables": []}, False),
+            ("declared", {"variables": [{"name": "repo"}]}, True),
+        ]
+    )
+    def test_is_template(self, _name, metadata, expected) -> None:
+        self.assertEqual(is_template(metadata), expected)
+
+    def test_parse_skips_malformed_and_dedupes(self) -> None:
+        variables = parse_template_variables(
+            {
+                "variables": [
+                    {"name": "repo"},
+                    {"no_name": 1},
+                    "bad",
+                    {"name": "repo"},
+                    {"name": "branch", "default": "main"},
+                ]
+            }
+        )
+        self.assertEqual([v.name for v in variables], ["repo", "branch"])
+        # Bare declaration defaults to required; a default makes it optional.
+        self.assertTrue(variables[0].required)
+        self.assertFalse(variables[1].required)
+
+    def test_render_substitutes_and_records_bindings(self) -> None:
+        rendered = render_template_skill(
+            metadata={"variables": [{"name": "repo", "required": True}]},
+            body="watch {{ repo }}",
+            files=[{"path": "a.md", "content": "ref {{ repo }}", "content_type": "text/plain"}],
+            supplied={"repo": "posthog/posthog"},
+        )
+        self.assertEqual(rendered.body, "watch posthog/posthog")
+        self.assertEqual(rendered.files[0]["content"], "ref posthog/posthog")
+        self.assertEqual(rendered.bindings, {"repo": "posthog/posthog"})
+
+    def test_render_missing_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                metadata={"variables": [{"name": "repo", "required": True}]},
+                body="watch {{ repo }}",
+                files=[],
+                supplied={},
+            )
+
+    def test_render_unknown_placeholder_raises(self) -> None:
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                metadata={"variables": [{"name": "repo", "required": True}]},
+                body="watch {{ repo }} and {{ undeclared }}",
+                files=[],
+                supplied={"repo": "x"},
+            )

--- a/products/ai_observability/backend/api/test/test_community_skills.py
+++ b/products/ai_observability/backend/api/test/test_community_skills.py
@@ -319,6 +319,16 @@ class TestSkillTemplateRendering(APIBaseTest):
                 supplied={"repo-name": "x"},
             )
 
+    def test_render_allows_braces_inside_supplied_value(self) -> None:
+        # Validation is on the source template, so a value containing literal {{ }} is not re-parsed.
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "snippet", "required": True}]}),
+            body="config: {{ snippet }}",
+            files=[],
+            supplied={"snippet": "{{ not_a_var }}"},
+        )
+        self.assertEqual(rendered.body, "config: {{ not_a_var }}")
+
     def test_render_oversized_output_raises(self) -> None:
         with self.assertRaises(TemplateRenderTooLargeError):
             render_template_skill(

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -151,6 +151,20 @@ export const TrustTierEnumApi = {
 } as const
 
 /**
+ * One declared variable of a templated skill — the schema a client renders a form from.
+ */
+export interface CommunitySkillTemplateVariableApi {
+    /** Variable identifier, substituted for `{{ name }}` in the skill body. */
+    name: string
+    /** Human-readable question shown when collecting a value for this variable. */
+    prompt: string
+    /** Whether a value must be supplied at install time (otherwise it falls back to the default). */
+    is_required: boolean
+    /** Value used when none is supplied. Empty when the variable has no default. */
+    default: string
+}
+
+/**
  * Arbitrary key-value metadata carried from the skill's frontmatter.
  */
 export type CommunitySkillListApiMetadata = { [key: string]: unknown }
@@ -186,6 +200,8 @@ export interface CommunitySkillListApi {
     readonly author_handle: string
     /** Link to the skill's source directory on GitHub. */
     readonly github_url: string
+    /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+    readonly template_variables: readonly CommunitySkillTemplateVariableApi[]
     /** Number of times this skill has been installed into a team. */
     readonly install_count: number
     /** Total number of upvotes this skill has received. */
@@ -254,6 +270,8 @@ export interface CommunitySkillApi {
     readonly github_url: string
     /** Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint. */
     readonly files: readonly CommunitySkillFileManifestApi[]
+    /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+    readonly template_variables: readonly CommunitySkillTemplateVariableApi[]
     /** Number of times this skill has been installed into a team. */
     readonly install_count: number
     /** Total number of upvotes this skill has received. */
@@ -269,12 +287,19 @@ export interface CommunitySkillApi {
     readonly updated_at: string
 }
 
+/**
+ * Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills.
+ */
+export type CommunitySkillInstallApiVariables = { [key: string]: string }
+
 export interface CommunitySkillInstallApi {
     /**
      * Name for the installed skill in your team. Defaults to the community skill's slug.
      * @maxLength 64
      */
     new_name?: string
+    /** Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills. */
+    variables?: CommunitySkillInstallApiVariables
 }
 
 /**

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -17,6 +17,12 @@ export const CommunitySkillsInstallCreateBody = /* @__PURE__ */ zod.object({
         .max(communitySkillsInstallCreateBodyNewNameMax)
         .optional()
         .describe("Name for the installed skill in your team. Defaults to the community skill's slug."),
+    variables: zod
+        .record(zod.string(), zod.string())
+        .optional()
+        .describe(
+            "Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills."
+        ),
 })
 
 export const datasetItemsCreateBodyRefTraceIdMax = 255

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11524,6 +11524,20 @@ export namespace Schemas {
       content_type?: string;
     }
 
+    /**
+     * One declared variable of a templated skill — the schema a client renders a form from.
+     */
+    export interface CommunitySkillTemplateVariable {
+      /** Variable identifier, substituted for `{{ name }}` in the skill body. */
+      name: string;
+      /** Human-readable question shown when collecting a value for this variable. */
+      prompt: string;
+      /** Whether a value must be supplied at install time (otherwise it falls back to the default). */
+      is_required: boolean;
+      /** Value used when none is supplied. Empty when the variable has no default. */
+      default: string;
+    }
+
     export interface CommunitySkill {
       readonly id: string;
       /** Stable identifier matching the skill's directory in the community-skills repo. */
@@ -11556,6 +11570,8 @@ export namespace Schemas {
       readonly github_url: string;
       /** Bundled files manifest (path + content_type only). Fetch full content via the skill detail endpoint. */
       readonly files: readonly CommunitySkillFileManifest[];
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */
@@ -11571,12 +11587,19 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    /**
+     * Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills.
+     */
+    export type CommunitySkillInstallVariables = {[key: string]: string};
+
     export interface CommunitySkillInstall {
       /**
          * Name for the installed skill in your team. Defaults to the community skill's slug.
          * @maxLength 64
          */
       new_name?: string;
+      /** Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills. */
+      variables?: CommunitySkillInstallVariables;
     }
 
     /**
@@ -11615,6 +11638,8 @@ export namespace Schemas {
       readonly author_handle: string;
       /** Link to the skill's source directory on GitHub. */
       readonly github_url: string;
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */


### PR DESCRIPTION
## Problem

Internal scouts and other reusable skills often hardcode a value — a repo, a warehouse table — which stops them being shared. We want to publish such skills as **templates** and let each user instantiate one against their own values, distributed through the same community marketplace we're already building.

Stacked on top of #63425 (community skills marketplace); base branch is that PR's branch, so this diff shows only the templating slice.

## Changes

A community skill is a **template** when its `metadata.variables` declares one or more variables — no new model, no migration, just a convention carried by the existing synced `metadata`. The body and bundled files use `{{ var }}` placeholders that are bound to user-supplied values when the skill is installed into a team.

- **`skill_template_services.py`** (new) — the reusable render core: parse the variable schema (tolerant of malformed synced rows), resolve bindings (defaults + required enforcement), and substitute placeholders. Rendering is deliberately plain `{{ }}` string substitution, **server-side, never a template engine** — a community-published template must not execute logic against tenant data.
- **`install_community_skill`** becomes instantiate for templates: render body + files, drop the variable schema from the copied metadata, and stamp `instantiated_from = <slug>@<source_sha>` + `variable_bindings` provenance. The installed row is a plain `LLMSkill`, so it works identically for PostHog's own agents and for coding agents via the existing store-install flow. Non-template install is unchanged.
- **Serializers** — a typed `template_variables` output field (in both list and detail, so cards can badge templates without a detail fetch) and a `variables` install input.
- **Viewset** — a missing required value or an undeclared placeholder map to `400`s; install analytics records whether the skill was instantiated as a template.

This is the **backend slice of Phase 1**. Still to come before this is user-facing (tracked, not in this PR): `hogli build:openapi` codegen so the frontend client/types pick up `variables` and `template_variables`, the Community-tab template badge + install dialog, and the `metadata.variables` validation gate in the `PostHog/community-skills` repo's `build_registry.py`.

## How did you test this code?

I'm an agent (Claude Code). Automated only:

- `ruff check` + `ruff format` clean on all changed files.
- The pure render logic (`skill_template_services.py`, no Django/DB deps) was executed against every test scenario — substitution, defaults, required enforcement, undeclared-placeholder and missing-required errors, whitespace-variant placeholders — all assertions passed.
- Wrote DB-backed API tests and a `TestSkillTemplateRendering` unit class in `test_community_skills.py`, but **could not run the DB-backed suite in this environment** (no Docker daemon for `APIBaseTest`'s Postgres, and Python 3.13 isn't installable in-sandbox — the same toolchain gap #63425 documents). Run `hogli test products/ai_observability/backend/api/test/test_community_skills.py` in a real env before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @andrewm4894.

Authored with Claude Code. We first researched the existing PostHog skills primitives, the Anthropic Agent Skills spec, and the in-flight community marketplace (#63425), then chose to model templating as a `metadata.variables` convention on the existing `CommunitySkill`/`LLMSkill` rather than a new type — zero schema change, and it rides the marketplace's sync and publish pipelines unchanged. Key deliberate decision: render server-side with plain string substitution instead of a template engine, so a publicly-published template can never execute logic against a tenant's data. Install becomes instantiate only when variables are declared; the non-template path is untouched.

Left intentionally for a follow-up once the toolchain is available: OpenAPI/type codegen and the frontend, to avoid committing frontend code that references not-yet-generated types and reddening CI on generated-types drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9Jp2aj9HSAEJAnRUpnAw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Jp2aj9HSAEJAnRUpnAw5)_