### PR TITLE
feat(lemon-ui): add DatePicker wrapper as the LemonUI->Quill migration seam

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -324,6 +324,26 @@ snapshots:
         hash: v1.k794b7964.32b24bae31f6eac19655d6e880fec124ed6615fb8853542b494f547d5de7d64c.073AKdbdUItMfB0p5BZ8oB2AKlO5Ot7qUJ_J95RdFlg
     components-currencydropdown--currency-dropdown-story--light:
         hash: v1.k794b7964.308820a64ca20fabbe59e144555db5958fa365bd12fb8dfabb04940d8085ec2d.yEtSxmQ7TRrC1qv2ve30E_AOodG23EDmmX-6KYESnYE
+    components-date-picker--clearable--dark:
+        hash: v1.k794b7964.a2e9779c1a3ac497310fb5f89072e664cc0d0897713e2c7d2eac53079d8388b0.dE-k_vFwZ2xVhbsPhYYQDdCDew277Ycuq8RV-pSl1Nc
+    components-date-picker--clearable--light:
+        hash: v1.k794b7964.928b54b94f34a13915da372486a2e16b7dde18f17564aa0517d2bf63c182f922.CLhe9k_bTztvGW1yt3MG2slsjT9bPGy4TNyVVXDqUHs
+    components-date-picker--empty--dark:
+        hash: v1.k794b7964.e6480c3af3602a6b510c6f8615588170d0e0161c7c67d95e16a00b52fcfaae76.oD-qBT1I2fy9ucD4QnDNxzOTd3Z0cEi1zCxk8cYGfsA
+    components-date-picker--empty--light:
+        hash: v1.k794b7964.8cb7d91fd14805d6dd97ddf91c73692958b49b5303c45a23c015881dc8e5b4d5.9I5dROdqb8yLagmIJJtPVDZmB49n4FJ3CtDk_AxL2JY
+    components-date-picker--past-only--dark:
+        hash: v1.k794b7964.1edeb2b451c40f4668794b3f0b2ce26310d8de3d86251268e05e29907aefa32f.MQyuYmfzDfAt5PomF5hX-5T6Y8SbwHU1u5WNAZ-sCp8
+    components-date-picker--past-only--light:
+        hash: v1.k794b7964.55110c91efc330aafd9b3e13aca56ce6f318ab8705b467a4dd17ff8c0d3bcc5c.osuoC2s8h8s0ulbWzM5oSXRHH0B5jQ1uMGoOHoTqSVM
+    components-date-picker--with-time--dark:
+        hash: v1.k794b7964.65c714e51e6bcbb96db62c5287c287106aabc63fc6e2ea9576eeb641956c4463.zD6m1LyQaP5xoQeZEWw-WpPwIojsj6JWX9c4-S3Dl_4
+    components-date-picker--with-time--light:
+        hash: v1.k794b7964.4cfe603eba8a77f44532fbee8a983ae252b4736af1b8dea4e287a0fff412907f.TR8kTZIFnXs2OCSfkS-Vk93fZxGLTjaZy-xx4PrmlOE
+    components-date-picker--with-value--dark:
+        hash: v1.k794b7964.060a1f70aa678134dc749f71641c8557442eeb88f301d2ec07d8dcb35d442c60.aj4F0bxV7lHWSzkvqFT-RtCtV9q6X9PIDcrUWeW54gM
+    components-date-picker--with-value--light:
+        hash: v1.k794b7964.977ad69538501eb024c8298cf2f40f41a0939d50f53400d5032c7843e108e089.9ehxQrCCMr97Ygbk_EsA8sYCOnzErU8dBuhFSXE90zc
     components-definition-icons--event-definition-icons--dark:
         hash: v1.k794b7964.854a8bd4d9c75ba270f00d8fc294ce05e361e930f9c451395fcc340888e40e42.9fzj4k7yiSGvoH54qpkZUgaJljKv1I-90MPGNuAqneU
     components-definition-icons--event-definition-icons--light:

