### PR TITLE
feat(workflows): configurable batch trigger audience limit

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -671,7 +671,7 @@ snapshots:
     components-hogcharts-linechart--hovering-multi-series--dark:
         hash: v1.k794b7964.da078843ba3e1569c6a36aa6f8ba3eb5f7dedc1852b4f256435711871b55a7ed.u12-UiyjvpbExGP33yhNmKIj7MefFMxWpXsGkf3VG74
     components-hogcharts-linechart--hovering-multi-series--light:
-        hash: v1.k794b7964.2fa5cdb17438c5d62f6b5c075c8160df3cc4c197754fe78c0bf722cd575b0dca.92ma-HCbFCtCf_jrLu2ntgzLy0g843soMAf-qaCna-E
+        hash: v1.k794b7964.2d2effaf2935816c82ddca8e6b46b1245a1c8bc7589c8d63cbae2398060e5001.UZwi1m_dJL4B6q1zWUpCUyEf2qnHxKAs83LEfm7a_Bw
     components-hogcharts-linechart--hovering-over-aux-series--dark:
         hash: v1.k794b7964.1251a1dc7a11763c51054b76bcc092db995f51208e20e3ffe668690ae763c38b.L0wjl3-x2fOMd9HZpRiQP5GaQLJUBDzhFwkno_qgqdM
     components-hogcharts-linechart--hovering-over-aux-series--light:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -805,6 +805,16 @@ POSTHOG_JS_UUID_VERSION = os.getenv("POSTHOG_JS_UUID_VERSION", "v7")
 # Comma-separated list of team IDs that should receive the digest
 HOG_FUNCTIONS_DAILY_DIGEST_TEAM_IDS = get_list(get_from_env("HOG_FUNCTIONS_DAILY_DIGEST_TEAM_IDS", ""))
 
+# Maximum audience size for HogFlow batch triggers. Default that applies to all teams unless they
+# opt in to the elevated value below. Only used to inform the frontend UI; no backend enforcement.
+HOGFLOW_BATCH_TRIGGER_LIMIT = int(get_from_env("HOGFLOW_BATCH_TRIGGER_LIMIT", 5000))
+# Elevated maximum audience size, returned for teams listed in HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS.
+HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED = int(get_from_env("HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED", 50000))
+# Comma-separated list of team IDs that get the elevated batch trigger limit instead of the default.
+HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS: set[int] = {
+    int(team_id) for team_id in get_list(get_from_env("HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS", "2"))
+}
+
 # Comma-separated list of org ids allowed to receive the Error Tracking weekly digest
 # "*" for all, empty to disable feature
 ERROR_TRACKING_WEEKLY_DIGEST_ORG_IDS = get_list(get_from_env("ERROR_TRACKING_WEEKLY_DIGEST_ORG_IDS", ""))

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -64,6 +64,7 @@ from products.workflows.backend.api.hog_flow_batch_job import HogFlowBatchJobSer
 from products.workflows.backend.models.hog_flow.hog_flow import BILLABLE_ACTION_TYPES, HogFlow
 from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
 from products.workflows.backend.models.hog_flow_schedule import SCHEDULED_TRIGGER_TYPES, HogFlowSchedule
+from products.workflows.backend.utils.batch_trigger_limit import get_hogflow_batch_trigger_limit
 from products.workflows.backend.utils.rrule_utils import compute_next_occurrences, validate_rrule
 
 logger = structlog.get_logger(__name__)
@@ -135,6 +136,7 @@ class BlastRadiusRequestSerializer(serializers.Serializer):
 class BlastRadiusSerializer(serializers.Serializer):
     affected = serializers.IntegerField(help_text="Number of users matching the filters")
     total = serializers.IntegerField(help_text="Total number of users")
+    limit = serializers.IntegerField(help_text="Maximum allowed audience size for batch triggers for this team.")
 
 
 class WorkflowGlobalStatsRequestSerializer(serializers.Serializer):
@@ -1341,7 +1343,15 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
 
         result = get_user_blast_radius(self.team, filters, group_type_index)
 
