### PR TITLE
feat(phai): add embeddable read-only sandbox run viewer

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -4,7 +4,6 @@ import posthog from 'posthog-js'
 import React, { useLayoutEffect, useMemo, useState } from 'react'
 
 import {
-    IconBrain,
     IconChevronRight,
     IconCollapse,
     IconCopy,
@@ -41,7 +40,6 @@ import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { NotFound } from 'lib/components/NotFound'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
-import { inStorybookTestRunner } from 'lib/utils/dom'
 import { pluralize } from 'lib/utils/strings'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -68,7 +66,7 @@ import { PendingApproval, Region } from '~/types'
 
 import { LogEntry } from 'products/tasks/frontend/lib/parse-logs'
 
-import { LangGraphActivity, SandboxActivity, ShimmeringContent } from './components/Activity'
+import { LangGraphActivity, ShimmeringContent } from './components/Activity'
 import { FeedbackDisplay } from './components/FeedbackDisplay'
 import { MaxWebAnalyticsNudge } from './components/MaxWebAnalyticsNudge'
 import { SandboxContextUsage } from './components/SandboxContextUsage'
@@ -82,30 +80,21 @@ import { EnhancedToolCall, ToolRegistration, getToolDefinitionFromToolCall } fro
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { ThreadMessage, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
-import type { SandboxToolCallMessage } from './maxTypes'
 import { AssistantFailureMessage } from './messages/AssistantFailureMessage'
 import { MessageTemplate } from './messages/MessageTemplate'
 import { MultiQuestionFormRecap } from './messages/MultiQuestionForm'
 import { NotebookArtifactAnswer } from './messages/NotebookArtifactAnswer'
+import { ReasoningAnswer } from './messages/ReasoningAnswer'
 import { SessionSummarizationProgress } from './messages/SessionSummarizationProgress'
 import { RecordingsWidget, isRenderableUIPayloadTool } from './messages/UIPayloadAnswer'
 import { VisualizationArtifact } from './messages/VisualizationArtifact'
-import { SandboxToolCall } from './sandbox/components/tool/SandboxToolCall'
-import { SandboxPullRequestCard } from './sandbox/SandboxPullRequestCard'
-import { SandboxRunContext } from './sandbox/SandboxRunContext'
-import {
-    SandboxCompactBoundaryItem,
-    SandboxStatusItem,
-    SandboxTaskNotificationItem,
-} from './sandbox/SandboxThreadItems'
-import { resolveToolCall } from './sandbox/sandboxToolResolver'
+import { SandboxThreadView } from './sandbox/components/SandboxThreadView'
 import { sandboxStreamLogic } from './sandboxStreamLogic'
 import { MAX_SLASH_COMMANDS, SlashCommandName } from './slash-commands'
 import { TicketPrompt } from './TicketPrompt'
 import { getTicketPromptData, getTicketSummaryData, isTicketConfirmationMessage } from './ticketUtils'
 import { ToolCallWidgetDef, getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import { TraceIdProvider, useTraceId } from './TraceIdContext'
-import type { SandboxProgressStep, ThreadItem as SandboxThreadItem } from './types/sandboxStreamTypes'
 import { useFeedback } from './useFeedback'
 import {
     isArtifactMessage,
@@ -119,207 +108,11 @@ import {
     isVisualizationArtifactContent,
     visualizationTypeToQuery,
 } from './utils'
-import { getRandomThinkingMessage, getThinkingMessageFromResponse } from './utils/thinkingMessages'
+import { getThinkingMessageFromResponse } from './utils/thinkingMessages'
 
 // Helper function to check if a message is an error or failure
 function isErrorMessage(message: ThreadMessage): boolean {
     return message.type !== 'human' && (message.status === 'error' || message.type === 'ai/failure')
-}
-
-/** Maps a raw merged `ToolInvocation` into the flat `SandboxToolCallMessage` the registry renderers read. */
-function toolInvocationToMessage(
-    invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
-): SandboxToolCallMessage | null {
-    if (!invocation) {
-        return null
-    }
-    const resolved = resolveToolCall(invocation)
-    return {
-        id: invocation.toolCallId,
-        resolvedKey: resolved.resolvedKey,
-        rawServerName: invocation.rawServerName,
-        rawToolName: invocation.rawToolName,
-        innerToolName: resolved.innerToolName,
-        claudeToolName: resolved.claudeToolName,
-        rawInput: invocation.input,
-        innerInput: resolved.innerInput,
-        rawOutput: invocation.output,
-        content: invocation.contentBlocks,
-        status: invocation.status,
-        title: invocation.title,
-        kind: invocation.kind,
-        locations: invocation.locations,
-        error: invocation.error,
-    }
-}
-
-/**
- * Sandbox-runtime thread renderer. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
- * tool-invocation references, run separators, inline errors) and dispatches tool cards through
- * `sandboxToolRegistry`. Coexistence sibling to the LangGraph thread render path; selected by
- * `conversation.agent_runtime === 'sandbox'`.
- */
-function SandboxThread(): JSX.Element {
-    // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
-    // message while the run is active, falling back to the canned rotation.
-    const {
-        threadItems,
-        toolInvocations,
-        currentProgress,
-        isThinking,
-        streamPhase,
-        runArtifacts,
-        turnComplete,
-        currentRunStatus,
-    } = useValues(sandboxStreamLogic)
-    const turnCancelled = currentRunStatus === 'cancelled'
-    const hasActiveProgressItem = threadItems.some(
-        (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
-    )
-
-    return (
-        <>
-            {runArtifacts.branch && (
-                <SandboxRunContext
-                    branch={runArtifacts.branch}
-                    baseBranch={runArtifacts.baseBranch}
-                    repo={runArtifacts.repo}
-                />
-            )}
-            {threadItems.map((item, index) => {
-                if (item.type === 'human_message') {
-                    return (
-                        <MessageTemplate key={item.id} type="human">
-                            <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
-                        </MessageTemplate>
-                    )
-                }
-                if (item.type === 'assistant_message') {
-                    return (
-                        <MessageTemplate key={item.id} type="ai">
-                            <MarkdownMessage content={item.text ?? ''} id={item.id} />
-                        </MessageTemplate>
-                    )
-                }
-                if (item.type === 'assistant_thought') {
-                    // Empty chunks prime the stream before any reasoning text arrives — skip them so
-                    // a contentless "Thought" never shows; the bottom indicator covers that gap.
-                    if (!item.text?.trim()) {
-                        return null
-                    }
-                    // Collapse to "Thought" once a later block starts or the run stops thinking —
-                    // mirrors the LangGraph thread's reasoning-complete rule.
-                    const completed = index !== threadItems.length - 1 || !isThinking
-                    return (
-                        <ReasoningAnswer
-                            key={item.id}
-                            content={item.text}
-                            id={item.id}
-                            completed={completed}
-                            showCompletionIcon={false}
-                        />
-                    )
-                }
-                if (item.type === 'tool_invocation' && item.toolCallId) {
-                    const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
-                    if (!message) {
-                        return null
-                    }
-                    return (
-                        <SandboxToolCall
-                            key={item.id}
-                            message={message}
-                            turnComplete={turnComplete}
-                            turnCancelled={turnCancelled}
-                        />
-                    )
-                }
-                if (item.type === 'error') {
-                    return <AssistantFailureMessage key={item.id} id={item.id} content={item.errorMessage} />
-                }
-                if (item.type === 'status') {
-                    return <SandboxStatusItem key={item.id} item={item} />
-                }
-                if (item.type === 'compact_boundary') {
-                    return <SandboxCompactBoundaryItem key={item.id} item={item} />
-                }
-                if (item.type === 'task_notification') {
-                    return <SandboxTaskNotificationItem key={item.id} item={item} />
-                }
-                if (item.type === 'progress') {
-                    return <SandboxProgressItem key={item.id} item={item} />
-                }
-                return null
-            })}
-            {streamPhase === 'thinking' && !hasActiveProgressItem && (
-                <SandboxThinkingIndicator progress={currentProgress} />
-            )}
-            {/* Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking. */}
-            {!isThinking && runArtifacts.prUrl && (
-                <SandboxPullRequestCard prUrl={runArtifacts.prUrl} branch={runArtifacts.branch} />
-            )}
-        </>
-    )
-}
-
-function progressStepText(step: SandboxProgressStep): string {
-    return step.detail ? `${step.label}\n\n${step.detail}` : step.label
-}
-
-function resolveSandboxProgressState(steps: SandboxProgressStep[]): ExecutionStatus {
-    if (steps.some((step) => step.status === 'failed')) {
-        return ExecutionStatus.Failed
-    }
-    if (steps.some((step) => step.status === 'in_progress')) {
-        return ExecutionStatus.InProgress
-    }
-    if (steps.length > 0 && steps.every((step) => step.status === 'pending')) {
-        return ExecutionStatus.Pending
-    }
-    return ExecutionStatus.Completed
-}
-
-function resolveSandboxProgressHeadline(steps: SandboxProgressStep[]): string {
-    const active = steps.find((step) => step.status === 'in_progress')
-    if (active) {
-        return active.label
-    }
-    return steps.at(-1)?.label ?? 'Working'
-}
-
-function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element | null {
-    const steps = item.progressSteps ?? []
-    if (!steps.length) {
-        return null
-    }
-
-    const headline = resolveSandboxProgressHeadline(steps)
-    const substeps = steps.length > 1 ? steps.map(progressStepText) : []
-    const state = resolveSandboxProgressState(steps)
-
-    return (
-        <SandboxActivity
-            id={item.id}
-            content={headline}
-            substeps={substeps}
-            state={state}
-            icon={<IconWrench />}
-            showCompletionIcon={true}
-        />
-    )
-}
-
-/**
- * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
- * `_posthog/progress` message when present, otherwise the canned thinking rotation.
- */
-function SandboxThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
-    // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
-    const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
-    const message = progress?.trim() ? progress : fallbackMessage
-    // Match the LangGraph loader: a bubble-free reasoning line (muted brain icon + muted text),
-    // static (no shimmer), via the shared Activity primitive — not a MessageTemplate bubble.
-    return <ReasoningAnswer content={message} id="sandbox-thinking" completed={false} showCompletionIcon={false} />
 }
 
 export function Thread({ className }: { className?: string }): JSX.Element | null {
@@ -343,7 +136,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                     logic={sandboxStreamLogic}
                     props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
                 >
-                    <SandboxThread />
+                    <SandboxThreadView />
                 </BindLogic>
             </div>
         )
@@ -363,7 +156,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                     logic={sandboxStreamLogic}
                     props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
                 >
-                    <SandboxThread />
+                    <SandboxThreadView />
                 </BindLogic>
             </div>
         )
@@ -1207,34 +1000,6 @@ function PlanningAnswer({ toolCall, isLastPlanningMessage = true }: PlanningAnsw
                 </div>
             )}
         </div>
-    )
-}
-
-interface ReasoningAnswerProps {
-    content: string
-    completed: boolean
-    id: string
-    showCompletionIcon?: boolean
-    animate?: boolean
-}
-
-function ReasoningAnswer({
-    content,
-    completed,
-    id,
-    showCompletionIcon = true,
-    animate = false,
-}: ReasoningAnswerProps): JSX.Element {
-    return (
-        <LangGraphActivity
-            id={id}
-            content={completed ? 'Thought' : content}
-            substeps={completed ? [content] : []}
-            state={completed ? ExecutionStatus.Completed : ExecutionStatus.InProgress}
-            icon={<IconBrain />}
-            animate={!inStorybookTestRunner() && animate} // Avoiding flaky snapshots in Storybook
-            showCompletionIcon={showCompletionIcon}
-        />
     )
 }
 

