### PR TITLE
fix(nodejs): correct recording-rasterizer dist path after move

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -24,9 +24,9 @@ frontend/src/toolbar/product-tours/** @PostHog/team-surveys
 # Nodejs Services - ownership is split between ingestion and workflows teams
 nodejs/tests/ @PostHog/team-ingestion
 nodejs/src/ingestion/ @PostHog/team-ingestion
+nodejs/src/ingestion/pipelines/sessionreplay/ @PostHog/team-replay @PostHog/team-ingestion
 nodejs/src/cdp/ @PostHog/team-workflows
-nodejs/src/session-replay/ @PostHog/team-replay
-nodejs/src/session-replay/shared/ @PostHog/team-replay @PostHog/team-ingestion
+nodejs/src/recording-rasterizer/ @PostHog/team-replay
 
 # CDP / Workflows - owned by @PostHog/team-workflows
 posthog/cdp/** @PostHog/team-workflows

--- a/Dockerfile.recording-rasterizer
+++ b/Dockerfile.recording-rasterizer
@@ -178,4 +178,4 @@ RUN chrome-headless-shell --version && ffmpeg -version
 
 EXPOSE 6740
 
-CMD ["node", "nodejs/dist/session-replay/recording-rasterizer/index.js"]
+CMD ["node", "nodejs/dist/recording-rasterizer/index.js"]

--- a/bin/temporal-recording-rasterizer-worker
+++ b/bin/temporal-recording-rasterizer-worker
@@ -99,7 +99,7 @@ docker run --rm \
     -e SCREENSHOT_FORMAT="${SCREENSHOT_FORMAT:-jpeg}" \
     -e SCREENSHOT_JPEG_QUALITY="${SCREENSHOT_JPEG_QUALITY:-80}" \
     -e CHROME_HOST_RESOLVER_RULES="MAP localhost host.docker.internal" \
-    -v "$ROOT_DIR/nodejs/dist/session-replay/recording-rasterizer:/code/nodejs/dist/session-replay/recording-rasterizer" \
+    -v "$ROOT_DIR/nodejs/dist/recording-rasterizer:/code/nodejs/dist/recording-rasterizer" \
     -v "$ROOT_DIR/common/replay-headless/dist:/code/common/replay-headless/dist" \
     "$IMAGE_NAME" \
     2>&1 | pnpm --filter=@posthog/nodejs exec pino-pretty --colorize

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -49,7 +49,7 @@
         "generate:personhog-proto": "cd ../proto && buf generate --template ../nodejs/buf.gen.yaml --path personhog/service --path personhog/types .",
         "update-ai-costs": "ts-node src/ingestion/ai/costs/scripts/update-ai-costs.ts",
         "sync-segment-icons": "DATABASE_URL=something ts-node src/cdp/segment/sync-segment-icons.ts",
-        "start:recording-rasterizer": "node dist/session-replay/recording-rasterizer/index.js"
+        "start:recording-rasterizer": "node dist/recording-rasterizer/index.js"
     },
     "dependencies": {
         "@amplitude/ua-parser-js": "^0.7.33",


### PR DESCRIPTION
## Problem

The `chore(nodejs): separate ingestion code from CDP` refactor (#64506) moved the recording rasterizer from `src/session-replay/recording-rasterizer` to `src/recording-rasterizer`, so the build now emits `dist/recording-rasterizer/index.js`. Three launch points still pointed at the old `dist/session-replay/recording-rasterizer/index.js`, crashing the worker at startup with `MODULE_NOT_FOUND`. CODEOWNERS also still referenced the old session replay locations.

## Changes

- Update the Dockerfile `CMD` to run `nodejs/dist/recording-rasterizer/index.js`
- Update the `start:recording-rasterizer` script in `nodejs/package.json`
- Update the local-dev volume mount in `bin/temporal-recording-rasterizer-worker`
- Add `nodejs/src/recording-rasterizer/` ownership to team-replay in CODEOWNERS
- Add `nodejs/src/ingestion/pipelines/sessionreplay/` co-ownership to team-replay and team-ingestion
- Remove the dead `nodejs/src/session-replay/` CODEOWNERS entries (no tracked files remain there)

## How did you test this code?

I'm an agent. No automated tests were run — these are path/config changes. Verified by grepping the repo to confirm no remaining references to the old `dist/session-replay/recording-rasterizer` path and that `src/recording-rasterizer/index.ts` is the build entry point.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triggered by a `MODULE_NOT_FOUND` crash after #64506 merged. Traced the moved directory, found the three stale runtime/launch references plus the stale CODEOWNERS entries, and fixed them. For the session replay pipeline ownership (now living inside the ingestion lane at `src/ingestion/pipelines/sessionreplay/`), confirmed with the human that it should be co-owned by team-replay and team-ingestion rather than replay-solo.
