### PR TITLE
feat(llma): templated community skills server (6/7)

### DIFF
--- a/products/skills/backend/api/community_skill_serializers.py
+++ b/products/skills/backend/api/community_skill_serializers.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ..models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillTrustTier
+from .skill_template_services import parse_template_variables
 
 ALLOWED_LIST_ORDERINGS = frozenset(
     {
@@ -19,6 +20,23 @@ ALLOWED_LIST_ORDERINGS = frozenset(
         "-vote_count",
     }
 )
+
+
+class CommunitySkillTemplateVariableSerializer(serializers.Serializer):
+    """One declared variable of a templated skill — the schema a client renders a form from."""
+
+    name = serializers.CharField(help_text="Variable identifier, substituted for `{{ name }}` in the skill body.")
+    prompt = serializers.CharField(
+        allow_blank=True,
+        help_text="Human-readable question shown when collecting a value for this variable.",
+    )
+    is_required = serializers.BooleanField(
+        help_text="Whether a value must be supplied at install time (otherwise it falls back to the default).",
+    )
+    default = serializers.CharField(
+        allow_blank=True,
+        help_text="Value used when none is supplied. Empty when the variable has no default.",
+    )
 
 
 class CommunitySkillFileSerializer(serializers.ModelSerializer):
@@ -58,6 +76,12 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
     files = serializers.SerializerMethodField(
         help_text="Bundled files manifest — path and content_type only. File contents are copied in on install.",
     )
+    template_variables = serializers.SerializerMethodField(
+        help_text=(
+            "Declared template variables, parsed from metadata. Non-empty marks this skill as a template: "
+            "collect a value for each and pass them as `variables` when installing."
+        ),
+    )
     vote_count = serializers.SerializerMethodField(
         help_text="Total number of upvotes this skill has received.",
     )
@@ -82,6 +106,7 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
             "author_handle",
             "github_url",
             "files",
+            "template_variables",
             "install_count",
             "vote_count",
             "has_voted",
@@ -108,6 +133,13 @@ class CommunitySkillSerializer(serializers.ModelSerializer):
         # Iterate the related manager so prefetch_related's cache is used — .values() would issue a
         # second query and defeat the viewset's manifest-only prefetch.
         return [{"path": f.path, "content_type": f.content_type} for f in instance.files.all()]
+
+    @extend_schema_field(CommunitySkillTemplateVariableSerializer(many=True))
+    def get_template_variables(self, instance: CommunitySkill) -> list[dict[str, Any]]:
+        return [
+            {"name": v.name, "prompt": v.prompt, "is_required": v.required, "default": v.default}
+            for v in parse_template_variables(instance.metadata)
+        ]
 
     def get_vote_count(self, instance: CommunitySkill) -> int:
         # Provided by the viewset's annotated queryset; fall back to a count for unannotated instances.
@@ -156,6 +188,16 @@ class CommunitySkillInstallSerializer(serializers.Serializer):
         required=False,
         allow_blank=True,
         help_text="Name for the installed skill in your team. Defaults to the community skill's slug.",
+    )
+    variables = serializers.DictField(
+        # trim_whitespace=False so a value's exact text (multiline snippets, leading/trailing
+        # whitespace meant for the rendered output) survives into the installed skill.
+        child=serializers.CharField(allow_blank=True, trim_whitespace=False),
+        required=False,
+        help_text=(
+            "Values for a template skill's declared variables, as a {name: value} map. Required only when "
+            "installing a template (see the skill's `template_variables`); ignored for non-template skills."
+        ),
     )
 
 

--- a/products/skills/backend/api/community_skill_services.py
+++ b/products/skills/backend/api/community_skill_services.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import IntegrityError, transaction
 from django.db.models import F
 
@@ -9,6 +11,7 @@ from ..models.community_skills import CommunitySkill, CommunitySkillVote
 from ..models.skills import LLMSkill
 from .skill_serializers import validate_allowed_tool, validate_skill_file_path, validate_skill_name_value
 from .skill_services import MAX_SKILL_FILE_BYTES, create_skill
+from .skill_template_services import parse_template_variables, render_template_skill
 
 # Namespaces where PostHog auto-registers and runs a skill under privileged scopes on an enrolled
 # team: Signals scouts on the scout coordinator, ReviewHog's review skills on a team's first PR
@@ -82,12 +85,17 @@ def install_community_skill(
     user: User,
     slug: str,
     new_name: str | None = None,
+    variables: dict[str, str] | None = None,
 ) -> LLMSkill:
     """Copy a community skill into a team as a regular LLMSkill and bump its install counter.
 
+    When the community skill is a template (its metadata declares `variables`), the user-supplied
+    `variables` are bound into the body and bundled files before the LLMSkill is created.
+
     Raises CommunitySkillNotFoundError if the slug is unknown, LLMSkillDuplicateNameConflictError
-    if the target name already exists in the team, and CommunitySkillInvalidPayloadError if the
-    catalog entry can't be safely installed.
+    if the target name already exists in the team, CommunitySkillInvalidPayloadError if the catalog
+    entry can't be safely installed, and MissingTemplateVariableError /
+    UnknownTemplatePlaceholderError on template render failures.
     """
     community_skill = get_community_skill_by_slug(slug)
     if community_skill is None:
