### PR TITLE
fix(property-defs): dedupe property definitions within a batch write

### DIFF
--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -219,10 +219,15 @@ impl PropertyDefinitionsBatch {
             group_type_index.unwrap_or(-1),
         );
         if let Some(&idx) = self.seen.get(&dedup_key) {
-            // Last write wins, mirroring the DO UPDATE: refresh the columns the write can change.
+            // Last write wins for the single row we'll write, mirroring the DO UPDATE: refresh the
+            // columns the write can change.
             self.are_numerical[idx] = pd.is_numerical;
             self.property_types[idx] = property_type;
-            self.cached[idx] = Update::Property(pd);
+            // `cached` stays append-only: every appended update was marked in the shared cache by
+            // the producer, so a failed batch must uncache all of them (a superseded duplicate may
+            // have a different property_type and therefore a different cache key). Overwriting here
+            // would leak the older key, leaving it cached as if persisted and never retried.
+            self.cached.push(Update::Property(pd));
             return;
         }
         self.seen.insert(dedup_key, self.ids.len());
@@ -677,5 +682,18 @@ mod tests {
 
         assert_eq!(batch.len(), 1);
         assert_eq!(batch.property_types, vec![Some("Numeric".to_string())]);
+    }
+
+    #[test]
+    fn append_keeps_every_update_cached_for_uncaching() {
+        // Dedupe only collapses the row we write; `cached` must still hold every appended update
+        // so a failed batch uncaches all of them, including superseded duplicates that carry a
+        // different cache key.
+        let mut batch = PropertyDefinitionsBatch::new(100);
+        batch.append(prop_def("revenue", None));
+        batch.append(prop_def("revenue", Some(PropertyValueType::Numeric)));
+
+        assert_eq!(batch.len(), 1); // one row written
+        assert_eq!(batch.cached.len(), 2); // both updates still uncacheable on failure
     }
 }

