### PR TITLE
fix(deps): align ai_gateway posthog-js lockfile entry to 1.391.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2564,7 +2564,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.391.6
+        version: 1.391.7
       react:
         specifier: 18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` is failing on master and on every open PR that merges master:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'posthog-js@1.391.6' in pnpm-lock.yaml
```

The `posthog-js` catalog in `pnpm-workspace.yaml` is `^1.391.7`, but the `products/ai_gateway` importer in `pnpm-lock.yaml` still resolves it to `1.391.6`. That single stale entry makes the lockfile inconsistent with the catalog, so every frozen-lockfile install (jest, frontend formatting/typecheck, build, unit tests, MCP, playwright) dies before doing any real work.

## Changes

One line: `products/ai_gateway` → `posthog-js` resolves to `1.391.7` (matching the catalog), regenerating what the lockfile would have contained had the bump and the new importer landed in order.

Root cause: a merge-ordering race. #65159 bumped the catalog to `1.391.7` and regenerated the lockfile at 10:54. ~17 min later #64511 ("add AI gateway usage page") merged **without rebasing** past the bump — its branch was cut when the catalog was still `1.391.6`, so its newly-added `products/ai_gateway` importer block pinned `1.391.6`. Git had no way to know the earlier bump should rewrite a block that didn't exist yet, so the stale resolution slipped onto master.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated check I actually ran, against a clean worktree off `origin/master` with this fix applied:

```
pnpm --filter=@posthog/playwright... install --frozen-lockfile   # exit 0, previously exit 1
```

Confirmed zero remaining `1.391.6` references in the lockfile and that the diff is exactly one line.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced while fixing CI on an unrelated signals PR (#65155), whose install-dependent jobs were all failing for this reason rather than anything in that PR's diff. Root-caused the breakage to master itself and split this minimal lockfile fix into its own PR rather than carrying it on the feature branch. Tool used: Claude Code. No repo skills were needed for the fix; the catalog/lockfile mechanics were verified empirically with `pnpm`.