@@ -126,23 +134,42 @@ def install_community_skill(
         if not (locked.description or "").strip():
             raise CommunitySkillInvalidPayloadError("This community skill has no description and can't be installed.")
         files = _validate_installable_files(locked)
+        body = locked.body
+
+        # Stamp provenance so an installed skill can be traced back to its community source, but
+        # first drop any internal ReviewHog ownership keys the catalog entry might carry.
+        metadata: dict[str, Any] = {
+            **{k: v for k, v in (locked.metadata or {}).items() if k not in _INTERNAL_METADATA_KEYS},
+            "community_skill_slug": locked.slug,
+            "community_skill_id": str(locked.id),
+        }
+
+        template_variables = parse_template_variables(locked.metadata)
+        if template_variables:
+            rendered = render_template_skill(
+                variables=template_variables,
+                body=locked.body,
+                files=files,
+                supplied=variables,
+            )
+            body = rendered.body
+            files = rendered.files
+            # The instantiated skill is a concrete skill, not a template — drop the variable schema and
+            # record what it was rendered from so a re-render stays deterministic.
+            metadata.pop("variables", None)
+            metadata["instantiated_from"] = f"{locked.slug}@{locked.source_sha}"
+            metadata["variable_bindings"] = rendered.bindings
 
         installed = create_skill(
             team,
             user=user,
             name=target_name,
             description=locked.description,
-            body=locked.body,
+            body=body,
             license=locked.license,
             compatibility=locked.compatibility,
             allowed_tools=locked.allowed_tools,
-            # Stamp provenance so an installed skill can be traced back to its community source, but
-            # first drop any internal ReviewHog ownership keys the catalog entry might carry.
-            metadata={
-                **{k: v for k, v in (locked.metadata or {}).items() if k not in _INTERNAL_METADATA_KEYS},
-                "community_skill_slug": locked.slug,
-                "community_skill_id": str(locked.id),
-            },
+            metadata=metadata,
             files=files or None,
         )
 

--- a/products/skills/backend/api/community_skills.py
+++ b/products/skills/backend/api/community_skills.py
@@ -34,6 +34,12 @@ from .community_skill_services import (
 )
 from .skill_serializers import LLMSkillSerializer
 from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimitError, LLMSkillFilePathConflictError
+from .skill_template_services import (
+    MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
+    UnknownTemplatePlaceholderError,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -190,11 +196,26 @@ class CommunitySkillViewSet(
                 user=cast(User, request.user),
                 slug=slug,
                 new_name=payload.validated_data.get("new_name"),
+                variables=payload.validated_data.get("variables"),
             )
         except CommunitySkillNotFoundError:
             return Response(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+        except (MissingTemplateVariableError, TemplateRenderTooLargeError, UnknownSuppliedVariableError) as err:
+            # All three are fixable by the caller (supply the value / shorter values / fix the key),
+            # so they're 400s.
+            return Response(
+                {"attr": "variables", "detail": str(err)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except UnknownTemplatePlaceholderError as err:
+            # The template body references a variable it never declared — a content-repo bug the
+            # caller can't fix, so surface it as a server-side fault, not a bad request.
+            return Response(
+                {"detail": str(err)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         except LLMSkillDuplicateNameConflictError:
             # Only blame the new_name field when the caller actually supplied it — otherwise the
@@ -226,6 +247,7 @@ class CommunitySkillViewSet(
             {
                 "community_skill_slug": slug,
                 "installed_skill_name": installed.name,
+                "installed_as_template": "instantiated_from" in (installed.metadata or {}),
             },
             team=self.team,
             request=request,

--- a/products/skills/backend/api/community_skills.py
+++ b/products/skills/backend/api/community_skills.py
@@ -34,6 +34,12 @@ from .community_skill_services import (
 )
 from .skill_serializers import LLMSkillSerializer
 from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimitError, LLMSkillFilePathConflictError
+from .skill_template_services import (
+    MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
+    UnknownTemplatePlaceholderError,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -186,11 +192,26 @@ class CommunitySkillViewSet(
                 user=cast(User, request.user),
                 slug=slug,
                 new_name=payload.validated_data.get("new_name"),
+                variables=payload.validated_data.get("variables"),
             )
         except CommunitySkillNotFoundError:
             return Response(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+        except (MissingTemplateVariableError, TemplateRenderTooLargeError, UnknownSuppliedVariableError) as err:
+            # All three are fixable by the caller (supply the value / shorter values / fix the key),
+            # so they're 400s.
+            return Response(
+                {"attr": "variables", "detail": str(err)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except UnknownTemplatePlaceholderError as err:
+            # The template body references a variable it never declared — a content-repo bug the
+            # caller can't fix, so surface it as a server-side fault, not a bad request.
+            return Response(
+                {"detail": str(err)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         except LLMSkillDuplicateNameConflictError:
             # Only blame the new_name field when the caller actually supplied it — otherwise the
@@ -222,6 +243,7 @@ class CommunitySkillViewSet(
             {
                 "community_skill_slug": slug,
                 "installed_skill_name": installed.name,
+                "installed_as_template": "instantiated_from" in (installed.metadata or {}),
             },
             team=self.team,
             request=request,

--- a/products/skills/backend/api/community_skills.py
+++ b/products/skills/backend/api/community_skills.py
@@ -37,6 +37,7 @@ from .skill_services import LLMSkillDuplicateNameConflictError, LLMSkillFileLimi
 from .skill_template_services import (
     MissingTemplateVariableError,
     TemplateRenderTooLargeError,
+    TemplateVariableTooLargeError,
     UnknownSuppliedVariableError,
     UnknownTemplatePlaceholderError,
 )
@@ -199,8 +200,13 @@ class CommunitySkillViewSet(
                 {"detail": f"Community skill '{slug}' not found."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except (MissingTemplateVariableError, TemplateRenderTooLargeError, UnknownSuppliedVariableError) as err:
-            # All three are fixable by the caller (supply the value / shorter values / fix the key),
+        except (
+            MissingTemplateVariableError,
+            TemplateRenderTooLargeError,
+            TemplateVariableTooLargeError,
+            UnknownSuppliedVariableError,
+        ) as err:
+            # All four are fixable by the caller (supply the value / shorter values / fix the key),
             # so they're 400s.
             return Response(
                 {"attr": "variables", "detail": str(err)},
@@ -208,7 +214,14 @@ class CommunitySkillViewSet(
             )
         except UnknownTemplatePlaceholderError as err:
             # The template body references a variable it never declared — a content-repo bug the
-            # caller can't fix, so surface it as a server-side fault, not a bad request.
+            # caller can't fix, so surface it as a server-side fault, not a bad request. Returning a
+            # hand-built 500 skips DRF's exception handler, so log it here or a broken catalog entry
+            # fails every install with no server-side signal.
+            logger.exception(
+                "Community skill template references an undeclared placeholder",
+                slug=slug,
+                placeholder=err.placeholder,
+            )
             return Response(
                 {"detail": str(err)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/products/skills/backend/api/community_skills.py
+++ b/products/skills/backend/api/community_skills.py
@@ -7,7 +7,7 @@ import posthoganalytics
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -207,11 +207,8 @@ class CommunitySkillViewSet(
             UnknownSuppliedVariableError,
         ) as err:
             # All four are fixable by the caller (supply the value / shorter values / fix the key),
-            # so they're 400s.
-            return Response(
-                {"attr": "variables", "detail": str(err)},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            # so they're 400s against the field that carried them.
+            raise ValidationError({"variables": str(err)}) from err
         except UnknownTemplatePlaceholderError as err:
             # The template body references a variable it never declared — a content-repo bug the
             # caller can't fix, so surface it as a server-side fault, not a bad request. Returning a

--- a/products/skills/backend/api/skill_template_services.py
+++ b/products/skills/backend/api/skill_template_services.py
@@ -1,0 +1,184 @@
+"""Server-side rendering for templated skills.
+
+A skill is a *template* when its `metadata.variables` declares one or more variables. The body and
+bundled files carry `{{ variable }}` placeholders that get bound to user-supplied values when the
+skill is instantiated (installed) into a team. Rendering is deliberately plain string substitution —
+never a template engine — so a community-published template can't execute logic against tenant data.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from .skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES
+
+# `{{ name }}` with optional surrounding whitespace. Names are Python-identifier-like.
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+# Any residual `{{ ... }}` after substitution — catches placeholders whose declared name isn't a
+# valid identifier (e.g. `{{ repo-name }}`), which the strict pattern above silently skips.
+_LOOSE_PLACEHOLDER_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class TemplateVariable:
+    name: str
+    prompt: str
+    required: bool
+    default: str
+
+
+class TemplateRenderError(Exception):
+    """Base class for failures while rendering a templated skill."""
+
+
+class MissingTemplateVariableError(TemplateRenderError):
+    """A required variable had no supplied value and no default."""
+
+    def __init__(self, variable: TemplateVariable) -> None:
+        self.variable = variable
+        super().__init__(f"Missing required template variable '{variable.name}': {variable.prompt}")
+
+
+class UnknownTemplatePlaceholderError(TemplateRenderError):
+    """The body or a file referenced a `{{ placeholder }}` with no declared variable."""
+
+    def __init__(self, placeholder: str) -> None:
+        self.placeholder = placeholder
+        super().__init__(f"Template references undeclared variable '{placeholder}'.")
+
+
+class TemplateRenderTooLargeError(TemplateRenderError):
+    """Rendering expanded the body or a file past the skill size limit."""
+
+    def __init__(self, what: str, limit: int) -> None:
+        super().__init__(f"Rendered {what} exceeds the {limit} byte size limit.")
+
+
+class UnknownSuppliedVariableError(TemplateRenderError):
+    """The caller supplied values for variables the template doesn't declare (likely a typo)."""
+
+    def __init__(self, names: list[str]) -> None:
+        self.names = names
+        super().__init__(f"Unknown template variable(s) supplied: {', '.join(names)}.")
+
+
+def parse_template_variables(metadata: dict[str, Any] | None) -> list[TemplateVariable]:
+    """Read the `variables` schema out of a skill's frontmatter metadata.
+
+    Tolerant of malformed entries from synced/external content: a non-dict metadata or anything
+    without a usable string `name` is skipped rather than raising, so a bad row never breaks
+    discovery or install.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    raw = metadata.get("variables")
+    if not isinstance(raw, list):
+        return []
+
+    variables: list[TemplateVariable] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name or name in seen:
+            continue
+        seen.add(name)
+        default = item.get("default", "")
+        variables.append(
+            TemplateVariable(
+                name=name,
+                prompt=str(item.get("prompt", "")),
+                # Default to required unless a default is supplied or `required` is explicitly false.
+                required=bool(item.get("required", "default" not in item)),
+                default=str(default) if default is not None else "",
+            )
+        )
+    return variables
+
+
+def is_template(metadata: dict[str, Any] | None) -> bool:
+    return len(parse_template_variables(metadata)) > 0
+
+
+def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str] | None) -> dict[str, str]:
+    """Build the final {name: value} map, applying defaults and enforcing required variables.
+
+    An explicitly supplied value (including "") is used verbatim — only an absent key falls back to
+    the default. Supplying a value for an undeclared variable is an error (likely a typo).
+    """
+    supplied = supplied or {}
+    unknown = sorted(set(supplied) - {v.name for v in variables})
+    if unknown:
+        raise UnknownSuppliedVariableError(unknown)
+
+    bindings: dict[str, str] = {}
+    for variable in variables:
+        if variable.name in supplied:
+            value = supplied[variable.name]
+            if value == "" and variable.required:
+                raise MissingTemplateVariableError(variable)
+        elif variable.default:
+            value = variable.default
+        elif variable.required:
+            raise MissingTemplateVariableError(variable)
+        else:
+            value = ""
+        bindings[variable.name] = value
+    return bindings
+
+
+def render_text(text: str, bindings: dict[str, str]) -> str:
+    """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name.
+
+    Validation runs against the source `text` only, before substitution — a supplied value may
+    legitimately contain literal `{{ }}` and must not be re-interpreted as a placeholder.
+    """
+    for match in _LOOSE_PLACEHOLDER_RE.finditer(text):
+        token = match.group(0)
+        strict = _PLACEHOLDER_RE.fullmatch(token)
+        if strict is None:
+            # A `{{ ... }}` whose name the strict pattern can't match (e.g. a hyphen) — fail loudly
+            # rather than install a skill with a dangling placeholder.
+            raise UnknownTemplatePlaceholderError(token.strip())
+        if strict.group(1) not in bindings:
+            raise UnknownTemplatePlaceholderError(strict.group(1))
+
+    return _PLACEHOLDER_RE.sub(lambda m: bindings[m.group(1)], text)
+
+
+@dataclass(frozen=True)
+class RenderedTemplate:
+    body: str
+    files: list[dict[str, str]]
+    bindings: dict[str, str]
+
+
+def render_template_skill(
+    *,
+    variables: list[TemplateVariable],
+    body: str,
+    files: list[dict[str, str]],
+    supplied: dict[str, str] | None,
+) -> RenderedTemplate:
+    """Resolve user-supplied values against the declared variables and render body + files.
+
+    `variables` is the already-parsed schema (see `parse_template_variables`) so the caller can
+    parse once and reuse the result. Raises MissingTemplateVariableError when a required value is
+    absent, UnknownTemplatePlaceholderError when a placeholder has no matching declared variable,
+    and TemplateRenderTooLargeError when a user-supplied value expands output past the size limit.
+    """
+    bindings = resolve_bindings(variables, supplied)
+
+    rendered_body = render_text(body, bindings)
+    if len(rendered_body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+        raise TemplateRenderTooLargeError("skill body", MAX_SKILL_BODY_BYTES)
+
+    rendered_files: list[dict[str, str]] = []
+    for file in files:
+        content = render_text(file["content"], bindings)
+        if len(content.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+            raise TemplateRenderTooLargeError(f"file '{file['path']}'", MAX_SKILL_FILE_BYTES)
+        rendered_files.append({**file, "content": content})
+
+    return RenderedTemplate(body=rendered_body, files=rendered_files, bindings=bindings)

--- a/products/skills/backend/api/skill_template_services.py
+++ b/products/skills/backend/api/skill_template_services.py
@@ -22,6 +22,11 @@ _PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
 MAX_TEMPLATE_VARIABLE_BYTES = 10_000
 MAX_TEMPLATE_BINDINGS_BYTES = 100_000
 
+# Every rendered file and the body together. The per-file limit alone bounds nothing in aggregate:
+# a template of 200 small files that each repeat a placeholder renders to 200 MB while every
+# individual file stays under its own 1 MB cap.
+MAX_RENDERED_SKILL_BYTES = 5_000_000
+
 
 def _iter_placeholder_tokens(text: str) -> Iterator[str]:
     r"""Yield every `{{ ... }}` token, shortest-match, in one forward pass.
@@ -169,18 +174,14 @@ def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str]
     return bindings
 
 
-def render_text(text: str, bindings: dict[str, str], *, limit: int, what: str) -> str:
-    """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name.
+def _validate_and_project(text: str, bindings: dict[str, str], binding_sizes: dict[str, int]) -> int:
+    """Check every placeholder is declared and return the exact rendered byte size, allocating nothing.
 
-    Validation runs against the source `text` only, before substitution — a supplied value may
-    legitimately contain literal `{{ }}` and must not be re-interpreted as a placeholder.
-
-    The size check runs on the projected output rather than the built string: a template that
-    repeats one placeholder amplifies its binding, so measuring afterwards would mean allocating
-    the amplified result first. Every token is a strict placeholder by the time we get past the
-    loop, so summing the substitution deltas gives the exact rendered size.
+    Validation runs against the source `text` only — a supplied value may legitimately contain
+    literal `{{ }}` and must not be re-interpreted as a placeholder. Sizing the output without
+    building it is what lets the caller reject an amplifying template before it allocates: every
+    token here is a strict placeholder, so summing the substitution deltas is exact.
     """
-    binding_sizes = {name: len(value.encode("utf-8")) for name, value in bindings.items()}
     projected = len(text.encode("utf-8"))
     for token in _iter_placeholder_tokens(text):
         strict = _PLACEHOLDER_RE.fullmatch(token)
@@ -192,10 +193,10 @@ def render_text(text: str, bindings: dict[str, str], *, limit: int, what: str) -
         if name not in bindings:
             raise UnknownTemplatePlaceholderError(name)
         projected += binding_sizes[name] - len(token.encode("utf-8"))
+    return projected
 
-    if projected > limit:
-        raise TemplateRenderTooLargeError(what, limit)
 
+def _substitute(text: str, bindings: dict[str, str]) -> str:
     return _PLACEHOLDER_RE.sub(lambda m: bindings[m.group(1)], text)
 
 
@@ -222,12 +223,20 @@ def render_template_skill(
     when a user-supplied value expands output past the size limit.
     """
     bindings = resolve_bindings(variables, supplied)
+    binding_sizes = {name: len(value.encode("utf-8")) for name, value in bindings.items()}
 
-    rendered_body = render_text(body, bindings, limit=MAX_SKILL_BODY_BYTES, what="skill body")
-
-    rendered_files: list[dict[str, str]] = []
+    # Size the whole skill before substituting any of it, so an amplifying template is rejected
+    # rather than allocated: peak memory here is the aggregate cap, not the sum of the per-file ones.
+    total = _validate_and_project(body, bindings, binding_sizes)
+    if total > MAX_SKILL_BODY_BYTES:
+        raise TemplateRenderTooLargeError("skill body", MAX_SKILL_BODY_BYTES)
     for file in files:
-        content = render_text(file["content"], bindings, limit=MAX_SKILL_FILE_BYTES, what=f"file '{file['path']}'")
-        rendered_files.append({**file, "content": content})
+        size = _validate_and_project(file["content"], bindings, binding_sizes)
+        if size > MAX_SKILL_FILE_BYTES:
+            raise TemplateRenderTooLargeError(f"file '{file['path']}'", MAX_SKILL_FILE_BYTES)
+        total += size
+        if total > MAX_RENDERED_SKILL_BYTES:
+            raise TemplateRenderTooLargeError("skill", MAX_RENDERED_SKILL_BYTES)
 
-    return RenderedTemplate(body=rendered_body, files=rendered_files, bindings=bindings)
+    rendered_files = [{**file, "content": _substitute(file["content"], bindings)} for file in files]
+    return RenderedTemplate(body=_substitute(body, bindings), files=rendered_files, bindings=bindings)

--- a/products/skills/backend/api/skill_template_services.py
+++ b/products/skills/backend/api/skill_template_services.py
@@ -7,6 +7,7 @@ never a template engine — so a community-published template can't execute logi
 """
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,9 +15,32 @@ from .skill_services import MAX_SKILL_BODY_BYTES, MAX_SKILL_FILE_BYTES
 
 # `{{ name }}` with optional surrounding whitespace. Names are Python-identifier-like.
 _PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
-# Any residual `{{ ... }}` after substitution — catches placeholders whose declared name isn't a
-# valid identifier (e.g. `{{ repo-name }}`), which the strict pattern above silently skips.
-_LOOSE_PLACEHOLDER_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+
+# A single supplied value, and all resolved bindings together. Bindings are persisted verbatim on
+# the installed skill's metadata, so these bound that row independently of what the values render
+# into — an unused variable never reaches the render-size checks below.
+MAX_TEMPLATE_VARIABLE_BYTES = 10_000
+MAX_TEMPLATE_BINDINGS_BYTES = 100_000
+
+
+def _iter_placeholder_tokens(text: str) -> Iterator[str]:
+    r"""Yield every `{{ ... }}` token, shortest-match, in one forward pass.
+
+    Deliberately not a regex: `\{\{.*?\}\}` rescans the rest of the input for every unmatched `{{`,
+    so a template carrying kilobytes of unclosed delimiters costs quadratic time and ties up an
+    installer's worker. Both indices here only move forward, so a hostile template costs one pass.
+    An unclosed trailing `{{` yields nothing and stays literal, matching the regex it replaces.
+    """
+    pos = 0
+    while True:
+        start = text.find("{{", pos)
+        if start == -1:
+            return
+        end = text.find("}}", start + 2)
+        if end == -1:
+            return
+        yield text[start : end + 2]
+        pos = end + 2
 
 
 @dataclass(frozen=True)
@@ -52,6 +76,13 @@ class TemplateRenderTooLargeError(TemplateRenderError):
 
     def __init__(self, what: str, limit: int) -> None:
         super().__init__(f"Rendered {what} exceeds the {limit} byte size limit.")
+
+
+class TemplateVariableTooLargeError(TemplateRenderError):
+    """A supplied value, or all of them together, exceeded the template variable size limit."""
+
+    def __init__(self, what: str, limit: int) -> None:
+        super().__init__(f"Template variable {what} exceeds the {limit} byte size limit.")
 
 
 class UnknownSuppliedVariableError(TemplateRenderError):
@@ -105,7 +136,8 @@ def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str]
     """Build the final {name: value} map, applying defaults and enforcing required variables.
 
     An explicitly supplied value (including "") is used verbatim — only an absent key falls back to
-    the default. Supplying a value for an undeclared variable is an error (likely a typo).
+    the default. Supplying a value for an undeclared variable is an error (likely a typo), and a
+    value (or a whole binding set) past the size caps is rejected before anything is persisted.
     """
     supplied = supplied or {}
     unknown = sorted(set(supplied) - {v.name for v in variables})
@@ -125,24 +157,44 @@ def resolve_bindings(variables: list[TemplateVariable], supplied: dict[str, str]
         else:
             value = ""
         bindings[variable.name] = value
+
+    total = 0
+    for name, value in bindings.items():
+        size = len(value.encode("utf-8"))
+        if size > MAX_TEMPLATE_VARIABLE_BYTES:
+            raise TemplateVariableTooLargeError(f"'{name}'", MAX_TEMPLATE_VARIABLE_BYTES)
+        total += size
+    if total > MAX_TEMPLATE_BINDINGS_BYTES:
+        raise TemplateVariableTooLargeError("values in total", MAX_TEMPLATE_BINDINGS_BYTES)
     return bindings
 
 
-def render_text(text: str, bindings: dict[str, str]) -> str:
+def render_text(text: str, bindings: dict[str, str], *, limit: int, what: str) -> str:
     """Substitute every `{{ name }}` placeholder, erroring on any undeclared/unrenderable name.
 
     Validation runs against the source `text` only, before substitution — a supplied value may
     legitimately contain literal `{{ }}` and must not be re-interpreted as a placeholder.
+
+    The size check runs on the projected output rather than the built string: a template that
+    repeats one placeholder amplifies its binding, so measuring afterwards would mean allocating
+    the amplified result first. Every token is a strict placeholder by the time we get past the
+    loop, so summing the substitution deltas gives the exact rendered size.
     """
-    for match in _LOOSE_PLACEHOLDER_RE.finditer(text):
-        token = match.group(0)
+    binding_sizes = {name: len(value.encode("utf-8")) for name, value in bindings.items()}
+    projected = len(text.encode("utf-8"))
+    for token in _iter_placeholder_tokens(text):
         strict = _PLACEHOLDER_RE.fullmatch(token)
         if strict is None:
             # A `{{ ... }}` whose name the strict pattern can't match (e.g. a hyphen) — fail loudly
             # rather than install a skill with a dangling placeholder.
             raise UnknownTemplatePlaceholderError(token.strip())
-        if strict.group(1) not in bindings:
-            raise UnknownTemplatePlaceholderError(strict.group(1))
+        name = strict.group(1)
+        if name not in bindings:
+            raise UnknownTemplatePlaceholderError(name)
+        projected += binding_sizes[name] - len(token.encode("utf-8"))
+
+    if projected > limit:
+        raise TemplateRenderTooLargeError(what, limit)
 
     return _PLACEHOLDER_RE.sub(lambda m: bindings[m.group(1)], text)
 
@@ -166,19 +218,16 @@ def render_template_skill(
     `variables` is the already-parsed schema (see `parse_template_variables`) so the caller can
     parse once and reuse the result. Raises MissingTemplateVariableError when a required value is
     absent, UnknownTemplatePlaceholderError when a placeholder has no matching declared variable,
-    and TemplateRenderTooLargeError when a user-supplied value expands output past the size limit.
+    TemplateVariableTooLargeError when a supplied value is oversized, and TemplateRenderTooLargeError
+    when a user-supplied value expands output past the size limit.
     """
     bindings = resolve_bindings(variables, supplied)
 
-    rendered_body = render_text(body, bindings)
-    if len(rendered_body.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
-        raise TemplateRenderTooLargeError("skill body", MAX_SKILL_BODY_BYTES)
+    rendered_body = render_text(body, bindings, limit=MAX_SKILL_BODY_BYTES, what="skill body")
 
     rendered_files: list[dict[str, str]] = []
     for file in files:
-        content = render_text(file["content"], bindings)
-        if len(content.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
-            raise TemplateRenderTooLargeError(f"file '{file['path']}'", MAX_SKILL_FILE_BYTES)
+        content = render_text(file["content"], bindings, limit=MAX_SKILL_FILE_BYTES, what=f"file '{file['path']}'")
         rendered_files.append({**file, "content": content})
 
     return RenderedTemplate(body=rendered_body, files=rendered_files, bindings=bindings)

--- a/products/skills/backend/api/test/test_community_skills.py
+++ b/products/skills/backend/api/test/test_community_skills.py
@@ -6,6 +6,15 @@ from rest_framework import status
 
 from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
 from ...models.skills import LLMSkill
+from ..skill_template_services import (
+    MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
+    UnknownTemplatePlaceholderError,
+    is_template,
+    parse_template_variables,
+    render_template_skill,
+)
 
 
 def _create_community_skill(
@@ -25,6 +34,23 @@ def _create_community_skill(
         tags=["web-analytics"],
         install_count=install_count,
         deleted=deleted,
+    )
+
+
+def _create_template_skill(*, slug: str = "feed-scout") -> CommunitySkill:
+    return CommunitySkill.objects.create(
+        slug=slug,
+        name="Feed scout",
+        description="Watch a feed for problems.",
+        body="# Scout\nWatch table {{ feed_table }} on {{ default_branch }}.",
+        trust_tier="official",
+        source_sha="sha123",
+        metadata={
+            "variables": [
+                {"name": "feed_table", "prompt": "Warehouse table", "required": True},
+                {"name": "default_branch", "prompt": "Branch", "default": "main"},
+            ]
+        },
     )
 
 
@@ -170,6 +196,58 @@ class TestCommunitySkillAPI(APIBaseTest):
         response = self.client.post(self._url("does-not-exist/install/"), {})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_retrieve_surfaces_template_variables(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.get(self._url("feed-scout/"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        variables = response.json()["template_variables"]
+        self.assertEqual([v["name"] for v in variables], ["feed_table", "default_branch"])
+        self.assertEqual(
+            variables[0], {"name": "feed_table", "prompt": "Warehouse table", "is_required": True, "default": ""}
+        )
+        self.assertFalse(variables[1]["is_required"])  # has a default
+
+    def test_install_template_renders_variables(self, _mock_flag) -> None:
+        skill = _create_template_skill(slug="feed-scout")
+        CommunitySkillFile.objects.create(
+            skill=skill, path="references/notes.md", content="Query {{ feed_table }} carefully."
+        )
+
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc", "default_branch": "develop"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on develop.")
+        self.assertEqual(installed.files.get(path="references/notes.md").content, "Query slack_abc carefully.")
+        # The instantiated skill is concrete, not a template.
+        self.assertNotIn("variables", installed.metadata)
+        self.assertEqual(installed.metadata["instantiated_from"], "feed-scout@sha123")
+        self.assertEqual(
+            installed.metadata["variable_bindings"], {"feed_table": "slack_abc", "default_branch": "develop"}
+        )
+
+    def test_install_template_uses_default_when_omitted(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on main.")
+
+    def test_install_template_missing_required_returns_400(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(self._url("feed-scout/install/"), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "variables")
+        self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
+
     def test_vote_toggles_on_and_off(self, _mock_flag) -> None:
         _create_community_skill(slug="web-analytics-triage")
 
@@ -179,3 +257,119 @@ class TestCommunitySkillAPI(APIBaseTest):
         second = self.client.post(self._url("web-analytics-triage/vote/"))
         self.assertEqual(second.json(), {"vote_count": 0, "has_voted": False})
         self.assertFalse(CommunitySkillVote.objects.exists())
+
+
+class TestSkillTemplateRendering(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("no metadata", None, False),
+            ("empty", {}, False),
+            ("non-list variables", {"variables": "nope"}, False),
+            ("empty list", {"variables": []}, False),
+            ("declared", {"variables": [{"name": "repo"}]}, True),
+        ]
+    )
+    def test_is_template(self, _name, metadata, expected) -> None:
+        self.assertEqual(is_template(metadata), expected)
+
+    def test_parse_skips_malformed_and_dedupes(self) -> None:
+        variables = parse_template_variables(
+            {
+                "variables": [
+                    {"name": "repo"},
+                    {"no_name": 1},
+                    "bad",
+                    {"name": "repo"},
+                    {"name": "branch", "default": "main"},
+                ]
+            }
+        )
+        self.assertEqual([v.name for v in variables], ["repo", "branch"])
+        # Bare declaration defaults to required; a default makes it optional.
+        self.assertTrue(variables[0].required)
+        self.assertFalse(variables[1].required)
+
+    def test_render_substitutes_and_records_bindings(self) -> None:
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+            body="watch {{ repo }}",
+            files=[{"path": "a.md", "content": "ref {{ repo }}", "content_type": "text/plain"}],
+            supplied={"repo": "posthog/posthog"},
+        )
+        self.assertEqual(rendered.body, "watch posthog/posthog")
+        self.assertEqual(rendered.files[0]["content"], "ref posthog/posthog")
+        self.assertEqual(rendered.bindings, {"repo": "posthog/posthog"})
+
+    def test_render_missing_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="watch {{ repo }}",
+                files=[],
+                supplied={},
+            )
+
+    def test_render_unknown_placeholder_raises(self) -> None:
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="watch {{ repo }} and {{ undeclared }}",
+                files=[],
+                supplied={"repo": "x"},
+            )
+
+    def test_render_rejects_unrenderable_variable_name(self) -> None:
+        # A declared name the placeholder regex can't match (hyphen) must fail, not install dangling.
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo-name", "required": True}]}),
+                body="watch {{ repo-name }}",
+                files=[],
+                supplied={"repo-name": "x"},
+            )
+
+    def test_render_explicit_blank_overrides_default(self) -> None:
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "suffix", "default": "!"}]}),
+            body="hi{{ suffix }}",
+            files=[],
+            supplied={"suffix": ""},
+        )
+        self.assertEqual(rendered.body, "hi")
+
+    def test_render_explicit_blank_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="{{ repo }}",
+                files=[],
+                supplied={"repo": ""},
+            )
+
+    def test_render_unknown_supplied_key_raises(self) -> None:
+        with self.assertRaises(UnknownSuppliedVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "feed_table", "required": True}]}),
+                body="{{ feed_table }}",
+                files=[],
+                supplied={"feed_table": "x", "feedtable": "typo"},
+            )
+
+    def test_render_allows_braces_inside_supplied_value(self) -> None:
+        # Validation is on the source template, so a value containing literal {{ }} is not re-parsed.
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "snippet", "required": True}]}),
+            body="config: {{ snippet }}",
+            files=[],
+            supplied={"snippet": "{{ not_a_var }}"},
+        )
+        self.assertEqual(rendered.body, "config: {{ not_a_var }}")
+
+    def test_render_oversized_output_raises(self) -> None:
+        with self.assertRaises(TemplateRenderTooLargeError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "v", "required": True}]}),
+                body="{{ v }}",
+                files=[],
+                supplied={"v": "x" * 1_000_001},
+            )

--- a/products/skills/backend/api/test/test_community_skills.py
+++ b/products/skills/backend/api/test/test_community_skills.py
@@ -11,6 +11,15 @@ from posthog.models.user import User
 
 from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
 from ...models.skills import LLMSkill
+from ..skill_template_services import (
+    MissingTemplateVariableError,
+    TemplateRenderTooLargeError,
+    UnknownSuppliedVariableError,
+    UnknownTemplatePlaceholderError,
+    is_template,
+    parse_template_variables,
+    render_template_skill,
+)
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -35,6 +44,23 @@ def _create_community_skill(
         tags=["web-analytics"],
         install_count=install_count,
         deleted=deleted,
+    )
+
+
+def _create_template_skill(*, slug: str = "feed-scout") -> CommunitySkill:
+    return CommunitySkill.objects.create(
+        slug=slug,
+        name="Feed scout",
+        description="Watch a feed for problems.",
+        body="# Scout\nWatch table {{ feed_table }} on {{ default_branch }}.",
+        trust_tier="official",
+        source_sha="sha123",
+        metadata={
+            "variables": [
+                {"name": "feed_table", "prompt": "Warehouse table", "required": True},
+                {"name": "default_branch", "prompt": "Branch", "default": "main"},
+            ]
+        },
     )
 
 
@@ -180,6 +206,58 @@ class TestCommunitySkillAPI(APIBaseTest):
         response = self.client.post(self._url("does-not-exist/install/"), {})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_retrieve_surfaces_template_variables(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.get(self._url("feed-scout/"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        variables = response.json()["template_variables"]
+        self.assertEqual([v["name"] for v in variables], ["feed_table", "default_branch"])
+        self.assertEqual(
+            variables[0], {"name": "feed_table", "prompt": "Warehouse table", "is_required": True, "default": ""}
+        )
+        self.assertFalse(variables[1]["is_required"])  # has a default
+
+    def test_install_template_renders_variables(self, _mock_flag) -> None:
+        skill = _create_template_skill(slug="feed-scout")
+        CommunitySkillFile.objects.create(
+            skill=skill, path="references/notes.md", content="Query {{ feed_table }} carefully."
+        )
+
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc", "default_branch": "develop"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on develop.")
+        self.assertEqual(installed.files.get(path="references/notes.md").content, "Query slack_abc carefully.")
+        # The instantiated skill is concrete, not a template.
+        self.assertNotIn("variables", installed.metadata)
+        self.assertEqual(installed.metadata["instantiated_from"], "feed-scout@sha123")
+        self.assertEqual(
+            installed.metadata["variable_bindings"], {"feed_table": "slack_abc", "default_branch": "develop"}
+        )
+
+    def test_install_template_uses_default_when_omitted(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "slack_abc"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        installed = LLMSkill.objects.get(team=self.team, name="feed-scout")
+        self.assertEqual(installed.body, "# Scout\nWatch table slack_abc on main.")
+
+    def test_install_template_missing_required_returns_400(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(self._url("feed-scout/install/"), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["attr"], "variables")
+        self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
+
     def test_vote_toggles_on_and_off(self, _mock_flag) -> None:
         _create_community_skill(slug="web-analytics-triage")
 
@@ -244,3 +322,119 @@ class TestCommunitySkillFeatureFlagGate(APIBaseTest):
             response = self.client.get(f"/api/projects/{self.team.id}/community_skills/")
 
         self.assertEqual(response.status_code, expected_status, response.content)
+
+
+class TestSkillTemplateRendering(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("no metadata", None, False),
+            ("empty", {}, False),
+            ("non-list variables", {"variables": "nope"}, False),
+            ("empty list", {"variables": []}, False),
+            ("declared", {"variables": [{"name": "repo"}]}, True),
+        ]
+    )
+    def test_is_template(self, _name, metadata, expected) -> None:
+        self.assertEqual(is_template(metadata), expected)
+
+    def test_parse_skips_malformed_and_dedupes(self) -> None:
+        variables = parse_template_variables(
+            {
+                "variables": [
+                    {"name": "repo"},
+                    {"no_name": 1},
+                    "bad",
+                    {"name": "repo"},
+                    {"name": "branch", "default": "main"},
+                ]
+            }
+        )
+        self.assertEqual([v.name for v in variables], ["repo", "branch"])
+        # Bare declaration defaults to required; a default makes it optional.
+        self.assertTrue(variables[0].required)
+        self.assertFalse(variables[1].required)
+
+    def test_render_substitutes_and_records_bindings(self) -> None:
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+            body="watch {{ repo }}",
+            files=[{"path": "a.md", "content": "ref {{ repo }}", "content_type": "text/plain"}],
+            supplied={"repo": "posthog/posthog"},
+        )
+        self.assertEqual(rendered.body, "watch posthog/posthog")
+        self.assertEqual(rendered.files[0]["content"], "ref posthog/posthog")
+        self.assertEqual(rendered.bindings, {"repo": "posthog/posthog"})
+
+    def test_render_missing_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="watch {{ repo }}",
+                files=[],
+                supplied={},
+            )
+
+    def test_render_unknown_placeholder_raises(self) -> None:
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="watch {{ repo }} and {{ undeclared }}",
+                files=[],
+                supplied={"repo": "x"},
+            )
+
+    def test_render_rejects_unrenderable_variable_name(self) -> None:
+        # A declared name the placeholder regex can't match (hyphen) must fail, not install dangling.
+        with self.assertRaises(UnknownTemplatePlaceholderError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo-name", "required": True}]}),
+                body="watch {{ repo-name }}",
+                files=[],
+                supplied={"repo-name": "x"},
+            )
+
+    def test_render_explicit_blank_overrides_default(self) -> None:
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "suffix", "default": "!"}]}),
+            body="hi{{ suffix }}",
+            files=[],
+            supplied={"suffix": ""},
+        )
+        self.assertEqual(rendered.body, "hi")
+
+    def test_render_explicit_blank_required_raises(self) -> None:
+        with self.assertRaises(MissingTemplateVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "repo", "required": True}]}),
+                body="{{ repo }}",
+                files=[],
+                supplied={"repo": ""},
+            )
+
+    def test_render_unknown_supplied_key_raises(self) -> None:
+        with self.assertRaises(UnknownSuppliedVariableError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "feed_table", "required": True}]}),
+                body="{{ feed_table }}",
+                files=[],
+                supplied={"feed_table": "x", "feedtable": "typo"},
+            )
+
+    def test_render_allows_braces_inside_supplied_value(self) -> None:
+        # Validation is on the source template, so a value containing literal {{ }} is not re-parsed.
+        rendered = render_template_skill(
+            variables=parse_template_variables({"variables": [{"name": "snippet", "required": True}]}),
+            body="config: {{ snippet }}",
+            files=[],
+            supplied={"snippet": "{{ not_a_var }}"},
+        )
+        self.assertEqual(rendered.body, "config: {{ not_a_var }}")
+
+    def test_render_oversized_output_raises(self) -> None:
+        with self.assertRaises(TemplateRenderTooLargeError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "v", "required": True}]}),
+                body="{{ v }}",
+                files=[],
+                supplied={"v": "x" * 1_000_001},
+            )

