### PR TITLE
feat(mcp): add general posthog-feedback tool

### DIFF
--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -413,6 +413,10 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP feedback submitted",
             "description": "Fires when a user submits feedback through the MCP server's feedback tool.",
         },
+        "posthog feedback submitted": {
+            "label": "PostHog feedback submitted",
+            "description": "Fires when general feedback about PostHog is submitted through the MCP server's posthog-feedback tool.",
+        },
         "$snapshot": {
             "label": "Session recording snapshot",
             "description": "Carries session replay data to the backend. These events do not contribute to event counts.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5690,6 +5690,22 @@
             "readOnlyHint": true
         }
     },
+    "posthog-feedback": {
+        "description": "Optional: relay general feedback about PostHog itself — any product, feature, or workflow the user encountered (e.g. product analytics, session replay, feature flags, the data warehouse, docs). Unlike `agent-feedback` (which is strictly about this MCP server), this is a catch-all channel for product feedback, and ALL sentiment is welcome: bugs, confusion, feature requests, AND praise. Use it when the user expresses an opinion about PostHog, hits a bug, wishes a capability existed, finds something confusing, or is delighted by something — or when you observe a concrete product issue worth flagging. Keep `summary` to one sentence and write `details` as clear, concise bullet points, quoting exact UI labels, queries, or error messages where possible. Do not include user PII or sensitive customer data. IMPORTANT: submitting feedback does NOT mean your work is done — keep going and finish the user's task using the other available tools.",
+        "category": "Feedback",
+        "feature": "feedback",
+        "summary": "Optional: relay general feedback about any part of PostHog.",
+        "title": "Submit PostHog feedback",
+        "required_scopes": [],
+        "always_available": true,
+        "feature_flag": "mcp-feedback-tool",
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": false,
+            "readOnlyHint": true
+        }
+    },
     "pr-lifecycle": {
         "description": "The timeline of a single pull request: a header (number, title, author, state, draft, timestamps) plus ordered events — opened, CI started, CI finished, and merged or closed. Use this to answer \"where is this PR stuck and what happened to it\". metric_quality is \"partial\" — it covers CI events only; review and comment events are not yet available. For aggregate questions use the pull-requests and workflow-health tools.",
         "category": "Engineering analytics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5698,7 +5698,7 @@
         "title": "Submit PostHog feedback",
         "required_scopes": [],
         "always_available": true,
-        "feature_flag": "mcp-feedback-tool",
+        "feature_flag": "mcp-posthog-feedback-tool",
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -29,6 +29,22 @@
             "readOnlyHint": true
         }
     },
+    "posthog-feedback": {
+        "description": "Optional: relay general feedback about PostHog itself — any product, feature, or workflow the user encountered (e.g. product analytics, session replay, feature flags, the data warehouse, docs). Unlike `agent-feedback` (which is strictly about this MCP server), this is a catch-all channel for product feedback, and ALL sentiment is welcome: bugs, confusion, feature requests, AND praise. Use it when the user expresses an opinion about PostHog, hits a bug, wishes a capability existed, finds something confusing, or is delighted by something — or when you observe a concrete product issue worth flagging. Keep `summary` to one sentence and write `details` as clear, concise bullet points, quoting exact UI labels, queries, or error messages where possible. Do not include user PII or sensitive customer data. IMPORTANT: submitting feedback does NOT mean your work is done — keep going and finish the user's task using the other available tools.",
+        "category": "Feedback",
+        "feature": "feedback",
+        "summary": "Optional: relay general feedback about any part of PostHog.",
+        "title": "Submit PostHog feedback",
+        "required_scopes": [],
+        "always_available": true,
+        "feature_flag": "mcp-feedback-tool",
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": false,
+            "readOnlyHint": true
+        }
+    },
     "agent-resolve-resource": {
         "description": "Fetch an operator playbook — a markdown guide for doing a class of agent-platform operations well. These are the same skills the agent concierge loads; resolve the relevant one BEFORE a non-trivial operation (editing/promoting a revision, wiring secrets, authoring an agent, debugging a session). Many `agent-applications-*` tool descriptions name the playbook to read first. Pass either a bare id or its `posthog://agent-platform/playbooks/<id>` URI — the `resource` parameter enumerates the available playbooks. Returns `{ id, uri, title, content }` where `content` is the full markdown.",
         "category": "Agent stack",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -37,7 +37,7 @@
         "title": "Submit PostHog feedback",
         "required_scopes": [],
         "always_available": true,
-        "feature_flag": "mcp-feedback-tool",
+        "feature_flag": "mcp-posthog-feedback-tool",
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -504,6 +504,47 @@
             },
             "required": ["orgId"]
         },
