### PR TITLE
fix(postgres): handle binary offset overflow when materializing batches

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -231,28 +231,30 @@ def test_table_from_py_list_with_null_filled_binary_column():
     )
 
 
-def test_to_list_array_binary_offset_overflow_falls_back_to_large_binary():
-    # A `bytea` column whose chunk exceeds 2GB makes `combine_chunks()` overflow the int32
-    # binary offset; the helper must recover by casting to large_binary instead of raising.
+@pytest.mark.parametrize(
+    "error_msg, large_type, values",
+    [
+        (
+            "offset overflow while concatenating arrays, consider casting input from `binary` to `large_binary` first.",
+            pa.large_binary(),
+            [b"a", b"b", b"c"],
+        ),
+        (
+            "offset overflow while concatenating arrays, consider casting input from `string` to `large_string` first.",
+            pa.large_string(),
+            ["a", "b"],
+        ),
+    ],
+)
+def test_to_list_array_offset_overflow_falls_back_to_large_type(error_msg, large_type, values):
+    # A column whose chunk exceeds 2GB makes `combine_chunks()` overflow the int32 offset;
+    # the helper must recover by casting to the large-offset variant instead of raising.
     overflowing = MagicMock(spec=pa.ChunkedArray)
-    overflowing.combine_chunks.side_effect = pa.ArrowInvalid(
-        "offset overflow while concatenating arrays, consider casting input from `binary` to `large_binary` first."
-    )
-    overflowing.cast.return_value = pa.chunked_array([pa.array([b"a", b"b", b"c"], type=pa.large_binary())])
+    overflowing.combine_chunks.side_effect = pa.ArrowInvalid(error_msg)
+    overflowing.cast.return_value = pa.chunked_array([pa.array(values, type=large_type)])
 
-    assert _to_list_array(overflowing) == [b"a", b"b", b"c"]
-    overflowing.cast.assert_called_once_with(pa.large_binary())
-
-
-def test_to_list_array_string_offset_overflow_falls_back_to_large_string():
-    overflowing = MagicMock(spec=pa.ChunkedArray)
-    overflowing.combine_chunks.side_effect = pa.ArrowInvalid(
-        "offset overflow while concatenating arrays, consider casting input from `string` to `large_string` first."
-    )
-    overflowing.cast.return_value = pa.chunked_array([pa.array(["a", "b"], type=pa.large_string())])
-
-    assert _to_list_array(overflowing) == ["a", "b"]
-    overflowing.cast.assert_called_once_with(pa.large_string())
+    assert _to_list_array(overflowing) == values
+    overflowing.cast.assert_called_once_with(large_type)
 
 
 def test_to_list_array_reraises_unrelated_arrow_invalid():

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -17,6 +17,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KE
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     SchemaColumnTypeChangedException,
     _get_max_decimal_type,
+    _to_list_array,
     append_partition_key_to_table,
     evolve_pyarrow_schema,
     normalize_table_column_names,
@@ -228,6 +229,38 @@ def test_table_from_py_list_with_null_filled_binary_column():
             ]
         )
     )