--- a/products/skills/backend/api/test/test_community_skills.py
+++ b/products/skills/backend/api/test/test_community_skills.py
@@ -14,6 +14,7 @@ from posthog.models.user import User
 from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
 from ...models.skills import LLMSkill
 from ..skill_template_services import (
+    MAX_RENDERED_SKILL_BYTES,
     MAX_TEMPLATE_BINDINGS_BYTES,
     MAX_TEMPLATE_VARIABLE_BYTES,
     MissingTemplateVariableError,
@@ -495,6 +496,21 @@ class TestSkillTemplateRendering(APIBaseTest):
                 files=[],
                 supplied=dict.fromkeys(names, "x" * size),
             )
+
+    def test_render_rejects_oversized_total_across_files(self) -> None:
+        # Each file renders to ~700 KB, under the 1 MB per-file cap, but 200 of them are 140 MB.
+        # A per-file limit bounds nothing in aggregate, so the whole-skill cap has to exist.
+        with self.assertRaises(TemplateRenderTooLargeError) as ctx:
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": "v", "required": True}]}),
+                body="small",
+                files=[
+                    {"path": f"references/{i}.md", "content": "{{ v }}" * 100, "content_type": "text/plain"}
+                    for i in range(200)
+                ],
+                supplied={"v": "x" * 7_000},
+            )
+        self.assertIn(str(MAX_RENDERED_SKILL_BYTES), str(ctx.exception))
 
     def test_render_scans_unmatched_delimiters_in_one_pass(self) -> None:
         # Unclosed `{{` stay literal. A `{{.*?}}` regex rescans the rest of the input for each of

