### PR TITLE
feat(llma): publish skills to community server (4/7)

### DIFF
--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -130,3 +130,9 @@ The target repo is public, so a failed publish must not leave anything behind:
 Errors surface as `400` (invalid payload), `404` (unknown skill), `502` (GitHub refused a step), or
 `503` when the instance has no `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` configured. The 503 is the
 fail-safe that keeps publishing off until the GitHub App is installed.
+
+The three are kept apart on purpose, because each sends the publisher somewhere different. The skill
+is rendered before GitHub is touched, so a skill that has to be edited answers `400` even while the
+App is down. `503` is reserved for an installation GitHub says is absent or refuses the App's
+credentials for; any other failed status while minting the publish token is an outage and answers
+`502`, so a transient failure doesn't read as "this instance can't publish".

--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -65,3 +65,42 @@ trusting the sync:
 
 Errors surface as `400` (invalid payload / duplicate name) or `404` (unknown or removed slug).
 A duplicate-name conflict only blames the `new_name` field when the caller actually supplied it.
+
+## Publishing to the community
+
+Publishing runs the other way: it renders a team's own `LLMSkill` into the repo's
+`skills/<slug>/SKILL.md` layout and opens a pull request for a maintainer to review.
+
+| Method | Path                                              | Purpose                                  |
+| ------ | ------------------------------------------------- | ---------------------------------------- |
+| `POST` | `llm_skills/name/{skill_name}/publish-community/` | Open a PR adding or updating this skill. |
+
+Lives on `LLMSkillViewSet` (`products/skills/backend/api/skills.py`), not the community viewset,
+because the subject is a team-owned skill.
+Rendering and the GitHub calls are in `community_publish_services.py`.
+
+- Gated by `CommunityPublishFeatureFlagPermission`, which applies the same
+  `llm-analytics-community-skills` check as the browse endpoints to this action alone. Skills is GA,
+  so the flag cannot sit on the viewset.
+- Session auth only, and throttled at 6/hour and 20/day. The API-shaped `BurstRateThrottle` would not
+  fire here at all: it only counts personal-API-key traffic.
+- `display_name` is capped at 64 characters to match `CommunitySkill.name`. A longer name would pass
+  review and then be dropped by ingest, so the skill would never appear in the catalog.
+- Bundled files are text only. `CommunitySkillFile.content` is a `TextField` and the renderer takes
+  `str`, so a skill referencing an image or other binary asset cannot round-trip through the catalog.
+
+### Repo writes
+
+The target repo is public, so a failed publish must not leave anything behind:
+
+- The branch is `community-skill/<slug>`, derived from the slug rather than random, so re-publishing
+  rewrites that branch and returns the PR already open for it instead of opening a second one.
+- Every rendered file lands in a single tree and commit, built before the branch reference exists.
+  A failure part way through leaves no branch, and reviewers see one commit rather than one per file.
+- If opening the PR fails, the branch is deleted again.
+- Content becomes public at the branch write, before the pull request that moderates it. Confirming
+  that with the user is a UI concern, and it gates enabling the flag rather than shipping this code.
+
+Errors surface as `400` (invalid payload), `404` (unknown skill), `502` (GitHub refused a step), or
+`503` when the instance has no `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` configured. The 503 is the
+fail-safe that keeps publishing off until the GitHub App is installed.

--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -82,8 +82,14 @@ Rendering and the GitHub calls are in `community_publish_services.py`.
 - Gated by `CommunityPublishFeatureFlagPermission`, which applies the same
   `llm-analytics-community-skills` check as the browse endpoints to this action alone. Skills is GA,
   so the flag cannot sit on the viewset.
-- Session auth only, and throttled at 6/hour and 20/day. The API-shaped `BurstRateThrottle` would not
-  fire here at all: it only counts personal-API-key traffic.
+- Throttled at 6/hour and 20/day, **keyed by team rather than by credential**. `_ensure_web_authenticated`
+  also accepts a personal API key, and the inherited throttle key prefers the key hash, so one member
+  with several keys would otherwise get a fresh budget with each of them. The API-shaped
+  `BurstRateThrottle` would not fire here at all: it only counts personal-API-key traffic.
+- The slug is held to the same rule ingest applies (`SKILL_NAME_PATTERN`, no reserved name), and body,
+  file count, and per-file size to the same caps, so a publish that ingest would silently drop is
+  refused before the pull request exists. The manifest is also checked for paths that differ only by
+  case and for a name used as both a file and a folder, neither of which a git tree can hold.
 - `display_name` is capped at 64 characters to match `CommunitySkill.name`. A longer name would pass
   review and then be dropped by ingest, so the skill would never appear in the catalog.
 - `author_handle` is validated against GitHub's username shape, and is self-reported. Nothing checks it

--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -86,15 +86,30 @@ Rendering and the GitHub calls are in `community_publish_services.py`.
   fire here at all: it only counts personal-API-key traffic.
 - `display_name` is capped at 64 characters to match `CommunitySkill.name`. A longer name would pass
   review and then be dropped by ingest, so the skill would never appear in the catalog.
+- `author_handle` is validated against GitHub's username shape, and is self-reported. Nothing checks it
+  against the publisher's PostHog account, so the PR body presents it as a handle the publisher gave.
 - Bundled files are text only. `CommunitySkillFile.content` is a `TextField` and the renderer takes
   `str`, so a skill referencing an image or other binary asset cannot round-trip through the catalog.
