### PR TITLE
chore(devex): disable unshared flox install cache in CI

### DIFF
--- a/.github/workflows/ci-dev-setup.yml
+++ b/.github/workflows/ci-dev-setup.yml
@@ -29,6 +29,11 @@ jobs:
 
             - name: Install Flox
               uses: flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a # v2.4.0
+              with:
+                  # This workflow only runs on pull_request, so the cache is never seeded on
+                  # master and every PR writes a branch-scoped copy nothing else can read.
+                  # Re-downloading the installer on a free runner is cheaper than the churn.
+                  use-cache: false
 
             - name: Activate Flox and verify dev setup
               run: |


### PR DESCRIPTION
## Problem

The Dev Setup (Flox) workflow (`ci-dev-setup.yml`) runs on `pull_request` only — never on `push` to master. `flox/install-flox-action` caches the downloaded flox installer by default, but because the workflow never runs on master, that cache is never seeded on the default branch. GitHub's cache is ref-isolated (a PR can read only its own ref + master), so every triggering PR writes a branch-scoped copy that no other PR can ever restore — write-once, read-never.

That churn was sitting at ~1.8 GB of the 10 GB repo cache cap, spread across ~20 unshared per-PR islands with a near-zero hit rate, evicting caches that actually get reused (pnpm store, typegen, etc.).

## Changes

Set `use-cache: false` on the action. The installer is a small download on a free `ubuntu-24.04` runner, so re-fetching it each run is cheaper than the cap pressure the unshared cache caused. The input already exists in the pinned `v2.4.0`, so no version bump.

This is a sibling cleanup to #64497 (pnpm cache dedup) — same root issue (branch-scoped cache writes fragmenting the shared cap), different action. The pnpm fix gated saves to master because we own those steps; here the save lives inside a third-party action and the cache can't be shared at all under this trigger, so turning it off is the right call rather than trying to gate it.

## How did you test this code?

I'm an agent (Claude Code). No code logic to test — this is a single CI workflow input. Verified via the GitHub Actions cache API that all flox installer caches were PR-scoped with none on master (confirming the unshared pattern), and confirmed `use-cache` exists as an input at the pinned action SHA. `actionlint` / `format:yaml` ran clean via lint-staged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tooling: Claude Code. No repo skills invoked (CI-config-only change).

Came out of an audit of the repo cache after #64497 merged: deleted the stale pre-merge `node-cache-*` entries, then traced the next-largest consumer to this workflow's flox installer cache. Considered adding a `push: [master]` trigger to seed a shareable baseline instead, but that adds master runs to rescue an optimization that saves only a trivial download on a free runner — not worth it. Disabling the cache is simpler and strictly better here.
