### PR TITLE
feat(llma): templated community skills UI (7/7)

### DIFF
--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -4,6 +4,8 @@ import { IconGithub, IconThumbsUp } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
@@ -14,7 +16,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { CommunitySkillTrustTier, communitySkillsLogic } from './communitySkillsLogic'
-import type { CommunitySkillListApi } from './generated/api.schemas'
+import type { CommunitySkillListApi, CommunitySkillTemplateVariableApi } from './generated/api.schemas'
 import { SkillsSceneShell } from './SkillsSceneShell'
 
 export const scene: SceneExport = {
@@ -34,17 +36,51 @@ function TrustTierBadge({ tier }: { tier: CommunitySkillTrustTier }): JSX.Elemen
     return <LemonTag type={config.type}>{config.label}</LemonTag>
 }
 
+// A template declares variables that must be bound before install. Collect a value per variable,
+// then install with them. Defaults prefill; required variables are guarded.
+function openTemplateInstallDialog(
+    skill: CommunitySkillListApi,
+    variables: readonly CommunitySkillTemplateVariableApi[],
+    install: (slug: string, newName?: string, values?: Record<string, string>) => void
+): void {
+    LemonDialog.openForm({
+        title: `Install "${skill.name}"`,
+        description: 'This is a template — provide a value for each variable below to customize the installed skill.',
+        initialValues: Object.fromEntries(variables.map((v) => [v.name, v.default ?? ''])),
+        content: (
+            <div className="flex flex-col gap-2">
+                {variables.map((v) => (
+                    <LemonField key={v.name} name={v.name} label={v.prompt || v.name}>
+                        <LemonInput data-attr={`community-skill-template-var-${v.name}`} autoFocus={false} />
+                    </LemonField>
+                ))}
+            </div>
+        ),
+        errors: Object.fromEntries(
+            variables
+                .filter((v) => v.is_required)
+                .map((v) => [v.name, (value: string) => (!value?.trim() ? 'This variable is required' : undefined)])
+        ),
+        onSubmit: (values) => install(skill.slug, undefined, values as Record<string, string>),
+    })
+}
+
 function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.Element {
     const { installingSlugs, votingSlugs } = useValues(communitySkillsLogic)
     const { installSkill, toggleVote } = useActions(communitySkillsLogic)
     const installing = !!installingSlugs[skill.slug]
     const voting = !!votingSlugs[skill.slug]
+    const templateVariables = skill.template_variables ?? []
+    const isTemplate = templateVariables.length > 0
 
     return (
         <div className="flex flex-col gap-2 border rounded p-4 bg-bg-light h-full">
             <div className="flex items-start justify-between gap-2">
                 <h3 className="font-semibold m-0">{skill.name}</h3>
-                <TrustTierBadge tier={skill.trust_tier as CommunitySkillTrustTier} />
+                <div className="flex items-center gap-1 shrink-0">
+                    {isTemplate ? <LemonTag type="highlight">Template</LemonTag> : null}
+                    <TrustTierBadge tier={skill.trust_tier as CommunitySkillTrustTier} />
+                </div>
             </div>
             <p className="text-muted text-sm grow line-clamp-3">{skill.description}</p>
             <div className="flex flex-wrap gap-1">
@@ -87,9 +123,13 @@ function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.El
                         type="primary"
                         loading={installing}
                         disabledReason={installing ? 'Installing…' : undefined}
-                        onClick={() => installSkill(skill.slug)}
+                        onClick={() =>
+                            isTemplate
+                                ? openTemplateInstallDialog(skill, templateVariables, installSkill)
+                                : installSkill(skill.slug)
+                        }
                     >
-                        Install
+                        {isTemplate ? 'Install…' : 'Install'}
                     </LemonButton>
                 </div>
             </div>

--- a/products/skills/frontend/CommunitySkillsScene.tsx
+++ b/products/skills/frontend/CommunitySkillsScene.tsx
@@ -4,6 +4,8 @@ import { IconGithub, IconThumbsUp } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -16,7 +18,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import { communitySkillsLogic } from './communitySkillsLogic'
 import { TrustTierEnumApi } from './generated/api.schemas'
-import type { CommunitySkillListApi } from './generated/api.schemas'
+import type { CommunitySkillListApi, CommunitySkillTemplateVariableApi } from './generated/api.schemas'
 import { COMMUNITY_SKILLS_TAB_DESCRIPTION, COMMUNITY_SKILLS_TAB_KEY, SkillsSceneShell } from './SkillsSceneShell'
 
 export const scene: SceneExport = {
@@ -64,18 +66,52 @@ function AuthorHandle({ handle }: { handle: string }): JSX.Element {
     )
 }
 
+// A template declares variables that must be bound before install. Collect a value per variable,
+// then install with them. Defaults prefill; required variables are guarded.
+function openTemplateInstallDialog(
+    skill: CommunitySkillListApi,
+    variables: readonly CommunitySkillTemplateVariableApi[],
+    install: (slug: string, newName?: string, values?: Record<string, string>) => void
+): void {
+    LemonDialog.openForm({
+        title: `Install "${skill.name}"`,
+        description: 'This is a template. Provide a value for each variable to customize the installed skill.',
+        initialValues: Object.fromEntries(variables.map((v) => [v.name, v.default ?? ''])),
+        content: (
+            <div className="flex flex-col gap-2">
+                {variables.map((v) => (
+                    <LemonField key={v.name} name={v.name} label={v.prompt || v.name}>
+                        <LemonInput data-attr={`community-skill-template-var-${v.name}`} autoFocus={false} />
+                    </LemonField>
+                ))}
+            </div>
+        ),
+        errors: Object.fromEntries(
+            variables
+                .filter((v) => v.is_required)
+                .map((v) => [v.name, (value: string) => (!value?.trim() ? 'This variable is required' : undefined)])
+        ),
+        onSubmit: (values) => install(skill.slug, undefined, values as Record<string, string>),
+    })
+}
+
 function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.Element {
     const { installingSlugs, votingSlugs } = useValues(communitySkillsLogic)
     const { installSkill, toggleVote } = useActions(communitySkillsLogic)
     const installing = !!installingSlugs[skill.slug]
     const voting = !!votingSlugs[skill.slug]
     const sourceUrl = skill.github_url ? githubSourceUrl(skill.github_url) : null
+    const templateVariables = skill.template_variables ?? []
+    const isTemplate = templateVariables.length > 0
 
     return (
         <div className="flex flex-col gap-2 border rounded p-4 bg-bg-light h-full">
             <div className="flex items-start justify-between gap-2">
                 <h3 className="font-semibold m-0">{skill.name}</h3>
-                <TrustTierBadge tier={skill.trust_tier} />
+                <div className="flex items-center gap-1 shrink-0">
+                    {isTemplate ? <LemonTag type="highlight">Template</LemonTag> : null}
+                    <TrustTierBadge tier={skill.trust_tier} />
+                </div>
             </div>
             <p className="text-muted text-sm grow line-clamp-3">{skill.description}</p>
             <div className="flex flex-wrap gap-1">
@@ -113,9 +149,13 @@ function CommunitySkillCard({ skill }: { skill: CommunitySkillListApi }): JSX.El
                         type="primary"
                         loading={installing}
                         disabledReason={installing ? 'Installing…' : undefined}
-                        onClick={() => installSkill(skill.slug)}
+                        onClick={() =>
+                            isTemplate
+                                ? openTemplateInstallDialog(skill, templateVariables, installSkill)
+                                : installSkill(skill.slug)
+                        }
                     >
-                        Install
+                        {isTemplate ? 'Install…' : 'Install'}
                     </LemonButton>
                 </div>
             </div>

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -77,10 +77,12 @@ export interface communitySkillsLogicValues {
 export interface communitySkillsLogicActions {
     installSkill: (
         slug: string,
-        newName?: string
+        newName?: string,
+        variables?: Record<string, string>
     ) => {
         newName: string | undefined
         slug: string
+        variables: Record<string, string> | undefined
     }
     installSkillFailure: (slug: string) => {
         slug: string

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -176,7 +176,11 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             debounce,
         }),
         loadSkills: (debounce: boolean = true) => ({ debounce }),
-        installSkill: (slug: string, newName?: string) => ({ slug, newName }),
+        installSkill: (slug: string, newName?: string, variables?: Record<string, string>) => ({
+            slug,
+            newName,
+            variables,
+        }),
         installSkillSuccess: (slug: string) => ({ slug }),
         installSkillFailure: (slug: string) => ({ slug }),
         toggleVote: (slug: string) => ({ slug }),
@@ -287,10 +291,11 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             }
         },
 
-        installSkill: async ({ slug, newName }) => {
+        installSkill: async ({ slug, newName, variables }) => {
             try {
                 await communitySkillsInstallCreate(String(ApiConfig.getCurrentTeamId()), slug, {
                     new_name: newName,
+                    variables,
                 })
                 lemonToast.success(`Installed "${newName || slug}" into your project.`)
                 actions.installSkillSuccess(slug)

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -71,10 +71,12 @@ export interface communitySkillsLogicValues {
 export interface communitySkillsLogicActions {
     installSkill: (
         slug: string,
-        newName?: string
+        newName?: string,
+        variables?: Record<string, string>
     ) => {
         newName: string | undefined
         slug: string
+        variables: Record<string, string> | undefined
     }
     installSkillFailure: (slug: string) => {
         slug: string

--- a/products/skills/frontend/communitySkillsLogic.ts
+++ b/products/skills/frontend/communitySkillsLogic.ts
@@ -170,7 +170,11 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             debounce,
         }),
         loadSkills: (debounce: boolean = true) => ({ debounce }),
-        installSkill: (slug: string, newName?: string) => ({ slug, newName }),
+        installSkill: (slug: string, newName?: string, variables?: Record<string, string>) => ({
+            slug,
+            newName,
+            variables,
+        }),
         installSkillSuccess: (slug: string) => ({ slug }),
         installSkillFailure: (slug: string) => ({ slug }),
         toggleVote: (slug: string) => ({ slug }),
@@ -278,10 +282,11 @@ export const communitySkillsLogic = kea<communitySkillsLogicType>([
             }
         },
 
-        installSkill: async ({ slug, newName }) => {
+        installSkill: async ({ slug, newName, variables }) => {
             try {
                 await communitySkillsInstallCreate(String(ApiConfig.getCurrentTeamId()), slug, {
                     new_name: newName,
+                    variables,
                 })
                 lemonToast.success(`Installed "${newName || slug}" into your project.`)
                 actions.installSkillSuccess(slug)


### PR DESCRIPTION
## Problem

The templated-skills backend (#65015) needs a UI: mark templates in the catalog and collect a value for each variable before installing. Seventh of the community skills stack.

## Changes

- A `Template` badge on community cards whose `template_variables` is non-empty.
- For a template, the Install button reads `Install…` and opens a dialog with one field per variable — the variable's `prompt` as the label, its `default` prefilled, and required variables guarded (Submit stays disabled until they're filled). Submitting passes the collected `{name: value}` map to install; non-template install is unchanged.
- `installSkill` carries an optional `variables` map through to the generated install client.

## How did you test this code?

Agent-authored. `pnpm --filter=@posthog/frontend typescript:check` and oxlint both clean. Browser-verified in the running app against a seeded template skill: the badge renders, the dialog labels each field with its prompt, the default prefills, Submit is disabled until the required variable is filled, and on submit the install rendered both placeholders server-side (`Watch table events_warehouse.feed on branch main`) with `instantiated_from` + `variable_bindings` stamped — then redirected to the installed skill.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs yet — flag-gated. Add `skip-inkeep-docs` if preferred.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Invoked `/adopting-generated-api-types`. PR 7/7, stacked on #65015. The frontend was built fresh (it was an unbuilt TODO in the original plan, not a port).
