### PR TITLE
feat(signals): surface resolved reports in the inbox Archive tab

### DIFF
--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -165,7 +165,12 @@ export function ReportCard({
     })
 
     // On the Archive tab, surface why it was dismissed (reason tag + note tooltip) when we have it.
-    const dismissalLabel = isArchived ? dismissalReasonLabel(report.dismissal_reason) : null
+    // Key off the report still being suppressed, not the tab: a report that was dismissed, restored,
+    // then resolved keeps its old dismissal artefact, and showing that tag would mislabel finished work.
+    const dismissalLabel =
+        isArchived && report.status === SignalReportStatus.SUPPRESSED
+            ? dismissalReasonLabel(report.dismissal_reason)
+            : null
 
     // PR cards show repo · source; reports show source · status · actionability.
     const showMeta = hasPr

--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -140,6 +140,9 @@ export function ReportCard({
     onRestore?: () => void
 }): JSX.Element {
     const isArchived = tabKey === 'archived'
+    // Resolved reports are terminal (their implementation PR merged) – shown for reference in the
+    // Archive tab but with no row action: they can't be restored or re-archived.
+    const isResolved = report.status === SignalReportStatus.RESOLVED
     const prUrl = safeHttpUrl(report.implementation_pr_url)
     const prUrlParts = prUrl ? parsePrUrlParts(prUrl) : null
     const hasPr = prUrlParts != null
@@ -247,49 +250,52 @@ export function ReportCard({
                 </div>
             </Link>
 
-            <div className="flex items-center justify-end gap-2.5 shrink-0 @lg:self-stretch @lg:border-l @lg:border-primary @lg:pl-3">
-                {isArchived ? (
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        icon={<IconUndo />}
-                        tooltip="Restore this report to the inbox"
-                        aria-label="Restore this report to the inbox"
-                        onClick={(event) => {
-                            event.preventDefault()
-                            event.stopPropagation()
-                            onRestore?.()
-                        }}
-                    >
-                        Restore
-                    </LemonButton>
-                ) : (
-                    <>
+            {/* Terminal resolved reports carry no row action – skip the action column (and its divider). */}
+            {!isResolved && (
+                <div className="flex items-center justify-end gap-2.5 shrink-0 @lg:self-stretch @lg:border-l @lg:border-primary @lg:pl-3">
+                    {isArchived ? (
                         <LemonButton
                             type="secondary"
                             size="small"
-                            icon={<IconArchive />}
-                            tooltip="Archive this report"
-                            aria-label="Archive this report"
-                            loading={isArchiving}
-                            onClick={onArchiveClick}
-                        >
-                            Archive
-                        </LemonButton>
-                        <LemonButton
-                            type="primary"
-                            size="small"
+                            icon={<IconUndo />}
+                            tooltip="Restore this report to the inbox"
+                            aria-label="Restore this report to the inbox"
                             onClick={(event) => {
                                 event.preventDefault()
                                 event.stopPropagation()
-                                router.actions.push(detailUrl)
+                                onRestore?.()
                             }}
                         >
-                            Review
+                            Restore
                         </LemonButton>
-                    </>
-                )}
-            </div>
+                    ) : (
+                        <>
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                icon={<IconArchive />}
+                                tooltip="Archive this report"
+                                aria-label="Archive this report"
+                                loading={isArchiving}
+                                onClick={onArchiveClick}
+                            >
+                                Archive
+                            </LemonButton>
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={(event) => {
+                                    event.preventDefault()
+                                    event.stopPropagation()
+                                    router.actions.push(detailUrl)
+                                }}
+                            >
+                                Review
+                            </LemonButton>
+                        </>
+                    )}
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -48,6 +48,8 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
 
     const showCreatePr = canCreateImplementationPr(report)
     const isArchived = report.status === SignalReportStatus.SUPPRESSED
+    // Resolved reports are terminal (their implementation PR merged) – nothing to archive, restore, or kick off.
+    const isResolved = report.status === SignalReportStatus.RESOLVED
 
     const { isArchiving, onArchiveClick } = useReportArchive({
         reportId: report.id,
@@ -83,6 +85,11 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
         } finally {
             setIsRestoring(false)
         }
+    }
+
+    // A resolved report is terminal – its PR already merged, so no detail actions apply.
+    if (isResolved) {
+        return <></>
     }
 
     // An already-archived report offers Restore instead of Archive (and no Create PR).

--- a/frontend/src/scenes/inbox/components/tabs/ArchivedTab.tsx
+++ b/frontend/src/scenes/inbox/components/tabs/ArchivedTab.tsx
@@ -5,9 +5,9 @@ import { ReportCard } from '../cards/ReportCard'
 import { InboxReportList } from '../InboxReportList'
 
 /**
- * Reports the user dismissed (status `suppressed`). Same flat-list primitive as the other
- * report tabs – only the filter differs. Each card offers a Restore action that re-promotes
- * the report back into the inbox.
+ * Terminal reports: ones the user dismissed (status `suppressed`, restorable via a Restore action)
+ * and ones resolved by a merged implementation PR (status `resolved`, shown for reference only).
+ * Same flat-list primitive as the other report tabs – only the filter differs.
  */
 export function ArchivedTab(): JSX.Element {
     return (
@@ -18,7 +18,8 @@ export function ArchivedTab(): JSX.Element {
             emptyState={{
                 icon: <IconArchive className="text-2xl" />,
                 title: 'Nothing archived',
-                description: 'Reports you archive land here, where you can review them or restore them to the inbox.',
+                description:
+                    'Reports you archive land here, where you can restore them to the inbox. Resolved reports (their pull request merged) also appear here for reference.',
             }}
         />
     )

--- a/frontend/src/scenes/inbox/components/tabs/ArchivedTab.tsx
+++ b/frontend/src/scenes/inbox/components/tabs/ArchivedTab.tsx
@@ -19,7 +19,7 @@ export function ArchivedTab(): JSX.Element {
                 icon: <IconArchive className="text-2xl" />,
                 title: 'Nothing archived',
                 description:
-                    'Reports you archive land here, where you can restore them to the inbox. Resolved reports (their pull request merged) also appear here for reference.',
+                    'Reports you archive land here, where you can restore them to the inbox. Resolved reports also appear here for reference.',
             }}
         />
     )

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -36,8 +36,9 @@ export const INBOX_FLAT_TAB_LIST_PARAMS: Record<InboxFlatListTabKey, ReportListP
         actionability: ACTIONABLE_ACTIONABILITY_VALUES.join(','),
     },
     'not-actionable': { actionability: 'not_actionable' },
-    // Archived = reports the user dismissed (suppressed). Restorable back into the inbox.
-    archived: { status: 'suppressed' },
+    // Archive = terminal reports: ones the user dismissed (suppressed, restorable) and ones
+    // resolved by a merged implementation PR (terminal, not restorable).
+    archived: { status: 'suppressed,resolved' },
 }
 
 function teammateUuidFromScope(scope: string): string | undefined {

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -223,6 +223,10 @@ export const reportListLogic = kea<reportListLogicType>([
                 // Fire only after the restore persists, matching ReportDetailActions' fallback path.
                 captureInboxReportAction({ report, actionType: 'restore', surface: 'list_row' })
                 lemonToast.success('Report restored to inbox')
+                // Restore maps through restore_target_status server-side, so a report suppressed while
+                // resolved returns to `resolved` and still belongs in this tab. Reconcile against the
+                // server rather than trusting the optimistic removal, which over-drops those rows.
+                actions.refresh()
             } catch (error: any) {
                 lemonToast.error(error?.detail || error?.message || 'Failed to restore report')
                 actions.refresh()


### PR DESCRIPTION
## Problem

When a signal report is completed — e.g. its implementation PR gets merged — it transitions to the `resolved` status and then disappears from the inbox entirely. There's no "Done" tab, and `resolved` isn't part of any tab's filter, so completed reports are unreachable from the UI. There's no way to track or even confirm recently-completed work.

## Changes

Resolved reports now show up in the existing **Archive** tab alongside dismissed (suppressed) ones — a minimal change that reuses the tab built for terminal reports rather than adding a whole new surface.

- **Archive tab filter** now queries both terminal states (`suppressed,resolved`) instead of just `suppressed`.
- Resolved cards are **reference-only**: the Restore action (and its divider column) is hidden in the list, since resolving is terminal — there's nothing to restore. They're visually distinct from dismissed cards for free, via the existing badges: a resolved report with a merged PR already renders the green **merged #1234** PR badge, and one without a PR shows the green **Resolved** status badge.
- **Detail page** for a resolved report now renders no actions, instead of falling through to the (nonsensical, and likely invalid-transition) **Archive** / **Create PR** buttons it would otherwise show.
- Updated the Archive tab's empty-state copy to mention resolved reports appear there for reference.

No backend changes — the list API already accepts `status=suppressed,resolved` and applies no default exclusion when an explicit status is passed.

## How did you test this code?

I'm an agent (Claude Code). I did **not** perform manual testing in a running app. The change is frontend-only and small. No existing automated tests cover these files, so none were run; verification was by code inspection:

- Confirmed the per-tab `status` param flows straight to the list API — `INBOX_PIPELINE_STATUS_FILTERS` (which excludes `resolved`/`suppressed`) is only used by the staff-only "Runs" tab, not the flat-list tabs.
- Confirmed the backend status filter (`_apply_signal_report_status_filter`) treats `resolved` as a valid filterable status and does not re-exclude it when an explicit status is supplied.

Manual smoke-testing of the Archive tab rendering and the resolved detail view by a reviewer would be worthwhile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked where completed reports go once resolved (e.g. after a PR merges), and we confirmed they currently vanish from the inbox with no surface to track them. We chose the minimal option — fold them into the existing Archive tab rather than build a new "Done" tab.

Two design forks were decided with Andy:
- **Restore on resolved cards:** hidden — resolving is terminal, so restore doesn't apply.
- **Tab labeling:** keep the "Archive" label, just tweak the empty-state copy (a full rename was considered and rejected as out of scope for now).

Tools: Claude Code (Opus 4.8), using the Explore agent to map the inbox report lifecycle, tab filters, card/detail rendering, and the backend status filter. No repo skills were invoked. While scoping, found that the detail page branches on `report.status === SUPPRESSED` rather than the tab, so resolved reports needed explicit terminal-state handling there too — otherwise click-through would have exposed broken actions.
