### PR TITLE
fix(mixpanel): retry export stream drops in-process

### DIFF
--- a/posthog/temporal/data_imports/sources/mixpanel/mixpanel.py
+++ b/posthog/temporal/data_imports/sources/mixpanel/mixpanel.py
@@ -277,6 +277,10 @@ def _stream_export_day(
             return
         except _STREAM_RETRYABLE_ERRORS as e:
             if attempt == STREAM_MAX_ATTEMPTS:
+                logger.warning(
+                    f"Mixpanel export: stream for {from_date} dropped ({type(e).__name__}); "
+                    f"giving up after {STREAM_MAX_ATTEMPTS} attempts"
+                )
                 raise
             backoff = min(60.0, 2.0 * 2 ** (attempt - 1)) + random.uniform(0, 1)
             logger.warning(

--- a/posthog/temporal/data_imports/sources/mixpanel/mixpanel.py
+++ b/posthog/temporal/data_imports/sources/mixpanel/mixpanel.py
@@ -1,3 +1,5 @@
+import time
+import random
 import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
@@ -230,6 +232,60 @@ def _request(
     return _check_response(response, url, logger)
 
 
+# The export body is read lazily while iterating `iter_lines`, i.e. outside `_request`'s
+# retry. A connection dropped mid-day surfaces there (`requests` wraps the underlying
+# `IncompleteRead` as `ChunkedEncodingError`), so it must be retried separately or a single
+# truncated download fails the whole sync.
+STREAM_MAX_ATTEMPTS = 5
+_STREAM_RETRYABLE_ERRORS = (
+    requests.exceptions.ChunkedEncodingError,
+    requests.ConnectionError,
+    requests.ReadTimeout,
+)
+
+
+def _stream_export_day(
+    url: str,
+    *,
+    username: str,
+    secret: str,
+    project_id: str,
+    from_date: str,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    """Stream one UTC day of the raw export as `CHUNK_SIZE` batches.
+
+    On a transient mid-stream drop the whole day is re-fetched from the start; already-yielded
+    rows are re-emitted, but merge dedupes them on `$insert_id` (the same property the day-level
+    resume relies on)."""
+    params = {"from_date": from_date, "to_date": from_date, "project_id": project_id}
+    for attempt in range(1, STREAM_MAX_ATTEMPTS + 1):
+        try:
+            with _request(
+                "GET", url, username=username, secret=secret, logger=logger, params=params, stream=True
+            ) as response:
+                batch: list[dict[str, Any]] = []
+                for line in response.iter_lines():
+                    if not line:
+                        continue
+                    batch.append(_flatten_event(orjson.loads(line)))
+                    if len(batch) >= CHUNK_SIZE:
+                        yield batch
+                        batch = []
+                if batch:
+                    yield batch
+            return
+        except _STREAM_RETRYABLE_ERRORS as e:
+            if attempt == STREAM_MAX_ATTEMPTS:
+                raise
+            backoff = min(60.0, 2.0 * 2 ** (attempt - 1)) + random.uniform(0, 1)
+            logger.warning(
+                f"Mixpanel export: stream for {from_date} dropped ({type(e).__name__}); "
+                f"re-fetching day (attempt {attempt}/{STREAM_MAX_ATTEMPTS})"
+            )
+            time.sleep(backoff)
+
+
 def _iter_export(
     region: str,
     username: str,
@@ -255,22 +311,14 @@ def _iter_export(
         logger.debug(f"Mixpanel export: resuming from {resumed_from.isoformat()}")
 
     while current <= end_date:
-        from_date = current.isoformat()
-        params = {"from_date": from_date, "to_date": from_date, "project_id": project_id}
-
-        with _request(
-            "GET", url, username=username, secret=secret, logger=logger, params=params, stream=True
-        ) as response:
-            batch: list[dict[str, Any]] = []
-            for line in response.iter_lines():
-                if not line:
-                    continue
-                batch.append(_flatten_event(orjson.loads(line)))
-                if len(batch) >= CHUNK_SIZE:
-                    yield batch
-                    batch = []
-            if batch:
-                yield batch
+        yield from _stream_export_day(
+            url,
+            username=username,
+            secret=secret,
+            project_id=project_id,
+            from_date=current.isoformat(),
+            logger=logger,
+        )
 
         # Day complete: advance the resume cursor so a restart skips finished days.
         next_day = current + timedelta(days=1)

--- a/posthog/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/posthog/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -40,12 +40,16 @@ class FakeResponse:
         lines: Optional[list[bytes]] = None,
         text: str = "",
         headers: Optional[dict[str, str]] = None,
+        error: Optional[BaseException] = None,
     ) -> None:
         self.status_code = status_code
         self._json = json_data
         self._lines = lines or []
         self.text = text
         self.headers = headers or {}
+        # Raised after the available lines are yielded, to simulate a connection dropped
+        # mid-stream while reading the export body.
+        self._error = error
 
     @property
     def ok(self) -> bool:
@@ -55,7 +59,9 @@ class FakeResponse:
         return self._json
 
     def iter_lines(self):
-        return iter(self._lines)
+        yield from self._lines
+        if self._error is not None:
+            raise self._error
 
     def raise_for_status(self) -> None:
         if not self.ok:
@@ -302,6 +308,76 @@ class TestExportIterator:
         rows = self._run(manager, date(2024, 1, 1), date(2024, 1, 1), [FakeResponse(lines=[])])
         assert rows == []
         assert [s.from_date for s in manager.saved] == ["2024-01-02"]
+
+
+class TestExportStreamRetry:
+    def _line(self, insert_id: str) -> bytes:
+        return orjson.dumps({"event": "A", "properties": {"time": 1, "$insert_id": insert_id}})
+
+    def test_retries_day_on_mid_stream_drop(self) -> None:
+        manager = FakeManager()
+        incomplete_read = requests.exceptions.ChunkedEncodingError(
+            "Connection broken: IncompleteRead(237 bytes read, 275 more expected)"
+        )
+        failing = FakeResponse(lines=[self._line("i1")], error=incomplete_read)
+        succeeding = FakeResponse(lines=[self._line("i1")])
+        with (
+            patch.object(mp, "_request", side_effect=[failing, succeeding]) as mock_request,
+            patch.object(mp.time, "sleep") as mock_sleep,
+        ):
+            batches = list(
+                mp._iter_export(
+                    "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
+                )  # type: ignore[arg-type]
+            )
+
+        rows = [row for batch in batches for row in batch]
+        assert [r["$insert_id"] for r in rows] == ["i1"]
+        # The same day is fetched twice; the dropped attempt yields nothing before the retry.
+        assert mock_request.call_count == 2
+        assert {c.kwargs["params"]["from_date"] for c in mock_request.call_args_list} == {"2024-01-01"}
+        mock_sleep.assert_called_once()
+        # Cursor only advances once the day finally completes.
+        assert [s.from_date for s in manager.saved] == ["2024-01-02"]
+
+    def test_gives_up_after_max_attempts(self) -> None:
+        manager = FakeManager()
+        responses = [
+            FakeResponse(lines=[], error=requests.exceptions.ChunkedEncodingError("Connection broken"))
+            for _ in range(mp.STREAM_MAX_ATTEMPTS)
+        ]
+        with (
+            patch.object(mp, "_request", side_effect=responses) as mock_request,
+            patch.object(mp.time, "sleep") as mock_sleep,
+        ):
+            with pytest.raises(requests.exceptions.ChunkedEncodingError):
+                list(
+                    mp._iter_export(
+                        "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
+                    )  # type: ignore[arg-type]
+                )
+
+        assert mock_request.call_count == mp.STREAM_MAX_ATTEMPTS
+        assert mock_sleep.call_count == mp.STREAM_MAX_ATTEMPTS - 1
+        # The failing day's cursor is never advanced.
+        assert manager.saved == []
+
+    def test_does_not_retry_unrelated_error(self) -> None:
+        manager = FakeManager()
+        failing = FakeResponse(lines=[], error=ValueError("malformed payload"))
+        with (
+            patch.object(mp, "_request", side_effect=[failing]) as mock_request,
+            patch.object(mp.time, "sleep") as mock_sleep,
+        ):
+            with pytest.raises(ValueError):
+                list(
+                    mp._iter_export(
+                        "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
+                    )  # type: ignore[arg-type]
+                )
+
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 class TestEngageIterator:

--- a/posthog/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/posthog/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -316,6 +316,7 @@ class TestExportStreamRetry:
 
     def test_retries_day_on_mid_stream_drop(self) -> None:
         manager = FakeManager()
+        day = date(2024, 1, 1)
         incomplete_read = requests.exceptions.ChunkedEncodingError(
             "Connection broken: IncompleteRead(237 bytes read, 275 more expected)"
         )
@@ -326,9 +327,7 @@ class TestExportStreamRetry:
             patch.object(mp.time, "sleep") as mock_sleep,
         ):
             batches = list(
-                mp._iter_export(
-                    "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
-                )  # type: ignore[arg-type]
+                mp._iter_export("us", "u", "s", "123", LOGGER, manager, start_date=day, end_date=day)  # type: ignore[arg-type]
             )
 
         rows = [row for batch in batches for row in batch]
@@ -342,6 +341,7 @@ class TestExportStreamRetry:
 
     def test_gives_up_after_max_attempts(self) -> None:
         manager = FakeManager()
+        day = date(2024, 1, 1)
         responses = [
             FakeResponse(lines=[], error=requests.exceptions.ChunkedEncodingError("Connection broken"))
             for _ in range(mp.STREAM_MAX_ATTEMPTS)
@@ -352,9 +352,7 @@ class TestExportStreamRetry:
         ):
             with pytest.raises(requests.exceptions.ChunkedEncodingError):
                 list(
-                    mp._iter_export(
-                        "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
-                    )  # type: ignore[arg-type]
+                    mp._iter_export("us", "u", "s", "123", LOGGER, manager, start_date=day, end_date=day)  # type: ignore[arg-type]
                 )
 
         assert mock_request.call_count == mp.STREAM_MAX_ATTEMPTS
@@ -364,6 +362,7 @@ class TestExportStreamRetry:
 
     def test_does_not_retry_unrelated_error(self) -> None:
         manager = FakeManager()
+        day = date(2024, 1, 1)
         failing = FakeResponse(lines=[], error=ValueError("malformed payload"))
         with (
             patch.object(mp, "_request", side_effect=[failing]) as mock_request,
@@ -371,9 +370,7 @@ class TestExportStreamRetry:
         ):
             with pytest.raises(ValueError):
                 list(
-                    mp._iter_export(
-                        "us", "u", "s", "123", LOGGER, manager, start_date=date(2024, 1, 1), end_date=date(2024, 1, 1)
-                    )  # type: ignore[arg-type]
+                    mp._iter_export("us", "u", "s", "123", LOGGER, manager, start_date=day, end_date=day)  # type: ignore[arg-type]
                 )
 
         assert mock_request.call_count == 1


### PR DESCRIPTION
## Problem

The Mixpanel data warehouse import surfaced an `IncompleteRead(237 bytes read, 275 more expected)` crash from `_iter_export` in error tracking — a connection dropped partway through streaming a day's raw event export.

The source already retries transient connection errors (`ReadTimeout`, `ConnectionError`) in `_request`, but the export uses `stream=True`: the response body is consumed lazily by `iter_lines()` in `_iter_export`, *after* `_request` has returned. So a mid-stream drop — which `requests` raises as `ChunkedEncodingError` wrapping the underlying `http.client.IncompleteRead` — escapes that retry layer entirely and fails the whole sync on a single truncated download.

This is a transient infrastructure error, so it should stay retryable (not become a non-retryable error). The bug is that the retry never reaches the streaming read.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ee8a1-b731-7f20-b0fc-f32a815ad8ca

## Changes

Extract the per-day streaming into `_stream_export_day`, wrapped in a bounded in-process retry (`STREAM_MAX_ATTEMPTS = 5`, exponential backoff with jitter) that re-fetches the day on a transient mid-stream drop (`ChunkedEncodingError` / `ConnectionError` / `ReadTimeout`). Non-transient errors propagate immediately, unchanged.

Re-fetching a day re-emits any rows already yielded from the failed attempt, but merge dedupes them on `$insert_id` — the same property the existing day-level resume already relies on (a crash re-fetches the in-flight day). This mirrors the established pattern in the codebase where sibling sources treat `ChunkedEncodingError` as a retryable transient drop (e.g. `mailerlite`, `notion`).

This is scoped to the Mixpanel export path; the global pipeline retry policy is untouched.

## How did you test this code?

I'm an agent. I added and ran automated tests (`posthog/temporal/data_imports/sources/mixpanel/test_mixpanel.py`, 65 passing). New regression tests cover:

- a mid-stream `ChunkedEncodingError` re-fetches the same day and yields the rows, advancing the resume cursor only after the day completes;
- the retry gives up after `STREAM_MAX_ATTEMPTS` and re-raises, never advancing the cursor;
- a non-transient error (e.g. `ValueError`) propagates immediately without retry.

`ruff check` and `ruff format` are clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Mixpanel import source. Investigation used the PostHog error-tracking MCP tools to confirm the issue (stack frame `_iter_export`, line consuming `response.iter_lines()`), then read the source and sibling sources.

Decision: this is a transient connection drop, so it must remain retryable rather than be added to `NonRetryableErrors`. The real gap is that mixpanel's retry layer (`_request`) doesn't cover the lazy streaming body read — confirmed the same structural gap exists in `gladly`/`amplitude`, and that `mailerlite`/`notion` already treat `ChunkedEncodingError` as retryable. Fix re-fetches the whole day on a mid-stream drop, relying on the source's existing `$insert_id` merge-dedup guarantee, rather than buffering the day (which would defeat the deliberate line-by-line streaming) or restructuring to spool-to-temp-file (out of scope).

Checked for duplicates: no open PR addresses this; the maintainer's open PRs follow the same "retry transient X in-process" pattern but none touch the mixpanel streaming path.