+
+### Settings
+
+| Setting                                   | Effect                                                                              |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` | Installation of the GitHub App that opens the PRs. Empty (the default) returns 503. |
+| `COMMUNITY_SKILLS_GITHUB_REPO`            | Bare repo name to publish into. The owner comes from the installation's account.    |
+
+`COMMUNITY_SKILLS_GITHUB_REPO` is publish-only. The hourly catalog sync reads `registry.json` from the
+repo pinned in `community_skill_sync.py`, so pointing this setting elsewhere sends pull requests to a
+repo the sync never reads back.
 
 ### Repo writes
 
 The target repo is public, so a failed publish must not leave anything behind:
 
-- The branch is `community-skill/<slug>`, derived from the slug rather than random, so re-publishing
-  rewrites that branch and returns the PR already open for it instead of opening a second one.
+- The branch is `community-skill/<slug>-<publisher key>`, so re-publishing rewrites that branch and
+  returns the PR already open for it instead of opening a second one. The publisher key is a short
+  hash of the team's uuid: a slug is only unique within a team, so a branch keyed on the slug alone
+  would let one team force-update another team's open pull request.
 - Every rendered file lands in a single tree and commit, built before the branch reference exists.
   A failure part way through leaves no branch, and reviewers see one commit rather than one per file.
 - If opening the PR fails, the branch is deleted again.

--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -90,6 +90,11 @@ Rendering and the GitHub calls are in `community_publish_services.py`.
   file count, and per-file size to the same caps, so a publish that ingest would silently drop is
   refused before the pull request exists. The manifest is also checked for paths that differ only by
   case and for a name used as both a file and a folder, neither of which a git tree can hold.
+- Bundled paths are canonicalized and allowed-tool names are held to ingest's no-whitespace rule,
+  both through the shared validators in `skill_services.py`. `create_skill` (the path the Max tool
+  takes) stores either field without the REST serializer's checks, so a skill can hold
+  `references\guide.md` or a tool named `Bash Write`. Publishing one unchanged merges a pull
+  request whose entry ingest then drops.
 - `display_name` is capped at 64 characters to match `CommunitySkill.name`. A longer name would pass
   review and then be dropped by ingest, so the skill would never appear in the catalog.
 - `author_handle` is validated against GitHub's username shape, and is self-reported. Nothing checks it

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -4352,6 +4352,14 @@ export interface PatchedUserApi {
     readonly requires_credential_review?: boolean
 }
 
+export interface UserGithubLoginApi {
+    /**
+     * The user's resolved GitHub login, or null when no GitHub identity is linked.
+     * @nullable
+     */
+    github_login: string | null
+}
+
 export interface UserGitHubAccountApi {
     /**
      * GitHub account type for the installation (e.g. User or Organization).

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3699,6 +3699,14 @@ export interface PatchedUserApi {
     readonly requires_credential_review?: boolean
 }
 
+export interface UserGithubLoginApi {
+    /**
+     * The user's resolved GitHub login, or null when no GitHub identity is linked.
+     * @nullable
+     */
+    github_login: string | null
+}
+
 export interface UserGitHubAccountApi {
     /**
      * GitHub account type for the installation (e.g. User or Organization).

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -76,6 +76,7 @@ import type {
     UserGitHubLinkStartRequestApi,
     UserGitHubLinkStartResponseApi,
     UserGitHubPrepareCallbackRequestApi,
+    UserGithubLoginApi,
     UserPushTokenItemApi,
     UserPushTokenRegisterRequestApi,
     UserPushTokenUnregisterRequestApi,
@@ -2422,8 +2423,8 @@ export const getUsersGithubLoginRetrieveUrl = (uuid: string) => {
     return `/api/users/${uuid}/github_login/`
 }
 
-export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getUsersGithubLoginRetrieveUrl(uuid), {
+export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<UserGithubLoginApi> => {
+    return apiMutator<UserGithubLoginApi>(getUsersGithubLoginRetrieveUrl(uuid), {
         ...options,
         method: 'GET',
     })

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -80,6 +80,7 @@ import type {
     UserGitHubLinkStartRequestApi,
     UserGitHubLinkStartResponseApi,
     UserGitHubPrepareCallbackRequestApi,
+    UserGithubLoginApi,
     UserPushTokenItemApi,
     UserPushTokenRegisterRequestApi,
     UserPushTokenUnregisterRequestApi,
@@ -3003,8 +3004,8 @@ export const getUsersGithubLoginRetrieveUrl = (uuid: string) => {
     return `/api/users/${uuid}/github_login/`
 }
 
-export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getUsersGithubLoginRetrieveUrl(uuid), {
+export const usersGithubLoginRetrieve = async (uuid: string, options?: RequestInit): Promise<UserGithubLoginApi> => {
+    return apiMutator<UserGithubLoginApi>(getUsersGithubLoginRetrieveUrl(uuid), {
         ...options,
         method: 'GET',
     })

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -959,6 +959,13 @@ class RevokeOtherSessionsResponseSerializer(serializers.Serializer):
     revoked_count = serializers.IntegerField(help_text="Number of other login sessions that were revoked.")
 
 
+class UserGithubLoginSerializer(serializers.Serializer):
+    github_login = serializers.CharField(
+        allow_null=True,
+        help_text="The user's resolved GitHub login, or null when no GitHub identity is linked.",
+    )
+
+
 @extend_schema(extensions={"x-product": "core"})
 @extend_schema_view(
     retrieve=extend_schema(
@@ -1065,6 +1072,7 @@ class UserViewSet(
         report_user_deleted_account(user)
         super().perform_destroy(user)
 
+    @extend_schema(responses=UserGithubLoginSerializer)
     @action(methods=["GET"], detail=True, url_path="github_login")
     def github_login(self, request, **kwargs):
         user = self.get_object()

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -892,6 +892,13 @@ class RevokeOtherSessionsResponseSerializer(serializers.Serializer):
     revoked_count = serializers.IntegerField(help_text="Number of other login sessions that were revoked.")
 
 
+class UserGithubLoginSerializer(serializers.Serializer):
+    github_login = serializers.CharField(
+        allow_null=True,
+        help_text="The user's resolved GitHub login, or null when no GitHub identity is linked.",
+    )
+
+
 @extend_schema(extensions={"x-product": "core"})
 @extend_schema_view(
     retrieve=extend_schema(
@@ -997,6 +1004,7 @@ class UserViewSet(
         report_user_deleted_account(user)
         super().perform_destroy(user)
 
+    @extend_schema(responses=UserGithubLoginSerializer)
     @action(methods=["GET"], detail=True, url_path="github_login")
     def github_login(self, request, **kwargs):
         user = self.get_object()

--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -1239,12 +1239,12 @@ class GitHubIntegrationBase:
             return []
         return [pr["html_url"] for pr in pulls if isinstance(pr, dict) and isinstance(pr.get("html_url"), str)]
 
-    def get_open_pr_base_for_head(self, repository: str, branch: str) -> str | None:
-        """Return the base branch of an OPEN pull request whose head is ``branch``, if one exists.
+    def get_open_pull_request_for_head(self, repository: str, branch: str) -> dict[str, Any] | None:
+        """Return the OPEN pull request whose head is ``branch`` — its number, HTML url, and base ref.
 
-        ``repository`` is ``owner/repo`` (or a bare repo, resolved against the org). Distinguishes
-        a branch that *heads* an open PR (work continues on it) from a branch used as a PR *base*.
-        Best-effort: returns None on a bad repo, non-200, no open PR, or any error.
+        ``repository`` is ``owner/repo`` (or a bare repo, resolved against the org). Lets a caller
+        that owns a deterministic branch name find the PR it already opened, instead of opening a
+        second one. Best-effort: returns None on a bad repo, non-200, no open PR, or any error.
         """
         repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
         owner = repo_path.split("/", 1)[0]
@@ -1258,12 +1258,29 @@ class GitHubIntegrationBase:
         try:
             pulls = response.json()
         except Exception:
-            logger.warning("GitHubIntegration: get_open_pr_base_for_head non-JSON response", repository=repo_path)
+            logger.warning("GitHubIntegration: get_open_pull_request_for_head non-JSON response", repository=repo_path)
             return None
         if not isinstance(pulls, list) or not pulls or not isinstance(pulls[0], dict):
             return None
-        base = (pulls[0].get("base") or {}).get("ref")
-        return base if isinstance(base, str) and base else None
+        pull = pulls[0]
+        number = pull.get("number")
+        if not isinstance(number, int):
+            return None
+        base = (pull.get("base") or {}).get("ref")
+        return {
+            "number": number,
+            "url": pull.get("html_url") if isinstance(pull.get("html_url"), str) else None,
+            "base": base if isinstance(base, str) and base else None,
+        }
+
+    def get_open_pr_base_for_head(self, repository: str, branch: str) -> str | None:
+        """Return the base branch of an OPEN pull request whose head is ``branch``, if one exists.
+
+        Distinguishes a branch that *heads* an open PR (work continues on it) from a branch used as
+        a PR *base*. Best-effort: returns None on a bad repo, non-200, no open PR, or any error.
+        """
+        pull = self.get_open_pull_request_for_head(repository, branch)
+        return pull.get("base") if pull else None
 
     _PR_SNAPSHOT_QUERY = """
     query($owner: String!, $repo: String!, $number: Int!) {

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3814,6 +3814,7 @@ class GitHubIntegration(GitHubIntegrationBase):
         base_branch: str,
         files: Mapping[str, str],
         commit_message: str,
+        replace_directory: str | None = None,
     ) -> dict[str, Any]:
         """Point ``branch_name`` at a single commit on top of ``base_branch`` writing every file in
         ``files`` (repo-relative path → text content).
@@ -3824,6 +3825,12 @@ class GitHubIntegration(GitHubIntegrationBase):
         one per file. An existing branch is force-updated to the new commit, discarding whatever was
         on it — callers republishing generated content want exactly that, callers collaborating on a
         branch do not.
+
+        ``replace_directory`` makes the commit *replace* that directory with exactly the files given
+        under it, instead of merging them into whatever ``base_branch`` already holds there. Without
+        it a path that existed on the base and is absent from ``files`` survives, because the tree is
+        built on the base tree: a caller republishing a generated directory would keep shipping files
+        it has since deleted or renamed. Files outside the directory are still merged as usual.
         """
         if not files:
             return {"success": False, "error": "No files to commit"}
@@ -3858,17 +3865,47 @@ class GitHubIntegration(GitHubIntegrationBase):
 
         # Inline `content` lets GitHub create the blobs as part of the tree, so no separate blob
         # round trip per file. 100644 is a non-executable file.
+        def blob_entries(paths: Mapping[str, str]) -> list[dict[str, str]]:
+            return [
+                {"path": path, "mode": "100644", "type": "blob", "content": content} for path, content in paths.items()
+            ]
+
+        entries: list[dict[str, str]] = []
+        if replace_directory:
+            prefix = replace_directory.rstrip("/") + "/"
+            inside = {path[len(prefix) :]: content for path, content in files.items() if path.startswith(prefix)}
+            # Built with no base_tree, so this tree holds the given files and nothing else. Pointing
+            # the directory entry at it swaps the whole subtree in one step, which is what makes a
+            # path the caller dropped disappear rather than survive from the base tree.
+            subtree_response = self.api_request(
+                "POST",
+                f"/repos/{org}/{repository}/git/trees",
+                endpoint="/repos/{owner}/{repo}/git/trees",
+                json_body={"tree": blob_entries(inside)},
+            )
+            if subtree_response.status_code != 201:
+                return {
+                    "success": False,
+                    "error": f"Failed to create tree for {replace_directory}: {subtree_response.text}",
+                    "status_code": subtree_response.status_code,
+                }
+            entries.append(
+                {
+                    "path": replace_directory.rstrip("/"),
+                    "mode": "040000",
+                    "type": "tree",
+                    "sha": subtree_response.json()["sha"],
+                }
+            )
+            entries.extend(blob_entries({p: c for p, c in files.items() if not p.startswith(prefix)}))
+        else:
+            entries = blob_entries(files)
+
         tree_response = self.api_request(
             "POST",
             f"/repos/{org}/{repository}/git/trees",
             endpoint="/repos/{owner}/{repo}/git/trees",
-            json_body={
-                "base_tree": base_tree_sha,
-                "tree": [
-                    {"path": path, "mode": "100644", "type": "blob", "content": content}
-                    for path, content in files.items()
-                ],
-            },
+            json_body={"base_tree": base_tree_sha, "tree": entries},
         )
         if tree_response.status_code != 201:
             return {

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3926,9 +3926,32 @@ class GitHubIntegration(GitHubIntegrationBase):
             }
         return {"success": True, "branch_name": branch_name, "commit_sha": commit_sha, "created_branch": False}
 
-    def delete_branch(self, repository: str, branch_name: str) -> dict[str, Any]:
-        """Delete a branch reference. A branch that is already gone counts as success."""
+    def delete_branch(self, repository: str, branch_name: str, expected_sha: str | None = None) -> dict[str, Any]:
+        """Delete a branch reference. A branch that is already gone counts as success.
+
+        ``expected_sha`` makes the delete conditional: the ref is read first and left alone when it
+        has moved on, which is what a caller cleaning up its own failed write wants on a branch name
+        that is shared by construction. GitHub has no conditional delete, so this narrows the race
+        rather than closing it.
+        """
         org = self.organization()
+
+        if expected_sha is not None:
+            head_response = self.api_request(
+                "GET",
+                f"/repos/{org}/{repository}/git/ref/heads/{branch_name}",
+                endpoint="/repos/{owner}/{repo}/git/ref/heads/{branch}",
+            )
+            if head_response.status_code == 404:
+                return {"success": True, "branch_name": branch_name}
+            if head_response.status_code != 200:
+                return {
+                    "success": False,
+                    "error": f"Failed to read branch {branch_name}: {head_response.text}",
+                    "status_code": head_response.status_code,
+                }
+            if head_response.json()["object"]["sha"] != expected_sha:
+                return {"success": True, "branch_name": branch_name, "skipped": True}
 
         response = self.api_request(
             "DELETE",

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3807,6 +3807,142 @@ class GitHubIntegration(GitHubIntegrationBase):
                 "status_code": response.status_code,
             }
 
+    def commit_files_to_branch(
+        self,
+        repository: str,
+        branch_name: str,
+        base_branch: str,
+        files: Mapping[str, str],
+        commit_message: str,
+    ) -> dict[str, Any]:
+        """Point ``branch_name`` at a single commit on top of ``base_branch`` writing every file in
+        ``files`` (repo-relative path → text content).
+
+        Prefer this over ``create_branch`` plus one ``update_file`` per file when the files only make
+        sense together: the commit object is built before the branch reference exists, so a failure
+        part way through leaves nothing in the repository, and reviewers get one commit rather than
+        one per file. An existing branch is force-updated to the new commit, discarding whatever was
+        on it — callers republishing generated content want exactly that, callers collaborating on a
+        branch do not.
+        """
+        if not files:
+            return {"success": False, "error": "No files to commit"}
+
+        org = self.organization()
+
+        base_ref_response = self.api_request(
+            "GET",
+            f"/repos/{org}/{repository}/git/ref/heads/{base_branch}",
+            endpoint="/repos/{owner}/{repo}/git/ref/heads/{branch}",
+        )
+        if base_ref_response.status_code != 200:
+            return {
+                "success": False,
+                "error": f"Failed to get base branch {base_branch}: {base_ref_response.text}",
+                "status_code": base_ref_response.status_code,
+            }
+        base_sha = base_ref_response.json()["object"]["sha"]
+
+        base_commit_response = self.api_request(
+            "GET",
+            f"/repos/{org}/{repository}/git/commits/{base_sha}",
+            endpoint="/repos/{owner}/{repo}/git/commits/{commit_sha}",
+        )
+        if base_commit_response.status_code != 200:
+            return {
+                "success": False,
+                "error": f"Failed to read base commit {base_sha}: {base_commit_response.text}",
+                "status_code": base_commit_response.status_code,
+            }
+        base_tree_sha = base_commit_response.json()["tree"]["sha"]
+
+        # Inline `content` lets GitHub create the blobs as part of the tree, so no separate blob
+        # round trip per file. 100644 is a non-executable file.
+        tree_response = self.api_request(
+            "POST",
+            f"/repos/{org}/{repository}/git/trees",
+            endpoint="/repos/{owner}/{repo}/git/trees",
+            json_body={
+                "base_tree": base_tree_sha,
+                "tree": [
+                    {"path": path, "mode": "100644", "type": "blob", "content": content}
+                    for path, content in files.items()
+                ],
+            },
+        )
+        if tree_response.status_code != 201:
+            return {
+                "success": False,
+                "error": f"Failed to create tree: {tree_response.text}",
+                "status_code": tree_response.status_code,
+            }
+
+        commit_response = self.api_request(
+            "POST",
+            f"/repos/{org}/{repository}/git/commits",
+            endpoint="/repos/{owner}/{repo}/git/commits",
+            json_body={
+                "message": commit_message,
+                "tree": tree_response.json()["sha"],
+                "parents": [base_sha],
+            },
+        )
+        if commit_response.status_code != 201:
+            return {
+                "success": False,
+                "error": f"Failed to create commit: {commit_response.text}",
+                "status_code": commit_response.status_code,
+            }
+        commit_sha = commit_response.json()["sha"]
+
+        create_ref_response = self.api_request(
+            "POST",
+            f"/repos/{org}/{repository}/git/refs",
+            endpoint="/repos/{owner}/{repo}/git/refs",
+            json_body={"ref": f"refs/heads/{branch_name}", "sha": commit_sha},
+        )
+        if create_ref_response.status_code == 201:
+            return {"success": True, "branch_name": branch_name, "commit_sha": commit_sha, "created_branch": True}
+
+        # 422 is what GitHub returns for a reference that already exists; move it instead.
+        if create_ref_response.status_code != 422:
+            return {
+                "success": False,
+                "error": f"Failed to create branch {branch_name}: {create_ref_response.text}",
+                "status_code": create_ref_response.status_code,
+            }
+
+        update_ref_response = self.api_request(
+            "PATCH",
+            f"/repos/{org}/{repository}/git/refs/heads/{branch_name}",
+            endpoint="/repos/{owner}/{repo}/git/refs/heads/{branch}",
+            json_body={"sha": commit_sha, "force": True},
+        )
+        if update_ref_response.status_code != 200:
+            return {
+                "success": False,
+                "error": f"Failed to update branch {branch_name}: {update_ref_response.text}",
+                "status_code": update_ref_response.status_code,
+            }
+        return {"success": True, "branch_name": branch_name, "commit_sha": commit_sha, "created_branch": False}
+
+    def delete_branch(self, repository: str, branch_name: str) -> dict[str, Any]:
+        """Delete a branch reference. A branch that is already gone counts as success."""
+        org = self.organization()
+
+        response = self.api_request(
+            "DELETE",
+            f"/repos/{org}/{repository}/git/refs/heads/{branch_name}",
+            endpoint="/repos/{owner}/{repo}/git/refs/heads/{branch}",
+        )
+        if response.status_code in (204, 404, 422):
+            return {"success": True, "branch_name": branch_name}
+        return {
+            "success": False,
+            "error": f"Failed to delete branch {branch_name}: {response.text}",
+            "status_code": response.status_code,
+        }
+
     def get_diff(
         self,
         repository: str,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3995,8 +3995,19 @@ class GitHubIntegration(GitHubIntegrationBase):
             f"/repos/{org}/{repository}/git/refs/heads/{branch_name}",
             endpoint="/repos/{owner}/{repo}/git/refs/heads/{branch}",
         )
-        if response.status_code in (204, 404, 422):
+        if response.status_code in (204, 404):
             return {"success": True, "branch_name": branch_name}
+        # GitHub answers a delete with 422 both for a reference that is already gone and for one it
+        # refused to remove, so the status alone can't tell "done" from "still there". Read the ref
+        # back: absent is the success the caller wanted, present is a branch it has to hear about.
+        if response.status_code == 422:
+            recheck_response = self.api_request(
+                "GET",
+                f"/repos/{org}/{repository}/git/ref/heads/{branch_name}",
+                endpoint="/repos/{owner}/{repo}/git/ref/heads/{branch}",
+            )
+            if recheck_response.status_code == 404:
+                return {"success": True, "branch_name": branch_name}
         return {
             "success": False,
             "error": f"Failed to delete branch {branch_name}: {response.text}",

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1933,11 +1933,103 @@ class TestGitHubIntegrationModel(BaseTest):
         assert result["success"] is False
         assert result["status_code"] == 502
 
+    def _github_for_org(self) -> GitHubIntegration:
+        integration = self.create_integration(
+            config={"account": {"name": "PostHog"}}, sensitive_config={"access_token": "ACCESS_TOKEN"}
+        )
+        return GitHubIntegration(integration)
+
+    @staticmethod
+    def _git_data_api_request(*, ref_status: int = 201):
+        """Fake the git-data endpoints commit_files_to_branch walks, recording each call."""
+        calls: list[tuple[str, str, Optional[dict]]] = []
+
+        def _request(method, path, **kwargs):
+            calls.append((method, path, kwargs.get("json_body")))
+            if "/git/ref/heads/" in path and method == "GET":
+                return MagicMock(status_code=200, **{"json.return_value": {"object": {"sha": "base-sha"}}})
+            if "/git/commits/" in path:
+                return MagicMock(status_code=200, **{"json.return_value": {"tree": {"sha": "base-tree"}}})
+            if path.endswith("/git/trees"):
+                return MagicMock(status_code=201, **{"json.return_value": {"sha": "new-tree"}})
+            if path.endswith("/git/commits"):
+                return MagicMock(status_code=201, **{"json.return_value": {"sha": "new-commit"}})
+            if path.endswith("/git/refs"):
+                return MagicMock(status_code=ref_status, text="Reference already exists")
+            if "/git/refs/heads/" in path and method == "PATCH":
+                return MagicMock(status_code=200)
+            raise AssertionError(f"unexpected request {method} {path}")
+
+        return _request, calls
+
+    def test_commit_files_to_branch_writes_every_file_in_one_commit(self):
+        github = self._github_for_org()
+        request, calls = self._git_data_api_request()
+
+        with patch.object(github, "api_request", side_effect=request):
+            result = github.commit_files_to_branch(
+                "community-skills", "community-skill/x", "main", {"a.md": "A", "b/c.md": "C"}, "msg"
+            )
+
+        assert result["success"] is True
+        assert result["commit_sha"] == "new-commit"
+        tree_body = next(body for _, path, body in calls if path.endswith("/git/trees"))
+        assert {entry["path"] for entry in tree_body["tree"]} == {"a.md", "b/c.md"}
+        assert tree_body["base_tree"] == "base-tree"
+        # The branch reference is written last, so a failure earlier leaves no branch in the repo.
+        assert calls[-1][1].endswith("/git/refs")
+
+    def test_commit_files_to_branch_force_updates_an_existing_branch(self):
+        github = self._github_for_org()
+        request, calls = self._git_data_api_request(ref_status=422)
+
+        with patch.object(github, "api_request", side_effect=request):
+            result = github.commit_files_to_branch(
+                "community-skills", "community-skill/x", "main", {"a.md": "A"}, "msg"
+            )
+
+        assert result["success"] is True
+        assert result["created_branch"] is False
+        method, path, body = calls[-1]
+        assert (method, path) == ("PATCH", "/repos/PostHog/community-skills/git/refs/heads/community-skill/x")
+        assert body == {"sha": "new-commit", "force": True}
+
+    @parameterized.expand([("deleted", 204), ("already gone", 404)])
+    def test_delete_branch_treats_a_missing_branch_as_deleted(self, _name: str, status_code: int):
+        github = self._github_for_org()
+        with patch.object(github, "api_request", return_value=MagicMock(status_code=status_code)):
+            assert github.delete_branch("community-skills", "community-skill/x")["success"] is True
+
+    def test_get_open_pull_request_for_head_returns_number_and_url(self):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = [
+            {
+                "number": 7,
+                "html_url": "https://github.com/PostHog/posthog/pull/7",
+                "base": {"ref": "master"},
+            }
+        ]
+        with patch.object(github, "_installation_authenticated_get", return_value=mock_response):
+            assert github.get_open_pull_request_for_head("PostHog/posthog", "posthog-code/fix") == {
+                "number": 7,
+                "url": "https://github.com/PostHog/posthog/pull/7",
+                "base": "master",
+            }
+
     def test_get_open_pr_base_for_head_returns_base_ref_of_open_pr(self):
         integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
         github = GitHubIntegration(integration)
         mock_response = MagicMock(status_code=200)
-        mock_response.json.return_value = [{"base": {"ref": "master"}, "head": {"ref": "posthog-code/fix"}}]
+        mock_response.json.return_value = [
+            {
+                "number": 7,
+                "html_url": "https://github.com/PostHog/posthog/pull/7",
+                "base": {"ref": "master"},
+                "head": {"ref": "posthog-code/fix"},
+            }
+        ]
         with patch.object(github, "_installation_authenticated_get", return_value=mock_response) as mock_get:
             result = github.get_open_pr_base_for_head("PostHog/posthog", "posthog-code/fix")
         assert result == "master"

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1941,7 +1941,6 @@ class TestGitHubIntegrationModel(BaseTest):
 
     @staticmethod
     def _git_data_api_request(*, ref_status: int = 201):
-        """Fake the git-data endpoints commit_files_to_branch walks, recording each call."""
         calls: list[tuple[str, str, Optional[dict]]] = []
 
         def _request(method, path, **kwargs):
@@ -1999,6 +1998,25 @@ class TestGitHubIntegrationModel(BaseTest):
         github = self._github_for_org()
         with patch.object(github, "api_request", return_value=MagicMock(status_code=status_code)):
             assert github.delete_branch("community-skills", "community-skill/x")["success"] is True
+
+    @parameterized.expand([("the expected commit", "mine", True), ("someone else's commit", "theirs", False)])
+    def test_delete_branch_with_an_expected_sha_only_deletes_its_own_commit(
+        self, _name: str, head_sha: str, deleted: bool
+    ):
+        github = self._github_for_org()
+        methods: list[str] = []
+
+        def _request(method, path, **kwargs):
+            methods.append(method)
+            if method == "GET":
+                return MagicMock(status_code=200, **{"json.return_value": {"object": {"sha": head_sha}}})
+            return MagicMock(status_code=204)
+
+        with patch.object(github, "api_request", side_effect=_request):
+            result = github.delete_branch("community-skills", "community-skill/x", expected_sha="mine")
+
+        assert result["success"] is True
+        assert ("DELETE" in methods) is deleted
 
     def test_get_open_pull_request_for_head_returns_number_and_url(self):
         integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -2025,6 +2025,21 @@ class TestGitHubIntegrationModel(BaseTest):
         with patch.object(github, "api_request", return_value=MagicMock(status_code=status_code)):
             assert github.delete_branch("community-skills", "community-skill/x")["success"] is True
 
+    @parameterized.expand([("the ref is gone", 404, True), ("the ref is still there", 200, False)])
+    def test_delete_branch_reads_the_ref_back_after_an_ambiguous_422(self, _name: str, recheck: int, deleted: bool):
+        github = self._github_for_org()
+
+        def _request(method, path, **kwargs):
+            if method == "DELETE":
+                return MagicMock(status_code=422, text="Validation failed")
+            return MagicMock(status_code=recheck, **{"json.return_value": {"object": {"sha": "abc"}}})
+
+        with patch.object(github, "api_request", side_effect=_request):
+            result = github.delete_branch("community-skills", "community-skill/x")
+
+        # A 422 the caller reads as success is a branch left on a public repo with nobody warned.
+        assert result["success"] is deleted
+
     @parameterized.expand([("the expected commit", "mine", True), ("someone else's commit", "theirs", False)])
     def test_delete_branch_with_an_expected_sha_only_deletes_its_own_commit(
         self, _name: str, head_sha: str, deleted: bool

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1978,6 +1978,32 @@ class TestGitHubIntegrationModel(BaseTest):
         # The branch reference is written last, so a failure earlier leaves no branch in the repo.
         assert calls[-1][1].endswith("/git/refs")
 
+    def test_commit_files_to_branch_replaces_a_directory_rather_than_merging_into_it(self):
+        github = self._github_for_org()
+        request, calls = self._git_data_api_request()
+
+        with patch.object(github, "api_request", side_effect=request):
+            result = github.commit_files_to_branch(
+                "community-skills",
+                "community-skill/x",
+                "main",
+                {"skills/x/SKILL.md": "S", "skills/x/refs/g.md": "G", "README.md": "R"},
+                "msg",
+                replace_directory="skills/x",
+            )
+
+        assert result["success"] is True
+        subtree_body, tree_body = (body for _, path, body in calls if path.endswith("/git/trees"))
+        # No base_tree on the subtree, so it holds these files and nothing else. That is what makes a
+        # path the caller dropped disappear instead of surviving from the base.
+        assert "base_tree" not in subtree_body
+        assert {entry["path"] for entry in subtree_body["tree"]} == {"SKILL.md", "refs/g.md"}
+        assert tree_body["base_tree"] == "base-tree"
+        assert {(entry["path"], entry["type"]) for entry in tree_body["tree"]} == {
+            ("skills/x", "tree"),
+            ("README.md", "blob"),
+        }
+
     def test_commit_files_to_branch_force_updates_an_existing_branch(self):
         github = self._github_for_org()
         request, calls = self._git_data_api_request(ref_status=422)

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -84,7 +84,9 @@ STAMPHOG_SANDBOX_EXTRA_EGRESS_DOMAINS = get_list(get_from_env("STAMPHOG_SANDBOX_
 # endpoint returns 503 and the UI falls back to the manual-PR path.
 COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID = get_from_env("COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID", "")
 # Bare repo name (no owner prefix) — the owner is the App installation's account. Defaults to the
-# PostHog/community-skills repo.
+# PostHog/community-skills repo. Publish-only: the hourly catalog sync reads its registry from the
+# repo pinned in community_skill_sync.py, so pointing this elsewhere sends pull requests to a repo the
+# sync does not read back.
 COMMUNITY_SKILLS_GITHUB_REPO = get_from_env("COMMUNITY_SKILLS_GITHUB_REPO", "community-skills")
 
 META_ADS_APP_CLIENT_ID = get_from_env("META_ADS_APP_CLIENT_ID", "")

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -79,6 +79,13 @@ STAMPHOG_GITHUB_APP_SLUG = get_from_env("STAMPHOG_GITHUB_APP_SLUG", "")
 # PyPI, the LLM gateway host, the PostHog capture host). Comma-separated; an ops escape hatch for
 # when a legitimate dependency host is missing — never a way to open the sandbox wide.
 STAMPHOG_SANDBOX_EXTRA_EGRESS_DOMAINS = get_list(get_from_env("STAMPHOG_SANDBOX_EXTRA_EGRESS_DOMAINS", ""))
+# Installation id of the GitHub App on the PostHog/community-skills repo, used by the in-product
+# "Publish to community" flow to open skill PRs. Empty (the default) disables publishing → the
+# endpoint returns 503 and the UI falls back to the manual-PR path.
+COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID = get_from_env("COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID", "")
+# Bare repo name (no owner prefix) — the owner is the App installation's account. Defaults to the
+# PostHog/community-skills repo.
+COMMUNITY_SKILLS_GITHUB_REPO = get_from_env("COMMUNITY_SKILLS_GITHUB_REPO", "community-skills")
 
 META_ADS_APP_CLIENT_ID = get_from_env("META_ADS_APP_CLIENT_ID", "")
 META_ADS_APP_CLIENT_SECRET = get_from_env("META_ADS_APP_CLIENT_SECRET", "")

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -65,6 +65,13 @@ STAMPHOG_GITHUB_APP_SLUG = get_from_env("STAMPHOG_GITHUB_APP_SLUG", "")
 # PyPI, the LLM gateway host, the PostHog capture host). Comma-separated; an ops escape hatch for
 # when a legitimate dependency host is missing — never a way to open the sandbox wide.
 STAMPHOG_SANDBOX_EXTRA_EGRESS_DOMAINS = get_list(get_from_env("STAMPHOG_SANDBOX_EXTRA_EGRESS_DOMAINS", ""))
+# Installation id of the GitHub App on the PostHog/community-skills repo, used by the in-product
+# "Publish to community" flow to open skill PRs. Empty (the default) disables publishing → the
+# endpoint returns 503 and the UI falls back to the manual-PR path.
+COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID = get_from_env("COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID", "")
+# Bare repo name (no owner prefix) — the owner is the App installation's account. Defaults to the
+# PostHog/community-skills repo.
+COMMUNITY_SKILLS_GITHUB_REPO = get_from_env("COMMUNITY_SKILLS_GITHUB_REPO", "community-skills")
 
 ZENDESK_ADMIN_EMAIL = get_from_env("ZENDESK_ADMIN_EMAIL", "")
 ZENDESK_API_TOKEN = get_from_env("ZENDESK_API_TOKEN", "")

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -1,0 +1,259 @@
+"""Publish a team's LLMSkill to the PostHog/community-skills repo as a pull request.
+
+The heavy lifting (branch + commit + PR) reuses the existing `GitHubIntegration` that already
+powers the Tasks product. This module owns the pure rendering of an `LLMSkill` into the repo's
+`skills/<slug>/SKILL.md` layout; the GitHub side lives in `publish_skill_to_community`.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from django.conf import settings
+
+import yaml
+import structlog
+
+from posthog.models.integration import GitHubIntegration, Integration
+
+logger = structlog.get_logger(__name__)
+
+# Mirror the community-skills repo's slug rule (scripts/build_registry.py) so we never open a PR the
+# repo's own validation would reject.
+SLUG_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+MAX_SLUG_LENGTH = 64
+SKILLS_DIR = "skills"
+COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
+
+
+class CommunitySkillPublishError(Exception):
+    """Raised when a skill can't be rendered or published to the community repo."""
+
+
+class CommunitySkillPublishNotConfiguredError(CommunitySkillPublishError):
+    """Raised when the community-skills GitHub App installation isn't configured on this instance."""
+
+
+@dataclass(frozen=True)
+class RenderedFile:
+    """A single file to commit, at its path within the community-skills repo."""
+
+    path: str
+    content: str
+
+
+def _validate_slug(slug: str) -> str:
+    if not SLUG_PATTERN.match(slug) or "--" in slug or len(slug) > MAX_SLUG_LENGTH:
+        raise CommunitySkillPublishError(
+            f"'{slug}' is not a valid community skill slug (lowercase letters, numbers, single hyphens)."
+        )
+    return slug
+
+
+def render_skill_md(
+    *,
+    name: str,
+    description: str,
+    body: str,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> str:
+    """Render an LLMSkill's fields into community-skills `SKILL.md` content (frontmatter + body).
+
+    Output parses cleanly under the repo's `build_registry.py` frontmatter regex and field rules:
+    `name` and `description` are required; `trust_tier` defaults to `community` (maintainers set
+    `official`/`verified` on review); optional fields are omitted when empty.
+    """
+    if not name.strip():
+        raise CommunitySkillPublishError("Skill name is required to publish.")
+    if not description.strip():
+        raise CommunitySkillPublishError("Skill description is required to publish.")
+
+    frontmatter: dict[str, Any] = {
+        "name": name.strip(),
+        "description": description.strip(),
+        "trust_tier": "community",
+    }
+    if tags:
+        frontmatter["tags"] = list(tags)
+    if author_handle.strip():
+        frontmatter["author_handle"] = author_handle.strip()
+    if license.strip():
+        frontmatter["license"] = license.strip()
+    if compatibility.strip():
+        frontmatter["compatibility"] = compatibility.strip()
+    if allowed_tools:
+        frontmatter["allowed_tools"] = list(allowed_tools)
+
+    # sort_keys=False keeps the human-friendly field order above; default_flow_style=False emits
+    # block-style YAML (lists as `- item`) that the repo's yaml.safe_load round-trips.
+    rendered_frontmatter = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    return f"---\n{rendered_frontmatter}---\n\n{body.strip()}\n"
+
+
+def render_community_skill_files(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    body: str,
+    files: list[dict[str, str]] | None = None,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> list[RenderedFile]:
+    """Render the full set of files to commit for a skill: SKILL.md plus any bundled files.
+
+    Bundled files keep their skill-relative path under `skills/<slug>/` (e.g. a skill file at
+    `references/playbook.md` becomes `skills/<slug>/references/playbook.md`).
+    """
+    _validate_slug(slug)
+    skill_root = f"{SKILLS_DIR}/{slug}"
+
+    rendered: list[RenderedFile] = [
+        RenderedFile(
+            path=f"{skill_root}/SKILL.md",
+            content=render_skill_md(
+                name=name,
+                description=description,
+                body=body,
+                tags=tags,
+                allowed_tools=allowed_tools,
+                license=license,
+                compatibility=compatibility,
+                author_handle=author_handle,
+            ),
+        )
+    ]
+
+    for file in files or []:
+        rel_path = file["path"].lstrip("/")
+        # Confine writes to the skill directory — a bundled file must never escape skills/<slug>/.
+        if rel_path == "SKILL.md" or ".." in rel_path.split("/"):
+            raise CommunitySkillPublishError(f"Invalid bundled file path '{file['path']}'.")
+        rendered.append(RenderedFile(path=f"{skill_root}/{rel_path}", content=file["content"]))
+
+    return rendered
+
+
+def get_community_skills_publisher() -> GitHubIntegration | None:
+    """Build a GitHubIntegration bound to the central community-skills installation, or None.
+
+    Mints a fresh installation token via the GitHub App JWT (the same flow the per-team integration
+    uses) and wraps it in a transient, unsaved Integration — we never persist a teamless central row.
+    Returns None when the App or the community-skills installation isn't configured, so callers can
+    surface a clean "not configured" error instead of failing.
+    """
+    installation_id = settings.COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID
+    if not installation_id or not settings.GITHUB_APP_CLIENT_ID or not settings.GITHUB_APP_PRIVATE_KEY:
+        return None
+
+    info_response = GitHubIntegration.client_request(f"installations/{installation_id}")
+    token_response = GitHubIntegration.client_request(f"installations/{installation_id}/access_tokens", method="POST")
+    if info_response.status_code != 200 or token_response.status_code != 201:
+        logger.warning(
+            "community_skills_publisher_unavailable",
+            info_status=info_response.status_code,
+            token_status=token_response.status_code,
+        )
+        return None
+
+    account = info_response.json().get("account") or {}
+    token = token_response.json().get("token")
+    if not token or not account.get("login"):
+        return None
+
+    # Transient (never saved) Integration: the write helpers only read the access token + account
+    # name and don't trigger a refresh/save, so this avoids polluting the team-scoped Integration table.
+    integration = Integration(
+        team_id=None,
+        kind="github",
+        integration_id=str(installation_id),
+        config={"account": {"name": account["login"], "type": account.get("type")}},
+        sensitive_config={"access_token": token},
+    )
+    return GitHubIntegration(integration)
+
+
+def _community_pr_body(*, name: str, slug: str, author_handle: str) -> str:
+    # No PostHog user PII here — this PR is public. Attribution is only the GitHub handle the
+    # publisher explicitly provided for public sharing.
+    credit = f"Published by @{author_handle}" if author_handle else "Published from the PostHog skills marketplace"
+    return (
+        f"Adds the **{name}** community skill (`skills/{slug}/`).\n\n"
+        f"{credit} via the in-product *Publish to community* flow.\n\n"
+        "A maintainer should review the instructions for safety before merging; "
+        "set `trust_tier` on review. On merge, CI regenerates `registry.json` and PostHog syncs it."
+    )
+
+
+def publish_skill_to_community(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    body: str,
+    files: list[dict[str, str]] | None = None,
+    tags: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    license: str = "",
+    compatibility: str = "",
+    author_handle: str = "",
+) -> dict[str, Any]:
+    """Open a PR in PostHog/community-skills adding (or updating) this skill. Returns the PR url/number.
+
+    Reuses the existing GitHubIntegration branch/commit/PR helpers. Raises CommunitySkillPublishError
+    when any GitHub step fails, or CommunitySkillPublishNotConfiguredError when publishing is disabled.
+    """
+    publisher = get_community_skills_publisher()
+    if publisher is None:
+        raise CommunitySkillPublishNotConfiguredError("Community skill publishing is not configured.")
+
+    rendered = render_community_skill_files(
+        slug=slug,
+        name=name,
+        description=description,
+        body=body,
+        files=files,
+        tags=tags,
+        allowed_tools=allowed_tools,
+        license=license,
+        compatibility=compatibility,
+        author_handle=author_handle,
+    )
+
+    repo = settings.COMMUNITY_SKILLS_GITHUB_REPO
+    base = COMMUNITY_SKILLS_PR_BASE_BRANCH
+    branch = f"community-skill/{slug}-{uuid.uuid4().hex[:8]}"
+
+    branch_result = publisher.create_branch(repo, branch, base)
+    if not branch_result.get("success"):
+        raise CommunitySkillPublishError(f"Failed to create branch: {branch_result.get('error')}")
+
+    for rendered_file in rendered:
+        commit_result = publisher.update_file(
+            repo, rendered_file.path, rendered_file.content, f"Add {rendered_file.path}", branch
+        )
+        if not commit_result.get("success"):
+            raise CommunitySkillPublishError(f"Failed to commit {rendered_file.path}: {commit_result.get('error')}")
+
+    pr_result = publisher.create_pull_request(
+        repo,
+        f"Add community skill: {name}",
+        _community_pr_body(name=name, slug=slug, author_handle=author_handle),
+        branch,
+        base,
+    )
+    if not pr_result.get("success"):
+        raise CommunitySkillPublishError(f"Failed to open pull request: {pr_result.get('error')}")
+
+    logger.info("community_skill_published", slug=slug, pr_number=pr_result.get("pr_number"))
+    return {"pr_url": pr_result["pr_url"], "pr_number": pr_result["pr_number"], "branch": branch}

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import re
 import json
 import hashlib
-from dataclasses import dataclass
 from typing import Any
 
 from django.conf import settings
@@ -19,10 +18,12 @@ import yaml
 import requests
 import structlog
 
+from posthog.dataclasses import frozen
 from posthog.egress.github.transport import GitHubRateLimitError
 from posthog.models.github_integration_base import GitHubIntegrationError
 from posthog.models.integration import GitHubIntegration, Integration
 
+from ..marketplace.packaging import SPEC_DESCRIPTION_MAX_LENGTH
 from .skill_services import (
     MAX_SKILL_BODY_BYTES,
     MAX_SKILL_FILE_BYTES,
@@ -59,6 +60,9 @@ MAX_DISPLAY_NAME_LENGTH = 64
 DISPLAY_NAME_PATTERN = re.compile(r"^[^\x00-\x1f\x7f]*$")
 MAX_TAG_LENGTH = 64
 SKILLS_DIR = "skills"
+# The subtree one publish owns. Rewritten whole on every publish, so a file dropped from the skill
+# stops being published rather than surviving on the branch the previous publish left it on.
+SKILL_TREE_MODE = "040000"
 COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
 COMMUNITY_SKILLS_BRANCH_PREFIX = "community-skill/"
 
@@ -92,7 +96,7 @@ class _CommunitySkillsPublisher(GitHubIntegration):
         raise GitHubIntegrationError("The community-skills publisher mints a token per publish and cannot refresh.")
 
 
-@dataclass(frozen=True)
+@frozen
 class RenderedFile:
     """A single file to commit, at its path within the community-skills repo."""
 
@@ -183,6 +187,13 @@ def render_skill_md(
         raise CommunitySkillPublishValidationError("Skill name must be one line, with no line breaks.")
     if not description.strip():
         raise CommunitySkillPublishValidationError("Skill description is required to publish.")
+    # LLMSkill.description holds 4096, and the Agent Skills spec stops at 1024. A longer one
+    # publishes, syncs and installs, and then validate_for_export refuses the installed skill, so the
+    # publisher hands someone a skill they can never export.
+    if len(description.strip()) > SPEC_DESCRIPTION_MAX_LENGTH:
+        raise CommunitySkillPublishValidationError(
+            f"Skill description must be {SPEC_DESCRIPTION_MAX_LENGTH} characters or fewer to publish."
+        )
     # The same rule install_community_skill applies on the way back in, where a blank body is refused
     # as having no instructions. Without it the publish succeeds, the entry merges into the catalog,
     # and the listing is one nobody can install.
@@ -239,7 +250,7 @@ def render_community_skill_files(
     `references/playbook.md` becomes `skills/<slug>/references/playbook.md`).
     """
     _validate_slug(slug)
-    _validate_publishable_size(body=body, files=files or [])
+    _validate_entry_caps(body=body, files=files or [])
     skill_root = f"{SKILLS_DIR}/{slug}"
 
     rendered: list[RenderedFile] = [
@@ -277,6 +288,7 @@ def render_community_skill_files(
         rendered.append(RenderedFile(path=path, content=file["content"]))
 
     _reject_blob_directory_collisions(seen_paths)
+    _validate_publishable_tree_size(rendered)
     return rendered
 
 
@@ -299,13 +311,12 @@ def _encoded_payload_bytes(content: str) -> int:
     return len(json.dumps(content).encode("utf-8"))
 
 
-def _validate_publishable_size(*, body: str, files: list[dict[str, str]]) -> None:
-    """Hold a publish to the limits the catalog and GitHub will hold it to anyway.
+def _validate_entry_caps(*, body: str, files: list[dict[str, str]]) -> None:
+    """Hold a publish to ingest's own per-entry caps, which it measures on the stored bytes.
 
-    The per-skill limits are ingest's (`community_skill_sync._validate_entry_within_caps`), where
-    breaching one drops the whole entry: the pull request merges and the skill never appears. They
-    are the stored bytes, which is what ingest measures. The aggregate is GitHub's request cap, where
-    breaching it fails the tree write with a 502 nobody can act on, so it measures the encoded form.
+    These are `community_skill_sync._validate_entry_within_caps`, where breaching one drops the whole
+    entry: the pull request merges and the skill never appears in the catalog. The file count is
+    checked here rather than after rendering so an absurd manifest never gets rendered at all.
     """
     if len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
         raise CommunitySkillPublishValidationError(
@@ -313,14 +324,22 @@ def _validate_publishable_size(*, body: str, files: list[dict[str, str]]) -> Non
         )
     if len(files) > MAX_SKILL_FILE_COUNT:
         raise CommunitySkillPublishValidationError(f"A skill can publish at most {MAX_SKILL_FILE_COUNT} files.")
-
-    total = _encoded_payload_bytes(body)
     for file in files:
         if len(file["content"].encode("utf-8")) > MAX_SKILL_FILE_BYTES:
             raise CommunitySkillPublishValidationError(
                 f"'{file['path']}' must be under {MAX_SKILL_FILE_BYTES // 1_000_000} MB."
             )
-        total += _encoded_payload_bytes(file["content"])
+
+
+def _validate_publishable_tree_size(rendered: list[RenderedFile]) -> None:
+    """Hold the whole manifest to GitHub's cap on the create-tree request that writes it.
+
+    Measured on what is actually sent, which is why it runs on the rendered files rather than the
+    fields they came from: SKILL.md carries frontmatter as well as the body, and neither the tag list
+    nor `allowed_tools` has a count cap, so the difference is not a rounding error. Breaching the cap
+    fails the write with a 502 nobody can act on.
+    """
+    total = sum(_encoded_payload_bytes(file.content) + len(file.path.encode("utf-8")) for file in rendered)
     if total > MAX_PUBLISH_TREE_BYTES:
         raise CommunitySkillPublishValidationError(
             f"This skill is too large to publish. Trim it to under "
@@ -521,17 +540,25 @@ def _write_branch_and_pull_request(
         base,
         {rendered_file.path: rendered_file.content for rendered_file in rendered},
         f"{'Update' if existing_pr else 'Add'} community skill: {name}",
+        # The skill's directory is rewritten whole rather than merged onto whatever main already
+        # holds there. Merged, a bundled file the skill has since dropped keeps being published, and
+        # a rename that only changes case leaves both spellings, which ingest folds together and
+        # rejects: the pull request merges and the skill disappears from the catalog.
+        replace_directory=f"{SKILLS_DIR}/{slug}",
     )
     if not commit_result.get("success"):
         raise CommunitySkillPublishError(f"Failed to commit skill files: {commit_result.get('error')}")
     commit_sha = commit_result.get("commit_sha")
 
     if existing_pr is not None:
-        pr_url = existing_pr.get("url")
-        if not pr_url:
-            raise CommunitySkillPublishError("A pull request for this skill is already open for review.")
-        logger.info("community_skill_publish_updated_open_pr", slug=slug, pr_number=existing_pr["number"])
-        return {"pr_url": pr_url, "pr_number": existing_pr["number"], "branch": branch}
+        # Re-read rather than trusting the lookup from before the write. A maintainer merging or
+        # closing that review in between would otherwise leave our commit on a public branch with no
+        # open review, reported as a success pointing at a pull request that no longer takes it.
+        still_open = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch, base=base)
+        if still_open is not None:
+            logger.info("community_skill_publish_updated_open_pr", slug=slug, pr_number=still_open["pr_number"])
+            return still_open
+        logger.info("community_skill_publish_reopening_after_review_ended", slug=slug, pr_number=existing_pr["number"])
 
     try:
         pr_result = publisher.create_pull_request(

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -27,6 +27,8 @@ from .skill_services import (
     MAX_SKILL_FILE_COUNT,
     RESERVED_SKILL_NAMES,
     SKILL_NAME_PATTERN,
+    check_allowed_tool_name,
+    normalize_skill_file_path,
 )
 
 logger = structlog.get_logger(__name__)
@@ -124,6 +126,23 @@ def _validate_slug(slug: str) -> str:
     return slug
 
 
+def _validate_allowed_tool(tool: object) -> None:
+    """Hold one allowed-tool name to the rule ingest applies to a registry entry.
+
+    `create_skill` writes what a tool call passed straight to the model, without the REST
+    serializer's `validate_allowed_tool`, and `allowed_tools` is a JSONField, so a stored
+    `"Bash Write"` (or a non-string) renders into frontmatter that
+    community_skill_sync._validate_entry_shape rejects: the pull request merges and the skill never
+    appears in the catalog.
+    """
+    if not isinstance(tool, str):
+        raise CommunitySkillPublishError("Allowed tools must be a list of tool names.")
+    try:
+        check_allowed_tool_name(tool)
+    except ValueError as err:
+        raise CommunitySkillPublishError(f"'{tool}' can't be published as a tool name. {err}") from err
+
+
 def render_skill_md(
     *,
     name: str,
@@ -151,6 +170,8 @@ def render_skill_md(
         raise CommunitySkillPublishError("Skill description is required to publish.")
     if author_handle.strip() and not GITHUB_HANDLE_PATTERN.match(author_handle.strip()):
         raise CommunitySkillPublishError(f"'{author_handle}' is not a valid GitHub username.")
+    for tool in allowed_tools or []:
+        _validate_allowed_tool(tool)
 
     frontmatter: dict[str, Any] = {
         "name": name.strip(),
@@ -217,10 +238,12 @@ def render_community_skill_files(
 
     seen_paths = {rendered[0].path.lower()}
     for file in files or []:
-        rel_path = file["path"].lstrip("/")
-        # Confine writes to the skill directory — a bundled file must never escape skills/<slug>/.
-        if ".." in rel_path.split("/"):
-            raise CommunitySkillPublishError(f"Invalid bundled file path '{file['path']}'.")
+        # Canonical and confined to the skill directory, by the same rule ingest applies. A bundled
+        # file must never escape skills/<slug>/, and `create_skill` stores a tool-supplied path
+        # verbatim, so `references\guide.md` and `references/guide.md` arrive here as two distinct
+        # paths that community_skill_sync._validate_entry_within_caps then folds into one and
+        # rejects as a duplicate: the pull request merges and the skill never appears in the catalog.
+        rel_path = _publishable_file_path(file["path"])
         path = f"{skill_root}/{rel_path}"
         # Case-insensitive, matching community_skill_sync._validate_entry_within_caps: two paths
         # differing only by case pass every check on this side, and then ingest rejects the whole
@@ -233,6 +256,13 @@ def render_community_skill_files(
 
     _reject_blob_directory_collisions(seen_paths)
     return rendered
+
+
+def _publishable_file_path(raw_path: str) -> str:
+    try:
+        return normalize_skill_file_path(raw_path)
+    except ValueError as err:
+        raise CommunitySkillPublishError(f"'{raw_path}' can't be published as a file path. {err}") from err
 
 
 def _validate_publishable_size(*, body: str, files: list[dict[str, str]]) -> None:

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -37,6 +37,10 @@ OPTIONAL_GITHUB_HANDLE_PATTERN = re.compile(f"^$|{GITHUB_HANDLE_PATTERN.pattern}
 # Matches CommunitySkill.name — a longer name publishes and merges, then ingest rejects the entry and
 # the skill silently never appears in the catalog.
 MAX_DISPLAY_NAME_LENGTH = 64
+# The display name is interpolated into the App-authored commit message, the pull request title and
+# its Markdown body. A newline in it can forge a commit trailer, so `Co-authored-by:` would make
+# GitHub attribute our App's commit to an unrelated account. Hold the name to one printable line.
+DISPLAY_NAME_PATTERN = re.compile(r"^[^\x00-\x1f\x7f]*$")
 MAX_TAG_LENGTH = 64
 SKILLS_DIR = "skills"
 COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
@@ -80,7 +84,11 @@ def publishable_tags(tags: object) -> list[str]:
     """
     if not isinstance(tags, list):
         return []
-    return [tag for tag in tags if isinstance(tag, str) and tag.strip() and len(tag) <= MAX_TAG_LENGTH]
+    # Stripped, like the serializer's own CharField already gives us for request-supplied tags. Sync
+    # only lowercases a tag, and catalog filtering matches it exactly, so a stored `" github "` would
+    # publish as a tag no filter can ever select.
+    stripped = (tag.strip() for tag in tags if isinstance(tag, str))
+    return [tag for tag in stripped if tag and len(tag) <= MAX_TAG_LENGTH]
 
 
 def publisher_branch_key(publisher_id: str) -> str:
@@ -122,6 +130,8 @@ def render_skill_md(
         raise CommunitySkillPublishError("Skill name is required to publish.")
     if len(name.strip()) > MAX_DISPLAY_NAME_LENGTH:
         raise CommunitySkillPublishError(f"Skill name must be {MAX_DISPLAY_NAME_LENGTH} characters or fewer.")
+    if not DISPLAY_NAME_PATTERN.match(name.strip()):
+        raise CommunitySkillPublishError("Skill name must be one line, with no line breaks.")
     if not description.strip():
         raise CommunitySkillPublishError("Skill description is required to publish.")
     if author_handle.strip() and not GITHUB_HANDLE_PATTERN.match(author_handle.strip()):
@@ -330,6 +340,8 @@ def _write_branch_and_pull_request(
 
     # Read the open PR before writing, so a failed write doesn't get blamed on a PR that predates it.
     existing_pr = publisher.get_open_pull_request_for_head(repo, branch)
+    if existing_pr is not None:
+        _require_publishable_base(existing_pr, base=base)
 
     commit_result = publisher.commit_files_to_branch(
         repo,
@@ -361,7 +373,7 @@ def _write_branch_and_pull_request(
         # request, and api_request doesn't retry a POST. Reconcile before cleaning up, so a timeout
         # can't delete a branch that now heads a live review.
         logger.warning("community_skill_publish_pr_create_ambiguous", slug=slug, branch=branch, exc_info=True)
-        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch)
+        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch, base=base)
         if reconciled is not None:
             return reconciled
         _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch)
@@ -376,7 +388,7 @@ def _write_branch_and_pull_request(
     # is on that branch and so inside that review, so return it rather than reporting a failure for
     # content that is already public. Cleanup would belong to that review's branch, not to us.
     if "already exists" in error.lower():
-        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch)
+        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch, base=base)
         if reconciled is not None:
             return reconciled
         raise CommunitySkillPublishError("A pull request for this skill is already open for review.")
@@ -391,12 +403,34 @@ def _write_branch_and_pull_request(
     raise CommunitySkillPublishError(f"Failed to open pull request: {error}")
 
 
-def _reconcile_open_pr(publisher: GitHubIntegration, *, repo: str, slug: str, branch: str) -> dict[str, Any] | None:
+def _require_publishable_base(pull: dict[str, Any], *, base: str) -> None:
+    """Refuse a pull request on our branch that no longer targets the branch the catalog is built from.
+
+    Merging a retargeted pull request writes to that other branch, so the skill would never reach the
+    catalog even though publishing reported success. Its branch is also under live review, which is
+    why this runs before the commit: we neither force-update that branch nor delete it.
+    """
+    if pull.get("base") == base:
+        return
+    raise CommunitySkillPublishError(
+        f"Pull request #{pull['number']} for this skill is open against "
+        f"'{pull.get('base') or 'another branch'}' instead of '{base}'. "
+        "Ask a maintainer to retarget or close it, then publish again."
+    )
+
+
+def _reconcile_open_pr(
+    publisher: GitHubIntegration, *, repo: str, slug: str, branch: str, base: str
+) -> dict[str, Any] | None:
     """Re-read the pull request open for ``branch`` after an ambiguous create, or None if there is none.
 
     A None here means "found nothing", not "the branch has no pull request": the lookup is
     best-effort and answers None for most failures. It still raises when GitHub rate-limits the read,
     which is caught here so a caller cleaning up after a failure isn't handed a second one.
+
+    A pull request retargeted away from ``base`` raises instead of returning: it is not ours to
+    report as this publish's destination, and the raise also keeps the caller from deleting a branch
+    that is under review.
     """
     try:
         pull = publisher.get_open_pull_request_for_head(repo, branch)
@@ -405,6 +439,7 @@ def _reconcile_open_pr(publisher: GitHubIntegration, *, repo: str, slug: str, br
         return None
     if pull is None or not pull.get("url"):
         return None
+    _require_publishable_base(pull, base=base)
     logger.info("community_skill_publish_reconciled_open_pr", slug=slug, pr_number=pull["number"])
     return {"pr_url": pull["url"], "pr_number": pull["number"], "branch": branch}
 

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -21,12 +21,22 @@ from posthog.egress.github.transport import GitHubRateLimitError
 from posthog.models.github_integration_base import GitHubIntegrationError
 from posthog.models.integration import GitHubIntegration, Integration
 
+from .skill_services import (
+    MAX_SKILL_BODY_BYTES,
+    MAX_SKILL_FILE_BYTES,
+    MAX_SKILL_FILE_COUNT,
+    RESERVED_SKILL_NAMES,
+    SKILL_NAME_PATTERN,
+)
+
 logger = structlog.get_logger(__name__)
 
-# Mirror the community-skills repo's slug rule (scripts/build_registry.py) so we never open a PR the
-# repo's own validation would reject.
-SLUG_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 MAX_SLUG_LENGTH = 64
+# GitHub caps one create-tree request at 7 MB, and commit_files_to_branch inlines every file's
+# content in that single request, so a skill above the cap can only ever fail with a 502. Held well
+# under it: the content is JSON-escaped on the way out, so the request is larger than the sum of the
+# files.
+MAX_PUBLISH_TREE_BYTES = 5_000_000
 # GitHub usernames are alphanumeric with single inner hyphens, up to 39 characters. The handle is
 # self-reported and lands in a public PR body and in the listing, so hold it to the shape of a real
 # username rather than letting free text through.
@@ -102,10 +112,15 @@ def publisher_branch_key(publisher_id: str) -> str:
 
 
 def _validate_slug(slug: str) -> str:
-    if not SLUG_PATTERN.match(slug) or "--" in slug or len(slug) > MAX_SLUG_LENGTH:
+    # The same rule community_skill_sync._validate_entry_shape applies to a registry entry, so a slug
+    # that would be dropped on ingest is refused here instead of merging into a catalog that skips
+    # it. fullmatch, not match: `$` also matches before a trailing newline.
+    if not SKILL_NAME_PATTERN.fullmatch(slug) or "--" in slug or len(slug) > MAX_SLUG_LENGTH:
         raise CommunitySkillPublishError(
             f"'{slug}' is not a valid community skill slug (lowercase letters, numbers, single hyphens)."
         )
+    if slug.lower() in RESERVED_SKILL_NAMES:
+        raise CommunitySkillPublishError(f"'{slug}' is a reserved name and can't be published to the community.")
     return slug
 
 
@@ -181,6 +196,7 @@ def render_community_skill_files(
     `references/playbook.md` becomes `skills/<slug>/references/playbook.md`).
     """
     _validate_slug(slug)
+    _validate_publishable_size(body=body, files=files or [])
     skill_root = f"{SKILLS_DIR}/{slug}"
 
     rendered: list[RenderedFile] = [
@@ -215,7 +231,52 @@ def render_community_skill_files(
         seen_paths.add(path.lower())
         rendered.append(RenderedFile(path=path, content=file["content"]))
 
+    _reject_blob_directory_collisions(seen_paths)
     return rendered
+
+
+def _validate_publishable_size(*, body: str, files: list[dict[str, str]]) -> None:
+    """Hold a publish to the limits the catalog and GitHub will hold it to anyway.
+
+    The per-skill limits are ingest's (`community_skill_sync._validate_entry_within_caps`), where
+    breaching one drops the whole entry: the pull request merges and the skill never appears. The
+    aggregate is GitHub's, where breaching it fails the tree write with a 502 nobody can act on.
+    """
+    if len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+        raise CommunitySkillPublishError(f"The skill body must be under {MAX_SKILL_BODY_BYTES // 1_000_000} MB.")
+    if len(files) > MAX_SKILL_FILE_COUNT:
+        raise CommunitySkillPublishError(f"A skill can publish at most {MAX_SKILL_FILE_COUNT} files.")
+
+    total = len(body.encode("utf-8"))
+    for file in files:
+        size = len(file["content"].encode("utf-8"))
+        if size > MAX_SKILL_FILE_BYTES:
+            raise CommunitySkillPublishError(f"'{file['path']}' must be under {MAX_SKILL_FILE_BYTES // 1_000_000} MB.")
+        total += size
+    if total > MAX_PUBLISH_TREE_BYTES:
+        raise CommunitySkillPublishError(
+            f"This skill is too large to publish. Trim it to under "
+            f"{MAX_PUBLISH_TREE_BYTES // 1_000_000} MB of body and files, then publish again."
+        )
+
+
+def _reject_blob_directory_collisions(paths: set[str]) -> None:
+    """Refuse a manifest where one path is a file and also a directory in another path.
+
+    A git tree can't hold `references` as both a blob and a tree, so GitHub rejects the whole tree
+    and the skill can't be published at all. Saying which path collides beats the API's error.
+    """
+    directories = {parent for path in paths for parent in _parent_directories(path)}
+    collisions = sorted(directories & paths)
+    if collisions:
+        raise CommunitySkillPublishError(
+            f"'{collisions[0].split('/', 2)[-1]}' is used as both a file and a folder. Rename one of them."
+        )
+
+
+def _parent_directories(path: str) -> list[str]:
+    parts = path.split("/")
+    return ["/".join(parts[:index]) for index in range(1, len(parts))]
 
 
 def get_community_skills_publisher() -> GitHubIntegration | None:

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -8,6 +8,7 @@ powers the Tasks product. This module owns the pure rendering of an `LLMSkill` i
 from __future__ import annotations
 
 import re
+import json
 import hashlib
 from dataclasses import dataclass
 from typing import Any
@@ -15,6 +16,7 @@ from typing import Any
 from django.conf import settings
 
 import yaml
+import requests
 import structlog
 
 from posthog.egress.github.transport import GitHubRateLimitError
@@ -35,13 +37,15 @@ logger = structlog.get_logger(__name__)
 
 MAX_SLUG_LENGTH = 64
 # GitHub caps one create-tree request at 7 MB, and commit_files_to_branch inlines every file's
-# content in that single request, so a skill above the cap can only ever fail with a 502. Held well
-# under it: the content is JSON-escaped on the way out, so the request is larger than the sum of the
-# files.
+# content in that single request, so a skill above the cap can only ever fail with a 502. Measured
+# against the escaped form the request actually carries, and held under the cap for the frontmatter,
+# paths and envelope that ride along with it.
 MAX_PUBLISH_TREE_BYTES = 5_000_000
 # GitHub usernames are alphanumeric with single inner hyphens, up to 39 characters. The handle is
 # self-reported and lands in a public PR body and in the listing, so hold it to the shape of a real
-# username rather than letting free text through.
+# username rather than letting free text through. The pattern alone can't bound the total, since each
+# repetition may contribute a hyphen and a character, so the length is checked beside it.
+MAX_GITHUB_HANDLE_LENGTH = 39
 GITHUB_HANDLE_PATTERN = re.compile(r"^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$")
 # The API field is optional, so the shape it publishes to clients has to accept an empty string too —
 # otherwise generated validators reject the blank the endpoint itself allows.
@@ -65,6 +69,15 @@ class CommunitySkillPublishError(Exception):
 
 class CommunitySkillPublishNotConfiguredError(CommunitySkillPublishError):
     """Raised when the community-skills GitHub App installation isn't configured on this instance."""
+
+
+class CommunitySkillPublishValidationError(CommunitySkillPublishError):
+    """Raised when the skill itself can't be published, before anything is written to GitHub.
+
+    Split from the GitHub failures the base class also carries because the two need opposite advice:
+    this one is fixed by editing the skill, and republishing it unchanged fails the same way, so the
+    endpoint answers it 400 rather than the 502 it answers an unreachable GitHub with.
+    """
 
 
 class _CommunitySkillsPublisher(GitHubIntegration):
@@ -118,11 +131,13 @@ def _validate_slug(slug: str) -> str:
     # that would be dropped on ingest is refused here instead of merging into a catalog that skips
     # it. fullmatch, not match: `$` also matches before a trailing newline.
     if not SKILL_NAME_PATTERN.fullmatch(slug) or "--" in slug or len(slug) > MAX_SLUG_LENGTH:
-        raise CommunitySkillPublishError(
+        raise CommunitySkillPublishValidationError(
             f"'{slug}' is not a valid community skill slug (lowercase letters, numbers, single hyphens)."
         )
     if slug.lower() in RESERVED_SKILL_NAMES:
-        raise CommunitySkillPublishError(f"'{slug}' is a reserved name and can't be published to the community.")
+        raise CommunitySkillPublishValidationError(
+            f"'{slug}' is a reserved name and can't be published to the community."
+        )
     return slug
 
 
@@ -136,11 +151,11 @@ def _validate_allowed_tool(tool: object) -> None:
     appears in the catalog.
     """
     if not isinstance(tool, str):
-        raise CommunitySkillPublishError("Allowed tools must be a list of tool names.")
+        raise CommunitySkillPublishValidationError("Allowed tools must be a list of tool names.")
     try:
         check_allowed_tool_name(tool)
     except ValueError as err:
-        raise CommunitySkillPublishError(f"'{tool}' can't be published as a tool name. {err}") from err
+        raise CommunitySkillPublishValidationError(f"'{tool}' can't be published as a tool name. {err}") from err
 
 
 def render_skill_md(
@@ -161,15 +176,22 @@ def render_skill_md(
     `official`/`verified` on review); optional fields are omitted when empty.
     """
     if not name.strip():
-        raise CommunitySkillPublishError("Skill name is required to publish.")
+        raise CommunitySkillPublishValidationError("Skill name is required to publish.")
     if len(name.strip()) > MAX_DISPLAY_NAME_LENGTH:
-        raise CommunitySkillPublishError(f"Skill name must be {MAX_DISPLAY_NAME_LENGTH} characters or fewer.")
+        raise CommunitySkillPublishValidationError(f"Skill name must be {MAX_DISPLAY_NAME_LENGTH} characters or fewer.")
     if not DISPLAY_NAME_PATTERN.match(name.strip()):
-        raise CommunitySkillPublishError("Skill name must be one line, with no line breaks.")
+        raise CommunitySkillPublishValidationError("Skill name must be one line, with no line breaks.")
     if not description.strip():
-        raise CommunitySkillPublishError("Skill description is required to publish.")
-    if author_handle.strip() and not GITHUB_HANDLE_PATTERN.match(author_handle.strip()):
-        raise CommunitySkillPublishError(f"'{author_handle}' is not a valid GitHub username.")
+        raise CommunitySkillPublishValidationError("Skill description is required to publish.")
+    # The same rule install_community_skill applies on the way back in, where a blank body is refused
+    # as having no instructions. Without it the publish succeeds, the entry merges into the catalog,
+    # and the listing is one nobody can install.
+    if not body.strip():
+        raise CommunitySkillPublishValidationError("Skill instructions are required to publish.")
+    if author_handle.strip() and (
+        len(author_handle.strip()) > MAX_GITHUB_HANDLE_LENGTH or not GITHUB_HANDLE_PATTERN.match(author_handle.strip())
+    ):
+        raise CommunitySkillPublishValidationError(f"'{author_handle}' is not a valid GitHub username.")
     for tool in allowed_tools or []:
         _validate_allowed_tool(tool)
 
@@ -250,7 +272,7 @@ def render_community_skill_files(
         # entry, so the pull request merges and the skill never appears in the catalog. Seeding the
         # set with SKILL.md is also what stops a bundled file from overwriting the rendered one.
         if path.lower() in seen_paths:
-            raise CommunitySkillPublishError(f"Duplicate bundled file path '{file['path']}'.")
+            raise CommunitySkillPublishValidationError(f"Duplicate bundled file path '{file['path']}'.")
         seen_paths.add(path.lower())
         rendered.append(RenderedFile(path=path, content=file["content"]))
 
@@ -262,29 +284,45 @@ def _publishable_file_path(raw_path: str) -> str:
     try:
         return normalize_skill_file_path(raw_path)
     except ValueError as err:
-        raise CommunitySkillPublishError(f"'{raw_path}' can't be published as a file path. {err}") from err
+        raise CommunitySkillPublishValidationError(f"'{raw_path}' can't be published as a file path. {err}") from err
+
+
+def _encoded_payload_bytes(content: str) -> int:
+    """Size this content adds to the one create-tree request GitHub caps at 7 MB.
+
+    What counts against that cap is the escaped form, because commit_files_to_branch inlines every
+    file's content in a single JSON body: a newline costs two bytes there and one here, and a control
+    character costs six. Counting raw bytes instead lets a body of newlines clear a 5 MB check and
+    still blow the limit, which fails the publish with a 502 nobody can act on. `json.dumps` defaults
+    match what `requests` serializes the body with, escaping included.
+    """
+    return len(json.dumps(content).encode("utf-8"))
 
 
 def _validate_publishable_size(*, body: str, files: list[dict[str, str]]) -> None:
     """Hold a publish to the limits the catalog and GitHub will hold it to anyway.
 
     The per-skill limits are ingest's (`community_skill_sync._validate_entry_within_caps`), where
-    breaching one drops the whole entry: the pull request merges and the skill never appears. The
-    aggregate is GitHub's, where breaching it fails the tree write with a 502 nobody can act on.
+    breaching one drops the whole entry: the pull request merges and the skill never appears. They
+    are the stored bytes, which is what ingest measures. The aggregate is GitHub's request cap, where
+    breaching it fails the tree write with a 502 nobody can act on, so it measures the encoded form.
     """
     if len(body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
-        raise CommunitySkillPublishError(f"The skill body must be under {MAX_SKILL_BODY_BYTES // 1_000_000} MB.")
+        raise CommunitySkillPublishValidationError(
+            f"The skill body must be under {MAX_SKILL_BODY_BYTES // 1_000_000} MB."
+        )
     if len(files) > MAX_SKILL_FILE_COUNT:
-        raise CommunitySkillPublishError(f"A skill can publish at most {MAX_SKILL_FILE_COUNT} files.")
+        raise CommunitySkillPublishValidationError(f"A skill can publish at most {MAX_SKILL_FILE_COUNT} files.")
 
-    total = len(body.encode("utf-8"))
+    total = _encoded_payload_bytes(body)
     for file in files:
-        size = len(file["content"].encode("utf-8"))
-        if size > MAX_SKILL_FILE_BYTES:
-            raise CommunitySkillPublishError(f"'{file['path']}' must be under {MAX_SKILL_FILE_BYTES // 1_000_000} MB.")
-        total += size
+        if len(file["content"].encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+            raise CommunitySkillPublishValidationError(
+                f"'{file['path']}' must be under {MAX_SKILL_FILE_BYTES // 1_000_000} MB."
+            )
+        total += _encoded_payload_bytes(file["content"])
     if total > MAX_PUBLISH_TREE_BYTES:
-        raise CommunitySkillPublishError(
+        raise CommunitySkillPublishValidationError(
             f"This skill is too large to publish. Trim it to under "
             f"{MAX_PUBLISH_TREE_BYTES // 1_000_000} MB of body and files, then publish again."
         )
@@ -299,7 +337,7 @@ def _reject_blob_directory_collisions(paths: set[str]) -> None:
     directories = {parent for path in paths for parent in _parent_directories(path)}
     collisions = sorted(directories & paths)
     if collisions:
-        raise CommunitySkillPublishError(
+        raise CommunitySkillPublishValidationError(
             f"'{collisions[0].split('/', 2)[-1]}' is used as both a file and a folder. Rename one of them."
         )
 
@@ -309,20 +347,54 @@ def _parent_directories(path: str) -> list[str]:
     return ["/".join(parts[:index]) for index in range(1, len(parts))]
 
 
+# The publish only writes files and opens a pull request, in one repository. An unscoped mint would
+# hand this transient token every repository and every optional permission the installation holds, so
+# it is requested down to what a publish uses. A permission the installation lacks fails the mint,
+# which is the same 502 an unusable installation would produce on the first write anyway.
+PUBLISHER_TOKEN_PERMISSIONS = {"contents": "write", "pull_requests": "write", "metadata": "read"}
+
+
+def _publisher_token_request_body() -> dict[str, Any]:
+    # The `repositories` field takes bare names; the setting is normally one already, but accept an
+    # `owner/repo` spelling rather than scoping the token to a repository that doesn't exist.
+    repo = (settings.COMMUNITY_SKILLS_GITHUB_REPO or "").split("/")[-1]
+    body: dict[str, Any] = {"permissions": dict(PUBLISHER_TOKEN_PERMISSIONS)}
+    if repo:
+        body["repositories"] = [repo]
+    return body
+
+
 def get_community_skills_publisher() -> GitHubIntegration | None:
     """Build a GitHubIntegration bound to the central community-skills installation, or None.
 
     Mints a fresh installation token via the GitHub App JWT (the same flow the per-team integration
-    uses) and wraps it in a transient, unsaved Integration — we never persist a teamless central row.
-    Returns None when the App or the community-skills installation isn't configured, so callers can
-    surface a clean "not configured" error instead of failing.
+    uses), downscoped to the publish repository and the permissions a publish needs, and wraps it in a
+    transient, unsaved Integration — we never persist a teamless central row. Returns None when the
+    App or the community-skills installation isn't configured, so callers can surface a clean "not
+    configured" error instead of failing.
+
+    Raises CommunitySkillPublishError when GitHub can't be reached to mint the token: an outage here
+    is the same failure as an outage on the write that follows, and must not read as "not configured".
     """
     installation_id = settings.COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID
     if not installation_id or not settings.GITHUB_APP_CLIENT_ID or not settings.GITHUB_APP_PRIVATE_KEY:
         return None
 
-    info_response = GitHubIntegration.client_request(f"installations/{installation_id}")
-    token_response = GitHubIntegration.client_request(f"installations/{installation_id}/access_tokens", method="POST")
+    try:
+        info_response = GitHubIntegration.client_request(f"installations/{installation_id}")
+        token_response = GitHubIntegration.client_request(
+            f"installations/{installation_id}/access_tokens",
+            method="POST",
+            json_body=_publisher_token_request_body(),
+        )
+    except (requests.RequestException, GitHubIntegrationError, GitHubRateLimitError) as err:
+        # client_request talks to the transport directly, so unlike api_request it hands a timeout
+        # back raw. Without this the publish path answers a GitHub outage with an unhandled 500.
+        logger.warning("community_skills_publisher_unreachable", exc_info=True)
+        raise CommunitySkillPublishError(
+            "Could not reach GitHub to publish this skill. Try again in a few minutes."
+        ) from err
+
     if info_response.status_code != 200 or token_response.status_code != 201:
         logger.warning(
             "community_skills_publisher_unavailable",

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -37,6 +37,7 @@ OPTIONAL_GITHUB_HANDLE_PATTERN = re.compile(f"^$|{GITHUB_HANDLE_PATTERN.pattern}
 # Matches CommunitySkill.name — a longer name publishes and merges, then ingest rejects the entry and
 # the skill silently never appears in the catalog.
 MAX_DISPLAY_NAME_LENGTH = 64
+MAX_TAG_LENGTH = 64
 SKILLS_DIR = "skills"
 COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
 COMMUNITY_SKILLS_BRANCH_PREFIX = "community-skill/"
@@ -68,6 +69,18 @@ class RenderedFile:
 
     path: str
     content: str
+
+
+def publishable_tags(tags: object) -> list[str]:
+    """Keep only the entries of a skill's stored tags that the catalog can actually accept.
+
+    `LLMSkill.metadata` is an arbitrary dict, so its `tags` can hold any JSON, while ingest requires
+    every tag to be a string within the catalog's cap and drops the whole entry otherwise. Publishing
+    the unusable ones would open a pull request that merges and then never appears in the catalog.
+    """
+    if not isinstance(tags, list):
+        return []
+    return [tag for tag in tags if isinstance(tag, str) and tag.strip() and len(tag) <= MAX_TAG_LENGTH]
 
 
 def publisher_branch_key(publisher_id: str) -> str:
@@ -290,11 +303,13 @@ def publish_skill_to_community(
         return _write_branch_and_pull_request(
             publisher, rendered=rendered, slug=slug, name=name, author_handle=author_handle, branch=branch
         )
-    except (GitHubIntegrationError, GitHubRateLimitError):
+    except (GitHubIntegrationError, GitHubRateLimitError) as err:
         # The client only ever sees this class of failure as "GitHub is unreachable", so the detail
         # has to reach the logs here or it is lost.
         logger.warning("community_skill_publish_github_unavailable", slug=slug, branch=branch, exc_info=True)
-        raise CommunitySkillPublishError("Could not reach GitHub to publish this skill. Try again in a few minutes.")
+        raise CommunitySkillPublishError(
+            "Could not reach GitHub to publish this skill. Try again in a few minutes."
+        ) from err
 
 
 def _write_branch_and_pull_request(

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -371,6 +371,10 @@ def _parent_directories(path: str) -> list[str]:
 # it is requested down to what a publish uses. A permission the installation lacks fails the mint,
 # which is the same 502 an unusable installation would produce on the first write anyway.
 PUBLISHER_TOKEN_PERMISSIONS = {"contents": "write", "pull_requests": "write", "metadata": "read"}
+# Statuses that mean the App isn't installed here or its credentials are rejected: unauthenticated,
+# not permitted, or no such installation. Rate limits never reach this set — the transport raises
+# them, including the 403 spellings.
+PUBLISHER_NOT_CONFIGURED_STATUSES = frozenset({401, 403, 404})
 
 
 def _publisher_token_request_body() -> dict[str, Any]:
@@ -414,13 +418,25 @@ def get_community_skills_publisher() -> GitHubIntegration | None:
             "Could not reach GitHub to publish this skill. Try again in a few minutes."
         ) from err
 
-    if info_response.status_code != 200 or token_response.status_code != 201:
+    failed_statuses = [
+        response.status_code
+        for response, expected in ((info_response, 200), (token_response, 201))
+        if response.status_code != expected
+    ]
+    if failed_statuses:
         logger.warning(
             "community_skills_publisher_unavailable",
             info_status=info_response.status_code,
             token_status=token_response.status_code,
         )
-        return None
+        # A missing installation or App credentials GitHub refuses are settings nobody can retry
+        # their way out of, which is the 503 this returns None for. Any other status is GitHub
+        # failing a call we were entitled to make, and has to read as a gateway error instead —
+        # answering a transient 500 with "not configured" sends the publisher to the manual path
+        # for an outage that clears on its own.
+        if all(status in PUBLISHER_NOT_CONFIGURED_STATUSES for status in failed_statuses):
+            return None
+        raise CommunitySkillPublishError("Could not reach GitHub to publish this skill. Try again in a few minutes.")
 
     account = info_response.json().get("account") or {}
     token = token_response.json().get("token")
@@ -486,10 +502,9 @@ def publish_skill_to_community(
     Raises CommunitySkillPublishError when any GitHub step fails, or
     CommunitySkillPublishNotConfiguredError when publishing is disabled.
     """
-    publisher = get_community_skills_publisher()
-    if publisher is None:
-        raise CommunitySkillPublishNotConfiguredError("Community skill publishing is not configured.")
-
+    # Rendering is pure and deterministic, so it runs before the publisher is acquired: a skill the
+    # publisher has to edit gets the 400 that says so, rather than a 502 or 503 about GitHub that
+    # sends them away to retry a publish that would never have succeeded.
     rendered = render_community_skill_files(
         slug=slug,
         name=name,
@@ -502,6 +517,10 @@ def publish_skill_to_community(
         compatibility=compatibility,
         author_handle=author_handle,
     )
+
+    publisher = get_community_skills_publisher()
+    if publisher is None:
+        raise CommunitySkillPublishNotConfiguredError("Community skill publishing is not configured.")
 
     branch = f"{COMMUNITY_SKILLS_BRANCH_PREFIX}{slug}-{publisher_branch_key(publisher_id)}"
     try:

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -146,7 +146,10 @@ def render_skill_md(
     # sort_keys=False keeps the human-friendly field order above; default_flow_style=False emits
     # block-style YAML (lists as `- item`) that the repo's yaml.safe_load round-trips.
     rendered_frontmatter = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False, allow_unicode=True)
-    return f"---\n{rendered_frontmatter}---\n\n{body.strip()}\n"
+    # rstrip, not strip: leading whitespace is content. A body that opens with an indented code block
+    # becomes an ordinary paragraph once it's trimmed, so the published skill would instruct
+    # differently from the skill it was published from.
+    return f"---\n{rendered_frontmatter}---\n\n{body.rstrip()}\n"
 
 
 def render_community_skill_files(
@@ -271,8 +274,9 @@ def publish_skill_to_community(
     One open PR per skill per publisher: the branch is derived from the slug and ``publisher_id``, so
     re-publishing rewrites that branch and returns the pull request already open for it instead of
     opening a second one. Every file lands in a single commit, and a failure after the branch write
-    deletes the branch again — this repo is public, so a half-written skill or an unreviewed branch
-    must not survive a failed publish.
+    deletes the branch again, since this repo is public and a half-written skill or an unreviewed
+    branch must not survive a failed publish. A failure that may still have opened a pull request is
+    reconciled against GitHub first, so cleanup can never remove a branch under live review.
 
     ``publisher_id`` identifies the publishing team and is required. Leaving the branch keyed on the
     slug alone would let one team's publish force-update another team's open pull request, because a
@@ -344,29 +348,40 @@ def _write_branch_and_pull_request(
         logger.info("community_skill_publish_updated_open_pr", slug=slug, pr_number=existing_pr["number"])
         return {"pr_url": pr_url, "pr_number": existing_pr["number"], "branch": branch}
 
-    pr_result = publisher.create_pull_request(
-        repo,
-        f"Add community skill: {name}",
-        _community_pr_body(name=name, slug=slug, author_handle=author_handle),
-        branch,
-        base,
-    )
+    try:
+        pr_result = publisher.create_pull_request(
+            repo,
+            f"Add community skill: {name}",
+            _community_pr_body(name=name, slug=slug, author_handle=author_handle),
+            branch,
+            base,
+        )
+    except (GitHubIntegrationError, GitHubRateLimitError):
+        # A transport failure on this POST is ambiguous: GitHub may still have opened the pull
+        # request, and api_request doesn't retry a POST. Reconcile before cleaning up, so a timeout
+        # can't delete a branch that now heads a live review.
+        logger.warning("community_skill_publish_pr_create_ambiguous", slug=slug, branch=branch, exc_info=True)
+        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch)
+        if reconciled is not None:
+            return reconciled
+        _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch)
+        raise
+
     if pr_result.get("success"):
         logger.info("community_skill_published", slug=slug, pr_number=pr_result.get("pr_number"))
         return {"pr_url": pr_result["pr_url"], "pr_number": pr_result["pr_number"], "branch": branch}
 
     error = str(pr_result.get("error") or "")
-    # Cleanup is for debris this call just created. A branch that already heads a pull request (a
-    # concurrent publish won the race) belongs to that review, so leave it alone.
-    if "already exists" not in error.lower():
-        cleanup_result = publisher.delete_branch(repo, branch)
-        if not cleanup_result.get("success"):
-            logger.warning(
-                "community_skill_publish_branch_cleanup_failed",
-                slug=slug,
-                branch=branch,
-                error=cleanup_result.get("error"),
-            )
+    # A branch that already heads a pull request means a concurrent publish won the race. Our commit
+    # is on that branch and so inside that review, so return it rather than reporting a failure for
+    # content that is already public. Cleanup would belong to that review's branch, not to us.
+    if "already exists" in error.lower():
+        reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch)
+        if reconciled is not None:
+            return reconciled
+        raise CommunitySkillPublishError("A pull request for this skill is already open for review.")
+
+    _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch)
     # GitHub refuses a pull request with an empty diff, which is what an unchanged skill produces.
     if "no commits between" in error.lower():
         raise CommunitySkillPublishError(
@@ -374,3 +389,41 @@ def _write_branch_and_pull_request(
             "Edit the skill, then publish again."
         )
     raise CommunitySkillPublishError(f"Failed to open pull request: {error}")
+
+
+def _reconcile_open_pr(publisher: GitHubIntegration, *, repo: str, slug: str, branch: str) -> dict[str, Any] | None:
+    """Re-read the pull request open for ``branch`` after an ambiguous create, or None if there is none.
+
+    A None here means "found nothing", not "the branch has no pull request": the lookup is
+    best-effort and answers None for most failures. It still raises when GitHub rate-limits the read,
+    which is caught here so a caller cleaning up after a failure isn't handed a second one.
+    """
+    try:
+        pull = publisher.get_open_pull_request_for_head(repo, branch)
+    except (GitHubIntegrationError, GitHubRateLimitError):
+        logger.warning("community_skill_publish_pr_lookup_failed", slug=slug, branch=branch, exc_info=True)
+        return None
+    if pull is None or not pull.get("url"):
+        return None
+    logger.info("community_skill_publish_reconciled_open_pr", slug=slug, pr_number=pull["number"])
+    return {"pr_url": pull["url"], "pr_number": pull["number"], "branch": branch}
+
+
+def _delete_publish_branch(publisher: GitHubIntegration, *, repo: str, slug: str, branch: str) -> None:
+    """Remove a branch this publish created. Cleanup failure is logged, never raised over the cause.
+
+    This also runs while handling a GitHub failure, where a raise here would replace the error that
+    actually explains the publish with one about the tidy-up after it.
+    """
+    try:
+        cleanup_result = publisher.delete_branch(repo, branch)
+    except (GitHubIntegrationError, GitHubRateLimitError):
+        logger.warning("community_skill_publish_branch_cleanup_failed", slug=slug, branch=branch, exc_info=True)
+        return
+    if not cleanup_result.get("success"):
+        logger.warning(
+            "community_skill_publish_branch_cleanup_failed",
+            slug=slug,
+            branch=branch,
+            error=cleanup_result.get("error"),
+        )

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -199,12 +199,21 @@ def render_community_skill_files(
         )
     ]
 
+    seen_paths = {rendered[0].path.lower()}
     for file in files or []:
         rel_path = file["path"].lstrip("/")
         # Confine writes to the skill directory — a bundled file must never escape skills/<slug>/.
-        if rel_path == "SKILL.md" or ".." in rel_path.split("/"):
+        if ".." in rel_path.split("/"):
             raise CommunitySkillPublishError(f"Invalid bundled file path '{file['path']}'.")
-        rendered.append(RenderedFile(path=f"{skill_root}/{rel_path}", content=file["content"]))
+        path = f"{skill_root}/{rel_path}"
+        # Case-insensitive, matching community_skill_sync._validate_entry_within_caps: two paths
+        # differing only by case pass every check on this side, and then ingest rejects the whole
+        # entry, so the pull request merges and the skill never appears in the catalog. Seeding the
+        # set with SKILL.md is also what stops a bundled file from overwriting the rendered one.
+        if path.lower() in seen_paths:
+            raise CommunitySkillPublishError(f"Duplicate bundled file path '{file['path']}'.")
+        seen_paths.add(path.lower())
+        rendered.append(RenderedFile(path=path, content=file["content"]))
 
     return rendered
 
@@ -352,6 +361,7 @@ def _write_branch_and_pull_request(
     )
     if not commit_result.get("success"):
         raise CommunitySkillPublishError(f"Failed to commit skill files: {commit_result.get('error')}")
+    commit_sha = commit_result.get("commit_sha")
 
     if existing_pr is not None:
         pr_url = existing_pr.get("url")
@@ -376,7 +386,7 @@ def _write_branch_and_pull_request(
         reconciled = _reconcile_open_pr(publisher, repo=repo, slug=slug, branch=branch, base=base)
         if reconciled is not None:
             return reconciled
-        _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch)
+        _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch, commit_sha=commit_sha)
         raise
 
     if pr_result.get("success"):
@@ -393,7 +403,7 @@ def _write_branch_and_pull_request(
             return reconciled
         raise CommunitySkillPublishError("A pull request for this skill is already open for review.")
 
-    _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch)
+    _delete_publish_branch(publisher, repo=repo, slug=slug, branch=branch, commit_sha=commit_sha)
     # GitHub refuses a pull request with an empty diff, which is what an unchanged skill produces.
     if "no commits between" in error.lower():
         raise CommunitySkillPublishError(
@@ -444,14 +454,20 @@ def _reconcile_open_pr(
     return {"pr_url": pull["url"], "pr_number": pull["number"], "branch": branch}
 
 
-def _delete_publish_branch(publisher: GitHubIntegration, *, repo: str, slug: str, branch: str) -> None:
+def _delete_publish_branch(
+    publisher: GitHubIntegration, *, repo: str, slug: str, branch: str, commit_sha: str | None
+) -> None:
     """Remove a branch this publish created. Cleanup failure is logged, never raised over the cause.
 
     This also runs while handling a GitHub failure, where a raise here would replace the error that
     actually explains the publish with one about the tidy-up after it.
+
+    The delete is conditional on ``commit_sha``: the branch name is shared by every publish of this
+    skill from this team, so an unconditional delete could take out a concurrent publisher's commit,
+    which they cannot recover the way the publisher who wrote it can.
     """
     try:
-        cleanup_result = publisher.delete_branch(repo, branch)
+        cleanup_result = publisher.delete_branch(repo, branch, expected_sha=commit_sha)
     except (GitHubIntegrationError, GitHubRateLimitError):
         logger.warning("community_skill_publish_branch_cleanup_failed", slug=slug, branch=branch, exc_info=True)
         return

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -8,6 +8,7 @@ powers the Tasks product. This module owns the pure rendering of an `LLMSkill` i
 from __future__ import annotations
 
 import re
+import hashlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,6 +17,8 @@ from django.conf import settings
 import yaml
 import structlog
 
+from posthog.egress.github.transport import GitHubRateLimitError
+from posthog.models.github_integration_base import GitHubIntegrationError
 from posthog.models.integration import GitHubIntegration, Integration
 
 logger = structlog.get_logger(__name__)
@@ -24,6 +27,13 @@ logger = structlog.get_logger(__name__)
 # repo's own validation would reject.
 SLUG_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 MAX_SLUG_LENGTH = 64
+# GitHub usernames are alphanumeric with single inner hyphens, up to 39 characters. The handle is
+# self-reported and lands in a public PR body and in the listing, so hold it to the shape of a real
+# username rather than letting free text through.
+GITHUB_HANDLE_PATTERN = re.compile(r"^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$")
+# The API field is optional, so the shape it publishes to clients has to accept an empty string too —
+# otherwise generated validators reject the blank the endpoint itself allows.
+OPTIONAL_GITHUB_HANDLE_PATTERN = re.compile(f"^$|{GITHUB_HANDLE_PATTERN.pattern}")
 # Matches CommunitySkill.name — a longer name publishes and merges, then ingest rejects the entry and
 # the skill silently never appears in the catalog.
 MAX_DISPLAY_NAME_LENGTH = 64
@@ -40,12 +50,34 @@ class CommunitySkillPublishNotConfiguredError(CommunitySkillPublishError):
     """Raised when the community-skills GitHub App installation isn't configured on this instance."""
 
 
+class _CommunitySkillsPublisher(GitHubIntegration):
+    """Publisher client whose Integration row is transient and belongs to no team.
+
+    A fresh installation token is minted for every publish, so a 401 is a real failure rather than an
+    expiry to heal — and the inherited refresh would try to save a teamless row, which the model's
+    team foreign key forbids.
+    """
+
+    def refresh_access_token(self) -> None:
+        raise GitHubIntegrationError("The community-skills publisher mints a token per publish and cannot refresh.")
+
+
 @dataclass(frozen=True)
 class RenderedFile:
     """A single file to commit, at its path within the community-skills repo."""
 
     path: str
     content: str
+
+
+def publisher_branch_key(publisher_id: str) -> str:
+    """Short, stable, opaque branch suffix for one publisher.
+
+    Skill slugs are only unique within a team, but a branch name is global to the community repo, so a
+    slug alone would let one team's publish force-update another team's open pull request. Hashing
+    keeps the publisher's identifier out of a public branch name.
+    """
+    return hashlib.sha256(publisher_id.encode()).hexdigest()[:8]
 
 
 def _validate_slug(slug: str) -> str:
@@ -79,6 +111,8 @@ def render_skill_md(
         raise CommunitySkillPublishError(f"Skill name must be {MAX_DISPLAY_NAME_LENGTH} characters or fewer.")
     if not description.strip():
         raise CommunitySkillPublishError("Skill description is required to publish.")
+    if author_handle.strip() and not GITHUB_HANDLE_PATTERN.match(author_handle.strip()):
+        raise CommunitySkillPublishError(f"'{author_handle}' is not a valid GitHub username.")
 
     frontmatter: dict[str, Any] = {
         "name": name.strip(),
@@ -185,13 +219,18 @@ def get_community_skills_publisher() -> GitHubIntegration | None:
         config={"account": {"name": account["login"], "type": account.get("type")}},
         sensitive_config={"access_token": token},
     )
-    return GitHubIntegration(integration)
+    return _CommunitySkillsPublisher(integration)
 
 
 def _community_pr_body(*, name: str, slug: str, author_handle: str) -> str:
     # No PostHog user PII here — this PR is public. Attribution is only the GitHub handle the
     # publisher explicitly provided for public sharing.
-    credit = f"Published by @{author_handle}" if author_handle else "Published from the PostHog skills marketplace"
+    # The handle is self-reported, so say so: a maintainer must not read it as a verified identity.
+    credit = (
+        f"Published from the PostHog skills marketplace. The publisher gave @{author_handle} as the author handle"
+        if author_handle
+        else "Published from the PostHog skills marketplace"
+    )
     return (
         f"Adds the **{name}** community skill (`skills/{slug}/`).\n\n"
         f"{credit} via the in-product *Publish to community* flow.\n\n"
@@ -203,6 +242,7 @@ def _community_pr_body(*, name: str, slug: str, author_handle: str) -> str:
 def publish_skill_to_community(
     *,
     slug: str,
+    publisher_id: str,
     name: str,
     description: str,
     body: str,
@@ -215,10 +255,15 @@ def publish_skill_to_community(
 ) -> dict[str, Any]:
     """Open a PR in PostHog/community-skills adding (or updating) this skill. Returns the PR url/number.
 
-    One open PR per slug: the branch name is derived from the slug, so re-publishing a skill rewrites
-    that branch and returns the PR already open for it instead of opening a second one. Every file
-    lands in a single commit, and a failure after the branch write deletes the branch again — this
-    repo is public, so a half-written skill or an unreviewed branch must not survive a failed publish.
+    One open PR per skill per publisher: the branch is derived from the slug and ``publisher_id``, so
+    re-publishing rewrites that branch and returns the pull request already open for it instead of
+    opening a second one. Every file lands in a single commit, and a failure after the branch write
+    deletes the branch again — this repo is public, so a half-written skill or an unreviewed branch
+    must not survive a failed publish.
+
+    ``publisher_id`` identifies the publishing team and is required. Leaving the branch keyed on the
+    slug alone would let one team's publish force-update another team's open pull request, because a
+    skill slug is only unique within a team.
 
     Raises CommunitySkillPublishError when any GitHub step fails, or
     CommunitySkillPublishNotConfiguredError when publishing is disabled.
@@ -240,9 +285,29 @@ def publish_skill_to_community(
         author_handle=author_handle,
     )
 
+    branch = f"{COMMUNITY_SKILLS_BRANCH_PREFIX}{slug}-{publisher_branch_key(publisher_id)}"
+    try:
+        return _write_branch_and_pull_request(
+            publisher, rendered=rendered, slug=slug, name=name, author_handle=author_handle, branch=branch
+        )
+    except (GitHubIntegrationError, GitHubRateLimitError):
+        # The client only ever sees this class of failure as "GitHub is unreachable", so the detail
+        # has to reach the logs here or it is lost.
+        logger.warning("community_skill_publish_github_unavailable", slug=slug, branch=branch, exc_info=True)
+        raise CommunitySkillPublishError("Could not reach GitHub to publish this skill. Try again in a few minutes.")
+
+
+def _write_branch_and_pull_request(
+    publisher: GitHubIntegration,
+    *,
+    rendered: list[RenderedFile],
+    slug: str,
+    name: str,
+    author_handle: str,
+    branch: str,
+) -> dict[str, Any]:
     repo = settings.COMMUNITY_SKILLS_GITHUB_REPO
     base = COMMUNITY_SKILLS_PR_BASE_BRANCH
-    branch = f"{COMMUNITY_SKILLS_BRANCH_PREFIX}{slug}"
 
     # Read the open PR before writing, so a failed write doesn't get blamed on a PR that predates it.
     existing_pr = publisher.get_open_pull_request_for_head(repo, branch)

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -171,10 +171,10 @@ def get_community_skills_publisher() -> GitHubIntegration | None:
     if not token or not account.get("login"):
         return None
 
-    # Transient (never saved) Integration: the write helpers only read the access token + account
-    # name and don't trigger a refresh/save, so this avoids polluting the team-scoped Integration table.
+    # Transient (never saved) Integration, left unattached to any team: the write helpers only read
+    # the access token + account name and don't trigger a refresh/save, so this avoids polluting the
+    # team-scoped Integration table.
     integration = Integration(
-        team_id=None,
         kind="github",
         integration_id=str(installation_id),
         config={"account": {"name": account["login"], "type": account.get("type")}},

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -8,7 +8,6 @@ powers the Tasks product. This module owns the pure rendering of an `LLMSkill` i
 from __future__ import annotations
 
 import re
-import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,8 +24,12 @@ logger = structlog.get_logger(__name__)
 # repo's own validation would reject.
 SLUG_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 MAX_SLUG_LENGTH = 64
+# Matches CommunitySkill.name — a longer name publishes and merges, then ingest rejects the entry and
+# the skill silently never appears in the catalog.
+MAX_DISPLAY_NAME_LENGTH = 64
 SKILLS_DIR = "skills"
 COMMUNITY_SKILLS_PR_BASE_BRANCH = "main"
+COMMUNITY_SKILLS_BRANCH_PREFIX = "community-skill/"
 
 
 class CommunitySkillPublishError(Exception):
@@ -72,6 +75,8 @@ def render_skill_md(
     """
     if not name.strip():
         raise CommunitySkillPublishError("Skill name is required to publish.")
+    if len(name.strip()) > MAX_DISPLAY_NAME_LENGTH:
+        raise CommunitySkillPublishError(f"Skill name must be {MAX_DISPLAY_NAME_LENGTH} characters or fewer.")
     if not description.strip():
         raise CommunitySkillPublishError("Skill description is required to publish.")
 
@@ -210,8 +215,13 @@ def publish_skill_to_community(
 ) -> dict[str, Any]:
     """Open a PR in PostHog/community-skills adding (or updating) this skill. Returns the PR url/number.
 
-    Reuses the existing GitHubIntegration branch/commit/PR helpers. Raises CommunitySkillPublishError
-    when any GitHub step fails, or CommunitySkillPublishNotConfiguredError when publishing is disabled.
+    One open PR per slug: the branch name is derived from the slug, so re-publishing a skill rewrites
+    that branch and returns the PR already open for it instead of opening a second one. Every file
+    lands in a single commit, and a failure after the branch write deletes the branch again — this
+    repo is public, so a half-written skill or an unreviewed branch must not survive a failed publish.
+
+    Raises CommunitySkillPublishError when any GitHub step fails, or
+    CommunitySkillPublishNotConfiguredError when publishing is disabled.
     """
     publisher = get_community_skills_publisher()
     if publisher is None:
@@ -232,18 +242,27 @@ def publish_skill_to_community(
 
     repo = settings.COMMUNITY_SKILLS_GITHUB_REPO
     base = COMMUNITY_SKILLS_PR_BASE_BRANCH
-    branch = f"community-skill/{slug}-{uuid.uuid4().hex[:8]}"
+    branch = f"{COMMUNITY_SKILLS_BRANCH_PREFIX}{slug}"
 
-    branch_result = publisher.create_branch(repo, branch, base)
-    if not branch_result.get("success"):
-        raise CommunitySkillPublishError(f"Failed to create branch: {branch_result.get('error')}")
+    # Read the open PR before writing, so a failed write doesn't get blamed on a PR that predates it.
+    existing_pr = publisher.get_open_pull_request_for_head(repo, branch)
 
-    for rendered_file in rendered:
-        commit_result = publisher.update_file(
-            repo, rendered_file.path, rendered_file.content, f"Add {rendered_file.path}", branch
-        )
-        if not commit_result.get("success"):
-            raise CommunitySkillPublishError(f"Failed to commit {rendered_file.path}: {commit_result.get('error')}")
+    commit_result = publisher.commit_files_to_branch(
+        repo,
+        branch,
+        base,
+        {rendered_file.path: rendered_file.content for rendered_file in rendered},
+        f"{'Update' if existing_pr else 'Add'} community skill: {name}",
+    )
+    if not commit_result.get("success"):
+        raise CommunitySkillPublishError(f"Failed to commit skill files: {commit_result.get('error')}")
+
+    if existing_pr is not None:
+        pr_url = existing_pr.get("url")
+        if not pr_url:
+            raise CommunitySkillPublishError("A pull request for this skill is already open for review.")
+        logger.info("community_skill_publish_updated_open_pr", slug=slug, pr_number=existing_pr["number"])
+        return {"pr_url": pr_url, "pr_number": existing_pr["number"], "branch": branch}
 
     pr_result = publisher.create_pull_request(
         repo,
@@ -252,8 +271,26 @@ def publish_skill_to_community(
         branch,
         base,
     )
-    if not pr_result.get("success"):
-        raise CommunitySkillPublishError(f"Failed to open pull request: {pr_result.get('error')}")
+    if pr_result.get("success"):
+        logger.info("community_skill_published", slug=slug, pr_number=pr_result.get("pr_number"))
+        return {"pr_url": pr_result["pr_url"], "pr_number": pr_result["pr_number"], "branch": branch}
 
-    logger.info("community_skill_published", slug=slug, pr_number=pr_result.get("pr_number"))
-    return {"pr_url": pr_result["pr_url"], "pr_number": pr_result["pr_number"], "branch": branch}
+    error = str(pr_result.get("error") or "")
+    # Cleanup is for debris this call just created. A branch that already heads a pull request (a
+    # concurrent publish won the race) belongs to that review, so leave it alone.
+    if "already exists" not in error.lower():
+        cleanup_result = publisher.delete_branch(repo, branch)
+        if not cleanup_result.get("success"):
+            logger.warning(
+                "community_skill_publish_branch_cleanup_failed",
+                slug=slug,
+                branch=branch,
+                error=cleanup_result.get("error"),
+            )
+    # GitHub refuses a pull request with an empty diff, which is what an unchanged skill produces.
+    if "no commits between" in error.lower():
+        raise CommunitySkillPublishError(
+            "This skill already matches what's published, so there's nothing to send. "
+            "Edit the skill, then publish again."
+        )
+    raise CommunitySkillPublishError(f"Failed to open pull request: {error}")

--- a/products/skills/backend/api/community_skill_sync.py
+++ b/products/skills/backend/api/community_skill_sync.py
@@ -11,8 +11,14 @@ from rest_framework.serializers import ValidationError as DRFValidationError
 from posthog.egress.github.transport import github_request
 
 from ..models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier
-from .skill_serializers import RESERVED_SKILL_NAMES, SKILL_NAME_PATTERN, validate_skill_file_path
-from .skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES, MAX_SKILL_FILE_COUNT
+from .skill_serializers import validate_skill_file_path
+from .skill_services import (
+    MAX_SKILL_BODY_BYTES,
+    MAX_SKILL_FILE_BYTES,
+    MAX_SKILL_FILE_COUNT,
+    RESERVED_SKILL_NAMES,
+    SKILL_NAME_PATTERN,
+)
 
 logger = structlog.get_logger(__name__)
 

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -11,7 +11,7 @@ from posthog.api.shared import UserBasicSerializer
 from products.ai_observability.backend.markdown_outline import get_markdown_outline
 
 from ..models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
-from .community_publish_services import MAX_DISPLAY_NAME_LENGTH, OPTIONAL_GITHUB_HANDLE_PATTERN
+from .community_publish_services import MAX_DISPLAY_NAME_LENGTH, MAX_TAG_LENGTH, OPTIONAL_GITHUB_HANDLE_PATTERN
 from .skill_services import (
     LLMSkillOwnerNotFoundError,
     resolve_owner_users,
@@ -857,7 +857,7 @@ class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
         help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
     )
     tags = serializers.ListField(
-        child=serializers.CharField(max_length=64),
+        child=serializers.CharField(max_length=MAX_TAG_LENGTH),
         required=False,
         help_text="Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].",
     )

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -13,6 +13,7 @@ from ..models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
 from .community_publish_services import (
     DISPLAY_NAME_PATTERN,
     MAX_DISPLAY_NAME_LENGTH,
+    MAX_GITHUB_HANDLE_LENGTH,
     MAX_TAG_LENGTH,
     OPTIONAL_GITHUB_HANDLE_PATTERN,
 )
@@ -853,6 +854,9 @@ class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
         OPTIONAL_GITHUB_HANDLE_PATTERN,
         required=False,
         allow_blank=True,
+        # The pattern can't bound the total on its own: each of its repetitions may contribute a
+        # hyphen and a character, so it alone accepts 77 characters — not a username GitHub can hold.
+        max_length=MAX_GITHUB_HANDLE_LENGTH,
         help_text=(
             "The publisher's GitHub username, used for public attribution on the listing and PR. Optional, "
             "and self-reported: it is not verified against the publisher's PostHog account."

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -11,6 +11,7 @@ from posthog.api.shared import UserBasicSerializer
 from products.ai_observability.backend.markdown_outline import get_markdown_outline
 
 from ..models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
+from .community_publish_services import MAX_DISPLAY_NAME_LENGTH
 from .skill_services import (
     LLMSkillOwnerNotFoundError,
     resolve_owner_users,
@@ -852,7 +853,7 @@ class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
     display_name = serializers.CharField(
         required=False,
         allow_blank=True,
-        max_length=200,
+        max_length=MAX_DISPLAY_NAME_LENGTH,
         help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
     )
     tags = serializers.ListField(

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -846,3 +846,31 @@ class LLMSkillMarketplaceCommandSerializer(serializers.Serializer):
     )
     created_at = serializers.DateTimeField(allow_null=True, help_text="When the credential was created.")
     last_rolled_at = serializers.DateTimeField(allow_null=True, help_text="When the credential was last rotated.")
+
+
+class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
+    display_name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=200,
+        help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=64),
+        required=False,
+        help_text="Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].",
+    )
+    author_handle = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=100,
+        help_text="The publisher's GitHub username, used for public attribution on the listing and PR. Optional.",
+    )
+
+
+class CommunitySkillPublishResultSerializer(serializers.Serializer):
+    pr_url = serializers.URLField(
+        help_text="URL of the pull request opened in the community-skills repo for maintainer review."
+    )
+    pr_number = serializers.IntegerField(help_text="Number of the opened pull request.")
+    branch = serializers.CharField(help_text="Name of the branch created in the community-skills repo.")

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -11,7 +11,7 @@ from posthog.api.shared import UserBasicSerializer
 from products.ai_observability.backend.markdown_outline import get_markdown_outline
 
 from ..models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
-from .community_publish_services import MAX_DISPLAY_NAME_LENGTH
+from .community_publish_services import MAX_DISPLAY_NAME_LENGTH, OPTIONAL_GITHUB_HANDLE_PATTERN
 from .skill_services import (
     LLMSkillOwnerNotFoundError,
     resolve_owner_users,
@@ -861,11 +861,14 @@ class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
         required=False,
         help_text="Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].",
     )
-    author_handle = serializers.CharField(
+    author_handle = serializers.RegexField(
+        OPTIONAL_GITHUB_HANDLE_PATTERN,
         required=False,
         allow_blank=True,
-        max_length=100,
-        help_text="The publisher's GitHub username, used for public attribution on the listing and PR. Optional.",
+        help_text=(
+            "The publisher's GitHub username, used for public attribution on the listing and PR. Optional, "
+            "and self-reported: it is not verified against the publisher's PostHog account."
+        ),
     )
 
 

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -11,7 +11,12 @@ from posthog.api.shared import UserBasicSerializer
 from products.ai_observability.backend.markdown_outline import get_markdown_outline
 
 from ..models.skills import LLMSkill, LLMSkillFile, category_for_skill_name
-from .community_publish_services import MAX_DISPLAY_NAME_LENGTH, MAX_TAG_LENGTH, OPTIONAL_GITHUB_HANDLE_PATTERN
+from .community_publish_services import (
+    DISPLAY_NAME_PATTERN,
+    MAX_DISPLAY_NAME_LENGTH,
+    MAX_TAG_LENGTH,
+    OPTIONAL_GITHUB_HANDLE_PATTERN,
+)
 from .skill_services import (
     LLMSkillOwnerNotFoundError,
     resolve_owner_users,
@@ -850,11 +855,15 @@ class LLMSkillMarketplaceCommandSerializer(serializers.Serializer):
 
 
 class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
-    display_name = serializers.CharField(
+    display_name = serializers.RegexField(
+        DISPLAY_NAME_PATTERN,
         required=False,
         allow_blank=True,
         max_length=MAX_DISPLAY_NAME_LENGTH,
-        help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
+        help_text=(
+            "Human-friendly display name for the community listing. Defaults to a title-cased skill slug. "
+            "Must be a single line: it is used as the pull request title and commit message."
+        ),
     )
     tags = serializers.ListField(
         child=serializers.CharField(max_length=MAX_TAG_LENGTH),

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -20,15 +20,14 @@ from .skill_services import (
     RESERVED_SKILL_NAMES,
     SKILL_NAME_PATTERN,
     LLMSkillOwnerNotFoundError,
+    check_allowed_tool_name,
+    normalize_skill_file_path,
     resolve_owner_users,
     resolve_skill_owners,
     seed_skill_owner,
     set_skill_owners,
 )
 
-# Bundled-file paths that would collide with generated artifacts in the exported skill
-# tree / plugin marketplace (the rendered SKILL.md). Compared case-insensitively.
-RESERVED_SKILL_FILE_PATHS = {"skill.md"}
 DEFAULT_VERSION_PAGE_SIZE = 50
 # Body-paging metadata is meaningless without the body, so the list serializer drops it alongside body/files.
 _LIST_EXCLUDED_FIELDS = ("body", "body_total_length", "body_next_offset", "files")
@@ -79,26 +78,10 @@ def validate_skill_name_value(value: str) -> str:
 
 
 def validate_skill_file_path(value: str) -> str:
-    # Paths become git tree entries (and zip/marketplace paths), so anything that would
-    # produce an empty or ambiguous entry name must be rejected — otherwise a single bad
-    # path synthesizes a corrupt git tree and breaks the whole team's marketplace clone.
-    normalized = value.replace("\\", "/")
-    if not normalized or normalized != normalized.strip():
-        raise serializers.ValidationError("File path must be a non-empty, trimmed relative path.")
-    if normalized.startswith("/"):
-        raise serializers.ValidationError("File paths must be relative, not absolute.")
-    if normalized.endswith("/"):
-        raise serializers.ValidationError("File paths must not end with a slash.")
-    if any(part in ("", ".", "..") for part in normalized.split("/")):
-        raise serializers.ValidationError("File paths must not contain empty, '.', or '..' segments.")
-    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in normalized):
-        raise serializers.ValidationError("File paths must not contain control characters.")
-    if normalized.lower() in RESERVED_SKILL_FILE_PATHS:
-        raise serializers.ValidationError(f"'{value}' is a reserved file path and cannot be used.")
-    # Persist the normalized (forward-slash) form, not the original: backslashes mean "separator"
-    # here, so storing them verbatim would make `references\guide.md` a single flat tree entry
-    # rather than a file under `references/`, and would let the two spellings dodge dedup.
-    return normalized
+    try:
+        return normalize_skill_file_path(value)
+    except ValueError as err:
+        raise serializers.ValidationError(str(err)) from err
 
 
 def _validate_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -124,11 +107,11 @@ def validate_skill_body_size(body: str) -> str:
 
 
 def validate_allowed_tool(value: str) -> None:
-    # The Agent Skills spec serializes allowed-tools as a single space-separated string, so a tool
-    # name containing whitespace would silently fracture into multiple tools on export/round-trip.
     # Returns None (raise-only) so it fits a DRF `validators=[...]` list.
-    if any(ch.isspace() for ch in value):
-        raise serializers.ValidationError("Tool names cannot contain whitespace.")
+    try:
+        check_allowed_tool_name(value)
+    except ValueError as err:
+        raise serializers.ValidationError(str(err)) from err
 
 
 class LLMSkillFetchQuerySerializer(serializers.Serializer):

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any
 
 from django.db import transaction
@@ -18,6 +17,8 @@ from .community_publish_services import (
     OPTIONAL_GITHUB_HANDLE_PATTERN,
 )
 from .skill_services import (
+    RESERVED_SKILL_NAMES,
+    SKILL_NAME_PATTERN,
     LLMSkillOwnerNotFoundError,
     resolve_owner_users,
     resolve_skill_owners,
@@ -25,10 +26,6 @@ from .skill_services import (
     set_skill_owners,
 )
 
-# Skill names that collide with reserved /skills routes and so can't be used: "new" is the create
-# form, and the rest mirror the tab slugs registered under /skills/<slug> in
-# products/skills/manifest.tsx — a skill with such a name would be shadowed by its tab route.
-RESERVED_SKILL_NAMES = {"new", "scouts", "review-hog", "community"}
 # Bundled-file paths that would collide with generated artifacts in the exported skill
 # tree / plugin marketplace (the rendered SKILL.md). Compared case-insensitively.
 RESERVED_SKILL_FILE_PATHS = {"skill.md"}
@@ -49,7 +46,6 @@ MAX_SKILL_OWNERS = 25
 # null, never a guess. Sized to sit under observed transport truncation with room for the
 # response envelope (outline, file manifest, metadata).
 DEFAULT_BODY_PAGE_LENGTH = 8000
-SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 # Tools that opt a scout skill into the report channel. Local copy of
 # products/signals/backend/scout_harness/skill_loader.REPORT_CHANNEL_TOOLS — skills must not
 # import signals internals, and drift fails closed: a report tool unknown here keeps owners

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -830,3 +830,31 @@ class LLMSkillMarketplaceCommandSerializer(serializers.Serializer):
     )
     created_at = serializers.DateTimeField(allow_null=True, help_text="When the credential was created.")
     last_rolled_at = serializers.DateTimeField(allow_null=True, help_text="When the credential was last rotated.")
+
+
+class LLMSkillPublishToCommunitySerializer(serializers.Serializer):
+    display_name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=200,
+        help_text="Human-friendly display name for the community listing. Defaults to a title-cased skill slug.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=64),
+        required=False,
+        help_text="Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].",
+    )
+    author_handle = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=100,
+        help_text="The publisher's GitHub username, used for public attribution on the listing and PR. Optional.",
+    )
+
+
+class CommunitySkillPublishResultSerializer(serializers.Serializer):
+    pr_url = serializers.URLField(
+        help_text="URL of the pull request opened in the community-skills repo for maintainer review."
+    )
+    pr_number = serializers.IntegerField(help_text="Number of the opened pull request.")
+    branch = serializers.CharField(help_text="Name of the branch created in the community-skills repo.")

--- a/products/skills/backend/api/skill_services.py
+++ b/products/skills/backend/api/skill_services.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -19,6 +20,13 @@ MAX_SKILL_VERSION = 2000
 MAX_SKILL_BODY_BYTES = 1_000_000
 MAX_SKILL_FILE_BYTES = 1_000_000
 MAX_SKILL_FILE_COUNT = 200
+# Skill names that collide with reserved /skills routes and so can't be used: "new" is the create
+# form, and the rest mirror the category-tab slugs registered under /skills/<slug> in
+# products/skills/manifest.tsx — a skill with such a name would be shadowed by its tab route.
+# Here rather than in skill_serializers so the publish path can hold a slug to the same rule without
+# importing the serializers that import it.
+RESERVED_SKILL_NAMES = {"new", "scouts", "review-hog", "community"}
+SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
 class LLMSkillNotFoundError(Exception):

--- a/products/skills/backend/api/skill_services.py
+++ b/products/skills/backend/api/skill_services.py
@@ -27,6 +27,46 @@ MAX_SKILL_FILE_COUNT = 200
 # importing the serializers that import it.
 RESERVED_SKILL_NAMES = {"new", "scouts", "review-hog", "community"}
 SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+# Bundled-file paths that would collide with generated artifacts in the exported skill
+# tree / plugin marketplace (the rendered SKILL.md). Compared case-insensitively.
+RESERVED_SKILL_FILE_PATHS = {"skill.md"}
+
+
+def normalize_skill_file_path(value: str) -> str:
+    """Return the canonical relative path for a bundled file, raising ValueError if it has none.
+
+    Here rather than in skill_serializers so the publish path can canonicalize a path the same way
+    without importing the serializers that import it. skill_serializers wraps it as the DRF
+    validator, so the request layer keeps reporting these as field errors.
+    """
+    # Paths become git tree entries (and zip/marketplace paths), so anything that would
+    # produce an empty or ambiguous entry name must be rejected — otherwise a single bad
+    # path synthesizes a corrupt git tree and breaks the whole team's marketplace clone.
+    normalized = value.replace("\\", "/")
+    if not normalized or normalized != normalized.strip():
+        raise ValueError("File path must be a non-empty, trimmed relative path.")
+    if normalized.startswith("/"):
+        raise ValueError("File paths must be relative, not absolute.")
+    if normalized.endswith("/"):
+        raise ValueError("File paths must not end with a slash.")
+    if any(part in ("", ".", "..") for part in normalized.split("/")):
+        raise ValueError("File paths must not contain empty, '.', or '..' segments.")
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in normalized):
+        raise ValueError("File paths must not contain control characters.")
+    if normalized.lower() in RESERVED_SKILL_FILE_PATHS:
+        raise ValueError(f"'{value}' is a reserved file path and cannot be used.")
+    # Persist the normalized (forward-slash) form, not the original: backslashes mean "separator"
+    # here, so storing them verbatim would make `references\guide.md` a single flat tree entry
+    # rather than a file under `references/`, and would let the two spellings dodge dedup.
+    return normalized
+
+
+def check_allowed_tool_name(value: str) -> None:
+    """Raise ValueError when a tool name can't survive the Agent Skills allowed-tools encoding."""
+    # The Agent Skills spec serializes allowed-tools as a single space-separated string, so a tool
+    # name containing whitespace would silently fracture into multiple tools on export/round-trip.
+    if any(ch.isspace() for ch in value):
+        raise ValueError("Tool names cannot contain whitespace.")
 
 
 class LLMSkillNotFoundError(Exception):

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -43,10 +43,16 @@ from ..marketplace.credentials import (
 )
 from ..marketplace.packaging import SkillImportError, build_skill_zip, parse_skill_zip, validate_for_export
 from ..models.skills import LLMSkill, LLMSkillFile
+from .community_publish_services import (
+    CommunitySkillPublishError,
+    CommunitySkillPublishNotConfiguredError,
+    publish_skill_to_community,
+)
 from .skill_serializers import (
     DEFAULT_BODY_PAGE_LENGTH,
     MAX_SKILL_FILE_BYTES,
     PUBLISH_CONTENT_FIELDS,
+    CommunitySkillPublishResultSerializer,
     LLMSkillBodyFetchQuerySerializer,
     LLMSkillCreateSerializer,
     LLMSkillDuplicateSerializer,
@@ -61,6 +67,7 @@ from .skill_serializers import (
     LLMSkillMarketplaceCommandSerializer,
     LLMSkillMarketplaceIssueSerializer,
     LLMSkillPublishSerializer,
+    LLMSkillPublishToCommunitySerializer,
     LLMSkillResolveQuerySerializer,
     LLMSkillResolveResponseSerializer,
     LLMSkillSerializer,
@@ -175,7 +182,7 @@ class LLMSkillViewSet(
         return get_active_skill_queryset(self.team)
 
     def get_throttles(self):
-        if self.action in ["update_by_name", "get_by_name", "resolve_by_name"]:
+        if self.action in ["update_by_name", "get_by_name", "resolve_by_name", "publish_to_community"]:
             return [BurstRateThrottle(), SustainedRateThrottle()]
         return super().get_throttles()
 
@@ -907,6 +914,70 @@ class LLMSkillViewSet(
             request=request,
         )
         return Response(self._serialize_skill(new_skill), status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=LLMSkillPublishToCommunitySerializer, responses={201: CommunitySkillPublishResultSerializer})
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path=r"name/(?P<skill_name>[^/]+)/publish-community",
+        required_scopes=["llm_skill:write"],
+    )
+    @llma_track_latency("llma_skills_publish_community")
+    @monitor(feature=None, endpoint="llma_skills_publish_community", method="POST")
+    def publish_to_community(self, request: Request, skill_name: str = "", **kwargs) -> Response:
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
+        skill = get_skill_by_name_from_db(self.team, skill_name)
+        if skill is None:
+            return self._skill_not_found_response(skill_name)
+
+        payload = LLMSkillPublishToCommunitySerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        files = [{"path": f.path, "content": f.content, "content_type": f.content_type} for f in skill.files.all()]
+        metadata_tags = (skill.metadata or {}).get("tags")
+        tags = payload.validated_data.get("tags") or (metadata_tags if isinstance(metadata_tags, list) else [])
+        # The LLMSkill name is the kebab slug; default the community display name to a title-cased form.
+        display_name = payload.validated_data.get("display_name") or skill.name.replace("-", " ").title()
+
+        try:
+            result = publish_skill_to_community(
+                slug=skill.name,
+                name=display_name,
+                description=skill.description,
+                body=skill.body,
+                files=files or None,
+                tags=tags,
+                allowed_tools=skill.allowed_tools or [],
+                license=skill.license or "",
+                compatibility=skill.compatibility or "",
+                author_handle=payload.validated_data.get("author_handle", ""),
+            )
+        except CommunitySkillPublishNotConfiguredError:
+            return Response(
+                {"detail": "Publishing to the community is not available on this instance."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except CommunitySkillPublishError as err:
+            return Response({"detail": str(err)}, status=status.HTTP_502_BAD_GATEWAY)
+
+        props = {**_skill_analytics_props(skill), "community_pr_number": result["pr_number"]}
+        logger.info(
+            "llma_skill_published_to_community",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
+        report_user_action(
+            cast(User, request.user),
+            "llma skill published to community",
+            props,
+            team=self.team,
+            request=request,
+        )
+        return Response(result, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         parameters=[LLMSkillFetchQuerySerializer],

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -182,15 +182,26 @@ class CommunityPublishFeatureFlagPermission(CommunitySkillFeatureFlagPermission)
         return super().has_permission(request, view)
 
 
-class CommunityPublishBurstThrottle(PersonalApiKeyOrUserRateThrottle):
+class _CommunityPublishThrottle(PersonalApiKeyOrUserRateThrottle):
     # Publishing opens a pull request in a public repo, so the ceiling is "a handful, by hand", not
     # the API-shaped hundreds-per-minute of BurstRateThrottle. That one also extends
-    # PersonalApiKeyRateThrottle, which ignores session traffic — and this endpoint is session-only.
+    # PersonalApiKeyRateThrottle, which ignores session traffic.
+    def get_cache_key(self, request, view):
+        # Per team, not per credential. The inherited key prefers the personal API key hash, so one
+        # member holding several keys would get a fresh budget with each of them — and the skill
+        # being published belongs to the team either way.
+        team_id = self.safely_get_team_id_from_view(view)
+        if team_id is None:
+            return super().get_cache_key(request, view)
+        return self.cache_format % {"scope": self.scope, "ident": f"team-{team_id}"}
+
+
+class CommunityPublishBurstThrottle(_CommunityPublishThrottle):
     scope = "community_skill_publish_burst"
     rate = "6/hour"
 
 
-class CommunityPublishSustainedThrottle(PersonalApiKeyOrUserRateThrottle):
+class CommunityPublishSustainedThrottle(_CommunityPublishThrottle):
     scope = "community_skill_publish_sustained"
     rate = "20/day"
 

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -27,7 +27,7 @@ from posthog.auth import (
 from posthog.event_usage import report_user_action
 from posthog.models import User
 from posthog.permissions import AccessControlPermission, get_authenticator_scopes
-from posthog.rate_limit import BurstRateThrottle, SustainedRateThrottle
+from posthog.rate_limit import BurstRateThrottle, PersonalApiKeyOrUserRateThrottle, SustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 
 from products.ai_observability.backend.api.metrics import llma_track_latency
@@ -48,6 +48,7 @@ from .community_publish_services import (
     CommunitySkillPublishNotConfiguredError,
     publish_skill_to_community,
 )
+from .community_skills import CommunitySkillFeatureFlagPermission
 from .skill_serializers import (
     DEFAULT_BODY_PAGE_LENGTH,
     MAX_SKILL_FILE_BYTES,
@@ -166,6 +167,33 @@ ALLOWED_LIST_ORDERINGS = frozenset(
 )
 
 
+class CommunityPublishFeatureFlagPermission(CommunitySkillFeatureFlagPermission):
+    """Gates publishing to the community marketplace, and nothing else on this viewset.
+
+    The Skills product is GA and the marketplace is not, so the flag can only bind to the one action —
+    otherwise the whole product goes dark, and without it publish goes live everywhere the moment the
+    GitHub App is installed and the 503 fail-safe stops firing.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        if getattr(view, "action", None) != "publish_to_community":
+            return True
+        return super().has_permission(request, view)
+
+
+class CommunityPublishBurstThrottle(PersonalApiKeyOrUserRateThrottle):
+    # Publishing opens a pull request in a public repo, so the ceiling is "a handful, by hand", not
+    # the API-shaped hundreds-per-minute of BurstRateThrottle. That one also extends
+    # PersonalApiKeyRateThrottle, which ignores session traffic — and this endpoint is session-only.
+    scope = "community_skill_publish_burst"
+    rate = "6/hour"
+
+
+class CommunityPublishSustainedThrottle(PersonalApiKeyOrUserRateThrottle):
+    scope = "community_skill_publish_sustained"
+    rate = "20/day"
+
+
 class LLMSkillViewSet(
     TeamAndOrgViewSetMixin,
     AccessControlViewSetMixin,
@@ -176,13 +204,15 @@ class LLMSkillViewSet(
     scope_object = "llm_skill"
     queryset = LLMSkill.objects.all()
     serializer_class = LLMSkillSerializer
-    permission_classes = [AccessControlPermission]
+    permission_classes = [AccessControlPermission, CommunityPublishFeatureFlagPermission]
 
     def safely_get_queryset(self, queryset: QuerySet[LLMSkill]) -> QuerySet[LLMSkill]:
         return get_active_skill_queryset(self.team)
 
     def get_throttles(self):
-        if self.action in ["update_by_name", "get_by_name", "resolve_by_name", "publish_to_community"]:
+        if self.action == "publish_to_community":
+            return [CommunityPublishBurstThrottle(), CommunityPublishSustainedThrottle()]
+        if self.action in ["update_by_name", "get_by_name", "resolve_by_name"]:
             return [BurstRateThrottle(), SustainedRateThrottle()]
         return super().get_throttles()
 

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -968,18 +968,25 @@ class LLMSkillViewSet(
 
         files = [{"path": f.path, "content": f.content, "content_type": f.content_type} for f in skill.files.all()]
         metadata_tags = (skill.metadata or {}).get("tags")
-        tags = payload.validated_data.get("tags") or (metadata_tags if isinstance(metadata_tags, list) else [])
+        supplied_tags = payload.validated_data.get("tags")
+        # An explicit empty list means "publish with no tags", so fall back to the skill's own tags
+        # only when the caller omitted the field.
+        if supplied_tags is None:
+            supplied_tags = metadata_tags if isinstance(metadata_tags, list) else []
         # The LLMSkill name is the kebab slug; default the community display name to a title-cased form.
         display_name = payload.validated_data.get("display_name") or skill.name.replace("-", " ").title()
 
         try:
             result = publish_skill_to_community(
                 slug=skill.name,
+                # Scopes the publish branch to this team, so one team cannot rewrite another team's
+                # open pull request for the same slug.
+                publisher_id=str(self.team.uuid),
                 name=display_name,
                 description=skill.description,
                 body=skill.body,
                 files=files or None,
-                tags=tags,
+                tags=supplied_tags,
                 allowed_tools=skill.allowed_tools or [],
                 license=skill.license or "",
                 compatibility=skill.compatibility or "",
@@ -991,6 +998,15 @@ class LLMSkillViewSet(
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except CommunitySkillPublishError as err:
+            # The client sees the reason once; without this the server keeps no record of a publish
+            # that failed against GitHub.
+            logger.warning(
+                "llma_skill_publish_to_community_failed",
+                team_id=self.team.id,
+                user_id=cast(User, request.user).id,
+                skill_name=skill.name,
+                error=str(err),
+            )
             return Response({"detail": str(err)}, status=status.HTTP_502_BAD_GATEWAY)
 
         props = {**_skill_analytics_props(skill), "community_pr_number": result["pr_number"]}

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -47,6 +47,7 @@ from .community_publish_services import (
     CommunitySkillPublishError,
     CommunitySkillPublishNotConfiguredError,
     publish_skill_to_community,
+    publishable_tags,
 )
 from .community_skills import CommunitySkillFeatureFlagPermission
 from .skill_serializers import (
@@ -967,12 +968,12 @@ class LLMSkillViewSet(
         payload.is_valid(raise_exception=True)
 
         files = [{"path": f.path, "content": f.content, "content_type": f.content_type} for f in skill.files.all()]
-        metadata_tags = (skill.metadata or {}).get("tags")
         supplied_tags = payload.validated_data.get("tags")
         # An explicit empty list means "publish with no tags", so fall back to the skill's own tags
-        # only when the caller omitted the field.
+        # only when the caller omitted the field. Those are unvalidated metadata, unlike the ones the
+        # serializer checked, so they go through publishable_tags first.
         if supplied_tags is None:
-            supplied_tags = metadata_tags if isinstance(metadata_tags, list) else []
+            supplied_tags = publishable_tags((skill.metadata or {}).get("tags"))
         # The LLMSkill name is the kebab slug; default the community display name to a title-cased form.
         display_name = payload.validated_data.get("display_name") or skill.name.replace("-", " ").title()
 

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -46,6 +46,7 @@ from ..models.skills import LLMSkill, LLMSkillFile
 from .community_publish_services import (
     CommunitySkillPublishError,
     CommunitySkillPublishNotConfiguredError,
+    CommunitySkillPublishValidationError,
     publish_skill_to_community,
     publishable_tags,
 )
@@ -1009,6 +1010,10 @@ class LLMSkillViewSet(
                 {"detail": "Publishing to the community is not available on this instance."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
+        except CommunitySkillPublishValidationError as err:
+            # Nothing reached GitHub, and republishing the same skill fails the same way — the
+            # publisher has to edit it. That is a 400, not the 502 an unreachable GitHub gets.
+            return Response({"detail": str(err)}, status=status.HTTP_400_BAD_REQUEST)
         except CommunitySkillPublishError as err:
             # The client sees the reason once; without this the server keeps no record of a publish
             # that failed against GitHub.

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -43,10 +43,16 @@ from ..marketplace.credentials import (
 )
 from ..marketplace.packaging import SkillImportError, build_skill_zip, parse_skill_zip, validate_for_export
 from ..models.skills import LLMSkill, LLMSkillFile
+from .community_publish_services import (
+    CommunitySkillPublishError,
+    CommunitySkillPublishNotConfiguredError,
+    publish_skill_to_community,
+)
 from .skill_serializers import (
     DEFAULT_BODY_PAGE_LENGTH,
     MAX_SKILL_FILE_BYTES,
     PUBLISH_CONTENT_FIELDS,
+    CommunitySkillPublishResultSerializer,
     LLMSkillBodyFetchQuerySerializer,
     LLMSkillCreateSerializer,
     LLMSkillDuplicateSerializer,
@@ -61,6 +67,7 @@ from .skill_serializers import (
     LLMSkillMarketplaceCommandSerializer,
     LLMSkillMarketplaceIssueSerializer,
     LLMSkillPublishSerializer,
+    LLMSkillPublishToCommunitySerializer,
     LLMSkillResolveQuerySerializer,
     LLMSkillResolveResponseSerializer,
     LLMSkillSerializer,
@@ -175,7 +182,7 @@ class LLMSkillViewSet(
         return get_active_skill_queryset(self.team)
 
     def get_throttles(self):
-        if self.action in ["update_by_name", "get_by_name", "resolve_by_name"]:
+        if self.action in ["update_by_name", "get_by_name", "resolve_by_name", "publish_to_community"]:
             return [BurstRateThrottle(), SustainedRateThrottle()]
         return super().get_throttles()
 
@@ -905,6 +912,70 @@ class LLMSkillViewSet(
             request=request,
         )
         return Response(self._serialize_skill(new_skill), status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=LLMSkillPublishToCommunitySerializer, responses={201: CommunitySkillPublishResultSerializer})
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path=r"name/(?P<skill_name>[^/]+)/publish-community",
+        required_scopes=["llm_skill:write"],
+    )
+    @llma_track_latency("llma_skills_publish_community")
+    @monitor(feature=None, endpoint="llma_skills_publish_community", method="POST")
+    def publish_to_community(self, request: Request, skill_name: str = "", **kwargs) -> Response:
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
+        skill = get_skill_by_name_from_db(self.team, skill_name)
+        if skill is None:
+            return self._skill_not_found_response(skill_name)
+
+        payload = LLMSkillPublishToCommunitySerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        files = [{"path": f.path, "content": f.content, "content_type": f.content_type} for f in skill.files.all()]
+        metadata_tags = (skill.metadata or {}).get("tags")
+        tags = payload.validated_data.get("tags") or (metadata_tags if isinstance(metadata_tags, list) else [])
+        # The LLMSkill name is the kebab slug; default the community display name to a title-cased form.
+        display_name = payload.validated_data.get("display_name") or skill.name.replace("-", " ").title()
+
+        try:
+            result = publish_skill_to_community(
+                slug=skill.name,
+                name=display_name,
+                description=skill.description,
+                body=skill.body,
+                files=files or None,
+                tags=tags,
+                allowed_tools=skill.allowed_tools or [],
+                license=skill.license or "",
+                compatibility=skill.compatibility or "",
+                author_handle=payload.validated_data.get("author_handle", ""),
+            )
+        except CommunitySkillPublishNotConfiguredError:
+            return Response(
+                {"detail": "Publishing to the community is not available on this instance."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except CommunitySkillPublishError as err:
+            return Response({"detail": str(err)}, status=status.HTTP_502_BAD_GATEWAY)
+
+        props = {**_skill_analytics_props(skill), "community_pr_number": result["pr_number"]}
+        logger.info(
+            "llma_skill_published_to_community",
+            team_id=self.team.id,
+            user_id=cast(User, request.user).id,
+            **props,
+        )
+        report_user_action(
+            cast(User, request.user),
+            "llma skill published to community",
+            props,
+            team=self.team,
+            request=request,
+        )
+        return Response(result, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         parameters=[LLMSkillFetchQuerySerializer],

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -1,0 +1,96 @@
+import re
+
+import yaml
+
+from products.skills.backend.api.community_publish_services import (
+    CommunitySkillPublishError,
+    render_community_skill_files,
+    render_skill_md,
+)
+
+# Mirror of the community-skills repo's frontmatter parser (scripts/build_registry.py) so these
+# tests fail if we ever render a SKILL.md the repo's own CI would reject.
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+def _parse(content: str) -> tuple[dict, str]:
+    match = FRONTMATTER_RE.match(content)
+    assert match is not None, "rendered SKILL.md must start with a YAML frontmatter block"
+    return yaml.safe_load(match.group(1)) or {}, match.group(2).strip()
+
+
+class TestRenderSkillMd:
+    def test_renders_required_fields_and_body(self) -> None:
+        content = render_skill_md(
+            name="Make PR", description="Open a PR for the current branch.", body="# Make PR\n\nDo it."
+        )
+        frontmatter, body = _parse(content)
+        assert frontmatter["name"] == "Make PR"
+        assert frontmatter["description"] == "Open a PR for the current branch."
+        assert frontmatter["trust_tier"] == "community"
+        assert body == "# Make PR\n\nDo it."
+
+    def test_optional_fields_omitted_when_empty(self) -> None:
+        frontmatter, _ = _parse(render_skill_md(name="X", description="Y", body="Z"))
+        for omitted in ("tags", "author_handle", "license", "compatibility", "allowed_tools"):
+            assert omitted not in frontmatter
+
+    def test_optional_fields_included_when_set(self) -> None:
+        content = render_skill_md(
+            name="Make PR",
+            description="Open a PR.",
+            body="body",
+            tags=["github", "workflow"],
+            allowed_tools=["query", "docs-search"],
+            license="MIT",
+            compatibility="Requires gh",
+            author_handle="andymaguire",
+        )
+        frontmatter, _ = _parse(content)
+        assert frontmatter["tags"] == ["github", "workflow"]
+        assert frontmatter["allowed_tools"] == ["query", "docs-search"]
+        assert frontmatter["license"] == "MIT"
+        assert frontmatter["compatibility"] == "Requires gh"
+        assert frontmatter["author_handle"] == "andymaguire"
+
+    def test_requires_name_and_description(self) -> None:
+        for kwargs in ({"name": "  ", "description": "d"}, {"name": "n", "description": ""}):
+            try:
+                render_skill_md(body="b", **kwargs)
+            except CommunitySkillPublishError:
+                continue
+            raise AssertionError(f"expected CommunitySkillPublishError for {kwargs}")
+
+
+class TestRenderCommunitySkillFiles:
+    def test_skill_md_path_and_bundled_files(self) -> None:
+        rendered = render_community_skill_files(
+            slug="make-pr",
+            name="Make PR",
+            description="Open a PR.",
+            body="body",
+            files=[{"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}],
+        )
+        paths = {f.path for f in rendered}
+        assert paths == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
+
+    def test_rejects_bad_slug(self) -> None:
+        for bad in ["Make-PR", "make_pr", "-bad", "double--hyphen", "x" * 65]:
+            try:
+                render_community_skill_files(slug=bad, name="n", description="d", body="b")
+            except CommunitySkillPublishError:
+                continue
+            raise AssertionError(f"expected rejection for slug {bad!r}")
+
+    def test_rejects_path_traversal_in_bundled_file(self) -> None:
+        try:
+            render_community_skill_files(
+                slug="make-pr",
+                name="n",
+                description="d",
+                body="b",
+                files=[{"path": "../escape.md", "content": "x", "content_type": "text/plain"}],
+            )
+        except CommunitySkillPublishError:
+            return
+        raise AssertionError("expected rejection for path traversal")

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -1,12 +1,14 @@
 import re
 
 import pytest
+from unittest.mock import MagicMock, patch
 
 import yaml
 from parameterized import parameterized
 
 from products.skills.backend.api.community_publish_services import (
     CommunitySkillPublishError,
+    publish_skill_to_community,
     render_community_skill_files,
     render_skill_md,
 )
@@ -56,7 +58,14 @@ class TestRenderSkillMd:
         assert frontmatter["compatibility"] == "Requires gh"
         assert frontmatter["author_handle"] == "andymaguire"
 
-    @parameterized.expand([("blank name", "  ", "d"), ("blank description", "n", "")])
+    @parameterized.expand(
+        [
+            ("blank name", "  ", "d"),
+            ("blank description", "n", ""),
+            # Longer than CommunitySkill.name: the PR would merge and ingest would then drop the entry.
+            ("name over 64 chars", "x" * 65, "d"),
+        ]
+    )
     def test_requires_name_and_description(self, _label: str, name: str, description: str) -> None:
         with pytest.raises(CommunitySkillPublishError):
             render_skill_md(name=name, description=description, body="b")
@@ -94,3 +103,77 @@ class TestRenderCommunitySkillFiles:
         except CommunitySkillPublishError:
             return
         raise AssertionError("expected rejection for path traversal")
+
+
+class TestPublishSkillToCommunity:
+    def _publisher(self, *, open_pr: dict | None = None) -> MagicMock:
+        publisher = MagicMock()
+        publisher.get_open_pull_request_for_head.return_value = open_pr
+        publisher.commit_files_to_branch.return_value = {"success": True, "commit_sha": "abc123"}
+        publisher.create_pull_request.return_value = {
+            "success": True,
+            "pr_number": 12,
+            "pr_url": "https://github.com/PostHog/community-skills/pull/12",
+        }
+        publisher.delete_branch.return_value = {"success": True}
+        return publisher
+
+    def _publish(self, publisher: MagicMock) -> dict:
+        with patch(
+            "products.skills.backend.api.community_publish_services.get_community_skills_publisher",
+            return_value=publisher,
+        ):
+            return publish_skill_to_community(
+                slug="make-pr",
+                name="Make PR",
+                description="Open a PR.",
+                body="body",
+                files=[{"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}],
+            )
+
+    def test_commits_every_file_in_one_commit(self) -> None:
+        publisher = self._publisher()
+
+        result = self._publish(publisher)
+
+        assert result == {
+            "pr_url": "https://github.com/PostHog/community-skills/pull/12",
+            "pr_number": 12,
+            "branch": "community-skill/make-pr",
+        }
+        publisher.commit_files_to_branch.assert_called_once()
+        committed_files = publisher.commit_files_to_branch.call_args.args[3]
+        assert set(committed_files) == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
+
+    @parameterized.expand(
+        [
+            ("transient github failure", "GitHub said no", True),
+            # A branch that already heads a pull request belongs to that review, not to this call.
+            (
+                "pull request already exists",
+                "A pull request already exists for PostHog:community-skill/make-pr.",
+                False,
+            ),
+        ]
+    )
+    def test_branch_cleanup_when_the_pull_request_fails(self, _label: str, error: str, deleted: bool) -> None:
+        publisher = self._publisher()
+        publisher.create_pull_request.return_value = {"success": False, "error": error}
+
+        with pytest.raises(CommunitySkillPublishError):
+            self._publish(publisher)
+
+        assert publisher.delete_branch.called is deleted
+        if deleted:
+            assert publisher.delete_branch.call_args.args[1] == "community-skill/make-pr"
+
+    def test_reuses_the_open_pull_request_for_the_same_slug(self) -> None:
+        publisher = self._publisher(
+            open_pr={"number": 5, "url": "https://github.com/PostHog/community-skills/pull/5", "base": "main"}
+        )
+
+        result = self._publish(publisher)
+
+        assert result["pr_number"] == 5
+        publisher.create_pull_request.assert_not_called()
+        publisher.commit_files_to_branch.assert_called_once()

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock, patch
 import yaml
 from parameterized import parameterized
 
+from posthog.models.github_integration_base import GitHubIntegrationError
+
 from products.skills.backend.api.community_publish_services import (
     CommunitySkillPublishError,
     publish_skill_to_community,
+    publisher_branch_key,
     render_community_skill_files,
     render_skill_md,
 )
@@ -105,6 +108,12 @@ class TestRenderCommunitySkillFiles:
         raise AssertionError("expected rejection for path traversal")
 
 
+TEAM_A = "11111111-1111-1111-1111-111111111111"
+TEAM_B = "22222222-2222-2222-2222-222222222222"
+# Branch for slug "make-pr" published by TEAM_A.
+TEAM_A_BRANCH = f"community-skill/make-pr-{publisher_branch_key(TEAM_A)}"
+
+
 class TestPublishSkillToCommunity:
     def _publisher(self, *, open_pr: dict | None = None) -> MagicMock:
         publisher = MagicMock()
@@ -118,13 +127,14 @@ class TestPublishSkillToCommunity:
         publisher.delete_branch.return_value = {"success": True}
         return publisher
 
-    def _publish(self, publisher: MagicMock) -> dict:
+    def _publish(self, publisher: MagicMock, *, publisher_id: str = TEAM_A) -> dict:
         with patch(
             "products.skills.backend.api.community_publish_services.get_community_skills_publisher",
             return_value=publisher,
         ):
             return publish_skill_to_community(
                 slug="make-pr",
+                publisher_id=publisher_id,
                 name="Make PR",
                 description="Open a PR.",
                 body="body",
@@ -139,7 +149,7 @@ class TestPublishSkillToCommunity:
         assert result == {
             "pr_url": "https://github.com/PostHog/community-skills/pull/12",
             "pr_number": 12,
-            "branch": "community-skill/make-pr",
+            "branch": TEAM_A_BRANCH,
         }
         publisher.commit_files_to_branch.assert_called_once()
         committed_files = publisher.commit_files_to_branch.call_args.args[3]
@@ -149,11 +159,7 @@ class TestPublishSkillToCommunity:
         [
             ("transient github failure", "GitHub said no", True),
             # A branch that already heads a pull request belongs to that review, not to this call.
-            (
-                "pull request already exists",
-                "A pull request already exists for PostHog:community-skill/make-pr.",
-                False,
-            ),
+            ("pull request already exists", "A pull request already exists for PostHog:community-skill/x.", False),
         ]
     )
     def test_branch_cleanup_when_the_pull_request_fails(self, _label: str, error: str, deleted: bool) -> None:
@@ -165,9 +171,9 @@ class TestPublishSkillToCommunity:
 
         assert publisher.delete_branch.called is deleted
         if deleted:
-            assert publisher.delete_branch.call_args.args[1] == "community-skill/make-pr"
+            assert publisher.delete_branch.call_args.args[1] == TEAM_A_BRANCH
 
-    def test_reuses_the_open_pull_request_for_the_same_slug(self) -> None:
+    def test_reuses_the_open_pull_request_for_the_same_skill(self) -> None:
         publisher = self._publisher(
             open_pr={"number": 5, "url": "https://github.com/PostHog/community-skills/pull/5", "base": "main"}
         )
@@ -177,3 +183,20 @@ class TestPublishSkillToCommunity:
         assert result["pr_number"] == 5
         publisher.create_pull_request.assert_not_called()
         publisher.commit_files_to_branch.assert_called_once()
+
+    def test_another_team_publishing_the_same_slug_writes_its_own_branch(self) -> None:
+        # Slugs are unique per team, so a slug-only branch would let team B rewrite team A's open PR.
+        publisher = self._publisher()
+
+        self._publish(publisher, publisher_id=TEAM_B)
+
+        branch = publisher.commit_files_to_branch.call_args.args[1]
+        assert branch.startswith("community-skill/make-pr-")
+        assert branch != TEAM_A_BRANCH
+
+    def test_github_being_unreachable_raises_a_publish_error(self) -> None:
+        publisher = self._publisher()
+        publisher.get_open_pull_request_for_head.side_effect = GitHubIntegrationError("network error")
+
+        with pytest.raises(CommunitySkillPublishError):
+            self._publish(publisher)

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -13,6 +13,7 @@ from parameterized import parameterized
 from posthog.models.github_integration_base import GitHubIntegrationError
 
 from products.skills.backend.api.community_publish_services import (
+    MAX_TAG_LENGTH,
     CommunitySkillPublishError,
     get_community_skills_publisher,
     publish_skill_to_community,
@@ -21,6 +22,7 @@ from products.skills.backend.api.community_publish_services import (
     render_skill_md,
 )
 from products.skills.backend.api.skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES, MAX_SKILL_FILE_COUNT
+from products.skills.backend.marketplace.packaging import SPEC_DESCRIPTION_MAX_LENGTH
 
 # Mirror of the community-skills repo's frontmatter parser (scripts/build_registry.py) so these
 # tests fail if we ever render a SKILL.md the repo's own CI would reject.
@@ -81,6 +83,9 @@ class TestRenderSkillMd:
             # install_community_skill refuses a blank body as having no instructions, so publishing
             # one merges a listing that nobody can ever install.
             ("blank body", "n", "d", "  \n  "),
+            # Longer than the Agent Skills spec allows, so validate_for_export refuses the skill once
+            # someone installs it from the catalog.
+            ("description over the spec cap", "n", "x" * (SPEC_DESCRIPTION_MAX_LENGTH + 1), "b"),
             # Longer than CommunitySkill.name: the PR would merge and ingest would then drop the entry.
             ("name over 64 chars", "x" * 65, "d", "b"),
             # The name becomes the commit message, where a trailer would reattribute the App's commit.
@@ -208,6 +213,21 @@ class TestPublishableSize:
                 ],
             )
 
+    def test_counts_the_rendered_frontmatter_against_the_tree_cap(self) -> None:
+        # Nothing caps how many tags a skill stores, and every one is rendered into SKILL.md, so
+        # measuring the fields the files came from instead of the files themselves leaves the
+        # difference between them unbounded.
+        files = [
+            {"path": f"references/{index}.md", "content": "x" * MAX_SKILL_FILE_BYTES, "content_type": "text/markdown"}
+            for index in range(4)
+        ]
+        fields: dict[str, Any] = {"slug": "make-pr", "name": "n", "description": "d", "body": "x" * 990_000}
+
+        render_community_skill_files(**fields, files=files)
+
+        with pytest.raises(CommunitySkillPublishError):
+            render_community_skill_files(**fields, files=files, tags=["t" * MAX_TAG_LENGTH] * 4000)
+
     def test_rejects_a_skill_whose_encoded_payload_blows_the_tree_cap(self) -> None:
         # 3 MB of newlines clears every raw-byte check, and doubles once escaped into the single JSON
         # body the tree write inlines it in. Counted raw, this publishes and then fails against
@@ -317,6 +337,9 @@ class TestPublishSkillToCommunity:
             "branch": TEAM_A_BRANCH,
         }
         publisher.commit_files_to_branch.assert_called_once()
+        # The skill's directory is replaced, not merged onto main, so a bundled file dropped since
+        # the last publish stops being published instead of surviving on the branch.
+        assert publisher.commit_files_to_branch.call_args.kwargs["replace_directory"] == "skills/make-pr"
         committed_files = publisher.commit_files_to_branch.call_args.args[3]
         assert set(committed_files) == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
 
@@ -348,6 +371,20 @@ class TestPublishSkillToCommunity:
         assert result["pr_number"] == 5
         publisher.create_pull_request.assert_not_called()
         publisher.commit_files_to_branch.assert_called_once()
+
+    def test_a_reused_pull_request_that_ends_mid_publish_opens_a_new_one(self) -> None:
+        # Open when we look before the write, merged by the time the commit lands. Returning it would
+        # report success for a review that no longer carries the commit, and leave that commit on a
+        # public branch with nothing open over it.
+        open_pr = {"number": 5, "url": "https://github.com/PostHog/community-skills/pull/5", "base": "main"}
+        publisher = self._publisher(open_pr=open_pr)
+        publisher.get_open_pull_request_for_head.side_effect = [open_pr, None]
+
+        result = self._publish(publisher)
+
+        assert result["pr_number"] == 12
+        publisher.create_pull_request.assert_called_once()
+        publisher.delete_branch.assert_not_called()
 
     def test_refuses_a_pull_request_retargeted_away_from_the_base_branch(self) -> None:
         # Merging it writes to that other branch, so the skill never reaches the catalog. Reusing it

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -15,6 +15,7 @@ from posthog.models.github_integration_base import GitHubIntegrationError
 from products.skills.backend.api.community_publish_services import (
     MAX_TAG_LENGTH,
     CommunitySkillPublishError,
+    CommunitySkillPublishValidationError,
     get_community_skills_publisher,
     publish_skill_to_community,
     publisher_branch_key,
@@ -277,6 +278,42 @@ class TestCommunitySkillsPublisher:
         # blast radius this transient token has no use for.
         assert mint_body["permissions"] == {"contents": "write", "pull_requests": "write", "metadata": "read"}
 
+    @parameterized.expand(
+        [
+            ("the app is not installed here", 404, False),
+            ("github refuses the app credentials", 401, False),
+            ("github fails the mint", 500, True),
+        ]
+    )
+    def test_only_a_refused_installation_reads_as_not_configured(
+        self, _label: str, token_status: int, is_gateway_failure: bool
+    ) -> None:
+        # None here becomes the endpoint's 503, which tells the publisher this instance can't publish
+        # at all. A transient failure must not say that: it sends them to the manual path over an
+        # outage that clears by itself.
+        settings_override = override_settings(
+            COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID="4242",
+            COMMUNITY_SKILLS_GITHUB_REPO="community-skills",
+            GITHUB_APP_CLIENT_ID="client",
+            GITHUB_APP_PRIVATE_KEY="key",
+        )
+        with (
+            settings_override,
+            patch(
+                "products.skills.backend.api.community_publish_services.GitHubIntegration.client_request"
+            ) as mock_request,
+        ):
+            mock_request.side_effect = [
+                self._response(200, {"account": {"login": "PostHog", "type": "Organization"}}),
+                self._response(token_status, {}),
+            ]
+
+            if is_gateway_failure:
+                with pytest.raises(CommunitySkillPublishError):
+                    get_community_skills_publisher()
+            else:
+                assert get_community_skills_publisher() is None
+
     @override_settings(
         COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID="4242",
         COMMUNITY_SKILLS_GITHUB_REPO="community-skills",
@@ -325,6 +362,19 @@ class TestPublishSkillToCommunity:
                 body="body",
                 files=[{"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}],
             )
+
+    def test_a_skill_that_cannot_be_published_is_rejected_before_the_publisher_is_acquired(self) -> None:
+        # Acquiring the publisher talks to GitHub, so a skill that fails rendering used to come back
+        # as 502 or 503 whenever the App was down or unconfigured — advice to retry, for a publish
+        # that can only succeed once the publisher edits the skill.
+        with patch(
+            "products.skills.backend.api.community_publish_services.get_community_skills_publisher",
+            side_effect=AssertionError("the publisher was acquired before the skill was validated"),
+        ):
+            with pytest.raises(CommunitySkillPublishValidationError):
+                publish_skill_to_community(
+                    slug="make-pr", publisher_id=TEAM_A, name="Make PR", description="", body="body"
+                )
 
     def test_commits_every_file_in_one_commit(self) -> None:
         publisher = self._publisher()

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -1,6 +1,9 @@
 import re
 
+import pytest
+
 import yaml
+from parameterized import parameterized
 
 from products.skills.backend.api.community_publish_services import (
     CommunitySkillPublishError,
@@ -53,13 +56,10 @@ class TestRenderSkillMd:
         assert frontmatter["compatibility"] == "Requires gh"
         assert frontmatter["author_handle"] == "andymaguire"
 
-    def test_requires_name_and_description(self) -> None:
-        for kwargs in ({"name": "  ", "description": "d"}, {"name": "n", "description": ""}):
-            try:
-                render_skill_md(body="b", **kwargs)
-            except CommunitySkillPublishError:
-                continue
-            raise AssertionError(f"expected CommunitySkillPublishError for {kwargs}")
+    @parameterized.expand([("blank name", "  ", "d"), ("blank description", "n", "")])
+    def test_requires_name_and_description(self, _label: str, name: str, description: str) -> None:
+        with pytest.raises(CommunitySkillPublishError):
+            render_skill_md(name=name, description=description, body="b")
 
 
 class TestRenderCommunitySkillFiles:

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -74,6 +74,8 @@ class TestRenderSkillMd:
             ("blank description", "n", ""),
             # Longer than CommunitySkill.name: the PR would merge and ingest would then drop the entry.
             ("name over 64 chars", "x" * 65, "d"),
+            # The name becomes the commit message, where a trailer would reattribute the App's commit.
+            ("name spanning two lines", "Make PR\nCo-authored-by: someone <a@b.c>", "d"),
         ]
     )
     def test_requires_name_and_description(self, _label: str, name: str, description: str) -> None:
@@ -190,6 +192,19 @@ class TestPublishSkillToCommunity:
         assert result["pr_number"] == 5
         publisher.create_pull_request.assert_not_called()
         publisher.commit_files_to_branch.assert_called_once()
+
+    def test_refuses_a_pull_request_retargeted_away_from_the_base_branch(self) -> None:
+        # Merging it writes to that other branch, so the skill never reaches the catalog. Reusing it
+        # would report a successful publish for content nothing will ever pick up.
+        publisher = self._publisher(
+            open_pr={"number": 5, "url": "https://github.com/PostHog/community-skills/pull/5", "base": "draft"}
+        )
+
+        with pytest.raises(CommunitySkillPublishError):
+            self._publish(publisher)
+
+        publisher.commit_files_to_branch.assert_not_called()
+        publisher.delete_branch.assert_not_called()
 
     def test_another_team_publishing_the_same_slug_writes_its_own_branch(self) -> None:
         # Slugs are unique per team, so a slug-only branch would let team B rewrite team A's open PR.

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -4,13 +4,17 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 import yaml
+import requests
 from parameterized import parameterized
 
 from posthog.models.github_integration_base import GitHubIntegrationError
 
 from products.skills.backend.api.community_publish_services import (
     CommunitySkillPublishError,
+    get_community_skills_publisher,
     publish_skill_to_community,
     publisher_branch_key,
     render_community_skill_files,
@@ -72,17 +76,36 @@ class TestRenderSkillMd:
 
     @parameterized.expand(
         [
-            ("blank name", "  ", "d"),
-            ("blank description", "n", ""),
+            ("blank name", "  ", "d", "b"),
+            ("blank description", "n", "", "b"),
+            # install_community_skill refuses a blank body as having no instructions, so publishing
+            # one merges a listing that nobody can ever install.
+            ("blank body", "n", "d", "  \n  "),
             # Longer than CommunitySkill.name: the PR would merge and ingest would then drop the entry.
-            ("name over 64 chars", "x" * 65, "d"),
+            ("name over 64 chars", "x" * 65, "d", "b"),
             # The name becomes the commit message, where a trailer would reattribute the App's commit.
-            ("name spanning two lines", "Make PR\nCo-authored-by: someone <a@b.c>", "d"),
+            ("name spanning two lines", "Make PR\nCo-authored-by: someone <a@b.c>", "d", "b"),
         ]
     )
-    def test_requires_name_and_description(self, _label: str, name: str, description: str) -> None:
+    def test_requires_the_fields_a_listing_cannot_do_without(
+        self, _label: str, name: str, description: str, body: str
+    ) -> None:
         with pytest.raises(CommunitySkillPublishError):
-            render_skill_md(name=name, description=description, body="b")
+            render_skill_md(name=name, description=description, body=body)
+
+    @parameterized.expand(
+        [
+            ("with a space in it", "not a handle"),
+            ("with a double hyphen", "andy--maguire"),
+            # 77 characters: the pattern's repetition can contribute a hyphen and a character each, so
+            # nothing bounds the total unless the length is held beside it, and the listing would
+            # attribute the skill to a handle GitHub cannot hold.
+            ("longer than a GitHub username", "-".join("a" for _ in range(39))),
+        ]
+    )
+    def test_rejects_an_author_handle_that_is_not_a_github_username(self, _label: str, handle: str) -> None:
+        with pytest.raises(CommunitySkillPublishError):
+            render_skill_md(name="n", description="d", body="b", author_handle=handle)
 
     @parameterized.expand(
         [
@@ -184,6 +207,70 @@ class TestPublishableSize:
                     for index in range(file_count)
                 ],
             )
+
+    def test_rejects_a_skill_whose_encoded_payload_blows_the_tree_cap(self) -> None:
+        # 3 MB of newlines clears every raw-byte check, and doubles once escaped into the single JSON
+        # body the tree write inlines it in. Counted raw, this publishes and then fails against
+        # GitHub with a 502 the publisher can do nothing with.
+        with pytest.raises(CommunitySkillPublishError):
+            render_community_skill_files(
+                slug="make-pr",
+                name="n",
+                description="d",
+                body="b",
+                files=[
+                    {
+                        "path": f"references/{index}.md",
+                        "content": "\n" * MAX_SKILL_FILE_BYTES,
+                        "content_type": "text/markdown",
+                    }
+                    for index in range(3)
+                ],
+            )
+
+
+class TestCommunitySkillsPublisher:
+    def _response(self, status_code: int, payload: dict) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = payload
+        return response
+
+    @override_settings(
+        COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID="4242",
+        COMMUNITY_SKILLS_GITHUB_REPO="community-skills",
+        GITHUB_APP_CLIENT_ID="client",
+        GITHUB_APP_PRIVATE_KEY="key",
+    )
+    @patch("products.skills.backend.api.community_publish_services.GitHubIntegration.client_request")
+    def test_mints_a_token_scoped_to_the_publish_repository(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [
+            self._response(200, {"account": {"login": "PostHog", "type": "Organization"}}),
+            self._response(201, {"token": "ghs_x"}),
+        ]
+
+        assert get_community_skills_publisher() is not None
+
+        mint_body = mock_request.call_args.kwargs["json_body"]
+        assert mint_body["repositories"] == ["community-skills"]
+        # A publish writes files and opens a pull request. Anything else the installation holds is
+        # blast radius this transient token has no use for.
+        assert mint_body["permissions"] == {"contents": "write", "pull_requests": "write", "metadata": "read"}
+
+    @override_settings(
+        COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID="4242",
+        COMMUNITY_SKILLS_GITHUB_REPO="community-skills",
+        GITHUB_APP_CLIENT_ID="client",
+        GITHUB_APP_PRIVATE_KEY="key",
+    )
+    @patch("products.skills.backend.api.community_publish_services.GitHubIntegration.client_request")
+    def test_github_being_unreachable_while_minting_raises_a_publish_error(self, mock_request: MagicMock) -> None:
+        # client_request goes to the transport directly, so a timeout arrives raw rather than as the
+        # GitHubIntegrationError api_request would wrap it in. Unhandled, the endpoint answers 500.
+        mock_request.side_effect = requests.ConnectTimeout("boom")
+
+        with pytest.raises(CommunitySkillPublishError):
+            get_community_skills_publisher()
 
 
 TEAM_A = "11111111-1111-1111-1111-111111111111"

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -61,6 +61,13 @@ class TestRenderSkillMd:
         assert frontmatter["compatibility"] == "Requires gh"
         assert frontmatter["author_handle"] == "andymaguire"
 
+    def test_preserves_leading_whitespace_in_the_body(self) -> None:
+        # strip() would turn an opening indented code block into an ordinary paragraph, so the
+        # published skill would instruct differently from the skill it was published from.
+        content = render_skill_md(name="X", description="Y", body="    indented code\n\ntext\n\n\n")
+
+        assert content.endswith("---\n\n    indented code\n\ntext\n")
+
     @parameterized.expand(
         [
             ("blank name", "  ", "d"),
@@ -193,6 +200,45 @@ class TestPublishSkillToCommunity:
         branch = publisher.commit_files_to_branch.call_args.args[1]
         assert branch.startswith("community-skill/make-pr-")
         assert branch != TEAM_A_BRANCH
+
+    def test_a_concurrent_publish_returns_the_pull_request_that_won_the_race(self) -> None:
+        # Both requests force-update the same branch, so the loser's commit is already inside the
+        # winner's review. Reporting a failure would deny content that is public by then.
+        publisher = self._publisher()
+        winner = {"number": 9, "url": "https://github.com/PostHog/community-skills/pull/9", "base": "main"}
+        publisher.get_open_pull_request_for_head.side_effect = [None, winner]
+        publisher.create_pull_request.return_value = {
+            "success": False,
+            "error": "A pull request already exists for PostHog:community-skill/x.",
+        }
+
+        result = self._publish(publisher)
+
+        assert result["pr_number"] == 9
+        publisher.delete_branch.assert_not_called()
+
+    def test_a_pull_request_create_that_times_out_after_landing_keeps_the_branch(self) -> None:
+        # api_request doesn't retry a POST, so a transport failure here can still have opened the
+        # pull request. Cleaning up blind would delete a branch under live review.
+        publisher = self._publisher()
+        landed = {"number": 9, "url": "https://github.com/PostHog/community-skills/pull/9", "base": "main"}
+        publisher.get_open_pull_request_for_head.side_effect = [None, landed]
+        publisher.create_pull_request.side_effect = GitHubIntegrationError("timeout")
+
+        result = self._publish(publisher)
+
+        assert result["pr_number"] == 9
+        publisher.delete_branch.assert_not_called()
+
+    def test_a_pull_request_create_that_times_out_with_nothing_landed_deletes_the_branch(self) -> None:
+        publisher = self._publisher()
+        publisher.get_open_pull_request_for_head.side_effect = [None, None]
+        publisher.create_pull_request.side_effect = GitHubIntegrationError("timeout")
+
+        with pytest.raises(CommunitySkillPublishError):
+            self._publish(publisher)
+
+        assert publisher.delete_branch.call_args.args[1] == TEAM_A_BRANCH
 
     def test_github_being_unreachable_raises_a_publish_error(self) -> None:
         publisher = self._publisher()

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -103,18 +103,24 @@ class TestRenderCommunitySkillFiles:
                 continue
             raise AssertionError(f"expected rejection for slug {bad!r}")
 
-    def test_rejects_path_traversal_in_bundled_file(self) -> None:
-        try:
+    @parameterized.expand(
+        [
+            ("path traversal", ["../escape.md"]),
+            ("overwriting the rendered SKILL.md", ["SKILL.md"]),
+            # Ingest case-folds paths and drops the whole entry on a collision, so publishing both
+            # opens a pull request that merges and then never appears in the catalog.
+            ("paths differing only by case", ["references/Guide.md", "references/guide.md"]),
+        ]
+    )
+    def test_rejects_unpublishable_bundled_file_paths(self, _label: str, paths: list[str]) -> None:
+        with pytest.raises(CommunitySkillPublishError):
             render_community_skill_files(
                 slug="make-pr",
                 name="n",
                 description="d",
                 body="b",
-                files=[{"path": "../escape.md", "content": "x", "content_type": "text/plain"}],
+                files=[{"path": path, "content": "x", "content_type": "text/plain"} for path in paths],
             )
-        except CommunitySkillPublishError:
-            return
-        raise AssertionError("expected rejection for path traversal")
 
 
 TEAM_A = "11111111-1111-1111-1111-111111111111"
@@ -254,6 +260,9 @@ class TestPublishSkillToCommunity:
             self._publish(publisher)
 
         assert publisher.delete_branch.call_args.args[1] == TEAM_A_BRANCH
+        # Conditional on our own commit: the branch name is shared with every concurrent publish of
+        # this skill from this team, and deleting theirs destroys work only we could have recovered.
+        assert publisher.delete_branch.call_args.kwargs["expected_sha"] == "abc123"
 
     def test_github_being_unreachable_raises_a_publish_error(self) -> None:
         publisher = self._publisher()

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -15,6 +15,7 @@ from products.skills.backend.api.community_publish_services import (
     render_community_skill_files,
     render_skill_md,
 )
+from products.skills.backend.api.skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES, MAX_SKILL_FILE_COUNT
 
 # Mirror of the community-skills repo's frontmatter parser (scripts/build_registry.py) so these
 # tests fail if we ever render a SKILL.md the repo's own CI would reject.
@@ -96,7 +97,9 @@ class TestRenderCommunitySkillFiles:
         assert paths == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
 
     def test_rejects_bad_slug(self) -> None:
-        for bad in ["Make-PR", "make_pr", "-bad", "double--hyphen", "x" * 65]:
+        # "new" and the category-tab slugs are rejected by ingest, so publishing one merges a pull
+        # request whose skill never appears in the catalog. A trailing newline needs `fullmatch`.
+        for bad in ["Make-PR", "make_pr", "-bad", "double--hyphen", "x" * 65, "new", "review-hog", "make-pr\n"]:
             try:
                 render_community_skill_files(slug=bad, name="n", description="d", body="b")
             except CommunitySkillPublishError:
@@ -110,6 +113,9 @@ class TestRenderCommunitySkillFiles:
             # Ingest case-folds paths and drops the whole entry on a collision, so publishing both
             # opens a pull request that merges and then never appears in the catalog.
             ("paths differing only by case", ["references/Guide.md", "references/guide.md"]),
+            # A git tree can't hold `references` as both a blob and a directory, so GitHub rejects
+            # the whole tree and the skill can't be published at all.
+            ("a name used as both file and folder", ["references", "references/guide.md"]),
         ]
     )
     def test_rejects_unpublishable_bundled_file_paths(self, _label: str, paths: list[str]) -> None:
@@ -120,6 +126,34 @@ class TestRenderCommunitySkillFiles:
                 description="d",
                 body="b",
                 files=[{"path": path, "content": "x", "content_type": "text/plain"} for path in paths],
+            )
+
+
+class TestPublishableSize:
+    @parameterized.expand(
+        [
+            # Ingest's own per-entry caps: breaching one drops the whole entry, so the pull request
+            # merges and the skill never appears in the catalog.
+            ("body over the catalog cap", "x" * (MAX_SKILL_BODY_BYTES + 1), 1, 10),
+            ("more files than the catalog takes", "b", MAX_SKILL_FILE_COUNT + 1, 10),
+            ("one file over the catalog cap", "b", 1, MAX_SKILL_FILE_BYTES + 1),
+            # GitHub's cap on a single create-tree request, which inlines every file's content.
+            ("files summing over the tree cap", "b", 6, MAX_SKILL_FILE_BYTES),
+        ]
+    )
+    def test_rejects_a_skill_no_publish_could_survive(
+        self, _label: str, body: str, file_count: int, file_size: int
+    ) -> None:
+        with pytest.raises(CommunitySkillPublishError):
+            render_community_skill_files(
+                slug="make-pr",
+                name="n",
+                description="d",
+                body=body,
+                files=[
+                    {"path": f"references/{index}.md", "content": "x" * file_size, "content_type": "text/markdown"}
+                    for index in range(file_count)
+                ],
             )
 
 

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -83,6 +84,20 @@ class TestRenderSkillMd:
         with pytest.raises(CommunitySkillPublishError):
             render_skill_md(name=name, description=description, body="b")
 
+    @parameterized.expand(
+        [
+            ("a tool name with a space", ["Bash Write"]),
+            ("a tool name with a newline", ["Bash\nWrite"]),
+            ("a tool name that is not a string", [123]),
+        ]
+    )
+    def test_rejects_allowed_tools_ingest_would_drop(self, _label: str, allowed_tools: list[Any]) -> None:
+        # create_skill stores what a tool call passed without the REST serializer's checks, and
+        # ingest rejects a whitespace-bearing or non-string tool name, so publishing one opens a
+        # pull request that merges and whose skill never appears in the catalog.
+        with pytest.raises(CommunitySkillPublishError):
+            render_skill_md(name="n", description="d", body="b", allowed_tools=allowed_tools)
+
 
 class TestRenderCommunitySkillFiles:
     def test_skill_md_path_and_bundled_files(self) -> None:
@@ -91,10 +106,20 @@ class TestRenderCommunitySkillFiles:
             name="Make PR",
             description="Open a PR.",
             body="body",
-            files=[{"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}],
+            files=[
+                {"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"},
+                # A skill created through the Max tool can store the backslash spelling, and ingest
+                # canonicalizes it, so the publish has to write the forward-slash path ingest will
+                # then look for rather than one flat `scripts\\run.sh` tree entry.
+                {"path": "scripts\\run.sh", "content": "echo hi", "content_type": "text/plain"},
+            ],
         )
         paths = {f.path for f in rendered}
-        assert paths == {"skills/make-pr/SKILL.md", "skills/make-pr/references/playbook.md"}
+        assert paths == {
+            "skills/make-pr/SKILL.md",
+            "skills/make-pr/references/playbook.md",
+            "skills/make-pr/scripts/run.sh",
+        }
 
     def test_rejects_bad_slug(self) -> None:
         # "new" and the category-tab slugs are rejected by ingest, so publishing one merges a pull
@@ -113,6 +138,10 @@ class TestRenderCommunitySkillFiles:
             # Ingest case-folds paths and drops the whole entry on a collision, so publishing both
             # opens a pull request that merges and then never appears in the catalog.
             ("paths differing only by case", ["references/Guide.md", "references/guide.md"]),
+            # Same reason: ingest canonicalizes the backslash spelling, so the two paths that look
+            # distinct here are one duplicate path by the time the merged entry is read.
+            ("the same path spelled with a backslash", ["references\\guide.md", "references/guide.md"]),
+            ("an absolute path", ["/references/guide.md"]),
             # A git tree can't hold `references` as both a blob and a directory, so GitHub rejects
             # the whole tree and the skill can't be published at all.
             ("a name used as both file and folder", ["references", "references/guide.md"]),

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -1295,6 +1295,9 @@ class TestLLMSkillAPI(APIBaseTest):
             ("explicit empty list", {"tags": []}, ["github"], []),
             # metadata is an arbitrary dict, and ingest drops an entry whose tags are not all strings.
             ("unusable metadata tags", {}, ["github", 123, {"name": "x"}, "  ", "y" * 65], ["github"]),
+            # Sync only lowercases a tag and filtering matches it exactly, so an unstripped tag would
+            # publish as one no catalog filter can select.
+            ("padded metadata tags", {}, [" github "], ["github"]),
         ]
     )
     @patch(COMMUNITY_FLAG, return_value=True)
@@ -1318,14 +1321,22 @@ class TestLLMSkillAPI(APIBaseTest):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_publish.assert_not_called()
 
+    @parameterized.expand(
+        [
+            # Longer than CommunitySkill.name: the PR merges and ingest then drops the entry.
+            ("over the catalog limit", "x" * 65),
+            # The name becomes the commit message, where a trailer would reattribute the App's commit.
+            ("spanning two lines", "Make PR\nCo-authored-by: someone <a@b.c>"),
+        ]
+    )
     @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_rejects_display_name_over_catalog_limit(self, mock_publish, _mock_flag):
+    def test_publish_to_community_rejects_display_name(self, _label: str, display_name: str, mock_publish, _mock_flag):
         self.create_skill(name="make-pr")
 
         response = self.client.post(
             self._url("name/make-pr/publish-community"),
-            data={"display_name": "x" * 65},
+            data={"display_name": display_name},
             format="json",
         )
 

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -14,7 +14,11 @@ from posthog.models.organization import OrganizationMembership
 
 from ee.models.rbac.access_control import AccessControl
 
-from ...api.community_publish_services import CommunitySkillPublishError, CommunitySkillPublishNotConfiguredError
+from ...api.community_publish_services import (
+    CommunitySkillPublishError,
+    CommunitySkillPublishNotConfiguredError,
+    CommunitySkillPublishValidationError,
+)
 from ...api.skill_serializers import DEFAULT_BODY_PAGE_LENGTH
 from ...api.skill_services import (
     MAX_SKILL_FILE_COUNT,
@@ -1362,6 +1366,19 @@ class TestLLMSkillAPI(APIBaseTest):
         response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
 
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    @patch(COMMUNITY_FLAG, return_value=True)
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_invalid_skill_returns_400(self, mock_publish, _mock_flag):
+        # Nothing reached GitHub and republishing the same skill fails the same way, so a 502 would
+        # tell the publisher to retry an upstream request that was never the problem.
+        mock_publish.side_effect = CommunitySkillPublishValidationError("that slug is reserved")
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "that slug is reserved"
 
     @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -1291,6 +1291,17 @@ class TestLLMSkillAPI(APIBaseTest):
 
     @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_explicit_empty_tags_are_not_replaced(self, mock_publish, _mock_flag):
+        mock_publish.return_value = {"pr_url": "https://github.com/x/y/pull/1", "pr_number": 1, "branch": "b"}
+        self.create_skill(name="make-pr", metadata={"tags": ["github"]})
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={"tags": []}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert mock_publish.call_args.kwargs["tags"] == []
+
+    @patch(COMMUNITY_FLAG, return_value=True)
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
     def test_publish_to_community_unknown_skill_returns_404(self, mock_publish, _mock_flag):
         response = self.client.post(self._url("name/does-not-exist/publish-community"), data={}, format="json")
 

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -1289,16 +1289,26 @@ class TestLLMSkillAPI(APIBaseTest):
             {"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}
         ]
 
+    @parameterized.expand(
+        [
+            # An explicit empty list means "no tags" and must not fall back to the skill's own tags.
+            ("explicit empty list", {"tags": []}, ["github"], []),
+            # metadata is an arbitrary dict, and ingest drops an entry whose tags are not all strings.
+            ("unusable metadata tags", {}, ["github", 123, {"name": "x"}, "  ", "y" * 65], ["github"]),
+        ]
+    )
     @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_explicit_empty_tags_are_not_replaced(self, mock_publish, _mock_flag):
+    def test_publish_to_community_tags(
+        self, _label: str, payload: dict, metadata_tags: list, expected: list, mock_publish, _mock_flag
+    ):
         mock_publish.return_value = {"pr_url": "https://github.com/x/y/pull/1", "pr_number": 1, "branch": "b"}
-        self.create_skill(name="make-pr", metadata={"tags": ["github"]})
+        self.create_skill(name="make-pr", metadata={"tags": metadata_tags})
 
-        response = self.client.post(self._url("name/make-pr/publish-community"), data={"tags": []}, format="json")
+        response = self.client.post(self._url("name/make-pr/publish-community"), data=payload, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert mock_publish.call_args.kwargs["tags"] == []
+        assert mock_publish.call_args.kwargs["tags"] == expected
 
     @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -26,6 +26,8 @@ from ...api.skill_services import (
 )
 from ...models.skills import LLMSkill, LLMSkillFile
 
+COMMUNITY_FLAG = "products.skills.backend.api.community_skills.posthoganalytics.feature_enabled"
+
 
 class TestLLMSkillAPI(APIBaseTest):
     def _url(self, path: str = "") -> str:
@@ -1249,12 +1251,13 @@ class TestLLMSkillAPI(APIBaseTest):
 
     # --- Publish to community ---
 
+    @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_succeeds(self, mock_publish):
+    def test_publish_to_community_succeeds(self, mock_publish, _mock_flag):
         mock_publish.return_value = {
             "pr_url": "https://github.com/PostHog/community-skills/pull/7",
             "pr_number": 7,
-            "branch": "community-skill/make-pr-abc123",
+            "branch": "community-skill/make-pr",
         }
         skill = self.create_skill(
             name="make-pr",
@@ -1286,15 +1289,41 @@ class TestLLMSkillAPI(APIBaseTest):
             {"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}
         ]
 
+    @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_unknown_skill_returns_404(self, mock_publish):
+    def test_publish_to_community_unknown_skill_returns_404(self, mock_publish, _mock_flag):
         response = self.client.post(self._url("name/does-not-exist/publish-community"), data={}, format="json")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_publish.assert_not_called()
 
+    @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_not_configured_returns_503(self, mock_publish):
+    def test_publish_to_community_rejects_display_name_over_catalog_limit(self, mock_publish, _mock_flag):
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(
+            self._url("name/make-pr/publish-community"),
+            data={"display_name": "x" * 65},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_publish.assert_not_called()
+
+    @patch(COMMUNITY_FLAG, return_value=False)
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_is_gated_on_the_community_flag(self, mock_publish, _mock_flag):
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_publish.assert_not_called()
+
+    @patch(COMMUNITY_FLAG, return_value=True)
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_not_configured_returns_503(self, mock_publish, _mock_flag):
         mock_publish.side_effect = CommunitySkillPublishNotConfiguredError("nope")
         self.create_skill(name="make-pr")
 
@@ -1302,8 +1331,9 @@ class TestLLMSkillAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
+    @patch(COMMUNITY_FLAG, return_value=True)
     @patch("products.skills.backend.api.skills.publish_skill_to_community")
-    def test_publish_to_community_github_error_returns_502(self, mock_publish):
+    def test_publish_to_community_github_error_returns_502(self, mock_publish, _mock_flag):
         mock_publish.side_effect = CommunitySkillPublishError("github exploded")
         self.create_skill(name="make-pr")
 

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -1,6 +1,7 @@
 import uuid
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from django.core.cache import cache
 
@@ -13,6 +14,7 @@ from posthog.models.organization import OrganizationMembership
 
 from ee.models.rbac.access_control import AccessControl
 
+from ...api.community_publish_services import CommunitySkillPublishError, CommunitySkillPublishNotConfiguredError
 from ...api.skill_serializers import DEFAULT_BODY_PAGE_LENGTH
 from ...api.skill_services import (
     MAX_SKILL_FILE_COUNT,
@@ -1244,6 +1246,70 @@ class TestLLMSkillAPI(APIBaseTest):
         assert len(data["versions"]) == 2
         assert data["versions"][0]["version"] == 2
         assert data["versions"][1]["version"] == 1
+
+    # --- Publish to community ---
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_succeeds(self, mock_publish):
+        mock_publish.return_value = {
+            "pr_url": "https://github.com/PostHog/community-skills/pull/7",
+            "pr_number": 7,
+            "branch": "community-skill/make-pr-abc123",
+        }
+        skill = self.create_skill(
+            name="make-pr",
+            description="Open a PR.",
+            body="# Make PR",
+            allowed_tools=["query"],
+            metadata={"tags": ["github"]},
+        )
+        LLMSkillFile.objects.create(
+            skill=skill, path="references/playbook.md", content="hints", content_type="text/markdown"
+        )
+
+        response = self.client.post(
+            self._url("name/make-pr/publish-community"),
+            data={"author_handle": "andymaguire"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json() == mock_publish.return_value
+        _, kwargs = mock_publish.call_args
+        assert kwargs["slug"] == "make-pr"
+        assert kwargs["name"] == "Make Pr"  # default display name = title-cased slug
+        assert kwargs["description"] == "Open a PR."
+        assert kwargs["tags"] == ["github"]  # falls back to metadata tags
+        assert kwargs["allowed_tools"] == ["query"]
+        assert kwargs["author_handle"] == "andymaguire"
+        assert kwargs["files"] == [
+            {"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}
+        ]
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_unknown_skill_returns_404(self, mock_publish):
+        response = self.client.post(self._url("name/does-not-exist/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_publish.assert_not_called()
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_not_configured_returns_503(self, mock_publish):
+        mock_publish.side_effect = CommunitySkillPublishNotConfiguredError("nope")
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_github_error_returns_502(self, mock_publish):
+        mock_publish.side_effect = CommunitySkillPublishError("github exploded")
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
 # llm_skill is its own access-control resource (see ACCESS_CONTROL_RESOURCES in

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -1,6 +1,7 @@
 import uuid
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from django.core.cache import cache
 
@@ -13,6 +14,7 @@ from posthog.models.organization import OrganizationMembership
 
 from ee.models.rbac.access_control import AccessControl
 
+from ...api.community_publish_services import CommunitySkillPublishError, CommunitySkillPublishNotConfiguredError
 from ...api.skill_serializers import DEFAULT_BODY_PAGE_LENGTH
 from ...api.skill_services import (
     MAX_SKILL_FILE_COUNT,
@@ -1204,6 +1206,70 @@ class TestLLMSkillAPI(APIBaseTest):
         assert len(data["versions"]) == 2
         assert data["versions"][0]["version"] == 2
         assert data["versions"][1]["version"] == 1
+
+    # --- Publish to community ---
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_succeeds(self, mock_publish):
+        mock_publish.return_value = {
+            "pr_url": "https://github.com/PostHog/community-skills/pull/7",
+            "pr_number": 7,
+            "branch": "community-skill/make-pr-abc123",
+        }
+        skill = self.create_skill(
+            name="make-pr",
+            description="Open a PR.",
+            body="# Make PR",
+            allowed_tools=["query"],
+            metadata={"tags": ["github"]},
+        )
+        LLMSkillFile.objects.create(
+            skill=skill, path="references/playbook.md", content="hints", content_type="text/markdown"
+        )
+
+        response = self.client.post(
+            self._url("name/make-pr/publish-community"),
+            data={"author_handle": "andymaguire"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json() == mock_publish.return_value
+        _, kwargs = mock_publish.call_args
+        assert kwargs["slug"] == "make-pr"
+        assert kwargs["name"] == "Make Pr"  # default display name = title-cased slug
+        assert kwargs["description"] == "Open a PR."
+        assert kwargs["tags"] == ["github"]  # falls back to metadata tags
+        assert kwargs["allowed_tools"] == ["query"]
+        assert kwargs["author_handle"] == "andymaguire"
+        assert kwargs["files"] == [
+            {"path": "references/playbook.md", "content": "hints", "content_type": "text/markdown"}
+        ]
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_unknown_skill_returns_404(self, mock_publish):
+        response = self.client.post(self._url("name/does-not-exist/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_publish.assert_not_called()
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_not_configured_returns_503(self, mock_publish):
+        mock_publish.side_effect = CommunitySkillPublishNotConfiguredError("nope")
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    @patch("products.skills.backend.api.skills.publish_skill_to_community")
+    def test_publish_to_community_github_error_returns_502(self, mock_publish):
+        mock_publish.side_effect = CommunitySkillPublishError("github exploded")
+        self.create_skill(name="make-pr")
+
+        response = self.client.post(self._url("name/make-pr/publish-community"), data={}, format="json")
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
 # llm_skill is its own access-control resource (see ACCESS_CONTROL_RESOURCES in

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -656,8 +656,8 @@ export interface LLMSkillPublishToCommunityApi {
      */
     tags?: string[]
     /**
-     * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
-     * @maxLength 100
+     * The publisher's GitHub username, used for public attribution on the listing and PR. Optional, and self-reported: it is not verified against the publisher's PostHog account.
+     * @pattern ^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$
      */
     author_handle?: string
 }

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -658,6 +658,7 @@ export interface LLMSkillPublishToCommunityApi {
     tags?: string[]
     /**
      * The publisher's GitHub username, used for public attribution on the listing and PR. Optional, and self-reported: it is not verified against the publisher's PostHog account.
+     * @maxLength 39
      * @pattern ^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$
      */
     author_handle?: string

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -644,6 +644,33 @@ export interface LLMSkillFileApi {
     content_type?: string
 }
 
+export interface LLMSkillPublishToCommunityApi {
+    /**
+     * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+     * @maxLength 200
+     */
+    display_name?: string
+    /**
+     * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+     * @items.maxLength 64
+     */
+    tags?: string[]
+    /**
+     * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+     * @maxLength 100
+     */
+    author_handle?: string
+}
+
+export interface CommunitySkillPublishResultApi {
+    /** URL of the pull request opened in the community-skills repo for maintainer review. */
+    pr_url: string
+    /** Number of the opened pull request. */
+    pr_number: number
+    /** Name of the branch created in the community-skills repo. */
+    branch: string
+}
+
 export interface LLMSkillVersionSummaryApi {
     readonly id: string
     readonly version: number

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -647,7 +647,7 @@ export interface LLMSkillFileApi {
 export interface LLMSkillPublishToCommunityApi {
     /**
      * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
-     * @maxLength 200
+     * @maxLength 64
      */
     display_name?: string
     /**

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -646,8 +646,9 @@ export interface LLMSkillFileApi {
 
 export interface LLMSkillPublishToCommunityApi {
     /**
-     * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+     * Human-friendly display name for the community listing. Defaults to a title-cased skill slug. Must be a single line: it is used as the pull request title and commit message.
      * @maxLength 64
+     * @pattern ^[^\u0000-\u001f\u007f]*$
      */
     display_name?: string
     /**

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -622,6 +622,33 @@ export interface LLMSkillFileApi {
     content_type?: string
 }
 
+export interface LLMSkillPublishToCommunityApi {
+    /**
+     * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+     * @maxLength 200
+     */
+    display_name?: string
+    /**
+     * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+     * @items.maxLength 64
+     */
+    tags?: string[]
+    /**
+     * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+     * @maxLength 100
+     */
+    author_handle?: string
+}
+
+export interface CommunitySkillPublishResultApi {
+    /** URL of the pull request opened in the community-skills repo for maintainer review. */
+    pr_url: string
+    /** Number of the opened pull request. */
+    pr_number: number
+    /** Name of the branch created in the community-skills repo. */
+    branch: string
+}
+
 export interface LLMSkillVersionSummaryApi {
     readonly id: string
     readonly version: number

--- a/products/skills/frontend/generated/api.ts
+++ b/products/skills/frontend/generated/api.ts
@@ -11,6 +11,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
     CommunitySkillApi,
     CommunitySkillInstallApi,
+    CommunitySkillPublishResultApi,
     CommunitySkillVoteResponseApi,
     CommunitySkillsListParams,
     LLMSkillApi,
@@ -22,6 +23,7 @@ import type {
     LLMSkillImportApi,
     LLMSkillMarketplaceCommandApi,
     LLMSkillMarketplaceIssueApi,
+    LLMSkillPublishToCommunityApi,
     LLMSkillResolveResponseApi,
     LlmSkillsListParams,
     LlmSkillsNameExportRetrieveParams,
@@ -447,6 +449,24 @@ export const llmSkillsNameFilesDestroy = async (
     return apiMutator<LLMSkillApi>(getLlmSkillsNameFilesDestroyUrl(projectId, skillName, filePath, params), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getLlmSkillsNamePublishCommunityCreateUrl = (projectId: string, skillName: string) => {
+    return `/api/projects/${projectId}/llm_skills/name/${skillName}/publish-community/`
+}
+
+export const llmSkillsNamePublishCommunityCreate = async (
+    projectId: string,
+    skillName: string,
+    lLMSkillPublishToCommunityApi?: LLMSkillPublishToCommunityApi,
+    options?: RequestInit
+): Promise<CommunitySkillPublishResultApi> => {
+    return apiMutator<CommunitySkillPublishResultApi>(getLlmSkillsNamePublishCommunityCreateUrl(projectId, skillName), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(lLMSkillPublishToCommunityApi),
     })
 }
 

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -288,7 +288,9 @@ export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 64
 
 export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
 
-export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax = 100
+export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleRegExp = new RegExp(
+    '^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$'
+)
 
 export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod
@@ -302,7 +304,9 @@ export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.objec
         .describe("Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage']."),
     author_handle: zod
         .string()
-        .max(llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax)
+        .regex(llmSkillsNamePublishCommunityCreateBodyAuthorHandleRegExp)
         .optional()
-        .describe("The publisher's GitHub username, used for public attribution on the listing and PR. Optional."),
+        .describe(
+            "The publisher's GitHub username, used for public attribution on the listing and PR. Optional, and self-reported: it is not verified against the publisher's PostHog account."
+        ),
 })

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -286,6 +286,7 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
 
 export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 64
 
+export const llmSkillsNamePublishCommunityCreateBodyDisplayNameRegExp = new RegExp('^[^\\u0000-\\u001f\\u007f]\*$')
 export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
 
 export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleRegExp = new RegExp(
@@ -296,8 +297,11 @@ export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.objec
     display_name: zod
         .string()
         .max(llmSkillsNamePublishCommunityCreateBodyDisplayNameMax)
+        .regex(llmSkillsNamePublishCommunityCreateBodyDisplayNameRegExp)
         .optional()
-        .describe('Human-friendly display name for the community listing. Defaults to a title-cased skill slug.'),
+        .describe(
+            'Human-friendly display name for the community listing. Defaults to a title-cased skill slug. Must be a single line: it is used as the pull request title and commit message.'
+        ),
     tags: zod
         .array(zod.string().max(llmSkillsNamePublishCommunityCreateBodyTagsItemMax))
         .optional()

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -289,6 +289,8 @@ export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 64
 export const llmSkillsNamePublishCommunityCreateBodyDisplayNameRegExp = new RegExp('^[^\\u0000-\\u001f\\u007f]\*$')
 export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
 
+export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax = 39
+
 export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleRegExp = new RegExp(
     '^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$'
 )
@@ -308,6 +310,7 @@ export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.objec
         .describe("Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage']."),
     author_handle: zod
         .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax)
         .regex(llmSkillsNamePublishCommunityCreateBodyAuthorHandleRegExp)
         .optional()
         .describe(

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -283,3 +283,26 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
             'Latest version you are editing from. If provided, the request fails with 409 when another write has landed in the meantime.'
         ),
 })
+
+export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 200
+
+export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
+
+export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax = 100
+
+export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.object({
+    display_name: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyDisplayNameMax)
+        .optional()
+        .describe('Human-friendly display name for the community listing. Defaults to a title-cased skill slug.'),
+    tags: zod
+        .array(zod.string().max(llmSkillsNamePublishCommunityCreateBodyTagsItemMax))
+        .optional()
+        .describe("Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage']."),
+    author_handle: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax)
+        .optional()
+        .describe("The publisher's GitHub username, used for public attribution on the listing and PR. Optional."),
+})

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -284,7 +284,7 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
         ),
 })
 
-export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 200
+export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 64
 
 export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
 

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -276,3 +276,26 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
             'Latest version you are editing from. If provided, the request fails with 409 when another write has landed in the meantime.'
         ),
 })
+
+export const llmSkillsNamePublishCommunityCreateBodyDisplayNameMax = 200
+
+export const llmSkillsNamePublishCommunityCreateBodyTagsItemMax = 64
+
+export const llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax = 100
+
+export const LlmSkillsNamePublishCommunityCreateBody = /* @__PURE__ */ zod.object({
+    display_name: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyDisplayNameMax)
+        .optional()
+        .describe('Human-friendly display name for the community listing. Defaults to a title-cased skill slug.'),
+    tags: zod
+        .array(zod.string().max(llmSkillsNamePublishCommunityCreateBodyTagsItemMax))
+        .optional()
+        .describe("Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage']."),
+    author_handle: zod
+        .string()
+        .max(llmSkillsNamePublishCommunityCreateBodyAuthorHandleMax)
+        .optional()
+        .describe("The publisher's GitHub username, used for public attribution on the listing and PR. Optional."),
+})

--- a/products/skills/mcp/tools.yaml
+++ b/products/skills/mcp/tools.yaml
@@ -30,6 +30,9 @@ tools:
     llm-skills-name-export-retrieve:
         operation: llm_skills_name_export_retrieve
         enabled: false
+    llm-skills-name-publish-community-create:
+        operation: llm_skills_name_publish_community_create
+        enabled: false
     skill-archive:
         operation: llm_skills_name_archive_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44579,8 +44579,8 @@ export namespace Schemas {
          */
       tags?: string[];
       /**
-         * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
-         * @maxLength 100
+         * The publisher's GitHub username, used for public attribution on the listing and PR. Optional, and self-reported: it is not verified against the publisher's PostHog account.
+         * @pattern ^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$
          */
       author_handle?: string;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44569,8 +44569,9 @@ export namespace Schemas {
 
     export interface LLMSkillPublishToCommunity {
       /**
-         * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+         * Human-friendly display name for the community listing. Defaults to a title-cased skill slug. Must be a single line: it is used as the pull request title and commit message.
          * @maxLength 64
+         * @pattern ^[^\u0000-\u001f\u007f]*$
          */
       display_name?: string;
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17898,6 +17898,15 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    export interface CommunitySkillPublishResult {
+      /** URL of the pull request opened in the community-skills repo for maintainer review. */
+      pr_url: string;
+      /** Number of the opened pull request. */
+      pr_number: number;
+      /** Name of the branch created in the community-skills repo. */
+      branch: string;
+    }
+
     export interface CommunitySkillVoteResponse {
       /** Total upvotes after applying the toggle. */
       vote_count: number;
@@ -44556,6 +44565,24 @@ export namespace Schemas {
     export interface LLMSkillMarketplaceIssue {
       /** Roll the existing marketplace credential to issue a fresh token, replacing the old one (this invalidates any setup using the previous token). Ignored when no credential exists yet — the first call always mints one. Only affects this user's own credential. */
       rotate?: boolean;
+    }
+
+    export interface LLMSkillPublishToCommunity {
+      /**
+         * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+         * @maxLength 200
+         */
+      display_name?: string;
+      /**
+         * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+         * @items.maxLength 64
+         */
+      tags?: string[];
+      /**
+         * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+         * @maxLength 100
+         */
+      author_handle?: string;
     }
 
     export interface LLMSkillVersionSummary {
@@ -80925,6 +80952,14 @@ export namespace Schemas {
     export interface UserGitHubPrepareCallbackRequest {
       /** GitHub App installation id being managed on github.com. */
       installation_id: string;
+    }
+
+    export interface UserGithubLogin {
+      /**
+         * The user's resolved GitHub login, or null when no GitHub identity is linked.
+         * @nullable
+         */
+      github_login: string | null;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44581,6 +44581,7 @@ export namespace Schemas {
       tags?: string[];
       /**
          * The publisher's GitHub username, used for public attribution on the listing and PR. Optional, and self-reported: it is not verified against the publisher's PostHog account.
+         * @maxLength 39
          * @pattern ^$|^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$
          */
       author_handle?: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44570,7 +44570,7 @@ export namespace Schemas {
     export interface LLMSkillPublishToCommunity {
       /**
          * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
-         * @maxLength 200
+         * @maxLength 64
          */
       display_name?: string;
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15117,6 +15117,15 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    export interface CommunitySkillPublishResult {
+      /** URL of the pull request opened in the community-skills repo for maintainer review. */
+      pr_url: string;
+      /** Number of the opened pull request. */
+      pr_number: number;
+      /** Name of the branch created in the community-skills repo. */
+      branch: string;
+    }
+
     export interface CommunitySkillVoteResponse {
       /** Total upvotes after applying the toggle. */
       vote_count: number;
@@ -37111,6 +37120,24 @@ export namespace Schemas {
     export interface LLMSkillMarketplaceIssue {
       /** Roll the existing marketplace credential to issue a fresh token, replacing the old one (this invalidates any setup using the previous token). Ignored when no credential exists yet — the first call always mints one. Only affects this user's own credential. */
       rotate?: boolean;
+    }
+
+    export interface LLMSkillPublishToCommunity {
+      /**
+         * Human-friendly display name for the community listing. Defaults to a title-cased skill slug.
+         * @maxLength 200
+         */
+      display_name?: string;
+      /**
+         * Tags used for filtering and discovery in the marketplace, e.g. ['web-analytics', 'triage'].
+         * @items.maxLength 64
+         */
+      tags?: string[];
+      /**
+         * The publisher's GitHub username, used for public attribution on the listing and PR. Optional.
+         * @maxLength 100
+         */
+      author_handle?: string;
     }
 
     export interface LLMSkillVersionSummary {
@@ -69338,6 +69365,14 @@ export namespace Schemas {
     export interface UserGitHubPrepareCallbackRequest {
       /** GitHub App installation id being managed on github.com. */
       installation_id: string;
+    }
+
+    export interface UserGithubLogin {
+      /**
+         * The user's resolved GitHub login, or null when no GitHub identity is linked.
+         * @nullable
+         */
+      github_login: string | null;
     }
 
     /**


### PR DESCRIPTION
## Problem

A team that writes a good skill can only share it by hand-authoring a pull request in `PostHog/community-skills`. This PR adds the server side of publishing from inside PostHog: one action that renders the skill into the repo's layout and opens a pull request for a maintainer to review. Fourth of the 7-PR stack (#65010 to #65016) superseding #63425. The UI that calls it is #65014.

Publishing writes to a public repo, so the failure modes are not private. The hardening in this PR closes the ones a review of the earlier revision found.

## Changes

- `POST llm_skills/name/<name>/publish-community` renders an `LLMSkill` into `skills/<slug>/SKILL.md` plus its bundled files, then opens a pull request. Slug and bundled paths are validated, so a skill cannot write outside its own directory.
- The GitHub side reuses the `GitHubIntegration` client the Tasks product already uses, against one PostHog-owned App installation. No new credential class.
- Every rendered file lands in one tree and commit, built before the branch reference exists. The earlier revision created the branch and then wrote one commit per file, so a failure mid-loop left a half-written skill on a branch in the public repo.
- The branch is `community-skill/<slug>-<publisher key>` rather than carrying a random suffix, so re-publishing rewrites that branch and returns the pull request already open for it. The earlier revision opened a second one each time.
- The publisher key is a short hash of the team's uuid. A slug is only unique within a team, so a branch keyed on the slug alone would let one team force-update another team's open pull request.
- If opening the pull request fails, the branch is deleted. The delete is skipped when GitHub reports a pull request already exists for the branch, so a concurrent publish cannot destroy the head of a live review.
- `CommunityPublishFeatureFlagPermission` binds `llm-analytics-community-skills` to the publish action alone. Skills is GA, so the flag cannot sit on the viewset, and without this publishing goes live everywhere the moment the App is installed.
- Publishing is throttled at 6/hour and 20/day. The throttles the earlier revision used extend `PersonalApiKeyRateThrottle`, which counts personal-API-key traffic only, so they never fired on this session-only endpoint.
- `display_name` is capped at 64 to match `CommunitySkill.name`. A longer name passed review and was then dropped by ingest, so the skill never appeared in the catalog.
- A GitHub failure now returns 502 rather than 500: the service converts `GitHubIntegrationError` and rate limits into its own error, and the transient publisher no longer tries to persist a token refresh against its teamless `Integration` row.
- A publisher whose skill cannot be published sees which field to fix even while GitHub is down. The skill is rendered before the publisher is acquired, so that failure answers 400 rather than the 502 or 503 the GitHub call would have produced first.
- A transient GitHub failure while minting the publish token now answers 502, not the 503 that says publishing is off on this instance. Only an installation GitHub reports as absent, or refuses the App's credentials for, still reads as not configured.
- A branch GitHub refuses to delete no longer passes as deleted. `delete_branch` read every 422 as success, so publish cleanup could leave a branch on the public repo with nothing logged; the ref is read back after a 422 and only its absence counts.
- `author_handle` is validated against GitHub's username shape, and the pull request body presents it as self-reported. Nothing verifies it against the publisher's PostHog account.
- An explicit `tags: []` publishes with no tags. It used to fall back to the skill's metadata tags on a truthiness check.
- Tags taken from the skill's metadata are filtered to strings within the catalog's cap. `metadata` is an arbitrary dict, and ingest drops an entry whose tags are not all strings, so `{"tags": [123]}` used to publish a pull request that would merge and never appear in the catalog.
- `users/{id}/github_login` now declares a response serializer. It generated as `Promise<void>`, so the publish dialog could not prefill the author handle.
- New settings: `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` (empty default) and `COMMUNITY_SKILLS_GITHUB_REPO`. The second one redirects publishing only, which is documented: the catalog sync reads its registry from a pinned repo.

> [!NOTE]
> Until infra installs the GitHub App on the community repo, the endpoint returns 503 and the UI falls back to the manual path. Publishing stays behind the flag either way.

Two known limits are documented in `docs/internal/skills/community-skills-api.md` rather than fixed here. Bundled files are text only, because `CommunitySkillFile.content` is a `TextField`. Content becomes public at the branch write, before the pull request that moderates it, so confirming that with the user gates enabling the flag and belongs with the UI in #65014.

No frontend changes, so there is nothing to screenshot.

## How did you test this code?

Agent-authored, no manual testing. Automated tests I ran locally:

- `test_community_publish_services.py` covers the render round-trip against a mirror of the repo's own frontmatter parser, plus the repo-write behaviors: one commit for all files, the branch deleted after a failed pull request but kept when one already exists, an open pull request reused instead of duplicated, a second team getting its own branch for the same slug, an unreachable GitHub raising a publish error, a skill rejected before the publisher is acquired, and the split between a refused installation and a failing GitHub.
- `test_skills.py` covers the endpoint responses. The 403-when-the-flag-is-off case is the one that catches the gate silently coming off.
- `test_integration_model.py` covers the new client helpers: the tree and commit bodies, the force-update path when the branch exists, a delete that treats a missing branch as done, and the read-back that separates a 422 which deleted the branch from one that did not.

Not checked: anything against real GitHub. Every test mocks the client at the API boundary, so the payloads are asserted against GitHub's documented shapes, not a live repo. The three `test_authorize_url` failures reported earlier no longer reproduce after the update from master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/skills/community-skills-api.md` gains a publish section: the endpoint, the gating, the repo-write guarantees, and the two limits above. No user-facing docs while the feature is flagged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @andrewm4894. An earlier session rebased the branch off the merged #65012 onto master and applied the five planned hardening items. This session updated the branch from master again, resolving one conflict where master had moved `RESERVED_SKILL_NAMES` and added `community` to it while this branch had moved the same constant into `skill_services.py` to break an import cycle. Both changes are kept. Every open review thread is answered, and the three taken this round are fixed.

Three bots caught the cross-tenant branch on the same push that introduced it. The first hardening commit made the branch deterministic to stop duplicate pull requests and made it global by mistake; the second commit scopes it to the publishing team. Declined with evidence: enforcing object-level access on this action alone, since `check_object_permissions` appears nowhere in `skills.py` and every `name/<slug>` action shares the pattern. That is recorded as a product-wide follow-on.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Two design decisions worth a reviewer's attention. The atomic commit needed a client helper (`commit_files_to_branch`), which lives in `GitHubIntegration` next to `create_branch` rather than in the product, so the tree and ref handling stays with the rest of the GitHub HTTP. `get_open_pr_base_for_head` now delegates to a new `get_open_pull_request_for_head` that returns the number and url too; its existing caller in the Tasks product is unaffected.

Public artifact: nothing here draws on anything outside this repository.

