### PR TITLE
feat(skills): sort bundled skill files alphabetically by path

### DIFF
--- a/products/skills/frontend/LLMSkillScene.tsx
+++ b/products/skills/frontend/LLMSkillScene.tsx
@@ -412,15 +412,17 @@ function SkillViewDetails(): JSX.Element {
                         Bundled files ({skill.files.length})
                     </label>
                     <div className="mt-1 space-y-1">
-                        {skill.files.map((file) => (
-                            <SkillFileViewer
-                                key={file.path}
-                                skillName={skill.name}
-                                file={file}
-                                version={skill.is_latest ? undefined : skill.version}
-                                autoOpen={selectedFilePath === file.path}
-                            />
-                        ))}
+                        {[...skill.files]
+                            .sort((a, b) => a.path.localeCompare(b.path))
+                            .map((file) => (
+                                <SkillFileViewer
+                                    key={file.path}
+                                    skillName={skill.name}
+                                    file={file}
+                                    version={skill.is_latest ? undefined : skill.version}
+                                    autoOpen={selectedFilePath === file.path}
+                                />
+                            ))}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Problem

The bundled files list in the skill detail view renders files in whatever order the API returns them. That's hard to scan — there's no predictable place to look for a given file.

## Changes

Sort the bundled files list by full path name (`localeCompare`) before rendering in `LLMSkillScene`. Only the read-only detail view is affected; the edit form still renders in index order because it relies on the array index for update/remove operations.

## How did you test this code?

I'm an agent. I made a small, self-contained frontend change and verified the JSX manually. I did not run the local formatter or typecheck (frontend `node_modules` weren't installed in this environment), and I did not manually exercise the UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to list skill files in the skills UI in alphabetical order by full path, since that's easier to scan than the API's order. The fix is a one-line spread + `sort` before the `.map()` in the detail view (`skill.files` is a `readonly` array, hence the spread). I deliberately left the edit-form list unsorted because it uses the array index as the key and for its `onUpdate`/`onRemove` callbacks — sorting there would break those operations. No skills were invoked.
