### PR TITLE
fix(phai): correct sandbox thinking loader visibility and style

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -29,7 +29,6 @@ import {
     LemonDivider,
     LemonInput,
     LemonSkeleton,
-    Spinner,
     Tooltip,
 } from '@posthog/lemon-ui'
 
@@ -244,10 +243,9 @@ function SandboxThread(): JSX.Element {
                 }
                 return null
             })}
-            {streamPhase === 'provisioning' && !hasActiveProgressItem && (
-                <SandboxProvisioningIndicator progress={currentProgress} />
+            {streamPhase === 'thinking' && !hasActiveProgressItem && (
+                <SandboxThinkingIndicator progress={currentProgress} />
             )}
-            {isThinking && !hasActiveProgressItem && <SandboxThinkingIndicator progress={currentProgress} />}
             {/* Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking. */}
             {!isThinking && runArtifacts.prUrl && (
                 <SandboxPullRequestCard prUrl={runArtifacts.prUrl} branch={runArtifacts.branch} />
@@ -304,23 +302,6 @@ function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element
 }
 
 /**
- * Pre-first-message status line for sandbox conversations. While the workflow provisions the sandbox
- * and starts the agent (before `_posthog/run_started`), the thinking indicator is gated off — so this
- * surfaces the already-ingested `_posthog/progress` label with a setup-oriented fallback.
- */
-function SandboxProvisioningIndicator({ progress }: { progress: string | null }): JSX.Element {
-    const message = progress?.trim() ? progress : 'Setting up your workspace…'
-    return (
-        <MessageTemplate type="ai">
-            <div className="flex items-center gap-2 text-muted">
-                <Spinner className="size-4" />
-                <span>{message}</span>
-            </div>
-        </MessageTemplate>
-    )
-}
-
-/**
  * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
  * `_posthog/progress` message when present, otherwise the canned thinking rotation.
  */
@@ -328,14 +309,9 @@ function SandboxThinkingIndicator({ progress }: { progress: string | null }): JS
     // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
     const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
     const message = progress?.trim() ? progress : fallbackMessage
-    return (
-        <MessageTemplate type="ai">
-            <div className="flex items-center gap-2 text-muted">
-                <Spinner className="size-4" />
-                <span>{message}</span>
-            </div>
-        </MessageTemplate>
-    )
+    // Match the LangGraph loader: a bubble-free reasoning line (muted brain icon + muted text),
+    // static (no shimmer), via the shared Activity primitive — not a MessageTemplate bubble.
+    return <ReasoningAnswer content={message} id="sandbox-thinking" completed={false} showCompletionIcon={false} />
 }
 
 export function Thread({ className }: { className?: string }): JSX.Element | null {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -1263,11 +1263,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             },
         ],
         /**
-         * Stream lifecycle phase for the pre-first-message status line. `provisioning` = the stream
-         * is opening or open but the agent hasn't started yet (the workflow is still setting up the
-         * sandbox and emitting `_posthog/progress`), so the thinking indicator's `run_started` gate
-         * would otherwise hide that progress; `thinking` = the agent is working a turn (mirrors
-         * `isThinking`); `idle` otherwise (terminal, errored, or not yet connecting).
+         * Stream lifecycle phase gating the bottom-of-thread thinking indicator. `provisioning` = the
+         * cold-boot window — the stream is opening or open but the agent hasn't started yet (the
+         * workflow is still setting up the sandbox); it holds the gerund loader off until `run_started`
+         * so it can't show before a turn begins. Boot UX is surfaced by `_posthog/progress` items, not
+         * a dedicated indicator. `thinking` = the agent is working a turn (mirrors `isThinking`), and is
+         * what `SandboxThread` gates the gerund loader on; `idle` otherwise (terminal, errored, or not
+         * yet connecting).
          */
         streamPhase: [
             (s) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus],

--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -36,6 +36,7 @@ export const THINKING_MESSAGES = [
     'Swizzling', // techy weirdness
     'Grokking', // deep understanding
     'Hedging', // hedgehog pun
+    'Posthogging', // brand pun
     'Scheming', // clever planning
     'Unfurling', // opening up ideas
     'Puzzling', // solving something tricky

--- a/frontend/src/scenes/max/utils/thinkingMessages.ts
+++ b/frontend/src/scenes/max/utils/thinkingMessages.ts
@@ -37,6 +37,8 @@ export const THINKING_MESSAGES = [
     'Grokking', // deep understanding
     'Hedging', // hedgehog pun
     'Posthogging', // brand pun
+    'Self-driving', // autonomy pun
+    'Signaling', // signals pun
     'Scheming', // clever planning
     'Unfurling', // opening up ideas
     'Puzzling', // solving something tricky


### PR DESCRIPTION
## Problem

Sandbox-runtime PostHog AI conversations render a bottom-of-thread "thinking" loader — the cycling gerund verbs ("Booping…", "Crunching…"). Two problems:

1. **Wrong visibility window.** The loader was gated on the broad `isThinking` selector, which intentionally also lights during the pre-`run_started` cold-boot window. So the gerund loader could appear before a turn actually started, and could even render at the same time as the separate "Setting up your workspace…" provisioning bubble.
2. **Wrong style.** It was a `MessageTemplate` "ai" bubble with a `Spinner`, instead of matching the LangGraph loader, which is bubble-free: a muted brain icon + muted gerund text, static.

The separate `SandboxProvisioningIndicator` ("Setting up your workspace…") is also redundant. The sandbox boot window is already rendered by the progress-item system: the `execute_sandbox` workflow emits `_posthog/progress` frames at boot ("Setting up sandbox", "Starting agent"), which fold into progress thread items and render bubble-free via `SandboxProgressItem`. The provisioning indicator was only a fallback for the micro-gap before the first progress frame.

## Changes

All rendering changes are in `Thread.tsx` (consuming existing selectors — no new streaming logic, per `scenes/max/CLAUDE.md`); plus one doc-comment refresh in `sandboxStreamLogic.ts`. No selector logic changed, so existing `isThinking`/`streamPhase` tests stay green.

- **Gate the gerund loader on `streamPhase === 'thinking'`** instead of raw `isThinking`. `streamPhase === 'thinking'` already means "isThinking AND past the cold-boot/provisioning window AND not terminal/errored" — i.e. exactly "the turn has started and not finished." This mirrors the symmetry the old `streamPhase === 'provisioning'` branch already had.
- **Restyle `SandboxThinkingIndicator` to match the LangGraph loader** — render through the shared local `ReasoningAnswer` component (muted `IconBrain` + muted text via the Activity primitive, static, no shimmer) instead of a `MessageTemplate` bubble + `Spinner`. A 1:1 match with the LangGraph thread's loader call site.
- **Remove the redundant `SandboxProvisioningIndicator`** ("Setting up your workspace…"). The boot window stays covered by `SandboxProgressItem` progress frames.
- Drop the now-unused `Spinner` import.
- Refresh the `streamPhase` doc comment to document `provisioning` as the cold-boot phase that gates the gerund loader off until `run_started`, with boot UX surfaced by progress items.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:

- `pnpm --filter=@posthog/frontend typescript:check` — passed.
- `hogli test frontend/src/scenes/max/sandboxStreamLogic.test.ts` — 131/131 passed. The `isThinking` and `streamPhase` selectors are unchanged, so their existing tests (including the cold-boot "queued window" coverage) stay green.
- oxlint + oxfmt on the two changed files — clean.

I did not run the live app or capture screenshots. Worth a reviewer's eye in the running app: during boot only the progress steps render (no gerund loader, no "Setting up your workspace…" bubble); once the turn starts the gerund loader appears bubble-free, matching the LangGraph thread; and it disappears on turn completion/error/cancel.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Opus 4.8) from a detailed plan provided by the human DRI.
- No repo skills were required: the change is confined to the sandbox thread renderer and consumes existing selectors. Per `scenes/max/CLAUDE.md`, streaming/runtime logic stays in `sandboxStreamLogic` and components only consume selectors — so no selector, wire-parsing, or SSE changes were made.
- Decision notes: gated on the existing `streamPhase === 'thinking'` rather than adding a new selector; reused the local `ReasoningAnswer` component (already used by the sandbox `assistant_thought` path and the LangGraph loader) instead of building a new bubble-free presenter, which keeps the loader visually identical to LangGraph for free.
