### PR TITLE
fix(postgres): don't fail full-table syncs on a COUNT(*) statement timeout

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1896,7 +1896,13 @@ def _role_subject_to_rls(cursor: psycopg.Cursor, schema: str, table_name: str, l
         return False
 
 
-def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger: FilteringBoundLogger) -> int:
+def _get_rows_to_sync(
+    cursor: psycopg.Cursor,
+    count_query: sql.Composed,
+    logger: FilteringBoundLogger,
+    *,
+    should_use_incremental_field: bool = False,
+) -> int:
     try:
         _explain_query(cursor, count_query, logger)
         logger.debug(f"Running query: {count_query.as_string()}")
@@ -1914,7 +1920,18 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
 
         return int(rows_to_sync)
     except psycopg.errors.QueryCanceled:
-        raise
+        # This COUNT(*) is one unbounded scan — far more expensive than the chunked server-cursor
+        # reads extraction actually runs (each FETCH is its own statement under statement_timeout),
+        # so a timeout here says nothing about whether extraction can complete (mirrors
+        # `_get_table_chunk_size`). Incremental syncs share an indexed WHERE with the reader, so
+        # re-raise and let the caller map it to the actionable non-retryable QueryTimeoutException.
+        # Full-table syncs fall back to an unknown count and let the streaming read loop classify
+        # the real outcome, rather than leaking a raw, retryable QueryCanceled that Temporal
+        # re-attempts forever on a count this table can never complete.
+        if should_use_incremental_field:
+            raise
+        logger.debug("_get_rows_to_sync: statement_timeout on COUNT(*). Using 0 as rows to sync")
+        return 0
     except Exception as e:
         # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.
         # It shares its FROM/WHERE with the real extraction query, so any genuine problem
