### PR TITLE
feat(llma): community skills catalog models + ingest

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -259,6 +259,8 @@ def get_scoped_models() -> tuple[dict[str, set[str]], set[str], set[str], set[st
         "PromptSequence",
         "UserPromptState",
         # --- Global catalogs ---
+        "CommunitySkill",  # instance-global community skills catalog, synced from GitHub
+        "CommunitySkillFile",  # bundled files of a CommunitySkill (scoped via the catalog row)
         "HogFunctionTemplate",
         "MCPServer",
         # --- Special (has source_team + destination_team, not a plain team) ---

--- a/.semgrep/rules/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/idor-team-scoped-models.yaml
@@ -826,7 +826,8 @@ rules:
                 metavariable: $MODEL
                 regex: |
                     (?x)(
-                        DashboardPrivilege
+                        CommunitySkillVote
+                        |DashboardPrivilege
                         |PersonalAPIKey
                         |ScoreDefinitionVersion
                         |SignalUserAutonomyConfig

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -87,6 +87,7 @@ from products.feature_flags.backend.tasks import (
 )
 from products.logs.backend.facade.tasks import logs_alert_events_cleanup_task
 from products.reminders.backend.tasks import process_due_reminders
+from products.skills.backend.tasks import sync_community_skills
 from products.streamlit_apps.backend.facade.api import (
     auto_restart_crashed_streamlit_sandboxes,
     cleanup_deleted_streamlit_app_zips,
@@ -381,6 +382,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="4", minute="15"),
         send_ai_observability_usage_reports.s(),
         name="send llm analytics usage reports",
+    )
+
+    # Sync the community skills catalog from GitHub hourly
+    sender.add_periodic_task(
+        crontab(minute="20"),
+        sync_community_skills.s(),
+        name="sync community skills catalog",
     )
 
     # Send HogFunctions daily digest at 9:30 AM UTC (good for US and EU)

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -385,7 +385,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Sync the community skills catalog from GitHub hourly
-    sender.add_periodic_task(
+    add_periodic_task_with_expiry(
+        sender,
         crontab(minute="20"),
         sync_community_skills.s(),
         name="sync community skills catalog",

--- a/products/skills/backend/api/community_skill_sync.py
+++ b/products/skills/backend/api/community_skill_sync.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+from django.db import transaction
+from django.utils import timezone
+
+import requests
+import structlog
+
+from ..models.community_skills import CommunitySkill, CommunitySkillFile
+
+logger = structlog.get_logger(__name__)
+
+COMMUNITY_SKILLS_REPO = "PostHog/community-skills"
+COMMUNITY_SKILLS_BRANCH = "main"
+COMMUNITY_SKILLS_REGISTRY_URL = (
+    f"https://raw.githubusercontent.com/{COMMUNITY_SKILLS_REPO}/{COMMUNITY_SKILLS_BRANCH}/registry.json"
+)
+COMMUNITY_SKILLS_SYNC_TIMEOUT_SECONDS = 30
+
+
+def _upsert_community_skill(entry: dict[str, Any]) -> bool:
+    """Upsert a single registry entry. Returns True if the row was created or updated."""
+    slug = entry["slug"]
+    source_sha = entry.get("source_sha", "")
+
+    existing = CommunitySkill.objects.filter(slug=slug).first()
+    if existing is not None and existing.source_sha and existing.source_sha == source_sha and not existing.deleted:
+        return False
+
+    defaults: dict[str, Any] = {
+        "name": entry["name"],
+        "description": entry["description"],
+        "body": entry.get("body", ""),
+        "license": entry.get("license", ""),
+        "compatibility": entry.get("compatibility", ""),
+        "allowed_tools": entry.get("allowed_tools", []),
+        "metadata": entry.get("metadata", {}),
+        "tags": entry.get("tags", []),
+        "trust_tier": entry.get("trust_tier", "community"),
+        "author_handle": entry.get("author_handle", ""),
+        "github_url": entry.get("github_url", ""),
+        "source_sha": source_sha,
+        "deleted": False,
+    }
+    if entry.get("published_at"):
+        defaults["published_at"] = entry["published_at"]
+
+    with transaction.atomic():
+        skill, _ = CommunitySkill.objects.update_or_create(slug=slug, defaults=defaults)
+        if skill.published_at is None:
+            CommunitySkill.objects.filter(pk=skill.pk).update(published_at=timezone.now())
+
+        skill.files.all().delete()
+        files = entry.get("files", [])
+        if files:
+            CommunitySkillFile.objects.bulk_create(
+                [
+                    CommunitySkillFile(
+                        skill=skill,
+                        path=f["path"],
+                        content=f.get("content", ""),
+                        content_type=f.get("content_type", "text/plain"),
+                    )
+                    for f in files
+                ]
+            )
+    return True
+
+
+def sync_community_skills_from_github(registry_url: str = COMMUNITY_SKILLS_REGISTRY_URL) -> dict[str, int]:
+    """Pull the community-skills registry and reconcile the local read-model.
+
+    The registry.json is generated in the repo's CI and embeds each skill's content, so a
+    single fetch is enough. Skills missing from the registry are soft-deleted. Returns a
+    summary of {synced, skipped, removed} counts.
+    """
+    response = requests.get(registry_url, timeout=COMMUNITY_SKILLS_SYNC_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    payload = response.json()
+    entries = payload.get("skills", [])
+
+    # Fail closed on malformed/empty payloads: a missing/empty `skills` key (bad generated
+    # registry, proxy error, rate-limit body) would otherwise soft-delete the entire catalog.
+    if not isinstance(entries, list):
+        raise ValueError("Registry payload 'skills' must be a list")
+    if not entries:
+        logger.warning("community_skills_sync_skipped_empty_registry")
+        return {"synced": 0, "skipped": 0, "removed": 0}
+
+    synced = 0
+    skipped = 0
+    seen_slugs: set[str] = set()
+    for entry in entries:
+        slug = entry.get("slug")
+        if not slug:
+            continue
+        seen_slugs.add(slug)
+        if _upsert_community_skill(entry):
+            synced += 1
+        else:
+            skipped += 1
+
+    removed = CommunitySkill.objects.filter(deleted=False).exclude(slug__in=seen_slugs).update(deleted=True)
+
+    logger.info("community_skills_synced", synced=synced, skipped=skipped, removed=removed, total=len(entries))
+    return {"synced": synced, "skipped": skipped, "removed": removed}

--- a/products/skills/backend/api/community_skill_sync.py
+++ b/products/skills/backend/api/community_skill_sync.py
@@ -7,6 +7,7 @@ import requests
 import structlog
 
 from ..models.community_skills import CommunitySkill, CommunitySkillFile
+from .skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES, MAX_SKILL_FILE_COUNT
 
 logger = structlog.get_logger(__name__)
 
@@ -18,10 +19,30 @@ COMMUNITY_SKILLS_REGISTRY_URL = (
 COMMUNITY_SKILLS_SYNC_TIMEOUT_SECONDS = 30
 
 
+def _validate_entry_within_caps(entry: dict[str, Any]) -> None:
+    """Reject oversized registry entries before persisting, mirroring the skill import caps.
+
+    The registry is built in a review-gated repo, but the same body/file caps the normal
+    import path enforces are cheap insurance against one bad entry bloating Postgres.
+    """
+    body = entry.get("body", "") or ""
+    if len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+        raise ValueError(f"body exceeds the {MAX_SKILL_BODY_BYTES} byte limit")
+
+    files = entry.get("files", []) or []
+    if len(files) > MAX_SKILL_FILE_COUNT:
+        raise ValueError(f"has more than {MAX_SKILL_FILE_COUNT} files")
+    for f in files:
+        content = f.get("content", "") or ""
+        if len(content.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+            raise ValueError(f"file '{f.get('path')}' exceeds the {MAX_SKILL_FILE_BYTES} byte limit")
+
+
 def _upsert_community_skill(entry: dict[str, Any]) -> bool:
     """Upsert a single registry entry. Returns True if the row was created or updated."""
     slug = entry["slug"]
     source_sha = entry.get("source_sha", "")
+    _validate_entry_within_caps(entry)
 
     existing = CommunitySkill.objects.filter(slug=slug).first()
     if existing is not None and existing.source_sha and existing.source_sha == source_sha and not existing.deleted:
@@ -91,14 +112,32 @@ def sync_community_skills_from_github(registry_url: str = COMMUNITY_SKILLS_REGIS
     skipped = 0
     seen_slugs: set[str] = set()
     for entry in entries:
+        if not isinstance(entry, dict):
+            continue
         slug = entry.get("slug")
         if not slug:
             continue
+        # Mark the slug seen before upserting so a malformed entry can't soft-delete the
+        # existing row for a skill that's still present in the registry.
         seen_slugs.add(slug)
-        if _upsert_community_skill(entry):
+        try:
+            created_or_updated = _upsert_community_skill(entry)
+        except (KeyError, ValueError, TypeError):
+            # One bad entry (missing required field, oversized payload) must not abort the
+            # whole loop or skip the soft-delete reconciliation below.
+            logger.warning("community_skills_sync_skipped_invalid_entry", slug=slug, exc_info=True)
+            skipped += 1
+            continue
+        if created_or_updated:
             synced += 1
         else:
             skipped += 1
+
+    # Fail-safe: a non-empty registry that parsed into zero valid slugs (schema change, generator
+    # bug, every entry malformed) must not soft-delete the entire catalog — skip reconciliation.
+    if not seen_slugs:
+        logger.warning("community_skills_sync_skipped_no_valid_slugs", entry_count=len(entries))
+        return {"synced": synced, "skipped": skipped, "removed": 0}
 
     removed = CommunitySkill.objects.filter(deleted=False).exclude(slug__in=seen_slugs).update(deleted=True)
 

--- a/products/skills/backend/api/test/test_community_skill_sync.py
+++ b/products/skills/backend/api/test/test_community_skill_sync.py
@@ -1,0 +1,88 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from ...models.community_skills import CommunitySkill
+from ..community_skill_sync import sync_community_skills_from_github
+
+
+def _create_community_skill(
+    *,
+    slug: str = "web-analytics-triage",
+    name: str = "Web analytics triage",
+    trust_tier: str = "official",
+    install_count: int = 0,
+    deleted: bool = False,
+) -> CommunitySkill:
+    return CommunitySkill.objects.create(
+        slug=slug,
+        name=name,
+        description="Investigate a change in web traffic.",
+        body="# Triage\nDo the thing.",
+        trust_tier=trust_tier,
+        tags=["web-analytics"],
+        install_count=install_count,
+        deleted=deleted,
+    )
+
+
+class TestCommunitySkillSync(APIBaseTest):
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_upserts_and_soft_deletes_missing(self, mock_get) -> None:
+        _create_community_skill(slug="stale-skill", install_count=3)
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "version": 1,
+            "skills": [
+                {
+                    "slug": "fresh-skill",
+                    "name": "Fresh skill",
+                    "description": "New one",
+                    "body": "# Fresh",
+                    "trust_tier": "community",
+                    "source_sha": "abc123",
+                    "files": [{"path": "ref.md", "content": "x"}],
+                }
+            ],
+        }
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 1, "skipped": 0, "removed": 1})
+
+        fresh = CommunitySkill.objects.get(slug="fresh-skill")
+        self.assertEqual(fresh.files.count(), 1)
+        self.assertFalse(fresh.deleted)
+        self.assertIsNotNone(fresh.published_at)
+
+        self.assertTrue(CommunitySkill.objects.get(slug="stale-skill").deleted)
+
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_skips_unchanged_sha(self, mock_get) -> None:
+        existing = _create_community_skill(slug="web-analytics-triage")
+        CommunitySkill.objects.filter(pk=existing.pk).update(source_sha="same-sha")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "skills": [
+                {
+                    "slug": "web-analytics-triage",
+                    "name": "Web analytics triage",
+                    "description": "Investigate a change in web traffic.",
+                    "source_sha": "same-sha",
+                }
+            ],
+        }
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 1, "removed": 0})
+
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_empty_registry_does_not_wipe_catalog(self, mock_get) -> None:
+        _create_community_skill(slug="keep-me")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {"skills": []}
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 0, "removed": 0})
+        self.assertFalse(CommunitySkill.objects.get(slug="keep-me").deleted)

