### PR TITLE
fix(stripe): skip parent objects deleted mid-sync in nested resources

### DIFF
--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -302,7 +302,6 @@ def get_rows(
                     if not _is_stripe_resource_missing_error(e):
                         raise
                     logger.debug(f"Stripe: skipping {resource.nested_parent_param}={parent_obj_id}, no longer exists")
-                    continue
         else:
             stripe_objects = _call_stripe(
                 resource.method, params={**default_params, **resource.params, **resume_params}

--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -117,6 +117,13 @@ def _call_stripe(method: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         raise
 
 
+def _is_stripe_resource_missing_error(error: stripe_lib.StripeError) -> bool:
+    """True for Stripe's ``resource_missing`` 404 — e.g. a customer deleted between when we
+    listed it and when we fetched its nested resources. The object is genuinely gone, so the
+    caller can skip it instead of failing the whole sync."""
+    return getattr(error, "code", None) == "resource_missing"
+
+
 def _stripe_base_addresses() -> BaseAddresses:
     # Redirect Stripe API calls to a local mock (e.g. STRIPE_API_BASE=http://localhost:12111)
     # when running the stripe-mock dev service. No-op in production where the var is unset.
@@ -267,25 +274,35 @@ def get_rows(
                 params={**default_params, **resource.parent.params, **resume_params},
             )
             for obj in stripe_parent_objects.auto_paging_iter():
-                stripe_nested_objects = _call_stripe(
-                    resource.method,
-                    **{resource.nested_parent_param: obj[resource.parent_id]},
-                    params={**default_params, **resource.params},
-                )
-                for nested_obj in stripe_nested_objects.auto_paging_iter():  # noqa: UP028
-                    batcher.batch(
-                        {
-                            **nested_obj,
-                            **{resource.nested_parent_param: obj[resource.parent_id]},
-                        }
+                parent_obj_id = obj[resource.parent_id]
+                try:
+                    stripe_nested_objects = _call_stripe(
+                        resource.method,
+                        **{resource.nested_parent_param: parent_obj_id},
+                        params={**default_params, **resource.params},
                     )
+                    for nested_obj in stripe_nested_objects.auto_paging_iter():
+                        batcher.batch(
+                            {
+                                **nested_obj,
+                                **{resource.nested_parent_param: parent_obj_id},
+                            }
+                        )
 
-                    if batcher.should_yield():
-                        py_table = batcher.get_table()
-                        yield py_table
+                        if batcher.should_yield():
+                            py_table = batcher.get_table()
+                            yield py_table
 
-                        last_cur = py_table.column(resource.nested_parent_param)[-1].as_py()
-                        resumable_source_manager.save_state(StripeResumeConfig(starting_after=last_cur))
+                            last_cur = py_table.column(resource.nested_parent_param)[-1].as_py()
+                            resumable_source_manager.save_state(StripeResumeConfig(starting_after=last_cur))
+                except stripe_lib.InvalidRequestError as e:
+                    # The parent was deleted between listing it and fetching its nested resources,
+                    # so Stripe 404s the nested call. Skip the now-gone parent and keep syncing the
+                    # rest rather than failing the whole import.
+                    if not _is_stripe_resource_missing_error(e):
+                        raise
+                    logger.debug(f"Stripe: skipping {resource.nested_parent_param}={parent_obj_id}, no longer exists")
+                    continue
         else:
             stripe_objects = _call_stripe(
                 resource.method, params={**default_params, **resource.params, **resume_params}

--- a/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,9 +1,28 @@
 import pytest
 from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import stripe as stripe_lib
 
 from posthog.temporal.data_imports.sources.generated_configs import StripeAuthMethodConfig, StripeSourceConfig
+from posthog.temporal.data_imports.sources.stripe import stripe as stripe_module
+from posthog.temporal.data_imports.sources.stripe.constants import (
+    CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME,
+    CUSTOMER_RESOURCE_NAME,
+)
 from posthog.temporal.data_imports.sources.stripe.source import StripeSource
-from posthog.temporal.data_imports.sources.stripe.stripe import StripeAuthenticationError
+from posthog.temporal.data_imports.sources.stripe.stripe import (
+    StripeAuthenticationError,
+    StripeNestedResource,
+    StripeResource,
+    get_rows,
+)
+
+
+def _list_object(items):
+    obj = MagicMock()
+    obj.auto_paging_iter.return_value = iter(items)
+    return obj
 
 
 class TestStripeSource:
@@ -85,3 +104,61 @@ class TestStripeSource:
         assert message is not None
         assert pasted_secret not in message
         assert message.startswith("Stripe rejected the API key.")
+
+
+def _run_nested_get_rows(nested_method):
+    parent = StripeResource(
+        method=lambda **kwargs: _list_object([{"id": "cus_ok1"}, {"id": "cus_gone"}, {"id": "cus_ok2"}])
+    )
+    resource = StripeNestedResource(
+        method=nested_method,
+        nested_parent_param="customer",
+        parent_id="id",
+        parent=parent,
+        parent_name=CUSTOMER_RESOURCE_NAME,
+    )
+
+    resumable_source_manager = MagicMock()
+    resumable_source_manager.can_resume.return_value = False
+
+    with (
+        patch.object(stripe_module, "StripeClient"),
+        patch.object(
+            stripe_module,
+            "_build_resources",
+            return_value={CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME: resource},
+        ),
+    ):
+        rows: list[dict] = []
+        for table in get_rows(
+            api_key="sk_test_123",
+            endpoint=CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME,
+            account_id=None,
+            db_incremental_field_last_value=None,
+            db_incremental_field_earliest_value=None,
+            logger=MagicMock(),
+            resumable_source_manager=resumable_source_manager,
+        ):
+            rows.extend(table.to_pylist())
+    return rows
+
+
+class TestStripeNestedResourceGetRows:
+    def test_skips_parent_deleted_mid_sync(self):
+        def nested_method(customer=None, params=None):
+            if customer == "cus_gone":
+                raise stripe_lib.InvalidRequestError(
+                    f"No such customer: '{customer}'", "customer", code="resource_missing", http_status=404
+                )
+            return _list_object([{"id": f"cbt_{customer}", "amount": 100}])
+
+        rows = _run_nested_get_rows(nested_method)
+
+        assert {row["customer"] for row in rows} == {"cus_ok1", "cus_ok2"}
+
+    def test_other_invalid_request_errors_still_raise(self):
+        def nested_method(customer=None, params=None):
+            raise stripe_lib.InvalidRequestError("Invalid string", "expand", code="parameter_unknown", http_status=400)
+
+        with pytest.raises(stripe_lib.InvalidRequestError):
+            _run_nested_get_rows(nested_method)


### PR DESCRIPTION
## Problem

The Stripe import crashes whenever a customer is deleted while a nested-resource sync is in flight.

Nested resources — customer balance transactions and customer payment methods — sync by paging the parent customer list and then fetching each customer's nested objects one customer at a time. In a large account this loop runs for a while, and customers get deleted in Stripe during that window. When we reach a customer that's already gone, Stripe rejects the nested list call with a `404 resource_missing` (`InvalidRequestError: No such customer: 'cus_...'`), which propagated straight out of `get_rows` and failed the entire import activity.

Surfaced by error tracking: [InvalidRequestError — No such customer](https://us.posthog.com/project/2/error_tracking/019eea71-3436-7610-94c7-f3ee5637b6b7). The stack bottoms out in `get_rows` → `_call_stripe` in `posthog/temporal/data_imports/sources/stripe/stripe.py`.

## Changes

This is a fixable fragility, not a credential/config problem — a deleted customer is normal in a healthy account, so it shouldn't fail the whole sync (and adding it to `NonRetryableErrors` would permanently break every sync that happens to contain one deleted customer).

- In the nested-resource branch of `get_rows`, catch `resource_missing` `InvalidRequestError` per parent, skip that parent, and continue syncing the rest.
- Added `_is_stripe_resource_missing_error` to classify the error by its stable Stripe `code` rather than the volatile message (which carries a request id and object id).
- Any other `InvalidRequestError` still propagates — we don't want to swallow real bugs (e.g. a bad request param).

## How did you test this code?

I'm an agent. I added and ran automated tests at the `get_rows` layer:

- `test_skips_parent_deleted_mid_sync` — one of three customers 404s with `resource_missing`; the sync completes and yields rows for the two surviving customers.
- `test_other_invalid_request_errors_still_raise` — a non-`resource_missing` `InvalidRequestError` still propagates.

`uv run python -m pytest posthog/temporal/data_imports/sources/stripe/tests/test_stripe_source.py` — 14 passed. `ruff check` / `ruff format` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Stripe data-warehouse source. Confirmed the issue in PostHog error tracking (full stack trace, exception type, two affected teams), traced the failing frame to the nested-resource loop in `get_rows`, and decided this is a graceful-skip bug rather than a non-retryable credential error. Checked open PRs (including the maintainer's) for duplicates — none address this root cause. Scope kept tight: classify by Stripe error `code`, skip the missing parent, leave all other errors retryable.