### PR TITLE
feat(file-system): publish freeform canvas code via desktop API + MCP tool

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2701,6 +2701,7 @@ export interface PatchedFileSystemApi {
 export interface PatchedCanvasPublishApi {
     code?: string
     prompt?: string
+    name?: string
 }
 
 export interface ContextGenerationApi {

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2695,6 +2695,14 @@ export interface PatchedFileSystemApi {
     readonly last_viewed_at?: string | null
 }
 
+/**
+ * Payload for publishing a freeform canvas's React source via the agent.
+ */
+export interface PatchedCanvasPublishApi {
+    code?: string
+    prompt?: string
+}
+
 export interface ContextGenerationApi {
     /**
      * ID of the Task currently generating this folder's CONTEXT.md, or null if none.

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -55,6 +55,7 @@ import type {
     PaginatedProjectSecretAPIKeyListApi,
     PaginatedUserGitHubIntegrationListResponseListApi,
     PaginatedUserListApi,
+    PatchedCanvasPublishApi,
     PatchedEnterprisePropertyDefinitionApi,
     PatchedFileSystemApi,
     PatchedFileSystemShortcutApi,
@@ -1323,6 +1324,32 @@ export const desktopFileSystemDestroy = async (projectId: string, id: string, op
     return apiMutator<void>(getDesktopFileSystemDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getDesktopFileSystemCanvasPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/canvas/`
+}
+
+/**
+ * Publish a new version of a freeform canvas's React source.
+ *
+ * Merges into the dashboard row's `meta` (never replaces it), so existing
+ * keys like `channelId`/`templateId` survive. Appends a full-file version
+ * snapshot and points `currentVersionId` at it — the server-side mirror of
+ * the app's dashboardsService.saveFreeform.
+ */
+export const desktopFileSystemCanvasPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedCanvasPublishApi?: PatchedCanvasPublishApi,
+    options?: RequestInit
+): Promise<FileSystemApi> => {
+    return apiMutator<FileSystemApi>(getDesktopFileSystemCanvasPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedCanvasPublishApi),
     })
 }
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -8969,6 +8969,7 @@ export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
     .object({
         code: zod.string().optional(),
         prompt: zod.string().optional(),
+        name: zod.string().optional(),
     })
     .describe("Payload for publishing a freeform canvas's React source via the agent.")
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -8958,6 +8958,21 @@ export const DesktopFileSystemPartialUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Publish a new version of a freeform canvas's React source.
+ *
+ * Merges into the dashboard row's `meta` (never replaces it), so existing
+ * keys like `channelId`/`templateId` survive. Appends a full-file version
+ * snapshot and points `currentVersionId` at it — the server-side mirror of
+ * the app's dashboardsService.saveFreeform.
+ */
+export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        code: zod.string().optional(),
+        prompt: zod.string().optional(),
+    })
+    .describe("Payload for publishing a freeform canvas's React source via the agent.")
+
+/**
  * Set or clear the Task associated with this folder's CONTEXT.md generation.
  */
 export const DesktopFileSystemContextGenerationUpdateBody = /* @__PURE__ */ zod.object({

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -965,6 +965,7 @@ class CanvasPublishSerializer(serializers.Serializer):
 
     code = serializers.CharField(allow_blank=True, trim_whitespace=False)
     prompt = serializers.CharField(required=False, allow_blank=True, trim_whitespace=False)
+    name = serializers.CharField(required=False, allow_blank=False, trim_whitespace=True)
 
 
 @extend_schema(extensions={"x-product": "core"})
@@ -1041,6 +1042,7 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
         payload.is_valid(raise_exception=True)
         code = payload.validated_data["code"]
         prompt = payload.validated_data.get("prompt")
+        name = payload.validated_data.get("name")
 
         now_ms = int(time.time() * 1000)
         version: dict[str, Any] = {"id": str(uuid4()), "code": code, "createdAt": now_ms}
@@ -1070,7 +1072,17 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
                 }
             )
             dashboard.meta = meta
-            dashboard.save(update_fields=["meta"])
+
+            update_fields = ["meta"]
+            if name:
+                # The canvas's display name is the leaf segment of its path; rename in place.
+                segments = split_path(dashboard.path)
+                segments[-1] = name
+                dashboard.path = join_path(segments)
+                dashboard.depth = len(segments)
+                update_fields += ["path", "depth"]
+
+            dashboard.save(update_fields=update_fields)
 
         return Response(self.get_serializer(dashboard).data)
 

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1,7 +1,9 @@
 import re
