### PR TITLE
feat(phai): render task run log inline in inbox run detail

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -61,6 +61,7 @@ from products.posthog_ai.backend.models.assistant import Conversation
 from products.tasks.backend.constants import INITIAL_PERMISSION_MODE_CHOICES
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.repo_selection.cascade import select_repository_for_message
+from products.tasks.backend.visibility import task_visibility_q
 
 from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_team_limited
 from ee.hogai.api.serializers import ConversationMinimalSerializer, ConversationSerializer
@@ -249,6 +250,20 @@ class SandboxOpenSerializer(serializers.Serializer):
             "for an already-existing conversation."
         ),
     )
+
+    def validate_task_id(self, value: uuid.UUID) -> Task:
+        """Resolve the Task to bind, scoped to the team and the requesting user's visibility.
+
+        Mirrors the tasks API's `task_visibility_q` gate so a team member can't bind a conversation
+        to a teammate's private task by guessing its id. Returns the resolved Task (consumed directly
+        by the view), so an unreadable id surfaces as a 400 here rather than failing deeper in routing.
+        """
+        team = self.context["team"]
+        user = self.context["user"]
+        try:
+            return Task.objects.filter(team=team, deleted=False).filter(task_visibility_q(user.id)).get(id=value)
+        except Task.DoesNotExist:
+            raise serializers.ValidationError("Task not found or not accessible.")
 
 
 class SandboxMessageResponseSerializer(serializers.Serializer):
