### PR TITLE
feat(logs): add curated OTel resource-attribute facets with presence gating

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -24,7 +24,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
     const { severityLevels, serviceNames, filterGroup } = useValues(logsViewerFiltersLogic)
-    const { facetValues, loadingFacetKeys, facetSearch } = useValues(facetCountsLogic({ id }))
+    const { facetValues, loadingFacetKeys, facetSearch, visibleFacets } = useValues(facetCountsLogic({ id }))
     const { setFacetSearch } = useActions(facetCountsLogic({ id }))
     const { collapsedFacets } = useValues(facetRailLogic({ id }))
     const { toggleFacetValue, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
@@ -125,7 +125,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 <span className="text-xs font-semibold text-secondary uppercase tracking-wide">Filters</span>
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto p-2">
-                {facetsByGroup().map(([group, facets]) => (
+                {facetsByGroup(visibleFacets).map(([group, facets]) => (
                     <div key={group}>
                         <div className="px-1 pb-1 mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted border-b border-primary">
                             {group}

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
@@ -8,10 +8,14 @@ import { UniversalFiltersGroup } from '~/types'
 
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
-import { logsFacetValuesCreate } from '../../../generated/api'
+import { logsAttributesRetrieve, logsFacetValuesCreate } from '../../../generated/api'
 import { _LogFacetValueApi, _LogPropertyFilterApi, _LogsFacetValuesBodyApi } from '../../../generated/api.schemas'
 import type { facetCountsLogicType } from './facetCountsLogicType'
 import { FACETS, FacetConfig } from './facets'
+
+// Broad, filter-independent window for the "which resource attributes does this tenant emit" probe.
+// Cheap: keys-only group-by on the log_attributes aggregation table (no value scan).
+const PRESENCE_LOOKBACK = { date_from: '-90d' }
 
 export interface FacetCountsLogicProps {
     id: string
@@ -69,19 +73,15 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                 loadFacetValuesForKeyFailure: () => null,
             },
         ],
-    }),
-
-    selectors({
-        // Per-facet loading state. A filter-change reload and a per-facet search have independent
-        // breakpoints and can overlap, so union both sources — otherwise whichever settles first would
-        // clear the other's spinners. Keeping them as separate single-flight reducers means neither can
-        // leak a stuck spinner: each clears wholesale on its own settle.
-        loadingFacetKeys: [
-            (s) => [s.loadingReloadKeys, s.loadingSearchKey],
-            (loadingReloadKeys: string[], loadingSearchKey: string | null): string[] =>
-                loadingSearchKey && !loadingReloadKeys.includes(loadingSearchKey)
-                    ? [...loadingReloadKeys, loadingSearchKey]
-                    : loadingReloadKeys,
+        // Latches true once the presence probe settles (success or failure). Until then the value
+        // fetch is deferred, so column facets aren't fetched on mount and then re-fetched once
+        // presence resolves and the resource-attribute facets become visible.
+        presenceLoaded: [
+            false,
+            {
+                loadPresentResourceKeysSuccess: () => true,
+                loadPresentResourceKeysFailure: () => true,
+            },
         ],
     }),
 
@@ -132,7 +132,9 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                     // Refetch all facets (null) or a subset — used when filters change.
                     loadFacetValues: async (facetKeys: string[] | null, breakpoint) => {
                         await breakpoint(300)
-                        const facets = facetKeys ? FACETS.filter((f) => facetKeys.includes(f.key)) : FACETS
+                        const facets = facetKeys
+                            ? values.visibleFacets.filter((f) => facetKeys.includes(f.key))
+                            : values.visibleFacets
                         const result = await mergeFetched(facets)
                         breakpoint()
                         return result
@@ -148,21 +150,72 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                     },
                 },
             ],
+            presentResourceKeys: [
+                [] as string[],
+                {
+                    // Which resource attribute keys the tenant emits — gates which curated facets render.
+                    loadPresentResourceKeys: async () => {
+                        if (!values.currentTeamId) {
+                            return []
+                        }
+                        const response = await logsAttributesRetrieve(String(values.currentTeamId), {
+                            attribute_type: 'resource',
+                            dateRange: PRESENCE_LOOKBACK,
+                            limit: 100,
+                        })
+                        return response.results.map((r) => r.name)
+                    },
+                },
+            ],
         }
+    }),
+
+    selectors({
+        // Column facets always render; resource-attribute facets only when the tenant emits the key.
+        visibleFacets: [
+            (s) => [s.presentResourceKeys],
+            (presentResourceKeys): FacetConfig[] =>
+                FACETS.filter((f) => f.source.type === 'column' || presentResourceKeys.includes(f.source.key)),
+        ],
+        // Per-facet loading state. A filter-change reload and a per-facet search have independent
+        // breakpoints and can overlap, so union both sources — otherwise whichever settles first would
+        // clear the other's spinners. Keeping them as separate single-flight reducers means neither can
+        // leak a stuck spinner: each clears wholesale on its own settle.
+        loadingFacetKeys: [
+            (s) => [s.loadingReloadKeys, s.loadingSearchKey],
+            (loadingReloadKeys: string[], loadingSearchKey: string | null): string[] =>
+                loadingSearchKey && !loadingReloadKeys.includes(loadingSearchKey)
+                    ? [...loadingReloadKeys, loadingSearchKey]
+                    : loadingReloadKeys,
+        ],
     }),
 
     listeners(({ actions }) => ({
         // A facet's search changed — refetch only that facet, via its own action so it doesn't
         // cancel a still-debouncing full reload (independent breakpoint).
         setFacetSearch: ({ facetKey }) => actions.loadFacetValuesForKey(facetKey),
+        // Presence settled — drive the first full fetch now that visibleFacets is known. On failure
+        // we still fetch so the column facets (Level/Service) load even if the probe errored.
+        loadPresentResourceKeysSuccess: () => actions.loadFacetValues(null),
+        loadPresentResourceKeysFailure: () => actions.loadFacetValues(null),
     })),
 