--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
@@ -146,6 +146,13 @@ impl EventDefinitionsBatch {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PropertyDefinitionsBatch {
     batch_size: usize,
+    // Maps a row's ON CONFLICT key -> its index in the parallel vectors below, so append() can
+    // collapse duplicates within a single batch. The write does
+    //   INSERT ... ON CONFLICT (coalesce(project_id, team_id), name, type, coalesce(group_type_index, -1)) DO UPDATE
+    // and Postgres rejects a statement that proposes two rows with the same conflict key
+    // ("ON CONFLICT DO UPDATE command cannot affect row a second time", SQLSTATE 21000), which
+    // rolls back the entire batch. Deduping on insert keeps each write to one row per key.
+    seen: HashMap<(i64, String, i16, i16), usize>,
     pub ids: Vec<Uuid>,
     pub team_ids: Vec<i32>,
     pub project_ids: Vec<i64>,
@@ -162,6 +169,7 @@ impl PropertyDefinitionsBatch {
     pub fn new(batch_size: usize) -> Self {
         Self {
             batch_size,
+            seen: HashMap::with_capacity(batch_size),
             ids: Vec::with_capacity(batch_size),
             team_ids: Vec::with_capacity(batch_size),
             project_ids: Vec::with_capacity(batch_size),
@@ -199,6 +207,25 @@ impl PropertyDefinitionsBatch {
         }
 
         let property_type: Option<String> = pd.property_type.clone().map(|pvt| pvt.to_string());
+
+        // Collapse duplicates on the write's ON CONFLICT key so a property name that appears more
+        // than once in a batch can't make Postgres raise a "cannot affect row a second time"
+        // cardinality error and roll back the whole batch (issue #64253). project_id is always set
+        // here, so coalesce(project_id, team_id) is just project_id.
+        let dedup_key = (
+            pd.project_id,
+            pd.name.clone(),
+            pd.event_type as i16,
+            group_type_index.unwrap_or(-1),
+        );
+        if let Some(&idx) = self.seen.get(&dedup_key) {
+            // Last write wins, mirroring the DO UPDATE: refresh the columns the write can change.
+            self.are_numerical[idx] = pd.is_numerical;
+            self.property_types[idx] = property_type;
+            self.cached[idx] = Update::Property(pd);
+            return;
+        }
+        self.seen.insert(dedup_key, self.ids.len());
 
         self.ids.push(Uuid::now_v7());
         self.team_ids.push(pd.team_id);
@@ -585,5 +612,70 @@ async fn write_event_definitions_batch(
                 return Ok(());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PropertyValueType;
+
+    fn prop_def(name: &str, property_type: Option<PropertyValueType>) -> PropertyDefinition {
+        PropertyDefinition {
+            team_id: 1,
+            project_id: 1,
+            name: name.to_string(),
+            is_numerical: false,
+            property_type,
+            event_type: PropertyParentType::Event,
+            group_type_index: None,
+            property_type_format: None,
+            volume_30_day: None,
+            query_usage_30_day: None,
+        }
+    }
+
+    #[test]
+    fn append_dedups_repeated_keys_within_batch() {
+        // A common property name appearing more than once in a batch must collapse to a single
+        // row. Otherwise the ON CONFLICT write proposes two rows with the same conflict key and
+        // Postgres aborts the whole batch with SQLSTATE 21000 (issue #64253).
+        let mut batch = PropertyDefinitionsBatch::new(100);
+        batch.append(prop_def("brand", None));
+        batch.append(prop_def("brand", None));
+        batch.append(prop_def("current_page", None));
+
+        assert_eq!(batch.len(), 2);
+        assert_eq!(
+            batch.names,
+            vec!["brand".to_string(), "current_page".to_string()]
+        );
+    }
+
+    #[test]
+    fn append_keeps_rows_that_differ_on_the_conflict_key() {
+        // Same name but a different parent type is a different unique key, so it must not collapse.
+        let mut event_prop = prop_def("name", None);
+        event_prop.event_type = PropertyParentType::Event;
+        let mut person_prop = prop_def("name", None);
+        person_prop.event_type = PropertyParentType::Person;
+
+        let mut batch = PropertyDefinitionsBatch::new(100);
+        batch.append(event_prop);
+        batch.append(person_prop);
+
+        assert_eq!(batch.len(), 2);
+    }
+
+    #[test]
+    fn append_last_write_wins_for_mutable_columns() {
+        // The write's DO UPDATE refreshes property_type/is_numerical, so the last occurrence in
+        // the batch is the one that should survive the dedup.
+        let mut batch = PropertyDefinitionsBatch::new(100);
+        batch.append(prop_def("revenue", None));
+        batch.append(prop_def("revenue", Some(PropertyValueType::Numeric)));
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch.property_types, vec![Some("Numeric".to_string())]);
     }
 }

--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -87,6 +87,13 @@ impl EventPropertiesBatch {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EventDefinitionsBatch {
     batch_size: usize,
+    // Maps a row's ON CONFLICT key -> its index in the parallel vectors below, so append() can
+    // collapse duplicates within a single batch. The write does
+    //   INSERT ... ON CONFLICT (coalesce(project_id, team_id::bigint), name) DO UPDATE SET last_seen_at=...
+    // and Postgres rejects a statement that proposes two rows with the same conflict key
+    // ("ON CONFLICT DO UPDATE command cannot affect row a second time", SQLSTATE 21000), which
+    // rolls back the entire batch. Deduping on insert keeps each write to one row per key (issue #64253).
+    seen: HashMap<(i64, String), usize>,
     pub ids: Vec<Uuid>,
     pub names: Vec<String>,
     pub team_ids: Vec<i32>,
@@ -100,6 +107,7 @@ impl EventDefinitionsBatch {
     pub fn new(batch_size: usize) -> Self {
         Self {
             batch_size,
+            seen: HashMap::with_capacity(batch_size),
             ids: Vec::with_capacity(batch_size),
             names: Vec::with_capacity(batch_size),
             team_ids: Vec::with_capacity(batch_size),
@@ -110,6 +118,25 @@ impl EventDefinitionsBatch {
     }
 
     pub fn append(&mut self, ed: EventDefinition) {
+        // Collapse duplicates on the write's ON CONFLICT key so a repeated event name in one batch
+        // can't make Postgres raise a "cannot affect row a second time" cardinality error and roll
+        // back the whole batch (issue #64253). project_id is always set here, so
+        // coalesce(project_id, team_id) is just project_id.
+        let dedup_key = (ed.project_id, ed.name.clone());
+        if let Some(&idx) = self.seen.get(&dedup_key) {
+            // Keep the latest last_seen_at, mirroring the DO UPDATE that only advances it.
+            if ed.last_seen_at > self.last_seen_ats[idx] {
+                self.last_seen_ats[idx] = ed.last_seen_at;
+            }
+            // `cached` stays append-only: every appended update was marked in the shared cache by
+            // the producer, so a failed batch must uncache all of them (a superseded duplicate with
+            // a different last_seen_at carries a different cache key). Overwriting here would leak
+            // the older key, leaving it cached as if persisted and never retried.
+            self.cached.push(Update::Event(ed));
+            return;
+        }
+        self.seen.insert(dedup_key, self.ids.len());
+
         self.ids.push(Uuid::now_v7());
         self.names.push(ed.name.clone());
         self.team_ids.push(ed.team_id);
@@ -692,6 +719,63 @@ mod tests {
         let mut batch = PropertyDefinitionsBatch::new(100);
         batch.append(prop_def("revenue", None));
         batch.append(prop_def("revenue", Some(PropertyValueType::Numeric)));
+
+        assert_eq!(batch.len(), 1); // one row written
+        assert_eq!(batch.cached.len(), 2); // both updates still uncacheable on failure
+    }
+
+    fn event_def(name: &str, last_seen_at: DateTime<Utc>) -> EventDefinition {
+        EventDefinition {
+            name: name.to_string(),
+            team_id: 1,
+            project_id: 1,
+            last_seen_at,
+        }
+    }
+
+    #[test]
+    fn event_append_dedups_repeated_keys_within_batch() {
+        // A repeated event name in one batch must collapse to a single row. Otherwise the
+        // ON CONFLICT DO UPDATE write proposes two rows with the same conflict key and Postgres
+        // aborts the whole batch with SQLSTATE 21000 (issue #64253), just like property defs.
+        let ts = Utc::now();
+        let mut batch = EventDefinitionsBatch::new(100);
+        batch.append(event_def("$pageview", ts));
+        batch.append(event_def("$pageview", ts));
+        batch.append(event_def("$autocapture", ts));
+
+        assert_eq!(batch.len(), 2);
+        assert_eq!(
+            batch.names,
+            vec!["$pageview".to_string(), "$autocapture".to_string()]
+        );
+    }
+
+    #[test]
+    fn event_append_keeps_latest_last_seen_at() {
+        // The write's DO UPDATE only advances last_seen_at, so the deduped row must carry the
+        // greatest last_seen_at among the collapsed duplicates regardless of arrival order.
+        let earlier = Utc::now();
+        let later = earlier + Duration::from_secs(3600);
+        let mut batch = EventDefinitionsBatch::new(100);
+        batch.append(event_def("$pageview", later));
+        batch.append(event_def("$pageview", earlier));
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch.last_seen_ats, vec![later]);
+    }
+
+    #[test]
+    fn event_append_keeps_every_update_cached_for_uncaching() {
+        // Dedupe collapses the written row, but `cached` must keep every appended update so a
+        // failed batch uncaches all of them. EventDefinition hashes on last_seen_at too, so a
+        // superseded duplicate carries a different cache key and would leak if dropped.
+        let mut batch = EventDefinitionsBatch::new(100);
+        batch.append(event_def("$pageview", Utc::now()));
+        batch.append(event_def(
+            "$pageview",
+            Utc::now() + Duration::from_secs(3600),
+        ));
 
         assert_eq!(batch.len(), 1); // one row written
         assert_eq!(batch.cached.len(), 2); // both updates still uncacheable on failure


### PR DESCRIPTION
## Problem

The v2 property-defs writer buffers property definitions and flushes each batch with a single `INSERT ... SELECT unnest(...) ON CONFLICT (coalesce(project_id, team_id), name, type, coalesce(group_type_index, -1)) DO UPDATE`. `PropertyDefinitionsBatch::append` never deduplicates its rows, so when a common property name (`brand`, `current_page` — attached to nearly every event) shows up more than once in one batch, the statement proposes two rows with the same conflict key. Postgres rejects that with `ON CONFLICT DO UPDATE command cannot affect row a second time` (SQLSTATE 21000) and rolls back the **whole** batch, including the unrelated, genuinely-new definitions in it. On bulk imports and high-volume ingest this drops most property definitions, so properties are missing from the Trends/Funnels/Paths filter dropdowns even though the underlying events landed in ClickHouse.

Closes #64253.

## Changes

- `PropertyDefinitionsBatch` now tracks each row's `ON CONFLICT` key `(project_id, name, type, group_type_index ?? -1)` in a `seen` map. `append` collapses a repeat of a key already in the batch instead of pushing a second row, last-write-wins on the columns the write can change (`property_type`, `is_numerical`) to mirror the existing `DO UPDATE`. `project_id` is non-null on these rows, so `coalesce(project_id, team_id)` is just `project_id`.
- Unit tests covering: dedupe within a batch, keeping rows that differ on the key (e.g. same name, different parent type), and last-write-wins on the mutable columns.

One file, `rust/property-defs-rs/src/batch_ingestion.rs`, +93/-1.

## How did you test this code?

I'm an agent (Claude Code); this lists only automated tests I actually ran — no manual or cluster testing.

- `cargo test -p property-defs-rs --lib` — the 3 new tests plus the existing suite pass (11 total). I also confirmed the new tests **fail** with the dedupe removed (the batch keeps the duplicate rows) and pass with it in place, so they genuinely guard the fix.
- `cargo fmt -p property-defs-rs --check` and `cargo clippy -p property-defs-rs --lib` are clean.
- The fix is verified at the batch-construction layer, which needs no database. I did not run the `#[sqlx::test]` integration path in `tests/batch_ingestion.rs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

- Built with Claude Code. The issue reporter pinned the file and root cause; I confirmed it against the `ON CONFLICT` target in `write_property_definitions_batch` and matched the dedupe key to that target field-for-field.
- Deduping in `append` rather than at write time keeps the `seen` map scoped to the batch and leaves the write path untouched. Last-write-wins (not first) because the `DO UPDATE` refreshes `property_type`/`is_numerical`, so the most recent observation of a property should be the one that survives.
- No repo skills applied — this is a Rust crate, and the mandatory skills cover DRF/migrations/frontend.
