### PR TITLE
feat(signals): bring cloud inbox custom events in line with desktop

### DIFF
--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconArrowRight, IconBell, IconGithub, IconHeartPlus, IconLinear } from '@posthog/icons'
@@ -12,6 +11,7 @@ import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 
 import iconZendesk from 'public/services/zendesk.svg'
 
+import { captureSignalSourceInterest } from './inboxAnalytics'
 import { PgAnalyzeIcon as IconPgAnalyze } from './PgAnalyzeIcon'
 import { signalSourcesLogic } from './signalSourcesLogic'
 import { SignalSourceConfigStatus } from './types'
@@ -51,7 +51,7 @@ function NotifyMeButton({ source }: { source: string }): JSX.Element {
             size="xsmall"
             disabledReason={notified ? "We'll let you know!" : undefined}
             onClick={() => {
-                posthog.capture('signals source interest', { source })
+                captureSignalSourceInterest(source)
                 setNotified(true)
             }}
             icon={<IconBell />}

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -3,6 +3,7 @@ import { ComponentType, JSX, useEffect, useRef } from 'react'
 
 import { LemonBanner } from '@posthog/lemon-ui'
 
+import { captureInboxViewed } from '../inboxAnalytics'
 import { inboxFiltersLogic } from '../logics/inboxFiltersLogic'
 import { reportListLogic, ReportListLogicProps } from '../logics/reportListLogic'
 import { InboxFlatListTabKey, SignalReport } from '../types'
@@ -60,7 +61,25 @@ function ActiveFiltersBanner(): JSX.Element | null {
 function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps): JSX.Element {
     const { reports, count, hasMore, reportsResponseLoading, isLoaded } = useValues(reportListLogic)
     const { ensureLoaded, loadMore, archiveReport, restoreReport, refresh } = useActions(reportListLogic)
+    const { hasActiveFilters, sourceProductFilter, priorityFilter, scope } = useValues(inboxFiltersLogic)
     const sentinelRef = useRef<HTMLDivElement>(null)
+
+    // Fire `Inbox viewed` once per tab mount, the first time its list settles (loaded with a known count).
+    const viewedFiredRef = useRef(false)
+    useEffect(() => {
+        if (isLoaded && count !== null && !viewedFiredRef.current) {
+            viewedFiredRef.current = true
+            captureInboxViewed({
+                tab: tabKey,
+                reports,
+                totalCount: count,
+                hasActiveFilters,
+                sourceProductFilter,
+                priorityFilter,
+                scope,
+            })
+        }
+    }, [isLoaded, count, reports, tabKey, hasActiveFilters, sourceProductFilter, priorityFilter, scope])
 
     // Read fresh state at intersection time via refs so the observer is created once and not
     // rebuilt twice per page fetch (`hasMore`/`reportsResponseLoading` both flip during a load).

--- a/frontend/src/scenes/inbox/components/InboxReportList.tsx
+++ b/frontend/src/scenes/inbox/components/InboxReportList.tsx
@@ -4,6 +4,7 @@ import { ComponentType, JSX, useEffect, useRef } from 'react'
 import { LemonBanner } from '@posthog/lemon-ui'
 
 import { captureInboxViewed } from '../inboxAnalytics'
+import { inboxSceneLogic } from '../inboxSceneLogic'
 import { inboxFiltersLogic } from '../logics/inboxFiltersLogic'
 import { reportListLogic, ReportListLogicProps } from '../logics/reportListLogic'
 import { InboxFlatListTabKey, SignalReport } from '../types'
@@ -62,12 +63,17 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
     const { reports, count, hasMore, reportsResponseLoading, isLoaded } = useValues(reportListLogic)
     const { ensureLoaded, loadMore, archiveReport, restoreReport, refresh } = useActions(reportListLogic)
     const { hasActiveFilters, sourceProductFilter, priorityFilter, scope } = useValues(inboxFiltersLogic)
+    // The list stays mounted (hidden) while a report/scout detail is open, so gate the view event on
+    // the list actually being the visible surface — otherwise a deep-link to a report fires a phantom
+    // `Inbox viewed` and then suppresses the real one when the user navigates back to the list.
+    const { selectedReportId, selectedScoutSkillName } = useValues(inboxSceneLogic)
+    const listVisible = !selectedReportId && !selectedScoutSkillName
     const sentinelRef = useRef<HTMLDivElement>(null)
 
-    // Fire `Inbox viewed` once per tab mount, the first time its list settles (loaded with a known count).
+    // Fire `Inbox viewed` once per tab mount, the first time its list settles while visible.
     const viewedFiredRef = useRef(false)
     useEffect(() => {
-        if (isLoaded && count !== null && !viewedFiredRef.current) {
+        if (listVisible && isLoaded && count !== null && !viewedFiredRef.current) {
             viewedFiredRef.current = true
             captureInboxViewed({
                 tab: tabKey,
@@ -79,7 +85,7 @@ function InboxReportListInner({ tabKey, Card, emptyState }: InboxReportListProps
                 scope,
             })
         }
-    }, [isLoaded, count, reports, tabKey, hasActiveFilters, sourceProductFilter, priorityFilter, scope])
+    }, [listVisible, isLoaded, count, reports, tabKey, hasActiveFilters, sourceProductFilter, priorityFilter, scope])
 
     // Read fresh state at intersection time via refs so the observer is created once and not
     // rebuilt twice per page fetch (`hasMore`/`reportsResponseLoading` both flip during a load).

--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -153,7 +153,13 @@ export function ReportCard({
     const headline = deriveHeadline(report.summary)
     const detailUrl = urls.inboxReport(tabKey, report.id)
 
-    const { isArchiving, onArchiveClick } = useReportArchive({ reportId: report.id, cardTitle, onArchive })
+    const { isArchiving, onArchiveClick } = useReportArchive({
+        reportId: report.id,
+        cardTitle,
+        report,
+        surface: 'list_row',
+        onArchive,
+    })
 
     // On the Archive tab, surface why it was dismissed (reason tag + note tooltip) when we have it.
     const dismissalLabel = isArchived ? dismissalReasonLabel(report.dismissal_reason) : null

--- a/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
+++ b/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
@@ -41,11 +41,12 @@ export function useReportArchive({
         openDismissReportDialog({
             reportTitle: cardTitle,
             onConfirm: async ({ reason, note }) => {
+                // Only the structured reason — the free-form note can carry proprietary text.
                 captureInboxReportAction({
                     report: report ?? null,
                     actionType: 'dismiss',
                     surface: surface ?? 'list_row',
-                    extra: { dismissal_reason: reason, ...(note ? { dismissal_note: note } : {}) },
+                    extra: { dismissal_reason: reason },
                 })
                 if (onArchive) {
                     onArchive(reason, note)

--- a/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
+++ b/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
@@ -3,22 +3,32 @@ import { useState } from 'react'
 
 import api from 'lib/api'
 
+import { captureInboxReportAction, InboxReportActionSurface } from '../../inboxAnalytics'
+import { SignalReport } from '../../types'
 import { DismissalReasonValue } from '../../utils/dismissalReasons'
 import { openDismissReportDialog } from '../shell/DismissReportDialog'
 
 /**
  * Shared archive handler for the inbox cards (Report / Pull request). Opens the dismissal
  * dialog and either delegates to the bound list logic via `onArchive` (optimistic) or, when
- * used standalone (e.g. stories), falls back to a direct `signalReports.setState` call.
+ * used standalone (e.g. stories), falls back to a direct `signalReports.setState` call. The
+ * single-report `dismiss` analytics fire here so both the list card and the detail pane are
+ * covered from one place.
  */
 export function useReportArchive({
     reportId,
     cardTitle,
+    report,
+    surface,
     onArchive,
     onArchived,
 }: {
     reportId: string
     cardTitle: string
+    /** The report being archived, used to enrich the `dismiss` analytics. */
+    report?: SignalReport | null
+    /** Which surface the archive was triggered from, for the `dismiss` analytics. */
+    surface?: InboxReportActionSurface
     onArchive?: (reason: DismissalReasonValue, note: string) => void
     /** Fired once the report is archived (after `onArchive`, or after the fallback API call succeeds). */
     onArchived?: () => void
@@ -31,6 +41,12 @@ export function useReportArchive({
         openDismissReportDialog({
             reportTitle: cardTitle,
             onConfirm: async ({ reason, note }) => {
+                captureInboxReportAction({
+                    report: report ?? null,
+                    actionType: 'dismiss',
+                    surface: surface ?? 'list_row',
+                    extra: { dismissal_reason: reason, ...(note ? { dismissal_note: note } : {}) },
+                })
                 if (onArchive) {
                     onArchive(reason, note)
                     onArchived?.()

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconArchive, IconPullRequest, IconUndo } from '@posthog/icons'
@@ -9,24 +8,12 @@ import { LemonButton, lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
+import { captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxSceneLogic } from '../../inboxSceneLogic'
 import { inboxTaskKickoffLogic } from '../../inboxTaskKickoffLogic'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from '../../logics/reportListLogic'
 import { ACTIONABLE_ACTIONABILITY_VALUES, SignalReport, SignalReportStatus } from '../../types'
 import { useReportArchive } from '../cards/useReportArchive'
-
-/** Mirror desktop's `Inbox report action` analytics for detail-pane actions. */
-function fireReportAction(report: SignalReport, action: 'create_pr', extras: Record<string, unknown> = {}): void {
-    posthog.capture('Inbox report action', {
-        report_id: report.id,
-        report_title: report.title ?? null,
-        priority: report.priority ?? null,
-        actionability: report.actionability ?? null,
-        action_type: action,
-        surface: 'detail_pane',
-        ...extras,
-    })
-}
 
 /**
  * Should the Create PR action be offered? Mirrors desktop `canCreateImplementationPr` /
@@ -65,6 +52,8 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
     const { isArchiving, onArchiveClick } = useReportArchive({
         reportId: report.id,
         cardTitle: report.title ?? 'Untitled report',
+        report,
+        surface: 'detail_pane',
         // Back to the list once archived – the suppressed report drops out on the list's refetch.
         onArchived: () => router.actions.push(urls.inbox(activeTab)),
     })
@@ -77,6 +66,7 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
             listParams: INBOX_FLAT_TAB_LIST_PARAMS.archived,
         })
         if (archivedList) {
+            // The list logic fires the `restore` analytics; just drive navigation here.
             archivedList.actions.restoreReport(report.id)
             router.actions.push(urls.inbox(activeTab))
             return
@@ -85,6 +75,7 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
         setIsRestoring(true)
         try {
             await api.signalReports.setState(report.id, { state: 'potential' })
+            captureInboxReportAction({ report, actionType: 'restore', surface: 'detail_pane' })
             lemonToast.success('Report restored to inbox')
             router.actions.push(urls.inbox(activeTab))
         } catch (error: any) {
@@ -131,7 +122,7 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
                     loading={isCreatingPr}
                     tooltip="Have Self-driving open a pull request for this report"
                     onClick={() => {
-                        fireReportAction(report, 'create_pr')
+                        captureInboxReportAction({ report, actionType: 'create_pr', surface: 'detail_pane' })
                         createPrFromReport(report)
                     }}
                 >

--- a/frontend/src/scenes/inbox/components/detail/SuggestedReviewersSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/SuggestedReviewersSection.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import { useMemo, useState } from 'react'
 
 import { IconCheck, IconPeople, IconPlus, IconX } from '@posthog/icons'
@@ -8,6 +7,7 @@ import { LemonButton, LemonInput, Link, Spinner, Tooltip } from '@posthog/lemon-
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
+import { captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
 import { EnrichedReviewer, SignalReport } from '../../types'
 import { RightColumnSection } from './DetailSection'
@@ -64,14 +64,11 @@ export function SuggestedReviewersSection({ report }: { report: SignalReport }):
         action: 'add_suggested_reviewer' | 'remove_suggested_reviewer',
         login?: string | null
     ): void => {
-        posthog.capture('Inbox report action', {
-            report_id: report.id,
-            report_title: report.title ?? null,
-            priority: report.priority ?? null,
-            actionability: report.actionability ?? null,
-            action_type: action,
+        captureInboxReportAction({
+            report,
+            actionType: action,
             surface: 'detail_pane',
-            suggested_reviewer_login: login || undefined,
+            extra: { suggested_reviewer_login: login || undefined },
         })
     }
 

--- a/frontend/src/scenes/inbox/inboxAnalytics.test.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.test.ts
@@ -1,0 +1,132 @@
+import posthog from 'posthog-js'
+
+import {
+    captureInboxReportAction,
+    captureInboxViewed,
+    captureSignalSourceConnected,
+    INBOX_EVENTS,
+} from './inboxAnalytics'
+import { SignalReport, SignalReportStatus } from './types'
+
+jest.mock('posthog-js')
+
+function lastCapture(event: string): Record<string, any> | undefined {
+    const calls = (posthog.capture as jest.Mock).mock.calls.filter(([name]) => name === event)
+    return calls.length > 0 ? calls[calls.length - 1][1] : undefined
+}
+
+function makeReport(overrides: Partial<SignalReport> = {}): SignalReport {
+    return {
+        id: 'r1',
+        title: 'Something broke',
+        summary: null,
+        status: SignalReportStatus.READY,
+        total_weight: 1,
+        signal_count: 1,
+        relevant_user_count: null,
+        created_at: '2026-06-20T00:00:00Z',
+        updated_at: '2026-06-20T00:00:00Z',
+        artefact_count: 0,
+        is_suggested_reviewer: false,
+        priority: 'P1',
+        actionability: 'immediately_actionable',
+        ...overrides,
+    }
+}
+
+describe('inboxAnalytics', () => {
+    beforeEach(() => {
+        ;(posthog.capture as jest.Mock).mockClear()
+    })
+
+    it('stamps every event with the cloud client discriminator', () => {
+        captureInboxViewed({
+            tab: 'reports',
+            reports: [],
+            totalCount: 0,
+            hasActiveFilters: false,
+            sourceProductFilter: [],
+            priorityFilter: [],
+            scope: 'for-you',
+        })
+        expect(lastCapture(INBOX_EVENTS.VIEWED)?.inbox_client).toBe('cloud')
+    })
+
+    it('breaks the visible reports down by priority and actionability', () => {
+        captureInboxViewed({
+            tab: 'reports',
+            reports: [
+                makeReport({ id: 'a', priority: 'P0', actionability: 'immediately_actionable' }),
+                makeReport({ id: 'b', priority: 'P1', actionability: 'requires_human_input' }),
+                makeReport({ id: 'c', priority: null, actionability: null }),
+            ],
+            totalCount: 3,
+            hasActiveFilters: true,
+            sourceProductFilter: ['error_tracking'],
+            priorityFilter: ['P0'],
+            scope: 'entire-project',
+        })
+        const props = lastCapture(INBOX_EVENTS.VIEWED)
+        expect(props).toMatchObject({
+            report_count: 3,
+            total_count: 3,
+            is_empty: false,
+            has_active_filters: true,
+            source_product_filter: ['error_tracking'],
+            priority_p0_count: 1,
+            priority_p1_count: 1,
+            priority_unknown_count: 1,
+            actionability_immediately_actionable_count: 1,
+            actionability_requires_human_input_count: 1,
+            actionability_unknown_count: 1,
+        })
+    })
+
+    it('emits a single-report action with the report context', () => {
+        captureInboxReportAction({
+            report: makeReport(),
+            actionType: 'create_pr',
+            surface: 'detail_pane',
+        })
+        expect(lastCapture(INBOX_EVENTS.REPORT_ACTION)).toMatchObject({
+            report_id: 'r1',
+            action_type: 'create_pr',
+            surface: 'detail_pane',
+            is_bulk: false,
+            bulk_size: 1,
+        })
+    })
+
+    it('emits a bulk action with a null report and the selection size', () => {
+        captureInboxReportAction({
+            actionType: 'dismiss',
+            surface: 'bulk_bar',
+            isBulk: true,
+            bulkSize: 4,
+            extra: { dismissal_reason: 'wontfix_irrelevant' },
+        })
+        expect(lastCapture(INBOX_EVENTS.REPORT_ACTION)).toMatchObject({
+            report_id: null,
+            action_type: 'dismiss',
+            surface: 'bulk_bar',
+            is_bulk: true,
+            bulk_size: 4,
+            dismissal_reason: 'wontfix_irrelevant',
+        })
+    })
+
+    it('records a connected source with first-connection and wizard flags', () => {
+        captureSignalSourceConnected({
+            sourceProduct: 'github',
+            sourceType: 'issue',
+            isFirstConnection: true,
+            viaSetupWizard: true,
+        })
+        expect(lastCapture(INBOX_EVENTS.SOURCE_CONNECTED)).toMatchObject({
+            source_product: 'github',
+            source_type: 'issue',
+            is_first_connection: true,
+            via_setup_wizard: true,
+        })
+    })
+})

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -59,16 +59,20 @@ function reportAgeHours(report: Pick<SignalReport, 'created_at'>): number {
 
 interface BaseReportProperties {
     report_id: string
-    report_title: string | null
     report_age_hours: number
     priority: SignalReportPriority | null
     actionability: SignalReportActionability | null
 }
 
+/**
+ * Identity + classification for a report. Deliberately excludes free-form content (the report
+ * title, dismissal notes): reports are generated from a customer's own data, so their titles can
+ * carry proprietary detail, and these events flow to first-party app analytics. We keep events to
+ * opaque ids, enums, ages, and counts.
+ */
 function baseReportProperties(report: SignalReport): BaseReportProperties {
     return {
         report_id: report.id,
-        report_title: report.title ?? null,
         report_age_hours: reportAgeHours(report),
         priority: report.priority ?? null,
         actionability: report.actionability ?? null,
@@ -171,7 +175,7 @@ export function captureInboxReportAction(params: {
 }): void {
     const base = params.report
         ? baseReportProperties(params.report)
-        : { report_id: null, report_title: null, report_age_hours: 0, priority: null, actionability: null }
+        : { report_id: null, report_age_hours: 0, priority: null, actionability: null }
     captureInboxEvent(INBOX_EVENTS.REPORT_ACTION, {
         ...base,
         action_type: params.actionType,

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -1,0 +1,201 @@
+import posthog from 'posthog-js'
+
+import { dayjs } from 'lib/dayjs'
+
+import { SignalReport, SignalReportActionability, SignalReportPriority } from './types'
+
+/**
+ * Inbox telemetry. Mirrors the desktop "Code" app's inbox analytics (event names + property
+ * shapes from `packages/shared/src/analytics-events.ts`) so the two clients are comparable in
+ * one PostHog project. Every event carries `inbox_client` so funnels and breakdowns can split
+ * cloud from desktop — cloud sends `'cloud'`, the desktop app sends `'desktop'`.
+ */
+export const INBOX_CLIENT = 'cloud' as const
+
+export const INBOX_EVENTS = {
+    VIEWED: 'Inbox viewed',
+    REPORT_OPENED: 'Inbox report opened',
+    REPORT_CLOSED: 'Inbox report closed',
+    REPORT_ACTION: 'Inbox report action',
+    SOURCE_CONNECTED: 'Signal source connected',
+    SOURCE_INTEREST: 'signals source interest',
+} as const
+
+type InboxEvent = (typeof INBOX_EVENTS)[keyof typeof INBOX_EVENTS]
+
+/** Action surface an `Inbox report action` fired from. */
+export type InboxReportActionSurface = 'detail_pane' | 'list_row' | 'bulk_bar'
+
+/** How a report detail was opened. */
+export type InboxReportOpenMethod = 'click' | 'deeplink' | 'unknown'
+
+/** How a report detail was closed. */
+export type InboxReportCloseMethod = 'next_report' | 'deselected' | 'navigated_away' | 'unmount'
+
+/**
+ * Report actions. A superset of the desktop enum — `restore` is cloud-only (the Archive tab),
+ * the rest line up one-for-one so the `action_type` breakdown reads the same across clients.
+ */
+export type InboxReportActionType =
+    | 'dismiss'
+    | 'restore'
+    | 'create_pr'
+    | 'add_suggested_reviewer'
+    | 'remove_suggested_reviewer'
+    | 'click_suggested_reviewer'
+
+function captureInboxEvent(event: InboxEvent, properties: Record<string, unknown>): void {
+    posthog.capture(event, { inbox_client: INBOX_CLIENT, ...properties })
+}
+
+/** Whole hours since the report was created, rounded to one decimal. Mirrors desktop `report_age_hours`. */
+function reportAgeHours(report: Pick<SignalReport, 'created_at'>): number {
+    if (!report.created_at) {
+        return 0
+    }
+    const hours = dayjs().diff(dayjs(report.created_at), 'hour', true)
+    return Math.max(0, Math.round(hours * 10) / 10)
+}
+
+interface BaseReportProperties {
+    report_id: string
+    report_title: string | null
+    report_age_hours: number
+    priority: SignalReportPriority | null
+    actionability: SignalReportActionability | null
+}
+
+function baseReportProperties(report: SignalReport): BaseReportProperties {
+    return {
+        report_id: report.id,
+        report_title: report.title ?? null,
+        report_age_hours: reportAgeHours(report),
+        priority: report.priority ?? null,
+        actionability: report.actionability ?? null,
+    }
+}
+
+/** Per-priority counts of the visible reports (P0–P4, plus unknown). Mirrors desktop's breakdown. */
+function priorityBreakdown(reports: SignalReport[]): Record<string, number> {
+    const counts = { p0: 0, p1: 0, p2: 0, p3: 0, p4: 0, unknown: 0 }
+    for (const report of reports) {
+        const key = report.priority ? (report.priority.toLowerCase() as 'p0' | 'p1' | 'p2' | 'p3' | 'p4') : 'unknown'
+        counts[key] += 1
+    }
+    return {
+        priority_p0_count: counts.p0,
+        priority_p1_count: counts.p1,
+        priority_p2_count: counts.p2,
+        priority_p3_count: counts.p3,
+        priority_p4_count: counts.p4,
+        priority_unknown_count: counts.unknown,
+    }
+}
+
+/** Per-actionability counts of the visible reports. Mirrors desktop's breakdown. */
+function actionabilityBreakdown(reports: SignalReport[]): Record<string, number> {
+    const counts = { immediately_actionable: 0, requires_human_input: 0, not_actionable: 0, unknown: 0 }
+    for (const report of reports) {
+        const key = report.actionability ?? 'unknown'
+        counts[key] += 1
+    }
+    return {
+        actionability_immediately_actionable_count: counts.immediately_actionable,
+        actionability_requires_human_input_count: counts.requires_human_input,
+        actionability_not_actionable_count: counts.not_actionable,
+        actionability_unknown_count: counts.unknown,
+    }
+}
+
+export function captureInboxViewed(params: {
+    tab: string
+    reports: SignalReport[]
+    totalCount: number
+    hasActiveFilters: boolean
+    sourceProductFilter: string[]
+    priorityFilter: string[]
+    scope: string
+}): void {
+    captureInboxEvent(INBOX_EVENTS.VIEWED, {
+        tab: params.tab,
+        report_count: params.reports.length,
+        total_count: params.totalCount,
+        is_empty: params.totalCount === 0,
+        has_active_filters: params.hasActiveFilters,
+        source_product_filter: params.sourceProductFilter,
+        priority_filter: params.priorityFilter,
+        scope: params.scope,
+        ...priorityBreakdown(params.reports),
+        ...actionabilityBreakdown(params.reports),
+    })
+}
+
+export function captureInboxReportOpened(params: {
+    report: SignalReport
+    openMethod: InboxReportOpenMethod
+    previousReportId: string | null
+    rank: number | null
+    listSize: number | null
+}): void {
+    captureInboxEvent(INBOX_EVENTS.REPORT_OPENED, {
+        ...baseReportProperties(params.report),
+        status: params.report.status ?? null,
+        source_products: params.report.source_products ?? [],
+        open_method: params.openMethod,
+        previous_report_id: params.previousReportId,
+        rank: params.rank,
+        list_size: params.listSize,
+    })
+}
+
+export function captureInboxReportClosed(params: {
+    report: SignalReport
+    timeSpentMs: number
+    closeMethod: InboxReportCloseMethod
+}): void {
+    captureInboxEvent(INBOX_EVENTS.REPORT_CLOSED, {
+        ...baseReportProperties(params.report),
+        time_spent_ms: params.timeSpentMs,
+        close_method: params.closeMethod,
+    })
+}
+
+export function captureInboxReportAction(params: {
+    /** Omitted for bulk actions, which act on a selection rather than a single report. */
+    report?: SignalReport | null
+    actionType: InboxReportActionType
+    surface: InboxReportActionSurface
+    isBulk?: boolean
+    bulkSize?: number
+    extra?: Record<string, unknown>
+}): void {
+    const base = params.report
+        ? baseReportProperties(params.report)
+        : { report_id: null, report_title: null, report_age_hours: 0, priority: null, actionability: null }
+    captureInboxEvent(INBOX_EVENTS.REPORT_ACTION, {
+        ...base,
+        action_type: params.actionType,
+        surface: params.surface,
+        is_bulk: params.isBulk ?? false,
+        bulk_size: params.bulkSize ?? 1,
+        ...params.extra,
+    })
+}
+
+export function captureSignalSourceConnected(params: {
+    sourceProduct: string
+    sourceType: string
+    isFirstConnection: boolean
+    viaSetupWizard: boolean
+}): void {
+    captureInboxEvent(INBOX_EVENTS.SOURCE_CONNECTED, {
+        source_product: params.sourceProduct,
+        source_type: params.sourceType,
+        is_first_connection: params.isFirstConnection,
+        via_setup_wizard: params.viaSetupWizard,
+    })
+}
+
+export function captureSignalSourceInterest(source: string): void {
+    captureInboxEvent(INBOX_EVENTS.SOURCE_INTEREST, { source })
+}

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -30,11 +30,12 @@ export type InboxReportActionSurface = 'detail_pane' | 'list_row' | 'bulk_bar'
 export type InboxReportOpenMethod = 'click' | 'deeplink' | 'unknown'
 
 /** How a report detail was closed. */
-export type InboxReportCloseMethod = 'next_report' | 'deselected' | 'navigated_away' | 'unmount'
+export type InboxReportCloseMethod = 'next_report' | 'deselected' | 'unmount'
 
 /**
- * Report actions. A superset of the desktop enum — `restore` is cloud-only (the Archive tab),
- * the rest line up one-for-one so the `action_type` breakdown reads the same across clients.
+ * Report actions cloud actually emits. Names match the desktop enum one-for-one (so the
+ * `action_type` breakdown reads the same across clients), plus a cloud-only `restore` for the
+ * Archive tab. Desktop-only variants we don't fire yet are intentionally omitted.
  */
 export type InboxReportActionType =
     | 'dismiss'
@@ -42,7 +43,6 @@ export type InboxReportActionType =
     | 'create_pr'
     | 'add_suggested_reviewer'
     | 'remove_suggested_reviewer'
-    | 'click_suggested_reviewer'
 
 function captureInboxEvent(event: InboxEvent, properties: Record<string, unknown>): void {
     posthog.capture(event, { inbox_client: INBOX_CLIENT, ...properties })

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -12,6 +12,12 @@ import { userLogic } from 'scenes/userLogic'
 
 import { Breadcrumb } from '~/types'
 
+import {
+    captureInboxReportClosed,
+    captureInboxReportOpened,
+    InboxReportCloseMethod,
+    InboxReportOpenMethod,
+} from './inboxAnalytics'
 import { isAgentRunReport, isFinishedRunReport } from './inboxMembership'
 import type { inboxSceneLogicType } from './inboxSceneLogicType'
 import { INBOX_PIPELINE_STATUS_FILTERS } from './logics/inboxFiltersLogic'
@@ -52,6 +58,41 @@ function findLoadedReport(id: string, runsReports: SignalReport[]): SignalReport
 }
 
 /**
+ * Position (1-based) and size of the report's list, for `Inbox report opened`. Prefers the active
+ * Runs list when it's open, then any mounted flat-tab list that holds the report. Null when the
+ * report isn't in a loaded list (e.g. a cold deep-link).
+ */
+function findReportRank(
+    id: string,
+    activeTab: InboxTabKey,
+    runsReports: SignalReport[]
+): { rank: number | null; listSize: number | null } {
+    const lists: SignalReport[][] = []
+    if (activeTab === 'runs') {
+        lists.push(runsReports)
+    }
+    for (const tabKey of Object.keys(INBOX_FLAT_TAB_LIST_PARAMS) as InboxFlatListTabKey[]) {
+        const mounted = reportListLogic.findMounted({ tabKey, listParams: INBOX_FLAT_TAB_LIST_PARAMS[tabKey] })
+        if (mounted) {
+            lists.push(mounted.values.reports)
+        }
+    }
+    for (const list of lists) {
+        const idx = list.findIndex((r) => r.id === id)
+        if (idx >= 0) {
+            return { rank: idx + 1, listSize: list.length }
+        }
+    }
+    return { rank: null, listSize: null }
+}
+
+/** Open-report engagement tracking state, kept on the logic's `cache` (not reactive). */
+interface InboxOpenTracking {
+    report: SignalReport
+    openedAt: number
+}
+
+/**
  * Inbox scene orchestrator. Owns the active tab, the selected report (loaded by id),
  * the staff-only project-wide Runs list, and session-analysis. The per-tab report
  * lists + their counts live in the keyed `reportListLogic` (one instance per flat tab),
@@ -66,7 +107,10 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
     })),
 
     actions({
-        setSelectedReportId: (id: string | null) => ({ id }),
+        setSelectedReportId: (id: string | null, openMethod: InboxReportOpenMethod = 'unknown') => ({
+            id,
+            openMethod,
+        }),
         // Seed (or clear) the selected report synchronously from an already-loaded list row, so the
         // detail renders without a spinner while the authoritative fetch runs in the background.
         seedSelectedReport: (report: SignalReport | null) => ({ report }),
@@ -188,11 +232,26 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 actions.loadRuns()
             }
         },
-        setSelectedReportId: ({ id }) => {
+        setSelectedReportId: ({ id, openMethod }) => {
+            // Close the previously open report (if any) before opening/clearing. `next_report` when
+            // switching straight to another report, `deselected` when returning to the list.
+            const open: InboxOpenTracking | undefined = cache.openTracking
+            if (open) {
+                const closeMethod: InboxReportCloseMethod = id ? 'next_report' : 'deselected'
+                captureInboxReportClosed({
+                    report: open.report,
+                    timeSpentMs: Date.now() - open.openedAt,
+                    closeMethod,
+                })
+                cache.previousReportId = open.report.id
+                cache.openTracking = undefined
+            }
             if (!id) {
                 actions.seedSelectedReport(null)
                 return
             }
+            // The open method is resolved once the authoritative record lands in loadSelectedReportSuccess.
+            cache.pendingOpenMethod = openMethod
             // A report and a scout detail are mutually exclusive full-width views.
             if (values.selectedScoutSkillName !== null) {
                 actions.setSelectedScoutSkillName(null)
@@ -200,6 +259,24 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             // Reuse the list row if we already have it (instant render), then refresh from the server.
             actions.seedSelectedReport(findLoadedReport(id, values.runsTabReports))
             actions.loadSelectedReport({ id })
+        },
+        // Fire `Inbox report opened` once the authoritative record lands (skip background refreshes
+        // of the already-open report). Rank/list_size come from whichever loaded list holds it.
+        loadSelectedReportSuccess: ({ selectedReportResponse }) => {
+            const report = selectedReportResponse
+            if (!report || cache.openTracking?.report.id === report.id) {
+                return
+            }
+            const { rank, listSize } = findReportRank(report.id, values.activeTab, values.runsTabReports)
+            captureInboxReportOpened({
+                report,
+                openMethod: (cache.pendingOpenMethod as InboxReportOpenMethod | undefined) ?? 'unknown',
+                previousReportId: cache.previousReportId ?? null,
+                rank,
+                listSize,
+            })
+            cache.openTracking = { report, openedAt: Date.now() }
+            cache.pendingOpenMethod = undefined
         },
         setSelectedScoutSkillName: ({ skillName }) => {
             if (skillName !== null && values.selectedReportId !== null) {
@@ -235,6 +312,16 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         },
         beforeUnmount: () => {
             clearInterval(cache.sessionAnalysisPollInterval)
+            // Flush dwell time for a report still open when the scene unmounts (navigated away).
+            const open: InboxOpenTracking | undefined = cache.openTracking
+            if (open) {
+                captureInboxReportClosed({
+                    report: open.report,
+                    timeSpentMs: Date.now() - open.openedAt,
+                    closeMethod: 'unmount',
+                })
+                cache.openTracking = undefined
+            }
         },
     })),
 
@@ -271,8 +358,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values }) => ({
+    urlToAction(({ actions, values, cache }) => ({
         [urls.inbox()]: () => {
+            cache.inboxListVisited = true
             if (values.selectedReportId !== null) {
                 actions.setSelectedReportId(null)
             }
@@ -281,6 +369,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             }
         },
         [urls.inbox(':tab')]: ({ tab }: { tab?: string }) => {
+            cache.inboxListVisited = true
             // A bare report deep-link `/inbox/<reportId>`  redirected to report form
             if (tab && !isInboxTabKey(tab) && tab !== 'scouts') {
                 router.actions.replace(
@@ -339,7 +428,8 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             }
             const id = reportId ?? null
             if (values.selectedReportId !== id) {
-                actions.setSelectedReportId(id)
+                // First route to a report before any list URL was seen → cold deep-link; otherwise an in-app click.
+                actions.setSelectedReportId(id, id ? (cache.inboxListVisited ? 'click' : 'deeplink') : 'unknown')
             }
         },
     })),

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -264,7 +264,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         // of the already-open report). Rank/list_size come from whichever loaded list holds it.
         loadSelectedReportSuccess: ({ selectedReportResponse }) => {
             const report = selectedReportResponse
-            if (!report || cache.openTracking?.report.id === report.id) {
+            // Skip already-open refreshes, and stale loads for a report the user already navigated away
+            // from before the fetch returned (else we'd log a phantom open + a later bogus dwell close).
+            if (!report || values.selectedReportId !== report.id || cache.openTracking?.report.id === report.id) {
                 return
             }
             const { rank, listSize } = findReportRank(report.id, values.activeTab, values.runsTabReports)
@@ -369,8 +371,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             }
         },
         [urls.inbox(':tab')]: ({ tab }: { tab?: string }) => {
-            cache.inboxListVisited = true
-            // A bare report deep-link `/inbox/<reportId>`  redirected to report form
+            // A bare report deep-link `/inbox/<reportId>`  redirected to report form. Mark the list as
+            // visited only when we're actually staying on a list view — otherwise the redirected report
+            // would be misclassified as an in-app click instead of a deep-link.
             if (tab && !isInboxTabKey(tab) && tab !== 'scouts') {
                 router.actions.replace(
                     urls.inboxReport('reports', tab),
@@ -379,6 +382,7 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 )
                 return
             }
+            cache.inboxListVisited = true
             // Staff-only tabs (Runs, Not actionable): bounce non-staff to the default tab.
             if (isStaffOnlyTab(tab) && userLogic.values.user != null && !values.isStaff) {
                 actions.setActiveTab('pulls')

--- a/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
@@ -4,6 +4,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
+import { captureInboxReportAction } from '../inboxAnalytics'
 import type { DismissalReasonValue } from '../utils/dismissalReasons'
 import type { inboxBulkActionsLogicType } from './inboxBulkActionsLogicType'
 
@@ -83,6 +84,13 @@ export const inboxBulkActionsLogic = kea<inboxBulkActionsLogicType>([
                 return
             }
             const trimmedNote = note.trim().slice(0, 4000)
+            captureInboxReportAction({
+                actionType: 'dismiss',
+                surface: 'bulk_bar',
+                isBulk: true,
+                bulkSize: reportIds.length,
+                extra: { dismissal_reason: reason, ...(trimmedNote ? { dismissal_note: trimmedNote } : {}) },
+            })
             const results = await Promise.allSettled(
                 reportIds.map((id) =>
                     api.signalReports.setState(id, {

--- a/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
@@ -84,12 +84,13 @@ export const inboxBulkActionsLogic = kea<inboxBulkActionsLogicType>([
                 return
             }
             const trimmedNote = note.trim().slice(0, 4000)
+            // Only the structured reason — the free-form note can carry proprietary text.
             captureInboxReportAction({
                 actionType: 'dismiss',
                 surface: 'bulk_bar',
                 isBulk: true,
                 bulkSize: reportIds.length,
-                extra: { dismissal_reason: reason, ...(trimmedNote ? { dismissal_note: trimmedNote } : {}) },
+                extra: { dismissal_reason: reason },
             })
             const results = await Promise.allSettled(
                 reportIds.map((id) =>

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -6,6 +6,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { userLogic } from 'scenes/userLogic'
 
+import { captureInboxReportAction } from '../inboxAnalytics'
 import { ACTIONABLE_ACTIONABILITY_VALUES, INBOX_SCOPE_FOR_YOU, InboxFlatListTabKey, SignalReport } from '../types'
 import { DismissalReasonValue } from '../utils/dismissalReasons'
 import { inboxBulkActionsLogic } from './inboxBulkActionsLogic'
@@ -214,6 +215,8 @@ export const reportListLogic = kea<reportListLogicType>([
         // Restore a suppressed report back to the inbox (transition to `potential`). Optimistically
         // drops it from the Archived list; the report re-enters the pipeline and resurfaces elsewhere.
         restoreReport: async ({ reportId }) => {
+            const report = values.reports.find((r) => r.id === reportId)
+            captureInboxReportAction({ report, actionType: 'restore', surface: 'list_row' })
             actions.removeReport(reportId)
             try {
                 await api.signalReports.setState(reportId, { state: 'potential' })

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -216,10 +216,11 @@ export const reportListLogic = kea<reportListLogicType>([
         // drops it from the Archived list; the report re-enters the pipeline and resurfaces elsewhere.
         restoreReport: async ({ reportId }) => {
             const report = values.reports.find((r) => r.id === reportId)
-            captureInboxReportAction({ report, actionType: 'restore', surface: 'list_row' })
             actions.removeReport(reportId)
             try {
                 await api.signalReports.setState(reportId, { state: 'potential' })
+                // Fire only after the restore persists, matching ReportDetailActions' fallback path.
+                captureInboxReportAction({ report, actionType: 'restore', surface: 'list_row' })
                 lemonToast.success('Report restored to inbox')
             } catch (error: any) {
                 lemonToast.error(error?.detail || error?.message || 'Failed to restore report')

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -13,6 +13,7 @@ import { ExternalDataSource, ExternalDataSourceSchema, RecordingUniversalFilters
 
 import { sourcesDataLogic } from 'products/data_warehouse/frontend/shared/logics/sourcesDataLogic'
 
+import { captureSignalSourceConnected } from './inboxAnalytics'
 import type { signalSourcesLogicType } from './signalSourcesLogicType'
 import { SignalSourceConfig, SignalSourceConfigStatus, ToggleSignalSourceParams } from './types'
 
@@ -433,7 +434,7 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 }
                 const mapped = mapping[product]
                 if (mapped) {
-                    actions.toggleSignalSource({ ...mapped, enabled: true })
+                    actions.toggleSignalSource({ ...mapped, enabled: true, viaSetupWizard: true })
                 }
                 actions.closeDataSourceSetup()
             },
@@ -461,6 +462,16 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                     }
                     breakpoint()
                     actions.toggleSignalSourceSuccess(params)
+                    // Only a successful enable counts as a connection. First-time when there was no
+                    // persisted (non-placeholder) config for this product/type before the toggle.
+                    if (enabled) {
+                        captureSignalSourceConnected({
+                            sourceProduct,
+                            sourceType,
+                            isFirstConnection: !(existing && !existing.id.startsWith('new_')),
+                            viaSetupWizard: params.viaSetupWizard ?? false,
+                        })
+                    }
                     actions.loadSourceConfigs()
                 } catch (error: any) {
                     breakpoint()
@@ -473,6 +484,10 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
             toggleErrorTracking: async (_, breakpoint) => {
                 const desiredEnabled = !values.errorTrackingIsFullyEnabled
                 const configs = values.sourceConfigs ?? []
+                // First connection when no persisted error-tracking config existed before this enable.
+                const wasConnected = configs.some(
+                    (c) => c.source_product === SignalSourceProduct.ERROR_TRACKING && !c.id.startsWith('new_')
+                )
                 try {
                     for (const sourceType of ERROR_TRACKING_SIGNAL_SOURCE_TYPES) {
                         const existing = configs.find(
@@ -492,6 +507,14 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                     }
                     breakpoint()
                     actions.toggleErrorTrackingComplete()
+                    if (desiredEnabled) {
+                        captureSignalSourceConnected({
+                            sourceProduct: SignalSourceProduct.ERROR_TRACKING,
+                            sourceType: SignalSourceType.ISSUE_CREATED,
+                            isFirstConnection: !wasConnected,
+                            viaSetupWizard: false,
+                        })
+                    }
                     actions.loadSourceConfigs()
                 } catch (error: any) {
                     breakpoint() // re-throws if superseded, skipping the lines below

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -93,6 +93,8 @@ export interface ToggleSignalSourceParams {
     sourceType: SignalSourceType
     enabled: boolean
     config?: Record<string, any>
+    /** True when the enable came through the data-warehouse setup wizard, for `Signal source connected`. */
+    viaSetupWizard?: boolean
 }
 
 export enum SignalSourceConfigStatus {


### PR DESCRIPTION
## Problem

The cloud inbox (Signals) and the desktop "Code" app ship nearly the same inbox UI, but their telemetry had drifted badly apart. Desktop emits a full engagement funnel — `Inbox viewed`, `Inbox report opened`, `Inbox report closed` (with dwell time), a rich `Inbox report action`, and a real `Signal source connected`. Cloud only fired a thin slice: `Inbox report action` for `create_pr` + reviewer edits, and a `signals source interest` event. So for the cloud inbox we had no visibility into how often it's opened, which reports get drilled into, how long people spend on a report, or when sources actually get connected — and we couldn't compare the two clients in one project.

## Changes

Added a shared `inboxAnalytics.ts` module that mirrors the desktop app's inbox event names and property shapes, and wired the cloud inbox into it. Every event now carries an `inbox_client: 'cloud'` discriminator (desktop sends `'desktop'`) so funnels and breakdowns can split or combine the two clients.

Events now emitted from the cloud inbox:

| Event | When | Notable props |
|---|---|---|
| `Inbox viewed` | A report tab settles | `tab`, `report_count`, `total_count`, filters, priority/actionability breakdown |
| `Inbox report opened` | A report detail loads | `open_method` (click/deeplink), `previous_report_id`, `rank`, `list_size`, `report_age_hours` |
| `Inbox report closed` | Detail switches/closes/unmounts | `time_spent_ms`, `close_method` |
| `Inbox report action` | create_pr, dismiss (single + bulk), restore, reviewer add/remove | `surface`, `is_bulk`, `bulk_size`, `dismissal_reason` |
| `Signal source connected` | A source is successfully enabled | `source_product`, `is_first_connection`, `via_setup_wizard` |

The biggest gaps closed: dwell time per report, the open/view funnel, and instrumenting dismiss/restore (the archive UI existed but fired nothing). The existing `signals source interest` event is preserved, just routed through the shared module.

Centralizing also means the previously inline `posthog.capture(...)` calls scattered across three components now go through one typed helper, so the event names and payloads can't silently drift from desktop again.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- New unit test `inboxAnalytics.test.ts` (5 cases) covering the `inbox_client` stamp, priority/actionability breakdown, single vs bulk action shape, and the connected-source flags — all pass via `hogli test`.
- `pnpm --filter=@posthog/frontend typescript:check` — passes.
- `oxlint` + `oxfmt` on the touched files — clean.

No manual UI testing performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to compare the inbox telemetry between the desktop Code app (`../code`) and the cloud Signals inbox, then bring cloud up to parity with a proper set of custom events plus a client discriminator. I mapped both sides (desktop centralizes events in `packages/shared/src/analytics-events.ts` via tracking hooks; cloud had ad-hoc `posthog.capture` in three files), then mirrored the desktop event names and property shapes in a new cloud module.

Key decisions:
- Used `inbox_client` (not `surface`) as the cloud-vs-desktop discriminator, since desktop already uses `surface` for the action surface (`detail_pane`/`bulk_bar`/`list_row`).
- Fired open/close tracking from `inboxSceneLogic` keyed on the selected-report lifecycle, with dwell time and a flush on unmount; open method is inferred (cold deep-link vs in-app click) from whether a list URL was seen first.
- Centralized single-report `dismiss` in the shared `useReportArchive` hook so both the card and the detail pane are covered from one place; bulk dismiss fires once from `inboxBulkActionsLogic`.
- Kept `action_type` aligned with desktop's enum (added one cloud-only `restore` for the Archive tab).

No repo skills were required for this change. Regenerated kea logic types with `kea-typegen` (the `*LogicType.ts` files are gitignored / CI-regenerated).
