### PR TITLE
chore(reminders): transfer ownership to platform features

### DIFF
--- a/products/reminders/product.yaml
+++ b/products/reminders/product.yaml
@@ -1,3 +1,3 @@
 name: Reminders
 owners:
-    - team-analytics-platform
+    - team-platform-features


### PR DESCRIPTION
## Problem

The reminders product was attributed to the analytics platform team in its product metadata, but it is owned by the platform features team.

## Changes

- Reassign reminders product ownership to the platform features team

## How did you test this code?

Metadata-only change to `product.yaml`; no automated tests. Agent-authored.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?