+import time
 import shlex
 import builtins
 from typing import Any, cast
+from uuid import uuid4
 
 from django.db import transaction
 from django.db.models import Case, F, IntegerField, Q, QuerySet, Value, When
@@ -217,6 +219,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         "log_view",
         "undo_delete",
         "set_context_generation",
+        "publish_canvas",
     ]
 
     def _basename_regex(self, value: str) -> str:
@@ -957,6 +960,13 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 item.save()
 
 
+class CanvasPublishSerializer(serializers.Serializer):
+    """Payload for publishing a freeform canvas's React source via the agent."""
+
+    code = serializers.CharField(allow_blank=True, trim_whitespace=False)
+    prompt = serializers.CharField(required=False, allow_blank=True, trim_whitespace=False)
+
+
 @extend_schema(extensions={"x-product": "core"})
 class DesktopFileSystemViewSet(FileSystemViewSet):
     """
@@ -999,6 +1009,64 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return instance
+
+    def _get_dashboard_or_400(self) -> FileSystem | Response:
+        instance = self.get_object()
+        if instance.type != "dashboard":
+            return Response(
+                {"detail": "Canvas code can only be published to dashboards."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return instance
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvas_partial_update",
+        request=CanvasPublishSerializer,
+        responses={200: FileSystemSerializer},
+    )
+    @action(methods=["PATCH"], detail=True, url_path="canvas")
+    def publish_canvas(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Publish a new version of a freeform canvas's React source.
+
+        Merges into the dashboard row's `meta` (never replaces it), so existing
+        keys like `channelId`/`templateId` survive. Appends a full-file version
+        snapshot and points `currentVersionId` at it — the server-side mirror of
+        the app's dashboardsService.saveFreeform.
+        """
+        dashboard = self._get_dashboard_or_400()
+        if isinstance(dashboard, Response):
+            return dashboard
+
+        payload = CanvasPublishSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+        code = payload.validated_data["code"]
+        prompt = payload.validated_data.get("prompt")
+
+        now_ms = int(time.time() * 1000)
+        meta = dict(dashboard.meta or {})
+        version: dict[str, Any] = {"id": str(uuid4()), "code": code, "createdAt": now_ms}
+        if prompt:
+            version["prompt"] = prompt
+        # Snapshot the live author context onto the version (reverting restores it).
+        existing_context = meta.get("context")
+        if isinstance(existing_context, str):
+            version["context"] = existing_context
+        versions = list(meta.get("versions") or [])
+        versions.append(version)
+
+        meta.update(
+            {
+                "kind": "freeform",
+                "code": code,
+                "versions": versions,
+                "currentVersionId": version["id"],
+                "updatedAt": now_ms,
+            }
+        )
+        dashboard.meta = meta
+        dashboard.save(update_fields=["meta"])
+
+        return Response(self.get_serializer(dashboard).data)
 
     @extend_schema(responses={200: FolderInstructionsSerializer})
     @action(methods=["GET"], detail=True)

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1043,28 +1043,34 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
         prompt = payload.validated_data.get("prompt")
 
         now_ms = int(time.time() * 1000)
-        meta = dict(dashboard.meta or {})
         version: dict[str, Any] = {"id": str(uuid4()), "code": code, "createdAt": now_ms}
         if prompt:
             version["prompt"] = prompt
-        # Snapshot the live author context onto the version (reverting restores it).
-        existing_context = meta.get("context")
-        if isinstance(existing_context, str):
-            version["context"] = existing_context
-        versions = list(meta.get("versions") or [])
-        versions.append(version)
 
-        meta.update(
-            {
-                "kind": "freeform",
-                "code": code,
-                "versions": versions,
-                "currentVersionId": version["id"],
-                "updatedAt": now_ms,
-            }
-        )
-        dashboard.meta = meta
-        dashboard.save(update_fields=["meta"])
+        # Lock the row for the read-modify-write so concurrent publishes can't clobber
+        # each other's appended version (each would otherwise build `versions` from the
+        # same stale snapshot and the second write would drop the first).
+        with transaction.atomic():
+            dashboard = FileSystem.objects.select_for_update().get(pk=dashboard.pk)
+            meta = dict(dashboard.meta or {})
+            # Snapshot the live author context onto the version (reverting restores it).
+            existing_context = meta.get("context")
+            if isinstance(existing_context, str):
+                version["context"] = existing_context
+            versions = list(meta.get("versions") or [])
+            versions.append(version)
+
+            meta.update(
+                {
+                    "kind": "freeform",
+                    "code": code,
+                    "versions": versions,
+                    "currentVersionId": version["id"],
+                    "updatedAt": now_ms,
+                }
+            )
+            dashboard.meta = meta
+            dashboard.save(update_fields=["meta"])
 
         return Response(self.get_serializer(dashboard).data)
 

