### PR TITLE
feat(insights): series labels and values for quill SQL charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx
@@ -431,4 +431,45 @@ describe('SqlLineGraph', () => {
             expect(tooltip.value('a')).toBe(expected)
         })
     })
+
+    describe('custom series label', () => {
+        const legendText = (): string =>
+            document.querySelector('[data-attr="hog-chart-timeseries-line-legend"]')?.textContent ?? ''
+
+        it('shows the custom display label in the legend, not the column name', async () => {
+            await renderChart({
+                yData: [ySeries('mrr_usd', [1, 2, 3], { display: { label: 'Monthly revenue' } })],
+                chartSettings: { showLegend: true },
+            })
+
+            await waitFor(() => expect(legendText()).toContain('Monthly revenue'))
+            expect(legendText()).not.toContain('mrr_usd')
+        })
+    })
+
+    describe('show values on series', () => {
+        const waitForValueLabels = async (): Promise<string[]> => {
+            await waitFor(() => expect(getHogChart().valueLabels().length).toBeGreaterThan(0))
+            return getHogChart()
+                .valueLabels()
+                .map((label) => label.text)
+        }
+
+        it('draws a label per point formatted with the column settings', async () => {
+            await renderChart({
+                yData: [ySeries('revenue', [1200, 1400, 1300], { formatting: { prefix: '$' } })],
+                chartSettings: { showValuesOnSeries: true },
+            })
+
+            const labels = await waitForValueLabels()
+            expect(labels).toContain('$1200')
+            expect(labels).toContain('$1400')
+        })
+
+        it('draws no value labels when showValuesOnSeries is off', async () => {
+            await renderChart({ yData: [ySeries('revenue', [1200, 1400, 1300])] })
+
+            expect(getHogChart().valueLabels()).toHaveLength(0)
+        })
+    })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -1,4 +1,10 @@
-import { type TooltipContext, type TrendLineConfig, type YAxisConfig } from '@posthog/quill-charts'
+import {
+    type TooltipContext,
+    type TrendLineConfig,
+    type ValueLabelContext,
+    type ValueLabelsConfig,
+    type YAxisConfig,
+} from '@posthog/quill-charts'
 
 import { compactNumber } from 'lib/utils/numbers'
 
@@ -351,6 +357,27 @@ describe('sqlLineGraphAdapter', () => {
             expect(series.key).toBe('chrome')
         })
 
