### PR TITLE
fix(shopify): honor rate-limit refill time when retrying throttled requests

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import requests
 from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
@@ -80,10 +80,47 @@ class ShopifyPermissionError(Exception):
         super().__init__(message)
 
 
-class ShopifyRetryableError(Exception):
-    """Exception raised when Shopify issues a retryable error (e.g. rate limit, 5xx)."""
+# Shopify's GraphQL Admin API rate-limits on a cost-based leaky bucket, so a single bucket
+# can take this long to refill from empty (~2000 points at 100/sec on Plus). Cap the throttle
+# wait here so a malformed `restoreRate` can't stall the worker past its heartbeat.
+_SHOPIFY_MAX_THROTTLE_WAIT_SECONDS = 60.0
 
-    pass
+
+class ShopifyRetryableError(Exception):
+    """Exception raised when Shopify issues a retryable error (e.g. rate limit, 5xx).
+
+    `retry_after`, when set, is the number of seconds Shopify's throttle status says we
+    should wait before the leaky bucket has refilled enough to satisfy the query again.
+    """
+
+    def __init__(self, message: str, retry_after: float | None = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+def _throttle_retry_after(payload: Any) -> float | None:
+    """Seconds to wait for the cost bucket to refill enough for the requested query.
+
+    A throttled response carries `extensions.cost` with the points the query needed
+    (`requestedQueryCost`) and how fast the bucket refills (`throttleStatus.restoreRate`),
+    which is exactly how long to back off. Returns None when that data is missing or
+    malformed so the caller falls back to plain exponential backoff.
+    """
+    cost, ok = safe_unwrap(payload, path="extensions.cost")
+    if not ok or not isinstance(cost, dict):
+        return None
+    requested = cost.get("requestedQueryCost")
+    throttle = cost.get("throttleStatus")
+    if not isinstance(requested, int | float) or not isinstance(throttle, dict):
+        return None
+    available = throttle.get("currentlyAvailable")
+    restore_rate = throttle.get("restoreRate")
+    if not isinstance(available, int | float) or not isinstance(restore_rate, int | float) or restore_rate <= 0:
+        return None
+    deficit = requested - available
+    if deficit <= 0:
+        return None
+    return min(deficit / restore_rate, _SHOPIFY_MAX_THROTTLE_WAIT_SECONDS)
 
 
 def _get_retryable_error(payload: Any) -> ShopifyRetryableError | None:
@@ -92,7 +129,7 @@ def _get_retryable_error(payload: Any) -> ShopifyRetryableError | None:
     if ok:
         serialized_errors = json.dumps(errors).lower()
         if "throttled" in serialized_errors:
-            return ShopifyRetryableError("Shopify: rate limit exceeded...")
+            return ShopifyRetryableError("Shopify: rate limit exceeded...", retry_after=_throttle_retry_after(payload))
         if "internal_server_error" in serialized_errors:
             return ShopifyRetryableError(f"Shopify: internal errors in payload {serialized_errors}")
     currently_available, ok = safe_unwrap(payload, path="extensions.cost.throttleStatus.currentlyAvailable")
@@ -100,8 +137,27 @@ def _get_retryable_error(payload: Any) -> ShopifyRetryableError | None:
         # this check is a little liberal. if we find that we are getting rate limited
         # too often might be worth it to check against the requestedCost instead
         if currently_available <= 0:
-            return ShopifyRetryableError("Shopify: rate limit exceeded...")
+            return ShopifyRetryableError("Shopify: rate limit exceeded...", retry_after=_throttle_retry_after(payload))
     return None
+
+
+_shopify_backoff = wait_exponential_jitter(initial=1, max=30)
+
+
+def _shopify_retry_wait(retry_state: RetryCallState) -> float:
+    """Back off exponentially, but never for less than Shopify's reported refill time.
+
+    Plain exponential backoff tops out around 15s across the 5 attempts, which can give up
+    while the cost bucket is still draining. When a rate-limit response told us how long the
+    bucket needs (see `_throttle_retry_after`), honor that instead.
+    """
+    backoff = _shopify_backoff(retry_state)
+    outcome = retry_state.outcome
+    if outcome is not None and not outcome.cancelled():
+        exc = outcome.exception()
+        if isinstance(exc, ShopifyRetryableError) and exc.retry_after is not None:
+            return max(backoff, exc.retry_after)
+    return backoff
 
 
 def _make_paginated_shopify_request(
@@ -119,7 +175,7 @@ def _make_paginated_shopify_request(
     @retry(
         retry=retry_if_exception_type(ShopifyRetryableError),
         stop=stop_after_attempt(5),
-        wait=wait_exponential_jitter(initial=1, max=30),
+        wait=_shopify_retry_wait,
         reraise=True,
     )
     def execute(vars: dict[str, Any]):

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
@@ -1,0 +1,83 @@
+import pytest
+
+from tenacity import Future, RetryCallState
+
+from posthog.temporal.data_imports.sources.shopify.shopify import (
+    _SHOPIFY_MAX_THROTTLE_WAIT_SECONDS,
+    ShopifyRetryableError,
+    _get_retryable_error,
+    _shopify_retry_wait,
+    _throttle_retry_after,
+)
+
+
+def _throttled_payload(requested: float, available: float, restore_rate: float) -> dict:
+    return {
+        "errors": [{"message": "Throttled", "extensions": {"code": "THROTTLED"}}],
+        "extensions": {
+            "cost": {
+                "requestedQueryCost": requested,
+                "throttleStatus": {
+                    "maximumAvailable": 2000,
+                    "currentlyAvailable": available,
+                    "restoreRate": restore_rate,
+                },
+            }
+        },
+    }
+
+
+def _retry_state(exc: Exception) -> RetryCallState:
+    state = RetryCallState(retry_object=None, fn=None, args=(), kwargs={})
+    state.outcome = Future.construct(1, exc, True)
+    return state
+
+
+def test_throttle_retry_after_computes_refill_time():
+    # deficit 90 points at 50/sec => 1.8s
+    assert _throttle_retry_after(_throttled_payload(100, 10, 50)) == pytest.approx(1.8)
+
+
+def test_throttle_retry_after_is_capped():
+    # An enormous deficit (or tiny restore rate) must not stall the worker indefinitely.
+    assert _throttle_retry_after(_throttled_payload(10_000, 0, 1)) == _SHOPIFY_MAX_THROTTLE_WAIT_SECONDS
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"extensions": {}},
+        {"extensions": {"cost": {"requestedQueryCost": 100}}},
+        {"extensions": {"cost": {"requestedQueryCost": 100, "throttleStatus": {"currentlyAvailable": 10}}}},
+        # restoreRate of 0 would divide by zero
+        _throttled_payload(100, 10, 0),
+        # bucket already has enough headroom
+        _throttled_payload(100, 200, 50),
+    ],
+)
+def test_throttle_retry_after_returns_none_when_unavailable(payload):
+    assert _throttle_retry_after(payload) is None
+
+
+def test_get_retryable_error_attaches_retry_after():
+    error = _get_retryable_error(_throttled_payload(100, 10, 50))
+    assert isinstance(error, ShopifyRetryableError)
+    assert error.retry_after == pytest.approx(1.8)
+
+
+def test_get_retryable_error_throttled_without_cost_has_no_retry_after():
+    error = _get_retryable_error({"errors": [{"message": "Throttled"}]})
+    assert isinstance(error, ShopifyRetryableError)
+    assert error.retry_after is None
+
+
+def test_retry_wait_honors_throttle_refill_time():
+    # The exponential floor is ~1s on the first attempt; Shopify's refill time must win.
+    wait = _shopify_retry_wait(_retry_state(ShopifyRetryableError("rate limit", retry_after=20.0)))
+    assert wait >= 20.0
+
+
+def test_retry_wait_falls_back_to_backoff_without_retry_after():
+    wait = _shopify_retry_wait(_retry_state(ShopifyRetryableError("internal error")))
+    assert wait > 0

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tenacity import Future, RetryCallState
+from tenacity import Future, RetryCallState, Retrying
 
 from posthog.temporal.data_imports.sources.shopify.shopify import (
     _SHOPIFY_MAX_THROTTLE_WAIT_SECONDS,
@@ -28,7 +28,7 @@ def _throttled_payload(requested: float, available: float, restore_rate: float) 
 
 
 def _retry_state(exc: Exception) -> RetryCallState:
-    state = RetryCallState(retry_object=None, fn=None, args=(), kwargs={})
+    state = RetryCallState(retry_object=Retrying(), fn=None, args=(), kwargs={})
     state.outcome = Future.construct(1, exc, True)
     return state
 
@@ -80,4 +80,4 @@ def test_retry_wait_honors_throttle_refill_time():
 
 def test_retry_wait_falls_back_to_backoff_without_retry_after():
     wait = _shopify_retry_wait(_retry_state(ShopifyRetryableError("internal error")))
-    assert wait > 0
+    assert 1.0 <= wait <= 2.0  # initial=1, max=30, jitter up to 1s on attempt 1


### PR DESCRIPTION
## Problem

Shopify's data-warehouse import surfaced `ShopifyRetryableError: Shopify: rate limit exceeded...` in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019eec61-0f56-7051-923e-34dfc447bf19)), raised from `shopify.py` after the in-process retry loop gave up.

This is a transient upstream rate limit, not a credential/config problem — it must stay retryable (an existing test, `test_transient_graphql_errors_stay_retryable`, asserts exactly that), so it does **not** belong in `NonRetryableErrors`. The real weakness is in how we retry it.

Shopify's GraphQL Admin API rate-limits on a cost-based leaky bucket. A throttled response carries `extensions.cost` with the points the query needed (`requestedQueryCost`) and how fast the bucket refills (`throttleStatus.restoreRate`) — i.e. exactly how long to wait. The retry loop ignored that and backed off with plain exponential jitter, which tops out around 15s across its 5 attempts. For a heavy query against a drained bucket that isn't long enough, so all 5 attempts can fail and the error re-raises even though waiting a bit longer would have succeeded.

## Changes

- Compute the refill wait from the throttle status (`(requestedQueryCost - currentlyAvailable) / restoreRate`) and attach it to `ShopifyRetryableError` as `retry_after`.
- Replace the retry loop's blind exponential backoff with a wait that never backs off for *less* than Shopify's reported refill time, while keeping exponential growth as the floor. Capped at 60s so a malformed `restoreRate` can't stall the worker past its heartbeat.
- Falls back to plain exponential backoff when the cost data is absent or malformed, and 5xx/internal-error retries are unchanged.

Scoped strictly to this source's rate-limit retry — no change to global retry policy.

## How did you test this code?

I'm an agent. Added `test_rate_limit_retry.py` covering the refill-time computation, the cap, the malformed/missing-data fallbacks, that the error carries `retry_after`, and that the wait honors it. Ran the new tests plus the existing Shopify suite:

```
pytest posthog/temporal/data_imports/sources/shopify/tests/  ->  71 passed
```

`ruff check` and `ruff format` are clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the `shopify` warehouse source with PostHog's error-tracking MCP tools, confirming the stack genuinely originates in `posthog/temporal/data_imports/sources/shopify/shopify.py` (raised at the `_get_retryable_error` check inside the `execute` retry loop).

Decision: rate limiting is transient upstream pressure, so adding it to `NonRetryableErrors` would be wrong (and would contradict an existing test). Instead improved the existing in-process backoff to respect Shopify's own throttle status — mirroring the maintainer's recent "retry transient errors with backoff" fixes for other sources rather than the `NonRetryableErrors` pattern used for credential/permission errors. Checked open PRs (including the maintainer's) first to rule out a duplicate.
