### PR TITLE
chore(ci): validate frontend CI still triggers

### DIFF
--- a/products/data_warehouse/frontend/shared/components/SourceEditorAction.tsx
+++ b/products/data_warehouse/frontend/shared/components/SourceEditorAction.tsx
@@ -1,3 +1,4 @@
+// temporary marker to validate frontend/storybook CI still triggers for products/**/*.tsx changes — remove before any merge
 import React from 'react'
 
 import { AccessControlAction, AccessControlActionChildrenProps } from 'lib/components/AccessControlAction'


### PR DESCRIPTION
## Problem

`ci/skip-frontend-storybook-for-agent-services` adds an `outside_non_frontend_ts` paths-filter that is AND-ed into the frontend/storybook gate so that PRs touching only the Node-only agent-platform services/packages skip frontend CI. We need to confirm the AND doesn't accidentally skip frontend CI for a *genuine* frontend change.

This is a throwaway validation PR. **Do not merge.**

## Changes

One temporary marker comment added to a single `products/**/*.tsx` file (`products/data_warehouse/frontend/shared/components/SourceEditorAction.tsx`). That `products/**/*.tsx` rule is exactly what over-matched the agent-platform dirs originally, so a real products frontend file is the right positive case.

Base is the CI branch (not master) so the diff is just this one file, while `pull_request` still runs the CI branch's updated workflow (it runs the merged head workflow).

**Expected:** frontend checks (jest/typecheck/bundle-size) and the storybook visual-regression suite should run — `outside_non_frontend_ts` resolves `true` because the changed file lives outside the excluded dirs.

## How did you test this code?

I'm an agent. No manual testing — this PR *is* the test: open it as draft and observe that the Frontend and Storybook workflows run (rather than being skipped). The companion negative case (an agent-platform-services-only PR being skipped) can be validated separately if wanted.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben is the DRI.

Created with Claude Code to validate the path-filter change on `ci/skip-frontend-storybook-for-agent-services`. No repo skills were needed (comment-only change). Decision: targeted the CI branch as the PR base so the diff stays a single frontend file while the updated workflow still executes for the PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARD3kJxiEyoMAmhRsHBEKZ)_