--- a/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { dayjs } from 'lib/dayjs'
+
+import { DatePicker, DatePickerProps } from './DatePicker'
+
+type Story = StoryObj<typeof DatePicker>
+const meta: Meta<typeof DatePicker> = {
+    title: 'Components/Date picker',
+    component: DatePicker,
+    parameters: {
+        mockDate: '2023-01-26',
+    },
+    tags: ['autodocs'],
+}
+export default meta
+
+function Template(props: Partial<DatePickerProps>): JSX.Element {
+    const [value, setValue] = useState<dayjs.Dayjs | null>(props.value ?? null)
+    return (
+        <div className="w-80">
+            <DatePicker {...props} value={value} onChange={setValue} />
+        </div>
+    )
+}
+
+export const Empty: Story = { render: () => <Template placeholder="Select a date" /> }
+
+export const WithValue: Story = { render: () => <Template value={dayjs('2023-01-15')} /> }
+
+export const Clearable: Story = { render: () => <Template value={dayjs('2023-01-15')} clearable /> }
+
+export const WithTime: Story = {
+    render: () => <Template value={dayjs('2023-01-15')} granularity="minute" showTimeToggle />,
+}
+
+export const PastOnly: Story = { render: () => <Template placeholder="Select a past date" selectionPeriod="past" /> }

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -1,10 +1,8 @@
-import { render, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 
 import { dayjs } from 'lib/dayjs'
-
-import { getByDataAttr } from '~/test/byDataAttr'
 
 import { DatePicker, DatePickerProps } from './DatePicker'
 
@@ -46,9 +44,10 @@ describe('DatePicker', () => {
         const { container, onChange } = renderDatePicker(dayjs('2023-01-15'))
 
         await userEvent.click(within(container).getByText('January 15, 2023'))
-        const month = document.querySelector('.LemonCalendar__month') as HTMLElement
-        await userEvent.click(within(month).getByText('20'))
-        await userEvent.click(getByDataAttr(document.body, 'lemon-calendar-select-apply'))
+        // Accessible queries (role + name), not implementation-specific CSS classes / data-attrs,
+        // so this survives the eventual swap of the backing calendar.
+        await userEvent.click(await screen.findByRole('button', { name: '20' }))
+        await userEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
         expect(onChange).toHaveBeenCalledTimes(1)
         expect(onChange.mock.calls[0][0].format('YYYY-MM-DD')).toBe('2023-01-20')

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -1,0 +1,70 @@
+import { render, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+
+import { dayjs } from 'lib/dayjs'
+
+import { getByDataAttr } from '~/test/byDataAttr'
+
+import { DatePicker, DatePickerProps } from './DatePicker'
+
+const renderDatePicker = (
+    initialValue: dayjs.Dayjs | null = null,
+    props: Partial<DatePickerProps> = {}
+): { container: HTMLElement; onChange: jest.Mock } => {
+    const onChange = jest.fn()
+
+    function Test(): JSX.Element {
+        const [value, setValue] = useState<dayjs.Dayjs | null>(initialValue)
+        return (
+            <DatePicker
+                {...props}
+                value={value}
+                onChange={(next) => {
+                    setValue(next)
+                    onChange(next)
+                }}
+            />
+        )
+    }
+
+    const { container } = render(<Test />)
+    return { container, onChange }
+}
+
+describe('DatePicker', () => {
+    it('shows the placeholder when there is no value', () => {
+        const { container } = renderDatePicker(null, { placeholder: 'Pick a day' })
+        expect(within(container).getByText('Pick a day')).toBeTruthy()
+    })
+
+    it('renders the selected value with the default format', () => {
+        const { container } = renderDatePicker(dayjs('2023-01-15'))
+        expect(within(container).getByText('January 15, 2023')).toBeTruthy()
+    })
+
+    it('renders the selected value with a custom format', () => {
+        const { container } = renderDatePicker(dayjs('2023-01-15'), { format: 'YYYY-MM-DD' })
+        expect(within(container).getByText('2023-01-15')).toBeTruthy()
+    })
+
+    it('selecting a date in the popover calls onChange', async () => {
+        const { container, onChange } = renderDatePicker(dayjs('2023-01-15'))
+
+        await userEvent.click(within(container).getByText('January 15, 2023'))
+        const month = document.querySelector('.LemonCalendar__month') as HTMLElement
+        await userEvent.click(within(month).getByText('20'))
+        await userEvent.click(getByDataAttr(document.body, 'lemon-calendar-select-apply'))
+
+        expect(onChange).toHaveBeenCalledTimes(1)
+        expect(onChange.mock.calls[0][0].format('YYYY-MM-DD')).toBe('2023-01-20')
+    })
+
+    it('clearing resets the value to null when clearable', async () => {
+        const { container, onChange } = renderDatePicker(dayjs('2023-01-15'), { clearable: true })
+
+        await userEvent.click(within(container).getByLabelText('Clear date'))
+
+        expect(onChange).toHaveBeenCalledWith(null)
+    })
+})

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -33,19 +33,13 @@ const renderDatePicker = (
 }
 
 describe('DatePicker', () => {
-    it('shows the placeholder when there is no value', () => {
-        const { container } = renderDatePicker(null, { placeholder: 'Pick a day' })
-        expect(within(container).getByText('Pick a day')).toBeTruthy()
-    })
-
-    it('renders the selected value with the default format', () => {
-        const { container } = renderDatePicker(dayjs('2023-01-15'))
-        expect(within(container).getByText('January 15, 2023')).toBeTruthy()
-    })
-
-    it('renders the selected value with a custom format', () => {
-        const { container } = renderDatePicker(dayjs('2023-01-15'), { format: 'YYYY-MM-DD' })
-        expect(within(container).getByText('2023-01-15')).toBeTruthy()
+    it.each([
+        ['the placeholder when there is no value', null, { placeholder: 'Pick a day' }, 'Pick a day'],
+        ['the selected value with the default format', dayjs('2023-01-15'), {}, 'January 15, 2023'],
+        ['the selected value with a custom format', dayjs('2023-01-15'), { format: 'YYYY-MM-DD' }, '2023-01-15'],
+    ])('renders %s', (_name, value, props, expectedText) => {
+        const { container } = renderDatePicker(value, props)
+        expect(within(container).getByText(expectedText)).toBeTruthy()
     })
 
     it('selecting a date in the popover calls onChange', async () => {

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -5,9 +5,15 @@ import { LemonCalendarSelectInput, LemonCalendarSelectInputProps } from 'lib/lem
  * Design-system-agnostic single-date picker — the migration seam between the LemonUI
  * calendar family and Quill's DateTimePicker. Callers depend on this dayjs-facing API;
  * the internal rendering swaps from LemonUI to Quill in one place without touching callers.
+ * That swap should land behind a feature flag so LemonUI and Quill can run side by side
+ * and roll back without a revert.
  *
  * Trigger concerns (placeholder, clearable, format, ...) live here by design — Quill
  * separates the trigger from the picker panel, so the wrapper owns the trigger.
+ *
+ * The prop surface is intentionally minimal: trigger-styling props (size, type) and
+ * `selectionPeriodLimit` are deliberately omitted until a real caller needs them, rather
+ * than re-exposing the wrapped component's full API and losing the decoupling.
  */
 export interface DatePickerProps {
     value: dayjs.Dayjs | null
@@ -31,7 +37,7 @@ export interface DatePickerProps {
     clearable?: boolean
     /** dayjs format string for the trigger label. */
     format?: string
-    /** Stretch the trigger to fill its container. */
+    /** Stretch the trigger to fill its container. Defaults to true — the seam owns this default rather than inheriting it from the wrapped trigger. */
     fullWidth?: boolean
     /** Disable the trigger and explain why on hover. */
     disabledReason?: string
@@ -54,23 +60,16 @@ export function DatePicker({
     placeholder,
     clearable,
     format,
-    fullWidth,
+    fullWidth = true,
     disabledReason,
     visible,
     onClickOutside,
     'data-attr': dataAttr,
 }: DatePickerProps): JSX.Element {
-    // Only forward defined trigger props — the wrapped trigger hardcodes some defaults
-    // (e.g. fullWidth) that an explicit `undefined` would clobber when spread.
-    const buttonProps: NonNullable<LemonCalendarSelectInputProps['buttonProps']> = {}
-    if (fullWidth !== undefined) {
-        buttonProps.fullWidth = fullWidth
-    }
-    if (disabledReason !== undefined) {
-        buttonProps.disabledReason = disabledReason
-    }
-    if (dataAttr !== undefined) {
-        buttonProps['data-attr'] = dataAttr
+    const buttonProps: NonNullable<LemonCalendarSelectInputProps['buttonProps']> = {
+        fullWidth,
+        disabledReason,
+        'data-attr': dataAttr,
     }
 
     return (

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -1,0 +1,95 @@
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelectInput, LemonCalendarSelectInputProps } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+
+/**
+ * Design-system-agnostic single-date picker — the migration seam between the LemonUI
+ * calendar family and Quill's DateTimePicker. Callers depend on this dayjs-facing API;
+ * the internal rendering swaps from LemonUI to Quill in one place without touching callers.
+ *
+ * Trigger concerns (placeholder, clearable, format, ...) live here by design — Quill
+ * separates the trigger from the picker panel, so the wrapper owns the trigger.
+ */
+export interface DatePickerProps {
+    value: dayjs.Dayjs | null
+    onChange: (value: dayjs.Dayjs | null) => void
+    /** Precision of the selected value. */
+    granularity?: 'day' | 'hour' | 'minute'
+    /** Restrict selectable dates relative to now. */
+    selectionPeriod?: 'past' | 'upcoming'
+    /** Timezone used to decide which past/upcoming dates are selectable (defaults to browser local). */
+    selectionPeriodTimezone?: string
+    /** Offer an "Include time?" toggle that flips granularity between day and minute. */
+    showTimeToggle?: boolean
+    onToggleTime?: (includeTime: boolean) => void
+    /** Use 24-hour time entry instead of 12-hour with AM/PM. */
+    use24HourFormat?: boolean
+    /** Number of calendar months to render side by side. */
+    months?: number
+    /** Placeholder shown on the trigger when no value is set. */
+    placeholder?: string
+    /** Show a clear affordance on the trigger to reset the value to null. */
+    clearable?: boolean
+    /** dayjs format string for the trigger label. */
+    format?: string
+    /** Stretch the trigger to fill its container. */
+    fullWidth?: boolean
+    /** Disable the trigger and explain why on hover. */
+    disabledReason?: string
+    /** Externally control popover visibility. */
+    visible?: boolean
+    onClickOutside?: () => void
+    'data-attr'?: string
+}
+
+export function DatePicker({
+    value,
+    onChange,
+    granularity,
+    selectionPeriod,
+    selectionPeriodTimezone,
+    showTimeToggle,
+    onToggleTime,
+    use24HourFormat,
+    months,
+    placeholder,
+    clearable,
+    format,
+    fullWidth,
+    disabledReason,
+    visible,
+    onClickOutside,
+    'data-attr': dataAttr,
+}: DatePickerProps): JSX.Element {
+    // Only forward defined trigger props — the wrapped trigger hardcodes some defaults
+    // (e.g. fullWidth) that an explicit `undefined` would clobber when spread.
+    const buttonProps: NonNullable<LemonCalendarSelectInputProps['buttonProps']> = {}
+    if (fullWidth !== undefined) {
+        buttonProps.fullWidth = fullWidth
+    }
+    if (disabledReason !== undefined) {
+        buttonProps.disabledReason = disabledReason
+    }
+    if (dataAttr !== undefined) {
+        buttonProps['data-attr'] = dataAttr
+    }
+
+    return (
+        <LemonCalendarSelectInput
+            value={value}
+            onChange={onChange}
+            granularity={granularity}
+            selectionPeriod={selectionPeriod}
+            selectionPeriodTimezone={selectionPeriodTimezone}
+            showTimeToggle={showTimeToggle}
+            onToggleTime={onToggleTime}
+            use24HourFormat={use24HourFormat}
+            months={months}
+            placeholder={placeholder}
+            clearable={clearable}
+            format={format}
+            visible={visible}
+            onClickOutside={onClickOutside}
+            buttonProps={buttonProps}
+        />
+    )
+}

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -14,6 +14,11 @@ import { LemonCalendarSelectInput, LemonCalendarSelectInputProps } from 'lib/lem
  * The prop surface is intentionally minimal: trigger-styling props (size, type) and
  * `selectionPeriodLimit` are deliberately omitted until a real caller needs them, rather
  * than re-exposing the wrapped component's full API and losing the decoupling.
+ *
+ * Controlled visibility is a full trio: pass `visible` plus `onOpen` (fired when the
+ * trigger is clicked) and `onClickOutside` / `onClose` (fired when the panel dismisses) so
+ * the caller can drive `visible` itself. Without `onOpen` a controlled picker can't be
+ * opened from its own trigger.
  */
 export interface DatePickerProps {
     value: dayjs.Dayjs | null
@@ -41,9 +46,14 @@ export interface DatePickerProps {
     fullWidth?: boolean
     /** Disable the trigger and explain why on hover. */
     disabledReason?: string
-    /** Externally control popover visibility. */
+    /** Externally control popover visibility. Pair with `onOpen` + `onClickOutside`/`onClose`. */
     visible?: boolean
+    /** Fired when the trigger is clicked — set your `visible` state to true here. */
+    onOpen?: () => void
+    /** Fired when the panel is dismissed by clicking outside it. */
     onClickOutside?: () => void
+    /** Fired when the panel's Cancel/close control is used. */
+    onClose?: () => void
     'data-attr'?: string
 }
 
@@ -63,13 +73,20 @@ export function DatePicker({
     fullWidth = true,
     disabledReason,
     visible,
+    onOpen,
     onClickOutside,
+    onClose,
     'data-attr': dataAttr,
 }: DatePickerProps): JSX.Element {
     const buttonProps: NonNullable<LemonCalendarSelectInputProps['buttonProps']> = {
         fullWidth,
         disabledReason,
         'data-attr': dataAttr,
+    }
+    // The wrapped trigger only flips its own uncontrolled state; a controlled caller needs the
+    // click to drive their `visible`, so forward `onOpen` as the trigger's onClick when given.
+    if (onOpen) {
+        buttonProps.onClick = onOpen
     }
 
     return (
@@ -88,6 +105,7 @@ export function DatePicker({
             format={format}
             visible={visible}
             onClickOutside={onClickOutside}
+            onClose={onClose}
             buttonProps={buttonProps}
         />
     )

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
@@ -303,6 +303,7 @@ export function LemonCalendarSelectInput(props: LemonCalendarSelectInputProps): 
                         ? {
                               icon: <IconX />,
                               onClick: () => props.onChange?.(null),
+                              'aria-label': 'Clear date',
                           }
                         : (undefined as unknown as SideAction) // We know it will be a normal button if not clearable
                 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -1,6 +1,7 @@
 import { IconInfo } from '@posthog/icons'
-import { LemonCalendarSelectInput, LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
+import { LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
 
+import { DatePicker } from 'lib/components/DatePicker/DatePicker'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { DESTINATIONS } from './destinations'
@@ -36,7 +37,7 @@ export function BatchExportGeneralEditFields({
                         }
                     >
                         {({ value, onChange }) => (
-                            <LemonCalendarSelectInput
+                            <DatePicker
                                 value={value}
                                 onChange={onChange}
                                 placeholder="Select end date (optional)"

--- a/products/visual_review/frontend/components/QuarantineAction.tsx
+++ b/products/visual_review/frontend/components/QuarantineAction.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 
 import { LemonButton, LemonCheckbox, LemonInput, LemonModal } from '@posthog/lemon-ui'
 
+import { DatePicker } from 'lib/components/DatePicker/DatePicker'
 import { dayjs } from 'lib/dayjs'
-import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 
 const SUGGESTED_REASONS = [
     'Non-deterministic rendering (animations, timestamps)',
@@ -213,12 +213,7 @@ export function QuarantineAction({
 
                     <div>
                         <label className="text-sm font-medium mb-1 block">{copy.expiresLabel}</label>
-                        <LemonCalendarSelectInput
-                            value={expiresAt}
-                            onChange={setExpiresAt}
-                            placeholder="No expiry"
-                            clearable
-                        />
+                        <DatePicker value={expiresAt} onChange={setExpiresAt} placeholder="No expiry" clearable />
                     </div>
                 </div>
             </LemonModal>


### PR DESCRIPTION
## Problem

We want to replace the LemonUI date-picker family with Quill's `DateTimePicker`. The blocker isn't the components — it's that **~19 call sites depend directly on LemonUI single-date behaviour** (dayjs values, `granularity`, `selectionPeriod`, `clearable`, `placeholder`, `format`, ...), and Quill's picker is range-only, native-`Date`, with a different API. Migrating each caller individually would mean 19 risky rewrites of the same dayjs<->Date and feature-mapping logic.

This is the first concrete step of the migration route from issue #65019: establish a **seam** that callers migrate to once, behind which we can swap LemonUI for Quill in a single place.

## Changes

Adds `lib/components/DatePicker/DatePicker.tsx` — a design-system-agnostic, dayjs-facing single-date picker:

- Speaks the feature vocabulary callers already use (`granularity`, `selectionPeriod`, `showTimeToggle`, `use24HourFormat`, `clearable`, `placeholder`, `format`, controlled `visible`).
- Owns the **trigger**, matching Quill's deliberate separation of trigger from picker panel — so trigger concerns (placeholder, clearable, format, fullWidth, disabledReason) are wrapper props, not picker props.
- Exposes only **decoupled** trigger knobs, so it does not re-leak `LemonButtonProps` the way the raw components do.
- Renders `LemonCalendarSelectInput` internally **for now**. When Quill's panel reaches single-date parity, this one file flips to Quill behind a flag and every caller comes along for free.

Two pilot callers migrated to prove the seam is a near-mechanical swap that preserves behaviour:

- `BatchExportEditForm` (end-date field)
- `QuarantineAction` (expiry field)

Also gives the clear affordance an `aria-label` ("Clear date") — it previously had none, which was both an a11y gap and untestable.

### Why a wrapper rather than adopting Quill directly at call sites

The dayjs<->Date conversion and the LemonUI-only feature semantics have to live *somewhere*. Centralising them in one wrapper with one test suite means the eventual Quill swap is one reviewed diff, not 19 — and the behavioural-equivalence risk is contained, not smeared across the app.

This PR deliberately does **not** touch range pickers (3 call sites, all inside `DateFilter`) or the exotic single-date callers that override the trigger's children — those come in later increments once the seam is proven.

## How did you test this code?

I'm an agent (PostHog Code). I did not manually test in a browser. Automated tests run locally, all passing:

- New `DatePicker.test.tsx` — placeholder, value formatting (default + custom), in-popover selection calls `onChange`, clearable resets to null
- `LemonCalendarSelect.test.tsx` (the wrapped component) still green
- Typecheck clean on the new component and both pilot callers

A Storybook story (`DatePicker.stories.tsx`) covers empty / with-value / clearable / with-time / past-only for visual review.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this as the next step of the LemonUI -> Quill date-picker migration (#65019), choosing "build the wrapper seam" from a set of options. I first ran an inventory of all ~22 LemonUI date-picker call sites to ground the design: 19 are single-date, only 3 are range (all in `DateFilter`), Quill has one production adopter, and the "experimental" label is only a Storybook story name (no runtime gate). Key design decision: many "LemonUI-only" props (placeholder, clearable, format, visible) are *trigger* concerns, not *picker* concerns — Quill already separates those — so the wrapper owns the trigger and the real Quill panel gap shrinks to single-date + granularity + selectionPeriod semantics. Started with the two simplest callers as pilots to keep the proof small. No skills were required.

Separate from PR #65056 (the internal `getDateState`/`getTimeState` hook decoupling), which is groundwork; this PR is the actual migration seam and is independent of it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