+        "PostHogFeedbackSubmitSchema": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A one-sentence headline capturing the feedback (e.g. \"session replay player jumps to the wrong timestamp when clicking the timeline\"). This is the only required free-text field — keep it specific and self-contained."
+                },
+                "feedback_type": {
+                    "type": "string",
+                    "enum": ["bug", "feature_request", "confusion", "praise", "other"],
+                    "description": "The kind of feedback. \"bug\" = something is broken or behaves wrong, \"feature_request\" = a capability the user wants that does not exist, \"confusion\" = something was unclear or hard to understand, \"praise\" = positive feedback about what worked well, \"other\" = anything that does not fit."
+                },
+                "sentiment": {
+                    "type": "string",
+                    "enum": ["positive", "neutral", "mixed", "negative"],
+                    "description": "The overall sentiment of the feedback. Unlike agent-feedback, positive and neutral feedback is welcome here — this is a general PostHog feedback channel, not a problems-only one."
+                },
+                "product_area": {
+                    "description": "The PostHog product or area the feedback is about, in lowercase (e.g. \"product analytics\", \"session replay\", \"feature flags\", \"experiments\", \"data warehouse\", \"error tracking\", \"surveys\", \"web analytics\", \"llm analytics\", \"billing\", \"docs\", \"mcp\"). Free text — pick the closest area if unsure.",
+                    "type": "string"
+                },
+                "details": {
+                    "description": "The body of the feedback as clear, concise bullet points: what happened, what the user expected, and any steps to reproduce. Quote exact UI labels, query text, or error messages where possible. Do not include user PII or sensitive customer data.",
+                    "type": "string"
+                },
+                "suggested_improvement": {
+                    "description": "The single most impactful, concrete change that would address this feedback, if you can name one (e.g. \"let users pin a column in the persons table\"). Optional — leave empty for pure praise or when no specific change is obvious.",
+                    "type": "string"
+                },
+                "user_request": {
+                    "description": "A short, anonymised paraphrase of what the user was trying to do when this feedback came up. Do not include PII, customer names, or sensitive query content.",
+                    "type": "string"
+                },
+                "task_completed": {
+                    "description": "Whether the user was ultimately able to accomplish what they wanted. Useful signal for prioritising — omit if it doesn't apply.",
+                    "type": "boolean"
+                }
+            },
+            "required": ["summary", "feedback_type", "sentiment"]
+        },
         "ProjectGetAllSchema": {
             "type": "object",
             "properties": {}

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -59,7 +59,8 @@ export class InstructionsFormatter {
                 SCHEMA_WORKFLOW,
                 ENV_CONTEXT,
                 URL_PATTERNS,
-                ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK, POSTHOG_FEEDBACK] : []),
+                ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
+                ...(this.posthogFeedbackEnabled(ctx.featureFlags) ? [POSTHOG_FEEDBACK] : []),
                 EXAMPLES,
             ],
             ctx,
@@ -108,11 +109,18 @@ export class InstructionsFormatter {
         return this.compose(sections, renderCtx, { compact: false })
     }
 
-    /** The feedback sections are only useful when the feedback tools
-     *  (`agent-feedback`, `posthog-feedback`) are reachable, which is governed by
-     *  the `mcp-feedback-tool` flag evaluated in `resolveToolFeatureFlags`. */
+    /** The agent-feedback section is only useful when the `agent-feedback` tool
+     *  is reachable, which is governed by the `mcp-feedback-tool` flag evaluated
+     *  in `resolveToolFeatureFlags`. */
     private agentFeedbackEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
         return featureFlags?.['mcp-feedback-tool'] === true
