### PR TITLE
test(quill): add jest + RTL coverage for DatePicker and DateTimePicker

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -76,7 +76,12 @@ const esmModules = [
     'yaml/browser',
 ]
 function rootDirectories(): string[] {
-    return ['<rootDir>/src', '<rootDir>/../products', '<rootDir>/../packages/quill/packages/charts/src']
+    return [
+        '<rootDir>/src',
+        '<rootDir>/../products',
+        '<rootDir>/../packages/quill/packages/charts/src',
+        '<rootDir>/../packages/quill/packages/components/src',
+    ]
 }
 
 const config: Config = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
         "typegen:write": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors --use-cache",
         "typegen:write:no-cache": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors",
         "schema:build:json": "ts-node ./bin/build-schema-json.mjs && oxfmt ./src/queries/schema.json && ts-node ./bin/build-validators.mjs && oxfmt ./src/queries/validators.js",
-        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
+        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/|packages/quill/packages/components/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
         "jest": "pnpm build:products && jest",
         "typescript:check": "tsgo --noEmit && echo \"No errors reported by tsgo.\"",
         "typescript:version": "tsgo --version",

--- a/packages/quill/packages/components/src/date-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-picker.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { DatePicker } from './date-picker'
+
+// Base UI's Switch constructs PointerEvents, which jsdom doesn't implement.
+if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = class extends MouseEvent {} as typeof window.PointerEvent
+}
+
+const VALUE = new Date(2023, 0, 15, 10, 30) // 15 Jan 2023, 10:30
+const MAX = new Date(2030, 0, 1)
+
+describe('DatePicker', () => {
+    afterEach(cleanup)
+
+    it('applies a date-only value floored to the start of the day', async () => {
+        const onApply = jest.fn()
+        render(<DatePicker value={VALUE} maxDate={MAX} onApply={onApply} />)
+
+        await userEvent.click(screen.getByLabelText('Select Jan 20, 2023'))
+        await userEvent.click(screen.getByLabelText('Apply date'))
+
+        expect(onApply).toHaveBeenCalledTimes(1)
+        const applied: Date = onApply.mock.calls[0][0]
+        expect([applied.getFullYear(), applied.getMonth(), applied.getDate()]).toEqual([2023, 0, 20])
+        expect([applied.getHours(), applied.getMinutes()]).toEqual([0, 0])
+    })
+
+    it('keeps the time of day when showTime is on', async () => {
+        const onApply = jest.fn()
+        render(<DatePicker value={VALUE} maxDate={MAX} showTime onApply={onApply} />)
+
+        await userEvent.click(screen.getByLabelText('Select Jan 20, 2023'))
+        await userEvent.click(screen.getByLabelText('Apply date'))
+
+        const applied: Date = onApply.mock.calls[0][0]
+        expect([applied.getDate(), applied.getHours(), applied.getMinutes()]).toEqual([20, 10, 30])
+    })
+
+    it('re-floors to the start of the day when the time toggle is switched off', async () => {
+        const onApply = jest.fn()
+        render(<DatePicker value={VALUE} maxDate={MAX} showTime onApply={onApply} />)
+
+        await userEvent.click(screen.getByRole('switch', { name: 'Include time' })) // turn time off
+        await userEvent.click(screen.getByLabelText('Apply date'))
+
+        const applied: Date = onApply.mock.calls[0][0]
+        expect([applied.getDate(), applied.getHours(), applied.getMinutes()]).toEqual([15, 0, 0])
+    })
+
+    it('disables calendar days before minDate', () => {
+        render(<DatePicker value={VALUE} minDate={new Date(2023, 0, 10)} maxDate={MAX} onApply={jest.fn()} />)
+
+        expect(screen.getByLabelText('Select Jan 5, 2023').getAttribute('aria-disabled')).toBe('true')
+        expect(screen.getByLabelText('Select Jan 20, 2023').getAttribute('aria-disabled')).toBe('false')
+    })
+
+    it('calls onCancel without applying', async () => {
+        const onApply = jest.fn()
+        const onCancel = jest.fn()
+        render(<DatePicker value={VALUE} maxDate={MAX} onApply={onApply} onCancel={onCancel} />)
+
+        await userEvent.click(screen.getByLabelText('Cancel'))
+
+        expect(onCancel).toHaveBeenCalledTimes(1)
+        expect(onApply).not.toHaveBeenCalled()
+    })
+})

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { CUSTOM_RANGE } from './date-time-ranges'
+import { DateTimePicker } from './date-time-picker'
+
+// The day grid wraps each Button in a div carrying the data-is-* range flags.
+const dayCell = (label: string): HTMLElement => screen.getByLabelText(label).closest('[data-is-start]') as HTMLElement
+
+// Range entirely inside value.end's month (January), which the always-rendered right calendar shows.
+const VALUE = { start: new Date(2023, 0, 10), end: new Date(2023, 0, 20), range: CUSTOM_RANGE }
+const MAX = new Date(2030, 0, 1)
+
+describe('DateTimePicker', () => {
+    afterEach(cleanup)
+
+    it('marks the range start, end, and in-between days from the shared grid', () => {
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={jest.fn()} onCancel={jest.fn()} />)
+
+        expect(dayCell('Select Jan 10, 2023').getAttribute('data-is-start')).toBe('true')
+        expect(dayCell('Select Jan 20, 2023').getAttribute('data-is-end')).toBe('true')
+        expect(dayCell('Select Jan 15, 2023').getAttribute('data-is-between')).toBe('true')
+
+        const outside = dayCell('Select Jan 25, 2023')
+        expect(outside.getAttribute('data-is-start')).toBe('false')
+        expect(outside.getAttribute('data-is-end')).toBe('false')
+        expect(outside.getAttribute('data-is-between')).toBe('false')
+    })
+
+    it('applies the current range unchanged', async () => {
+        const onApply = jest.fn()
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={onApply} onCancel={jest.fn()} />)
+
+        await userEvent.click(screen.getByLabelText('Apply date range'))
+
+        expect(onApply).toHaveBeenCalledTimes(1)
+        const applied = onApply.mock.calls[0][0]
+        expect([applied.start.getDate(), applied.end.getDate()]).toEqual([10, 20])
+    })
+})

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -5,7 +5,13 @@ import { CUSTOM_RANGE } from './date-time-ranges'
 import { DateTimePicker } from './date-time-picker'
 
 // The day grid wraps each Button in a div carrying the data-is-* range flags.
