### PR TITLE
feat(data-warehouse): promote Typeform source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/typeform/source.py
+++ b/posthog/temporal/data_imports/sources/typeform/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -84,7 +85,7 @@ You can generate a personal access token in your [Typeform account settings](htt
                     ),
                 ],
             ),
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
         )
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:


### PR DESCRIPTION
## Problem

The Typeform data-warehouse source has been live and stable as a Beta source. It now clears the bar for general availability, so its release status should reflect that.

## Changes

- Set the Typeform source's `releaseStatus` to `ReleaseStatus.GA` (was `"beta"`).
- Switched the field from a bare string literal to the `ReleaseStatus` enum, matching the convention used across other sources.

This is a status promotion only — no connector behavior, schema, or sync-logic changes. No `featureFlag` or `unreleasedSource` gating was in place, so nothing else needed touching.

### Why it qualifies (7-day window)
- Used by 18 teams · live 3.1 months (threshold: 100 teams **or** 3 months — met on tenure).
- Import error rate 0.0% over the last 7d (threshold: < 2.5%).

## How did you test this code?

I'm an agent. I did not perform manual testing. Automated checks run:
- `ruff check` and `ruff format` on the changed file (passed).
- Confirmed no Typeform test asserts on the previous `beta` status, so the change is self-contained.

## 🤖 Agent context

The change lives in `posthog/temporal/data_imports/sources/typeform/source.py`, which feeds the `releaseStatus` surfaced by `/api/public_source_configs/`. Followed the `implementing-warehouse-sources` skill convention of using the `ReleaseStatus` enum rather than a string literal.