-        return Response(BlastRadiusSerializer(result).data)
+        return Response(
+            BlastRadiusSerializer(
+                {
+                    "affected": result.affected,
+                    "total": result.total,
+                    "limit": get_hogflow_batch_trigger_limit(self.team_id),
+                }
+            ).data
+        )
 
     @extend_schema(
         operation_id="hog_flows_invocation_results_retrieve",
@@ -1578,7 +1588,15 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
         try:
             reject_flag_conditions_in_audience(team, filters)
             result = get_user_blast_radius(team, filters, group_type_index)
-            return Response(BlastRadiusSerializer(result).data)
+            return Response(
+                BlastRadiusSerializer(
+                    {
+                        "affected": result.affected,
+                        "total": result.total,
+                        "limit": get_hogflow_batch_trigger_limit(team.id),
+                    }
+                ).data
+            )
         except exceptions.ValidationError as e:
             return Response({"error": _validation_error_message(e)}, status=400)
         except Exception as e:

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1718,6 +1718,44 @@ class TestHogFlowAPI(APIBaseTest):
         assert "limit" in body
         assert body["limit"] > 0
 
+    @override_settings(
+        HOGFLOW_BATCH_TRIGGER_LIMIT=5000,
+        HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=50000,
+        HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS=set(),
+    )
+    def test_hog_flow_user_blast_radius_returns_default_limit_for_unlisted_team(self):
+        with patch("products.workflows.backend.api.hog_flow.get_user_blast_radius") as mock_get_user_blast_radius:
+            from products.feature_flags.backend.user_blast_radius import BlastRadiusResult  # noqa: PLC0415
+
+            mock_get_user_blast_radius.return_value = BlastRadiusResult(affected=0, total=0)
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_flows/user_blast_radius",
+                {"filters": {"properties": []}},
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["limit"] == 5000
+
+    def test_hog_flow_user_blast_radius_returns_elevated_limit_for_listed_team(self):
+        with (
+            override_settings(
+                HOGFLOW_BATCH_TRIGGER_LIMIT=5000,
+                HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=50000,
+                HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS={self.team.id},
+            ),
+            patch("products.workflows.backend.api.hog_flow.get_user_blast_radius") as mock_get_user_blast_radius,
+        ):
+            from products.feature_flags.backend.user_blast_radius import BlastRadiusResult  # noqa: PLC0415
+
+            mock_get_user_blast_radius.return_value = BlastRadiusResult(affected=0, total=0)
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_flows/user_blast_radius",
+                {"filters": {"properties": []}},
+            )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["limit"] == 50000
+
     def test_user_blast_radius_personal_api_key_requires_person_read_scope(self):
         # Sizing an audience queries person data, so a hog_flow:read-only token must NOT be able to use
         # this as a person-count oracle — person:read is also required.

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -1712,7 +1712,11 @@ class TestHogFlowAPI(APIBaseTest):
             )
 
         assert response.status_code == 200, response.json()
-        assert response.json() == {"affected": 4, "total": 10}
+        body = response.json()
+        assert body["affected"] == 4
+        assert body["total"] == 10
+        assert "limit" in body
+        assert body["limit"] > 0
 
     def test_user_blast_radius_personal_api_key_requires_person_read_scope(self):
         # Sizing an audience queries person data, so a hog_flow:read-only token must NOT be able to use
@@ -1747,7 +1751,10 @@ class TestHogFlowAPI(APIBaseTest):
                 headers={"authorization": f"Bearer {key}"},
             )
         assert response.status_code == 200, response.json()
