### PR TITLE
fix(sentry): name the required scopes in credential errors

### DIFF
--- a/posthog/temporal/data_imports/sources/sentry/sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/sentry.py
@@ -26,6 +26,7 @@ from posthog.temporal.data_imports.sources.common.resumable import ResumableSour
 from posthog.temporal.data_imports.sources.sentry.settings import (
     ALLOWED_SENTRY_API_BASE_URLS,
     DEFAULT_SENTRY_API_BASE_URL,
+    REQUIRED_SENTRY_SCOPES,
     SENTRY_ENDPOINTS,
     SentryEndpointConfig,
 )
@@ -487,7 +488,12 @@ def validate_credentials(
         if response.status_code == 401:
             return False, "Invalid Sentry auth token"
         if response.status_code == 403:
-            return False, "Sentry token is missing required scopes"
+            return (
+                False,
+                "Sentry token is missing required scopes. Create a token with these scopes and reconnect: "
+                + ", ".join(REQUIRED_SENTRY_SCOPES)
+                + ".",
+            )
         if response.status_code == 404:
             return False, f"Sentry organization '{organization_slug}' not found"
 

--- a/posthog/temporal/data_imports/sources/sentry/settings.py
+++ b/posthog/temporal/data_imports/sources/sentry/settings.py
@@ -12,6 +12,18 @@ ALLOWED_SENTRY_API_BASE_URLS = (
     "https://de.sentry.io",
 )
 
+# Scopes a Sentry auth token needs to sync every dataset. Single source of truth for
+# the setup caption and the "missing scopes" credential errors, so the list we tell
+# users to grant can't drift from the list we check against.
+REQUIRED_SENTRY_SCOPES = (
+    "alerts:read",
+    "event:read",
+    "member:read",
+    "org:read",
+    "project:read",
+    "team:read",
+)
+
 LAST_SEEN_INCREMENTAL: IncrementalField = {
     "label": "lastSeen",
     "type": IncrementalFieldType.DateTime,

--- a/posthog/temporal/data_imports/sources/sentry/source.py
+++ b/posthog/temporal/data_imports/sources/sentry/source.py
@@ -27,6 +27,7 @@ from posthog.temporal.data_imports.sources.sentry.settings import (
     DEFAULT_SENTRY_API_BASE_URL,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
+    REQUIRED_SENTRY_SCOPES,
 )
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
@@ -45,16 +46,12 @@ class SentrySource(ResumableSource[SentrySourceConfig, SentryResumeConfig]):
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Sentry",
             iconPath="/static/services/sentry.png",
-            caption="""Enter a Sentry auth token and your organization slug to sync Sentry organization, project, issue, and monitor datasets.
-
-Create a token in Sentry and make sure it includes the scopes below if you want to sync all datasets:
-- `alerts:read`
-- `event:read`
-- `member:read`
-- `org:read`
-- `project:read`
-- `team:read`
-""",
+            caption=(
+                "Enter a Sentry auth token and your organization slug to sync Sentry organization, "
+                "project, issue, and monitor datasets.\n\n"
+                "Create a token in Sentry and make sure it includes the scopes below if you want to "
+                "sync all datasets:\n" + "\n".join(f"- `{scope}`" for scope in REQUIRED_SENTRY_SCOPES) + "\n"
+            ),
             docsUrl="https://posthog.com/docs/cdp/sources/sentry",
             fields=cast(
                 list[FieldType],
@@ -96,7 +93,9 @@ Create a token in Sentry and make sure it includes the scopes below if you want 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "401 Client Error": "Invalid Sentry auth token. Please update your token and reconnect.",
-            "403 Client Error": "Sentry token is missing required scopes. Please make sure it includes all scopes required for your schemas.",
+            "403 Client Error": "Sentry token is missing required scopes. Make sure it includes the scopes required for your schemas — the full set is: "
+            + ", ".join(REQUIRED_SENTRY_SCOPES)
+            + ".",
             "404 Client Error": "Sentry organization not found. Verify your organization slug.",
         }
 

--- a/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -20,6 +20,7 @@ from posthog.temporal.data_imports.sources.sentry.sentry import (
     sentry_source,
     validate_credentials,
 )
+from posthog.temporal.data_imports.sources.sentry.settings import REQUIRED_SENTRY_SCOPES
 from posthog.temporal.data_imports.sources.sentry.source import SentrySource
 
 
@@ -241,6 +242,18 @@ class TestSentryTransport:
             False,
             "API base URL must be one of https://sentry.io, https://us.sentry.io, or https://de.sentry.io.",
         )
+
+    @patch("posthog.temporal.data_imports.sources.sentry.sentry.make_tracked_session")
+    def test_validate_credentials_403_names_required_scopes(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = _response(None, status_code=403)
+
+        valid, error = validate_credentials(auth_token="token", organization_slug="acme")
+
+        assert not valid
+        assert error is not None
+        assert error.startswith("Sentry token is missing required scopes")
+        for scope in REQUIRED_SENTRY_SCOPES:
+            assert scope in error
 
     def test_sentry_source_rejects_unknown_api_base_url_at_runtime(self) -> None:
         with pytest.raises(


### PR DESCRIPTION
## Problem

When a Sentry data warehouse source fails to validate because the auth token is missing scopes, the user only saw:

> Sentry token is missing required scopes

It never said *which* scopes. The same terse wording appeared in the runtime non-retryable error during syncs. To find the answer a user had to scroll back to the setup form caption. Yesterday this message accounted for the Sentry source-creation failures.

## Changes

- Added a `REQUIRED_SENTRY_SCOPES` constant in `sentry/settings.py` as the single source of truth.
- The credential-validation 403 error and the runtime `403 Client Error` non-retryable message now list the scopes inline (e.g. `... Create a token with these scopes and reconnect: alerts:read, event:read, member:read, org:read, project:read, team:read.`).
- The setup caption's bullet list is now derived from the same constant, so the list we tell users to grant can't drift from the list we check against.

No change to sync behavior or schemas — error-message wording only.

## How did you test this code?

I'm an agent. Automated only:

- Added `test_validate_credentials_403_names_required_scopes` asserting the 403 message names every required scope.
- Ran the full `test_sentry.py` suite (59 passed) and `ruff check` / `ruff format` over the touched files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of data warehouse source-creation failures and classified each error message. The Sentry "missing required scopes" message was actionable in intent but didn't name the scopes, despite that list already existing in the same module's setup caption. Fix consolidates the list into one constant and surfaces it everywhere the user might hit the wall. Kept it minimal — no behavior change, just wording + a dedup. Safe error-message improvement, hence the `stamphog` label.