### PR TITLE
feat(notebooks): Toggle hide button on markdown notebook components

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -228,7 +228,7 @@ export function NotebookComponentShell({
                             <LemonButton
                                 aria-label={resultsLabel}
                                 size="xsmall"
-                                icon={<IconEye />}
+                                icon={componentPanels.results ? <IconEye /> : <IconHide />}
                                 active={componentPanels.results}
                                 tooltip={resultsLabel}
                                 onClick={() => toggleComponentPanel('results')}


### PR DESCRIPTION
## Problem

Bit of a nit; but 'Hide' button is more expressive when it expresses its state (content is hidden).

## Changes

Uses the hidden icon when results are hidden. Not collapsing the 'edit' section if its open.
Only changed for markdown-notebooks.

## How did you test this code?

<img width="1043" height="541" alt="2026-06-22 11 05 12" src="https://github.com/user-attachments/assets/212c4dac-2e1e-4eea-8844-7cafdca397d8" />