+    }
+
+    /** The posthog-feedback section is gated independently of agent-feedback so
+     *  the general product-feedback tool can roll out on its own schedule, via
+     *  the `mcp-posthog-feedback-tool` flag evaluated in `resolveToolFeatureFlags`. */
+    private posthogFeedbackEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
+        return featureFlags?.['mcp-posthog-feedback-tool'] === true
     }
 
     private compose(sections: string[], ctx: InstructionsContext, opts: { compact: boolean }): string {

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -21,6 +21,7 @@ import COMPACT_INSTRUCTIONS from '@/templates/sections/compact-instructions.md'
 import ENV_CONTEXT from '@/templates/sections/env-context.md'
 import EXAMPLES from '@/templates/sections/examples.md'
 import EXEC_TOOL_BLURB from '@/templates/sections/exec-tool-blurb.md'
+import POSTHOG_FEEDBACK from '@/templates/sections/posthog-feedback.md'
 import RETRIEVING_DATA from '@/templates/sections/retrieving-data.md'
 import SCHEMA_WORKFLOW from '@/templates/sections/schema-workflow.md'
 import TOOL_SEARCH from '@/templates/sections/tool-search.md'
@@ -58,7 +59,7 @@ export class InstructionsFormatter {
                 SCHEMA_WORKFLOW,
                 ENV_CONTEXT,
                 URL_PATTERNS,
-                ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
+                ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK, POSTHOG_FEEDBACK] : []),
                 EXAMPLES,
             ],
             ctx,
@@ -107,9 +108,9 @@ export class InstructionsFormatter {
         return this.compose(sections, renderCtx, { compact: false })
     }
 
-    /** The agent-feedback section is only useful when the `agent-feedback` tool
-     *  is reachable, which is governed by the `mcp-feedback-tool` flag evaluated
-     *  in `resolveToolFeatureFlags`. */
+    /** The feedback sections are only useful when the feedback tools
+     *  (`agent-feedback`, `posthog-feedback`) are reachable, which is governed by
+     *  the `mcp-feedback-tool` flag evaluated in `resolveToolFeatureFlags`. */
     private agentFeedbackEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
         return featureFlags?.['mcp-feedback-tool'] === true
     }

--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -4,6 +4,7 @@ export enum AnalyticsEvent {
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
     MCP_TOOL_CALL = 'mcp_tool_call', // matching @posthog/mcp-analytics
     MCP_FEEDBACK_SUBMITTED = 'mcp feedback submitted',
+    POSTHOG_FEEDBACK_SUBMITTED = 'posthog feedback submitted',
 }
 
 // Emitted as `$mcp_version` / `mcp_version` on analytics events. The MCP server

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -236,6 +236,55 @@ export const FeedbackSubmitSchema = z.object({
         ),
 })
 