@@ -2593,7 +2610,12 @@ def postgres_source(
                                 except Exception as e:
                                     logger.debug(f"Estimated row count failed, falling back to exact count: {e}")
                             if rows_to_sync is None:
-                                rows_to_sync = _get_rows_to_sync(cursor, count_query, logger)
+                                rows_to_sync = _get_rows_to_sync(
+                                    cursor,
+                                    count_query,
+                                    logger,
+                                    should_use_incremental_field=should_use_incremental_field,
+                                )
 
                             if _role_subject_to_rls(cursor, schema, table_name, logger):
                                 logger.warning(

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1134,6 +1134,52 @@ class TestStatementTimeoutAsNonRetryable:
         )
 
 
+class TestGetRowsToSyncStatementTimeout:
+    """The best-effort COUNT(*) in `_get_rows_to_sync` must not leak a raw, retryable
+    QueryCanceled for full-table syncs — a timeout on the unbounded count says nothing
+    about whether the chunked server-cursor extraction can complete, so it falls back to
+    an unknown count. Incremental syncs re-raise so the caller maps it to a non-retryable
+    QueryTimeoutException.
+    """
+
+    class _Cursor:
+        def __init__(self):
+            self.connection = mock.Mock(autocommit=True)
+
+        def execute(self, *args, **kwargs):
+            raise psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+
+        def fetchone(self):
+            raise AssertionError("fetchone should not be reached after the timeout")
+
+        def fetchall(self):
+            return []
+
+    @pytest.mark.parametrize("should_use_incremental_field", [True, False])
+    def test_count_statement_timeout(self, should_use_incremental_field):
+        logger = structlog.get_logger()
+        count_query = sql.SQL("SELECT count(*) FROM t").format()
+
+        if should_use_incremental_field:
+            with pytest.raises(psycopg.errors.QueryCanceled):
+                _get_rows_to_sync(
+                    self._Cursor(),
+                    count_query,
+                    logger,
+                    should_use_incremental_field=True,
+                )
+        else:
+            assert (
+                _get_rows_to_sync(
+                    self._Cursor(),
+                    count_query,
+                    logger,
+                    should_use_incremental_field=False,
+                )
+                == 0
+            )
+
+
 class TestServerCursorStatementTimeout:
     """The main server-cursor streaming path in `get_rows` must not leak a raw,
     retryable QueryCanceled when a FETCH hits the statement_timeout — it must map

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1155,29 +1155,18 @@ class TestGetRowsToSyncStatementTimeout:
         def fetchall(self):
             return []
 
-    @pytest.mark.parametrize("should_use_incremental_field", [True, False])
-    def test_count_statement_timeout(self, should_use_incremental_field):
+    def test_count_statement_timeout_full_table_returns_zero(self):
         logger = structlog.get_logger()
         count_query = sql.SQL("SELECT count(*) FROM t").format()
+        cursor = cast(psycopg.Cursor, self._Cursor())
+        assert _get_rows_to_sync(cursor, count_query, logger, should_use_incremental_field=False) == 0
 
-        if should_use_incremental_field:
-            with pytest.raises(psycopg.errors.QueryCanceled):
-                _get_rows_to_sync(
-                    self._Cursor(),
-                    count_query,
-                    logger,
-                    should_use_incremental_field=True,
-                )
-        else:
-            assert (
-                _get_rows_to_sync(
-                    self._Cursor(),
-                    count_query,
-                    logger,
-                    should_use_incremental_field=False,
-                )
-                == 0
-            )
+    def test_count_statement_timeout_incremental_reraises(self):
+        logger = structlog.get_logger()
+        count_query = sql.SQL("SELECT count(*) FROM t").format()
+        cursor = cast(psycopg.Cursor, self._Cursor())
+        with pytest.raises(psycopg.errors.QueryCanceled):
+            _get_rows_to_sync(cursor, count_query, logger, should_use_incremental_field=True)
 
 
 class TestServerCursorStatementTimeout:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `QueryCanceled: canceling statement due to statement timeout` for the Postgres data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019eecfc-5b2d-7a83-a67f-9df57c063cf0)). The stack genuinely originates in the source: `postgres.py:_get_rows_to_sync` → `psycopg` `cursor.execute`, reached via `source.py:source_for_pipeline` → `postgres_source`.

`_get_rows_to_sync` runs a best-effort `COUNT(*)` to estimate progress and size partitions. It re-raised any `QueryCanceled`. The setup-phase handler converts that to a non-retryable `QueryTimeoutException` **only** for incremental syncs; for full-table (non-incremental) syncs it falls through to a bare `raise`, leaking a raw, retryable `QueryCanceled`. Temporal then re-attempts the whole activity forever, and each attempt re-runs the same unbounded `COUNT(*)` that can never finish within `statement_timeout` — futile retries that also re-flood error tracking. The captured exception is a raw `QueryCanceled` (not `QueryTimeoutException`), confirming it came through the full-table path.

## Changes

When the `COUNT(*)` hits a statement timeout on a full-table sync, fall back to an unknown count (`0`) instead of re-raising. The `COUNT(*)` is one unbounded scan, far more expensive than the chunked server-cursor reads extraction actually runs (each FETCH is its own statement under `statement_timeout`), so a timeout on the count says nothing about whether extraction can complete. This mirrors the sibling probe `_get_table_chunk_size`, which already swallows the same cancellation for the same reason, and lets the streaming read loop classify the real extraction outcome.

Incremental syncs are unchanged: they still re-raise so the caller maps the timeout to the actionable non-retryable `QueryTimeoutException` ("ensure your incremental field has an index"). Scoped via a new `should_use_incremental_field` keyword passed only at the one call site.

This is **not** a `NonRetryableErrors` extension — adding the raw "canceling statement due to statement timeout" string would override the source's deliberate incremental-vs-full-table classification and make every statement timeout non-retryable.

## How did you test this code?

I'm an agent. Added a regression test (`TestGetRowsToSyncStatementTimeout`) that drives a `COUNT(*)` timeout and asserts the full-table path returns `0` while the incremental path re-raises `QueryCanceled`.

Automated tests run locally (`.venv/bin/python -m pytest`):
- New test plus the statement-timeout / server-cursor / non-retryable suites: 78 passed.
- Full file's non-DB tests: 405 passed (52 errors are pre-existing `*RealDb` setup failures from having no local Postgres, unrelated to this change).
- `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. Confirmed via the PostHog error-tracking MCP tools that the stack originates in `_get_rows_to_sync`, then traced the setup-phase handler to find the raw `QueryCanceled` leaking only on the full-table branch.

Decision: a tightly scoped code fix, not a `NonRetryableErrors` extension. The fix reuses the established philosophy already documented on the adjacent `_get_table_chunk_size` probe (a probe timeout doesn't predict extraction success; let the streaming read loop classify it). Checked open PRs including the maintainer's — #65083 is the closest but addresses a different path (`offset_chunking` in the streaming read loop, not the setup-time count); none touch `_get_rows_to_sync`.

Tools: Claude Code with the PostHog error-tracking MCP tools. No repo skills applied (no migration / DRF / generated-API surface touched).