-const dayCell = (label: string): HTMLElement => screen.getByLabelText(label).closest('[data-is-start]') as HTMLElement
+const dayCell = (label: string): HTMLElement => {
+    const cell = screen.getByLabelText(label).closest('[data-is-start]')
+    if (!(cell instanceof HTMLElement)) {
+        throw new Error(`No range-flagged day cell found for "${label}"`)
+    }
+    return cell
+}
 
 // Range entirely inside value.end's month (January), which the always-rendered right calendar shows.
 const VALUE = { start: new Date(2023, 0, 10), end: new Date(2023, 0, 20), range: CUSTOM_RANGE }
@@ -36,5 +42,6 @@ describe('DateTimePicker', () => {
         expect(onApply).toHaveBeenCalledTimes(1)
         const applied = onApply.mock.calls[0][0]
         expect([applied.start.getDate(), applied.end.getDate()]).toEqual([10, 20])
+        expect(applied.range).toBe(CUSTOM_RANGE)
     })
 })

--- a/packages/quill/packages/components/tsconfig.build.json
+++ b/packages/quill/packages/components/tsconfig.build.json
@@ -16,5 +16,5 @@
         }
     },
     "include": ["src"],
-    "exclude": ["src/**/*.stories.tsx", "src/**/*.stories.ts"]
+    "exclude": ["src/**/*.stories.tsx", "src/**/*.stories.ts", "src/**/*.test.tsx", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

The `quill-components` package shipped **zero tests** — only the sibling `charts` package had any. The new single-date `DatePicker` (#65098) and the grid/input extraction it performed on `DateTimePicker` therefore rested on inspection + Storybook alone, which the review of #65098 flagged (xp HIGH, correctness MEDIUM). This PR stands up the test harness for the package and adds the coverage that pins those behaviours.

> Stacked on #65098 — the code under test isn't on master yet. Base will retarget to `master` once #65098 merges.

## Changes

**Test infra** (mirrors how `charts` already runs under the frontend jest project):
- `frontend/jest.config.ts` — register `packages/quill/packages/components/src` in `rootDirectories()` so its `*.test.tsx` are discovered (the `@posthog/quill-components` / `-primitives` / `-tokens` module mappers already existed).
- `tsconfig.build.json` — exclude `*.test.*` from the dts build, matching `charts` (otherwise the build tries to emit declarations for test files).

**Tests:**
- `date-picker.test.tsx` — single-date selection, start-of-day flooring with the time toggle on / off, `minDate` day disabling, cancel-without-applying.
- `date-time-picker.test.tsx` — pins the extraction: range start / end / in-between markers come through the shared grid (`data-is-*`), and apply returns the range unchanged.

A minimal `PointerEvent` polyfill covers Base UI's `Switch` in jsdom. Assertions use core jest + DOM APIs (jest-dom matchers aren't loaded on this path).

## How did you test this code?

I'm an agent (PostHog Code). `pnpm exec jest packages/quill/packages/components` → **7 passed**. `pnpm --filter @posthog/quill-components build` stays green (test files excluded from dts). No `package.json`/lockfile change — the tests resolve RTL through the frontend jest project, so the package needs no new deps.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul chose to land the test coverage as a separate PR (rather than fold it into #65098). The interesting bits were discovering that quill tests run under the *frontend* jest project (not a per-package runner), that this jest config has RTL auto-cleanup off (hence the explicit `afterEach(cleanup)`) and no jest-dom matchers, and that Base UI's `Switch` needs a `PointerEvent` polyfill in jsdom. The `DateTimePicker` test deliberately asserts the extracted grid's range flags so a future regression in the shared `calendar-grid` is caught. No skills required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
