### PR TITLE
feat(logs): collapse keyboard shortcuts into tooltip

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
-import { IconExpand45 } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { IconExpand45, IconKeyboard } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonSegmentedButton, Tooltip } from '@posthog/lemon-ui'
 
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
@@ -63,23 +63,39 @@ export const LogsViewerToolbar = ({
                 {totalLogsCount !== undefined && totalLogsCount > 0 && (
                     <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
                 )}
-                <span className="text-muted text-xs flex items-center gap-1">
-                    <KeyboardShortcut arrowup />
-                    <KeyboardShortcut arrowdown />
-                    or
-                    <KeyboardShortcut j />
-                    <KeyboardShortcut k />
-                    navigate
-                    <span className="mx-1">·</span>
-                    <KeyboardShortcut enter />
-                    expand
-                    <span className="mx-1">·</span>
-                    <KeyboardShortcut p />
-                    prettify
-                    <span className="mx-1">·</span>
-                    <KeyboardShortcut r />
-                    refresh
-                </span>
+                <Tooltip
+                    title={
+                        <div className="flex flex-col gap-1.5 p-1">
+                            <div className="flex items-center justify-between gap-4">
+                                <span>Navigate</span>
+                                <span className="flex items-center gap-1">
+                                    <KeyboardShortcut arrowup />
+                                    <KeyboardShortcut arrowdown />
+                                    or
+                                    <KeyboardShortcut j />
+                                    <KeyboardShortcut k />
+                                </span>
+                            </div>
+                            <div className="flex items-center justify-between gap-4">
+                                <span>Expand</span>
+                                <KeyboardShortcut enter />
+                            </div>
+                            <div className="flex items-center justify-between gap-4">
+                                <span>Prettify</span>
+                                <KeyboardShortcut p />
+                            </div>
+                            <div className="flex items-center justify-between gap-4">
+                                <span>Refresh</span>
+                                <KeyboardShortcut r />
+                            </div>
+                        </div>
+                    }
+                >
+                    <span className="text-muted text-xs flex items-center gap-1 cursor-help">
+                        <IconKeyboard className="text-base" />
+                        Shortcuts
+                    </span>
+                </Tooltip>
             </div>
         </div>
     )

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -91,10 +91,14 @@ export const LogsViewerToolbar = ({
                         </div>
                     }
                 >
-                    <span className="text-muted text-xs flex items-center gap-1 cursor-help">
+                    <button
+                        type="button"
+                        className="text-muted text-xs flex items-center gap-1 cursor-help bg-transparent border-none p-0"
+                        aria-label="Keyboard shortcuts"
+                    >
                         <IconKeyboard className="text-base" />
                         Shortcuts
-                    </span>
+                    </button>
                 </Tooltip>
             </div>
         </div>


### PR DESCRIPTION
## Problem

The logs viewer toolbar renders ~16 inline elements for keyboard shortcuts (`KeyboardShortcut` chips + labels + `·` separators) in a single flex row. They compete for horizontal space and force `flex-wrap`, eating real estate that should belong to the logs themselves.

## Changes

Collapsed the whole shortcut strip into one muted `⌨ Shortcuts` item that reveals the full list on hover via a `Tooltip` (progressive disclosure). The tooltip shows a tidy action → key list for Navigate / Expand / Prettify / Refresh.

Chose a tooltip-embedded `KeyboardShortcut` over a click-popover because it's the dominant convention in the codebase for shortcut hints (PlayerController and others). Lightest option that fits an existing pattern — no new component, no extra state. `KeyboardShortcut` already returns `null` on mobile, so the item only renders where shortcuts apply.

## How did you test this code?

I'm an agent. I ran `typescript:check` (no errors referencing this file) and formatted the single changed file with oxfmt. I did **not** manually verify the tooltip render in a browser.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). Explored existing progressive-disclosure / shortcut-hint patterns before implementing and matched the tooltip convention used elsewhere in the app rather than introducing a popover. One open judgment call: the trigger is hover-only (not keyboard-focusable) — can switch to a `LemonButton` + `Popover` if accessibility via Tab/click is preferred.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*