### PR TITLE
fix(postgres): re-raise connection errors from the duplicate-PK probe

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1831,6 +1831,12 @@ def _has_duplicate_primary_keys(
         return row is not None
     except psycopg.errors.QueryCanceled:
         raise
+    except psycopg.OperationalError:
+        # A connection-level failure here (e.g. a foreign-data-wrapper server refusing a new
+        # connection with "too many connections") means the probe never ran — swallowing it as
+        # "no duplicate keys" would be a false negative. Propagate it so the activity's retry
+        # path handles it; these are transient and stay retryable.
+        raise
     except Exception as e:
         capture_exception(e)
         return False

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4067,6 +4067,31 @@ class TestHasDuplicatePrimaryKeys:
             result = _has_duplicate_primary_keys(cast(Any, dj_cursor), "public", "test_dup_table", ["id"], logger)
             assert result is True
 
+    def test_reraises_connection_errors_without_capturing(self):
+        logger = structlog.get_logger()
+        cursor = MagicMock()
+        # postgres_fdw surfaces a saturated foreign server while executing the probe query: the
+        # remote connection couldn't be established, so the probe never ran. This must propagate
+        # (transient, stays retryable), not be swallowed as "no duplicate keys" + captured as noise.
+        cursor.execute.side_effect = psycopg.errors.SqlclientUnableToEstablishSqlconnection(
+            'could not connect to server "posthog_fdw_payment"\n'
+            'DETAIL:  connection to server at "10.0.0.1", port 5432 failed: '
+            'FATAL:  too many connections for role "posthog_fdw_reader"'
+        )
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+            with pytest.raises(psycopg.OperationalError):
+                _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
+        mock_capture.assert_not_called()
+
+    def test_captures_and_returns_false_on_non_connection_error(self):
+        logger = structlog.get_logger()
+        cursor = MagicMock()
+        cursor.execute.side_effect = psycopg.errors.UndefinedColumn('column "id" does not exist')
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+            result = _has_duplicate_primary_keys(cast(Any, cursor), "public", "orders", ["id"], logger)
+        assert result is False
+        mock_capture.assert_called_once()
+
 
 class TestIsReadReplica:
     @pytest.mark.django_db


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `SqlclientUnableToEstablishSqlconnection` from the Postgres data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019eead7-3e9e-7ca3-b3e1-544bda75e147)):

```
could not connect to server "..."
DETAIL:  connection to server at "..." failed: FATAL:  too many connections for role "..."
```

The top in-app frame is `_has_duplicate_primary_keys` → `cursor.execute` in `postgres.py`. The probe runs a `GROUP BY ... HAVING COUNT(*) > 1` to decide whether a table's primary keys are unique. When the table is a `postgres_fdw` foreign table, executing that query makes the source open a connection to the **foreign** server, which here refused a new connection because a role hit its connection limit.

That's a **transient capacity** condition — a slot frees the moment another connection closes, so it recovers on retry, and `too many connections for role` is already (deliberately) classified retryable and kept out of `get_non_retryable_errors` (an existing test asserts this).

The bug is the handler: `_has_duplicate_primary_keys` wrapped the probe in a bare `except Exception: capture_exception(e); return False`. So a connection-level failure that meant *the probe never ran* was both:

- swallowed as a false `False` ("no duplicate keys") — a determination it never actually made, and
- reported to error tracking as if it were a bug, firing noise on a transient, self-recovering condition.

## Changes

`_has_duplicate_primary_keys` now re-raises `psycopg.OperationalError` (mirroring the existing `QueryCanceled` clause) instead of capturing and swallowing it. Connection/infrastructure failures propagate to the setup loop and the activity's retry path, where transient saturation recovers on a fresh attempt. Genuine query-shape errors (wrong column type, etc.) still fall through to the best-effort `capture_exception` + `return False`.

Scope is strictly this one probe — its only caller is the table-setup loop, already wrapped in the connection-drop / recovery-conflict retry handlers. No change to `get_non_retryable_errors` (the error stays retryable, as it should).

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not run the full DB-backed suite (no Postgres in the sandbox — the pre-existing `@pytest.mark.django_db` tests in this class error identically at connection setup).

- `test_reraises_connection_errors_without_capturing` — a probe whose `cursor.execute` raises `SqlclientUnableToEstablishSqlconnection` (the exact "too many connections for role" message) now propagates and is **not** captured.
- `test_captures_and_returns_false_on_non_connection_error` — a non-connection error (`UndefinedColumn`) is still swallowed, captured, and returns `False`.
- Both new tests pass, as do the 68 `TestPostgresSourceNonRetryableErrors` cases. `ruff check` and `ruff format --check` are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Confirmed the failure genuinely originates in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`_has_duplicate_primary_keys`, line 1809), not in serialized log context.

Decision: this is a fixable bug, not a `NonRetryableErrors` case. The error is a transient connection-saturation condition that the project already treats as retryable (see the existing connect-path handling in #64631 and the `too many connections for role` retryable test). The fix mirrors the established "don't capture expected connection failures" pattern (#65018) but at the probe layer: re-raise so the retry machinery handles it, rather than swallowing a false negative and emitting noise. Verified #64631 (connect path) and #65018 (CDC prereq API endpoints) do not touch this code path, so this is not a duplicate.
