### PR TITLE
feat(llma): publish skills to community UI (5/7)

### DIFF
--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -56,6 +56,7 @@ function buildSkillColumns(
     duplicateSkill: (name: string, newName: string) => void,
     deleteSkill: (name: string) => void,
     downloadSkillZip: (name: string) => void,
+    publishToCommunity: (skill: LLMSkillListApi) => void,
     options?: { showScoutOrigin?: boolean }
 ): LemonTableColumns<LLMSkillListApi> {
     return [
@@ -178,6 +179,19 @@ function buildSkillColumns(
                                         fullWidth
                                     >
                                         Duplicate
+                                    </LemonButton>
+                                </AccessControlAction>
+
+                                <AccessControlAction
+                                    resourceType={AccessControlResourceType.LlmSkill}
+                                    minAccessLevel={AccessControlLevel.Editor}
+                                >
+                                    <LemonButton
+                                        onClick={() => publishToCommunity(skill)}
+                                        data-attr="llma-skill-dropdown-publish-community"
+                                        fullWidth
+                                    >
+                                        Publish to community
                                     </LemonButton>
                                 </AccessControlAction>
 
@@ -421,8 +435,15 @@ function ConnectToClaudeCodeModal(): JSX.Element {
 }
 
 export function LLMSkillsScene(): JSX.Element {
-    const { setFilters, deleteSkill, duplicateSkill, downloadSkillZip, importSkill, setConnectModalOpen } =
-        useActions(llmSkillsLogic)
+    const {
+        setFilters,
+        deleteSkill,
+        duplicateSkill,
+        downloadSkillZip,
+        importSkill,
+        setConnectModalOpen,
+        publishToCommunity,
+    } = useActions(llmSkillsLogic)
     const {
         skills,
         skillsLoading,
@@ -435,6 +456,7 @@ export function LLMSkillsScene(): JSX.Element {
         activeTabKey,
         activeCategory,
         activeTabDescription,
+        githubLogin,
     } = useValues(llmSkillsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
@@ -446,12 +468,54 @@ export function LLMSkillsScene(): JSX.Element {
     // Discovery CTA: when a project has no skills of its own yet, point first-timers at the community catalog.
     const showCommunityDiscovery = communitySkillsEnabled && !skillsLoading && skills.count === 0 && !filters.search
 
+    const openPublishDialog = (skill: LLMSkillListApi): void => {
+        LemonDialog.openForm({
+            title: 'Publish to community',
+            description:
+                'Open a pull request adding this skill to the PostHog community catalog. A maintainer reviews it before it goes live.',
+            initialValues: {
+                display_name: skill.name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                tags: '',
+                // Prefill with the user's resolved GitHub handle when we have one; the field stays
+                // editable so users without a linked GitHub identity can still type one (free-text fallback).
+                author_handle: githubLogin ?? '',
+            },
+            content: (
+                <div className="flex flex-col gap-2">
+                    <LemonField name="display_name" label="Display name">
+                        <LemonInput data-attr="llma-publish-display-name" autoFocus />
+                    </LemonField>
+                    <LemonField name="tags" label="Tags (comma-separated)">
+                        <LemonInput data-attr="llma-publish-tags" placeholder="web-analytics, triage" />
+                    </LemonField>
+                    <LemonField name="author_handle" label="Your GitHub handle (optional)">
+                        <LemonInput data-attr="llma-publish-author-handle" placeholder="octocat" />
+                    </LemonField>
+                </div>
+            ),
+            onSubmit: ({ display_name, tags, author_handle }) =>
+                publishToCommunity(skill.name, {
+                    display_name: display_name?.trim() || undefined,
+                    tags: tags
+                        ? tags
+                              .split(',')
+                              .map((t: string) => t.trim())
+                              .filter(Boolean)
+                        : undefined,
+                    author_handle: author_handle?.trim() || undefined,
+                }),
+        })
+    }
+
     // Memoize columns so the array reference doesn't change every render — otherwise every
     // nested LemonTable inside the grouped tree reconciles on each parent re-render.
     const columns = useMemo(
-        () => buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, { showScoutOrigin }),
+        () =>
+            buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, openPublishDialog, {
+                showScoutOrigin,
+            }),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, showScoutOrigin]
+        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, publishToCommunity, githubLogin, showScoutOrigin]
     )
 
     const showGroupedView = filters.group_by_prefix && groupedSkills && !skillsLoading

--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -472,7 +472,7 @@ export function LLMSkillsScene(): JSX.Element {
         LemonDialog.openForm({
             title: 'Publish to community',
             description:
-                'Open a pull request adding this skill to the PostHog community catalog. A maintainer reviews it before it goes live.',
+                "Publishing commits the skill's instructions and every bundled file to a public GitHub repo, then opens a pull request for a maintainer to review. The contents are public from the moment you submit, so don't include credentials or internal details.",
             initialValues: {
                 display_name: skill.name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
                 tags: '',

--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -62,6 +62,7 @@ function buildSkillColumns(
     duplicateSkill: (name: string, newName: string) => void,
     deleteSkill: (name: string) => void,
     downloadSkillZip: (name: string) => void,
+    publishToCommunity: (skill: LLMSkillListApi) => void,
     options?: { showScoutOrigin?: boolean }
 ): LemonTableColumns<LLMSkillListApi> {
     return [
@@ -189,6 +190,19 @@ function buildSkillColumns(
 
                                 <AccessControlAction
                                     resourceType={AccessControlResourceType.LlmSkill}
+                                    minAccessLevel={AccessControlLevel.Editor}
+                                >
+                                    <LemonButton
+                                        onClick={() => publishToCommunity(skill)}
+                                        data-attr="llma-skill-dropdown-publish-community"
+                                        fullWidth
+                                    >
+                                        Publish to community
+                                    </LemonButton>
+                                </AccessControlAction>
+
+                                <AccessControlAction
+                                    resourceType={AccessControlResourceType.LlmAnalytics}
                                     minAccessLevel={AccessControlLevel.Editor}
                                 >
                                     <LemonButton
@@ -427,8 +441,15 @@ function ConnectToClaudeCodeModal(): JSX.Element {
 }
 
 export function LLMSkillsScene(): JSX.Element {
-    const { setFilters, deleteSkill, duplicateSkill, downloadSkillZip, importSkill, setConnectModalOpen } =
-        useActions(llmSkillsLogic)
+    const {
+        setFilters,
+        deleteSkill,
+        duplicateSkill,
+        downloadSkillZip,
+        importSkill,
+        setConnectModalOpen,
+        publishToCommunity,
+    } = useActions(llmSkillsLogic)
     const {
         skills,
         skillsLoading,
@@ -442,6 +463,7 @@ export function LLMSkillsScene(): JSX.Element {
         activeCategory,
         activeTabDescription,
         visibleCategoryTabs,
+        githubLogin,
     } = useValues(llmSkillsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
@@ -453,12 +475,54 @@ export function LLMSkillsScene(): JSX.Element {
     // Discovery CTA: when a project has no skills of its own yet, point first-timers at the community catalog.
     const showCommunityDiscovery = communitySkillsEnabled && !skillsLoading && skills.count === 0 && !filters.search
 
+    const openPublishDialog = (skill: LLMSkillListApi): void => {
+        LemonDialog.openForm({
+            title: 'Publish to community',
+            description:
+                'Open a pull request adding this skill to the PostHog community catalog. A maintainer reviews it before it goes live.',
+            initialValues: {
+                display_name: skill.name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                tags: '',
+                // Prefill with the user's resolved GitHub handle when we have one; the field stays
+                // editable so users without a linked GitHub identity can still type one (free-text fallback).
+                author_handle: githubLogin ?? '',
+            },
+            content: (
+                <div className="flex flex-col gap-2">
+                    <LemonField name="display_name" label="Display name">
+                        <LemonInput data-attr="llma-publish-display-name" autoFocus />
+                    </LemonField>
+                    <LemonField name="tags" label="Tags (comma-separated)">
+                        <LemonInput data-attr="llma-publish-tags" placeholder="web-analytics, triage" />
+                    </LemonField>
+                    <LemonField name="author_handle" label="Your GitHub handle (optional)">
+                        <LemonInput data-attr="llma-publish-author-handle" placeholder="octocat" />
+                    </LemonField>
+                </div>
+            ),
+            onSubmit: ({ display_name, tags, author_handle }) =>
+                publishToCommunity(skill.name, {
+                    display_name: display_name?.trim() || undefined,
+                    tags: tags
+                        ? tags
+                              .split(',')
+                              .map((t: string) => t.trim())
+                              .filter(Boolean)
+                        : undefined,
+                    author_handle: author_handle?.trim() || undefined,
+                }),
+        })
+    }
+
     // Memoize columns so the array reference doesn't change every render — otherwise every
     // nested LemonTable inside the grouped tree reconciles on each parent re-render.
     const columns = useMemo(
-        () => buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, { showScoutOrigin }),
+        () =>
+            buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, openPublishDialog, {
+                showScoutOrigin,
+            }),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, showScoutOrigin]
+        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, publishToCommunity, githubLogin, showScoutOrigin]
     )
 
     const showGroupedView = filters.group_by_prefix && groupedSkills && !skillsLoading

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -4,6 +4,7 @@ import { router, urlToAction } from 'kea-router'
 
 import { objectsEqual } from 'lib/utils/objects'
 
+import { usersGithubLoginRetrieve } from '~/generated/core/api'
 import api, { ApiConfig } from '~/lib/api'
 import { downloadBlob } from '~/lib/components/ExportButton/exporter'
 import { Sorting } from '~/lib/lemon-ui/LemonTable'
@@ -21,6 +22,7 @@ import {
     llmSkillsMarketplaceInstallCommandRetrieve,
     llmSkillsNameArchiveCreate,
     llmSkillsNameDuplicateCreate,
+    llmSkillsNamePublishCommunityCreate,
 } from 'products/skills/frontend/generated/api'
 import type {
     LLMSkillListApi,
@@ -396,6 +398,12 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
         setActiveTab: (tabKey: string) => ({ tabKey }),
         deleteSkill: (skillName: string) => ({ skillName }),
         duplicateSkill: (skillName: string, newName: string) => ({ skillName, newName }),
+        publishToCommunity: (
+            skillName: string,
+            options: { display_name?: string; tags?: string[]; author_handle?: string }
+        ) => ({ skillName, options }),
+        publishToCommunitySuccess: (skillName: string) => ({ skillName }),
+        publishToCommunityFailure: (skillName: string) => ({ skillName }),
         importSkill: (file: File) => ({ file }),
         setImporting: (importing: boolean) => ({ importing }),
         downloadSkillZip: (skillName: string) => ({ skillName }),
@@ -424,6 +432,15 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                         ...filters,
                         ...('page' in filters ? {} : { page: 1 }),
                     }),
+            },
+        ],
+        // Per-skill publish-in-flight state so the trigger can guard against double-submission.
+        publishingSkills: [
+            {} as Record<string, boolean>,
+            {
+                publishToCommunity: (state, { skillName }) => ({ ...state, [skillName]: true }),
+                publishToCommunitySuccess: (state, { skillName }) => ({ ...state, [skillName]: false }),
+                publishToCommunityFailure: (state, { skillName }) => ({ ...state, [skillName]: false }),
             },
         ],
         importing: [
@@ -524,6 +541,20 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                         })
                     )
                     return Object.fromEntries(entries)
+                },
+            },
+        ],
+        // Resolved GitHub handle for the current user — used to prefill the publish dialog's
+        // author_handle so the common case (GitHub-SSO'd users) is correct by default. Null when
+        // no GitHub identity is linked; the dialog field then falls back to free text.
+        githubLogin: [
+            null as string | null,
+            {
+                loadGithubLogin: async () => {
+                    // `@me` resolves to the current user server-side, so this doesn't race userLogic
+                    // loading the user object first.
+                    const response = await usersGithubLoginRetrieve('@me')
+                    return response.github_login ?? null
                 },
             },
         ],
@@ -668,6 +699,36 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
             }
         },
 