+export const PostHogFeedbackSubmitSchema = z.object({
+    summary: z
+        .string()
+        .min(1)
+        .describe(
+            'A one-sentence headline capturing the feedback (e.g. "session replay player jumps to the wrong timestamp when clicking the timeline"). This is the only required free-text field — keep it specific and self-contained.'
+        ),
+    feedback_type: z
+        .enum(['bug', 'feature_request', 'confusion', 'praise', 'other'])
+        .describe(
+            'The kind of feedback. "bug" = something is broken or behaves wrong, "feature_request" = a capability the user wants that does not exist, "confusion" = something was unclear or hard to understand, "praise" = positive feedback about what worked well, "other" = anything that does not fit.'
+        ),
+    sentiment: z
+        .enum(['positive', 'neutral', 'mixed', 'negative'])
+        .describe(
+            'The overall sentiment of the feedback. Unlike agent-feedback, positive and neutral feedback is welcome here — this is a general PostHog feedback channel, not a problems-only one.'
+        ),
+    product_area: z
+        .string()
+        .optional()
+        .describe(
+            'The PostHog product or area the feedback is about, in lowercase (e.g. "product analytics", "session replay", "feature flags", "experiments", "data warehouse", "error tracking", "surveys", "web analytics", "llm analytics", "billing", "docs", "mcp"). Free text — pick the closest area if unsure.'
+        ),
+    details: z
+        .string()
+        .optional()
+        .describe(
+            'The body of the feedback as clear, concise bullet points: what happened, what the user expected, and any steps to reproduce. Quote exact UI labels, query text, or error messages where possible. Do not include user PII or sensitive customer data.'
+        ),
+    suggested_improvement: z
+        .string()
+        .optional()
+        .describe(
+            'The single most impactful, concrete change that would address this feedback, if you can name one (e.g. "let users pin a column in the persons table"). Optional — leave empty for pure praise or when no specific change is obvious.'
+        ),
+    user_request: z
+        .string()
+        .optional()
+        .describe(
+            'A short, anonymised paraphrase of what the user was trying to do when this feedback came up. Do not include PII, customer names, or sensitive query content.'
+        ),
+    task_completed: z
+        .boolean()
+        .optional()
+        .describe(
+            "Whether the user was ultimately able to accomplish what they wanted. Useful signal for prioritising — omit if it doesn't apply."
+        ),
+})
+
 export const ExperimentResultsGetSchema = z.object({
     id: z.number().describe('The ID of the experiment to get comprehensive results for'),
     refresh: z

--- a/services/mcp/src/templates/sections/posthog-feedback.md
+++ b/services/mcp/src/templates/sections/posthog-feedback.md
@@ -1,0 +1,14 @@
+### Sharing feedback about PostHog
+
+The `posthog-feedback` tool is a general channel for relaying feedback about PostHog itself — any product, feature, or workflow (product analytics, session replay, feature flags, the data warehouse, docs, and so on). It is the counterpart to `agent-feedback`: use `agent-feedback` for problems with this MCP server, and `posthog-feedback` for everything else about the PostHog product.
+
+Unlike `agent-feedback`, **all sentiment is welcome here** — bugs, confusion, feature requests, _and_ praise. Call it when:
+
+- The user expresses an opinion about a PostHog product or feature (good or bad).
+- The user hits a bug, or wishes a capability existed that doesn't.
+- The user finds something confusing or hard to use.
+- You observe a concrete, reportable product issue worth flagging to the team.
+
+Keep `summary` to one sentence and write `details` as clear, concise bullet points — what happened, what was expected, and how to reproduce where relevant. Quote exact UI labels, queries, or error messages. Set `product_area` to the closest PostHog area, and add a `suggested_improvement` when you can name a specific change. Never include user PII or sensitive customer data.
+
+Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team — call it when warranted, then keep going and finish the user's task with the other tools.

--- a/services/mcp/src/tools/feedback/submitPostHog.ts
+++ b/services/mcp/src/tools/feedback/submitPostHog.ts
@@ -1,0 +1,62 @@
+import type { z } from 'zod'
+
+import { AnalyticsEvent } from '@/lib/posthog/analytics'
+import { PostHogFeedbackSubmitSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = PostHogFeedbackSubmitSchema
+
+type Params = z.infer<typeof schema>
+
+type Result = {
+    received: boolean
+    summary: string
+    feedback_type: Params['feedback_type']
+    sentiment: Params['sentiment']
+    message: string
+}
+
+const RESPONSE_MESSAGE =
+    'Thank you for the feedback — it has been recorded and will be reviewed by the PostHog team. ' +
+    "Submitting feedback does not mean your work is done: keep going and finish the user's task " +
+    'using the other available tools.'
+
+export const submitPostHogFeedbackHandler: ToolBase<typeof schema, Result>['handler'] = async (
+    context: Context,
+    params: Params
+) => {
+    // `context.trackEvent` is itself best-effort (the MCP-class implementation wraps
+    // analytics in its own try/catch). The outer try/catch here defends against any
+    // unexpected throw on the way *to* trackEvent so the agent never sees this tool
+    // fail because of an analytics issue.
+    try {
+        await context.trackEvent(AnalyticsEvent.POSTHOG_FEEDBACK_SUBMITTED, {
+            feedback_summary: params.summary,
+            feedback_type: params.feedback_type,
+            feedback_sentiment: params.sentiment,
+            feedback_product_area: params.product_area,
+            feedback_details: params.details,
+            feedback_suggested_improvement: params.suggested_improvement,
+            feedback_user_request: params.user_request,
+            feedback_task_completed: params.task_completed,
+        })
+    } catch {
+        // Analytics is non-fatal — never surface as a tool failure.
+    }
+
+    return {
+        received: true,
+        summary: params.summary,
+        feedback_type: params.feedback_type,
+        sentiment: params.sentiment,
+        message: RESPONSE_MESSAGE,
+    }
+}
+
+const tool = (): ToolBase<typeof schema, Result> => ({
+    name: 'posthog-feedback',
+    schema,
+    handler: submitPostHogFeedbackHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -11,6 +11,7 @@ import getExperimentResults from './experiments/getResults'
 import experimentListDeprecated from './experiments/listDeprecated'
 // Feedback
 import submitFeedback from './feedback/submit'
+import submitPostHogFeedback from './feedback/submitPostHog'
 // Generated tools (from definitions/*.yaml)
 import { GENERATED_TOOL_MAP } from './generated'
 // Insights
@@ -84,6 +85,7 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Feedback
     'agent-feedback': submitFeedback,
+    'posthog-feedback': submitPostHogFeedback,
 
     // Agent platform (read-only playbook resolver — CRUD lives in generated/agent_platform.ts)
     'agent-resolve-resource': resolveResource,

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -234,6 +234,21 @@ Every report must include a concrete `suggested_improvement` — if you can't na
 
 Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team about the MCP server — call it once at the end of a task when warranted, then keep going and finish the user's task with the other tools.
 
+### Sharing feedback about PostHog
+
+The `posthog-feedback` tool is a general channel for relaying feedback about PostHog itself — any product, feature, or workflow (product analytics, session replay, feature flags, the data warehouse, docs, and so on). It is the counterpart to `agent-feedback`: use `agent-feedback` for problems with this MCP server, and `posthog-feedback` for everything else about the PostHog product.
+
+Unlike `agent-feedback`, **all sentiment is welcome here** — bugs, confusion, feature requests, _and_ praise. Call it when:
+
+- The user expresses an opinion about a PostHog product or feature (good or bad).
+- The user hits a bug, or wishes a capability existed that doesn't.
+- The user finds something confusing or hard to use.
+- You observe a concrete, reportable product issue worth flagging to the team.
+
+Keep `summary` to one sentence and write `details` as clear, concise bullet points — what happened, what was expected, and how to reproduce where relevant. Quote exact UI labels, queries, or error messages. Set `product_area` to the closest PostHog area, and add a `suggested_improvement` when you can name a specific change. Never include user PII or sensitive customer data.
+
+Submitting feedback is **not** a way to end your turn or skip work. It is a side report to the PostHog team — call it when warranted, then keep going and finish the user's task with the other tools.
+
 ### Examples
 
 Before writing any queries, read the PostHog's skill `querying-posthog-data` to see if there are any relevant query examples and follow them.

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/posthog-feedback.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/posthog-feedback.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "details": {
+            "description": "The body of the feedback as clear, concise bullet points: what happened, what the user expected, and any steps to reproduce. Quote exact UI labels, query text, or error messages where possible. Do not include user PII or sensitive customer data.",
+            "type": "string"
+        },
+        "feedback_type": {
+            "description": "The kind of feedback. \"bug\" = something is broken or behaves wrong, \"feature_request\" = a capability the user wants that does not exist, \"confusion\" = something was unclear or hard to understand, \"praise\" = positive feedback about what worked well, \"other\" = anything that does not fit.",
+            "enum": ["bug", "feature_request", "confusion", "praise", "other"],
+            "type": "string"
+        },
+        "product_area": {
+            "description": "The PostHog product or area the feedback is about, in lowercase (e.g. \"product analytics\", \"session replay\", \"feature flags\", \"experiments\", \"data warehouse\", \"error tracking\", \"surveys\", \"web analytics\", \"llm analytics\", \"billing\", \"docs\", \"mcp\"). Free text — pick the closest area if unsure.",
+            "type": "string"
+        },
+        "sentiment": {
+            "description": "The overall sentiment of the feedback. Unlike agent-feedback, positive and neutral feedback is welcome here — this is a general PostHog feedback channel, not a problems-only one.",
+            "enum": ["positive", "neutral", "mixed", "negative"],
+            "type": "string"
+        },
+        "suggested_improvement": {
+            "description": "The single most impactful, concrete change that would address this feedback, if you can name one (e.g. \"let users pin a column in the persons table\"). Optional — leave empty for pure praise or when no specific change is obvious.",
+            "type": "string"
+        },
+        "summary": {
+            "description": "A one-sentence headline capturing the feedback (e.g. \"session replay player jumps to the wrong timestamp when clicking the timeline\"). This is the only required free-text field — keep it specific and self-contained.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "task_completed": {
+            "description": "Whether the user was ultimately able to accomplish what they wanted. Useful signal for prioritising — omit if it doesn't apply.",
+            "type": "boolean"
+        },
+        "user_request": {
+            "description": "A short, anonymised paraphrase of what the user was trying to do when this feedback came up. Do not include PII, customer names, or sensitive query content.",
+            "type": "string"
+        }
+    },
+    "required": ["summary", "feedback_type", "sentiment"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -41,7 +41,7 @@ const STATIC_CTX: InstructionsContext = {
     metadata: STATIC_METADATA,
     tools: STATIC_TOOLS,
     queryTools: STATIC_QUERY_TOOLS,
-    featureFlags: { 'mcp-feedback-tool': true, 'mcp-render-ui': true },
+    featureFlags: { 'mcp-feedback-tool': true, 'mcp-posthog-feedback-tool': true, 'mcp-render-ui': true },
     renderUiEnabled: true,
 }
 

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -92,6 +92,20 @@ describe('InstructionsFormatter', () => {
                 expect(result).not.toContain('### Sharing feedback on this MCP server')
             }
         })
+
+        it('includes the posthog-feedback section only when the mcp-posthog-feedback-tool flag is on', () => {
+            const formatter = new InstructionsFormatter()
+            const withFeedback = formatter.buildToolsInstructions({
+                ...fullCtx,
+                featureFlags: { 'mcp-posthog-feedback-tool': true },
+            })
+            expect(withFeedback).toContain('### Sharing feedback about PostHog')
+
+            for (const featureFlags of [undefined, { 'mcp-posthog-feedback-tool': false }, {}]) {
+                const result = formatter.buildToolsInstructions({ ...fullCtx, featureFlags })
+                expect(result).not.toContain('### Sharing feedback about PostHog')
+            }
+        })
     })
 
     describe('buildExecInstructions', () => {

--- a/services/mcp/tests/unit/posthog-feedback.test.ts
+++ b/services/mcp/tests/unit/posthog-feedback.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AnalyticsEvent } from '@/lib/posthog/analytics'
+import submitPostHogFeedback, { submitPostHogFeedbackHandler } from '@/tools/feedback/submitPostHog'
+import type { Context } from '@/tools/types'
+
+function createMockContext(trackEvent = vi.fn(async () => {})): Context {
+    return { trackEvent } as unknown as Context
+}
+
+describe('posthog-feedback', () => {
+    it('registers under the posthog-feedback name', () => {
+        expect(submitPostHogFeedback().name).toBe('posthog-feedback')
+    })
+
+    it('emits a "posthog feedback submitted" event with mapped properties', async () => {
+        const trackEvent = vi.fn(async () => {})
+        const ctx = createMockContext(trackEvent)
+
+        const result = await submitPostHogFeedbackHandler(ctx, {
+            summary: 'session replay player jumps to the wrong timestamp',
+            feedback_type: 'bug',
+            sentiment: 'negative',
+            product_area: 'session replay',
+            details: '- clicked the timeline at 0:30\n- player jumped to 0:00',
+            suggested_improvement: 'seek to the clicked position',
+            user_request: 'watch a recording around a specific moment',
+            task_completed: false,
+        })
+
+        expect(trackEvent).toHaveBeenCalledWith(AnalyticsEvent.POSTHOG_FEEDBACK_SUBMITTED, {
+            feedback_summary: 'session replay player jumps to the wrong timestamp',
+            feedback_type: 'bug',
+            feedback_sentiment: 'negative',
+            feedback_product_area: 'session replay',
+            feedback_details: '- clicked the timeline at 0:30\n- player jumped to 0:00',
+            feedback_suggested_improvement: 'seek to the clicked position',
+            feedback_user_request: 'watch a recording around a specific moment',
+            feedback_task_completed: false,
+        })
+        expect(result).toMatchObject({ received: true, feedback_type: 'bug', sentiment: 'negative' })
+    })
+
+    it('accepts positive feedback (unlike agent-feedback)', async () => {
+        const ctx = createMockContext()
+        const result = await submitPostHogFeedbackHandler(ctx, {
+            summary: 'the new funnels UI is much clearer',
+            feedback_type: 'praise',
+            sentiment: 'positive',
+        })
+        expect(result.received).toBe(true)
+        expect(result.sentiment).toBe('positive')
+    })
+
+    it('never throws when analytics tracking fails', async () => {
+        const trackEvent = vi.fn(async () => {
+            throw new Error('analytics down')
+        })
+        const ctx = createMockContext(trackEvent)
+
+        await expect(
+            submitPostHogFeedbackHandler(ctx, {
+                summary: 'wishing for column pinning in the persons table',
+                feedback_type: 'feature_request',
+                sentiment: 'neutral',
+            })
+        ).resolves.toMatchObject({ received: true })
+    })
+})

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -143,7 +143,7 @@ describe('Tool Filtering - Tools Allowlist', () => {
         it('should return only specified tools (plus always_available tools when enabled)', () => {
             const tools = getToolsForFeatures({
                 tools: ['dashboard-get', 'dashboard-create'],
-                featureFlags: { 'mcp-feedback-tool': true },
+                featureFlags: { 'mcp-feedback-tool': true, 'mcp-posthog-feedback-tool': true },
             })
             expect(tools).toContain('dashboard-get')
             expect(tools).toContain('dashboard-create')
@@ -163,7 +163,7 @@ describe('Tool Filtering - Tools Allowlist', () => {
         it('should return only always_available tools for nonexistent tool names', () => {
             const tools = getToolsForFeatures({
                 tools: ['nonexistent-tool'],
-                featureFlags: { 'mcp-feedback-tool': true },
+                featureFlags: { 'mcp-feedback-tool': true, 'mcp-posthog-feedback-tool': true },
             })
             const alwaysAvailableTools = collectAlwaysAvailableToolNames()
 
@@ -175,7 +175,7 @@ describe('Tool Filtering - Tools Allowlist', () => {
         it('should always include agent-feedback even when feature filter matches no tools', () => {
             const tools = getToolsForFeatures({
                 features: ['nonexistent-feature'],
-                featureFlags: { 'mcp-feedback-tool': true },
+                featureFlags: { 'mcp-feedback-tool': true, 'mcp-posthog-feedback-tool': true },
             })
             expect(tools).toContain('agent-feedback')
         })
@@ -188,6 +188,20 @@ describe('Tool Filtering - Tools Allowlist', () => {
             // No flags evaluated at all — also hidden (default behavior is `enable`).
             const toolsWithoutFlags = getToolsForFeatures({})
             expect(toolsWithoutFlags).not.toContain('agent-feedback')
+        })
+
+        it('should gate posthog-feedback on its own flag, independent of agent-feedback', () => {
+            // posthog-feedback rolls out separately: its flag on, agent-feedback's off.
+            const onlyPostHog = getToolsForFeatures({
+                featureFlags: { 'mcp-posthog-feedback-tool': true, 'mcp-feedback-tool': false },
+            })
+            expect(onlyPostHog).toContain('posthog-feedback')
+            expect(onlyPostHog).not.toContain('agent-feedback')
+
+            // And hidden when its own flag is off, even though it's always_available.
+            const off = getToolsForFeatures({ featureFlags: { 'mcp-posthog-feedback-tool': false } })
+            expect(off).not.toContain('posthog-feedback')
+            expect(getToolsForFeatures({})).not.toContain('posthog-feedback')
         })
 
         it('should union with features (OR) when both are provided', () => {
@@ -738,6 +752,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'tracing',
                 'visual-review',
                 'mcp-feedback-tool',
+                'mcp-posthog-feedback-tool',
                 'user-interviews',
                 'customer-analytics-csp',
                 'notebooks-collaboration',
@@ -753,7 +768,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'metrics',
             ])
         )
-        expect(flags).toHaveLength(19)
+        expect(flags).toHaveLength(20)
     })
 
     // Exercise the real predicate (toolPassesFlagGate) over hand-rolled entries

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -84,10 +84,11 @@ describe('Tool schema snapshots', () => {
     it('snapshots runtime tool schemas', async () => {
         const shouldUpdateSnapshots = isSnapshotUpdateAll()
         const root = path.resolve(__dirname, '__snapshots__', 'tool-schemas')
-        // Enable flag-gated tools we snapshot here: agent-feedback, tracing (APM spans), tasks,
-        // dashboard-widgets. Other flag-gated tools (logs-alerts, visual-review, etc.) stay off to keep the surface stable.
+        // Enable flag-gated tools we snapshot here: agent-feedback, posthog-feedback, tracing (APM spans),
+        // tasks, dashboard-widgets. Other flag-gated tools (logs-alerts, visual-review, etc.) stay off to keep the surface stable.
         const featureFlags = {
             'mcp-feedback-tool': true,
+            'mcp-posthog-feedback-tool': true,
             tracing: true,
             tasks: true,
             'dashboard-widgets': true,


### PR DESCRIPTION
## Problem

The MCP server already has an `agent-feedback` tool, but it's deliberately narrow: it only accepts **problems** (negative/mixed sentiment) and only about **the MCP server itself** — its tool descriptions, schemas, and errors. There was no channel for the much more common case: an agent (or the user it's helping) wanting to relay feedback about *PostHog the product* — a confusing insight, a session replay bug, a missing capability, a feature request, or even praise.

## Changes

Adds a sibling MCP tool, `posthog-feedback`, modeled directly on `agent-feedback` but broadened:

- **Any product area** — product analytics, session replay, feature flags, the data warehouse, docs, etc. (free-text `product_area`).
- **All sentiment welcome** — a `feedback_type` field (`bug` / `feature_request` / `confusion` / `praise` / `other`) and a `sentiment` field that includes `positive`/`neutral`, not just problems.
- **Analytics-event only**, exactly like `agent-feedback` — fires a new `posthog feedback submitted` event with the feedback fields as properties. No DB table, migration, or API endpoint.

It's gated on its **own** feature flag, `mcp-posthog-feedback-tool` (separate from `agent-feedback`'s `mcp-feedback-tool`), so it can roll out independently. The instructions gate is split accordingly, and the tool is marked `always_available` so it stays discoverable regardless of the client's feature allowlist. A dedicated instructions section tells the agent when to reach for it vs. `agent-feedback`.

The flag already exists on the main project, currently scoped to PostHog staff only (`@posthog.com` 100%, external 0%) for dogfooding. Generated artifacts (`tool-inputs.json`, `tool-definitions-all.json`) and the snapshots were regenerated via the repo's own scripts, not hand-edited.

## How did you test this code?

I'm an agent (Claude Code). I did **not** do manual end-to-end testing against a live MCP client. Automated checks I actually ran in `services/mcp`:

- New unit test `tests/unit/posthog-feedback.test.ts` (4 cases): tool name, event-property mapping, positive feedback accepted, and analytics failures never throw.
- `tool-filtering` (incl. a new test asserting `posthog-feedback` gates on `mcp-posthog-feedback-tool` independently of `agent-feedback`), `instructions-formatter` (incl. a new section-gating test), `instructions-formatter-snapshot`, and `tool-schema-snapshots` suites pass; snapshots and the required-flags assertion were updated.
- `tsgo --noEmit` typecheck clean; `lint-tool-names` passes.
- The only failing test in the full run is the pre-existing `tests/integration/manifest.test.ts`, which fails on a real network fetch to GitHub releases (`fetch failed`) — unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked for a more general counterpart to the existing `agent-feedback` MCP tool — something for any/all generic PostHog feedback rather than MCP-server friction. Design decisions settled along the way: scope (accept *any* feedback including praise + feature requests, via a `feedback_type` field), persistence (analytics-event only, mirroring `agent-feedback`, to keep the change small — no model/migration/endpoint), and gating. On gating we initially reused `agent-feedback`'s `mcp-feedback-tool` flag, then switched to a dedicated `mcp-posthog-feedback-tool` flag after checking the existing flag's rollout — decoupling the two tools so the general one can roll out on its own. The flag was created on the main project and scoped to staff for dogfooding.

Built by mirroring the `agent-feedback` wiring end to end: Zod input schema, hand-written tool handler, `TOOL_MAP` registration, a new `AnalyticsEvent` enum value, a `tool-definitions.json` entry, an instructions template section gated by the new flag, and a `taxonomy.py` event definition. No repo skills were required. Agent: Claude Code; tools: file edit/search + Bash for codegen/test scripts + the PostHog MCP for inspecting/creating the feature flag.
