### PR TITLE
fix(mssql): retry transient DBPROCESS-dead drops during schema discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -9,10 +9,11 @@ just holds an instance and validates credentials.
 
 from __future__ import annotations
 
+import time
 import collections
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, TypeVar
 
 import pyarrow as pa
 import pymssql
@@ -64,6 +65,50 @@ _IDENTIFIER_QUOTER = BracketIdentifierQuoter()
 # Schemas every MSSQL database ships with that never hold user tables. `db_*` covers the
 # fixed database roles (db_owner, db_datareader, …), which also surface as schemas.
 SYSTEM_MSSQL_SCHEMAS = ("sys", "guest", "INFORMATION_SCHEMA")
+
+_T = TypeVar("_T")
+
+# DB-Lib error 20047 — "DBPROCESS is dead or not enabled". The TDS connection died mid-stream (an
+# idle cull, a failover, a brief network blip), leaving pymssql's dbprocess dead so the in-flight
+# fetch raises. A fresh connection recovers, so this is transient rather than a config error.
+_TRANSIENT_CONNECTION_ERROR_SUBSTRINGS = ("DBPROCESS is dead or not enabled",)
+_MAX_DISCOVERY_CONNECTION_ATTEMPTS = 5
+
+
+def _is_transient_connection_error(error: BaseException) -> bool:
+    """True for a mid-stream TDS connection death that a fresh connection recovers from."""
+    message = " ".join(str(arg) for arg in error.args) if error.args else str(error)
+    return any(substring in message for substring in _TRANSIENT_CONNECTION_ERROR_SUBSTRINGS)
+
+
+def retry_on_transient_connection_error(
+    operation: Callable[[], _T],
+    *,
+    max_attempts: int = _MAX_DISCOVERY_CONNECTION_ATTEMPTS,
+) -> _T:
+    """Run `operation`, retrying a transient MSSQL connection death with bounded backoff.
+
+    Mirrors the in-process discovery retry the Postgres and MySQL sources use: a momentary
+    connection death recovers on a fresh connect-and-discover cycle, so retry it here instead of
+    failing schema discovery on the first blip and surfacing it as captured error-tracking noise.
+    Permanent errors re-raise immediately — `_is_transient_connection_error` only matches the
+    transient mid-stream drop.
+    """
+    attempt = 0
+    while True:
+        try:
+            return operation()
+        except pymssql.Error as e:
+            attempt += 1
+            if attempt >= max_attempts or not _is_transient_connection_error(e):
+                raise
+            structlog.get_logger().warning(
+                "Transient MSSQL connection death during schema discovery; retrying",
+                attempt=attempt,
+                max_attempts=max_attempts,
+                exc_info=e,
+            )
+            time.sleep(min(2 * attempt, 30))
 
 
 def _non_system_schema_clause(column: str) -> tuple[str, dict[str, str]]:

--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -71,14 +71,14 @@ _T = TypeVar("_T")
 # DB-Lib error 20047 — "DBPROCESS is dead or not enabled". The TDS connection died mid-stream (an
 # idle cull, a failover, a brief network blip), leaving pymssql's dbprocess dead so the in-flight
 # fetch raises. A fresh connection recovers, so this is transient rather than a config error.
-_TRANSIENT_CONNECTION_ERROR_SUBSTRINGS = ("DBPROCESS is dead or not enabled",)
+_TRANSIENT_CONNECTION_ERROR = "DBPROCESS is dead or not enabled"
 _MAX_DISCOVERY_CONNECTION_ATTEMPTS = 5
 
 
 def _is_transient_connection_error(error: BaseException) -> bool:
     """True for a mid-stream TDS connection death that a fresh connection recovers from."""
     message = " ".join(str(arg) for arg in error.args) if error.args else str(error)
-    return any(substring in message for substring in _TRANSIENT_CONNECTION_ERROR_SUBSTRINGS)
+    return _TRANSIENT_CONNECTION_ERROR in message
 
 
 def retry_on_transient_connection_error(

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -15,9 +15,10 @@ from posthog.exceptions_capture import capture_exception
 from posthog.temporal.data_imports.sources.common.base import FieldType
 from posthog.temporal.data_imports.sources.common.mixins import SSHTunnelMixin, ValidateDatabaseHostMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.common.sql.base import SQLSource
 from posthog.temporal.data_imports.sources.generated_configs import MSSQLSourceConfig
-from posthog.temporal.data_imports.sources.mssql.mssql import MSSQLImplementation
+from posthog.temporal.data_imports.sources.mssql.mssql import MSSQLImplementation, retry_on_transient_connection_error
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -97,6 +98,26 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # fully re-synced to adopt the new type.
             "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
         }
