### PR TITLE
fix(insights): render retention and other charts in insight-query MCP app

### DIFF
--- a/services/mcp/src/tools/insights/query.ts
+++ b/services/mcp/src/tools/insights/query.ts
@@ -83,16 +83,18 @@ export const queryHandler: ToolBase<typeof schema, Result>['handler'] = async (c
     const fullUrl = `${context.api.getProjectBaseUrl(projectId)}${path}`
     const queryInfo = analyzeQuery(insightResult.data.query)
 
-    // Trends/funnel UI visualizers consume the raw results array; every other
-    // visualization (HogQL/table, retention, lifecycle, paths) expects the
-    // `{ columns, results }` shape the structural guards look for.
-    const isSeries = queryInfo.visualization === 'trends' || queryInfo.visualization === 'funnel'
-    const results = isSeries
-        ? queryResult.data.results
-        : {
+    // Only HogQL/table results carry a separate `columns` array, so they're the only
+    // shape the UI app wraps as `{ columns, results }`. Every chart visualizer
+    // (trends, funnel, retention, lifecycle, stickiness, paths) consumes the raw
+    // results array directly — wrapping those breaks the structural guards and renders
+    // an empty table.
+    const isTabular = queryInfo.visualization === 'table'
+    const results = isTabular
+        ? {
               columns: queryResult.data.columns || [],
               results: queryResult.data.results || [],
           }
+        : queryResult.data.results
 
     // Optimized output surfaces the server-formatted summary as the model-facing text, but the
     // UI app still needs the structured results in structuredContent. Carry the formatted string

--- a/services/mcp/src/tools/shared.ts
+++ b/services/mcp/src/tools/shared.ts
@@ -1,6 +1,9 @@
 type QueryKind =
     | 'TrendsQuery'
     | 'FunnelsQuery'
+    | 'RetentionQuery'
+    | 'LifecycleQuery'
+    | 'StickinessQuery'
     | 'PathsQuery'
     | 'HogQLQuery'
     | 'InsightVizNode'
@@ -8,11 +11,21 @@ type QueryKind =
     | string
 
 interface QueryInfo {
-    visualization: 'trends' | 'funnel' | 'paths' | 'table'
+    visualization: 'trends' | 'funnel' | 'retention' | 'lifecycle' | 'stickiness' | 'paths' | 'table'
     /** The inner query kind (e.g., TrendsQuery inside InsightVizNode) */
     innerKind: QueryKind
     /** The inner query object for insight queries */
     innerQuery?: Record<string, unknown>
+}
+
+/** Insight query kinds whose results are a raw array consumed directly by the chart visualizers. */
+const SOURCE_VISUALIZATIONS: Record<string, QueryInfo['visualization']> = {
+    TrendsQuery: 'trends',
+    FunnelsQuery: 'funnel',
+    RetentionQuery: 'retention',
+    LifecycleQuery: 'lifecycle',
+    StickinessQuery: 'stickiness',
+    PathsQuery: 'paths',
 }
 
 /**
@@ -26,14 +39,9 @@ export function analyzeQuery(query: unknown): QueryInfo {
     const q = query as Record<string, unknown>
 
     // Direct insight queries
-    if (q.kind === 'TrendsQuery') {
-        return { visualization: 'trends', innerKind: 'TrendsQuery', innerQuery: q }
-    }
-    if (q.kind === 'FunnelsQuery') {
-        return { visualization: 'funnel', innerKind: 'FunnelsQuery', innerQuery: q }
-    }
-    if (q.kind === 'PathsQuery') {
-        return { visualization: 'paths', innerKind: 'PathsQuery', innerQuery: q }
+    const visualization = typeof q.kind === 'string' ? SOURCE_VISUALIZATIONS[q.kind] : undefined
+    if (visualization) {
+        return { visualization, innerKind: q.kind as string, innerQuery: q }
     }
     if (q.kind === 'HogQLQuery') {
         return { visualization: 'table', innerKind: 'HogQLQuery' }
@@ -42,14 +50,9 @@ export function analyzeQuery(query: unknown): QueryInfo {
     // InsightVizNode wraps insight queries
     if (q.kind === 'InsightVizNode' && q.source && typeof q.source === 'object') {
         const source = q.source as Record<string, unknown>
-        if (source.kind === 'TrendsQuery') {
-            return { visualization: 'trends', innerKind: 'TrendsQuery', innerQuery: source }
-        }
-        if (source.kind === 'FunnelsQuery') {
-            return { visualization: 'funnel', innerKind: 'FunnelsQuery', innerQuery: source }
-        }
-        if (source.kind === 'PathsQuery') {
-            return { visualization: 'paths', innerKind: 'PathsQuery', innerQuery: source }
+        const sourceVisualization = typeof source.kind === 'string' ? SOURCE_VISUALIZATIONS[source.kind] : undefined
+        if (sourceVisualization) {
+            return { visualization: sourceVisualization, innerKind: source.kind as string, innerQuery: source }
         }
     }
 

--- a/services/mcp/tests/unit/insights-query-handler.test.ts
+++ b/services/mcp/tests/unit/insights-query-handler.test.ts
@@ -238,4 +238,27 @@ describe('queryHandler — result shape for UI rendering', () => {
         expect(result.query).toEqual({ kind: 'TrendsQuery' })
         expect(result[POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]).toBe(formatted)
     })
+
+    it.each([
+        ['RetentionQuery', [{ date: '2024-01-01', label: 'Day 0', values: [{ count: 10 }] }]],
+        ['LifecycleQuery', [{ status: 'new', data: [1, 2], days: ['a', 'b'] }]],
+        ['StickinessQuery', [{ count: 5, data: [1, 2], labels: ['1 day', '2 days'] }]],
+        ['PathsQuery', [{ source: '0_a', target: '1_b', value: 3 }]],
+    ])('passes the raw results array through for %s insights', async (kind, chartResults) => {
+        const { context } = createContext({
+            getData: {
+                id: 42,
+                short_id: 'abc12345',
+                query: { kind: 'InsightVizNode', source: { kind } },
+            },
+            queryData: { results: chartResults },
+        })
+
+        const result = (await queryHandler(context, { insightId: '42', output_format: 'json' })) as QueryResult
+
+        // Chart visualizers read the raw array; wrapping it in { columns, results } makes the
+        // structural guards fall through to the table renderer and show an empty table.
+        expect(result.results).toBe(chartResults)
+        expect(result.query).toEqual({ kind })
+    })
 })


### PR DESCRIPTION
## Problem

The `insight-query` MCP UI app rendered an empty "Query results" card for retention insights — a "Showing 20 of 39+ rows" footer with no table body and no chart. The same bug silently affected lifecycle, stickiness, and paths insights too; only trends and funnel rendered correctly.

## Changes

Root cause was a data-shape mismatch between the tool handler and the UI app:

- `analyzeQuery` (`services/mcp/src/tools/shared.ts`) only recognised `TrendsQuery`, `FunnelsQuery`, `PathsQuery`, and HogQL. `RetentionQuery` / `LifecycleQuery` / `StickinessQuery` fell through to `'table'`.
- The handler (`services/mcp/src/tools/insights/query.ts`) wrapped every non-trends/funnel result as `{ columns, results }`. The UI's `isHogQLResult` guard matches that wrapper first, so retention rendered through the table visualizer — which had zero columns, hence the empty table.

The fix flips the rule to match reality: only HogQL/table results carry a separate `columns` array, so only those get wrapped. Every chart visualizer (trends, funnel, retention, lifecycle, stickiness, paths) reads the raw results array directly. `analyzeQuery` now also classifies retention/lifecycle/stickiness so their inner query (e.g. `retentionFilter`) reaches the visualizer.

These are `services/mcp` TypeScript changes — they take effect once the MCP server is rebuilt/redeployed.

## How did you test this code?

I'm an agent. I ran the automated unit suites for the changed code:

- `tests/unit/insights-query-handler.test.ts` (extended with a parameterized regression test asserting raw-array passthrough for retention, lifecycle, stickiness, and paths)
- `tests/unit/insight-visualizations.test.ts`

Both pass (97 tests). Typecheck is clean on the two changed source files (remaining `@posthog/quill` resolution errors are pre-existing in this worktree from unbuilt packages, unrelated to this change). No manual end-to-end MCP rendering was performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported by a user who saw the empty retention app in an MCP client. Traced the empty render back through the UI app's `inferVisualizationType` guards to the handler's result wrapping, and confirmed the handler comment claiming retention/lifecycle/paths want the `{ columns, results }` wrapper was wrong — those visualizers all consume raw arrays. Chose to invert the wrapping condition (wrap only `table`) rather than special-case each chart type, and to teach `analyzeQuery` the missing kinds so the correct `innerQuery` flows through. No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
