### PR TITLE
fix(ws): make job terminal statuses absorbing to prevent race overwrites

### DIFF
--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -1,5 +1,8 @@
 import datetime as dt
 
+from django.db import transaction
+
+from prometheus_client import Counter
 from structlog.types import FilteringBoundLogger
 
 from posthog.temporal.data_imports.metrics import TERMINAL_JOB_STATUSES, emit_data_import_app_metrics
@@ -12,28 +15,41 @@ from products.data_warehouse.backend.tasks import (
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
+JOB_STATUS_TRANSITION_REJECTED = Counter(
+    "dwh_job_status_transition_rejected",
+    "Job status transition rejected because the job was already in a different terminal state",
+)
+
 
 def update_external_job_status(
     job_id: str, team_id: int, status: ExternalDataJob.Status, logger: FilteringBoundLogger, latest_error: str | None
 ) -> ExternalDataJob:
-    model = ExternalDataJob.objects.get(id=job_id, team_id=team_id)
-    model.status = status
-    model.latest_error = latest_error
+    with transaction.atomic():
+        model = ExternalDataJob.objects.select_for_update().get(id=job_id, team_id=team_id)
 
-    # Both the finished_at stamp and the metric emission must only fire on the
-    # first terminal transition — a retried Temporal activity or redelivered
-    # Kafka message can land here with the job already in a terminal state, and
-    # re-emitting would inflate the counters.
-    is_first_terminal_transition = status in TERMINAL_JOB_STATUSES and model.finished_at is None
-    update_fields = ["status", "latest_error", "updated_at"]
-    if is_first_terminal_transition:
-        model.finished_at = dt.datetime.now(dt.UTC)
-        update_fields.append("finished_at")
+        # Terminal states are absorbing: same-status retries pass, different statuses are rejected.
+        if model.status in TERMINAL_JOB_STATUSES and model.status != status:
+            logger.warning(
+                "dwh_job_status_transition_rejected",
+                job_id=job_id,
+                current_status=model.status,
+                requested_status=status,
+            )
+            JOB_STATUS_TRANSITION_REJECTED.inc()
+            return model
 
-    # Scope the save to the fields we mutated so a concurrent F-update from
-    # `update_job_row_count` (V3 activity) isn't clobbered by writing back the
-    # in-memory `rows_synced` we read at the top of this function.
-    model.save(update_fields=update_fields)
+        model.status = status
+        model.latest_error = latest_error
+
+        # Only stamp finished_at and emit metrics on the first terminal transition.
+        is_first_terminal_transition = status in TERMINAL_JOB_STATUSES and model.finished_at is None
+        update_fields = ["status", "latest_error", "updated_at"]
+        if is_first_terminal_transition:
+            model.finished_at = dt.datetime.now(dt.UTC)
+            update_fields.append("finished_at")
+
+        # Scoped save so concurrent F-updates to rows_synced aren't clobbered.
+        model.save(update_fields=update_fields)
 
     if status == ExternalDataJob.Status.FAILED:
         schema_status: ExternalDataSchema.Status = ExternalDataSchema.Status.FAILED

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -52,18 +52,18 @@ def update_external_job_status(
         # Scoped save so concurrent F-updates to rows_synced aren't clobbered.
         model.save(update_fields=update_fields)
 
-    if status == ExternalDataJob.Status.FAILED:
-        schema_status: ExternalDataSchema.Status = ExternalDataSchema.Status.FAILED
-    else:
-        schema_status = status  # type: ignore
+        if status == ExternalDataJob.Status.FAILED:
+            schema_status: ExternalDataSchema.Status = ExternalDataSchema.Status.FAILED
+        else:
+            schema_status = status  # type: ignore
 
-    if model.schema_id is None:
-        raise ValueError(f"External data job {job_id} is not attached to a schema")
+        if model.schema_id is None:
+            raise ValueError(f"External data job {job_id} is not attached to a schema")
 
-    schema = ExternalDataSchema.objects.get(id=model.schema_id, team_id=team_id)
-    schema.status = schema_status
-    schema.latest_error = latest_error
-    schema.save()
+        schema = ExternalDataSchema.objects.select_for_update().get(id=model.schema_id, team_id=team_id)
+        schema.status = schema_status
+        schema.latest_error = latest_error
+        schema.save(update_fields=["status", "latest_error", "updated_at"])
 
     model.refresh_from_db()
 

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -24,6 +24,7 @@ JOB_STATUS_TRANSITION_REJECTED = Counter(
 def update_external_job_status(
     job_id: str, team_id: int, status: ExternalDataJob.Status, logger: FilteringBoundLogger, latest_error: str | None
 ) -> ExternalDataJob:
+    is_first_terminal_transition = False
     with transaction.atomic():
         model = ExternalDataJob.objects.select_for_update().get(id=job_id, team_id=team_id)
 

--- a/products/data_warehouse/backend/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_jobs.py
@@ -233,3 +233,61 @@ class TestUpdateExternalJobStatus:
 
         assert updated.status == ExternalDataJob.Status.FAILED
         assert updated.finished_at is not None
+
+    @pytest.mark.parametrize(
+        "first_status,rejected_status",
+        [
+            (ExternalDataJob.Status.COMPLETED, ExternalDataJob.Status.FAILED),
+            (ExternalDataJob.Status.FAILED, ExternalDataJob.Status.COMPLETED),
+        ],
+    )
+    def test_terminal_to_different_terminal_is_rejected(self, first_status, rejected_status):
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+
+        with patch("products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"):
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=first_status,
+                logger=MagicMock(),
+                latest_error="first error" if first_status == ExternalDataJob.Status.FAILED else None,
+            )
+
+        result = update_external_job_status(
+            job_id=str(job.id),
+            team_id=team.pk,
+            status=rejected_status,
+            logger=MagicMock(),
+            latest_error="late error",
+        )
+
+        assert result.status == first_status
+        db_job = ExternalDataJob.objects.get(id=job.id)
+        assert db_job.status == first_status
+
+    def test_rejected_transition_does_not_overwrite_schema_status(self):
+        team, _source, schema, job = _create_org_team_source_schema_job()
+
+        with patch("products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"):
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.COMPLETED,
+                logger=MagicMock(),
+                latest_error=None,
+            )
+
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.COMPLETED
+
+        update_external_job_status(
+            job_id=str(job.id),
+            team_id=team.pk,
+            status=ExternalDataJob.Status.FAILED,
+            logger=MagicMock(),
+            latest_error="late failure",
+        )
+
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.COMPLETED
+        assert schema.latest_error is None

--- a/products/data_warehouse/backend/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_jobs.py
@@ -264,6 +264,8 @@ class TestUpdateExternalJobStatus:
         assert result.status == first_status
         db_job = ExternalDataJob.objects.get(id=job.id)
         assert db_job.status == first_status
+        expected_error = "first error" if first_status == ExternalDataJob.Status.FAILED else None
+        assert db_job.latest_error == expected_error
 
     def test_rejected_transition_does_not_overwrite_schema_status(self):
         team, _source, schema, job = _create_org_team_source_schema_job()

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

In the V3 warehouse pipeline, the workflow's finally-block and the consumer can race on setting the `ExternalDataJob` status. If the consumer marks a job COMPLETED and then a post-import activity fails, the workflow overwrites the status to FAILED. The reverse race is also possible. There's no row-level locking or state machine guard, so whichever writer lands last wins.

This also corrupts the `ExternalDataSchema.status` since it mirrors the job status unconditionally.

## Changes

- `update_external_job_status` now wraps the job fetch + status write in `transaction.atomic()` with `select_for_update()` to serialize concurrent writers
- Added an absorbing-state guard: once a job reaches a terminal status (Completed, Failed, BillingLimitReached, BillingLimitTooLow), only the same status passes through (idempotent retry); a different status is rejected, the schema status overwrite is skipped, and a `dwh_job_status_transition_rejected` Prometheus counter is emitted
- Existing pre-checks in callers (`_mark_job_failed`, `_update_job_status_to_failed`, `_mark_job_failed_if_not_terminal`) are left as fast-path short-circuits; the central guard catches the TOCTOU races they miss

## How did you test this code?

Agent-authored. Added two new parameterized tests:
- `test_terminal_to_different_terminal_is_rejected` (COMPLETED->FAILED and FAILED->COMPLETED)
- `test_rejected_transition_does_not_overwrite_schema_status`

Could not run tests locally (Postgres not running); relying on CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is PR 1 of a series fixing critical bugs in the V3 warehouse pipeline identified during a Fable architecture review. 