### PR TITLE
fix(postgres): don't capture expected CDC prereq connection failures

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -2736,6 +2736,16 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 slot_name=request.data.get("cdc_slot_name") or None,
                 publication_name=request.data.get("cdc_publication_name") or None,
             )
+        except (OperationalError, BaseSSHTunnelForwarderError, SSLRequiredError) as e:
+            # Probing the source's database to validate it is expected to fail when the host,
+            # credentials, or SSH tunnel are wrong, the server requires/refuses SSL, or it drops the
+            # connection. Surface it as a 400, but don't capture it — these are user/upstream
+            # connection problems, not bugs in our code, and capturing every one floods error
+            # tracking. Mirrors the detail=False check_cdc_prerequisites handler.
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"Could not connect to source to check prerequisites: {e}"},
+            )
         except Exception as e:
             capture_exception(e, {"source_id": str(instance.id), "team_id": self.team_id})
             return Response(
@@ -2800,6 +2810,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 schema=schema_hint,
                 slot_name=request.data.get("cdc_slot_name") or None,
                 publication_name=request.data.get("cdc_publication_name") or None,
+            )
+        except (OperationalError, BaseSSHTunnelForwarderError, SSLRequiredError) as e:
+            # Expected user/upstream connection failure (bad host/credentials/SSH tunnel, server
+            # requires/refuses SSL, dropped connection). Surface as a 400 without capturing — see the
+            # check_cdc_prerequisites_for_source handler above.
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": f"Could not connect to source to check prerequisites: {e}"},
             )
         except Exception as e:
             capture_exception(e, {"source_id": str(instance.id), "team_id": self.team_id})

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -36,6 +36,7 @@ from posthog.temporal.data_imports.sources.bigquery.bigquery import BigQuerySour
 from posthog.temporal.data_imports.sources.common.base import FieldType, WebhookCreationResult
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.custom.source import MAX_CUSTOM_SOURCES_PER_TEAM
+from posthog.temporal.data_imports.sources.postgres.cdc.adapter import PostgresCDCAdapter
 from posthog.temporal.data_imports.sources.postgres.postgres import PostgresDiscoveredSchema, SSLRequiredError
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 from posthog.temporal.data_imports.sources.stripe.constants import (
@@ -8065,11 +8066,39 @@ class TestCheckCDCPrerequisitesForSource(APIBaseTest):
         assert mock_validate.call_args.kwargs["publication_name"] == "customer_pub"
         assert mock_validate.call_args.kwargs["management_mode"] == "self_managed"
 
-    @patch(
-        "posthog.temporal.data_imports.sources.postgres.cdc.adapter.PostgresCDCAdapter.validate_prerequisites",
-        side_effect=psycopg.OperationalError("connection refused"),
+    @parameterized.expand(
+        [
+            (
+                "ssl_required_error",
+                SSLRequiredError("SSL/TLS connection is required but your database does not support it."),
+            ),
+            (
+                "operational_error",
+                psycopg.OperationalError(
+                    'connection failed: connection to server at "127.0.0.1", port 5434 failed: '
+                    "server does not support SSL, but SSL was required"
+                ),
+            ),
+            ("ssh_tunnel_error", BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")),
+        ]
     )
-    def test_returns_400_on_connection_exception(self, _mock_validate) -> None:
+    @patch("products.data_warehouse.backend.api.external_data_source.capture_exception")
+    def test_connection_failure_returns_400_without_capture(self, _name, exc, mock_capture) -> None:
+        source = _make_postgres_source(self.team.pk, self.user)
+        with patch.object(PostgresCDCAdapter, "validate_prerequisites", side_effect=exc):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/check_cdc_prerequisites_for_source/",
+                data={"cdc_management_mode": "posthog"},
+                format="json",
+            )
+        assert response.status_code == 400
+        assert "Could not connect to source" in response.json()["message"]
+        # User/upstream connection failures must not pollute error tracking.
+        mock_capture.assert_not_called()
+
+    @patch("products.data_warehouse.backend.api.external_data_source.capture_exception")
+    @patch.object(PostgresCDCAdapter, "validate_prerequisites", side_effect=ValueError("unexpected bug"))
+    def test_unexpected_error_is_still_captured(self, _mock_validate, mock_capture) -> None:
         source = _make_postgres_source(self.team.pk, self.user)
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/check_cdc_prerequisites_for_source/",
@@ -8077,7 +8106,7 @@ class TestCheckCDCPrerequisitesForSource(APIBaseTest):
             format="json",
         )
         assert response.status_code == 400
-        assert "Could not connect to source" in response.json()["message"]
+        mock_capture.assert_called_once()
 
 
 class TestCheckCDCPrerequisitesWizard(APIBaseTest):

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -8261,12 +8261,41 @@ class TestEnableCDC(APIBaseTest):
         source.refresh_from_db()
         assert (source.job_inputs or {}).get("cdc_enabled") is not True
 
-    @patch("products.data_warehouse.backend.api.external_data_source.is_cdc_enabled_for_team", return_value=True)
-    @patch(
-        "posthog.temporal.data_imports.sources.postgres.cdc.adapter.PostgresCDCAdapter.validate_prerequisites",
-        side_effect=psycopg.OperationalError("connection refused"),
+    @parameterized.expand(
+        [
+            (
+                "ssl_required_error",
+                SSLRequiredError("SSL/TLS connection is required but your database does not support it."),
+            ),
+            (
+                "operational_error",
+                psycopg.OperationalError(
+                    'connection failed: connection to server at "127.0.0.1", port 5434 failed: '
+                    "server does not support SSL, but SSL was required"
+                ),
+            ),
+            ("ssh_tunnel_error", BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")),
+        ]
     )
-    def test_enable_cdc_returns_400_on_prereq_check_exception(self, _check, _flag) -> None:
+    @patch("products.data_warehouse.backend.api.external_data_source.is_cdc_enabled_for_team", return_value=True)
+    @patch("products.data_warehouse.backend.api.external_data_source.capture_exception")
+    def test_enable_cdc_connection_failure_returns_400_without_capture(self, _name, exc, mock_capture, _flag) -> None:
+        source = _make_postgres_source(self.team.pk, self.user)
+        with patch.object(PostgresCDCAdapter, "validate_prerequisites", side_effect=exc):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/enable_cdc/",
+                data={"cdc_management_mode": "posthog"},
+                format="json",
+            )
+        assert response.status_code == 400
+        assert "Could not connect to source" in response.json()["message"]
+        # User/upstream connection failures must not pollute error tracking.
+        mock_capture.assert_not_called()
+
+    @patch("products.data_warehouse.backend.api.external_data_source.is_cdc_enabled_for_team", return_value=True)
+    @patch("products.data_warehouse.backend.api.external_data_source.capture_exception")
+    @patch.object(PostgresCDCAdapter, "validate_prerequisites", side_effect=ValueError("unexpected bug"))
+    def test_enable_cdc_unexpected_error_is_still_captured(self, _check, mock_capture, _flag) -> None:
         source = _make_postgres_source(self.team.pk, self.user)
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/enable_cdc/",
@@ -8274,7 +8303,7 @@ class TestEnableCDC(APIBaseTest):
             format="json",
         )
         assert response.status_code == 400
-        assert "Could not connect to source" in response.json()["message"]
+        mock_capture.assert_called_once()
 
     @patch("products.data_warehouse.backend.api.external_data_source.is_cdc_enabled_for_team", return_value=True)
     @patch(


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `OperationalError` / `SSLRequiredError` from the Postgres data-warehouse source: `connection failed: ... server does not support SSL, but SSL was required` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ee518-a42e-75b0-b8bf-c7b821f4d3f3)).

