### PR TITLE
fix(notifications): fix toast open button and org-level mark read/unread

### DIFF
--- a/frontend/src/lib/components/NotificationsMenu/notificationsMenuLogic.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/notificationsMenuLogic.tsx
@@ -1,4 +1,6 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
+
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
 import type { notificationsMenuLogicType } from './notificationsMenuLogicType'
 
@@ -6,6 +8,9 @@ export type NotificationTab = 'all' | 'unread'
 
 export const notificationsMenuLogic = kea<notificationsMenuLogicType>([
     path(['lib', 'components', 'NotificationsMenu', 'notificationsMenuLogic']),
+    connect(() => ({
+        actions: [panelLayoutLogic, ['setActivePanelIdentifier', 'showLayoutPanel']],
+    })),
     actions({
         setNotificationsMenuOpen: (isOpen: boolean) => ({ isOpen }),
         toggleNotificationsMenu: true,
@@ -29,12 +34,12 @@ export const notificationsMenuLogic = kea<notificationsMenuLogicType>([
             },
         ],
     }),
-    listeners({
-        setNotificationsMenuOpen: ({ isOpen }) => {
-            // Reset to "all" tab when closing
-            if (!isOpen) {
-                // No-op — keep tab selection sticky
-            }
+    listeners(({ actions }) => ({
+        openToUnread: () => {
+            // The Notifications side panel's visibility is owned by panelLayoutLogic, so opening it
+            // (e.g. from a critical-notification toast button) has to go through these actions.
+            actions.setActivePanelIdentifier('Notifications')
+            actions.showLayoutPanel(true)
         },
-    }),
+    })),
 ])

--- a/products/notifications/backend/presentation/views.py
+++ b/products/notifications/backend/presentation/views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import cast
 
 from django.db.models import Exists, OuterRef, QuerySet, Subquery
+from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_datetime
 
 import posthoganalytics
@@ -244,6 +245,20 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         set_unread_count(user.id, self.team.organization_id, 0)
         return Response({"updated": len(event_ids)})
 
+    def _get_recipient_event_or_404(self) -> NotificationEvent:
+        # NotificationEvent is org-scoped + user-targeted, not team-scoped. self.get_object() applies
+        # the team_id URL filter from TeamAndOrgViewSetMixin and 404s on org-level notifications
+        # (team_id=NULL). (organization_id, resolved_user_ids__contains=[user.id]) is the real
+        # authorization boundary — the same pair the bulk mark endpoints use.
+        user = self._get_user()
+        return get_object_or_404(
+            NotificationEvent.objects.filter(  # nosemgrep: idor-lookup-without-team
+                organization_id=self.team.organization_id,
+                resolved_user_ids__contains=[user.id],
+            ),
+            pk=self.kwargs["pk"],  # nosemgrep: idor-taint-user-input-to-model-get
+        )
+
     @extend_schema(request=None)
     @action(methods=["POST"], detail=True, url_path="mark_read")
     def mark_read(self, request: Request, **kwargs) -> Response:
@@ -251,8 +266,7 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             return Response({"status": "ok"})
 
         user = self._get_user()
-        event = self.get_object()
-        # nosemgrep: idor-lookup-without-team -- event is already authorized via get_object()
+        event = self._get_recipient_event_or_404()
         NotificationReadState.objects.get_or_create(notification_event=event, user=user)
         invalidate_unread_count(user.id, self.team.organization_id)
         return Response({"status": "ok"})
@@ -264,8 +278,7 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             return Response({"status": "ok"})
 
         user = self._get_user()
-        event = self.get_object()
-        # nosemgrep: idor-lookup-without-team -- event is already authorized via get_object()
+        event = self._get_recipient_event_or_404()
         NotificationReadState.objects.filter(notification_event=event, user=user).delete()
         invalidate_unread_count(user.id, self.team.organization_id)
         return Response({"status": "ok"})

--- a/products/notifications/backend/tests/test_api.py
+++ b/products/notifications/backend/tests/test_api.py
@@ -68,6 +68,52 @@ class TestNotificationsAPI(BaseTest):
         assert resp.status_code == 200
         assert not NotificationReadState.objects.filter(notification_event=self.event, user=self.user).exists()
 
+    def test_mark_read_org_level_notification(self):
+        org_event = NotificationEvent.objects.create(
+            organization=self.organization,
+            team=None,
+            notification_type="comment_mention",
+            title="Org-level notification",
+            body="",
+            target_type="user",
+            target_id=str(self.user.id),
+            resolved_user_ids=[self.user.id],
+        )
+        resp = self.client.post(f"/api/environments/{self.team.id}/notifications/{org_event.id}/mark_read/")
+        assert resp.status_code == 200
+        assert NotificationReadState.objects.filter(notification_event=org_event, user=self.user).exists()
+
+    def test_mark_unread_org_level_notification(self):
+        org_event = NotificationEvent.objects.create(
+            organization=self.organization,
+            team=None,
+            notification_type="comment_mention",
+            title="Org-level notification",
+            body="",
+            target_type="user",
+            target_id=str(self.user.id),
+            resolved_user_ids=[self.user.id],
+        )
+        NotificationReadState.objects.create(notification_event=org_event, user=self.user)
+        resp = self.client.post(f"/api/environments/{self.team.id}/notifications/{org_event.id}/mark_unread/")
+        assert resp.status_code == 200
+        assert not NotificationReadState.objects.filter(notification_event=org_event, user=self.user).exists()
+
+    def test_mark_read_non_recipient_returns_404(self):
+        other_event = NotificationEvent.objects.create(
+            organization=self.organization,
+            team=None,
+            notification_type="comment_mention",
+            title="Not for me",
+            body="",
+            target_type="user",
+            target_id="999999",
+            resolved_user_ids=[999999],
+        )
+        resp = self.client.post(f"/api/environments/{self.team.id}/notifications/{other_event.id}/mark_read/")
+        assert resp.status_code == 404
+        assert not NotificationReadState.objects.filter(notification_event=other_event, user=self.user).exists()
+
     def test_mark_all_read(self):
         NotificationEvent.objects.create(
             organization=self.organization,


### PR DESCRIPTION
## Problem

Two in-app notification bugs: the critical-notification toast's open button did nothing, and marking an org-level notification (no team) read/unread returned 404.

## Changes

- Open the notifications side panel from the critical-notification toast's open button
- Allow mark read/unread for org-level notifications by scoping the lookup to org + recipient instead of team
- Non-recipients still get a 404

## How did you test this code?

- 3 backend unit tests added (org-level mark read/unread + non-recipient 404); full notifications API suite passes (30).
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Yasen reported both bugs; Claude Code investigated and fixed them. Root causes: the toast button called an action that only flipped internal menu state and never opened the panel (panel visibility is owned by the panel-layout logic), and the mark read/unread actions used the team-scoped object lookup, which filters out notifications with a null team. Both fixes reuse the existing org-scoped + recipient authorization boundary already used by the bulk mark endpoints. Invoked `/systematic-debugging`, `/writing-kea-logics`, and `/creating-pull-requests`.