--- a/products/skills/backend/api/test/test_community_skill_sync.py
+++ b/products/skills/backend/api/test/test_community_skill_sync.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from ...models.community_skills import CommunitySkill
 from ..community_skill_sync import sync_community_skills_from_github
+from ..skill_services import MAX_SKILL_BODY_BYTES
 
 
 def _create_community_skill(
@@ -86,3 +87,54 @@ class TestCommunitySkillSync(APIBaseTest):
         result = sync_community_skills_from_github()
         self.assertEqual(result, {"synced": 0, "skipped": 0, "removed": 0})
         self.assertFalse(CommunitySkill.objects.get(slug="keep-me").deleted)
+
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_skips_malformed_entry_but_still_reconciles(self, mock_get) -> None:
+        _create_community_skill(slug="stale-skill")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "skills": [
+                {"slug": "fresh-skill", "name": "Fresh skill", "description": "New one", "body": "# Fresh"},
+                {"slug": "bad-skill"},  # missing required name/description
+            ],
+        }
+
+        # One bad entry must not abort the loop or block the soft-delete of stale-skill.
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 1, "skipped": 1, "removed": 1})
+        self.assertTrue(CommunitySkill.objects.filter(slug="fresh-skill", deleted=False).exists())
+        self.assertFalse(CommunitySkill.objects.filter(slug="bad-skill").exists())
+        self.assertTrue(CommunitySkill.objects.get(slug="stale-skill").deleted)
+
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_does_not_wipe_catalog_when_no_valid_slugs(self, mock_get) -> None:
+        _create_community_skill(slug="keep-me")
+
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "skills": [{"name": "no slug here"}, {"foo": "bar"}],
+        }
+
+        # Non-empty registry that parses to zero valid slugs must not soft-delete everything.
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 0, "removed": 0})
+        self.assertFalse(CommunitySkill.objects.get(slug="keep-me").deleted)
+
+    @patch("products.skills.backend.api.community_skill_sync.requests.get")
+    def test_sync_skips_oversized_entry(self, mock_get) -> None:
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.json.return_value = {
+            "skills": [
+                {
+                    "slug": "huge-skill",
+                    "name": "Huge skill",
+                    "description": "Too big",
+                    "body": "x" * (MAX_SKILL_BODY_BYTES + 1),
+                }
+            ],
+        }
+
+        result = sync_community_skills_from_github()
+        self.assertEqual(result, {"synced": 0, "skipped": 1, "removed": 0})
+        self.assertFalse(CommunitySkill.objects.filter(slug="huge-skill").exists())

