### PR TITLE
fix(deps): align ai_gateway posthog-js lockfile entry to 1.391.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2564,7 +2564,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.391.6
+        version: 1.391.7
       react:
         specifier: 18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Problem

The `Container Images CD` build on master is failing at the `pnpm --frozen-lockfile` step:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'posthog-js@1.391.6' in pnpm-lock.yaml
```

A botched merge left the `products/ai_gateway` importer in `pnpm-lock.yaml` resolving `posthog-js` to `1.391.6`, while the catalog (`^1.391.7`) and all 27 other importers use `1.391.7`. There is no `packages:`/`snapshots:` entry for `1.391.6`, so the frozen install rejects the lockfile and the image build aborts.

## Changes

Bump the single stale `products/ai_gateway` importer entry from `1.391.6` to `1.391.7`. One-line change; the `1.391.7` package and snapshot entries already exist in the lockfile.

## How did you test this code?

I'm an agent (PostHog Slack app). I ran `pnpm install --frozen-lockfile --filter=@posthog/plugin-transpiler...` (the exact target that failed in CI) locally against the edited lockfile — it now resolves and installs cleanly. No manual app testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a failing master CD build at Ben White's request from a Slack thread. Traced the Depot build failure to a `frozen-lockfile` mismatch, isolated the single stale importer (`products/ai_gateway`, line 2567), and confirmed the fix by reproducing the failing `--frozen-lockfile` install locally before and after the edit. No skills invoked. Chose a surgical one-line edit over a full `pnpm install --no-frozen-lockfile` regen to keep the diff minimal and avoid incidental lockfile churn.
