### PR TITLE
feat(phai): queue sandbox follow-up messages while a turn is active

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3631,32 +3631,32 @@ describe('maxThreadLogic', () => {
             expect(logic.values.threadLoading).toBe(false)
         })
 
-        it('markTurnComplete drains the sandbox queue (consumeQueuedMessage + askMax)', async () => {
-            featureFlagLogic.mount()
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM]: true,
-            })
-            jest.spyOn(api.conversations.queue, 'delete').mockResolvedValue({ messages: [], max_queue_messages: 2 })
+        it('markTurnComplete drains the sandbox queue combined, without an optimistic echo', async () => {
+            // No POSTHOG_AI_QUEUE_MESSAGES_SYSTEM flag — sandbox queueing is flag-independent.
+            jest.spyOn(api.conversations.queue, 'clear').mockResolvedValue({ messages: [], max_queue_messages: 2 })
 
             const sandboxStreamInstance = await startSandboxTurn()
             // completeThreadGeneration's queue-drain only runs with a non-null conversation.
             // The id matches the mounted conversationId, so the setConversation listener won't clear the queue.
             logic.actions.setConversation(MOCK_CONVERSATION)
             logic.actions.setIsSandboxMode(true)
-            const queueMessage = { id: 'queue-1', content: 'Next message', created_at: new Date().toISOString() }
-            logic.actions.setQueuedMessages([queueMessage])
+            logic.actions.setQueuedMessages([
+                { id: 'queue-1', content: 'First', created_at: new Date().toISOString() },
+                { id: 'queue-2', content: 'Second', created_at: new Date().toISOString() },
+            ])
 
-            // markTurnComplete tears down streaming and then the queue-drain starts the next turn,
-            // so we assert the drain actions fired (not the final streamingActive, which the new
-            // turn flips back on).
+            // markTurnComplete tears down streaming, then the drain clears the queue and re-sends the
+            // combined text with addToThread:false (so it renders on the live echo, not optimistically).
             await expectLogic(logic, () => {
                 sandboxStreamInstance.actions.markTurnComplete()
-            }).toDispatchActions(['completeThreadGeneration', 'consumeQueuedMessage', 'askMax'])
-
-            featureFlagLogic.unmount()
+            }).toDispatchActions([
+                'completeThreadGeneration',
+                'clearQueuedMessages',
+                (action: any) => action.payload?.prompt === 'First\n\nSecond' && action.payload?.addToThread === false,
+            ])
         })
 
-        it('handleStreamError does NOT drain the sandbox queue (no consumeQueuedMessage, no askMax)', async () => {
+        it('handleStreamError does NOT drain the sandbox queue (no clearQueuedMessages, no askMax)', async () => {
             featureFlagLogic.mount()
             featureFlagLogic.actions.setFeatureFlags([], {
                 [FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM]: true,
@@ -3675,7 +3675,7 @@ describe('maxThreadLogic', () => {
                 })
             })
                 .toDispatchActions(['endStreaming'])
-                .toNotHaveDispatchedActions(['completeThreadGeneration', 'consumeQueuedMessage', 'askMax'])
+                .toNotHaveDispatchedActions(['completeThreadGeneration', 'clearQueuedMessages', 'askMax'])
 
             expect(logic.values.streamingActive).toBe(false)
             // The failed turn must not auto-start the queued message

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -1541,11 +1541,13 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // Process queued messages for sandbox conversations.
             // Regular conversations handle queue consumption on the backend
             // (process_chat_agent_activity pops and starts new workflows).
-            // Sandbox mode doesn't have this, so the frontend drives it.
+            // Sandbox mode doesn't have this, so the frontend drives it: combine every queued
+            // follow-up into one send. `addToThread: false` skips the optimistic echo so the message
+            // renders only when the live stream echoes it back (stream-confirmed), not at drain time.
             if (shouldConsumeSandboxQueue) {
-                const nextMessage = values.queuedMessages[0]
-                actions.consumeQueuedMessage(nextMessage)
-                actions.askMax(nextMessage.content)
+                const combined = values.queuedMessages.map((message) => message.content).join('\n\n')
+                actions.clearQueuedMessages()
+                actions.askMax(combined, false)
             }
 
             // Must go last. Otherwise, the logic will be unmounted before the lifecycle finishes.
@@ -1839,8 +1841,12 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         queueingEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM],
+            // Sandbox conversations always queue follow-ups sent mid-turn (the backend queue endpoints
+            // aren't flag-gated, and the sandbox runtime drives the drain itself); LangGraph stays
+            // behind the rollout flag.
+            (s) => [s.featureFlags, s.isSandboxMode],
+            (featureFlags, isSandboxMode): boolean =>
+                !!featureFlags[FEATURE_FLAGS.POSTHOG_AI_QUEUE_MESSAGES_SYSTEM] || isSandboxMode,
         ],
 
         queueIsFull: [

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -699,12 +699,22 @@ describe('sandboxStreamLogic', () => {
             )
         })
 
-        it('does not render a live (non-replay) user_message frame — it is echoed on send instead', async () => {
+        it('renders a live (non-replay) user_message frame with no optimistic echo (queue drain)', async () => {
             await expectLogic(logic, () => {
-                logic.actions.ingestAcpFrame(notification('_posthog/user_message', { content: 'live message' }))
+                logic.actions.ingestAcpFrame(notification('_posthog/user_message', { content: 'drained message' }))
             }).toFinishAllListeners()
 
-            expect(logic.values.threadItems).toHaveLength(0)
+            expect(logic.values.threadItems).toHaveLength(1)
+            expect(logic.values.threadItems[0]).toMatchObject({ type: 'human_message', text: 'drained message' })
+        })
+
+        it('does not double a live user_message frame already echoed optimistically on send', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.pushHumanMessage('hello agent')
+                logic.actions.ingestAcpFrame(notification('_posthog/user_message', { content: 'hello agent' }))
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.filter((item) => item.type === 'human_message')).toHaveLength(1)
         })
 
         // The backend persists the human turn as a session/update `user_message_chunk`, not a
@@ -872,14 +882,26 @@ describe('sandboxStreamLogic', () => {
             })
         })
 