Tracing the stack: the request came from the existing-source CDC prerequisite check (`check_cdc_prerequisites_for_source`) → `validate_prerequisites` → `cdc_pg_connection` → `_connect_to_postgres`. The connection code does the right thing — it raises a clear, actionable `SSLRequiredError` ("enable SSL/TLS on your server"). The problem is the caller: both existing-source CDC endpoints (`check_cdc_prerequisites_for_source` and `enable_cdc`) wrapped the probe in a bare `except Exception: capture_exception(e)`, so every expected connection failure got reported to error tracking as if it were a bug.

This is a user/upstream condition — the customer's database is reachable but doesn't speak SSL while SSL is required. There's nothing for us to fix on their database; the 400 we already return tells them exactly what to do. Capturing it just adds noise.

## Changes

Both endpoints now catch `(OperationalError, BaseSSHTunnelForwarderError, SSLRequiredError)` before the generic handler and return the same 400 **without** capturing — mirroring the creation-wizard endpoint (`check_cdc_prerequisites`), which was already fixed this way. Genuine, unexpected errors still fall through to `capture_exception`.

No change to the endpoint contract or response shape.

## How did you test this code?

I'm an agent. I could not run the DB-backed API tests in this sandbox (no Postgres available — the pre-existing tests in this file error identically at setup). I verified the changed files compile, pass `ruff check`, and are `ruff format`-clean. The test suite, which CI will run, was updated:

- `TestCheckCDCPrerequisitesForSource`: replaced the single connection-error test with a parameterized `test_connection_failure_returns_400_without_capture` covering `SSLRequiredError`, the raw SSL `OperationalError`, and an SSH-tunnel error — each asserting a 400 and `capture_exception` is **not** called.
- Added `test_unexpected_error_is_still_captured` asserting a non-connection bug (`ValueError`) is still captured.

These mirror the existing assertions on the wizard endpoint (`TestCheckCDCPrerequisitesWizard`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above using the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full stack trace and confirm the failing call path, then read the Postgres source under `posthog/temporal/data_imports/sources/postgres/` and the warehouse viewset.

Decision: this is a fixable bug, not a `NonRetryableErrors` case. The error doesn't flow through the Temporal retry pipeline at all — it's a synchronous API probe — and the streaming path already lists `SSLRequiredError` / `SSL/TLS connection is required` as non-retryable. The actual defect was over-capturing in the API layer, where the sibling wizard endpoint already had the correct pattern. Scoped the fix to the two existing-source endpoints that shared the defect; left the well-formed `SSLRequiredError` message untouched.