### PR TITLE
fix(warehouse): stage incremental cursor during extraction, promote on consumer completion

### DIFF
--- a/posthog/temporal/data_imports/pipelines/common/extract.py
+++ b/posthog/temporal/data_imports/pipelines/common/extract.py
@@ -259,14 +259,8 @@ async def update_incremental_field_values(
     earliest_incremental_field_value: Any,
     logger: FilteringBoundLogger,
     log_prefix: str = "",
+    staging_run_uuid: str | None = None,
 ) -> tuple[Any, Any]:
-    # Update the incremental_field_last_value.
-    # If the resource returns data sorted in ascending timestamp order, we can update the
-    # `incremental_field_last_value` in the schema.
-    # However, if the data is returned in descending order, we only want to update the
-    # `incremental_field_last_value` once we have processed all of the data, otherwise if we fail halfway through,
-    # we'd not process older data the next time we retry. But we do store the earliest available value so that we
-    # can resume syncs if they stop mid way through without having to start from the beginning
     last_value = get_incremental_field_value(schema, pa_table)
 
     if last_value is not None:
@@ -277,7 +271,12 @@ async def update_incremental_field_values(
             await logger.adebug(
                 f"{log_prefix}Updating incremental_field_last_value with {last_incremental_field_value}"
             )
-            await database_sync_to_async_pool(schema.update_incremental_field_value)(last_incremental_field_value)
+            if staging_run_uuid is not None:
+                await database_sync_to_async_pool(schema.stage_incremental_field_value)(
+                    staging_run_uuid, last_incremental_field_value
+                )
+            else:
+                await database_sync_to_async_pool(schema.update_incremental_field_value)(last_incremental_field_value)
 
         if resource.sort_mode == "desc":
             earliest_value = get_incremental_field_value(schema, pa_table, aggregate="min")
@@ -285,9 +284,14 @@ async def update_incremental_field_values(
             if earliest_incremental_field_value is None or earliest_value < earliest_incremental_field_value:
                 earliest_incremental_field_value = earliest_value
                 await logger.adebug(f"{log_prefix}Updating incremental_field_earliest_value with {earliest_value}")
-                await database_sync_to_async_pool(schema.update_incremental_field_value)(
-                    earliest_value, type="earliest"
-                )
+                if staging_run_uuid is not None:
+                    await database_sync_to_async_pool(schema.stage_incremental_field_value)(
+                        staging_run_uuid, None, earliest_value
+                    )
+                else:
+                    await database_sync_to_async_pool(schema.update_incremental_field_value)(
+                        earliest_value, type="earliest"
+                    )
 
     return last_incremental_field_value, earliest_incremental_field_value
 
@@ -328,16 +332,20 @@ async def finalize_desc_sort_incremental_value(
     last_incremental_field_value: Any,
     logger: FilteringBoundLogger,
     log_prefix: str = "",
+    staging_run_uuid: str | None = None,
 ) -> None:
-    # As mentioned above, for sort mode 'desc' we only want to update the `incremental_field_last_value` once we
-    # have processed all of the data (we could also update it here for 'asc' but it's not needed)
     if resource.sort_mode == "desc" and last_incremental_field_value is not None:
         await logger.adebug(
             f"{log_prefix}Sort mode is 'desc' -> updating incremental_field_last_value "
             f"with {last_incremental_field_value}"
         )
         await database_sync_to_async_pool(schema.refresh_from_db)()
-        await database_sync_to_async_pool(schema.update_incremental_field_value)(last_incremental_field_value)
+        if staging_run_uuid is not None:
+            await database_sync_to_async_pool(schema.stage_incremental_field_value)(
+                staging_run_uuid, last_incremental_field_value
+            )
+        else:
+            await database_sync_to_async_pool(schema.update_incremental_field_value)(last_incremental_field_value)
 
 
 async def advance_xmin_state(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -288,8 +288,6 @@ def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
 
 
 def _promote_staged_cursor(export_signal: ExportSignalMessage) -> None:
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-
     close_old_connections()
     try:
         schema = ExternalDataSchema.objects.get(id=export_signal.schema_id, team_id=export_signal.team_id)

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -265,6 +265,8 @@ def _release_pipeline_lock_for_job(export_signal: ExportSignalMessage) -> None:
 
 
 def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
+    _promote_staged_cursor(export_signal)
+
     update_external_job_status(
         job_id=export_signal.job_id,
         team_id=export_signal.team_id,
@@ -283,6 +285,28 @@ def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
     )
 
     _release_pipeline_lock_for_job(export_signal)
+
+
+def _promote_staged_cursor(export_signal: ExportSignalMessage) -> None:
+    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+
+    close_old_connections()
+    try:
+        schema = ExternalDataSchema.objects.get(id=export_signal.schema_id, team_id=export_signal.team_id)
+        promoted = schema.promote_staged_incremental_values(export_signal.run_uuid)
+        if promoted:
+            logger.info(
+                "staged_cursor_promoted",
+                run_uuid=export_signal.run_uuid,
+                external_data_schema_id=export_signal.schema_id,
+            )
+    except Exception as e:
+        logger.exception(
+            "staged_cursor_promotion_failed",
+            run_uuid=export_signal.run_uuid,
+            external_data_schema_id=export_signal.schema_id,
+        )
+        capture_exception(e)
 
 
 def _mark_job_failed(export_signal: ExportSignalMessage, error: Exception) -> None:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -1,12 +1,16 @@
 from typing import Any
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 from parameterized import parameterized
 
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
-from posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor import _apply_partitioning, _get_write_type
+from posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor import (
+    _apply_partitioning,
+    _get_write_type,
+    _promote_staged_cursor,
+)
 from posthog.temporal.data_imports.pipelines.test_mocks import mock_delta_table
 
 
@@ -111,3 +115,42 @@ class TestApplyPartitioning:
 
         assert PARTITION_KEY not in result.column_names
         assert result.equals(pa_table)
+
+
+class TestPromoteStagedCursor:
+    def _make_signal(self, **overrides: Any) -> MagicMock:
+        signal = MagicMock()
+        signal.schema_id = overrides.get("schema_id", "schema-1")
+        signal.team_id = overrides.get("team_id", 1)
+        signal.run_uuid = overrides.get("run_uuid", "run-abc-a1")
+        signal.job_id = overrides.get("job_id", "job-1")
+        return signal
+
+    @patch("posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor.ExternalDataSchema.objects")
+    def test_promotes_when_run_uuid_matches(self, mock_objects: MagicMock) -> None:
+        schema = MagicMock()
+        schema.promote_staged_incremental_values.return_value = True
+        mock_objects.get.return_value = schema
+
+        signal = self._make_signal()
+        _promote_staged_cursor(signal)
+
+        mock_objects.get.assert_called_once_with(id="schema-1", team_id=1)
+        schema.promote_staged_incremental_values.assert_called_once_with("run-abc-a1")
+
+    @patch("posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor.ExternalDataSchema.objects")
+    def test_does_not_raise_on_promotion_failure(self, mock_objects: MagicMock) -> None:
+        schema = MagicMock()
+        schema.promote_staged_incremental_values.side_effect = RuntimeError("db error")
+        mock_objects.get.return_value = schema
+
+        signal = self._make_signal()
+        _promote_staged_cursor(signal)
+
+    @patch("posthog.temporal.data_imports.pipelines.pipeline_v3.load.processor.ExternalDataSchema.objects")
+    def test_does_not_raise_when_schema_missing(self, mock_objects: MagicMock) -> None:
+        from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+
+        mock_objects.get.side_effect = ExternalDataSchema.DoesNotExist()
+        signal = self._make_signal()
+        _promote_staged_cursor(signal)

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -350,6 +350,7 @@ class PipelineV3(Generic[ResumableData]):
             self._earliest_incremental_field_value,
             self._logger,
             log_prefix="V3 Pipeline: ",
+            staging_run_uuid=self._s3_batch_writer.get_run_uuid(),
         )
 
         await update_row_tracking_after_batch(
@@ -384,7 +385,12 @@ class PipelineV3(Generic[ResumableData]):
         )
 
         await finalize_desc_sort_incremental_value(
-            self._resource, self._schema, self._last_incremental_field_value, self._logger, log_prefix="V3 Pipeline: "
+            self._resource,
+            self._schema,
+            self._last_incremental_field_value,
+            self._logger,
+            log_prefix="V3 Pipeline: ",
+            staging_run_uuid=self._s3_batch_writer.get_run_uuid(),
         )
 
         await advance_xmin_state(self._resource, self._schema, self._logger, log_prefix="V3 Pipeline: ")

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -320,7 +320,11 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         self.save()
 
     def stage_incremental_field_value(self, run_uuid: str, last_value: Any, earliest_value: Any = None) -> None:
-        staged: dict[str, Any] = {"run_uuid": run_uuid}
+        existing = self.sync_type_config.get("incremental_staged", {})
+        if existing.get("run_uuid") == run_uuid:
+            staged = existing
+        else:
+            staged = {"run_uuid": run_uuid}
         if last_value is not None:
             staged["last_value"] = self._serialize_incremental_value(last_value)
         if earliest_value is not None:

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -319,10 +319,60 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         self.sync_type_config["partition_format"] = partition_format
         self.save()
 
+    def stage_incremental_field_value(self, run_uuid: str, last_value: Any, earliest_value: Any = None) -> None:
+        staged: dict[str, Any] = {"run_uuid": run_uuid}
+        if last_value is not None:
+            staged["last_value"] = self._serialize_incremental_value(last_value)
+        if earliest_value is not None:
+            staged["earliest_value"] = self._serialize_incremental_value(earliest_value)
+        self.sync_type_config["incremental_staged"] = staged
+        self.save()
+
+    def promote_staged_incremental_values(self, run_uuid: str) -> bool:
+        staged = self.sync_type_config.get("incremental_staged")
+        if not staged or staged.get("run_uuid") != run_uuid:
+            return False
+        if "last_value" in staged:
+            self.sync_type_config["incremental_field_last_value"] = staged["last_value"]
+        if "earliest_value" in staged:
+            self.sync_type_config["incremental_field_earliest_value"] = staged["earliest_value"]
+        self.sync_type_config.pop("incremental_staged", None)
+        self.save()
+        return True
+
+    def _serialize_incremental_value(self, value: Any) -> Any:
+        incremental_field_type = self.sync_type_config.get("incremental_field_type")
+        if "numpy" in sys.modules:
+            import numpy  # noqa: PLC0415
+
+            value = value.item() if isinstance(value, numpy.generic) else value
+        if value is None:
+            return None
+        if (
+            incremental_field_type == IncrementalFieldType.Integer
+            or incremental_field_type == IncrementalFieldType.Numeric
+        ):
+            if isinstance(value, int | float):
+                return value
+            elif isinstance(value, datetime):
+                return value.isoformat()
+            else:
+                return int(value)
+        elif (
+            incremental_field_type == IncrementalFieldType.DateTime
+            or incremental_field_type == IncrementalFieldType.Timestamp
+        ):
+            if isinstance(value, datetime):
+                return value.isoformat()
+            else:
+                return str(value)
+        return str(value)
+
     def update_sync_type_config_for_reset_pipeline(self) -> None:
         self.sync_type_config.pop("reset_pipeline", None)
         self.sync_type_config.pop("incremental_field_last_value", None)
         self.sync_type_config.pop("incremental_field_earliest_value", None)
+        self.sync_type_config.pop("incremental_staged", None)
         self.sync_type_config.pop("partitioning_enabled", None)
         self.sync_type_config.pop("partition_size", None)
         self.sync_type_config.pop("partition_count", None)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -212,12 +212,22 @@ class TestStagedIncrementalCursor:
         staged = schema.sync_type_config["incremental_staged"]
         assert staged == {"run_uuid": "run-1", "earliest_value": 10}
 
-    def test_stage_overwrites_previous_staged(self) -> None:
-        schema = self._make_schema(incremental_staged={"run_uuid": "old", "last_value": 1})
+    def test_stage_overwrites_when_different_run_uuid(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "old", "last_value": 1, "earliest_value": 5})
         with patch.object(schema, "save"):
             schema.stage_incremental_field_value("run-2", 99)
-        assert schema.sync_type_config["incremental_staged"]["run_uuid"] == "run-2"
-        assert schema.sync_type_config["incremental_staged"]["last_value"] == 99
+        staged = schema.sync_type_config["incremental_staged"]
+        assert staged["run_uuid"] == "run-2"
+        assert staged["last_value"] == 99
+        assert "earliest_value" not in staged
+
+    def test_stage_merges_when_same_run_uuid(self) -> None:
+        schema = self._make_schema()
+        with patch.object(schema, "save"):
+            schema.stage_incremental_field_value("run-1", None, earliest_value=10)
+            schema.stage_incremental_field_value("run-1", 42)
+        staged = schema.sync_type_config["incremental_staged"]
+        assert staged == {"run_uuid": "run-1", "earliest_value": 10, "last_value": 42}
 
     def test_promote_moves_last_value_to_live(self) -> None:
         schema = self._make_schema(incremental_staged={"run_uuid": "run-1", "last_value": 42})

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -186,3 +186,69 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
 )
 def test_apply_incremental_lookback(value, field_type, lookback_seconds, expected) -> None:
     assert apply_incremental_lookback(value, field_type, lookback_seconds) == expected