@@ -673,11 +688,11 @@ class ConversationViewSet(
             raise QuotaLimitExceeded(
                 "Your organization reached its AI credit usage limit. Increase the limits in Billing settings, or ask an org admin to do so."
             )
-        serializer = SandboxOpenSerializer(data=request.data)
+        serializer = SandboxOpenSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
 
         conversation, created = self._get_or_create_sandbox_conversation(
-            request, bind_task_id=serializer.validated_data.get("task_id")
+            request, bind_task=serializer.validated_data.get("task_id")
         )
         has_content = bool(serializer.validated_data.get("content"))
         convert_to_acp, resumed_context = self._compute_sandbox_conversion(request, conversation, has_content)
@@ -696,7 +711,7 @@ class ConversationViewSet(
         )
 
     def _get_or_create_sandbox_conversation(
-        self, request: Request, *, bind_task_id: uuid.UUID | None = None
+        self, request: Request, *, bind_task: Task | None = None
     ) -> tuple[Conversation, bool]:
         """Resolve the URL-keyed conversation, creating it on first use (the client mints the id).
 
@@ -706,9 +721,9 @@ class ConversationViewSet(
         `open` immediately rejects. Returns whether the row was created this request so the caller can
         drop it again if nothing ends up being provisioned.
 
-        `bind_task_id` binds the new row to an existing Task (validated to this team), so the first
-        message resumes that Task's run instead of starting a fresh task. It only applies on create —
-        an existing conversation keeps the Task it was born with.
+        `bind_task` (already validated for team + visibility by `SandboxOpenSerializer`) binds the new
+        row to an existing Task, so the first message resumes that Task's run instead of starting a
+        fresh task. It only applies on create — an existing conversation keeps the Task it was born with.
         """
         conversation_id = self.kwargs[self.lookup_url_kwarg]
         user = cast(User, request.user)
@@ -727,7 +742,7 @@ class ConversationViewSet(
                 type=Conversation.Type.ASSISTANT,
                 is_internal=is_impersonated_session(request),
                 agent_runtime=Conversation.AgentRuntime.SANDBOX,
-                task=self._resolve_bind_task(bind_task_id) if bind_task_id is not None else None,
+                task=bind_task,
             )
             return conversation, True
         if conversation.user != user or conversation.team != self.team:
@@ -735,13 +750,6 @@ class ConversationViewSet(
         if conversation.deleted:
             raise exceptions.NotFound("Conversation does not exist")
         return conversation, False
-
-    def _resolve_bind_task(self, task_id: uuid.UUID) -> Task:
-        """Fetch the Task to bind a new conversation to, scoped to this team (IDOR-safe)."""
-        try:
-            return Task.objects.filter(team=self.team, deleted=False).get(id=task_id)
-        except Task.DoesNotExist:
-            raise exceptions.NotFound("Task not found.")
 
     def _compute_sandbox_conversion(
         self, request: Request, conversation: Conversation, has_content: bool

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -241,6 +241,14 @@ class SandboxOpenSerializer(serializers.Serializer):
             "Defaults to `auto`, which allows safe tool use while preserving explicit confirmations."
         ),
     )
+    task_id = serializers.UUIDField(
+        required=False,
+        help_text=(
+            "Bind a brand-new sandbox conversation to an existing Task so the first message resumes "
+            "that Task's run. Honored only when this request creates the conversation row; ignored "
+            "for an already-existing conversation."
+        ),
+    )
 
 
 class SandboxMessageResponseSerializer(serializers.Serializer):
@@ -668,7 +676,9 @@ class ConversationViewSet(
         serializer = SandboxOpenSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        conversation, created = self._get_or_create_sandbox_conversation(request)
+        conversation, created = self._get_or_create_sandbox_conversation(
+            request, bind_task_id=serializer.validated_data.get("task_id")
+        )
         has_content = bool(serializer.validated_data.get("content"))
         convert_to_acp, resumed_context = self._compute_sandbox_conversion(request, conversation, has_content)
 
@@ -685,7 +695,9 @@ class ConversationViewSet(
             request, conversation, resumed_context=resumed_context, convert_to_acp=convert_to_acp, created=created
         )
 
-    def _get_or_create_sandbox_conversation(self, request: Request) -> tuple[Conversation, bool]:
+    def _get_or_create_sandbox_conversation(
+        self, request: Request, *, bind_task_id: uuid.UUID | None = None
+    ) -> tuple[Conversation, bool]:
         """Resolve the URL-keyed conversation, creating it on first use (the client mints the id).
 
         `open` is create-or-resume: a brand-new conversation (first warm or first message) has no row
@@ -693,6 +705,10 @@ class ConversationViewSet(
         and only for a sandbox-eligible caller — otherwise we'd persist an orphaned LangGraph row that
         `open` immediately rejects. Returns whether the row was created this request so the caller can
         drop it again if nothing ends up being provisioned.
+
+        `bind_task_id` binds the new row to an existing Task (validated to this team), so the first
+        message resumes that Task's run instead of starting a fresh task. It only applies on create —
+        an existing conversation keeps the Task it was born with.
         """
         conversation_id = self.kwargs[self.lookup_url_kwarg]
         user = cast(User, request.user)
@@ -711,6 +727,7 @@ class ConversationViewSet(
                 type=Conversation.Type.ASSISTANT,
                 is_internal=is_impersonated_session(request),
                 agent_runtime=Conversation.AgentRuntime.SANDBOX,
+                task=self._resolve_bind_task(bind_task_id) if bind_task_id is not None else None,
             )
             return conversation, True
         if conversation.user != user or conversation.team != self.team:
@@ -718,6 +735,13 @@ class ConversationViewSet(
         if conversation.deleted:
             raise exceptions.NotFound("Conversation does not exist")
         return conversation, False
+
+    def _resolve_bind_task(self, task_id: uuid.UUID) -> Task:
+        """Fetch the Task to bind a new conversation to, scoped to this team (IDOR-safe)."""
+        try:
+            return Task.objects.filter(team=self.team, deleted=False).get(id=task_id)
+        except Task.DoesNotExist:
+            raise exceptions.NotFound("Task not found.")
 
     def _compute_sandbox_conversion(
         self, request: Request, conversation: Conversation, has_content: bool

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1341,6 +1341,98 @@ class TestConversationSandboxRoute(APIBaseTest):
         passed_conversation = m_session.call_args[0][0]
         self.assertEqual(str(passed_conversation.id), str(conversation.id))
 
+    def test_open_binds_new_conversation_to_existing_task(self):
+        # "Open task" opens a blank chat pre-bound to an existing Task: the first message creates the
+        # conversation row bound to that Task, so routing resumes the Task's run (terminal-resume)
+        # instead of starting a fresh task.
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        task.create_run(mode="background")
+        conversation_id = str(uuid.uuid4())
+        sentinel = SandboxRouteResult(
+            task_id=str(task.id), run_id="r", trace_id=None, run_status="queued", just_created_run=True
+        )
+        with (
+            patch("ee.api.conversation.has_sandbox_mode_feature_flag", return_value=True),
+            patch("ee.api.conversation.SandboxSession") as m_session,
+            patch("ee.api.conversation.report_user_action"),
+        ):
+            m_session.return_value.open.return_value = sentinel
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation_id}/open/",
+                {"content": "continue this task", "trace_id": str(uuid.uuid4()), "task_id": str(task.id)},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        conversation = Conversation.objects.get(id=conversation_id)
+        self.assertEqual(conversation.task_id, task.id)
+        self.assertEqual(conversation.agent_runtime, Conversation.AgentRuntime.SANDBOX)
+        # The session opens against the bound conversation, so its task_id drives terminal-run resume
+        # — no repository is auto-routed (the resumed Task already has one).
+        passed_conversation = m_session.call_args[0][0]
+        self.assertEqual(passed_conversation.task_id, task.id)
+        self.mock_select_repo.assert_not_awaited()
+
+    def test_open_rejects_task_id_from_another_team(self):
+        # IDOR guard: a Task from another team can't be bound. The request 404s and creates no row.
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        other_task = Task.objects.create(
+            team=other_team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        conversation_id = str(uuid.uuid4())
+        with (
+            patch("ee.api.conversation.has_sandbox_mode_feature_flag", return_value=True),
+            patch("ee.api.conversation.SandboxSession") as m_session,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation_id}/open/",
+                {"content": "continue this task", "trace_id": str(uuid.uuid4()), "task_id": str(other_task.id)},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertFalse(Conversation.objects.filter(id=conversation_id).exists())
+        m_session.return_value.open.assert_not_called()
+
+    def test_open_ignores_task_id_for_existing_conversation(self):
+        # Binding only happens on create — an existing conversation keeps the Task it was born with
+        # (here: none), even if a later `open` carries a `task_id`.
+        conversation = self._sandbox_conversation()
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        sentinel = SandboxRouteResult(
+            task_id="t", run_id="r", trace_id=None, run_status="queued", just_created_run=True
+        )
+        with (
+            patch("ee.api.conversation.SandboxSession") as m_session,
+            patch("ee.api.conversation.report_user_action"),
+        ):
+            m_session.return_value.open.return_value = sentinel
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/open/",
+                {"content": "hello", "trace_id": str(uuid.uuid4()), "task_id": str(task.id)},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        conversation.refresh_from_db()
+        self.assertIsNone(conversation.task_id)
+
     def test_open_first_message_routes_repository_into_session(self):
         # The auto-routed repository for a first message is threaded into the session opener.
         conversation = self._sandbox_conversation()

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -1380,7 +1380,8 @@ class TestConversationSandboxRoute(APIBaseTest):
         self.mock_select_repo.assert_not_awaited()
 
     def test_open_rejects_task_id_from_another_team(self):
-        # IDOR guard: a Task from another team can't be bound. The request 404s and creates no row.
+        # IDOR guard: a Task from another team isn't visible, so the serializer rejects it (400) and
+        # no conversation row is created.
         other_team = Team.objects.create(organization=self.organization, name="other team")
         other_task = Task.objects.create(
             team=other_team,
@@ -1400,9 +1401,64 @@ class TestConversationSandboxRoute(APIBaseTest):
                 format="json",
             )
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(Conversation.objects.filter(id=conversation_id).exists())
         m_session.return_value.open.assert_not_called()
+
+    def test_open_rejects_task_not_visible_to_user(self):
+        # A teammate's personal task isn't visible (task_visibility_q), so it can't be bound by id.
+        teammate = User.objects.create_and_join(self.organization, "teammate@posthog.com", "password")
+        teammate_task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=teammate,
+        )
+        conversation_id = str(uuid.uuid4())
+        with (
+            patch("ee.api.conversation.has_sandbox_mode_feature_flag", return_value=True),
+            patch("ee.api.conversation.SandboxSession") as m_session,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation_id}/open/",
+                {"content": "continue this task", "trace_id": str(uuid.uuid4()), "task_id": str(teammate_task.id)},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(Conversation.objects.filter(id=conversation_id).exists())
+        m_session.return_value.open.assert_not_called()
+
+    def test_open_binds_team_visible_signal_report_task(self):
+        # Signals tasks are team-scoped artifacts visible to any team member, even when created under a
+        # system-picked user — so a teammate's signal-report task can be bound.
+        teammate = User.objects.create_and_join(self.organization, "teammate2@posthog.com", "password")
+        signal_task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            created_by=teammate,
+        )
+        conversation_id = str(uuid.uuid4())
+        sentinel = SandboxRouteResult(
+            task_id=str(signal_task.id), run_id="r", trace_id=None, run_status="queued", just_created_run=True
+        )
+        with (
+            patch("ee.api.conversation.has_sandbox_mode_feature_flag", return_value=True),
+            patch("ee.api.conversation.SandboxSession") as m_session,
+            patch("ee.api.conversation.report_user_action"),
+        ):
+            m_session.return_value.open.return_value = sentinel
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation_id}/open/",
+                {"content": "continue this task", "trace_id": str(uuid.uuid4()), "task_id": str(signal_task.id)},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Conversation.objects.get(id=conversation_id).task_id, signal_task.id)
 
     def test_open_ignores_task_id_for_existing_conversation(self):
         # Binding only happens on create — an existing conversation keeps the Task it was born with

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6774,6 +6774,8 @@ const api = {
                 trace_id?: string
                 attached_context?: AttachedContext[]
                 initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi
+                /** Bind a brand-new sandbox conversation to an existing Task, resuming its run on the first message. */
+                task_id?: string
             }
         ): Promise<{
             task_id: string

--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 
 import {
     IconArrowRight,
@@ -14,9 +15,9 @@ import { LemonButton, Link, Spinner, LemonSelect, LemonSkeleton, LemonTag, Toolt
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SignalNode } from 'scenes/debug/signals/types'
-import { PENDING_SANDBOX_BIND_TASK_KEY } from 'scenes/max/maxLogic'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { SANDBOX_BIND_TASK_PARAM } from 'scenes/max/maxLogic'
 import { SandboxRunViewer } from 'scenes/max/sandbox/components/SandboxRunViewer'
 import { isTerminalRunStatus } from 'scenes/max/sandboxStreamLogic'
 import { urls } from 'scenes/urls'
@@ -210,29 +211,27 @@ function TaskLogBody({
 }
 
 /**
- * "Open task": continues the selected task in a new PostHog AI chat. It stashes the task id in
- * sessionStorage (recency-stamped, mirroring `PENDING_MAX_CONTEXT_KEY`) and opens a blank chat;
- * the user's first message creates a conversation bound to this task, resuming its run interactively.
- * Gated to a terminal run — the live Task log already covers an in-progress run, and taking over a
- * running automation run is out of scope.
+ * "Open task": continues the selected task in a new PostHog AI chat bound to it — the chat's first
+ * message creates a conversation linked to this task and resumes its run interactively. A plain click
+ * opens PostHog AI in the side panel (staying in the inbox); cmd/ctrl/middle-click follows the href to
+ * open a new tab, carrying the bind via the `bind_task` URL param. Gated to a terminal run — the live
+ * Task log already covers an in-progress run, and taking over a running automation run is out of scope.
  */
 function OpenTaskButton({ taskId, runStatus }: { taskId: string; runStatus?: TaskRunStatus }): JSX.Element {
+    const { openSidePanelMaxWithTaskBind } = useActions(maxGlobalLogic)
     const isTerminal = isTerminalRunStatus(runStatus)
-
-    const handleOpen = (): void => {
-        try {
-            sessionStorage.setItem(PENDING_SANDBOX_BIND_TASK_KEY, JSON.stringify({ taskId, timestamp: Date.now() }))
-        } catch {
-            // sessionStorage unavailable — the chat still opens, it just won't be pre-bound to the task.
-        }
-        newInternalTab(urls.ai())
-    }
 
     return (
         <LemonButton
             size="xsmall"
             type="secondary"
-            onClick={handleOpen}
+            to={combineUrl(urls.ai(), { [SANDBOX_BIND_TASK_PARAM]: taskId }).url}
+            onClick={(e) => {
+                // Plain left-click: open the side panel in place rather than navigating to /ai.
+                // Link lets a modified click (cmd/ctrl/middle) through to the href for a new tab.
+                e.preventDefault()
+                openSidePanelMaxWithTaskBind(taskId)
+            }}
             disabledReason={isTerminal ? undefined : 'Available once the run finishes'}
             tooltip="Continue this task in a new PostHog AI chat"
         >

--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { combineUrl } from 'kea-router'
 
 import {
     IconArrowRight,
@@ -11,12 +10,15 @@ import {
     IconTerminal,
     IconWarning,
 } from '@posthog/icons'
-import { Link, Spinner, LemonSelect, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, Link, Spinner, LemonSelect, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SignalNode } from 'scenes/debug/signals/types'
+import { PENDING_SANDBOX_BIND_TASK_KEY } from 'scenes/max/maxLogic'
 import { SandboxRunViewer } from 'scenes/max/sandbox/components/SandboxRunViewer'
+import { isTerminalRunStatus } from 'scenes/max/sandboxStreamLogic'
 import { urls } from 'scenes/urls'
 
 import { Task, TaskRunStatus } from 'products/tasks/frontend/types'
@@ -168,10 +170,12 @@ function TaskLogBody({
     loading,
     task,
     runId,
+    replayOnly,
 }: {
     loading: boolean
     task: Task | null
     runId: string | null
+    replayOnly: boolean
 }): JSX.Element {
     if (loading) {
         return (
@@ -185,7 +189,8 @@ function TaskLogBody({
     if (task && runId) {
         return (
             <div className="h-[calc(100vh-22rem)] min-h-[420px] w-full overflow-y-auto rounded border border-primary bg-surface-primary">
-                <SandboxRunViewer taskId={task.id} runId={runId} />
+                {/* In-progress runs stream live; terminal runs show the static replay. */}
+                <SandboxRunViewer taskId={task.id} runId={runId} replayOnly={replayOnly} />
             </div>
         )
     }
@@ -205,10 +210,42 @@ function TaskLogBody({
 }
 
 /**
+ * "Open task": continues the selected task in a new PostHog AI chat. It stashes the task id in
+ * sessionStorage (recency-stamped, mirroring `PENDING_MAX_CONTEXT_KEY`) and opens a blank chat;
+ * the user's first message creates a conversation bound to this task, resuming its run interactively.
+ * Gated to a terminal run — the live Task log already covers an in-progress run, and taking over a
+ * running automation run is out of scope.
+ */
+function OpenTaskButton({ taskId, runStatus }: { taskId: string; runStatus?: TaskRunStatus }): JSX.Element {
+    const isTerminal = isTerminalRunStatus(runStatus)
+
+    const handleOpen = (): void => {
+        try {
+            sessionStorage.setItem(PENDING_SANDBOX_BIND_TASK_KEY, JSON.stringify({ taskId, timestamp: Date.now() }))
+        } catch {
+            // sessionStorage unavailable — the chat still opens, it just won't be pre-bound to the task.
+        }
+        newInternalTab(urls.ai())
+    }
+
+    return (
+        <LemonButton
+            size="xsmall"
+            type="secondary"
+            onClick={handleOpen}
+            disabledReason={isTerminal ? undefined : 'Available once the run finishes'}
+            tooltip="Continue this task in a new PostHog AI chat"
+        >
+            Open task
+        </LemonButton>
+    )
+}
+
+/**
  * Inline "Task log": the selected linked task's agent transcript, rendered with the shared
- * read-only `SandboxRunViewer`. A `LemonSelect` switches between linked tasks (research /
- * implementation) when there's more than one; "Open task" deep-links to the full Tasks UI.
- * Mirrors desktop `AgentRunDetail`'s Task-log section.
+ * `SandboxRunViewer` — live for an in-progress run, static replay once terminal. A `LemonSelect`
+ * switches between linked tasks (research / implementation) when there's more than one; "Open task"
+ * continues the task in a new PostHog AI chat. Mirrors desktop `AgentRunDetail`'s Task-log section.
  */
 function TaskLogSection({ report }: { report: SignalReport }): JSX.Element {
     const { reportTasks, reportTasksLoading, selectedTask } = useValues(
@@ -218,7 +255,8 @@ function TaskLogSection({ report }: { report: SignalReport }): JSX.Element {
 
     const task = selectedTask?.task ?? null
     const runId = task?.latest_run?.id ?? null
-    const taskLogUrl = task ? combineUrl(urls.taskDetail(task.id), runId ? { runId } : {}).url : null
+    const runStatus = task?.latest_run?.status
+    const replayOnly = isTerminalRunStatus(runStatus)
 
     const rightSlot = task ? (
         <div className="flex items-center gap-2">
@@ -238,17 +276,18 @@ function TaskLogSection({ report }: { report: SignalReport }): JSX.Element {
                     }))}
                 />
             )}
-            {taskLogUrl && (
-                <Link to={taskLogUrl} className="text-xs">
-                    Open task
-                </Link>
-            )}
+            <OpenTaskButton taskId={task.id} runStatus={runStatus} />
         </div>
     ) : null
 
     return (
         <DetailSection icon={<IconTerminal />} title="Task log" rightSlot={rightSlot}>
-            <TaskLogBody loading={reportTasksLoading && !reportTasks} task={task} runId={runId} />
+            <TaskLogBody
+                loading={reportTasksLoading && !reportTasks}
+                task={task}
+                runId={runId}
+                replayOnly={replayOnly}
+            />
         </DetailSection>
     )
 }

--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -1,4 +1,5 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 
 import {
     IconArrowRight,
@@ -7,14 +8,18 @@ import {
     IconDocument,
     IconPullRequest,
     IconSearch,
+    IconTerminal,
     IconWarning,
 } from '@posthog/icons'
-import { Link, Spinner, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { Link, Spinner, LemonSelect, LemonSkeleton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { SignalNode } from 'scenes/debug/signals/types'
+import { SandboxRunViewer } from 'scenes/max/sandbox/components/SandboxRunViewer'
 import { urls } from 'scenes/urls'
+
+import { Task, TaskRunStatus } from 'products/tasks/frontend/types'
 
 import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
 import { SignalCard } from '../../SignalCard'
@@ -23,7 +28,7 @@ import { deriveHeadline, parsePrRepoSlug, parsePrUrlParts } from '../../utils/re
 import { getSourceProductMeta } from '../badges/sourceProductIcons'
 import { DetailSection, RightColumnSection } from './DetailSection'
 import { ReportDetailBadges } from './ReportDetail'
-import { ReportTasksSection } from './ReportTasksSection'
+import { RELATIONSHIP_LABEL, TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * Ready-state run output: a polished outcome card that links to the produced PR or report,
@@ -121,8 +126,8 @@ function RunOutputWidget({ report }: { report: SignalReport }): JSX.Element {
 
 /**
  * Compact run-state strip: live/finished status, the produced branch (when a PR exists), and run
- * timing. Mirrors desktop's run-state header line (status · branch · timing) without rebuilding the
- * run log – the actual log lives behind the linked runs (see `ReportTasksSection`).
+ * timing. Mirrors desktop's run-state header line (status · branch · timing); the agent transcript
+ * itself renders inline below in `TaskLogSection`.
  */
 function RunStateStrip({ report }: { report: SignalReport }): JSX.Element {
     const isLive =
@@ -158,10 +163,100 @@ function RunStateStrip({ report }: { report: SignalReport }): JSX.Element {
     )
 }
 
+/** The selected run's agent transcript, or a loading / empty placeholder. */
+function TaskLogBody({
+    loading,
+    task,
+    runId,
+}: {
+    loading: boolean
+    task: Task | null
+    runId: string | null
+}): JSX.Element {
+    if (loading) {
+        return (
+            <div className="flex flex-col gap-2">
+                <LemonSkeleton className="h-4 w-36" />
+                <LemonSkeleton className="h-28 w-full" />
+            </div>
+        )
+    }
+
+    if (task && runId) {
+        return (
+            <div className="h-[calc(100vh-22rem)] min-h-[420px] w-full overflow-y-auto rounded border border-primary bg-surface-primary">
+                <SandboxRunViewer taskId={task.id} runId={runId} />
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 rounded border border-primary bg-surface-primary px-4 py-3.5">
+            <span className="font-medium text-sm text-primary">
+                {task ? 'Run hasn’t started yet' : 'Waiting for the linked task'}
+            </span>
+            <span className="max-w-2xl text-xs text-secondary leading-snug">
+                {task
+                    ? 'This task is queued – its agent log will appear here once the run starts.'
+                    : 'Once the agent links this run to a task, its agent log appears here.'}
+            </span>
+        </div>
+    )
+}
+
 /**
- * Agent run detail body. Shows the run state strip + output state, the linked run(s) (which link out
- * to the task detail page – we do NOT rebuild the run-log viewer here), and contributing evidence.
- * Mirrors desktop `AgentRunDetail`'s intent with cloud's existing task-detail run log.
+ * Inline "Task log": the selected linked task's agent transcript, rendered with the shared
+ * read-only `SandboxRunViewer`. A `LemonSelect` switches between linked tasks (research /
+ * implementation) when there's more than one; "Open task" deep-links to the full Tasks UI.
+ * Mirrors desktop `AgentRunDetail`'s Task-log section.
+ */
+function TaskLogSection({ report }: { report: SignalReport }): JSX.Element {
+    const { reportTasks, reportTasksLoading, selectedTask } = useValues(
+        inboxReportDetailLogic({ reportId: report.id, report })
+    )
+    const { setSelectedTaskId } = useActions(inboxReportDetailLogic({ reportId: report.id, report }))
+
+    const task = selectedTask?.task ?? null
+    const runId = task?.latest_run?.id ?? null
+    const taskLogUrl = task ? combineUrl(urls.taskDetail(task.id), runId ? { runId } : {}).url : null
+
+    const rightSlot = task ? (
+        <div className="flex items-center gap-2">
+            {reportTasks && reportTasks.length > 1 && (
+                <LemonSelect
+                    size="small"
+                    value={task.id}
+                    onChange={(id) => setSelectedTaskId(id)}
+                    options={reportTasks.map((entry) => ({
+                        value: entry.task.id,
+                        label: (
+                            <span className="flex items-center gap-1.5">
+                                <TaskRunStatusDot status={entry.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED} />
+                                {RELATIONSHIP_LABEL[entry.relationship]}
+                            </span>
+                        ),
+                    }))}
+                />
+            )}
+            {taskLogUrl && (
+                <Link to={taskLogUrl} className="text-xs">
+                    Open task
+                </Link>
+            )}
+        </div>
+    ) : null
+
+    return (
+        <DetailSection icon={<IconTerminal />} title="Task log" rightSlot={rightSlot}>
+            <TaskLogBody loading={reportTasksLoading && !reportTasks} task={task} runId={runId} />
+        </DetailSection>
+    )
+}
+
+/**
+ * Agent run detail body. Shows the run state strip + output state, the linked run's agent transcript
+ * inline (`TaskLogSection`, via the shared `SandboxRunViewer`), and contributing evidence.
+ * Mirrors desktop `AgentRunDetail`.
  */
 export function AgentRunDetail({ report }: { report: SignalReport }): JSX.Element {
     const { reportSignals, reportSignalsLoading, isReResearch, priorityExplanation, actionabilityExplanation } =
@@ -190,7 +285,7 @@ export function AgentRunDetail({ report }: { report: SignalReport }): JSX.Elemen
                 <div className="flex flex-col min-w-0 gap-5">
                     <RunStateStrip report={report} />
                     <RunOutputWidget report={report} />
-                    <ReportTasksSection report={report} />
+                    <TaskLogSection report={report} />
                 </div>
 
                 <div className="flex flex-col min-w-0 gap-5">

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -1,5 +1,4 @@
 import { useValues } from 'kea'
-import { combineUrl } from 'kea-router'
 
 import { IconChevronRight, IconTerminal } from '@posthog/icons'
 import { Link, Spinner } from '@posthog/lemon-ui'
@@ -14,9 +13,9 @@ import { RightColumnSection } from './DetailSection'
 import { RELATIONSHIP_LABEL, TaskRunStatusDot } from './taskRunDisplay'
 
 /**
- * Renders the report's linked tasks inline (latest status + relationship) and links out to
- * cloud's existing task detail page. The run-log/session viewer lives there; this is the doorway.
- * Only `implementation` and `research` relationships are shown, implementation-first.
+ * Renders the report's linked tasks inline (latest status + relationship). Each row opens the
+ * report's run detail (`AgentRunDetail`), where the task's run log renders inline. Only
+ * `implementation` and `research` relationships are shown, implementation-first.
  */
 export function ReportTasksSection({ report }: { report: SignalReport }): JSX.Element | null {
     const { reportTasks, reportTasksLoading } = useValues(inboxReportDetailLogic({ reportId: report.id, report }))
@@ -40,23 +39,21 @@ export function ReportTasksSection({ report }: { report: SignalReport }): JSX.El
         <RightColumnSection icon={<IconTerminal />} title="Runs">
             <div className="flex flex-col gap-0.5">
                 {reportTasks.map((entry: ReportTaskEntry) => (
-                    <TaskRow key={entry.task.id} entry={entry} />
+                    <TaskRow key={entry.task.id} entry={entry} reportId={report.id} />
                 ))}
             </div>
         </RightColumnSection>
     )
 }
 
-function TaskRow({ entry }: { entry: ReportTaskEntry }): JSX.Element {
+function TaskRow({ entry, reportId }: { entry: ReportTaskEntry; reportId: string }): JSX.Element {
     const { task, relationship } = entry
     const status = task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
-    const runId = task.latest_run?.id
-    // Deep-link straight to the task's run logs in cloud's Tasks UI (selecting the latest run),
-    // rather than the in-inbox Runs route.
-    const taskLogUrl = runId ? combineUrl(urls.taskDetail(task.id), { runId }).url : urls.taskDetail(task.id)
+    // Open this report's run detail (the inbox Runs route); `inboxSceneLogic` handles the cross-tab
+    // open. The task's run log renders inline there — no need to leave the inbox for the Tasks UI.
     return (
         <Link
-            to={taskLogUrl}
+            to={urls.inboxReport('runs', reportId)}
             className="group flex items-center gap-2 rounded px-1.5 py-1 text-left text-xs no-underline transition-colors hover:bg-fill-highlight-50"
         >
             <TaskRunStatusDot status={status} />

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { useValues } from 'kea'
 import { combineUrl } from 'kea-router'
 
@@ -10,32 +9,9 @@ import { urls } from 'scenes/urls'
 import { Task, TaskRunStatus } from 'products/tasks/frontend/types'
 
 import { inboxReportDetailLogic, ReportTaskEntry } from '../../logics/inboxReportDetailLogic'
-import { SignalReport, SignalReportTaskRelationship } from '../../types'
+import { SignalReport } from '../../types'
 import { RightColumnSection } from './DetailSection'
-
-const RELATIONSHIP_LABEL: Record<SignalReportTaskRelationship, string> = {
-    research: 'Research',
-    implementation: 'Implementation',
-    repo_selection: 'Repo selection',
-}
-
-const TERMINAL_STATUSES: TaskRunStatus[] = [TaskRunStatus.COMPLETED, TaskRunStatus.FAILED, TaskRunStatus.CANCELLED]
-
-function TaskRunStatusDot({ status }: { status: TaskRunStatus }): JSX.Element {
-    const terminal = TERMINAL_STATUSES.includes(status)
-    const color =
-        status === TaskRunStatus.FAILED || status === TaskRunStatus.CANCELLED
-            ? 'bg-danger'
-            : terminal
-              ? 'bg-success'
-              : 'bg-primary'
-    return (
-        <span
-            className={clsx('inline-block size-1.5 shrink-0 rounded-full', color, !terminal && 'animate-pulse')}
-            aria-hidden
-        />
-    )
-}
+import { RELATIONSHIP_LABEL, TaskRunStatusDot } from './taskRunDisplay'
 
 /**
  * Renders the report's linked tasks inline (latest status + relationship) and links out to

--- a/frontend/src/scenes/inbox/components/detail/taskRunDisplay.tsx
+++ b/frontend/src/scenes/inbox/components/detail/taskRunDisplay.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx'
+
+import { TaskRunStatus } from 'products/tasks/frontend/types'
+
+import { SignalReportTaskRelationship } from '../../types'
+
+/** Human label for a report→task relationship, shown next to a run in the inbox. */
+export const RELATIONSHIP_LABEL: Record<SignalReportTaskRelationship, string> = {
+    research: 'Research',
+    implementation: 'Implementation',
+    repo_selection: 'Repo selection',
+}
+
+/** Run statuses that count as terminal. Mirrors desktop `isTerminalStatus`. */
+export const TERMINAL_STATUSES: TaskRunStatus[] = [
+    TaskRunStatus.COMPLETED,
+    TaskRunStatus.FAILED,
+    TaskRunStatus.CANCELLED,
+]
+
+/** Small status dot: red for failed/cancelled, green for completed, pulsing blue while in motion. */
+export function TaskRunStatusDot({ status }: { status: TaskRunStatus }): JSX.Element {
+    const terminal = TERMINAL_STATUSES.includes(status)
+    const color =
+        status === TaskRunStatus.FAILED || status === TaskRunStatus.CANCELLED
+            ? 'bg-danger'
+            : terminal
+              ? 'bg-success'
+              : 'bg-primary'
+    return (
+        <span
+            className={clsx('inline-block size-1.5 shrink-0 rounded-full', color, !terminal && 'animate-pulse')}
+            aria-hidden
+        />
+    )
+}

--- a/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxReportDetailLogic.ts
@@ -98,6 +98,8 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         setOptimisticReviewers: (reviewers: EnrichedReviewer[] | null) => ({ reviewers }),
         // Debounced server-side org-member search for the add-reviewer picker.
         searchAvailableReviewers: (query: string) => ({ query }),
+        // Which linked task's run log the detail view shows; null falls back to `primaryTask`.
+        setSelectedTaskId: (taskId: string | null) => ({ taskId }),
     }),
 
     loaders(({ props }) => ({
@@ -166,6 +168,15 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
             {
                 updateReviewers: (_, { optimistic }) => optimistic,
                 setOptimisticReviewers: (_, { reviewers }) => reviewers,
+            },
+        ],
+        // Explicit task selection for the run-log viewer. Reset when the report changes so a freshly
+        // opened run starts on its `primaryTask`.
+        selectedTaskId: [
+            null as string | null,
+            {
+                setSelectedTaskId: (_, { taskId }) => taskId,
+                setReport: () => null,
             },
         ],
     }),
@@ -266,6 +277,37 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 })
                 return hasInFlight && hasPriorTerminal
             },
+        ],
+        // The default task whose run log is shown: prefer one still in motion, tie-break by most-recent
+        // link. Mirrors desktop `AgentRunDetail`'s `pickPrimaryTask`.
+        primaryTask: [
+            (s) => [s.reportTasks],
+            (reportTasks: ReportTaskEntry[] | null): ReportTaskEntry | null => {
+                if (!reportTasks || reportTasks.length === 0) {
+                    return null
+                }
+                return [...reportTasks].sort((a, b) => {
+                    const aInMotion = !TERMINAL_RUN_STATUSES.includes(
+                        a.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
+                    )
+                    const bInMotion = !TERMINAL_RUN_STATUSES.includes(
+                        b.task.latest_run?.status ?? TaskRunStatus.NOT_STARTED
+                    )
+                    if (aInMotion !== bInMotion) {
+                        return aInMotion ? -1 : 1
+                    }
+                    return new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+                })[0]
+            },
+        ],
+        // The linked task the viewer renders: the explicit selection if it still exists, else `primaryTask`.
+        selectedTask: [
+            (s) => [s.reportTasks, s.selectedTaskId, s.primaryTask],
+            (
+                reportTasks: ReportTaskEntry[] | null,
+                selectedTaskId: string | null,
+                primaryTask: ReportTaskEntry | null
+            ): ReportTaskEntry | null => reportTasks?.find((rt) => rt.task.id === selectedTaskId) ?? primaryTask,
         ],
     }),
 

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -104,6 +104,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
     })),
     actions({
         openSidePanelMax: (conversationId?: string) => ({ conversationId }),
+        openSidePanelMaxWithTaskBind: (taskId: string) => ({ taskId }),
         askSidePanelMax: (prompt: string) => ({ prompt }),
         acceptDataProcessing: (testOnlyOverride?: boolean) => ({ testOnlyOverride }),
         registerTool: (tool: ToolRegistration) => ({ tool }),
@@ -242,6 +243,22 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
                 }
                 logic.actions.openConversation(conversationId)
             }
+        },
+        // Open the side panel on a fresh chat bound to a sandbox Task (inbox "Open task" — in-place,
+        // not a new tab). The side panel doesn't sync the URL, so the binding is seeded directly here
+        // rather than via the `bind_task` param the scene route reads. `setPendingBindTaskId` runs
+        // after `startNewConversation`, which clears it.
+        openSidePanelMaxWithTaskBind: ({ taskId }) => {
+            if (!values.sidePanelOpen || values.selectedTab !== SidePanelTab.Max) {
+                actions.openSidePanel(SidePanelTab.Max)
+            }
+            let logic = maxLogic.findMounted({ panelId: SIDE_PANEL_PANEL_ID })
+            if (!logic) {
+                logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
+                logic.mount() // we're never unmounting this
+            }
+            logic.actions.startNewConversation()
+            logic.actions.setPendingBindTaskId(taskId)
         },
         loadConversationHistoryFailure: ({ errorObject }) => {
             lemonToast.error(errorObject?.data?.detail || 'Failed to load conversation history.')

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -50,6 +50,18 @@ interface StoredMaxContext {
     timestamp: number
 }
 
+/** Key for a pending sandbox task-bind (set by inbox "Open task") in sessionStorage */
+export const PENDING_SANDBOX_BIND_TASK_KEY = 'posthog.pending_sandbox_bind_task'
+
+/** Maximum age for a restored task-bind (5 minutes) */
+const PENDING_BIND_TASK_MAX_AGE_MS = 5 * 60 * 1000
+
+/** Stored task-bind structure for sessionStorage */
+interface StoredSandboxBindTask {
+    taskId: string
+    timestamp: number
+}
+
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
 export type ThreadMessage = RootAssistantMessage & {
@@ -220,6 +232,7 @@ export const maxLogic = kea<maxLogicType>([
         incrActiveStreamingThreads: true,
         decrActiveStreamingThreads: true,
         setAutoRun: (autoRun: boolean) => ({ autoRun }),
+        setPendingBindTaskId: (taskId: string | null) => ({ taskId }),
     }),
 
     reducers(({ props }) => ({
@@ -245,6 +258,17 @@ export const maxLogic = kea<maxLogicType>([
                 setConversationId: (_, { conversationId }) => conversationId,
                 startNewConversation: () => null,
                 toggleConversationHistory: (state, { visible }) => (visible ? null : state),
+            },
+        ],
+
+        // A pending Task to bind a new sandbox conversation to (set by inbox "Open task"). Consumed by
+        // maxThreadLogic on the first message, which sends it as `task_id` so the open resumes that
+        // Task's run. Cleared once consumed, or when an explicit new chat starts without a bind.
+        pendingBindTaskId: [
+            null as string | null,
+            {
+                setPendingBindTaskId: (_, { taskId }) => taskId,
+                startNewConversation: () => null,
             },
         ],
 
@@ -691,6 +715,24 @@ export const maxLogic = kea<maxLogicType>([
                 actions.openConversation(search.chat)
             } else if (values.conversationHistoryVisible) {
                 actions.toggleConversationHistory()
+            }
+
+            // A fresh chat (no `chat` param) may carry a pending task-bind from inbox "Open task".
+            // Read it last so it survives the `startNewConversation` above (which clears it). The
+            // first message then resumes that task's run. Mirrors the PENDING_MAX_CONTEXT_KEY read.
+            if (!search.chat) {
+                try {
+                    const stored = sessionStorage.getItem(PENDING_SANDBOX_BIND_TASK_KEY)
+                    if (stored) {
+                        sessionStorage.removeItem(PENDING_SANDBOX_BIND_TASK_KEY)
+                        const { taskId, timestamp }: StoredSandboxBindTask = JSON.parse(stored)
+                        if (taskId && Date.now() - timestamp < PENDING_BIND_TASK_MAX_AGE_MS) {
+                            actions.setPendingBindTaskId(taskId)
+                        }
+                    }
+                } catch {
+                    // sessionStorage unavailable or data malformed — proceed as a normal new chat.
+                }
             }
         },
     })),

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -50,17 +50,13 @@ interface StoredMaxContext {
     timestamp: number
 }
 
-/** Key for a pending sandbox task-bind (set by inbox "Open task") in sessionStorage */
-export const PENDING_SANDBOX_BIND_TASK_KEY = 'posthog.pending_sandbox_bind_task'
-
-/** Maximum age for a restored task-bind (5 minutes) */
-const PENDING_BIND_TASK_MAX_AGE_MS = 5 * 60 * 1000
-
-/** Stored task-bind structure for sessionStorage */
-interface StoredSandboxBindTask {
-    taskId: string
-    timestamp: number
-}
+/**
+ * `/ai` query param carrying a sandbox Task to bind a fresh chat to (set by inbox "Open task").
+ * A URL param (rather than sessionStorage) so the binding survives opening the chat in a new tab or
+ * window. The side panel — which doesn't sync the URL — receives the same binding via a direct
+ * `setPendingBindTaskId` (see `maxGlobalLogic.openSidePanelMaxWithTaskBind`).
+ */
+export const SANDBOX_BIND_TASK_PARAM = 'bind_task'
 
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
@@ -717,22 +713,13 @@ export const maxLogic = kea<maxLogicType>([
                 actions.toggleConversationHistory()
             }
 
-            // A fresh chat (no `chat` param) may carry a pending task-bind from inbox "Open task".
-            // Read it last so it survives the `startNewConversation` above (which clears it). The
-            // first message then resumes that task's run. Mirrors the PENDING_MAX_CONTEXT_KEY read.
-            if (!search.chat) {
-                try {
-                    const stored = sessionStorage.getItem(PENDING_SANDBOX_BIND_TASK_KEY)
-                    if (stored) {
-                        sessionStorage.removeItem(PENDING_SANDBOX_BIND_TASK_KEY)
-                        const { taskId, timestamp }: StoredSandboxBindTask = JSON.parse(stored)
-                        if (taskId && Date.now() - timestamp < PENDING_BIND_TASK_MAX_AGE_MS) {
-                            actions.setPendingBindTaskId(taskId)
-                        }
-                    }
-                } catch {
-                    // sessionStorage unavailable or data malformed — proceed as a normal new chat.
-                }
+            // A fresh chat (no `chat` param) may carry a task to bind via the URL (inbox "Open task").
+            // Read it after the `startNewConversation` above (which clears it) so it survives, and the
+            // first message resumes that task's run. The param naturally drops once `setConversationId`
+            // rewrites the URL to `?chat=<id>` after the first message.
+            const bindTaskId = search[SANDBOX_BIND_TASK_PARAM]
+            if (!search.chat && bindTaskId) {
+                actions.setPendingBindTaskId(String(bindTaskId))
             }
         },
     })),

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -167,6 +167,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'threadLogicKey as activeThreadKey',
                 'activeStreamingThreads',
                 'conversationId as parentConversationId',
+                'pendingBindTaskId',
             ],
             maxContextLogic,
             ['compiledContext'],
@@ -199,6 +200,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'setConversationId',
                 'setAutoRun',
                 'loadConversationHistorySuccess',
+                'setPendingBindTaskId',
             ],
             maxGlobalLogic,
             ['loadConversation'],
@@ -724,11 +726,19 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             trace_id: traceId,
                             attached_context: attachedContext,
                             initial_permission_mode: SANDBOX_INITIAL_PERMISSION_MODE,
+                            // Bind a brand-new conversation to an existing Task (inbox "Open task") so the
+                            // backend resumes that Task's run. Only the first message carries it.
+                            ...(values.pendingBindTaskId ? { task_id: values.pendingBindTaskId } : {}),
                         })
                         if (handle) {
                             // The sent message consumes any in-flight warm — it's now the active run, so
                             // drop the release handle to avoid cancelling the run out from under it.
                             cache.warmRun = null
+                            // The bind is one-shot: the conversation now exists bound to the Task, so
+                            // follow-ups target it directly — don't re-send task_id.
+                            if (values.pendingBindTaskId) {
+                                actions.setPendingBindTaskId(null)
+                            }
                             actions.openSandboxSse({
                                 taskId: handle.task_id,
                                 runId: handle.run_id,
@@ -1383,6 +1393,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 }
                 actions.clearPendingApproval()
                 actions.setResolvedApprovalStatus(pendingProposalId, 'auto_rejected')
+            }
+            // A pending task-bind (inbox "Open task") makes this first message a sandbox task-resume:
+            // the conversation is created bound to the Task and its run is resumed. Force sandbox mode
+            // so the message routes through the sandbox `open` endpoint (which carries the task_id).
+            // Reducers apply synchronously, so the `is_sandbox` derivation below sees the new value.
+            if (values.pendingBindTaskId && !values.isSandboxMode) {
+                actions.setIsSandboxMode(true)
             }
             const agentMode = values.agentMode
 

--- a/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
+++ b/frontend/src/scenes/max/sandbox/components/SandboxRunViewer.tsx
@@ -15,28 +15,34 @@ export interface SandboxRunViewerProps {
     streamKey?: string
     /** Telemetry tag only — omit for conversation-less runs (automation, Slack, signals, PR-triggered). */
     conversationId?: string
+    /**
+     * Replay the persisted `logs/` snapshot once and never open SSE (default `true`, the safe choice
+     * for a static run viewer). Pass `false` for an in-progress run to stream live frames over SSE,
+     * falling back to replay automatically once the run goes terminal. Folded into the logic key, so a
+     * live and a replay viewer of the same run can never share state.
+     */
+    replayOnly?: boolean
     className?: string
 }
 
 /**
- * Embeddable, read-only replay of a task run's agent thread. Binds a `replayOnly` `sandboxStreamLogic`
- * instance (keyed separately from any live stream of the same run, so streaming can never bleed in),
- * replays the persisted `logs/` snapshot once, and renders the shared `SandboxThreadView`. No SSE, no
- * permissions, no composer. Drop in anywhere with just `(taskId, runId)`.
+ * Embeddable read-only viewer of a task run's agent thread. Binds a `sandboxStreamLogic` instance
+ * (keyed apart from any other stream of the same run) and renders the shared `SandboxThreadView`. With
+ * the default `replayOnly`, it replays the persisted `logs/` snapshot once — no SSE. With
+ * `replayOnly={false}` it streams an in-progress run live (and replays once terminal). No permissions,
+ * no composer. Drop in anywhere with just `(taskId, runId)`.
  */
 export function SandboxRunViewer({
     taskId,
     runId,
     streamKey,
     conversationId,
+    replayOnly = true,
     className,
 }: SandboxRunViewerProps): JSX.Element {
     return (
-        <BindLogic
-            logic={sandboxStreamLogic}
-            props={{ streamKey: streamKey ?? runId, conversationId, replayOnly: true }}
-        >
-            <SandboxRunViewerContent taskId={taskId} runId={runId} className={className} />
+        <BindLogic logic={sandboxStreamLogic} props={{ streamKey: streamKey ?? runId, conversationId, replayOnly }}>
+            <SandboxRunViewerContent taskId={taskId} runId={runId} replayOnly={replayOnly} className={className} />
         </BindLogic>
     )
 }
@@ -44,21 +50,25 @@ export function SandboxRunViewer({
 function SandboxRunViewerContent({
     taskId,
     runId,
+    replayOnly,
     className,
 }: {
     taskId: string
     runId: string
+    replayOnly: boolean
     className?: string
 }): JSX.Element {
     const { bootstrapLoading, threadItems } = useValues(sandboxStreamLogic)
     const { bootstrapRun, reset } = useActions(sandboxStreamLogic)
 
     useEffect(() => {
-        // Reset first so a reused instance (stable streamKey, changed run) replays the new snapshot
+        // Reset first so a reused instance (stable streamKey, changed run) replays/streams the new run
         // cleanly; the bound logic keys read-only instances apart from any live stream of the same run.
+        // `replayOnly` is in the deps so a status transition (live → terminal) re-bootstraps the right
+        // mode — the bound logic re-keys on it, so `bootstrapRun`/`reset` are fresh references anyway.
         reset()
         bootstrapRun({ taskId, runId })
-    }, [taskId, runId, bootstrapRun, reset])
+    }, [taskId, runId, replayOnly, bootstrapRun, reset])
 
     const showSpinner = bootstrapLoading && threadItems.length === 0
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -579,6 +579,8 @@ SPECTACULAR_SETTINGS = {
         "PropertyGroupTypeEnum": ["cohort", "person", "group"],
         "ExistenceOperatorEnum": ["is_set", "is_not_set"],
         "TaskExecutionModeEnum": ["interactive", "background"],
+        # Shared by ClaudeTaskRunCreateSchema and SandboxOpen (the conversations `open` body).
+        "InitialPermissionModeEnum": ["default", "acceptEdits", "plan", "bypassPermissions", "auto"],
         "HogFunctionTemplatingEnum": ["hog", "liquid"],
         "HogFlowEdgeTypeEnum": ["continue", "branch"],
         "SourceMatchEnum": ["none", "auto", "mapped"],

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -532,6 +532,24 @@ export interface SandboxAttachedContextItemApi {
 }
 
 /**
+ * * `default` - default
+ * * `acceptEdits` - acceptEdits
+ * * `plan` - plan
+ * * `bypassPermissions` - bypassPermissions
+ * * `auto` - auto
+ */
+export type InitialPermissionModeEnumApi =
+    (typeof InitialPermissionModeEnumApi)[keyof typeof InitialPermissionModeEnumApi]
+
+export const InitialPermissionModeEnumApi = {
+    Default: 'default',
+    AcceptEdits: 'acceptEdits',
+    Plan: 'plan',
+    BypassPermissions: 'bypassPermissions',
+    Auto: 'auto',
+} as const
+
+/**
  * Request body for `POST /conversations/{id}/open/`. A string `content` processes a turn; a
  * null/absent `content` warms a sandbox that idles awaiting the first message.
  */
@@ -546,6 +564,16 @@ export interface SandboxOpenApi {
     trace_id?: string
     /** Typed PostHog entities (and free text) attached to this message. */
     attached_context?: SandboxAttachedContextItemApi[]
+    /** Initial permission mode for the sandbox agent session. Defaults to `auto`, which allows safe tool use while preserving explicit confirmations.
+     *
+     * * `default` - default
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto */
+    initial_permission_mode?: InitialPermissionModeEnumApi
+    /** Bind a brand-new sandbox conversation to an existing Task so the first message resumes that Task's run. Honored only when this request creates the conversation row; ignored for an already-existing conversation. */
+    task_id?: string
 }
 
 /**

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -126,6 +126,21 @@ export const ConversationsOpenCreateBody = /* @__PURE__ */ zod
             )
             .optional()
             .describe('Typed PostHog entities (and free text) attached to this message.'),
+        initial_permission_mode: zod
+            .enum(['default', 'acceptEdits', 'plan', 'bypassPermissions', 'auto'])
+            .describe(
+                '\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto'
+            )
+            .optional()
+            .describe(
+                'Initial permission mode for the sandbox agent session. Defaults to `auto`, which allows safe tool use while preserving explicit confirmations.\n\n\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto'
+            ),
+        task_id: zod
+            .uuid()
+            .optional()
+            .describe(
+                "Bind a brand-new sandbox conversation to an existing Task so the first message resumes that Task's run. Honored only when this request creates the conversation row; ignored for an already-existing conversation."
+            ),
     })
     .describe(
         'Request body for `POST \/conversations\/{id}\/open\/`. A string `content` processes a turn; a\nnull\/absent `content` warms a sandbox that idles awaiting the first message.'

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -566,10 +566,10 @@ export const ReasoningEffortEnumApi = {
  * * `bypassPermissions` - bypassPermissions
  * * `auto` - auto
  */
-export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi =
-    (typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi)[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi]
+export type InitialPermissionModeEnumApi =
+    (typeof InitialPermissionModeEnumApi)[keyof typeof InitialPermissionModeEnumApi]
 
-export const ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi = {
+export const InitialPermissionModeEnumApi = {
     Default: 'default',
     AcceptEdits: 'acceptEdits',
     Plan: 'plan',
@@ -638,7 +638,7 @@ export interface ClaudeTaskRunCreateSchemaApi {
      * * `plan` - plan
      * * `bypassPermissions` - bypassPermissions
      * * `auto` - auto */
-    initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi
+    initial_permission_mode?: InitialPermissionModeEnumApi
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12303,10 +12303,10 @@ export namespace Schemas {
      * * `bypassPermissions` - bypassPermissions
      * * `auto` - auto
      */
-    export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum];
+    export type InitialPermissionModeEnum = typeof InitialPermissionModeEnum[keyof typeof InitialPermissionModeEnum];
 
 
-    export const ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = {
+    export const InitialPermissionModeEnum = {
       Default: 'default',
       AcceptEdits: 'acceptEdits',
       Plan: 'plan',
@@ -12375,7 +12375,7 @@ export namespace Schemas {
        * * `plan` - plan
        * * `bypassPermissions` - bypassPermissions
        * * `auto` - auto */
-      initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
+      initial_permission_mode?: InitialPermissionModeEnum;
     }
 
     export type ClickhouseEventProperties = { [key: string]: unknown };
@@ -45120,6 +45120,16 @@ export namespace Schemas {
       trace_id?: string;
       /** Typed PostHog entities (and free text) attached to this message. */
       attached_context?: SandboxAttachedContextItem[];
+      /** Initial permission mode for the sandbox agent session. Defaults to `auto`, which allows safe tool use while preserving explicit confirmations.
+       *
+       * * `default` - default
+       * * `acceptEdits` - acceptEdits
+       * * `plan` - plan
+       * * `bypassPermissions` - bypassPermissions
+       * * `auto` - auto */
+      initial_permission_mode?: InitialPermissionModeEnum;
+      /** Bind a brand-new sandbox conversation to an existing Task so the first message resumes that Task's run. Honored only when this request creates the conversation row; ignored for an already-existing conversation. */
+      task_id?: string;
     }
 
     export interface SavedHeatmapListResponse {


### PR DESCRIPTION
## Problem

The inbox run detail (Runs tab → a run) showed run status and output, but only *linked out* to the Tasks UI for the actual agent transcript. The standalone agents app shows the linked task's run log inline on this page, so you can read what the agent did without leaving the inbox. This brings that to PostHog web.

## Changes

- Replace the link-out "Runs" doorway in the inbox run detail with an inline **Task log** section that renders the linked task's agent transcript via the shared read-only `SandboxRunViewer` (from `scenes/max`).
- Add a task switcher (`LemonSelect`, shown when a report has more than one linked task — research / implementation) and an "Open task" deep-link to the full Tasks UI.
- Move task-selection state (`selectedTaskId`, `primaryTask`, `selectedTask`) into `inboxReportDetailLogic` (kea), mirroring the desktop `pickPrimaryTask` behaviour.
- Lift the shared `RELATIONSHIP_LABEL` / `TaskRunStatusDot` helpers into `taskRunDisplay.tsx` (still used by `ReportTasksSection`, which `ReportDetail` renders).

Read-only replay is intentional: for an in-progress run the panel shows the persisted snapshot at open. Live SSE streaming is a possible follow-up.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated checks I actually ran:

- `pnpm typegen:write` — kea logic types regenerate clean.
- `tsgo` typecheck — the four changed files are clean. The only errors reported are pre-existing on the base branch in unrelated files (`DebugCHQueries*`, `sandboxPermissionDisplayUtils*`); confirmed via a stash baseline that they exist without this change.
- `oxlint` on the four changed files — 0 warnings, 0 errors.

I did **not** run Storybook or the live app. The existing `AgentRunDetail` stories compile (component signature unchanged) and fall back to the panel's loading/empty state against mocks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8), directed by the PR assignee.
- No repo-provided skills were invoked for this change.
- Decisions: chose read-only replay via the existing `SandboxRunViewer` over building a live-streaming viewer (simpler, reuses the drop-in component); replaced the link-out doorway with the inline log to match the source page; kept selection logic in kea per repo conventions; lifted the shared display helpers rather than duplicating them.
- Stacked on #60860 (`feat/posthog-ai-sandboxes`), which carries the `SandboxRunViewer` dependency (merged from #65051).
