### PR TITLE
feat(replay-vision): capture enable/disable direction on scanner toggle

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { LemonSwitch } from './LemonSwitch'
+
+describe('LemonSwitch', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it.each([
+        { value: true, expected: 'true' },
+        { value: false, expected: 'false' },
+        { value: 'image', expected: 'image' },
+    ])('forwards data-ph-capture-attribute-* ($value) onto the clickable element', ({ value, expected }) => {
+        render(
+            <LemonSwitch
+                checked={false}
+                onChange={() => {}}
+                data-attr="my-switch"
+                data-ph-capture-attribute-will-be-enabled={value}
+            />
+        )
+
+        const button = screen.getByRole('switch')
+        expect(button).toHaveAttribute('data-ph-capture-attribute-will-be-enabled', expected)
+    })
+
+    it('renders without capture attributes', () => {
+        render(<LemonSwitch checked={true} onChange={() => {}} data-attr="my-switch" />)
+
+        const button = screen.getByRole('switch')
+        expect(button).toHaveAttribute('data-attr', 'my-switch')
+        expect(button).not.toHaveAttribute('data-ph-capture-attribute-will-be-enabled')
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -27,7 +27,7 @@ export interface LemonSwitchProps {
     sliderColorOverrideChecked?: string
     sliderColorOverrideUnchecked?: string
     loading?: boolean
-    /** Forwarded to the clickable element so autocapture can read them off the clicked switch. */
+    /** Forwarded to the switch element so autocapture can read them off the click. Autocapture only fires on the interactive (`onChange`) variant, which renders a button; a read-only switch renders a div and these never reach an autocapture event. */
     [captureAttribute: `data-ph-capture-attribute-${string}`]: string | boolean | undefined
 }
 

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -27,6 +27,8 @@ export interface LemonSwitchProps {
     sliderColorOverrideChecked?: string
     sliderColorOverrideUnchecked?: string
     loading?: boolean
+    /** Forwarded to the clickable element so autocapture can read them off the clicked switch. */
+    [captureAttribute: `data-ph-capture-attribute-${string}`]: string | boolean | undefined
 }
 
 /** Counter used for collision-less automatic switch IDs. */
@@ -52,6 +54,7 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
             sliderColorOverrideChecked,
             sliderColorOverrideUnchecked,
             loading = false,
+            ...captureAttributes
         },
         ref
     ): JSX.Element {
@@ -97,6 +100,7 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
                 data-attr={dataAttr}
                 disabled={isDisabled}
                 {...conditionalProps}
+                {...captureAttributes}
             >
                 <div className="LemonSwitch__handle">
                     {loading && (

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -86,6 +86,7 @@ export function ReplayScannersScene(): JSX.Element {
                             size="small"
                             data-attr="vision-scanner-toggle-enabled"
                             data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                            data-ph-capture-attribute-action={!scanner.enabled}
                         />
                     </AccessControlAction>
                     <span className={`inline-block min-w-[4.5rem] ${scanner.enabled ? 'text-success' : 'text-muted'}`}>

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -86,7 +86,7 @@ export function ReplayScannersScene(): JSX.Element {
                             size="small"
                             data-attr="vision-scanner-toggle-enabled"
                             data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                            data-ph-capture-attribute-action={!scanner.enabled}
+                            data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
                         />
                     </AccessControlAction>
                     <span className={`inline-block min-w-[4.5rem] ${scanner.enabled ? 'text-success' : 'text-muted'}`}>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -163,7 +163,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                                         loading={togglingEnabled}
                                         data-attr="vision-scanner-toggle-enabled"
                                         data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                                        data-ph-capture-attribute-action={!scanner.enabled}
+                                        data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
                                     />
                                 </AccessControlAction>
                                 <span className="text-muted text-xs">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -163,6 +163,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                                         loading={togglingEnabled}
                                         data-attr="vision-scanner-toggle-enabled"
                                         data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                                        data-ph-capture-attribute-action={!scanner.enabled}
                                     />
                                 </AccessControlAction>
                                 <span className="text-muted text-xs">


### PR DESCRIPTION
## Problem

The Replay Vision scanner enable/disable toggle is autocaptured (`data-attr="vision-scanner-toggle-enabled"`), but the captured event only told us the switch was clicked — not whether the user was enabling or disabling. That makes it impossible to count disables vs enables, so we can't estimate how many scanners are actually running from analytics alone.

## Changes

Add `data-ph-capture-attribute-will-be-enabled={!scanner.enabled}` to both toggle surfaces (the scanners list row and the readonly config "Status" row). Since `checked` reflects the pre-click state, `!scanner.enabled` is the resulting state, so each `$autocapture` click now carries `will-be-enabled: "true"` when it will enable and `will-be-enabled: "false"` when it will disable.

`LemonSwitch` previously only forwarded `data-attr`/`aria-label` onto its clickable element and silently dropped every other prop — so neither the new attribute nor the pre-existing `data-ph-capture-attribute-scanner-type` on the same switch reached the DOM, and autocapture could not read them. `LemonSwitch` now forwards `data-ph-capture-attribute-*` props onto the clickable element (mirroring how `LemonButton` spreads through to its button), which fixes both attributes and benefits every other `LemonSwitch` caller.

With this, "scanners running ≈ created − disabled + re-enabled" becomes a clean cross-customer query.

## How did you test this code?

Added `LemonSwitch.test.tsx` asserting that `data-ph-capture-attribute-*` props (including the boolean `false` -> `"false"` case) land on the rendered switch and that switches without them are unaffected. TypeScript check is clean for the touched files. I have not run the app manually.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at Paul's direction. The work started from a question about whether we capture scanner enable/disable events; investigation showed the toggle was autocaptured but direction-less, and Paul specified the exact fix (`data-ph-capture-attribute-will-be-enabled={!scanner.enabled}`). Applied to both components carrying the `vision-scanner-toggle-enabled` data-attr so the signal is uniform regardless of where the toggle is clicked. A reviewer then flagged that `LemonSwitch` drops unknown props, so the forwarding fix and a unit test were added at the component level.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1782032420952669)*