+
+
+class TestStagedIncrementalCursor:
+    def _make_schema(self, **config: object) -> ExternalDataSchema:
+        schema = ExternalDataSchema(
+            sync_type_config={
+                "incremental_field_type": IncrementalFieldType.Integer,
+                **config,
+            }
+        )
+        return schema
+
+    def test_stage_writes_run_uuid_and_last_value(self) -> None:
+        schema = self._make_schema()
+        with patch.object(schema, "save"):
+            schema.stage_incremental_field_value("run-1", 42)
+        staged = schema.sync_type_config["incremental_staged"]
+        assert staged == {"run_uuid": "run-1", "last_value": 42}
+
+    def test_stage_writes_earliest_value(self) -> None:
+        schema = self._make_schema()
+        with patch.object(schema, "save"):
+            schema.stage_incremental_field_value("run-1", None, earliest_value=10)
+        staged = schema.sync_type_config["incremental_staged"]
+        assert staged == {"run_uuid": "run-1", "earliest_value": 10}
+
+    def test_stage_overwrites_previous_staged(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "old", "last_value": 1})
+        with patch.object(schema, "save"):
+            schema.stage_incremental_field_value("run-2", 99)
+        assert schema.sync_type_config["incremental_staged"]["run_uuid"] == "run-2"
+        assert schema.sync_type_config["incremental_staged"]["last_value"] == 99
+
+    def test_promote_moves_last_value_to_live(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "run-1", "last_value": 42})
+        with patch.object(schema, "save"):
+            result = schema.promote_staged_incremental_values("run-1")
+        assert result is True
+        assert schema.sync_type_config["incremental_field_last_value"] == 42
+        assert "incremental_staged" not in schema.sync_type_config
+
+    def test_promote_moves_earliest_value_to_live(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "run-1", "earliest_value": 5})
+        with patch.object(schema, "save"):
+            result = schema.promote_staged_incremental_values("run-1")
+        assert result is True
+        assert schema.sync_type_config["incremental_field_earliest_value"] == 5
+
+    def test_promote_rejects_wrong_run_uuid(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "run-1", "last_value": 42})
+        with patch.object(schema, "save"):
+            result = schema.promote_staged_incremental_values("run-WRONG")
+        assert result is False
+        assert "incremental_field_last_value" not in schema.sync_type_config
+
+    def test_promote_returns_false_when_no_staged(self) -> None:
+        schema = self._make_schema()
+        with patch.object(schema, "save"):
+            result = schema.promote_staged_incremental_values("run-1")
+        assert result is False
+
+    def test_reset_pipeline_clears_staged(self) -> None:
+        schema = self._make_schema(incremental_staged={"run_uuid": "run-1", "last_value": 42})
+        with patch.object(schema, "save"):
+            schema.update_sync_type_config_for_reset_pipeline()
+        assert "incremental_staged" not in schema.sync_type_config


