### PR TITLE
fix(bigquery): treat unparseable private key as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -50,6 +50,13 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # stable `invalid_grant` code rather than `RefreshError`, which can also wrap transient
             # token-endpoint failures that should stay retryable.
             "invalid_grant": "Your BigQuery service account credentials were rejected by Google. The key may have been rotated or revoked, or the service account deleted. Please upload a new Google Cloud JSON key file.",
+            # Raised from `bigquery_client` when `service_account.Credentials.from_service_account_info`
+            # parses the uploaded key file's `private_key`. A truncated or corrupted PEM body (wrong
+            # padding, stray characters, copy-paste damage) makes the `cryptography` backend reject it
+            # as a `ValueError: Unable to load PEM file. ... InvalidData(InvalidPadding)`. The key can't
+            # be repaired by retrying — the user must re-upload an intact JSON key file. Matched on the
+            # stable "Unable to load PEM file" wording rather than the volatile InvalidData detail.
+            "Unable to load PEM file": "We couldn't read the private key in your Google Cloud JSON key file — it appears truncated or corrupted. Please download a fresh service account key from Google Cloud and re-upload the JSON file.",
             # BigQuery prefixes every IAM/permission failure with "Access Denied:" — e.g.
             # "Access Denied: Table <id>: Permission bigquery.tables.getData denied on table <id>
             # (or it may not exist).". The matched string above only covers the REST client's

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -460,6 +460,21 @@ def test_non_retryable_errors_match_offline_token_uri_endpoint(observed_error):
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Corrupted/truncated private key body in the uploaded service account JSON.
+        "Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. InvalidData(InvalidPadding)",
+        "ValueError: Unable to load PEM file. InvalidData(InvalidByte(1, 45))",
+    ],
+)
+def test_bigquery_unparseable_private_key_is_non_retryable(observed_error):
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Unparseable private key error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
     "transient_error",
     [
         # A token refresh that failed for a transient reason must stay retryable.

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ValueError: Unable to load PEM file. ... InvalidData(InvalidPadding)` from the BigQuery data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019eecb1-42ef-7090-95e4-24bf804219d1)).

The exception is raised in `bigquery_client` (`posthog/temporal/data_imports/sources/bigquery/bigquery.py:162`) when `service_account.Credentials.from_service_account_info` parses the `private_key` from the uploaded Google Cloud JSON key file. When that key body is truncated or corrupted (bad padding, copy-paste damage), the `cryptography` backend rejects it. This is a credentials problem on the customer's side — retrying the sync can never repair the key, so it just re-raises on every attempt and spams error tracking.

## Changes

- Add `"Unable to load PEM file"` to `BigQuerySource.get_non_retryable_errors()` with an actionable message telling the user to download a fresh service account key and re-upload it.
- Matched on the stable `"Unable to load PEM file"` wording rather than the volatile `InvalidData(...)` detail.
- Added a parameterized regression test asserting the error is recognised as non-retryable, alongside the existing transient-error guard that confirms the new key doesn't accidentally match retryable failures.

## How did you test this code?

I'm an agent. I ran the relevant unit tests:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py -k "non_retryable or unparseable"
# 29 passed
```

This covers the new `test_bigquery_unparseable_private_key_is_non_retryable` case and the existing `test_non_retryable_errors_does_not_match_transient_refresh_failures` guard.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a BigQuery import error delivered by error-tracking webhook. Confirmed the stack trace originates in the source's own `bigquery_client` credential-loading code (not just serialized log context), classified it as a user/upstream credentials error (a corrupt uploaded private key — unrecoverable by retry), and extended `NonRetryableErrors` mirroring the existing Stripe/BigQuery pattern rather than touching global retry policy. Verified no existing open PR (including the maintainer's own BigQuery PRs #65039, #64996, #64841) already covered this error before opening.