--- a/products/skills/backend/migrations/0004_communityskill.py
+++ b/products/skills/backend/migrations/0004_communityskill.py
@@ -1,0 +1,131 @@
+import django.utils.timezone
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("skills", "0003_backfill_scout_category"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CommunitySkill",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("slug", models.CharField(max_length=64, unique=True)),
+                ("name", models.CharField(max_length=64)),
+                ("description", models.CharField(max_length=4096)),
+                ("body", models.TextField()),
+                ("license", models.CharField(blank=True, default="", max_length=255)),
+                ("compatibility", models.CharField(blank=True, default="", max_length=500)),
+                ("allowed_tools", models.JSONField(blank=True, default=list)),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                ("tags", models.JSONField(blank=True, default=list)),
+                (
+                    "trust_tier",
+                    models.CharField(
+                        choices=[
+                            ("official", "Official"),
+                            ("verified", "Verified"),
+                            ("community", "Community"),
+                        ],
+                        default="community",
+                        max_length=20,
+                    ),
+                ),
+                ("author_handle", models.CharField(blank=True, default="", max_length=255)),
+                ("github_url", models.CharField(blank=True, default="", max_length=8201)),
+                ("source_sha", models.CharField(blank=True, default="", max_length=64)),
+                ("install_count", models.PositiveIntegerField(default=0)),
+                ("published_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("deleted", models.BooleanField(default=False)),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskill",
+            },
+        ),
+        migrations.CreateModel(
+            name="CommunitySkillFile",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("path", models.CharField(max_length=500)),
+                ("content", models.TextField()),
+                ("content_type", models.CharField(default="text/plain", max_length=100)),
+                (
+                    "skill",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="files",
+                        to="skills.communityskill",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskillfile",
+            },
+        ),
+        migrations.CreateModel(
+            name="CommunitySkillVote",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "skill",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="votes",
+                        to="skills.communityskill",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "llm_analytics_communityskillvote",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="communityskillfile",
+            constraint=models.UniqueConstraint(fields=("skill", "path"), name="unique_community_skill_file_path"),
+        ),
+        migrations.AddConstraint(
+            model_name="communityskillvote",
+            constraint=models.UniqueConstraint(fields=("skill", "user"), name="unique_community_skill_vote_per_user"),
+        ),
+    ]