+        publishToCommunity: async ({ skillName, options }) => {
+            try {
+                const result = await llmSkillsNamePublishCommunityCreate(
+                    String(ApiConfig.getCurrentTeamId()),
+                    skillName,
+                    {
+                        display_name: options.display_name,
+                        tags: options.tags,
+                        author_handle: options.author_handle,
+                    }
+                )
+                lemonToast.success(
+                    `Opened a community pull request for "${skillName}" — a maintainer will review it.`,
+                    {
+                        button: { label: 'View PR', action: () => window.open(result.pr_url, '_blank', 'noopener') },
+                    }
+                )
+                actions.publishToCommunitySuccess(skillName)
+            } catch (e: any) {
+                console.error('Failed to publish skill to community', e)
+                const detail = e?.data?.detail || e?.detail
+                lemonToast.error(
+                    e?.status === 503
+                        ? 'Publishing to the community is not available on this instance yet.'
+                        : detail || 'Failed to publish skill to the community'
+                )
+                actions.publishToCommunityFailure(skillName)
+            }
+        },
+
         importSkill: async ({ file }) => {
             actions.setImporting(true)
             try {
@@ -785,5 +846,6 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
     afterMount(({ actions }) => {
         actions.loadSkills()
         actions.loadCategoryCounts()
+        actions.loadGithubLogin()
     }),
 ])

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -200,6 +200,8 @@ export interface llmSkillsLogicValues {
     connectModalOpen: boolean
     count: number
     filters: SkillFilters
+    githubLogin: string | null
+    githubLoginLoading: boolean
     groupedSkills: SkillGroupTree | null
     importing: boolean
     issuingCredential: boolean
@@ -207,6 +209,7 @@ export interface llmSkillsLogicValues {
     marketplaceLoading: boolean
     marketplaceState: LLMSkillMarketplaceCommandApi | null
     pagination: PaginationManual | undefined
+    publishingSkills: Record<string, boolean>
     rawFilters: Partial<SkillFilters> | null
     skillCountLabel: string
     skills: PaginatedLLMSkillListListApi
@@ -235,6 +238,21 @@ export interface llmSkillsLogicActions {
     issueMarketplaceCommand: (rotate?: boolean) => {
         rotate: boolean
     }
+    loadGithubLogin: () => any
+    loadGithubLoginFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadGithubLoginSuccess: (
+        githubLogin: string | null,
+        payload?: any
+    ) => {
+        githubLogin: string | null
+        payload?: any
+    }
     loadMarketplaceState: () => {
         value: true
     }
@@ -258,6 +276,27 @@ export interface llmSkillsLogicActions {
         payload?: {
             debounce: boolean
         }
+    }
+    publishToCommunity: (
+        skillName: string,
+        options: {
+            author_handle?: string
+            display_name?: string
+            tags?: string[]
+        }
+    ) => {
+        options: {
+            author_handle?: string | undefined
+            display_name?: string | undefined
+            tags?: string[] | undefined
+        }
+        skillName: string
+    }
+    publishToCommunityFailure: (skillName: string) => {
+        skillName: string
+    }
+    publishToCommunitySuccess: (skillName: string) => {
+        skillName: string
     }
     setActiveTab: (tabKey: string) => {
         tabKey: string

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -4,6 +4,7 @@ import { router, urlToAction } from 'kea-router'
 
 import { objectsEqual } from 'lib/utils/objects'
 
+import { usersGithubLoginRetrieve } from '~/generated/core/api'
 import api, { ApiConfig } from '~/lib/api'
 import { downloadBlob } from '~/lib/components/ExportButton/exporter'
 import { Sorting } from '~/lib/lemon-ui/LemonTable'
@@ -21,6 +22,7 @@ import {
     llmSkillsMarketplaceInstallCommandRetrieve,
     llmSkillsNameArchiveCreate,
     llmSkillsNameDuplicateCreate,
+    llmSkillsNamePublishCommunityCreate,
 } from 'products/skills/frontend/generated/api'
 import type {
     LLMSkillListApi,
@@ -323,6 +325,12 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
         setActiveTab: (tabKey: string) => ({ tabKey }),
         deleteSkill: (skillName: string) => ({ skillName }),
         duplicateSkill: (skillName: string, newName: string) => ({ skillName, newName }),
+        publishToCommunity: (
+            skillName: string,
+            options: { display_name?: string; tags?: string[]; author_handle?: string }
+        ) => ({ skillName, options }),
+        publishToCommunitySuccess: (skillName: string) => ({ skillName }),
+        publishToCommunityFailure: (skillName: string) => ({ skillName }),
         importSkill: (file: File) => ({ file }),
         setImporting: (importing: boolean) => ({ importing }),
         downloadSkillZip: (skillName: string) => ({ skillName }),
@@ -351,6 +359,15 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                         ...filters,
                         ...('page' in filters ? {} : { page: 1 }),
                     }),
+            },
+        ],
+        // Per-skill publish-in-flight state so the trigger can guard against double-submission.
+        publishingSkills: [
+            {} as Record<string, boolean>,
+            {
+                publishToCommunity: (state, { skillName }) => ({ ...state, [skillName]: true }),
+                publishToCommunitySuccess: (state, { skillName }) => ({ ...state, [skillName]: false }),
+                publishToCommunityFailure: (state, { skillName }) => ({ ...state, [skillName]: false }),
             },
         ],
         importing: [
@@ -430,6 +447,20 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
                     }
 
                     return await llmSkillsList(String(ApiConfig.getCurrentTeamId()), params)
+                },
+            },
+        ],
+        // Resolved GitHub handle for the current user — used to prefill the publish dialog's
+        // author_handle so the common case (GitHub-SSO'd users) is correct by default. Null when
+        // no GitHub identity is linked; the dialog field then falls back to free text.
+        githubLogin: [
+            null as string | null,
+            {
+                loadGithubLogin: async () => {
+                    // `@me` resolves to the current user server-side, so this doesn't race userLogic
+                    // loading the user object first.
+                    const response = await usersGithubLoginRetrieve('@me')
+                    return response.github_login ?? null
                 },
             },
         ],