### PR DESCRIPTION
## Problem

In the V3 warehouse pipeline, the producer directly updates the incremental cursor (`incremental_field_last_value` / `incremental_field_earliest_value`) on `ExternalDataSchema` during extraction. If extraction completes but the consumer crashes before loading all batches, the cursor has already advanced past data that was never loaded. On retry, those rows are skipped, causing silent data loss.

## Changes

Introduces a staged cursor pattern: during extraction, incremental values are written to a staging slot (`sync_type_config["incremental_staged"]`) instead of the live cursor. The consumer promotes staged values to live only after all batches are successfully loaded.

**Model layer** (`ExternalDataSchema`):
- `stage_incremental_field_value(run_uuid, last_value, earliest_value)` writes to the staging slot
- `promote_staged_incremental_values(run_uuid)` atomically moves staged values to live keys, rejecting mismatched `run_uuid`
- `update_sync_type_config_for_reset_pipeline()` clears the staging slot

**Extract layer** (`extract.py`):
- `update_incremental_field_values` and `finalize_desc_sort_incremental_value` accept `staging_run_uuid` param. When set, they stage instead of writing directly.

**Pipeline V3** (`pipeline.py`):
- Passes `staging_run_uuid=self._s3_batch_writer.get_run_uuid()` to both extract functions

**Consumer** (`processor.py`):
- `_promote_staged_cursor` called from `_mark_job_completed` before status update. Errors are logged and captured but don't block job completion.

## How did you test this code?

Agent-authored. Ran the following test suites:

- `products/warehouse_sources/backend/tests/test_models.py::TestStagedIncrementalCursor` (8 tests): staging, promoting, run_uuid mismatch rejection, reset cleanup
- `posthog/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py::TestPromoteStagedCursor` (3 tests): promotion call, error resilience, missing schema handling

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is fix 1 from a Fable-generated investigation of the V3 warehouse pipeline. The staged cursor approach was chosen over alternatives (e.g., deferred cursor write at finalize-only) because it preserves per-batch progress visibility while keeping the live cursor safe from premature advancement. The `run_uuid` guard ensures stale attempts from prior retries can't promote their values over a successful run.