-    subscriptions(({ actions }) => {
+    events(({ actions }) => ({
+        afterMount: () => actions.loadPresentResourceKeys(),
+    })),
+
+    subscriptions(({ actions, values }) => {
         // Fires on mount (initial load) and on any change. We watch both `filters` (severity, service,
         // search, date, user filterGroup) and `queryFilterGroup` (which folds in pinnedFilters, e.g. the
         // person-tab distinct_id pin) so values re-fetch when the pinned scope changes too. `filterGroup`
         // feeds both, so a normal edit fires both — the 300ms debounce in the loader collapses that.
-        const reloadAll = (): void => actions.loadFacetValues(null)
+        const reloadAll = (): void => {
+            // Before the presence probe settles, defer to loadPresentResourceKeys{Success,Failure}
+            // so we issue one full fetch over the final visible set instead of two.
+            if (values.presenceLoaded) {
+                actions.loadFacetValues(null)
+            }
+        }
         return {
             filters: reloadAll,
             queryFilterGroup: reloadAll,

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
@@ -138,13 +138,54 @@ const SERVICE_FACET: FacetConfig = {
     maxHeight: 300,
 }
 
-/** The rail is rendered entirely from this list — append a config to add a facet (or a new group). */
-export const FACETS: FacetConfig[] = [LEVEL_FACET, SERVICE_FACET]
+// Curated OTel resource attributes worth faceting. Keys are the stable OTel semantic-convention names;
+// `deployment.environment.name` is the 1.27+ stable key (older data may use `deployment.environment`).
+function resourceAttributeFacet(key: string, slug: string, title: string, group: string): FacetConfig {
+    return {
+        key: slug,
+        title,
+        group,
+        kind: 'dynamic',
+        source: { type: 'resourceAttribute', key },
+        searchable: true,
+        searchPlaceholder: `Search ${title.toLowerCase()}…`,
+        emptyLabel: `No ${title.toLowerCase()} values`,
+        maxHeight: 300,
+    }
+}
 
-/** `FACETS` grouped by `group`, preserving first-appearance order of both groups and facets. */
-export function facetsByGroup(): [string, FacetConfig[]][] {
+const ENVIRONMENT_FACET = resourceAttributeFacet(
+    'deployment.environment.name',
+    'environment',
+    'Environment',
+    'Standard'
+)
+const NAMESPACE_FACET = resourceAttributeFacet('k8s.namespace.name', 'namespace', 'Namespace', 'Kubernetes')
+const DEPLOYMENT_FACET = resourceAttributeFacet('k8s.deployment.name', 'deployment', 'Deployment', 'Kubernetes')
+const POD_FACET = resourceAttributeFacet('k8s.pod.name', 'pod', 'Pod', 'Kubernetes')
+const NODE_FACET = resourceAttributeFacet('k8s.node.name', 'node', 'Node', 'Kubernetes')
+const HOST_FACET = resourceAttributeFacet('host.name', 'host', 'Host', 'Infrastructure')
+
+/**
+ * The rail is rendered entirely from this list — append a config to add a facet (or a new group).
+ * Ordered by group (Standard → Kubernetes → Infrastructure) since facetsByGroup keeps first-appearance order.
+ * Resource-attribute facets only render when the tenant actually emits the key (see facetCountsLogic).
+ */
+export const FACETS: FacetConfig[] = [
+    LEVEL_FACET,
+    SERVICE_FACET,
+    ENVIRONMENT_FACET,
+    NAMESPACE_FACET,
+    DEPLOYMENT_FACET,
+    POD_FACET,
+    NODE_FACET,
+    HOST_FACET,
+]
+
+/** Group facets by `group`, preserving first-appearance order of both groups and facets. */
+export function facetsByGroup(facets: FacetConfig[]): [string, FacetConfig[]][] {
     const groups: [string, FacetConfig[]][] = []
-    for (const facet of FACETS) {
+    for (const facet of facets) {
         const existing = groups.find(([group]) => group === facet.group)
         if (existing) {
             existing[1].push(facet)


### PR DESCRIPTION
## Problem

The logs facet rail previously only showed two hardcoded facets (Level and Service). Users running Kubernetes workloads or standard OTel-instrumented services had no way to filter by common resource attributes like environment, namespace, deployment, pod, node, or host — even when their logs contained those fields.

## Changes

**New curated facets:** Added six resource-attribute facets covering common OTel semantic conventions:
- `deployment.environment.name` → Environment (Standard group)
- `k8s.namespace.name` → Namespace (Kubernetes group)
- `k8s.deployment.name` → Deployment (Kubernetes group)
- `k8s.pod.name` → Pod (Kubernetes group)
- `k8s.node.name` → Node (Kubernetes group)
- `host.name` → Host (Infrastructure group)

**Presence-gated rendering:** Resource-attribute facets only appear when the tenant actually emits that key. On mount, `facetCountsLogic` fires a lightweight `logsAttributesRetrieve` call over a 90-day window (keys-only, no value scan) to determine which resource attribute keys exist. The `visibleFacets` selector then filters `FACETS` to only those whose key is present, preventing empty facets from cluttering the rail for tenants that don't use Kubernetes or a given attribute.

**`facetsByGroup` now accepts a facet list** rather than always iterating the full `FACETS` constant, so the rail renders only the visible subset.

## How did you test this code?

- [ ] Automated tests cover the `visibleFacets` selector logic and the presence-gating behavior.
- Manual verification: mount the facet rail against a tenant with and without Kubernetes resource attributes and confirm only the relevant facets appear.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented using Claude with repo context. The key design decision was to gate resource-attribute facets on a presence check rather than always rendering them — this avoids showing empty facets to tenants who don't emit those keys. The presence probe uses a broad 90-day lookback against the attributes aggregation table (cheap: no value scan, keys only) and fires once on mount. A `loadPresentResourceKeysSuccess` listener triggers a follow-up `loadFacetValues` so that facets fetched before presence resolved are refreshed with the correct visible set.