--- a/frontend/src/scenes/max/messages/ReasoningAnswer.tsx
+++ b/frontend/src/scenes/max/messages/ReasoningAnswer.tsx
@@ -1,0 +1,35 @@
+import { IconBrain } from '@posthog/icons'
+
+import { inStorybookTestRunner } from 'lib/utils/dom'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { LangGraphActivity } from '../components/Activity'
+
+export interface ReasoningAnswerProps {
+    content: string
+    completed: boolean
+    id: string
+    showCompletionIcon?: boolean
+    animate?: boolean
+}
+
+export function ReasoningAnswer({
+    content,
+    completed,
+    id,
+    showCompletionIcon = true,
+    animate = false,
+}: ReasoningAnswerProps): JSX.Element {
+    return (
+        <LangGraphActivity
+            id={id}
+            content={completed ? 'Thought' : content}
+            substeps={completed ? [content] : []}
+            state={completed ? ExecutionStatus.Completed : ExecutionStatus.InProgress}
+            icon={<IconBrain />}
+            animate={!inStorybookTestRunner() && animate} // Avoiding flaky snapshots in Storybook
+            showCompletionIcon={showCompletionIcon}
+        />
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
+++ b/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
@@ -1,0 +1,82 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { Spinner } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { sandboxStreamLogic } from '../../sandboxStreamLogic'
+import { SandboxThreadView } from './SandboxThreadView'
+
+export interface SandboxRunViewerProps {
+    taskId: string
+    runId: string
+    /** Stable logic key; defaults to `runId` (the run is the unit being viewed). */
+    streamKey?: string
+    /** Telemetry tag only — omit for conversation-less runs (automation, Slack, signals, PR-triggered). */
+    conversationId?: string
+    className?: string
+}
+
+/**
+ * Embeddable, read-only replay of a task run's agent thread. Binds a `replayOnly` `sandboxStreamLogic`
+ * instance (keyed separately from any live stream of the same run, so streaming can never bleed in),
+ * replays the persisted `logs/` snapshot once, and renders the shared `SandboxThreadView`. No SSE, no
+ * permissions, no composer. Drop in anywhere with just `(taskId, runId)`.
+ */
+export function SandboxRunViewer({
+    taskId,
+    runId,
+    streamKey,
+    conversationId,
+    className,
+}: SandboxRunViewerProps): JSX.Element {
+    return (
+        <BindLogic
+            logic={sandboxStreamLogic}
+            props={{ streamKey: streamKey ?? runId, conversationId, replayOnly: true }}
+        >
+            <SandboxRunViewerContent taskId={taskId} runId={runId} className={className} />
+        </BindLogic>
+    )
+}
+
+function SandboxRunViewerContent({
+    taskId,
+    runId,
+    className,
+}: {
+    taskId: string
+    runId: string
+    className?: string
+}): JSX.Element {
+    const { bootstrapLoading, threadItems } = useValues(sandboxStreamLogic)
+    const { bootstrapRun, reset } = useActions(sandboxStreamLogic)
+
+    useEffect(() => {
+        // Reset first so a reused instance (stable streamKey, changed run) replays the new snapshot
+        // cleanly; the bound logic keys read-only instances apart from any live stream of the same run.
+        reset()
+        bootstrapRun({ taskId, runId })
+    }, [taskId, runId, bootstrapRun, reset])
+
+    const showSpinner = bootstrapLoading && threadItems.length === 0
+
+    return (
+        <div
+            className={cn(
+                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
+                className
+            )}
+        >
+            {showSpinner ? (
+                <div className="flex justify-center py-8">
+                    <Spinner className="text-2xl" />
+                </div>
+            ) : (
+                // An error surfaces as a `handleStreamError` item folded into the thread, so it renders here too.
+                <SandboxThreadView />
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/max/sandbox/components/SandboxThreadView.tsx
+++ b/frontend/src/scenes/max/sandbox/components/SandboxThreadView.tsx
@@ -1,0 +1,218 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IconWrench } from '@posthog/icons'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import { SandboxActivity } from '../../components/Activity'
+import { MarkdownMessage } from '../../MarkdownMessage'
+import type { SandboxToolCallMessage } from '../../maxTypes'
+import { AssistantFailureMessage } from '../../messages/AssistantFailureMessage'
+import { MessageTemplate } from '../../messages/MessageTemplate'
+import { ReasoningAnswer } from '../../messages/ReasoningAnswer'
+import { sandboxStreamLogic } from '../../sandboxStreamLogic'
+import type { SandboxProgressStep, ThreadItem as SandboxThreadItem } from '../../types/sandboxStreamTypes'
+import { getRandomThinkingMessage } from '../../utils/thinkingMessages'
+import { SandboxPullRequestCard } from '../SandboxPullRequestCard'
+import { SandboxRunContext } from '../SandboxRunContext'
+import { SandboxCompactBoundaryItem, SandboxStatusItem, SandboxTaskNotificationItem } from '../SandboxThreadItems'
+import { resolveToolCall } from '../sandboxToolResolver'
+import { SandboxToolCall } from './tool/SandboxToolCall'
+
+/** Maps a raw merged `ToolInvocation` into the flat `SandboxToolCallMessage` the registry renderers read. */
+function toolInvocationToMessage(
+    invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
+): SandboxToolCallMessage | null {
+    if (!invocation) {
+        return null
+    }
+    const resolved = resolveToolCall(invocation)
+    return {
+        id: invocation.toolCallId,
+        resolvedKey: resolved.resolvedKey,
+        rawServerName: invocation.rawServerName,
+        rawToolName: invocation.rawToolName,
+        innerToolName: resolved.innerToolName,
+        claudeToolName: resolved.claudeToolName,
+        rawInput: invocation.input,
+        innerInput: resolved.innerInput,
+        rawOutput: invocation.output,
+        content: invocation.contentBlocks,
+        status: invocation.status,
+        title: invocation.title,
+        kind: invocation.kind,
+        locations: invocation.locations,
+        error: invocation.error,
+    }
+}
+
+/**
+ * Sandbox-runtime thread presenter. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
+ * tool-invocation references, run separators, inline errors) from whatever `sandboxStreamLogic`
+ * instance is bound above it — a live PostHog AI conversation or a read-only run viewer — and
+ * dispatches tool cards through the sandbox tool registry. Conversation-agnostic by design: it knows
+ * only the bound stream logic, never langgraph vs sandbox or the conversation.
+ */
+export function SandboxThreadView(): JSX.Element {
+    // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
+    // message while the run is active, falling back to the canned rotation.
+    const {
+        threadItems,
+        toolInvocations,
+        currentProgress,
+        isThinking,
+        streamPhase,
+        runArtifacts,
+        turnComplete,
+        currentRunStatus,
+    } = useValues(sandboxStreamLogic)
+    const turnCancelled = currentRunStatus === 'cancelled'
+    const hasActiveProgressItem = threadItems.some(
+        (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
+    )
+
+    return (
+        <>
+            {runArtifacts.branch && (
+                <SandboxRunContext
+                    branch={runArtifacts.branch}
+                    baseBranch={runArtifacts.baseBranch}
+                    repo={runArtifacts.repo}
+                />
+            )}
+            {threadItems.map((item, index) => {
+                if (item.type === 'human_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="human">
+                            <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
+                if (item.type === 'assistant_message') {
+                    return (
+                        <MessageTemplate key={item.id} type="ai">
+                            <MarkdownMessage content={item.text ?? ''} id={item.id} />
+                        </MessageTemplate>
+                    )
+                }
+                if (item.type === 'assistant_thought') {
+                    // Empty chunks prime the stream before any reasoning text arrives — skip them so
+                    // a contentless "Thought" never shows; the bottom indicator covers that gap.
+                    if (!item.text?.trim()) {
+                        return null
+                    }
+                    // Collapse to "Thought" once a later block starts or the run stops thinking —
+                    // mirrors the LangGraph thread's reasoning-complete rule.
+                    const completed = index !== threadItems.length - 1 || !isThinking
+                    return (
+                        <ReasoningAnswer
+                            key={item.id}
+                            content={item.text}
+                            id={item.id}
+                            completed={completed}
+                            showCompletionIcon={false}
+                        />
+                    )
+                }
+                if (item.type === 'tool_invocation' && item.toolCallId) {
+                    const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
+                    if (!message) {
+                        return null
+                    }
+                    return (
+                        <SandboxToolCall
+                            key={item.id}
+                            message={message}
+                            turnComplete={turnComplete}
+                            turnCancelled={turnCancelled}
+                        />
+                    )
+                }
+                if (item.type === 'error') {
+                    return <AssistantFailureMessage key={item.id} id={item.id} content={item.errorMessage} />
+                }
+                if (item.type === 'status') {
+                    return <SandboxStatusItem key={item.id} item={item} />
+                }
+                if (item.type === 'compact_boundary') {
+                    return <SandboxCompactBoundaryItem key={item.id} item={item} />
+                }
+                if (item.type === 'task_notification') {
+                    return <SandboxTaskNotificationItem key={item.id} item={item} />
+                }
+                if (item.type === 'progress') {
+                    return <SandboxProgressItem key={item.id} item={item} />
+                }
+                return null
+            })}
+            {streamPhase === 'thinking' && !hasActiveProgressItem && (
+                <SandboxThinkingIndicator progress={currentProgress} />
+            )}
+            {/* Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking. */}
+            {!isThinking && runArtifacts.prUrl && (
+                <SandboxPullRequestCard prUrl={runArtifacts.prUrl} branch={runArtifacts.branch} />
+            )}
+        </>
+    )
+}
+
+function progressStepText(step: SandboxProgressStep): string {
+    return step.detail ? `${step.label}\n\n${step.detail}` : step.label
+}
+
+function resolveSandboxProgressState(steps: SandboxProgressStep[]): ExecutionStatus {
+    if (steps.some((step) => step.status === 'failed')) {
+        return ExecutionStatus.Failed
+    }
+    if (steps.some((step) => step.status === 'in_progress')) {
+        return ExecutionStatus.InProgress
+    }
+    if (steps.length > 0 && steps.every((step) => step.status === 'pending')) {
+        return ExecutionStatus.Pending
+    }
+    return ExecutionStatus.Completed
+}
+
+function resolveSandboxProgressHeadline(steps: SandboxProgressStep[]): string {
+    const active = steps.find((step) => step.status === 'in_progress')
+    if (active) {
+        return active.label
+    }
+    return steps.at(-1)?.label ?? 'Working'
+}
+
+function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element | null {
+    const steps = item.progressSteps ?? []
+    if (!steps.length) {
+        return null
+    }
+
+    const headline = resolveSandboxProgressHeadline(steps)
+    const substeps = steps.length > 1 ? steps.map(progressStepText) : []
+    const state = resolveSandboxProgressState(steps)
+
+    return (
+        <SandboxActivity
+            id={item.id}
+            content={headline}
+            substeps={substeps}
+            state={state}
+            icon={<IconWrench />}
+            showCompletionIcon={true}
+        />
+    )
+}
+
+/**
+ * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
+ * `_posthog/progress` message when present, otherwise the canned thinking rotation.
+ */
+function SandboxThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
+    // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
+    const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
+    const message = progress?.trim() ? progress : fallbackMessage
+    // Match the LangGraph loader: a bubble-free reasoning line (muted brain icon + muted text),
+    // static (no shimmer), via the shared Activity primitive — not a MessageTemplate bubble.
+    return <ReasoningAnswer content={message} id="sandbox-thinking" completed={false} showCompletionIcon={false} />
+}

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -1650,6 +1650,117 @@ describe('sandboxStreamLogic', () => {
         })
     })
 
+    describe('replayOnly viewer (read-only)', () => {
+        function mountViewer(streamKey: string): ReturnType<typeof sandboxStreamLogic.build> {
+            const viewer = sandboxStreamLogic({ streamKey, replayOnly: true })
+            viewer.mount()
+            return viewer
+        }
+
+        it('replays a terminal run read-only without opening SSE and never thinks', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                notification('_posthog/run_started', {}) as any,
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'done' } }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            const viewer = mountViewer('run-ro-terminal')
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-1' })
+            await flushPromises()
+
+            expect(viewer.values.threadItems.find((item) => item.type === 'assistant_message')?.text).toEqual('done')
+            expect(viewer.values.currentRunStatus).toEqual('completed')
+            expect(MockStream.connections.length).toEqual(0)
+            expect(viewer.values.isThinking).toEqual(false)
+            expect(viewer.values.bootstrapLoading).toEqual(false)
+
+            viewer.unmount()
+        })
+
+        it('replays an in-progress snapshot without opening SSE and stays idle', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                notification('_posthog/run_started', {}) as any,
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'partial' } }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+
+            const viewer = mountViewer('run-ro-inprogress')
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-2' })
+            await flushPromises()
+
+            expect(viewer.values.threadItems.find((item) => item.type === 'assistant_message')?.text).toEqual('partial')
+            // run_started replayed, but a read-only snapshot never streams and never spins the indicator.
+            expect(MockStream.connections.length).toEqual(0)
+            expect(viewer.values.streamPhase).toEqual('idle')
+            expect(viewer.values.isThinking).toEqual(false)
+
+            viewer.unmount()
+        })
+
+        it('folds the snapshot only once across a re-bootstrap of the shared instance', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'once' } }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            const viewer = mountViewer('run-ro-idempotent')
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-3' })
+            await flushPromises()
+            // A second mounted viewer of the same run re-bootstraps the shared keyed instance.
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-3' })
+            await flushPromises()
+
+            expect(viewer.values.threadItems.filter((item) => item.type === 'assistant_message')).toHaveLength(1)
+
+            viewer.unmount()
+        })
+
+        it('surfaces an error item when the snapshot fetch fails and opens no SSE', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockRejectedValue({ status: 500 })
+
+            const viewer = mountViewer('run-ro-error')
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-4' })
+            await flushPromises()
+
+            expect(viewer.values.threadItems.some((item) => item.type === 'error')).toEqual(true)
+            expect(MockStream.connections.length).toEqual(0)
+            expect(viewer.values.bootstrapLoading).toEqual(false)
+
+            viewer.unmount()
+        })
+
+        it('keys read-only instances apart from a live stream of the same run', async () => {
+            jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue([
+                sessionUpdate({
+                    sessionUpdate: 'agent_message',
+                    messageId: 'm1',
+                    content: { text: 'replayed' },
+                }) as any,
+            ])
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)
+
+            const live = sandboxStreamLogic({ streamKey: 'run-shared' })
+            live.mount()
+            const viewer = mountViewer('run-shared')
+
+            // Same streamKey, but the read-only `replay:` namespace resolves a distinct instance.
+            expect(viewer).not.toBe(live)
+
+            viewer.actions.bootstrapRun({ taskId: 'task-1', runId: 'run-5' })
+            await flushPromises()
+
+            // The replay folds into the viewer only; the live instance is untouched — streaming can't bleed in.
+            expect(viewer.values.threadItems.find((item) => item.type === 'assistant_message')?.text).toEqual(
+                'replayed'
+            )
+            expect(live.values.threadItems).toHaveLength(0)
+
+            viewer.unmount()
+            live.unmount()
+        })
+    })
+
     describe('wire frame parsing through the SSE reader', () => {
         it('reads the snake_case error_message off task_run_state frames', async () => {
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -57,6 +57,12 @@ export interface SandboxStreamLogicProps {
     streamKey: string
     /** Optional telemetry tag — present for PostHog AI conversations, absent for a generic task viewer. */
     conversationId?: string
+    /**
+     * Read-only/replay mode for a generic run viewer: bootstrap replays the persisted `logs/` snapshot
+     * once and never opens SSE — even for an in-progress run. Folded into the logic key so a read-only
+     * instance can never share state with a live streaming instance, even for the same `streamKey`.
+     */
+    replayOnly?: boolean
 }
 
 /** Reconnect/backoff constants for the SSE drop-recovery loop. */
@@ -911,8 +917,11 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
  * so concurrent streams keep independent stream state and connections.
  */
 export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
-    props({} as SandboxStreamLogicProps),
-    key((props) => props.streamKey),
+    // `replayOnly` needs a default so selectors can depend on it as a prop (kea throws on a missing prop).
+    props({ replayOnly: false } as SandboxStreamLogicProps),
+    // A read-only viewer keys under a `replay:` namespace so it never shares an instance with a live
+    // stream of the same run — streaming can't bleed into a read-only thread.
+    key((props) => (props.replayOnly ? `replay:${props.streamKey}` : props.streamKey)),
     path((key) => ['scenes', 'max', 'sandboxStreamLogic', key]),
     connect(() => ({
         values: [projectLogic, ['currentProjectId']],
@@ -928,6 +937,8 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
         bootstrapRun: (payload: { taskId: string; runId: string; justCreatedRun?: boolean; traceId?: string }) =>
             payload,
         openSseForRun: (payload: { taskId: string; runId: string; startLatest?: boolean; traceId?: string }) => payload,
+        /** Internal: the read-only replay snapshot finished loading — clears the bootstrap spinner. */
+        bootstrapReplayComplete: true,
         closeSse: true,
         sseConnecting: true,
         sseOpened: true,
@@ -1094,6 +1105,19 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 appendEntries: (state, { entries }) =>
                     entries.length === 0 ? state : { entries: [...state.entries, ...entries] },
                 reset: () => ({ entries: [] }),
+            },
+        ],
+        // True while a bootstrap is in flight before the thread has anything to show. Cleared once the
+        // live stream opens, the read-only replay snapshot finishes, or an error surfaces. Drives the
+        // read-only viewer's initial spinner.
+        bootstrapLoading: [
+            false,
+            {
+                bootstrapRun: () => true,
+                sseOpened: () => false,
+                bootstrapReplayComplete: () => false,
+                handleStreamError: () => false,
+                reset: () => false,
             },
         ],
         // Whether the bootstrapped run is a resume run — drives the §6 resume-prompt filter in the
@@ -1269,8 +1293,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
          * the first `_posthog/run_started` frame, which `runStarted` alone misses.
          */
         isThinking: [
-            (s) => [s.runStarted, s.turnComplete, s.currentRunStatus, s.sseStatus],
-            (runStarted, turnComplete, currentRunStatus, sseStatus): boolean => {
+            // `replayOnly` always resolves (default in `props`); `!` drops the optional-prop `undefined`.
+            (s, p) => [s.runStarted, s.turnComplete, s.currentRunStatus, s.sseStatus, p.replayOnly!],
+            (runStarted, turnComplete, currentRunStatus, sseStatus, replayOnly): boolean => {
+                // A read-only snapshot is never "thinking" — it's a static replay, so the indicator
+                // must never spin (an in-progress run replayed read-only has no live turn to await).
+                if (replayOnly) {
+                    return false
+                }
                 if (sseStatus === 'error' || isTerminalRunStatus(currentRunStatus)) {
                     return false
                 }
@@ -1284,12 +1314,16 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
          * workflow is still setting up the sandbox); it holds the gerund loader off until `run_started`
          * so it can't show before a turn begins. Boot UX is surfaced by `_posthog/progress` items, not
          * a dedicated indicator. `thinking` = the agent is working a turn (mirrors `isThinking`), and is
-         * what `SandboxThread` gates the gerund loader on; `idle` otherwise (terminal, errored, or not
-         * yet connecting).
+         * what `SandboxThreadView` gates the gerund loader on; `idle` otherwise (terminal, errored, or
+         * not yet connecting). A read-only viewer is always `idle` — it never streams.
          */
         streamPhase: [
-            (s) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus],
-            (runStarted, isThinking, currentRunStatus, sseStatus): 'provisioning' | 'thinking' | 'idle' => {
+            (s, p) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus, p.replayOnly!],
+            (runStarted, isThinking, currentRunStatus, sseStatus, replayOnly): 'provisioning' | 'thinking' | 'idle' => {
+                // A read-only snapshot never provisions or thinks — there is no live stream behind it.
+                if (replayOnly) {
+                    return 'idle'
+                }
                 const connecting = sseStatus === 'connecting' || sseStatus === 'open' || sseStatus === 'reconnecting'
                 if (connecting && !runStarted && !isTerminalRunStatus(currentRunStatus)) {
                     return 'provisioning'
@@ -1311,6 +1345,48 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             const projectId = values.currentProjectId
             if (projectId === null) {
                 actions.handleStreamError({ errorTitle: 'No current project', retryable: false })
+                return
+            }
+
+            // Read-only viewer: replay the `logs/` snapshot once and never open SSE, regardless of run
+            // status. `breakpoint()` cancels a superseded in-flight bootstrap (a remount / StrictMode
+            // double-invoke), and the log-empty guard before folding keeps a re-bootstrap of a shared
+            // keyed instance (a second mounted viewer of the same run) from doubling the thread.
+            if (props.replayOnly) {
+                let replayRun: { status?: string; state?: unknown; output?: unknown; branch?: string | null }
+                try {
+                    replayRun = await api.tasks.runs.get(taskId, runId)
+                } catch (error) {
+                    actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+                    return
+                }
+                breakpoint()
+                actions.markBootstrapResumeRun(isResumeRun(replayRun))
+                actions.mergeRunArtifacts(extractRunArtifacts(replayRun))
+
+                let replayEntries: unknown[]
+                try {
+                    replayEntries = await api.tasks.runs.getLogEntries(taskId, runId)
+                } catch (error) {
+                    actions.handleStreamError(mapHttpStatusToStreamError((error as { status?: number })?.status))
+                    return
+                }
+                breakpoint()
+                if (values.log.entries.length === 0) {
+                    replayEntries
+                        .map(normalizeNotificationEntry)
+                        .filter((entry): entry is StoredLogEntry => entry !== null)
+                        .forEach((entry) => actions.ingestAcpFrame(entry, 'replay'))
+                }
+
+                if (isTerminalRunStatus(replayRun.status ?? null)) {
+                    // Record the terminal status read-only — no SSE to close, no termination telemetry.
+                    actions.handleTerminalStatus({
+                        status: replayRun.status as SandboxRunStatus,
+                        replayedFromHistory: true,
+                    })
+                }
+                actions.bootstrapReplayComplete()
                 return
             }
 
@@ -1393,6 +1469,11 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             dedupeBufferedAgainstHistory(buffered, history).forEach((entry) => actions.ingestAcpFrame(entry, 'live'))
         },
         openSseForRun: ({ taskId, runId, startLatest }) => {
+            // A read-only instance must never stream — guard here too, so even a stray or connected
+            // dispatch can't open SSE into a read-only thread.
+            if (props.replayOnly) {
+                return
+            }
             const projectId = values.currentProjectId
             if (projectId === null) {
                 actions.handleStreamError({ errorTitle: 'No current project', retryable: false })


### PR DESCRIPTION
## Problem

The sandbox runtime (PostHog AI's new path) renders its agent thread with `SandboxThread()`, locked inside `Thread.tsx` and wired to Max's conversation state. We want to replay *any* task run's agent thread — including runs with no conversation (automation, Slack, signals, PR-triggered coding runs) — anywhere in the app, given only `(taskId, runId)`, with no live streaming.

## Changes

This is the abstraction layer only — no consumer is wired up yet (that's follow-up work).

- **`sandboxStreamLogic`: read-only mode + key isolation.** New `replayOnly` prop, folded into the kea key (`replay:<streamKey>`) so a read-only instance can never share state with a live stream of the same run. A `replayOnly` bootstrap replays the persisted `logs/` snapshot once for any run status and never opens SSE (guarded in both `bootstrapRun` and `openSseForRun`). `isThinking` / `streamPhase` short-circuit so an in-progress snapshot never spins. Added a `bootstrapLoading` value for the viewer's spinner.
- **`SandboxThreadView` (new shared presenter).** The body of `SandboxThread()` moved into `sandbox/components/SandboxThreadView.tsx`, reading whatever `sandboxStreamLogic` instance is bound above it.
- **`SandboxRunViewer` (new embeddable).** `sandbox/components/SandboxRunViewer.tsx` binds a `replayOnly` instance, self-drives the replay on mount, and renders the presenter with a spinner.
- **`ReasoningAnswer` extracted** to `messages/ReasoningAnswer.tsx` — it's shared with the LangGraph path, so leaving it in `Thread.tsx` would have caused a circular import once the presenter moved out.
- **`Thread.tsx`** now renders `<SandboxThreadView />`; Max's live path (BindLogic mounts, composer, bootstrap) is unchanged.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8) and did **not** manually test in the running app. Automated checks I actually ran:

- `sandboxStreamLogic` suite: 137/137, including 5 new `replayOnly viewer` cases — terminal & in-progress replay open no SSE, idempotent re-bootstrap, snapshot-fetch failure surfaces an error item, and read-only instances key apart from a live stream of the same run.
- `maxThreadLogic` suite: 126/126 (live Max path unaffected).
- oxlint + oxfmt clean on all touched files; `tsgo` clean for the changed/new files. (Two pre-existing, unrelated type errors remain on the branch — `DebugCHQueriesType.ts` and `sandboxPermissionDisplayUtils.ts` — in files this PR doesn't touch.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal refactor plus a new reusable component, not yet surfaced to users.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (Opus 4.8) under direct human direction. No repo skills were required (frontend kea/React refactor).
- Key decisions: made read-only a *keyed* logic prop (not just an action flag) and folded it into the kea key, so a read-only thread and a live stream of the same run are guaranteed separate instances and streaming can't bleed into a read-only thread. Idempotency uses a fold-only-if-log-empty guard rather than a boolean latch, because a latch fights kea's `breakpoint()` cancellation on concurrent re-dispatch. Extracted `ReasoningAnswer` to break a would-be circular import.
- Note: the commit is **unsigned** — the devbox SSH signing agent was down at commit time; happy to re-sign once it's back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECMvSPHAMgQy6jfLMw34QJ