+
+    def get_schemas(
+        self,
+        config: MSSQLSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Schema discovery opens a fresh connection on its own periodic cadence. A transient TDS
+        # connection death mid-fetch (DB-Lib 20047, "DBPROCESS is dead or not enabled") recovers on
+        # a fresh connection, so retry the whole connect-and-discover cycle in-process rather than
+        # failing the discovery activity — and surfacing captured error-tracking noise — on the
+        # first blip.
+        def discover() -> list[SourceSchema]:
+            return super(MSSQLSource, self).get_schemas(
+                config, team_id, with_counts=with_counts, names=names, force_refresh=force_refresh
+            )
+
+        return retry_on_transient_connection_error(discover)
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import MagicMock
 
+import pymssql
+
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.common.sql import Table, TableStats
 from posthog.temporal.data_imports.sources.common.sql.predicates import ColumnTypeCategory, ValidatedRowFilter
@@ -9,7 +11,9 @@ from posthog.temporal.data_imports.sources.mssql.mssql import (
     MSSQLColumn,
     MSSQLImplementation,
     _build_query,
+    _is_transient_connection_error,
     filter_mssql_incremental_fields,
+    retry_on_transient_connection_error,
 )
 from posthog.temporal.data_imports.sources.mssql.source import MSSQLSource
 
@@ -605,3 +609,99 @@ class TestMSSQLSourceNonRetryableErrors:
     def test_conversion_failed_is_non_retryable(self, error_msg):
         non_retryable = MSSQLSource().get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+
+class TestIsTransientConnectionError:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # Real pymssql shape: DB-Lib error 20047 carried as (code, bytes) args.
+            pymssql.OperationalError(
+                20047, b"DB-Lib error message 20047, severity 9:\nDBPROCESS is dead or not enabled\n"
+            ),
+            # The SQL-Server-message rendering of the same drop.
+            pymssql.OperationalError(
+                "SQL Server message 20047, severity 9, state 0, procedure b'\\xc0\\xaa\\x12\\x08\\xff\\xff', "
+                "line 0:\nb'DB-Lib error message 20047, severity 9:\nDBPROCESS is dead or not enabled\n'"
+            ),
+        ],
+    )
+    def test_matches_dbprocess_dead(self, error):
+        assert _is_transient_connection_error(error)
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # Persistent failures must stay non-retryable, not be absorbed as transient.
+            pymssql.OperationalError("Login failed for user 'reporting'."),
+            pymssql.OperationalError("Invalid object name 'dbo.orders'."),
+            pymssql.OperationalError("The SELECT permission was denied on the object 'X'."),
+            pymssql.OperationalError(
+                "DB-Lib error message 20009, severity 9:\nUnable to connect: Adaptive Server is "
+                "unavailable or does not exist (db.example.com)"
+            ),
+            pymssql.OperationalError(),
+        ],
+    )
+    def test_does_not_match_other_errors(self, error):
+        assert not _is_transient_connection_error(error)
+
+
+class TestRetryOnTransientConnectionError:
+    def _dbprocess_dead(self) -> pymssql.OperationalError:
+        return pymssql.OperationalError(
+            20047, b"DB-Lib error message 20047, severity 9:\nDBPROCESS is dead or not enabled\n"
+        )
+
+    def test_retries_then_succeeds(self, mocker):
+        sleep = mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.time.sleep")
+        operation = MagicMock(side_effect=[self._dbprocess_dead(), "ok"])
+
+        assert retry_on_transient_connection_error(operation) == "ok"
+        assert operation.call_count == 2
+        sleep.assert_called_once()
+
+    def test_does_not_retry_non_transient(self, mocker):
+        sleep = mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.time.sleep")
+        operation = MagicMock(side_effect=pymssql.OperationalError("Login failed for user 'reporting'."))
+
+        with pytest.raises(pymssql.OperationalError):
+            retry_on_transient_connection_error(operation)
+        assert operation.call_count == 1
+        sleep.assert_not_called()
+
+    def test_gives_up_after_max_attempts(self, mocker):
+        mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.time.sleep")
+        operation = MagicMock(side_effect=self._dbprocess_dead())
+
+        with pytest.raises(pymssql.OperationalError):
+            retry_on_transient_connection_error(operation, max_attempts=3)
+        assert operation.call_count == 3
+
+
+class TestGetSchemasRetriesTransientDrop:
+    def test_get_schemas_retries_then_recovers(self, mocker):
+        # A transient DBPROCESS death mid-discovery must retry the whole connect-and-discover cycle
+        # in-process instead of failing the activity on the first blip.
+        mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.time.sleep")
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mocker.patch(
+            "posthog.temporal.data_imports.sources.mssql.mssql.pymssql.connect",
+            return_value=mock_conn,
+        )
+        get_columns = mocker.patch.object(
+            MSSQLImplementation,
+            "get_columns",
+            side_effect=[
+                pymssql.OperationalError(
+                    20047, b"DB-Lib error message 20047, severity 9:\nDBPROCESS is dead or not enabled\n"
+                ),
+                {},
+            ],
+        )
+
+        schemas = MSSQLSource().get_schemas(_make_config(), team_id=1)
+
+        assert schemas == []
+        assert get_columns.call_count == 2