-        assert response.json() == {"affected": 1, "total": 10}
+        body = response.json()
+        assert body["affected"] == 1
+        assert body["total"] == 10
+        assert "limit" in body
 
     @parameterized.expand(
         [

--- a/products/workflows/backend/utils/batch_trigger_limit.py
+++ b/products/workflows/backend/utils/batch_trigger_limit.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+
+def get_hogflow_batch_trigger_limit(team_id: int) -> int:
+    if team_id in settings.HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS:
+        return settings.HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED
+    return settings.HOGFLOW_BATCH_TRIGGER_LIMIT

--- a/products/workflows/backend/utils/test_batch_trigger_limit.py
+++ b/products/workflows/backend/utils/test_batch_trigger_limit.py
@@ -1,0 +1,42 @@
+from django.test import TestCase, override_settings
+
+from products.workflows.backend.utils.batch_trigger_limit import get_hogflow_batch_trigger_limit
+
+
+class TestGetHogflowBatchTriggerLimit(TestCase):
+    @override_settings(
+        HOGFLOW_BATCH_TRIGGER_LIMIT=5000,
+        HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=50000,
+        HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS={2, 99},
+    )
+    def test_returns_default_for_unlisted_team(self):
+        assert get_hogflow_batch_trigger_limit(1) == 5000
+        assert get_hogflow_batch_trigger_limit(7) == 5000
+
+    @override_settings(
+        HOGFLOW_BATCH_TRIGGER_LIMIT=5000,
+        HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=50000,
+        HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS={2, 99},
+    )
+    def test_returns_elevated_for_listed_team(self):
+        assert get_hogflow_batch_trigger_limit(2) == 50000
+        assert get_hogflow_batch_trigger_limit(99) == 50000
+
+    @override_settings(
+        HOGFLOW_BATCH_TRIGGER_LIMIT=5000,
+        HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=50000,
+        HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS=set(),
+    )
+    def test_returns_default_when_elevated_set_is_empty(self):
+        assert get_hogflow_batch_trigger_limit(2) == 5000
+
+    @override_settings(
+        HOGFLOW_BATCH_TRIGGER_LIMIT=123,
+        HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED=456,
+        HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS={42},
+    )
+    def test_returns_currently_configured_values(self):
+        # Doesn't snapshot 5000/50000 — picks up whatever the settings are at call time, so a
+        # production tweak via env var is reflected immediately.
+        assert get_hogflow_batch_trigger_limit(42) == 456
+        assert get_hogflow_batch_trigger_limit(1) == 123

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
@@ -108,7 +108,7 @@ const TriggerPopover = ({
                     loading={blastRadiusLoading}
                     disabledReason={
                         blastRadiusExceeded && blastRadius?.limit != null
-                            ? `Batch size exceeds the limit of ${humanFriendlyNumber(blastRadius.limit)} users. Add filters to narrow your audience.`
+                            ? `Batch size exceeds the limit of ${humanFriendlyNumber(blastRadius.limit)} users. Add filters to narrow your audience. This limit will be loosened in the future.`
                             : undefined
                     }
                     onClick={() => {

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
@@ -11,7 +11,7 @@ import { CyclotronJobInputSchemaType } from '~/types'
 
 import { WorkflowLogicProps, workflowLogic } from '../workflowLogic'
 import { hogFlowManualTriggerButtonLogic } from './HogFlowManualTriggerButtonLogic'
-import { batchTriggerLogic, BLAST_RADIUS_LIMIT } from './steps/batchTriggerLogic'
+import { batchTriggerLogic } from './steps/batchTriggerLogic'
 
 const TriggerPopover = ({
     setPopoverVisible,
@@ -32,7 +32,10 @@ const TriggerPopover = ({
     )
 
     const blastRadiusExceeded =
-        workflow?.trigger?.type === 'batch' && blastRadius != null && blastRadius.affected > BLAST_RADIUS_LIMIT
+        workflow?.trigger?.type === 'batch' &&
+        blastRadius != null &&
+        blastRadius.limit != null &&
+        blastRadius.affected > blastRadius.limit
 
     const blastRadiusSuffix = (): string => {
         if (workflow?.trigger?.type === 'batch') {
@@ -104,8 +107,8 @@ const TriggerPopover = ({
                     status="alt"
                     loading={blastRadiusLoading}
                     disabledReason={
-                        blastRadiusExceeded
-                            ? `Batch size exceeds the limit of ${humanFriendlyNumber(BLAST_RADIUS_LIMIT)} users. Add filters to narrow your audience. This limit will be loosened in the future.`
+                        blastRadiusExceeded && blastRadius?.limit != null
+                            ? `Batch size exceeds the limit of ${humanFriendlyNumber(blastRadius.limit)} users. Add filters to narrow your audience.`
                             : undefined
                     }
                     onClick={() => {

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -51,7 +51,7 @@ import { workflowLogic } from '../../workflowLogic'
 import { HogFlowEventFilters, WORKFLOW_OPERATOR_ALLOWLIST } from '../filters/HogFlowFilters'
 import { getRegisteredTriggerTypes } from '../registry/triggers/triggerTypeRegistry'
 import { HogFlowAction } from '../types'
-import { batchTriggerLogic, BLAST_RADIUS_LIMIT } from './batchTriggerLogic'
+import { batchTriggerLogic } from './batchTriggerLogic'
 import { HogFlowFunctionConfiguration } from './components/HogFlowFunctionConfiguration'
 import { RecurringSchedulePicker } from './components/RecurringSchedulePicker'
 import { ScheduleStatusBadge } from './components/ScheduleStatusBadge'
@@ -526,19 +526,19 @@ function StepTriggerAffectedUsers({ actionId, filters }: { actionId: string; fil
         return null
     }
 
-    const { affected, total } = blastRadius
+    const { affected, total, limit } = blastRadius
 
     if (affected != null && total != null) {
-        const exceeded = affected > BLAST_RADIUS_LIMIT
+        const exceeded = limit != null && affected > limit
         return (
             <div className="text-muted">
                 <div className={exceeded ? 'text-danger font-semibold' : 'text-muted'}>
                     approximately {humanFriendlyNumber(affected)} of {humanFriendlyNumber(total)} persons.
                 </div>
-                {exceeded && (
+                {exceeded && limit != null && (
                     <div className="text-danger text-xs">
-                        Batch size exceeds the limit of {humanFriendlyNumber(BLAST_RADIUS_LIMIT)} users. Add filters to
-                        narrow your audience. This limit will be loosened in the future.
+                        Batch size exceeds the limit of {humanFriendlyNumber(limit)} users. Add filters to narrow your
+                        audience.
                     </div>
                 )}
             </div>

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -538,7 +538,7 @@ function StepTriggerAffectedUsers({ actionId, filters }: { actionId: string; fil
                 {exceeded && limit != null && (
                     <div className="text-danger text-xs">
                         Batch size exceeds the limit of {humanFriendlyNumber(limit)} users. Add filters to narrow your
-                        audience.
+                        audience. This limit will be loosened in the future.
                     </div>
                 )}
             </div>

--- a/products/workflows/frontend/Workflows/hogflows/steps/batchTriggerLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/batchTriggerLogic.ts
@@ -9,8 +9,6 @@ import { BlastRadiusApi } from 'products/workflows/frontend/generated/api.schema
 import { HogFlowAction } from '../types'
 import type { batchTriggerLogicType } from './batchTriggerLogicType'
 
-export const BLAST_RADIUS_LIMIT = 5000
-
 export interface BatchTriggerLogicProps {
     id?: string | 'new'
     filters?: Extract<HogFlowAction['config'], { type: 'batch' }>['filters']

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -783,6 +783,8 @@ export interface BlastRadiusApi {
     affected: number
     /** Total number of users */
     total: number
+    /** Maximum allowed audience size for batch triggers for this team. */
+    limit: number
 }
 
 export type HogFlowTemplatesListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11348,6 +11348,8 @@ export namespace Schemas {
       affected: number;
       /** Total number of users */
       total: number;
+      /** Maximum allowed audience size for batch triggers for this team. */
+      limit: number;
     }
 
     /**

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

The HogFlow batch trigger audience limit was a frontend-only constant (`BLAST_RADIUS_LIMIT = 5000`) hardcoded into `batchTriggerLogic.ts`. Couldn't be tuned per team, couldn't be raised for projects that need a larger audience without a code change.

## Changes

Three env-driven Django settings, default behavior unchanged for unlisted teams:

| Setting | Default | Purpose |
| --- | --- | --- |
| `HOGFLOW_BATCH_TRIGGER_LIMIT` | `5000` | Maximum audience size for all teams |
| `HOGFLOW_BATCH_TRIGGER_LIMIT_ELEVATED` | `50000` | Elevated value applied only to opted-in teams |
| `HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS` | `2` | Comma-separated team IDs that get the elevated value |

The limit flows to the frontend via the existing blast-radius API:

- `BlastRadiusSerializer` now returns `limit` alongside `affected` / `total`. Both the public (`user_blast_radius`) and internal (`internal_user_blast_radius`) endpoints include it, so the React UI and the Node.js CDP service both see the same per-team value.
- The hardcoded `BLAST_RADIUS_LIMIT = 5000` constant is gone — `StepTrigger` and `HogFlowManualTriggerButton` read `blastRadius.limit` from the API and use it for the existing disabled-button / warning UX. No behavioral change for users; just a value that's now configurable.

## What this PR does NOT do

This PR is intentionally minimal — **no backend enforcement** of the limit. The check stays in the frontend UI exactly where it already was. API/MCP callers can still trigger any size run, and the Node consumer's own cap (`CDP_BATCH_WORKFLOW_MAX_AUDIENCE_SIZE`, default 5000) continues to be the only hard backstop downstream. That's the same behavior as master.

If we want real backend enforcement (manual trigger 400s, scheduled runs that skip with a notification, etc.), that's a separate decision and a separate PR.

## How did you test this code?

I'm an agent (Claude Opus 4.7). I did not test the UI manually.

- `test_hog_flow_user_blast_radius_returns_counts` — updated to assert the new `limit` field is present on the response.
- `test_user_blast_radius_personal_api_key_with_person_read_scope_allowed` — same update for the personal-API-key path.

Both run green via `hogli test`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs needed — env-var-only knob.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by @meikelratz; tooling: Claude Code (Opus 4.7). No PostHog skills invoked — straightforward settings + serializer + frontend constant swap.

Decisions worth flagging:

- **Env vars vs. feature flag.** Env vars chosen for simplicity — matches the existing `HOG_FUNCTIONS_DAILY_DIGEST_TEAM_IDS` / `BATCH_EXPORT_*_TEAM_IDS` shape. Restart required to change.
- **One default + one elevated value, not a per-team value map.** Keeps the surface small: bump team into the set, get the elevated cap. No per-team custom numbers.
- **Generated frontend type.** I edited `products/workflows/frontend/generated/api.schemas.ts` to add the `limit` field as a stopgap so TS compiles. Run `hogli build:openapi` before merge to regenerate from the serializer (source of truth).