### PR TITLE
feat(scene-menu-bar): add capture tracking and migrate notebook

### DIFF
--- a/bin/dev-sandbox.sb
+++ b/bin/dev-sandbox.sb
@@ -61,11 +61,12 @@
     (subpath (string-append (param "HOME") "/.local/share/flox")) ; flox metadata
     (subpath (string-append (param "HOME") "/Library/pnpm"))       ; pnpm content-addressed store
     (subpath (string-append (param "HOME") "/.local/share/pnpm"))  ; pnpm content-addressed store (PNPM_HOME)
-    ;; turbo (Vercel) global config — turbo reads auth.json on every run to check
-    ;; remote-cache login. A sandbox *deny* surfaces as EPERM, which turbo treats
-    ;; as a fatal "I/O error" (unlike a missing file, which it tolerates), killing
-    ;; the frontend pane. Read-only; the remote-cache token here is low-value.
+    ;; turbo global config — turbo reads auth.json on every run to check remote-cache
+    ;; login. A sandbox *deny* surfaces as EPERM, which turbo treats as a fatal "I/O
+    ;; error" (unlike a missing file, which it tolerates), killing the frontend pane /
+    ;; autorestart-looping the stack. Read-only; the remote-cache token is low-value.
     (subpath (string-append (param "HOME") "/Library/Application Support/com.vercel.cli"))
+    (subpath (string-append (param "HOME") "/Library/Application Support/turborepo"))
     (subpath (string-append (param "HOME") "/.duckdb"))            ; duckdb extension cache (ducklake warmup installs/stats extensions here)
     ;; git global config (read by version-detection / git-aware tooling). Config
     ;; only, by exact path — credentials (~/.git-credentials, keychain) stay blocked.

--- a/frontend/src/layout/scenes/components/SceneMenuBar.tsx
+++ b/frontend/src/layout/scenes/components/SceneMenuBar.tsx
@@ -1,7 +1,8 @@
 import { useActions, useValues } from 'kea'
-import { Children, ComponentProps, ReactNode } from 'react'
+import posthog from 'posthog-js'
+import { Children, ComponentProps, MouseEvent, ReactNode, useEffect } from 'react'
 
-import { IconExternal, IconSidePanel } from '@posthog/icons'
+import { IconExternal, IconSidePanel, IconSparkles } from '@posthog/icons'
 import {
     Badge,
     Button,
@@ -26,10 +27,23 @@ import {
 import { IconBlank } from 'lib/lemon-ui/icons'
 import { LinkPrimitive } from 'lib/lemon-ui/Link'
 import { cn } from 'lib/utils/css-classes'
+import { sceneLogic } from 'scenes/sceneLogic'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { SidePanelTab } from '~/types'
+
+/**
+ * Central instrumentation for the SceneMenuBar experiment (`SCENE_MENU_BAR` flag). Capturing
+ * here means every scene that adopts the bar reports engagement without per-scene wiring.
+ * Scene id is read off `sceneLogic` without subscribing so capture never triggers a re-render.
+ */
+function captureSceneMenuBar(event: string, properties: Record<string, unknown> = {}): void {
+    posthog.capture(event, {
+        scene: sceneLogic.findMounted()?.values.activeSceneId ?? null,
+        ...properties,
+    })
+}
 
 /**
  * Scene layouts where the surrounding container applies horizontal/vertical padding to
@@ -47,6 +61,10 @@ export function SceneMenuBar({ children, className }: SceneMenuBarProps): JSX.El
     const { sceneLayoutConfig } = useValues(sceneLayoutLogic)
     const layout = sceneLayoutConfig?.layout ?? 'app'
     const isPaddedLayout = PADDED_LAYOUTS.has(layout)
+
+    useEffect(() => {
+        captureSceneMenuBar('scene menu bar shown')
+    }, [])
 
     return (
         <div
@@ -72,7 +90,7 @@ export function SceneMenuBar({ children, className }: SceneMenuBarProps): JSX.El
             */}
             <Menubar className="gap-0 border-0">{children}</Menubar>
 
-            <Badge>OS-like menu (alpha)</Badge>
+            <Badge className="hidden @[800px]:flex">OS-like menu (alpha)</Badge>
             <SceneMenuBarRightLinks />
         </div>
     )