### PR DESCRIPTION
## Problem

Error tracking surfaced an `MSSQLDatabaseException` from the MSSQL data-warehouse import source:

```
SQL Server message 20047, severity 9, ... DBPROCESS is dead or not enabled
```

It originates in our code at `posthog/temporal/data_imports/sources/mssql/mssql.py` in `get_columns`, raised by pymssql while iterating `information_schema.columns` rows during schema discovery (`get_schemas` → `sync_new_schemas_activity`).

DB-Lib error **20047** ("DBPROCESS is dead or not enabled") means the underlying TDS connection died mid-stream — an idle cull, a failover, or a brief network blip left pymssql's `dbprocess` dead, so the in-flight fetch raises. This is transient: a fresh connection recovers from it. It is **not** a credential/config error, so it must stay retryable rather than be added to `NonRetryableErrors`.

The blip failed the discovery run and surfaced as captured error-tracking noise even though the next attempt would succeed.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ee947-df34-7933-ae79-8a635e03036b

## Changes

Retry the whole connect-and-discover cycle in-process on a transient `DBPROCESS is dead or not enabled` drop, with bounded backoff (up to 5 attempts). This mirrors the established in-process discovery retry the Postgres and MySQL sources already use for transient connection drops — the drop happens mid-fetch, not at connect, so retrying just the connect wouldn't catch it; the whole cycle (which opens a fresh connection) is what recovers.

- `mssql.py`: add `_is_transient_connection_error` (matches the stable substring, not the volatile procedure/line/code) and `retry_on_transient_connection_error`.
- `source.py`: override `MSSQLSource.get_schemas` to wrap the shared discovery in the retry.

Permanent errors (auth failures, invalid object/column, permission denied, server unreachable) re-raise immediately because the predicate only matches the transient mid-stream drop — so this does not widen what gets swallowed.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (full file: 77 passed):

- `_is_transient_connection_error` matches the DBPROCESS-dead drop in both its `(code, bytes)` and rendered-message forms, and does **not** match login-failed, invalid-object, permission-denied, or server-unreachable errors.
- `retry_on_transient_connection_error` retries-then-succeeds, gives up after `max_attempts`, and re-raises a non-transient error immediately without sleeping.
- `MSSQLSource.get_schemas` retries the full discovery cycle on a transient drop and recovers (`get_columns` called twice).

Ran `ruff check` and `ruff format --check` on the changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the stack genuinely originates in `sources/mssql/mssql.py`, then classified DB-Lib 20047 as a transient connection death (not user/upstream, not a logic bug). Surveyed the source tree and found a clear, active pattern for this class of error — in-process discovery retry (e.g. Postgres "retry transient SSL connection drops", MySQL "retry connect timeouts in-process") — rather than `NonRetryableErrors`, and mirrored it. Matched on a stable message substring, not the volatile procedure/line/error-code parts. Checked open PRs (including the maintainer's) for a duplicate; none addresses this error.
