### PR TITLE
fix(bigquery): surface a clear error when Google rejects the credentials

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -24,6 +24,7 @@ from typing import Any
 import pyarrow as pa
 import structlog
 from google.api_core.exceptions import BadRequest, Forbidden, NotFound
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery.job import QueryJobConfig
@@ -58,6 +59,7 @@ from products.data_warehouse.backend.types import IncrementalFieldType, Partitio
 
 __all__ = [
     "BIGQUERY_TOKEN_RESPONSE_ERROR",
+    "BigQueryCredentialsRejectedError",
     "BigQueryImplementation",
     "BigQueryTokenRefreshError",
     "bigquery_client",
@@ -89,6 +91,17 @@ class BigQueryTokenRefreshError(Exception):
     `TypeError: string indices must be integers` instead of a `RefreshError`. We re-raise it
     as this clear, non-retryable error so the sync stops hammering an endpoint that can't
     authenticate us, and the user gets an actionable message.
+    """
+
+
+class BigQueryCredentialsRejectedError(Exception):
+    """Raised when Google rejects the service-account grant with `invalid_grant`.
+
+    google-auth raises a `RefreshError` whose `str()` is an opaque tuple repr
+    (`('invalid_grant: Invalid JWT Signature.', {...})`). A rotated/revoked key or deleted
+    service account can't be recovered by retrying, so we re-raise it as this clear message
+    rather than leaking the repr to the source-creation wizard. The message keeps the
+    `invalid_grant` marker so `get_non_retryable_errors` still matches it on the sync path.
     """
 
 
@@ -709,6 +722,18 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                 raise
             raise BigQueryTokenRefreshError(
                 f"{BIGQUERY_TOKEN_RESPONSE_ERROR}. Please re-upload your service account key file and verify its token_uri."
+            ) from e
+        except RefreshError as e:
+            # google-auth rejects the service-account grant here with an `invalid_grant`
+            # `RefreshError` whose `str()` is an opaque tuple repr. Surface the actionable message
+            # instead of leaking it to the wizard. Other RefreshErrors (offline token_uri, transient
+            # token-endpoint failures) carry their own diagnoses, so let them propagate unchanged.
+            if "invalid_grant" not in str(e):
+                raise
+            raise BigQueryCredentialsRejectedError(
+                "Your BigQuery service account credentials were rejected by Google (invalid_grant). "
+                "The key may have been rotated or revoked, or the service account deleted. "
+                "Please upload a new Google Cloud JSON key file."
             ) from e
 
         for row in rows:

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -6,11 +6,13 @@ from unittest import mock
 
 from dateutil import parser
 from google.api_core.exceptions import BadRequest, Forbidden, InvalidArgument, NotFound, PermissionDenied
+from google.auth.exceptions import RefreshError
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from posthog.temporal.data_imports.sources.bigquery import bigquery as bq_module
 from posthog.temporal.data_imports.sources.bigquery.bigquery import (
     BIGQUERY_TOKEN_RESPONSE_ERROR,
+    BigQueryCredentialsRejectedError,
     BigQueryImplementation,
     BigQueryTokenRefreshError,
     _bq_select_clause,
@@ -130,6 +132,37 @@ def test_bigquery_get_columns_typeerror_handling(error_message, expected_type, i
         assert BIGQUERY_TOKEN_RESPONSE_ERROR in BigQuerySource().get_non_retryable_errors()
     else:
         assert error_message in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "error_message,expected_type,is_rejected",
+    [
+        # An `invalid_grant` RefreshError means Google rejected the service-account grant (rotated
+        # key, deleted account). `get_columns` must surface a clear message instead of the tuple repr.
+        (
+            "('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})",
+            BigQueryCredentialsRejectedError,
+            True,
+        ),
+        # Transient/other RefreshErrors carry their own diagnoses and must propagate unchanged.
+        ("('Failed to retrieve token', {'error': 'internal_failure'})", RefreshError, False),
+    ],
+)
+def test_bigquery_get_columns_refresh_error_handling(error_message, expected_type, is_rejected):
+    """`invalid_grant` RefreshErrors are wrapped as `BigQueryCredentialsRejectedError`; others propagate."""
+    fake_client = mock.MagicMock()
+    fake_client.query.side_effect = RefreshError(error_message)
+
+    with pytest.raises(expected_type) as exc_info:
+        BigQueryImplementation().get_columns(fake_client, _make_config(), names=None)
+
+    assert isinstance(exc_info.value, BigQueryCredentialsRejectedError) == is_rejected
+    if is_rejected:
+        # The wizard shows this str() directly, and it must keep the `invalid_grant` marker so the
+        # sync schema-discovery path still recognises it as non-retryable.
+        assert "invalid_grant" in str(exc_info.value)
+        assert "rejected by Google" in str(exc_info.value)
+        assert any(key in str(exc_info.value) for key in BigQuerySource().get_non_retryable_errors())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When a user creates a BigQuery warehouse source with a service-account key that Google rejects (rotated/revoked key, or a deleted service account), the wizard showed the raw google-auth error:

```
('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})
```

That tuple repr gives the user nothing to act on. It originates from `get_columns` in `bigquery.py` — `conn.query(...)` triggers google-auth's lazy service-account token refresh, which raises a `RefreshError`. Schema discovery let it propagate, and the source-creation endpoints surface `str(e)` directly.

## Changes

Catch the `invalid_grant` `RefreshError` in `get_columns` and re-raise it as a new `BigQueryCredentialsRejectedError` with an actionable message ("…rejected by Google… upload a new Google Cloud JSON key file").

The message intentionally keeps the `invalid_grant` marker, which is already a key in `BigQuerySource.get_non_retryable_errors()` — so the sync schema-discovery path (`sync_new_schemas`) still recognises it as non-retryable and skips quietly instead of spamming retries.

Other `RefreshError`s carry their own diagnoses (e.g. an offline `token_uri`, or transient token-endpoint failures that should stay retryable), so they propagate unchanged. This is scoped to the `invalid_grant` case and doesn't touch the existing non-retryable matchers.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_bigquery_get_columns_refresh_error_handling`) covering both the wrapped `invalid_grant` case and an unrelated transient `RefreshError` that must propagate, and ran the relevant subset:

```
.venv/bin/pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py -k "get_columns or non_retryable or rejected or refresh"
# 34 passed
```

`ruff check` and `ruff format` pass on both touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a batch of source-creation `warehouse credentials invalid` events. Classified this one as an internal error leaking to users (raw `RefreshError` tuple repr). Confirmed the leak path is schema discovery (`get_columns` → `str(e)` at the `database_schema`/`setup` endpoints), distinct from the validation path which already returns a generic message. Chose to fix at the raise site in `get_columns` so every `get_schemas` caller benefits, and kept the `invalid_grant` substring in the new message so the existing sync-path non-retryable matching is preserved. Checked open PRs (including the maintainer's BigQuery PRs #64841 offline token_uri and #65082 unparseable private key) — both only add `get_non_retryable_errors` dict entries and don't address the wizard leak, so no overlap.