@@ -87,6 +105,7 @@ function SceneMenuBarRightLinks(): JSX.Element {
             <Button
                 data-attr="scene-menu-bar-docs"
                 className={RIGHT_TRIGGER_CLASSES}
+                onClick={() => captureSceneMenuBar('scene menu bar right link clicked', { link: 'docs' })}
                 render={<LinkPrimitive to="https://posthog.com/docs" target="_blank" />}
             >
                 Docs
@@ -94,7 +113,10 @@ function SceneMenuBarRightLinks(): JSX.Element {
             </Button>
             <Button
                 type="button"
-                onClick={() => openSidePanel(SidePanelTab.Support)}
+                onClick={() => {
+                    captureSceneMenuBar('scene menu bar right link clicked', { link: 'support' })
+                    openSidePanel(SidePanelTab.Support)
+                }}
                 data-attr="scene-menu-bar-support"
                 className={RIGHT_TRIGGER_CLASSES}
             >
@@ -103,11 +125,15 @@ function SceneMenuBarRightLinks(): JSX.Element {
             </Button>
             <Button
                 type="button"
-                onClick={() => openSidePanel(SidePanelTab.Max)}
+                onClick={() => {
+                    captureSceneMenuBar('scene menu bar right link clicked', { link: 'ai' })
+                    openSidePanel(SidePanelTab.Max)
+                }}
                 data-attr="scene-menu-bar-ai"
                 className={RIGHT_TRIGGER_CLASSES}
                 variant="outline"
             >
+                <IconSparkles className="text-ai group-hover/button-primitive:animate-hue-rotate" />
                 PostHog AI
             </Button>
         </div>
@@ -176,7 +202,13 @@ export function SceneMenuBarMenu({
 }: SceneMenuBarMenuProps): JSX.Element {
     const isDisabled = disabled || hasNoRenderableChildren(children)
     return (
-        <MenubarMenu>
+        <MenubarMenu
+            onOpenChange={(open: boolean) => {
+                if (open) {
+                    captureSceneMenuBar('scene menu bar menu opened', { menu: label })
+                }
+            }}
+        >
             <MenubarTrigger
                 data-attr={dataAttr}
                 disabled={isDisabled}
@@ -214,9 +246,22 @@ type SceneMenuBarItemProps = ComponentProps<typeof MenubarItem> & {
  * Pass `variant="destructive"` for any "Delete X" / "Archive X" / "Remove X" action so the
  * visual signal (red text + icon) is consistent across PostHog scenes.
  */
-export function SceneMenuBarItem({ opensFloatingUi, tooltip, children, ...props }: SceneMenuBarItemProps): JSX.Element {
+export function SceneMenuBarItem({
+    opensFloatingUi,
+    tooltip,
+    children,
+    onClick,
+    ...props
+}: SceneMenuBarItemProps): JSX.Element {
+    const handleClick = (e: MouseEvent<HTMLDivElement>): void => {
+        const dataAttr = (props as Record<string, unknown>)['data-attr']
+        captureSceneMenuBar('scene menu bar item clicked', {
+            item: typeof dataAttr === 'string' ? dataAttr : typeof children === 'string' ? children : undefined,
+        })
+        onClick?.(e)
+    }
     return (
-        <MenubarItem title={tooltip} {...props}>
+        <MenubarItem title={tooltip} onClick={handleClick} {...props}>
             {children}
             {/*
               `-ms-2` cancels MenubarItem's parent flex `gap-2` so the ellipsis sits flush

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -18,7 +18,9 @@ import { Tooltip } from '@posthog/lemon-ui'
 import { ProductSetupButton } from 'lib/components/ProductSetup'
 import { RenderKeybind } from 'lib/components/Shortcuts/ShortcutMenu'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive, buttonPrimitiveVariants } from 'lib/ui/Button/ButtonPrimitives'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
@@ -50,6 +52,9 @@ export function SceneTitlePanelButton({
     const inactiveMaxToolProps: UseMaxToolOptions = { identifier: 'read_data', active: false }
     const { openMax, definition } = useMaxTool(maxToolProps ? { ...maxToolProps, active: true } : inactiveMaxToolProps)
 
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
+
     // Open Info tab if scene has panel content, otherwise default to PostHog AI
     const defaultTab = scenePanelIsPresent ? SidePanelTab.Info : SidePanelTab.Max
 
@@ -59,44 +64,45 @@ export function SceneTitlePanelButton({
 
     return (
         <>
-            <ButtonPrimitive
-                className={buttonClassName}
-                onClick={(e) => {
-                    e.stopPropagation()
-                    e.preventDefault()
-                    if (openMax) {
-                        openMax()
-                    } else {
-                        openSidePanel(SidePanelTab.Max)
+            {!sceneMenuBarEnabled && (
+                <ButtonPrimitive
+                    className={buttonClassName}
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        e.preventDefault()
+                        if (openMax) {
+                            openMax()
+                        } else {
+                            openSidePanel(SidePanelTab.Max)
+                        }
+                    }}
+                    tooltip={
+                        definition ? (
+                            <>
+                                Open PostHog AI
+                                <br />
+                                <div className="flex items-center">
+                                    {definition.icon || <IconWrench />}
+                                    <i className="ml-1.5">{definition.name}</i>
+                                </div>
+                            </>
+                        ) : (
+                            'Open PostHog AI'
+                        )
                     }
-                }}
-                tooltip={
-                    definition ? (
-                        <>
-                            Open PostHog AI
-                            <br />
-                            <div className="flex items-center">
-                                {definition.icon || <IconWrench />}
-                                <i className="ml-1.5">{definition.name}</i>
-                            </div>
-                        </>
-                    ) : (
-                        'Open PostHog AI'
-                    )
-                }
-                tooltipPlacement="bottom-end"
-                tooltipCloseDelayMs={0}
-                iconOnly
-                data-attr="open-context-panel-ai-button"
-            >
-                <div className="relative">
-                    <IconSparkles className="text-ai group-hover/button-primitive:animate-hue-rotate" />
-                    {maxToolProps && (
-                        <IconBrackets className="absolute size-2.5 top-0 -right-1 text-black dark:text-white" />
-                    )}
-                </div>
-            </ButtonPrimitive>
-
+                    tooltipPlacement="bottom-end"
+                    tooltipCloseDelayMs={0}
+                    iconOnly
+                    data-attr="open-context-panel-ai-button"
+                >
+                    <div className="relative">
+                        <IconSparkles className="text-ai group-hover/button-primitive:animate-hue-rotate" />
+                        {maxToolProps && (
+                            <IconBrackets className="absolute size-2.5 top-0 -right-1 text-black dark:text-white" />
+                        )}
+                    </div>
+                </ButtonPrimitive>
+            )}
             {/* Size to mimic lemon button small */}
             <ButtonPrimitive
                 className={cn(buttonClassName, 'group -mr-[2px]')}
@@ -241,7 +247,6 @@ export function SceneTitleSection({
     const sentinelRef = useRef<HTMLDivElement>(null)
     const effectiveDescription = description
     const hasDescription = effectiveDescription != null && (effectiveDescription || canEdit)
-
     // Always include ProductSetupButton alongside other actions
     // Product auto-selection is handled by SceneContent via globalSetupLogic
     const effectiveActions = (

--- a/frontend/src/scenes/notebooks/NotebookScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebookScene.tsx
@@ -9,7 +9,10 @@ import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { cn } from 'lib/utils/css-classes'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
@@ -30,6 +33,7 @@ import { NotebookShareModal } from './Notebook/NotebookShareModal'
 import { NotebookMenu } from './NotebookMenu'
 import { notebookPanelLogic } from './NotebookPanel/notebookPanelLogic'
 import { NotebookSceneLogicProps, notebookSceneLogic } from './notebookSceneLogic'
+import { NotebookSceneMenuBar } from './NotebookSceneMenuBar'
 import { LOCAL_NOTEBOOK_TEMPLATES } from './NotebookTemplates/notebookTemplates'
 import { NotebookTarget } from './types'
 
@@ -55,6 +59,8 @@ export function NotebookScene(): JSX.Element {
     const { selectNotebook, closeSidePanel } = useActions(notebookPanelLogic)
     const { selectedNotebook, visibility } = useValues(notebookPanelLogic)
     const [isMarkdownSourceOpen, setIsMarkdownSourceOpen] = useState(false)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     useEffect(() => {
         if (notebookId === 'new') {
@@ -125,7 +131,8 @@ export function NotebookScene(): JSX.Element {
 
     return (
         <>
-            <div className="flex items-center justify-between">
+            <NotebookSceneMenuBar shortId={notebookId} />
+            <div className={cn('flex items-center justify-between', sceneMenuBarEnabled && 'mt-2')}>
                 <div className="flex gap-2 items-center">
                     <SceneBreadcrumbBackButton />
                     {isTemplate && <LemonTag type="highlight">TEMPLATE</LemonTag>}
@@ -137,7 +144,7 @@ export function NotebookScene(): JSX.Element {
                     <NotebookSyncInfo shortId={notebookId} />
                     <NotebookPresence shortId={notebookId} />
 
-                    <NotebookMenu shortId={notebookId} />
+                    {!sceneMenuBarEnabled && <NotebookMenu shortId={notebookId} />}
 
                     {!isMarkdownNotebook ? (
                         <>
@@ -161,35 +168,43 @@ export function NotebookScene(): JSX.Element {
                                     : ''}
                                 Guide
                             </LemonButton>
-                            <NotebookTableOfContentsButton type="secondary" size="small" />
+                            {/* Moved into the View menu under SCENE_MENU_BAR. */}
+                            {!sceneMenuBarEnabled && <NotebookTableOfContentsButton type="secondary" size="small" />}
                         </>
                     ) : null}
-                    <NotebookKernelInfoButton
-                        type="secondary"
-                        size="small"
-                        onBeforeShowKernelInfo={isMarkdownNotebook ? () => setIsMarkdownSourceOpen(false) : undefined}
-                    />
-                    {!isMarkdownNotebook ? (
+                    {!sceneMenuBarEnabled && (
+                        <NotebookKernelInfoButton
+                            type="secondary"
+                            size="small"
+                            onBeforeShowKernelInfo={
+                                isMarkdownNotebook ? () => setIsMarkdownSourceOpen(false) : undefined
+                            }
+                        />
+                    )}
+                    {/* Markdown notebooks have no width toggle — they always fill the content width. */}
+                    {!sceneMenuBarEnabled && !isMarkdownNotebook && (
                         <NotebookExpandButton type="secondary" size="small" inPanel={false} />
-                    ) : null}
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        onClick={() => {
-                            selectNotebook(notebookId)
-                        }}
-                        tooltip={
-                            <>
-                                Opens the notebook in a context panel, that can be accessed from anywhere in the PostHog
-                                app. This is great for dragging and dropping elements like insights, recordings or even
-                                feature flags into your active notebook.
-                            </>
-                        }
-                        aria-label="Open in context panel"
-                        sideIcon={<IconOpenSidebar />}
-                    >
-                        <span className="hidden lg:inline">Open in context panel</span>
-                    </LemonButton>
+                    )}
+                    {!sceneMenuBarEnabled && (
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => {
+                                selectNotebook(notebookId)
+                            }}
+                            tooltip={
+                                <>
+                                    Opens the notebook in a context panel, that can be accessed from anywhere in the
+                                    PostHog app. This is great for dragging and dropping elements like insights,
+                                    recordings or even feature flags into your active notebook.
+                                </>
+                            }
+                            aria-label="Open in context panel"
+                            sideIcon={<IconOpenSidebar />}
+                        >
+                            <span className="hidden lg:inline">Open in context panel</span>
+                        </LemonButton>
+                    )}
                 </div>
             </div>
 

--- a/frontend/src/scenes/notebooks/NotebookSceneMenuBar.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSceneMenuBar.tsx
@@ -1,0 +1,160 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconCopy, IconDownload, IconOpenSidebar, IconShare, IconTrash } from '@posthog/icons'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { urls } from 'scenes/urls'
+
+import {
+    SceneMenuBar,
+    SceneMenuBarCheckboxItem,
+    SceneMenuBarItem,
+    SceneMenuBarMenu,
+    SceneMenuBarSeparator,
+    SceneMenuBarSubMenu,
+} from '~/layout/scenes/components/SceneMenuBar'
+import { notebooksModel } from '~/models/notebooksModel'
+
+import { isMarkdownNotebookContent } from './Notebook/markdownNotebookV2'
+import { notebookLogic } from './Notebook/notebookLogic'
+import { notebookSettingsLogic } from './Notebook/notebookSettingsLogic'
+import { notebookPanelLogic } from './NotebookPanel/notebookPanelLogic'
+
+const RESOURCE_TYPE = 'notebook'
+
+export function NotebookSceneMenuBar({ shortId }: { shortId: string }): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+        return null
+    }
+    return <NotebookSceneMenuBarInner shortId={shortId} />
+}
+
+function NotebookSceneMenuBarInner({ shortId }: { shortId: string }): JSX.Element {
+    const logic = notebookLogic({ shortId })
+    const { notebook, showHistory, isLocalOnly, content } = useValues(logic)
+    const { openShareModal, duplicateNotebook, exportJSON, downloadMarkdown, copyMarkdown, setShowHistory } =
+        useActions(logic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { showTableOfContents, isExpanded, showKernelInfo } = useValues(notebookSettingsLogic)
+    const { setShowTableOfContents, setIsExpanded, setShowKernelInfo } = useActions(notebookSettingsLogic)
+    const { selectNotebook } = useActions(notebookPanelLogic)
+    const isMarkdownNotebook = isMarkdownNotebookContent(content)
+    const canDelete = !isLocalOnly && !notebook?.is_template
+    const showKernelToggle = !!featureFlags[FEATURE_FLAGS.NOTEBOOK_PYTHON]
+
+    return (
+        <SceneMenuBar>
+            <SceneMenuBarMenu label="File" dataAttr={`${RESOURCE_TYPE}-menubar-file`}>
+                <SceneMenuBarSubMenu label="Export">
+                    {isMarkdownNotebook ? (
+                        <>
+                            <SceneMenuBarItem
+                                onClick={() => downloadMarkdown()}
+                                data-attr={`${RESOURCE_TYPE}-menubar-download-markdown`}
+                            >
+                                <IconDownload />
+                                Download markdown
+                            </SceneMenuBarItem>
+                            <SceneMenuBarItem
+                                onClick={() => copyMarkdown()}
+                                data-attr={`${RESOURCE_TYPE}-menubar-copy-markdown`}
+                            >
+                                <IconCopy />
+                                Copy markdown
+                            </SceneMenuBarItem>
+                        </>
+                    ) : (
+                        <SceneMenuBarItem
+                            onClick={() => exportJSON()}
+                            data-attr={`${RESOURCE_TYPE}-menubar-export-json`}
+                        >
+                            <IconDownload />
+                            Export JSON
+                        </SceneMenuBarItem>
+                    )}
+                </SceneMenuBarSubMenu>
+                <SceneMenuBarItem
+                    opensFloatingUi
+                    onClick={() => openShareModal()}
+                    data-attr={`${RESOURCE_TYPE}-menubar-share`}
+                >
+                    <IconShare />
+                    Share
+                </SceneMenuBarItem>
+                {canDelete && (
+                    <>
+                        <SceneMenuBarSeparator />
+                        <SceneMenuBarItem
+                            variant="destructive"
+                            onClick={() => {
+                                notebooksModel.actions.deleteNotebook(shortId, notebook?.title)
+                                router.actions.push(urls.notebooks())
+                            }}
+                            data-attr={`${RESOURCE_TYPE}-menubar-delete`}
+                        >
+                            <IconTrash />
+                            Delete
+                        </SceneMenuBarItem>
+                    </>
+                )}
+            </SceneMenuBarMenu>
+            <SceneMenuBarMenu label="Edit" dataAttr={`${RESOURCE_TYPE}-menubar-edit`}>
+                <SceneMenuBarItem onClick={() => duplicateNotebook()} data-attr={`${RESOURCE_TYPE}-menubar-duplicate`}>
+                    <IconCopy />
+                    Duplicate
+                </SceneMenuBarItem>
+                <SceneMenuBarSeparator />
+                <SceneMenuBarCheckboxItem
+                    checked={showHistory}
+                    onCheckedChange={(checked) => setShowHistory(checked)}
+                    data-attr={`${RESOURCE_TYPE}-menubar-show-history`}
+                >
+                    Show history
+                </SceneMenuBarCheckboxItem>
+            </SceneMenuBarMenu>
+            <SceneMenuBarMenu label="View" dataAttr={`${RESOURCE_TYPE}-menubar-view`}>
+                {/* Table of contents and width toggle only apply to rich (non-markdown) notebooks. */}
+                {!isMarkdownNotebook && (
+                    <>
+                        <SceneMenuBarCheckboxItem
+                            checked={showTableOfContents}
+                            onCheckedChange={(checked) => setShowTableOfContents(checked)}
+                            data-attr={`${RESOURCE_TYPE}-menubar-toc`}
+                        >
+                            Table of contents
+                        </SceneMenuBarCheckboxItem>
+                        <SceneMenuBarCheckboxItem
+                            checked={isExpanded}
+                            onCheckedChange={(checked) => setIsExpanded(checked)}
+                            data-attr={`${RESOURCE_TYPE}-menubar-fill-width`}
+                        >
+                            Fill content width
+                        </SceneMenuBarCheckboxItem>
+                    </>
+                )}
+                {showKernelToggle && (
+                    <SceneMenuBarCheckboxItem
+                        checked={showKernelInfo}
+                        onCheckedChange={(checked) => setShowKernelInfo(checked)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-kernel-info`}
+                    >
+                        Kernel info
+                    </SceneMenuBarCheckboxItem>
+                )}
+                {/* Only divide when a display toggle actually rendered above. */}
+                {(!isMarkdownNotebook || showKernelToggle) && <SceneMenuBarSeparator />}
+                <SceneMenuBarItem
+                    opensFloatingUi
+                    onClick={() => selectNotebook(shortId)}
+                    data-attr={`${RESOURCE_TYPE}-menubar-open-in-panel`}
+                >
+                    <IconOpenSidebar />
+                    Open in context panel
+                </SceneMenuBarItem>
+            </SceneMenuBarMenu>
+        </SceneMenuBar>
+    )
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
@@ -5,7 +5,6 @@ import { Badge, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
 
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -79,8 +78,8 @@ function NewQueryEngineTooltipBody(): JSX.Element {
 }
 
 export function WebAnalyticsSceneMenuBar(): JSX.Element | null {
-    const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
-    if (!sceneMenuBarEnabled) {
+    const { featureFlags } = useValues(featureFlagLogic)
+    if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
         return null
     }
     return <WebAnalyticsSceneMenuBarInner />

--- a/packages/quill/packages/primitives/src/alert-dialog.tsx
+++ b/packages/quill/packages/primitives/src/alert-dialog.tsx
@@ -55,7 +55,7 @@ function AlertDialogContent({ className, children, ...props }: AlertDialogPrimit
                 data-quill
                 data-quill-portal="modal-content"
                 data-slot="alert-dialog-content"
-                className={cn('quill-dialog__content grid gap-4', className)}
+                className={cn('quill-dialog__content', className)}
                 {...props}
             >
                 {children}

--- a/packages/quill/packages/primitives/src/dialog.css
+++ b/packages/quill/packages/primitives/src/dialog.css
@@ -117,10 +117,10 @@
     .quill-dialog__header {
         padding-inline: 1rem;
         padding-top: 1rem;
+        padding-bottom: 1rem;
     }
 
     .quill-dialog__header:has(~ [data-slot='dialog-body']) {
-        padding-bottom: 1rem;
         border-bottom: 1px solid var(--border);
     }
 

--- a/packages/quill/packages/primitives/src/dialog.tsx
+++ b/packages/quill/packages/primitives/src/dialog.tsx
@@ -67,7 +67,7 @@ function DialogContent({
                 data-quill-portal="modal-content"
                 data-slot="dialog-content"
                 data-size={size}
-                className={cn('quill-dialog__content grid gap-4', className)}
+                className={cn('quill-dialog__content grid', className)}
                 {...props}
             >
                 {children}


### PR DESCRIPTION
## Problem

The `SCENE_MENU_BAR` bar (the Mac-style menu above `SceneTitleSection`) shipped as an alpha with **no explicit capture instrumentation** — only `data-attr` autocapture, which is too noisy/unstable to use as an experiment metric. We want to release the bar as an experiment, which means we need reliable engagement events. Separately, the notebook scene hadn't adopted the bar yet.

## Changes

**Central instrumentation.** Capture now lives in the `SceneMenuBar` primitives (`SceneMenuBar.tsx`), so every scene that adopts the bar reports engagement with no per-scene wiring. Scene id is read off `sceneLogic` without subscribing, so capture never triggers a re-render. Events:

| Event | Fires when | Props |
| --- | --- | --- |
| `scene menu bar shown` | bar mounts | `scene` |
| `scene menu bar menu opened` | a top-level menu opens | `scene`, `menu` |
| `scene menu bar item clicked` | a menu item is clicked | `scene`, `item` |
| `scene menu bar right link clicked` | Docs / Support / PostHog AI clicked | `scene`, `link` |

Exposure is already covered by `$feature_flag_called` since each scene reads the flag via `featureFlagLogic`. These four events are the engagement metrics for the experiment; the flag stays a plain boolean (the experiment object is created in-app, not in this repo).

**Notebook migration.** New `NotebookSceneMenuBar.tsx` maps the legacy `NotebookMenu` dropdown and the scene's header view-controls into a **File / Edit / View** bar:
- **File** — Export (JSON or markdown download / copy markdown), Share…, Delete
- **Edit** — Duplicate, Show history toggle
- **View** — Table of contents, Fill content width, Kernel info (all display toggles backed by `notebookSettingsLogic`), Open in context panel

The legacy `NotebookMenu` dropdown and the redundant header buttons (ToC, kernel, expand, open-in-panel) hide when the flag is on; the Guide button and collab/sync/presence indicators stay. Table of contents and Fill content width only render for rich (non-markdown) notebooks.

**Consistency.** Standardized the flag gate on `featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]` (WebAnalytics was the lone `useFeatureFlag` outlier). Under the flag, `SceneTitleSection` hides its "Open PostHog AI" button since the bar's right cluster already provides it.

`View` follows `Edit` per the canonical menu order, and holds display/layout toggles — matching the existing WebAnalytics View menu precedent rather than the skill's narrower cross-resource-only wording.

## How did you test this code?

I'm an agent. I ran the automated checks I have access to; I did **not** manually click through the UI.
- `oxlint` — clean on all changed files
- `oxfmt` / lint-staged format — clean
- `pnpm typescript:check` — the five changed files report zero type errors (regenerated kea types via `typegen:write` first, since the working tree had stale `*Type.ts` drift). The only remaining repo-wide errors are pre-existing and unrelated (`DebugCHQueriesType.ts`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked: `/scene-menu-bar` (the repo's own convention skill for this surface).

Decisions worth flagging for review:
- **Instrumentation location** — chose central capture in the shared primitives over per-scene `eventUsageLogic` actions, so coverage is automatic for current and future scenes and the event shape stays consistent.
- **Notebook is not a clean drop-in** — `NotebookScene` has a bespoke legacy header (no `SceneTitleSection`), so the bar mounts at the top and the old controls are hidden under the flag rather than removed. A fuller header migration to `SceneContent`/`SceneTitleSection` is a reasonable follow-up.
- **View menu semantics** — put display/layout toggles (ToC, width, kernel) in View following the WebAnalytics precedent; the `scene-menu-bar` skill currently describes View more narrowly, so reviewers may want to broaden that wording.

Still missing the bar (clean drop-ins on `SceneTitleSection`, for a follow-up): Group, single Person, HogFunction, BatchExport, Definition view, and others.