+        it('honors a custom display label, falling back to the column name', () => {
+            const [custom, fallback] = buildSeries(
+                [ySeries('revenue', [1], { display: { label: 'Total revenue' } }), ySeries('count', [2])],
+                ChartDisplayType.ActionsLineGraph
+            )
+            expect(custom.label).toBe('Total revenue')
+            expect(fallback.label).toBe('count')
+        })
+
+        it('honors a custom display label on a breakdown series, falling back to the breakdown value', () => {
+            const [custom, fallback] = buildSeries(
+                [
+                    breakdownSeries('chrome', [1], { display: { label: 'Chrome browser' } }),
+                    breakdownSeries('safari', [2]),
+                ],
+                ChartDisplayType.ActionsLineGraph
+            )
+            expect(custom.label).toBe('Chrome browser')
+            expect(fallback.label).toBe('safari')
+        })
+
         it('derives each series quill type from its displayType', () => {
             const [bar, line, area] = buildSeries(
                 [
@@ -621,6 +648,33 @@ describe('sqlLineGraphAdapter', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC', goalLines })
             expect(config.goalLines).toHaveLength(1)
             expect(config.goalLines?.[0]).toMatchObject({ value: 100, label: 'Target' })
+        })
+
+        it('omits value labels unless showValuesOnSeries is set', () => {
+            const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC' })
+            expect(config.valueLabels).toBeUndefined()
+        })
+
+        it('formats each value label from its own series column when showValuesOnSeries is set', () => {
+            const config = buildLineChartConfig({
+                xData: dateXData,
+                chartSettings: { showValuesOnSeries: true },
+                timezone: 'UTC',
+                ySeriesData: [
+                    ySeries('revenue', [1200], { formatting: { prefix: '$' } }),
+                    ySeries('conversion', [12], { formatting: { suffix: '%' } }),
+                ],
+            })
+            expect(config.valueLabels).toEqual(expect.objectContaining({ formatter: expect.any(Function) }))
+            const formatter = (config.valueLabels as ValueLabelsConfig).formatter!
+            const ctx = (rawValue: number): ValueLabelContext => ({
+                rawValue,
+                bandValues: [rawValue],
+                isPercent: false,
+            })
+            // The label reads context.rawValue (not the percent-fraction `value` arg) with each series' settings.
+            expect(formatter(0, 0, 0, ctx(1200))).toBe('$1200')
+            expect(formatter(0, 1, 0, ctx(12))).toBe('12%')
         })
 
         it.each<[string, SqlLineYSeries[], TrendLineConfig[]]>([

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -9,6 +9,7 @@ import {
     type TooltipConfig,
     type TooltipContext,
     type TrendLineConfig,
+    type ValueLabelsConfig,
     type XAxisConfig,
     type YAxisConfig,
     createXAxisTickCallback,
@@ -78,7 +79,10 @@ export function hasMixedSeriesTypes(
     return false
 }
 
-const getSeriesLabel = (series: SqlLineYSeries): string => ('name' in series ? series.name : series.column.name)
+/** Honors a column's custom display label, falling back to the breakdown value / column name —
+ *  matches the legacy renderer (`LineGraph.tsx`). `||` so a blank label falls through. */
+const getSeriesLabel = (series: SqlLineYSeries): string =>
+    series.settings?.display?.label || ('name' in series ? series.name : series.column.name)
 
 const getSeriesKey = (series: SqlLineYSeries, index: number): string =>
     'breakdownValue' in series ? series.breakdownValue : `${series.column.name}-${index}`
@@ -348,6 +352,26 @@ function buildLegendConfig(chartSettings: ChartSettings): ChartLegendConfig {
     return { show: chartSettings.showLegend ?? false, position: 'top', interactive: true }
 }
 
+/**
+ * "Show values on series" — each on-series label formats with its own column's settings, reusing the
+ * tooltip's {@link formatSqlSeriesValue} path so labels read identically to the tooltip. `seriesIndex`
+ * aligns with `ySeriesData` because {@link buildSeries} preserves order and quill keeps hidden series
+ * in place (excluded, not removed). `context.rawValue` is the unscaled value (the `value` arg becomes a
+ * 0–1 fraction in percent-stacked bars), so labels always show the real number.
+ */
+function buildValueLabelsConfig(
+    chartSettings: ChartSettings,
+    ySeriesData: SqlLineYSeries[] | null | undefined
+): ValueLabelsConfig | undefined {
+    if (!chartSettings.showValuesOnSeries) {
+        return undefined
+    }
+    return {
+        formatter: (_value, seriesIndex, _dataIndex, context) =>
+            formatSqlSeriesValue(context.rawValue, ySeriesData?.[seriesIndex]?.settings),
+    }
+}
+
 export function buildLineChartConfig({
     xData,
     chartSettings,
@@ -379,6 +403,7 @@ export function buildLineChartConfig({
         goalLines: schemaGoalLinesToConfigs(goalLines),
         trendLines: buildTrendLineConfigs(ySeriesData),
         legend: buildLegendConfig(chartSettings),
+        valueLabels: buildValueLabelsConfig(chartSettings, ySeriesData),
         tooltip: buildSqlTooltipConfig(chartSettings, ySeriesData),
     }
 }
@@ -406,6 +431,7 @@ export function buildBarChartConfig({
         goalLines: schemaGoalLinesToConfigs(goalLines),
         barLayout,
         legend: buildLegendConfig(chartSettings),
+        valueLabels: buildValueLabelsConfig(chartSettings, ySeriesData),
         tooltip: { enabled: true, pinnable: true },
     }
 }
@@ -428,6 +454,7 @@ export function buildComboChartConfig({
         goalLines: schemaGoalLinesToConfigs(goalLines),
         barLayout: comboBarLayoutForDisplay(visualizationType),
         legend: buildLegendConfig(chartSettings),
+        valueLabels: buildValueLabelsConfig(chartSettings, ySeriesData),
         tooltip: buildSqlTooltipConfig(chartSettings, ySeriesData),
     }
 }


### PR DESCRIPTION
## Problem

Follow-up to #65004 (stacked on it). Two more SQL chart display options the editor exposes were still missing from the quill-charts path: custom series labels and "show values on series".

## Changes

- **Custom series label.** `getSeriesLabel` now honors `display.label`, falling back to the breakdown value / column name — matching the legacy renderer. Flows into the legend and tooltip.
- **Show values on series.** `chartSettings.showValuesOnSeries` wires quill's `valueLabels` onto the line and bar configs. Each on-series label formats from its own column's settings via the same `formatSqlSeriesValue` path the tooltip uses, so labels read identically to the tooltip. `seriesIndex` aligns with the source series order; `context.rawValue` is used so percent-stacked bars still label the real value rather than the 0–1 fraction.

App-only — no quill-charts package changes.

## How did you test this code?

I'm an agent (PostHog Code); I did **not** do manual testing. Automated tests only:

- `sqlLineGraphAdapter.test.ts` — custom-label resolution (regular + breakdown series) and per-series value-label formatting from `showValuesOnSeries`.
- `SqlLineGraph.test.tsx` — rendered-level assertions via the `getHogChart` accessor: the custom label shows in the legend (not the column name), and per-point value labels are present when enabled / absent when off.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Code agent; stacked on #65004. No repo skills were triggered.

This is the second PR in the SQL-chart display-option stack. Remaining items not yet done: axis borders (needs quill canvas border/grid decoupling), show-nulls-as-zero, and per-breakdown colors.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
