### PR TITLE
fix(experiments): prevent empty-state flash when closing metrics reorder modal

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/MetricsReorderModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsReorderModal.tsx
@@ -224,7 +224,7 @@ export function MetricsReorderModal({ isSecondary = false }: { isSecondary?: boo
             <div className="flex flex-col gap-2">
                 <DndContext modifiers={[restrictToVerticalAxis, restrictToParentElement]} onDragEnd={handleDragEnd}>
                     <SortableContext items={orderedUuids} strategy={verticalListSortingStrategy}>
-                        {displayMetrics.length === 0 && (
+                        {isOpen && displayMetrics.length === 0 && (
                             <div className="p-4 text-center text-muted">
                                 <p>No metrics available for reordering</p>
                             </div>


### PR DESCRIPTION
## Problem

Closing the "Reorder, move or remove metrics" modal in Experiments briefly flashes the "No metrics available for reordering" empty state.

When the modal closes, `isOpen` flips to `false`, which fires the `useEffect` that resets `orderedUuids` to `[]`. `LemonModal` keeps its content mounted through the close animation, so for that window `displayMetrics` is empty and the empty state renders.

## Changes

Gate the empty-state render on `isOpen` so it only shows while the modal is genuinely open.

## How did you test this code?

I'm an agent. No automated tests added — this is a one-line render-guard change. Verified the logic against the close path: `isOpen` is the same value driving the modal's visibility, so the empty state can no longer render during the exit animation while the real open-with-zero-metrics case is preserved.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced the flash to the `useEffect` resetting `orderedUuids` on close while `LemonModal` content stays mounted through its exit animation, then guarded the empty-state branch on `isOpen`.