--- a/products/skills/backend/api/test/test_community_skills.py
+++ b/products/skills/backend/api/test/test_community_skills.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
@@ -12,8 +14,11 @@ from posthog.models.user import User
 from ...models.community_skills import CommunitySkill, CommunitySkillFile, CommunitySkillVote
 from ...models.skills import LLMSkill
 from ..skill_template_services import (
+    MAX_TEMPLATE_BINDINGS_BYTES,
+    MAX_TEMPLATE_VARIABLE_BYTES,
     MissingTemplateVariableError,
     TemplateRenderTooLargeError,
+    TemplateVariableTooLargeError,
     UnknownSuppliedVariableError,
     UnknownTemplatePlaceholderError,
     is_template,
@@ -258,6 +263,34 @@ class TestCommunitySkillAPI(APIBaseTest):
         self.assertEqual(response.json()["attr"], "variables")
         self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
 
+    def test_install_template_oversized_variable_returns_400(self, _mock_flag) -> None:
+        _create_template_skill(slug="feed-scout")
+        response = self.client.post(
+            self._url("feed-scout/install/"),
+            {"variables": {"feed_table": "x" * (MAX_TEMPLATE_VARIABLE_BYTES + 1)}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
+
+    def test_install_template_undeclared_placeholder_is_logged(self, _mock_flag) -> None:
+        skill = _create_template_skill(slug="feed-scout")
+        skill.body = "Watch {{ feed_table }} and {{ undeclared }}."
+        skill.save(update_fields=["body"])
+
+        with patch("products.skills.backend.api.community_skills.logger.exception") as mock_exception:
+            response = self.client.post(
+                self._url("feed-scout/install/"),
+                {"variables": {"feed_table": "slack_abc"}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # The hand-built 500 bypasses DRF's exception handler, so this log line is the only signal
+        # that a catalog entry is broken.
+        mock_exception.assert_called_once()
+        self.assertFalse(LLMSkill.objects.filter(team=self.team, name="feed-scout").exists())
+
     def test_vote_toggles_on_and_off(self, _mock_flag) -> None:
         _create_community_skill(slug="web-analytics-triage")
 
@@ -431,10 +464,43 @@ class TestSkillTemplateRendering(APIBaseTest):
         self.assertEqual(rendered.body, "config: {{ not_a_var }}")
 
     def test_render_oversized_output_raises(self) -> None:
+        # A value well inside the per-variable cap still amplifies past the body limit when the
+        # template repeats its placeholder, so the size check can't assume a small input.
         with self.assertRaises(TemplateRenderTooLargeError):
             render_template_skill(
                 variables=parse_template_variables({"variables": [{"name": "v", "required": True}]}),
-                body="{{ v }}",
+                body="{{ v }}" * 200,
                 files=[],
-                supplied={"v": "x" * 1_000_001},
+                supplied={"v": "x" * 9_000},
             )
+
+    @parameterized.expand(
+        [
+            ("one oversized value", 1, MAX_TEMPLATE_VARIABLE_BYTES + 1),
+            (
+                "values oversized in total",
+                MAX_TEMPLATE_BINDINGS_BYTES // MAX_TEMPLATE_VARIABLE_BYTES + 1,
+                MAX_TEMPLATE_VARIABLE_BYTES,
+            ),
+        ]
+    )
+    def test_render_rejects_oversized_bindings(self, _name, count, size) -> None:
+        names = [f"v{i}" for i in range(count)]
+        with self.assertRaises(TemplateVariableTooLargeError):
+            render_template_skill(
+                variables=parse_template_variables({"variables": [{"name": n, "required": True} for n in names]}),
+                # Unrendered on purpose: bindings are persisted to the installed skill's metadata
+                # whether or not they appear in the body, so render-size checks don't bound them.
+                body="no placeholders here",
+                files=[],
+                supplied=dict.fromkeys(names, "x" * size),
+            )
+
+    def test_render_scans_unmatched_delimiters_in_one_pass(self) -> None:
+        # Unclosed `{{` stay literal. A `{{.*?}}` regex rescans the rest of the input for each of
+        # them, so this body took tens of seconds to validate before the scan became single-pass.
+        body = "{{" * 32_000
+        started = time.monotonic()
+        rendered = render_template_skill(variables=[], body=body, files=[], supplied=None)
+        self.assertEqual(rendered.body, body)
+        self.assertLess(time.monotonic() - started, 5)

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -21,6 +21,20 @@ export const TrustTierEnumApi = {
 } as const
 
 /**
+ * One declared variable of a templated skill — the schema a client renders a form from.
+ */
+export interface CommunitySkillTemplateVariableApi {
+    /** Variable identifier, substituted for `{{ name }}` in the skill body. */
+    name: string
+    /** Human-readable question shown when collecting a value for this variable. */
+    prompt: string
+    /** Whether a value must be supplied at install time (otherwise it falls back to the default). */
+    is_required: boolean
+    /** Value used when none is supplied. Empty when the variable has no default. */
+    default: string
+}
+
+/**
  * Arbitrary key-value metadata carried from the skill's frontmatter.
  */
 export type CommunitySkillListApiMetadata = { [key: string]: unknown }
@@ -56,6 +70,8 @@ export interface CommunitySkillListApi {
     readonly author_handle: string
     /** Link to the skill's source directory on GitHub. */
     readonly github_url: string
+    /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+    readonly template_variables: readonly CommunitySkillTemplateVariableApi[]
     /** Number of times this skill has been installed into a team. */
     readonly install_count: number
     /** Total number of upvotes this skill has received. */
@@ -124,6 +140,8 @@ export interface CommunitySkillApi {
     readonly github_url: string
     /** Bundled files manifest — path and content_type only. File contents are copied in on install. */
     readonly files: readonly CommunitySkillFileManifestApi[]
+    /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+    readonly template_variables: readonly CommunitySkillTemplateVariableApi[]
     /** Number of times this skill has been installed into a team. */
     readonly install_count: number
     /** Total number of upvotes this skill has received. */
@@ -139,12 +157,19 @@ export interface CommunitySkillApi {
     readonly updated_at: string
 }
 
+/**
+ * Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills.
+ */
+export type CommunitySkillInstallApiVariables = { [key: string]: string }
+
 export interface CommunitySkillInstallApi {
     /**
      * Name for the installed skill in your team. Defaults to the community skill's slug.
      * @maxLength 64
      */
     new_name?: string
+    /** Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills. */
+    variables?: CommunitySkillInstallApiVariables
 }
 
 /**

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -17,6 +17,12 @@ export const CommunitySkillsInstallCreateBody = /* @__PURE__ */ zod.object({
         .max(communitySkillsInstallCreateBodyNewNameMax)
         .optional()
         .describe("Name for the installed skill in your team. Defaults to the community skill's slug."),
+    variables: zod
+        .record(zod.string(), zod.string())
+        .optional()
+        .describe(
+            "Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills."
+        ),
 })
 
 export const llmSkillsCreateBodyNameMax = 64

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17792,6 +17792,20 @@ export namespace Schemas {
       content_type?: string;
     }
 
+    /**
+     * One declared variable of a templated skill — the schema a client renders a form from.
+     */
+    export interface CommunitySkillTemplateVariable {
+      /** Variable identifier, substituted for `{{ name }}` in the skill body. */
+      name: string;
+      /** Human-readable question shown when collecting a value for this variable. */
+      prompt: string;
+      /** Whether a value must be supplied at install time (otherwise it falls back to the default). */
+      is_required: boolean;
+      /** Value used when none is supplied. Empty when the variable has no default. */
+      default: string;
+    }
+
     export interface CommunitySkill {
       readonly id: string;
       /** Stable identifier matching the skill's directory in the community-skills repo. */
@@ -17824,6 +17838,8 @@ export namespace Schemas {
       readonly github_url: string;
       /** Bundled files manifest — path and content_type only. File contents are copied in on install. */
       readonly files: readonly CommunitySkillFileManifest[];
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */
@@ -17839,12 +17855,19 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    /**
+     * Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills.
+     */
+    export type CommunitySkillInstallVariables = {[key: string]: string};
+
     export interface CommunitySkillInstall {
       /**
          * Name for the installed skill in your team. Defaults to the community skill's slug.
          * @maxLength 64
          */
       new_name?: string;
+      /** Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills. */
+      variables?: CommunitySkillInstallVariables;
     }
 
     /**
@@ -17883,6 +17906,8 @@ export namespace Schemas {
       readonly author_handle: string;
       /** Link to the skill's source directory on GitHub. */
       readonly github_url: string;
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15011,6 +15011,20 @@ export namespace Schemas {
       content_type?: string;
     }
 
+    /**
+     * One declared variable of a templated skill — the schema a client renders a form from.
+     */
+    export interface CommunitySkillTemplateVariable {
+      /** Variable identifier, substituted for `{{ name }}` in the skill body. */
+      name: string;
+      /** Human-readable question shown when collecting a value for this variable. */
+      prompt: string;
+      /** Whether a value must be supplied at install time (otherwise it falls back to the default). */
+      is_required: boolean;
+      /** Value used when none is supplied. Empty when the variable has no default. */
+      default: string;
+    }
+
     export interface CommunitySkill {
       readonly id: string;
       /** Stable identifier matching the skill's directory in the community-skills repo. */
@@ -15043,6 +15057,8 @@ export namespace Schemas {
       readonly github_url: string;
       /** Bundled files manifest — path and content_type only. File contents are copied in on install. */
       readonly files: readonly CommunitySkillFileManifest[];
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */
@@ -15058,12 +15074,19 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    /**
+     * Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills.
+     */
+    export type CommunitySkillInstallVariables = {[key: string]: string};
+
     export interface CommunitySkillInstall {
       /**
          * Name for the installed skill in your team. Defaults to the community skill's slug.
          * @maxLength 64
          */
       new_name?: string;
+      /** Values for a template skill's declared variables, as a {name: value} map. Required only when installing a template (see the skill's `template_variables`); ignored for non-template skills. */
+      variables?: CommunitySkillInstallVariables;
     }
 
     /**
@@ -15102,6 +15125,8 @@ export namespace Schemas {
       readonly author_handle: string;
       /** Link to the skill's source directory on GitHub. */
       readonly github_url: string;
+      /** Declared template variables, parsed from metadata. Non-empty marks this skill as a template: collect a value for each and pass them as `variables` when installing. */
+      readonly template_variables: readonly CommunitySkillTemplateVariable[];
       /** Number of times this skill has been installed into a team. */
       readonly install_count: number;
       /** Total number of upvotes this skill has received. */


### PR DESCRIPTION
## Problem

Extend the community marketplace so a published skill can be a **template**: it declares variables (e.g. a warehouse table, a repo) that get bound to the installing team's own values. A single "watch a feed" scout becomes "watch *your* feed". This is the server side; the UI is the next PR. Sixth of the community skills stack (the publish-flow PRs #65010–#65014 land first).

## Changes

- New `skill_template_services.py`: parses a `metadata.variables` schema and renders `{{ variable }}` placeholders in the body and bundled files. Deliberately plain string substitution — **never a template engine** — so a community-published template can't execute logic against tenant data. Validates undeclared placeholders, enforces required variables, and caps rendered output at the skill size limit.
- Install becomes instantiate: when a community skill is a template, the user-supplied `variables` are bound before the `LLMSkill` is created. The installed skill is concrete (its `variables` schema is dropped) and stamped with `instantiated_from = <slug>@<source_sha>` + `variable_bindings` for deterministic re-render.
- Serializer surfaces `template_variables` (present in list + detail, so a card can badge without a detail fetch); install accepts a `variables` map.
- Viewset maps render failures to status codes: missing/oversized/unknown-key → 400 (`attr: variables`), undeclared-placeholder (a content-repo bug) → 500.
- Regenerated codegen (skills types + MCP).

## How did you test this code?

Agent-authored. `hogli test products/skills/backend/api/test/test_community_skills.py` — 28 green, covering the API path (template_variables surfaced, render with values, default-when-omitted, missing-required 400) plus a unit class over the render service (parse/dedupe, required inference, substitution, missing/unknown/oversized, literal `{{ }}` in supplied values). Browser-verified end-to-end alongside #65016: installing a template rendered both placeholders and stamped provenance.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs yet — flag-gated. Add `skip-inkeep-docs` if preferred.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Invoked `/improving-drf-endpoints` and `/adopting-generated-api-types`. PR 6/7, stacked on #65014. Ported from an earlier Phase-1 prototype that targeted the old `ai_observability` paths — rebuilt into `products/skills/` rather than rebased, since the feature relocated.