-        it('does not render a live (non-replay) user_message_chunk — it is echoed on send instead', async () => {
+        it('renders a live (non-replay) user_message_chunk with no optimistic echo (queue drain)', async () => {
             await expectLogic(logic, () => {
                 logic.actions.ingestAcpFrame(
-                    sessionUpdate({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'live' } })
+                    sessionUpdate({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'drained' } })
                 )
             }).toFinishAllListeners()
 
-            expect(logic.values.threadItems).toHaveLength(0)
+            expect(logic.values.threadItems).toHaveLength(1)
+            expect(logic.values.threadItems[0]).toMatchObject({ type: 'human_message', text: 'drained' })
+        })
+
+        it('dedupes a drained send echoed in both user_message wire forms into one bubble', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(notification('_posthog/user_message', { content: 'drained' }))
+                logic.actions.ingestAcpFrame(
+                    sessionUpdate({ sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'drained' } })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.filter((item) => item.type === 'human_message')).toHaveLength(1)
         })
     })
 

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -376,6 +376,24 @@ function insertHumanMessageAtTurnStart(state: ThreadItem[], item: ThreadItem): T
     return [...state.slice(0, turnStartIndex), item, ...currentTurn]
 }
 
+/**
+ * Is this human message already shown in the current turn (since the last separator)? Used to drop a
+ * live wire user echo that's already on screen — the optimistic `_client/human_message` of an idle
+ * send, or the first wire form of a queue-drained send (which can echo in two forms).
+ */
+function currentTurnHasHumanText(state: ThreadItem[], text: string): boolean {
+    for (let i = state.length - 1; i >= 0; i--) {
+        const item = state[i]
+        if (item.type === 'turn_separator') {
+            return false
+        }
+        if (item.type === 'human_message' && item.text === text) {
+            return true
+        }
+    }
+    return false
+}
+
 function mapAcpStatus(status: unknown): ToolInvocationStatus {
     switch (status) {
         case 'in_progress':
@@ -671,6 +689,21 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
         }
     }
 
+    const renderLiveHuman = (rawText: string): void => {
+        const text = unwrapUserMessageContent(rawText)
+        if (!text) {
+            return
+        }
+        // The server echoes every user send live. An idle send already rendered it optimistically via
+        // `_client/human_message`; a queue-drained send (dispatched with `addToThread: false`) did not,
+        // so its echo is what surfaces it. Render unless the current turn already shows this message —
+        // which both drops the optimistic-paired echo and dedupes a send echoed in two wire forms.
+        if (currentTurnHasHumanText(items, text)) {
+            return
+        }
+        pushHuman(text)
+    }
+
     const handleToolCallUpdate = (
         update: Record<string, unknown>,
         notification: StoredLogEntry['notification']
@@ -825,8 +858,11 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
             continue
         }
         if (method === '_posthog/user_message') {
+            const userText = extractUserMessageText(params.content as string | unknown[] | undefined)
             if (source === 'replay') {
-                renderReplayHuman(extractUserMessageText(params.content as string | unknown[] | undefined), true)
+                renderReplayHuman(userText, true)
+            } else {
+                renderLiveHuman(userText)
             }
             continue
         }
@@ -844,9 +880,12 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
         }
         const sessionUpdate = update.sessionUpdate
         if (sessionUpdate === 'user_message_chunk' || sessionUpdate === 'user_message') {
+            const content = update.content as { text?: string } | undefined
+            const userText = String(content?.text ?? update.text ?? '')
             if (source === 'replay') {
-                const content = update.content as { text?: string } | undefined
-                renderReplayHuman(String(content?.text ?? update.text ?? ''), false)
+                renderReplayHuman(userText, false)
+            } else {
+                renderLiveHuman(userText)
             }
             continue
         }


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