@@ -563,6 +594,36 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
             }
         },
 
+        publishToCommunity: async ({ skillName, options }) => {
+            try {
+                const result = await llmSkillsNamePublishCommunityCreate(
+                    String(ApiConfig.getCurrentTeamId()),
+                    skillName,
+                    {
+                        display_name: options.display_name,
+                        tags: options.tags,
+                        author_handle: options.author_handle,
+                    }
+                )
+                lemonToast.success(
+                    `Opened a community pull request for "${skillName}" — a maintainer will review it.`,
+                    {
+                        button: { label: 'View PR', action: () => window.open(result.pr_url, '_blank', 'noopener') },
+                    }
+                )
+                actions.publishToCommunitySuccess(skillName)
+            } catch (e: any) {
+                console.error('Failed to publish skill to community', e)
+                const detail = e?.data?.detail || e?.detail
+                lemonToast.error(
+                    e?.status === 503
+                        ? 'Publishing to the community is not available on this instance yet.'
+                        : detail || 'Failed to publish skill to the community'
+                )
+                actions.publishToCommunityFailure(skillName)
+            }
+        },
+
         importSkill: async ({ file }) => {
             actions.setImporting(true)
             try {
@@ -679,5 +740,6 @@ export const llmSkillsLogic = kea<llmSkillsLogicType>([
 
     afterMount(({ actions }) => {
         actions.loadSkills()
+        actions.loadGithubLogin()
     }),
 ])

--- a/products/skills/frontend/llmSkillsLogic.ts
+++ b/products/skills/frontend/llmSkillsLogic.ts
@@ -245,6 +245,8 @@ export interface llmSkillsLogicValues {
     connectModalOpen: boolean
     count: number
     filters: SkillFilters
+    githubLogin: string | null
+    githubLoginLoading: boolean
     groupedSkills: SkillGroupTree | null
     importing: boolean
     issuingCredential: boolean
@@ -252,6 +254,7 @@ export interface llmSkillsLogicValues {
     marketplaceLoading: boolean
     marketplaceState: LLMSkillMarketplaceCommandApi | null
     pagination: PaginationManual | undefined
+    publishingSkills: Record<string, boolean>
     rawFilters: Partial<SkillFilters> | null
     skillCountLabel: string
     skills: PaginatedLLMSkillListListApi
@@ -306,6 +309,21 @@ export interface llmSkillsLogicActions {
             value: true
         }
     }
+    loadGithubLogin: () => any
+    loadGithubLoginFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadGithubLoginSuccess: (
+        githubLogin: string | null,
+        payload?: any
+    ) => {
+        githubLogin: string | null
+        payload?: any
+    }
     loadMarketplaceState: () => {
         value: true
     }
@@ -329,6 +347,27 @@ export interface llmSkillsLogicActions {
         payload?: {
             debounce: boolean
         }
+    }
+    publishToCommunity: (
+        skillName: string,
+        options: {
+            author_handle?: string
+            display_name?: string
+            tags?: string[]
+        }
+    ) => {
+        options: {
+            author_handle?: string | undefined
+            display_name?: string | undefined
+            tags?: string[] | undefined
+        }
+        skillName: string
+    }
+    publishToCommunityFailure: (skillName: string) => {
+        skillName: string
+    }
+    publishToCommunitySuccess: (skillName: string) => {
+        skillName: string
     }
     setActiveTab: (tabKey: string) => {
         tabKey: string


### PR DESCRIPTION
## Problem

The publish-to-community server endpoint (#65013) needs a UI. This PR adds the trigger and dialog on `Your skills`. Last of the 5-PR stack superseding #63425.

## Changes

- `Publish to community` item in each skill's row menu (Editor-gated), opening a confirm dialog with display name (prefilled from the slug), tags, and an optional GitHub handle (prefilled from the user's resolved GitHub login, editable).
- Publish wiring in `llmSkillsLogic`: action/listener calling the generated client, a per-skill in-flight reducer to guard against double-submission, and a success toast with a `View PR` button.
- Fail-safe handling: a 503 from the server surfaces a clean "not available on this instance yet" toast.

## How did you test this code?

Agent-authored. `pnpm --filter=@posthog/frontend typescript:check` and oxlint both clean. Browser-verified in the running app: the row-menu item and dialog render with the expected prefills, and submitting against an unconfigured instance shows the 503 fallback toast (the whole UI → endpoint → service → 503 → toast chain).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs yet — flag-gated. Add `skip-inkeep-docs` if preferred.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Invoked `/adopting-generated-api-types`. PR 5/5, stacked on #65013. The publish slice was rebuilt against current master (the Skills scene had merged its sub-scenes and grown the column builder since the original branch).
