### PR TITLE
fix(data-warehouse): name the host in the DNS-resolution error

### DIFF
--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -89,7 +89,10 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
                 return False, _INTERNAL_IP_ERROR
     except socket.gaierror:
         _log("block", "dns_failure", _DNS_FAILURE_ERROR)
-        return False, _DNS_FAILURE_ERROR
+        return (
+            False,
+            f"Couldn't resolve the host '{host}'. Check that it's spelled correctly and reachable from the public internet.",
+        )
 
     _log("allow", "resolved_ip", None, resolved_ips)
     return True, None

--- a/posthog/temporal/data_imports/sources/common/test_mixins.py
+++ b/posthog/temporal/data_imports/sources/common/test_mixins.py
@@ -119,7 +119,9 @@ class TestIsHostSafe(SimpleTestCase):
         ):
             valid, error = _is_host_safe("nonexistent.invalid", team_id=999)
             assert not valid
-            assert error == "Host could not be resolved"
+            assert error is not None
+            assert "nonexistent.invalid" in error
+            assert "resolve" in error
 
     @override_settings(CLOUD_DEPLOYMENT="US")
     def test_blocked_host_logs_warning(self):


### PR DESCRIPTION
## Problem

When a database warehouse source host fails DNS resolution during the SSRF host check, the user saw:

> Host could not be resolved

It named neither the host that failed nor anything to do about it. This is the generic path every database source shares — it surfaced yesterday on a Supabase source where the entered host couldn't resolve (the Supabase *direct*-host case already has its own detailed IPv4 hint; this is the fallback for everything else, e.g. a mistyped pooler or Postgres host).

## Changes

`_is_host_safe` now returns, on `socket.gaierror`:

> Couldn't resolve the host '<host>'. Check that it's spelled correctly and reachable from the public internet.

The structured log keeps its stable `Host could not be resolved` reason string so telemetry/alerting on that label is unaffected. No change to the host-safety decision itself — wording only.

## How did you test this code?

I'm an agent. Automated only:

- Updated `test_unresolvable_host_blocked` to assert the message names the host and mentions resolving it.
- Ran `test_mixins.py` (39 passed) and `ruff check` / `ruff format` over the touched files.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

From a triage pass over data warehouse source-creation failures. The Supabase bucket's well-handled direct-host hint needed no change; the one terse outlier was this shared DNS-failure fallback, which gave the user nothing to act on. Fix names the host (already in scope) and keeps the log reason stable for telemetry. Safe error-message improvement, hence the `stamphog` label.