--- a/products/skills/backend/migrations/max_migration.txt
+++ b/products/skills/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_backfill_scout_category
+0004_communityskill

--- a/products/skills/backend/models/__init__.py
+++ b/products/skills/backend/models/__init__.py
@@ -1,3 +1,11 @@
+from .community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier, CommunitySkillVote
 from .skills import LLMSkill, LLMSkillFile
 
-__all__ = ["LLMSkill", "LLMSkillFile"]
+__all__ = [
+    "CommunitySkill",
+    "CommunitySkillFile",
+    "CommunitySkillTrustTier",
+    "CommunitySkillVote",
+    "LLMSkill",
+    "LLMSkillFile",
+]

--- a/products/skills/backend/models/community_skills.py
+++ b/products/skills/backend/models/community_skills.py
@@ -1,0 +1,89 @@
+from django.db import models
+from django.utils import timezone
+
+from posthog.models.utils import UUIDModel
+
+
+class CommunitySkillTrustTier(models.TextChoices):
+    OFFICIAL = "official", "Official"
+    VERIFIED = "verified", "Verified"
+    COMMUNITY = "community", "Community"
+
+
+class CommunitySkill(UUIDModel):
+    """Instance-global catalog of community-shared agent skills.
+
+    The source of truth for skill content is the PostHog/community-skills GitHub repo;
+    rows here are a synced read-model that powers in-app discovery, search, ranking, and
+    install. This model is deliberately NOT team-scoped — it is shared catalog data (the
+    same way DashboardTemplate GLOBAL templates are), so it has no team_id by design.
+    Installing a community skill copies it into a team as a regular LLMSkill.
+    """
+
+    class Meta:
+        db_table = "llm_analytics_communityskill"
+
+    # The repo directory name — the stable, human-readable identifier used in URLs.
+    slug = models.CharField(max_length=64, unique=True)
+
+    # Mirrors the Agent Skills spec fields carried by LLMSkill.
+    name = models.CharField(max_length=64)
+    description = models.CharField(max_length=4096)
+    body = models.TextField()
+    license = models.CharField(max_length=255, blank=True, default="")
+    compatibility = models.CharField(max_length=500, blank=True, default="")
+    allowed_tools = models.JSONField(blank=True, default=list)
+    metadata = models.JSONField(blank=True, default=dict)
+
+    # Marketplace fields.
+    tags = models.JSONField(blank=True, default=list)
+    trust_tier = models.CharField(
+        max_length=20,
+        choices=CommunitySkillTrustTier.choices,
+        default=CommunitySkillTrustTier.COMMUNITY,
+    )
+    author_handle = models.CharField(max_length=255, blank=True, default="")
+    github_url = models.CharField(max_length=8201, blank=True, default="")
+    # Commit SHA of the repo state this row was last synced from — lets the sync job skip unchanged skills.
+    source_sha = models.CharField(max_length=64, blank=True, default="")
+    # Denormalized install counter, incremented on each install. Strongest popularity signal.
+    install_count = models.PositiveIntegerField(default=0)
+
+    published_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+    # Soft-delete for skills removed from the repo, so install history and votes survive.
+    deleted = models.BooleanField(default=False)
+
+
+class CommunitySkillFile(UUIDModel):
+    class Meta:
+        db_table = "llm_analytics_communityskillfile"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["skill", "path"],
+                name="unique_community_skill_file_path",
+            ),
+        ]
+
+    skill = models.ForeignKey(CommunitySkill, on_delete=models.CASCADE, related_name="files")
+    path = models.CharField(max_length=500)
+    content = models.TextField()
+    content_type = models.CharField(max_length=100, default="text/plain")
+
+
+class CommunitySkillVote(UUIDModel):
+    """A single user's upvote of a community skill. User-scoped, not tenant data."""
+
+    class Meta:
+        db_table = "llm_analytics_communityskillvote"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["skill", "user"],
+                name="unique_community_skill_vote_per_user",
+            ),
+        ]
+
+    skill = models.ForeignKey(CommunitySkill, on_delete=models.CASCADE, related_name="votes")
+    user = models.ForeignKey("posthog.User", on_delete=models.CASCADE)
+    created_at = models.DateTimeField(default=timezone.now)

