### PR TITLE
fix(surveys): allow editing branding for API surveys customization

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1307,63 +1307,58 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                         </>
                                     ),
                                 },
-                                ...(survey.type !== SurveyType.API
-                                    ? [
-                                          {
-                                              key: SurveyEditSection.Customization,
-                                              header: 'Customization',
-                                              content: (
-                                                  <LemonField name="appearance" label="">
-                                                      {({ onChange }) => (
-                                                          <Customization
-                                                              survey={survey}
-                                                              hasBranchingLogic={hasBranchingLogic}
-                                                              deleteBranchingLogic={deleteBranchingLogic}
-                                                              onTranslationsChange={(translations) =>
-                                                                  setSurveyValue('translations', translations)
-                                                              }
-                                                              hasRatingButtons={survey.questions.some(
-                                                                  (question) =>
-                                                                      question.type === SurveyQuestionType.Rating
-                                                              )}
-                                                              hasPlaceholderText={survey.questions.some(
-                                                                  (question) =>
-                                                                      question.type === SurveyQuestionType.Open
-                                                              )}
-                                                              onAppearanceChange={(appearance) => {
-                                                                  const newAppearance = sanitizeSurveyAppearance({
-                                                                      ...survey.appearance,
-                                                                      ...appearance,
-                                                                  })
-                                                                  onChange(newAppearance)
-                                                                  if (newAppearance) {
-                                                                      setSurveyManualErrors(
-                                                                          validateSurveyAppearance(
-                                                                              newAppearance,
-                                                                              true,
-                                                                              survey.type
-                                                                          )
-                                                                      )
-                                                                  }
-                                                                  if (
-                                                                      'surveyPopupDelaySeconds' in appearance &&
-                                                                      !appearance.surveyPopupDelaySeconds &&
-                                                                      survey.conditions?.cancelEvents?.values?.length
-                                                                  ) {
-                                                                      setSurveyValue('conditions', {
-                                                                          ...survey.conditions,
-                                                                          cancelEvents: undefined,
-                                                                      })
-                                                                  }
-                                                              }}
-                                                              validationErrors={surveyErrors?.appearance}
-                                                          />
-                                                      )}
-                                                  </LemonField>
-                                              ),
-                                          },
-                                      ]
-                                    : []),
+                                {
+                                    key: SurveyEditSection.Customization,
+                                    header: 'Customization',
+                                    content: (
+                                        <LemonField name="appearance" label="">
+                                            {({ onChange }) => (
+                                                <Customization
+                                                    survey={survey}
+                                                    onlyBranding={survey.type === SurveyType.API}
+                                                    hasBranchingLogic={hasBranchingLogic}
+                                                    deleteBranchingLogic={deleteBranchingLogic}
+                                                    onTranslationsChange={(translations) =>
+                                                        setSurveyValue('translations', translations)
+                                                    }
+                                                    hasRatingButtons={survey.questions.some(
+                                                        (question) => question.type === SurveyQuestionType.Rating
+                                                    )}
+                                                    hasPlaceholderText={survey.questions.some(
+                                                        (question) => question.type === SurveyQuestionType.Open
+                                                    )}
+                                                    onAppearanceChange={(appearance) => {
+                                                        const newAppearance = sanitizeSurveyAppearance({
+                                                            ...survey.appearance,
+                                                            ...appearance,
+                                                        })
+                                                        onChange(newAppearance)
+                                                        if (newAppearance) {
+                                                            setSurveyManualErrors(
+                                                                validateSurveyAppearance(
+                                                                    newAppearance,
+                                                                    true,
+                                                                    survey.type
+                                                                )
+                                                            )
+                                                        }
+                                                        if (
+                                                            'surveyPopupDelaySeconds' in appearance &&
+                                                            !appearance.surveyPopupDelaySeconds &&
+                                                            survey.conditions?.cancelEvents?.values?.length
+                                                        ) {
+                                                            setSurveyValue('conditions', {
+                                                                ...survey.conditions,
+                                                                cancelEvents: undefined,
+                                                            })
+                                                        }
+                                                    }}
+                                                    validationErrors={surveyErrors?.appearance}
+                                                />
+                                            )}
+                                        </LemonField>
+                                    ),
+                                },
                                 ...(survey.type !== SurveyType.ExternalSurvey
                                     ? [
                                           {

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -387,6 +387,19 @@ export const NewSurveyCustomisationSection: Story = {
     parameters: { pageUrl: urls.survey('new') },
 }
 
+export const NewAPISurveyCustomisationSection: Story = {
+    render: () => {
+        useDelayedOnMountEffect(() => {
+            surveyLogic({ id: 'new' }).mount()
+            surveyLogic({ id: 'new' }).actions.setSurveyValue('type', SurveyType.API)
+            surveyLogic({ id: 'new' }).actions.setSelectedSection(SurveyEditSection.Customization)
+        })
+
+        return <App />
+    },
+    parameters: { pageUrl: urls.survey('new?edit=true') },
+}
+
 export const NewMultiQuestionSurveySection: Story = {
     render: () => {
         useDelayedOnMountEffect(() => {

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.test.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.test.tsx
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { SurveyType } from '~/types'
+
+import { Customization } from './SurveyCustomization'
+
+describe('Customization', () => {
+    beforeEach(() => {
+        initKeaTests()
+        useMocks({
+            get: {
+                '/api/projects/:team_id/surveys/': { results: [], count: 0 },
+                '/api/projects/:team_id/surveys/responses_count/': {},
+            },
+        })
+    })
+
+    const baseProps = {
+        survey: { type: SurveyType.API, appearance: { whiteLabel: false }, questions: [] } as any,
+        onAppearanceChange: jest.fn(),
+        hasRatingButtons: false,
+        hasPlaceholderText: false,
+        hasBranchingLogic: false,
+    }
+
+    it('renders only the branding control when onlyBranding is set (API surveys)', () => {
+        render(<Customization {...baseProps} onlyBranding />)
+
+        expect(screen.getByText('Hide PostHog branding')).toBeInTheDocument()
+        // the styling sections must not render in branding only mode.
+        expect(screen.queryByText('Theme')).not.toBeInTheDocument()
+        expect(screen.queryByText('Colors')).not.toBeInTheDocument()
+        expect(screen.queryByText('Behavior')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
@@ -50,12 +50,34 @@ export function Customization({
     validationErrors,
     disabledReason,
     onTranslationsChange,
+    onlyBranding,
 }: CustomizationProps): JSX.Element {
     const { surveysStylingAvailable } = useValues(surveysLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const surveyAppearance = { ...defaultSurveyAppearance, ...survey.appearance }
     const selectedThemeId = getMatchingSurveyThemeId(survey.appearance)
+
+    const brandingControl = (
+        <LemonCheckbox
+            label="Hide PostHog branding"
+            onChange={(checked) => {
+                if (checked) {
+                    guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                        onAppearanceChange({ whiteLabel: checked })
+                    )
+                } else {
+                    onAppearanceChange({ whiteLabel: checked })
+                }
+            }}
+            checked={survey.appearance?.whiteLabel}
+            disabledReason={disabledReason}
+        />
+    )
+
+    if (onlyBranding) {
+        return <CustomizationSection title="Branding">{brandingControl}</CustomizationSection>
+    }
 
     return (
         <div className="flex flex-col divide-y divide-border [&>*]:py-5 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
@@ -113,20 +135,7 @@ export function Customization({
 
             <CustomizationSection title="Behavior">
                 <div className="flex flex-col gap-3">
-                    <LemonCheckbox
-                        label="Hide PostHog branding"
-                        onChange={(checked) => {
-                            if (checked) {
-                                guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
-                                    onAppearanceChange({ whiteLabel: checked })
-                                )
-                            } else {
-                                onAppearanceChange({ whiteLabel: checked })
-                            }
-                        }}
-                        checked={survey.appearance?.whiteLabel}
-                        disabledReason={disabledReason}
-                    />
+                    {brandingControl}
                     <LemonDivider className="my-0" />
                     <SurveyBehaviorOptions
                         survey={survey}

--- a/frontend/src/scenes/surveys/survey-appearance/types.ts
+++ b/frontend/src/scenes/surveys/survey-appearance/types.ts
@@ -21,4 +21,6 @@ export interface CustomizationProps extends CommonProps {
     deleteBranchingLogic?: () => void
     /** When provided (i.e. inside the survey editor), enables inline per-language back button labels. */
     onTranslationsChange?: (translations: NonNullable<Survey['translations']>) => void
+    /** API surveys are rendered by the integration, so only the branding flag is editable. */
+    onlyBranding?: boolean
 }


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Surveys with type=API hid the entire customization section in the editor. The `appearance.whiteLabel` flag is returned by the API and controls the footer; there was no way to toggle it on a specific API survey other than toggling inside the project default appearance or the raw API.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #53036 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

The branding-only section reuses the same `CustomizationSection` + `LemonCheckbox`
as the other sections (title-only, matching `Colors`/`Behavior`), so it introduces
no new UI patterns.

I've added an optional `onlyBranding` prop to the customization section that when set renders the existing branding toggle, alse made customization section show for API surveys but with onlyBranding set. I've made sure to reuse the same components as other sections respecting the design system.

<img width="1512" height="903" alt="Screenshot 2026-06-22 at 02 56 37" src="https://github.com/user-attachments/assets/fb171bec-2539-4781-b208-babdec45dc95" />

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

Automatic
1. Added a survey customization test asserting that an API survey renders the branding control but not the styling sections.
2. Added a story

Manual
As noticed per screenshot above, I've tried both flows manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update