--- a/posthog/api/file_system/test/test_canvas_publish.py
+++ b/posthog/api/file_system/test/test_canvas_publish.py
@@ -1,0 +1,68 @@
+from typing import cast
+
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.models.file_system.file_system import FileSystem
+
+
+class TestDesktopCanvasPublishAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Staff gate mirrors the desktop/web file system beta gating.
+        self.user.is_staff = True
+        self.user.save()
+
+    def _create_dashboard(self, path: str = "MyChannel/MyCanvas", meta: dict | None = None) -> str:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/desktop_file_system/",
+            {"path": path, "type": "dashboard", "meta": meta or {}},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        return cast(str, response.json()["id"])
+
+    def _canvas_url(self, item_id: str) -> str:
+        return f"/api/projects/{self.team.id}/desktop_file_system/{item_id}/canvas/"
+
+    def test_publish_canvas_sets_code_and_appends_version(self):
+        item_id = self._create_dashboard(meta={"channelId": "chan-1", "kind": "freeform"})
+
+        response = self.client.patch(
+            self._canvas_url(item_id),
+            {"code": "export default () => <div>hi</div>", "prompt": "build a hello canvas"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        row = FileSystem.objects.get(id=item_id)
+        meta = row.meta
+        self.assertEqual(meta["code"], "export default () => <div>hi</div>")
+        self.assertEqual(meta["kind"], "freeform")
+        # Pre-existing meta keys survive the merge.
+        self.assertEqual(meta["channelId"], "chan-1")
+        # One version appended, pointed at by currentVersionId, carrying the prompt.
+        self.assertEqual(len(meta["versions"]), 1)
+        version = meta["versions"][0]
+        self.assertEqual(version["code"], "export default () => <div>hi</div>")
+        self.assertEqual(version["prompt"], "build a hello canvas")
+        self.assertEqual(meta["currentVersionId"], version["id"])
+
+    def test_publish_canvas_appends_to_existing_history(self):
+        item_id = self._create_dashboard()
+        self.client.patch(self._canvas_url(item_id), {"code": "v1"})
+        self.client.patch(self._canvas_url(item_id), {"code": "v2"})
+
+        meta = FileSystem.objects.get(id=item_id).meta
+        self.assertEqual(meta["code"], "v2")
+        self.assertEqual([v["code"] for v in meta["versions"]], ["v1", "v2"])
+        self.assertEqual(meta["currentVersionId"], meta["versions"][-1]["id"])
+
+    def test_publish_canvas_rejects_non_dashboard(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/desktop_file_system/",
+            {"path": "AChannel", "type": "folder"},
+        )
+        folder_id = response.json()["id"]
+
+        bad = self.client.patch(self._canvas_url(folder_id), {"code": "x"})
+        self.assertEqual(bad.status_code, status.HTTP_400_BAD_REQUEST, bad.json())

--- a/posthog/api/file_system/test/test_canvas_publish.py
+++ b/posthog/api/file_system/test/test_canvas_publish.py
@@ -35,7 +35,7 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
 
         row = FileSystem.objects.get(id=item_id)
-        meta = row.meta
+        meta = cast(dict, row.meta)
         self.assertEqual(meta["code"], "export default () => <div>hi</div>")
         self.assertEqual(meta["kind"], "freeform")
         # Pre-existing meta keys survive the merge.
@@ -52,7 +52,7 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
         self.client.patch(self._canvas_url(item_id), {"code": "v1"})
         self.client.patch(self._canvas_url(item_id), {"code": "v2"})
 
-        meta = FileSystem.objects.get(id=item_id).meta
+        meta = cast(dict, FileSystem.objects.get(id=item_id).meta)
         self.assertEqual(meta["code"], "v2")
         self.assertEqual([v["code"] for v in meta["versions"]], ["v1", "v2"])
         self.assertEqual(meta["currentVersionId"], meta["versions"][-1]["id"])
@@ -66,3 +66,11 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
 
         bad = self.client.patch(self._canvas_url(folder_id), {"code": "x"})
         self.assertEqual(bad.status_code, status.HTTP_400_BAD_REQUEST, bad.json())
+
+    def test_publish_canvas_requires_code(self):
+        item_id = self._create_dashboard()
+
+        # `code` is required by the serializer; omitting it is a 400, not a silent no-op.
+        bad = self.client.patch(self._canvas_url(item_id), {"prompt": "only a prompt"})
+        self.assertEqual(bad.status_code, status.HTTP_400_BAD_REQUEST, bad.json())
+        self.assertIn("code", bad.json())

--- a/posthog/api/file_system/test/test_canvas_publish.py
+++ b/posthog/api/file_system/test/test_canvas_publish.py
@@ -57,6 +57,27 @@ class TestDesktopCanvasPublishAPI(APIBaseTest):
         self.assertEqual([v["code"] for v in meta["versions"]], ["v1", "v2"])
         self.assertEqual(meta["currentVersionId"], meta["versions"][-1]["id"])
 
+    def test_publish_canvas_renames_via_name(self):
+        item_id = self._create_dashboard(path="MyChannel/Old name")
+
+        response = self.client.patch(
+            self._canvas_url(item_id),
+            {"code": "v1", "name": "New name"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        row = FileSystem.objects.get(id=item_id)
+        # Leaf segment renamed, parent folder preserved.
+        self.assertEqual(row.path, "MyChannel/New name")
+        self.assertEqual(cast(dict, row.meta)["code"], "v1")
+
+    def test_publish_canvas_without_name_keeps_path(self):
+        item_id = self._create_dashboard(path="MyChannel/Keep me")
+
+        self.client.patch(self._canvas_url(item_id), {"code": "v1"})
+
+        self.assertEqual(FileSystem.objects.get(id=item_id).path, "MyChannel/Keep me")
+
     def test_publish_canvas_rejects_non_dashboard(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/desktop_file_system/",

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -93,6 +93,27 @@ tools:
                     created automatically.
             type:
                 description: Use "folder" to create a channel.
+    desktop-file-system-canvas-partial-update:
+        operation: desktop_file_system_canvas_partial_update
+        enabled: true
+        scopes:
+            - file_system:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Update canvas code
+        description: >
+            Publish the React source for a freeform canvas (a "dashboard" item on the desktop surface). The `id` is the
+            canvas/dashboard id. Pass the COMPLETE single-file React source in `code` — each call replaces the live code
+            and appends a new version to the canvas's history. This is how a canvas-generation task saves its result;
+            do not write a local file.
+        param_overrides:
+            id:
+                description: ID of the canvas (desktop "dashboard" item) whose code to publish.
+            code:
+                description: >
+                    The complete single-file React source for the canvas. Replaces the current code wholesale.
     desktop-file-system-destroy:
         operation: desktop_file_system_destroy
         enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -79,11 +79,9 @@ tools:
             id:
                 description: ID of the canvas (desktop "dashboard" item) whose code to publish.
             code:
-                # Required by the backend CanvasPublishSerializer even though the endpoint is a
-                # PATCH (whose body fields Orval otherwise marks optional).
-                required: true
                 description: |
                     The complete single-file React source for the canvas. Replaces the current code wholesale.
+                required: true
             name:
                 description: |
                     Optional new display name for the canvas. When set, renames the canvas (the leaf of its path)

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -84,6 +84,10 @@ tools:
                 required: true
                 description: |
                     The complete single-file React source for the canvas. Replaces the current code wholesale.
+            name:
+                description: |
+                    Optional new display name for the canvas. When set, renames the canvas (the leaf of its path)
+                    in place. Omit to leave the name unchanged.
     desktop-file-system-context-generation-retrieve:
         operation: desktop_file_system_context_generation_retrieve
         enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -60,6 +60,27 @@ tools:
     delete-secret-token-backup-partial-update:
         operation: organizations_projects_delete_secret_token_backup_partial_update
         enabled: false
+    desktop-file-system-canvas-partial-update:
+        operation: desktop_file_system_canvas_partial_update
+        enabled: true
+        scopes:
+            - file_system:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Update canvas code
+        description: >
+            Publish the React source for a freeform canvas (a "dashboard" item on the desktop surface). The `id` is the
+            canvas/dashboard id. Pass the COMPLETE single-file React source in `code` — each call replaces the live code
+            and appends a new version to the canvas's history. This is how a canvas-generation task saves its result; do
+            not write a local file.
+        param_overrides:
+            id:
+                description: ID of the canvas (desktop "dashboard" item) whose code to publish.
+            code:
+                description: |
+                    The complete single-file React source for the canvas. Replaces the current code wholesale.
     desktop-file-system-context-generation-retrieve:
         operation: desktop_file_system_context_generation_retrieve
         enabled: false
@@ -93,27 +114,6 @@ tools:
                     created automatically.
             type:
                 description: Use "folder" to create a channel.
-    desktop-file-system-canvas-partial-update:
-        operation: desktop_file_system_canvas_partial_update
-        enabled: true
-        scopes:
-            - file_system:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Update canvas code
-        description: >
-            Publish the React source for a freeform canvas (a "dashboard" item on the desktop surface). The `id` is the
-            canvas/dashboard id. Pass the COMPLETE single-file React source in `code` — each call replaces the live code
-            and appends a new version to the canvas's history. This is how a canvas-generation task saves its result;
-            do not write a local file.
-        param_overrides:
-            id:
-                description: ID of the canvas (desktop "dashboard" item) whose code to publish.
-            code:
-                description: >
-                    The complete single-file React source for the canvas. Replaces the current code wholesale.
     desktop-file-system-destroy:
         operation: desktop_file_system_destroy
         enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -79,6 +79,9 @@ tools:
             id:
                 description: ID of the canvas (desktop "dashboard" item) whose code to publish.
             code:
+                # Required by the backend CanvasPublishSerializer even though the endpoint is a
+                # PATCH (whose body fields Orval otherwise marks optional).
+                required: true
                 description: |
                     The complete single-file React source for the canvas. Replaces the current code wholesale.
     desktop-file-system-context-generation-retrieve:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1952,6 +1952,20 @@
             "readOnlyHint": false
         }
     },
+    "desktop-file-system-canvas-partial-update": {
+        "description": "Publish the React source for a freeform canvas (a \"dashboard\" item on the desktop surface). The `id` is the canvas/dashboard id. Pass the COMPLETE single-file React source in `code` — each call replaces the live code and appends a new version to the canvas's history. This is how a canvas-generation task saves its result; do not write a local file.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Update canvas code",
+        "title": "Update canvas code",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "desktop-file-system-create": {
         "description": "Create a new channel (folder) on the desktop surface. Pass a slash-delimited `path` (parent folders are created automatically) and `type: folder`. A blank instruction set is created for the channel automatically; use the desktop-file-system-instructions-partial-update tool to fill it in.",
         "category": "Core",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1996,6 +1996,20 @@
             "readOnlyHint": false
         }
     },
+    "desktop-file-system-canvas-partial-update": {
+        "description": "Publish the React source for a freeform canvas (a \"dashboard\" item on the desktop surface). The `id` is the canvas/dashboard id. Pass the COMPLETE single-file React source in `code` — each call replaces the live code and appends a new version to the canvas's history. This is how a canvas-generation task saves its result; do not write a local file.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Update canvas code",
+        "title": "Update canvas code",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "desktop-file-system-create": {
         "description": "Create a new channel (folder) on the desktop surface. Pass a slash-delimited `path` (parent folders are created automatically) and `type: folder`. A blank instruction set is created for the channel automatically; use the desktop-file-system-instructions-partial-update tool to fill it in.",
         "category": "Core",

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -704,7 +704,13 @@ function composeToolSchema(
                 if (isWriteOp && !bodyFieldNames.includes(paramName)) {
                     bodyFieldNames.push(paramName)
                 }
-            } else if (override.description || override.default !== undefined || override.optional || castHelper) {
+            } else if (
+                override.description ||
+                override.default !== undefined ||
+                override.optional ||
+                override.required ||
+                castHelper
+            ) {
                 // Locate the Orval source schema this param came from, so we can reference
                 // its original field type via .shape and wrap it with .describe(...) / .default(...) / .optional() / cast.
                 let sourceImport: string | null = null
@@ -717,6 +723,12 @@ function composeToolSchema(
                 }
                 if (sourceImport) {
                     let expr = `${sourceImport}.shape['${paramName}']`
+                    if (override.required) {
+                        // PATCH body fields are `.optional()` in the Orval shape; unwrap so the
+                        // tool schema requires the field, matching the backend serializer.
+                        expr += '.unwrap()'
+                        optionalParamNames.delete(paramName)
+                    }
                     if (override.default !== undefined) {
                         expr += `.default(${JSON.stringify(override.default)}).optional()`
                     }

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -65,6 +65,14 @@ export const ToolConfigSchema = z
                          */
                         optional: z.boolean().optional(),
                         /**
+                         * When true, strip the optionality the Orval body schema applies
+                         * to PATCH fields, so the param is required in the tool schema.
+                         * Use when the backend serializer requires the field even though
+                         * the endpoint is a PATCH (drf-spectacular marks every PATCH body
+                         * field optional). Mutually exclusive with `optional`.
+                         */
+                        required: z.boolean().optional(),
+                        /**
                          * State manager key to resolve the param from when omitted.
                          * Supported keys: 'orgId' (→ getOrgID()), 'projectId' (→ getProjectId()).
                          */
@@ -90,6 +98,9 @@ export const ToolConfigSchema = z
                     })
                     .refine((data) => !(data.optional && !data.fallback), {
                         message: 'optional requires a fallback key to resolve the value from state',
+                    })
+                    .refine((data) => !(data.optional && data.required), {
+                        message: 'optional and required are mutually exclusive',
                     })
                     .refine((data) => !(data.cast && (data.input_schema || data.schema_ref)), {
                         message:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34255,6 +34255,14 @@ export namespace Schemas {
       readonly import_config?: unknown;
     }
 
+    /**
+     * Payload for publishing a freeform canvas's React source via the agent.
+     */
+    export interface PatchedCanvasPublish {
+      code?: string;
+      prompt?: string;
+    }
+
     export interface PatchedClusteringJob {
       readonly id?: string;
       /** @maxLength 100 */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34261,6 +34261,7 @@ export namespace Schemas {
     export interface PatchedCanvasPublish {
       code?: string;
       prompt?: string;
+      name?: string;
     }
 
     export interface PatchedClusteringJob {

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 9 enabled ops
+ * PostHog API - MCP 10 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -704,6 +704,30 @@ export const DesktopFileSystemRetrieveParams = /* @__PURE__ */ zod.object({
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
 })
+
+/**
+ * Publish a new version of a freeform canvas's React source.
+ *
+ * Merges into the dashboard row's `meta` (never replaces it), so existing
+ * keys like `channelId`/`templateId` survive. Appends a full-file version
+ * snapshot and points `currentVersionId` at it — the server-side mirror of
+ * the app's dashboardsService.saveFreeform.
+ */
+export const DesktopFileSystemCanvasPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this file system.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        code: zod.string().optional(),
+        prompt: zod.string().optional(),
+    })
+    .describe("Payload for publishing a freeform canvas's React source via the agent.")
 
 /**
  * Return the latest non-deleted instructions for this folder.

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -726,6 +726,7 @@ export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
     .object({
         code: zod.string().optional(),
         prompt: zod.string().optional(),
+        name: zod.string().optional(),
     })
     .describe("Payload for publishing a freeform canvas's React source via the agent.")
 

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -31,6 +31,9 @@ const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartia
         code: DesktopFileSystemCanvasPartialUpdateBody.shape['code']
             .unwrap()
             .describe('The complete single-file React source for the canvas. Replaces the current code wholesale.'),
+        name: DesktopFileSystemCanvasPartialUpdateBody.shape['name'].describe(
+            'Optional new display name for the canvas. When set, renames the canvas (the leaf of its path) in place. Omit to leave the name unchanged.'
+        ),
     })
 
 const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
@@ -47,6 +50,9 @@ const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
         }
         if (params.prompt !== undefined) {
             body['prompt'] = params.prompt
+        }
+        if (params.name !== undefined) {
+            body['name'] = params.name
         }
         const result = await context.api.request<Schemas.FileSystem>({
             method: 'PATCH',

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -22,6 +22,41 @@ import { castStringToInt } from '@/tools/cast-helpers'
 import { omitResponseFields } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
+const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
+    .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)
+    .extend({
+        id: DesktopFileSystemCanvasPartialUpdateParams.shape['id'].describe(
+            'ID of the canvas (desktop "dashboard" item) whose code to publish.'
+        ),
+        code: DesktopFileSystemCanvasPartialUpdateBody.shape['code'].describe(
+            'The complete single-file React source for the canvas. Replaces the current code wholesale.'
+        ),
+    })
+
+const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
+    typeof DesktopFileSystemCanvasPartialUpdateSchema,
+    Schemas.FileSystem
+> => ({
+    name: 'desktop-file-system-canvas-partial-update',
+    schema: DesktopFileSystemCanvasPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.code !== undefined) {
+            body['code'] = params.code
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        const result = await context.api.request<Schemas.FileSystem>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/`,
+            body,
+        })
+        return result
+    },
+})
+
 const DesktopFileSystemCreateSchema = DesktopFileSystemCreateBody.extend({
     path: DesktopFileSystemCreateBody.shape['path'].describe(
         'Slash-delimited location of the channel, e.g. "Marketing/Q1 Campaigns". Intermediate folders are created automatically.'
@@ -56,41 +91,6 @@ const desktopFileSystemCreate = (): ToolBase<typeof DesktopFileSystemCreateSchem
         const result = await context.api.request<Schemas.FileSystem>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/`,
-            body,
-        })
-        return result
-    },
-})
-
-const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
-    .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)
-    .extend({
-        id: DesktopFileSystemCanvasPartialUpdateParams.shape['id'].describe(
-            'ID of the canvas (desktop "dashboard" item) whose code to publish.'
-        ),
-        code: DesktopFileSystemCanvasPartialUpdateBody.shape['code'].describe(
-            'The complete single-file React source for the canvas. Replaces the current code wholesale.'
-        ),
-    })
-
-const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
-    typeof DesktopFileSystemCanvasPartialUpdateSchema,
-    Schemas.FileSystem
-> => ({
-    name: 'desktop-file-system-canvas-partial-update',
-    schema: DesktopFileSystemCanvasPartialUpdateSchema,
-    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasPartialUpdateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.code !== undefined) {
-            body['code'] = params.code
-        }
-        if (params.prompt !== undefined) {
-            body['prompt'] = params.prompt
-        }
-        const result = await context.api.request<Schemas.FileSystem>({
-            method: 'PATCH',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/`,
             body,
         })
         return result
@@ -551,8 +551,8 @@ const userSettingsUpdate = (): ToolBase<typeof UserSettingsUpdateSchema, Schemas
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
-    'desktop-file-system-create': desktopFileSystemCreate,
     'desktop-file-system-canvas-partial-update': desktopFileSystemCanvasPartialUpdate,
+    'desktop-file-system-create': desktopFileSystemCreate,
     'desktop-file-system-instructions-partial-update': desktopFileSystemInstructionsPartialUpdate,
     'desktop-file-system-instructions-retrieve': desktopFileSystemInstructionsRetrieve,
     'desktop-file-system-list': desktopFileSystemList,

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    DesktopFileSystemCanvasPartialUpdateBody,
+    DesktopFileSystemCanvasPartialUpdateParams,
     DesktopFileSystemCreateBody,
     DesktopFileSystemInstructionsPartialUpdateBody,
     DesktopFileSystemInstructionsPartialUpdateParams,
@@ -54,6 +56,41 @@ const desktopFileSystemCreate = (): ToolBase<typeof DesktopFileSystemCreateSchem
         const result = await context.api.request<Schemas.FileSystem>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/`,
+            body,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
+    .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)
+    .extend({
+        id: DesktopFileSystemCanvasPartialUpdateParams.shape['id'].describe(
+            'ID of the canvas (desktop "dashboard" item) whose code to publish.'
+        ),
+        code: DesktopFileSystemCanvasPartialUpdateBody.shape['code'].describe(
+            'The complete single-file React source for the canvas. Replaces the current code wholesale.'
+        ),
+    })
+
+const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
+    typeof DesktopFileSystemCanvasPartialUpdateSchema,
+    Schemas.FileSystem
+> => ({
+    name: 'desktop-file-system-canvas-partial-update',
+    schema: DesktopFileSystemCanvasPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.code !== undefined) {
+            body['code'] = params.code
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        const result = await context.api.request<Schemas.FileSystem>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/`,
             body,
         })
         return result
@@ -515,6 +552,7 @@ const userSettingsUpdate = (): ToolBase<typeof UserSettingsUpdateSchema, Schemas
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'desktop-file-system-create': desktopFileSystemCreate,
+    'desktop-file-system-canvas-partial-update': desktopFileSystemCanvasPartialUpdate,
     'desktop-file-system-instructions-partial-update': desktopFileSystemInstructionsPartialUpdate,
     'desktop-file-system-instructions-retrieve': desktopFileSystemInstructionsRetrieve,
     'desktop-file-system-list': desktopFileSystemList,

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -28,9 +28,9 @@ const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartia
         id: DesktopFileSystemCanvasPartialUpdateParams.shape['id'].describe(
             'ID of the canvas (desktop "dashboard" item) whose code to publish.'
         ),
-        code: DesktopFileSystemCanvasPartialUpdateBody.shape['code'].describe(
-            'The complete single-file React source for the canvas. Replaces the current code wholesale.'
-        ),
+        code: DesktopFileSystemCanvasPartialUpdateBody.shape['code']
+            .unwrap()
+            .describe('The complete single-file React source for the canvas. Replaces the current code wholesale.'),
     })
 
 const desktopFileSystemCanvasPartialUpdate = (): ToolBase<

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
@@ -13,6 +13,6 @@
             "type": "string"
         }
     },
-    "required": ["id"],
+    "required": ["id", "code"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
@@ -9,6 +9,10 @@
             "description": "ID of the canvas (desktop \"dashboard\" item) whose code to publish.",
             "type": "string"
         },
+        "name": {
+            "description": "Optional new display name for the canvas. When set, renames the canvas (the leaf of its path) in place. Omit to leave the name unchanged.",
+            "type": "string"
+        },
         "prompt": {
             "type": "string"
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-partial-update.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "code": {
+            "description": "The complete single-file React source for the canvas. Replaces the current code wholesale.",
+            "type": "string"
+        },
+        "id": {
+            "description": "ID of the canvas (desktop \"dashboard\" item) whose code to publish.",
+            "type": "string"
+        },
+        "prompt": {
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

The desktop file system surface lets agents create freeform canvases (React/TSX modules that render PostHog data). There was no server-side way to publish a canvas's source — saving had to go through the app's client-side `dashboardsService.saveFreeform`. A canvas-generation task running outside the app (e.g. an agent/MCP client) had no endpoint to write the generated code back to the canvas.

## Changes

- Add `PATCH /api/projects/{project}/desktop_file_system/{id}/canvas/` (`publish_canvas`) on `DesktopFileSystemViewSet`. It:
  - rejects non-`dashboard` items with a 400
  - merges into the dashboard row's `meta` rather than replacing it, so existing keys (`channelId`, `templateId`, `kind`, `generationTaskId`) survive
  - appends a full-file version snapshot (`{ id, code, createdAt, prompt?, context? }`), sets `code`, points `currentVersionId` at the new version, and bumps `updatedAt`
  - this is the server-side mirror of the app's `dashboardsService.saveFreeform`
- Expose it as the `desktop-file-system-canvas-partial-update` MCP tool (scope `file_system:write`) and regenerate the MCP tool definitions.
- Regenerate the frontend API types (`frontend/src/generated/core/*`) from the new endpoint.

State lives entirely in the existing `meta` JSONField, so there is no schema change and no migration.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing. Added `posthog/api/file_system/test/test_canvas_publish.py` covering:

- publishing sets `code`/`kind`, preserves pre-existing meta keys, appends one version, and sets `currentVersionId` + the version `prompt`
- repeated publishes append to existing version history in order
- publishing to a non-dashboard item returns 400

I did not run the suite locally (the local MCP dev server was build-broken in this environment); CI should exercise these tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus).
- The endpoint, MCP tool definition, and generated types in this branch were authored in a prior session; this session scoped the PR down to the coherent feature, wrote the commit, and opened the PR.
- Deliberately excluded from this PR: an unrelated `services/stripe-mock/uv.lock` dependency-churn change, and two divergent `creating-canvas` SKILL.md drafts that reference tools not part of this diff. They were left in the working tree, not committed.
- Design note for reviewers: the canvas's `generationTaskId` is stored as a `meta` key, whereas the analogous folder context-generation association uses a dedicated `FileSystemFolderContextGeneration` table + `task_id` column. Promoting the canvas task ID to a real column to match that pattern is a reasonable follow-up but is out of scope here — this diff touches only `code`/version storage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