+
+
+def test_to_list_array_binary_offset_overflow_falls_back_to_large_binary():
+    # A `bytea` column whose chunk exceeds 2GB makes `combine_chunks()` overflow the int32
+    # binary offset; the helper must recover by casting to large_binary instead of raising.
+    overflowing = MagicMock(spec=pa.ChunkedArray)
+    overflowing.combine_chunks.side_effect = pa.ArrowInvalid(
+        "offset overflow while concatenating arrays, consider casting input from `binary` to `large_binary` first."
+    )
+    overflowing.cast.return_value = pa.chunked_array([pa.array([b"a", b"b", b"c"], type=pa.large_binary())])
+
+    assert _to_list_array(overflowing) == [b"a", b"b", b"c"]
+    overflowing.cast.assert_called_once_with(pa.large_binary())
+
+
+def test_to_list_array_string_offset_overflow_falls_back_to_large_string():
+    overflowing = MagicMock(spec=pa.ChunkedArray)
+    overflowing.combine_chunks.side_effect = pa.ArrowInvalid(
+        "offset overflow while concatenating arrays, consider casting input from `string` to `large_string` first."
+    )
+    overflowing.cast.return_value = pa.chunked_array([pa.array(["a", "b"], type=pa.large_string())])
+
+    assert _to_list_array(overflowing) == ["a", "b"]
+    overflowing.cast.assert_called_once_with(pa.large_string())
+
+
+def test_to_list_array_reraises_unrelated_arrow_invalid():
+    failing = MagicMock(spec=pa.ChunkedArray)
+    failing.combine_chunks.side_effect = pa.ArrowInvalid("some other arrow problem")
+
+    with pytest.raises(pa.ArrowInvalid, match="some other arrow problem"):
+        _to_list_array(failing)
 
 
 def test_table_from_py_list_with_mixed_decimal_float_sizes():

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -669,8 +669,14 @@ def _to_list_array(column_data: pa.Array | pa.ChunkedArray | np.ndarray[Any, np.
         try:
             return column_data.combine_chunks().tolist()
         except pa.ArrowInvalid as e:
-            if "consider casting input from `string` to `large_string`" in "".join(e.args):
+            joined_args = "".join(e.args)
+            if "consider casting input from `string` to `large_string`" in joined_args:
                 return column_data.cast(pa.large_string()).combine_chunks().tolist()
+            # Same int32 offset overflow as above, for `binary`-typed columns (e.g. a Postgres
+            # `bytea` whose chunk exceeds 2GB). large_binary uses 64-bit offsets so combining
+            # the chunks no longer overflows.
+            if "consider casting input from `binary` to `large_binary`" in joined_args:
+                return column_data.cast(pa.large_binary()).combine_chunks().tolist()
 
             raise
 


### PR DESCRIPTION
## Problem

Postgres imports crash with `ArrowInvalid: offset overflow while concatenating arrays, consider casting input from `binary` to `large_binary` first.` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ee632-d643-78e0-b842-d55f23021392)).

Root cause, traced from the captured stack:

- `get_rows` (`postgres.py`) yields each read chunk through `table_from_iterator` -> `_process_batch`.
- A `bytea` column whose values exceed 2GB within a chunk makes `pa.array(values)` return a **multi-chunk** `ChunkedArray` (pyarrow auto-chunks to stay under the int32 binary capacity).
- `_process_batch` calls `_to_list_array` on **every** column to inspect its types — before binary columns are dropped. For the oversized binary column, `_to_list_array` calls `combine_chunks()`, which tries to merge the chunks back into one `binary` array and overflows the int32 offset.

`_to_list_array` already handled the byte-for-byte identical `string` -> `large_string` case, but not `binary` -> `large_binary`, so the import died instead of degrading gracefully.

## Changes

In `_to_list_array`, add a fallback for the `binary` offset-overflow message that casts to `large_binary` (64-bit offsets) before combining chunks — mirroring the existing `large_string` recovery. The binary column is still dropped further down `_process_batch` as it was before; this just stops the type-inference pass from crashing first.

This is a fixable bug, not a user/upstream error — our materialization code was fragile on a valid (if large) source column, so the fix is in the code rather than `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I added and ran automated unit tests for `_to_list_array` (no manual testing):

- `test_to_list_array_binary_offset_overflow_falls_back_to_large_binary` — the new regression test; reproduces the overflow and asserts the helper recovers via a `large_binary` cast.
- `test_to_list_array_string_offset_overflow_falls_back_to_large_string` — locks in the pre-existing string fallback.
- `test_to_list_array_reraises_unrelated_arrow_invalid` — an unrelated `ArrowInvalid` still propagates.

`uv run pytest posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py` — 77 passed. `ruff check` / `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Confirmed the issue via the error-tracking event data (exception type `ArrowInvalid`, live as of 2026-06-20) and pulled the full resolved stack trace to locate the failing frame at `_to_list_array` -> `ChunkedArray.combine_chunks` -> `concat_arrays`. Read the import pipeline (`postgres.py` `get_rows`, `utils.py` `_process_batch`/`_to_list_array`) to confirm the call path and that binary columns are dropped downstream, so the fix only needs to keep the type-inference pass from crashing. Chose to fix the shared `_to_list_array` helper (rather than the Postgres source) because that is where the overflow is raised and where the analogous `large_string` recovery already lives — any SQL source with large binary columns hits the same path. Tested the new branch with `MagicMock(spec=pa.ChunkedArray)` since a genuine >2GB trigger is not feasible in a unit test.
