### PR TITLE
fix(llma): break the scout runner/temporal import cycle

### DIFF
--- a/products/signals/backend/temporal/agentic/scout_scheduler.py
+++ b/products/signals/backend/temporal/agentic/scout_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 import structlog
 import temporalio
@@ -10,8 +11,12 @@ from temporalio.common import RetryPolicy
 from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.signals.backend.scout_harness.limits import WORKFLOW_HARD_CEILING_S
-from products.signals.backend.scout_harness.runner import RunResult, arun_signals_scout
 from products.signals.backend.temporal import metrics
+
+if TYPE_CHECKING:
+    # Type-only: importing the harness runner at module load would close the cycle
+    # runner -> temporal.agentic -> scout_coordinator -> scout_scheduler -> runner.
+    from products.signals.backend.scout_harness.runner import RunResult
 
 logger = structlog.get_logger(__name__)
 
@@ -55,6 +60,11 @@ async def run_signals_scout_activity(input: RunSignalsScoutInput) -> RunSignalsS
     workflow sees a `status='failed'` outcome. This matches the spec's "fail safe and
     silent" rule: a bad run does not retry blindly.
     """
+    # Deferred to break the runner <-> temporal import cycle (see the TYPE_CHECKING note
+    # above): importing the runner at module load leaves RunResult undefined when runner
+    # is the import entry point. Imported here at call time, after both modules are loaded.
+    from products.signals.backend.scout_harness.runner import arun_signals_scout  # noqa: PLC0415
+
     async with Heartbeater():
         result = await arun_signals_scout(
             team_id=input.team_id,

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -517,7 +517,7 @@ async def test_activity_returns_completed_outcome(ateam):
         )
 
     with patch(
-        "products.signals.backend.temporal.agentic.scout_scheduler.arun_signals_scout",
+        "products.signals.backend.scout_harness.runner.arun_signals_scout",
         side_effect=fake_arun,
     ):
         env = ActivityEnvironment()
@@ -549,7 +549,7 @@ async def test_activity_returns_skip_outcome_when_already_running(ateam):
         )
 
     with patch(
-        "products.signals.backend.temporal.agentic.scout_scheduler.arun_signals_scout",
+        "products.signals.backend.scout_harness.runner.arun_signals_scout",
         side_effect=fake_arun,
     ):
         env = ActivityEnvironment()


### PR DESCRIPTION
## Problem

Importing the signals-scout harness `runner` (or its test module) in isolation fails with a circular import:

```
runner.py
  → products.signals.backend.temporal.agentic        (imported at module top)
    → temporal/__init__.py → scout_coordinator
      → scout_scheduler
        → from ...scout_harness.runner import RunResult, arun_signals_scout   (back to runner)
```

`runner` imports `temporal.agentic` *before* `RunResult` is defined, so when `runner` is the import entry point the re-entry from `scout_scheduler` hits a partially initialized module:

```
ImportError: cannot import name 'RunResult' from partially initialized module
products.signals.backend.scout_harness.runner (most likely due to a circular import)
```

It only worked in practice because the full-suite test collection happens to import the temporal package first, which loads `runner` fully before anything needs it. Run `test_scout_harness.py` on its own (or import `runner` directly) and it breaks — reproduces on a clean `master`. It's a latent fragility: any future entry order that reaches `runner` first fails.

## Changes

Break the back-edge of the cycle in `scout_scheduler`, which only uses the two runner symbols lightly:

- `RunResult` is used only as a type annotation (`_to_output(result: RunResult)`), and the module already has `from __future__ import annotations`, so it's never evaluated at runtime — move it under `if TYPE_CHECKING`.
- `arun_signals_scout` is only called inside the activity — defer that import into the function body (with a justified `# noqa: PLC0415`, per the repo's inline-import rule for breaking a true cycle).

With `scout_scheduler` no longer importing `runner` at module load, the cycle is gone. No behavior change — all 14 workflows and 43 activities still register.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing claimed.

- Importing `runner` as the entry point now succeeds (was the failing path); `temporal.WORKFLOWS`/`ACTIVITIES` still register 14/43.
- `hogli test products/signals/backend/test/test_scout_harness.py` now **collects and passes in isolation** (it errored at collection on `master`).
- `test_scout_coordinator.py` + `TestSignalsProductModuleIntegrity` — 76 passed.
- `ruff check` / `ruff format --check` clean; `ty check` passed via lint-staged on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while running tests for the stranded-scout-run fix (PR #65028): `test_scout_harness.py` wouldn't collect standalone. Confirmed the cycle reproduces on clean `master`, so it's pre-existing and orthogonal to that fix — split it into this separate PR.

Chose to defer the back-edge (`scout_scheduler → runner`) rather than the `runner → temporal.agentic` edge: the scheduler needs `runner` only for a type annotation (free under `from __future__ import annotations`) and one call-time symbol, so the change is minimal and local to one file, versus several call sites in `runner`. A deeper structural fix (the harness depending on the temporal layer at all) would be a larger refactor and isn't needed to remove the cycle.
