### PR TITLE
fix(insights): use count fallback for total-value bar chart aggregation

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -126,9 +126,10 @@ export function TrendsBarChart({
     const hasData =
         !!indexedResults?.[0] &&
         (isAggregated
-            ? indexedResults.some(
-                  (r: IndexedTrendResult) => Number.isFinite(r.aggregated_value) && r.aggregated_value !== 0
-              )
+            ? indexedResults.some((r: IndexedTrendResult) => {
+                  const value = r.aggregated_value ?? r.count
+                  return Number.isFinite(value) && value !== 0
+              })
             : !!indexedResults[0].data && indexedResults.some((r: IndexedTrendResult) => r.count !== 0))
 
     const stackBreakdowns = !!querySource && !!getStackBreakdownValues(querySource)

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -172,6 +172,45 @@ describe('buildTrendsBarAggregatedSeries', () => {
         expect(series[0].data).toEqual([10, 20, 30])
     })
 
+    it('falls back to count when aggregated_value is unset (i.e. property-value sum)', () => {
+        const results = [
+            mkResult({ id: 'a', label: 'A', aggregated_value: undefined, count: 10 }),
+            mkResult({ id: 'b', label: 'B', aggregated_value: undefined, count: 20 }),
+        ]
+        const { series } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(series[0].data).toEqual([10, 20])
+    })
+
+    it('prefers aggregated_value over count when both are present', () => {
+        const results = [mkResult({ id: 'a', aggregated_value: 7, count: 99 })]
+        const { series } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED })
+        expect(series[0].data).toEqual([7])
+    })
+
+    it('falls back to count in stacked breakdown mode too', () => {
+        const results = [
+            mkResult({
+                id: 'a',
+                label: 'F',
+                order: 0,
+                breakdown_value: 'Chrome',
+                aggregated_value: undefined,
+                count: 5,
+            }),
+            mkResult({
+                id: 'b',
+                label: 'F',
+                order: 0,
+                breakdown_value: 'Safari',
+                aggregated_value: undefined,
+                count: 8,
+            }),
+        ]
+        const { series } = buildTrendsBarAggregatedSeries(results, { getColor: () => RED, stackBreakdowns: true })
+        expect(series[0].data[0]).toBe(5)
+        expect(series[1].data[1]).toBe(8)
+    })
+
     it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, undefined])(
         'replaces non-finite aggregated_value (%p) with 0',
         (badValue) => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -34,6 +34,9 @@ export interface TrendsBarResultLike {
     label?: string | null
     data: number[]
     aggregated_value?: number
+    // Some aggregations (i.e. property-value sum) carry the total in `count`, letting
+    // `aggregated_value` unset, fall back to it so the bar isn't dropped to zero.
+    count?: number
     days?: string[]
     compare?: boolean
     compare_label?: string | null
@@ -205,7 +208,10 @@ export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M 
             {
                 key: 'aggregated',
                 label: '',
-                data: visible.map((r) => (Number.isFinite(r.aggregated_value) ? r.aggregated_value! : 0)),
+                data: visible.map((r) => {
+                    const value = r.aggregated_value ?? r.count
+                    return Number.isFinite(value) ? value! : 0
+                }),
                 color: bars[0]?.color,
                 bars,
             },
@@ -220,7 +226,7 @@ export function buildTrendsBarAggregatedSeries<R extends TrendsBarResultLike, M 
     })
     const series = visible.map((r, index) => {
         const data = new Array<number>(n).fill(0)
-        const value = r.aggregated_value ?? 0
+        const value = r.aggregated_value ?? r.count ?? 0
         if (Number.isFinite(value)) {
             data[index] = value
         }


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
A trend insight using "Property value sum" on a numeric property renders correctly in `Total Value > Table` and `Time Series > Bar`, but `Total Value > Bar` shows "There are no matching events for this query".

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #60163

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
The aggregation referred and some others carry total in `count` and do not set `aggregated_value`. Since the `hasData` guard and aggregated series builders only read `aggregated_value` the bars computed to 0. I made the computation fall back to `count` when `aggregated_value` is unset, matching the way the codebase (usually) already resolves this value: the pie chart, table view's aggregation column, region/world maps... `aggregated_value` still takes precedence when present so existing behavior is unchanged.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

Automatic
Added test cases to the suite, confirming that previously nil values are now non-zero (and the appropriate positive integer in the case). tests fail at master and pass at solution branch

Manual
Checked manually too

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->