--- a/products/skills/backend/tasks.py
+++ b/products/skills/backend/tasks.py
@@ -1,0 +1,24 @@
+from celery import shared_task
+from structlog import get_logger
+
+from posthog.scoping_audit import skip_team_scope_audit
+
+from products.skills.backend.api.community_skill_sync import sync_community_skills_from_github
+
+logger = get_logger(__name__)
+
+
+@shared_task(ignore_result=True)
+@skip_team_scope_audit
+def sync_community_skills() -> None:
+    """Reconcile the local community-skills catalog with the PostHog/community-skills repo.
+
+    Operates on the instance-global CommunitySkill catalog (no team scope), so the team-scope
+    audit is intentionally skipped.
+    """
+    try:
+        result = sync_community_skills_from_github()
+    except Exception:
+        logger.exception("community_skills_sync_failed")
+        raise
+    logger.info("community_skills_sync_complete", **result)


### PR DESCRIPTION
## Problem

The community skills marketplace lets teams browse, install, and share agent skills sourced from the public `PostHog/community-skills` repo. This PR is the foundation: the instance-global catalog and the hourly ingest that keeps it in sync. First of a 5-PR stack that supersedes the monolithic #63425.

## Changes

- New instance-global models `CommunitySkill` / `CommunitySkillFile` / `CommunitySkillVote` (no `team_id` — these are a shared catalog, mirroring the `DashboardTemplate` precedent) in `products/skills/backend/models/community_skills.py`, plus skills-app migration `0004_communityskill`.
- Hourly Celery task `sync_community_skills` that fetches `registry.json` from the community repo and reconciles the catalog — soft-deletes skills dropped from the registry, fail-closed on empty/malformed payloads.
- IDOR coverage baseline updated to list the two new global-catalog models under "Global catalogs".

## How did you test this code?

Agent-authored. In a local dev env I ran `hogli test products/skills/backend/api/test/test_community_skill_sync.py` (sync reconcile scenarios, green) and `python manage.py makemigrations skills --check --dry-run` (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs yet — the feature is flag-gated and lands across this 5-PR stack. Add `skip-inkeep-docs` if preferred until the marketplace is enabled.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Invoked `/django-migrations` for the migration. PR 1/5 of the community skills marketplace stack (supersedes #63425); the whole feature ships behind the `llm-analytics-community-skills` flag. The feature was relocated into `products/skills/` (not `ai_observability`) after skills was extracted to its own product on master.
