### PR TITLE
feat(error-tracking): new issue filter bar and picker

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -1,7 +1,7 @@
 import { Placement } from '@floating-ui/react'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { forwardRef, useRef, useState } from 'react'
+import { ForwardedRef, ReactNode, forwardRef, useRef, useState } from 'react'
 
 import { IconCalendar, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDivider, LemonSwitch, Popover } from '@posthog/lemon-ui'
@@ -33,10 +33,19 @@ import { RelativeDateRangeSelector } from './RelativeDateRangeSelector'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
 import { DateOption } from './rollingDateRangeFilterLogic'
 
+export interface DateFilterTriggerProps {
+    label: ReactNode
+    isOpen: boolean
+    onClick: () => void
+    disabledReason?: string | null
+    tooltip: string
+    ref: ForwardedRef<HTMLButtonElement>
+}
+
 export interface DateFilterProps {
     showCustom?: boolean
     showRollingRangePicker?: boolean
-    makeLabel?: (key: React.ReactNode, startOfRange?: React.ReactNode, endOfRange?: React.ReactNode) => React.ReactNode
+    makeLabel?: (key: ReactNode, startOfRange?: ReactNode, endOfRange?: ReactNode) => ReactNode
     className?: string
     onChange?: (fromDate: string | null, toDate: string | null, explicitDate?: boolean) => void
     disabled?: boolean
@@ -45,6 +54,8 @@ export interface DateFilterProps {
     isDateFormatted?: boolean
     size?: LemonButtonProps['size']
     type?: LemonButtonProps['type']
+    /** Render a custom trigger instead of the default LemonButton. `size`, `type`, and `fullWidth` are ignored. */
+    renderTrigger?: (props: DateFilterTriggerProps) => JSX.Element
     dropdownPlacement?: Placement
     /* True when we're not dealing with ranges, but a single date / relative date */
     isFixedDateMode?: boolean
@@ -95,6 +106,7 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
         isDateFormatted = true,
         size,
         type,
+        renderTrigger,
         dropdownPlacement = 'bottom-start',
         max,
         isFixedDateMode = false,
@@ -393,20 +405,31 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
             onClickOutside={close}
             closeParentPopoverOnClickInside={false}
         >
-            <LemonButton
-                ref={ref}
-                id="daterange_selector"
-                size={size ?? 'small'}
-                type={type ?? 'secondary'}
-                disabledReason={disabledReason}
-                data-attr="date-filter"
-                icon={<IconCalendar />}
-                onClick={isVisible ? close : open}
-                fullWidth={fullWidth}
-                tooltip={formatResolvedDateRange(resolvedDateRange)}
-            >
-                <span className={clsx('text-nowrap', className)}>{label}</span>
-            </LemonButton>
+            {renderTrigger ? (
+                renderTrigger({
+                    ref,
+                    label: <span className={clsx('text-nowrap', className)}>{label}</span>,
+                    onClick: isVisible ? close : open,
+                    isOpen: isVisible,
+                    disabledReason,
+                    tooltip: formatResolvedDateRange(resolvedDateRange),
+                })
+            ) : (
+                <LemonButton
+                    ref={ref}
+                    id="daterange_selector"
+                    size={size ?? 'small'}
+                    type={type ?? 'secondary'}
+                    disabledReason={disabledReason}
+                    data-attr="date-filter"
+                    icon={<IconCalendar />}
+                    onClick={isVisible ? close : open}
+                    fullWidth={fullWidth}
+                    tooltip={formatResolvedDateRange(resolvedDateRange)}
+                >
+                    <span className={clsx('text-nowrap', className)}>{label}</span>
+                </LemonButton>
+            )}
         </Popover>
     )
 })

--- a/frontend/src/lib/components/FilterBar/FilterBar.stories.tsx
+++ b/frontend/src/lib/components/FilterBar/FilterBar.stories.tsx
@@ -1,0 +1,256 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useMemo, useState } from 'react'
+
+import { IconCircleDashed, IconCheckCircle, IconClock, IconPerson, IconWarning, IconX } from '@posthog/icons'
+
+import { FilterPickerNode, FilterPickerToken } from '../FilterPicker'
+import { FilterBar, FilterBarSortOption, SortDirection } from './FilterBar'
+
+const meta: Meta<typeof FilterBar> = {
+    title: 'Filters/Filter Bar',
+    component: FilterBar,
+    parameters: {
+        testOptions: { include3000: true },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof FilterBar>
+
+const SORT_OPTIONS: FilterBarSortOption[] = [
+    { value: 'last_seen', label: 'Last seen' },
+    { value: 'first_seen', label: 'First seen' },
+    { value: 'occurrences', label: 'Occurrences' },
+    { value: 'users', label: 'Users affected' },
+]
+
+const ISSUE_SECTION = { id: 'issue', label: 'Issue', icon: <IconWarning /> }
+const PERSON_SECTION = { id: 'person', label: 'Person', icon: <IconPerson /> }
+const TIME_SECTION = { id: 'time', label: 'Time', icon: <IconClock /> }
+
+function token(id: string, parts: string[], editPath: string[], onRemove: () => void): FilterPickerToken {
+    return {
+        id,
+        editPath: { nodeIds: editPath },
+        onRemove,
+        parts: parts.map((part, index) => ({
+            key: `${id}-${index}`,
+            kind: index === 1 ? 'operator' : 'text',
+            label: part,
+        })),
+    }
+}
+
+function useStoryFilterRoot(): {
+    rootNodes: FilterPickerNode[]
+    tokens: FilterPickerToken[]
+    setStatus: (status: string | null) => void
+    setAssignee: (assignee: string | null) => void
+    setLastSeen: (lastSeen: string | null) => void
+} {
+    const [status, setStatus] = useState<string | null>('Active')
+    const [assignee, setAssignee] = useState<string | null>('Jane Cooper')
+    const [lastSeen, setLastSeen] = useState<string | null>('Last 24 hours')
+
+    const rootNodes = useMemo<FilterPickerNode[]>(() => {
+        const statuses = [
+            { value: 'Active', icon: <IconCircleDashed /> },
+            { value: 'Resolved', icon: <IconCheckCircle /> },
+            { value: 'Suppressed', icon: <IconX /> },
+        ]
+        const assignees = ['Jane Cooper', 'Wade Warren', 'Product engineers']
+        const timeValues = ['Last hour', 'Last 24 hours', 'Last 7 days', 'Last 30 days']
+
+        return [
+            {
+                id: 'status',
+                label: 'Status',
+                section: ISSUE_SECTION,
+                kind: 'branch',
+                searchPlaceholder: 'Search statuses…',
+                getChildren: ({ query }) => ({
+                    isLoading: false,
+                    nodes: statuses
+                        .filter((option) => option.value.toLowerCase().includes(query.toLowerCase()))
+                        .map((option) => ({
+                            id: `status:${option.value}`,
+                            label: option.value,
+                            hint: 'State',
+                            kind: 'action',
+                            onSelect: ({ close }) => {
+                                setStatus(option.value)
+                                close()
+                            },
+                        })),
+                }),
+            },
+            {
+                id: 'assignee',
+                label: 'Assignee',
+                section: PERSON_SECTION,
+                kind: 'branch',
+                searchPlaceholder: 'Search assignees…',
+                getChildren: ({ query }) => ({
+                    isLoading: false,
+                    nodes: assignees
+                        .filter((name) => name.toLowerCase().includes(query.toLowerCase()))
+                        .map((name) => ({
+                            id: `assignee:${name}`,
+                            label: name,
+                            hint: name === 'Product engineers' ? 'Role' : 'User',
+                            kind: 'action',
+                            onSelect: ({ close }) => {
+                                setAssignee(name)
+                                close()
+                            },
+                        })),
+                }),
+            },
+            {
+                id: 'last-seen',
+                label: 'Last seen',
+                section: TIME_SECTION,
+                kind: 'branch',
+                searchPlaceholder: 'Choose a time filter…',
+                getChildren: ({ query }) => ({
+                    isLoading: false,
+                    nodes: timeValues
+                        .filter((value) => value.toLowerCase().includes(query.toLowerCase()))
+                        .map((value) => ({
+                            id: `last-seen:${value}`,
+                            label: value,
+                            hint: 'Shortcut',
+                            kind: 'action',
+                            onSelect: ({ close }) => {
+                                setLastSeen(value)
+                                close()
+                            },
+                        })),
+                }),
+            },
+        ]
+    }, [])
+
+    const tokens = [
+        ...(status ? [token(`status:${status}`, ['Status', '=', status], ['status'], () => setStatus(null))] : []),
+        ...(assignee
+            ? [token(`assignee:${assignee}`, ['Assignee', '=', assignee], ['assignee'], () => setAssignee(null))]
+            : []),
+        ...(lastSeen
+            ? [token(`last-seen:${lastSeen}`, ['Last seen', '=', lastSeen], ['last-seen'], () => setLastSeen(null))]
+            : []),
+    ]
+
+    return { rootNodes, tokens, setStatus, setAssignee, setLastSeen }
+}
+
+function Template({
+    manyTokens = false,
+    disabled = false,
+    loading = false,
+    longValues = false,
+}: {
+    manyTokens?: boolean
+    disabled?: boolean
+    loading?: boolean
+    longValues?: boolean
+}): JSX.Element {
+    const { rootNodes, tokens, setStatus } = useStoryFilterRoot()
+    const [dateFrom, setDateFrom] = useState<string | null>('-7d')
+    const [dateTo, setDateTo] = useState<string | null>(null)
+    const [sortValue, setSortValue] = useState('last_seen')
+    const [sortDirection, setSortDirection] = useState<SortDirection>('DESC')
+
+    const displayTokens = [...tokens]
+    if (manyTokens) {
+        displayTokens.push(
+            token('priority:high', ['Priority', '=', 'High'], ['status'], () => {}),
+            token('source:web', ['Source', '=', 'Browser'], ['status'], () => {}),
+            token('release:latest', ['Release', '=', '2026.06.20'], ['status'], () => {})
+        )
+    }
+    if (longValues) {
+        displayTokens.push(
+            token(
+                'message:long',
+                [
+                    'Exception message',
+                    '∋',
+                    'A very long error message value that should truncate cleanly in the toolbar',
+                ],
+                ['status'],
+                () => {}
+            )
+        )
+    }
+
+    return (
+        <div className="max-w-[760px] p-4">
+            <FilterBar
+                pickerRootNodes={rootNodes}
+                pickerTokens={displayTokens}
+                reloadConfig={{ onReload: () => setStatus('Active'), loading }}
+                dateConfig={{
+                    dateFrom,
+                    dateTo,
+                    onDateChange: (from, to) => {
+                        setDateFrom(from)
+                        setDateTo(to)
+                    },
+                }}
+                sortConfig={{
+                    options: SORT_OPTIONS,
+                    value: sortValue,
+                    direction: sortDirection,
+                    onChange: (value, direction) => {
+                        setSortValue(value)
+                        setSortDirection(direction)
+                    },
+                }}
+                disabledReason={disabled ? 'Filters are disabled while data loads' : undefined}
+                loading={loading}
+            />
+        </div>
+    )
+}
+
+export const BareToolbar: Story = {
+    render: () => <Template />,
+    parameters: {
+        docs: { description: { story: 'Reload, date, sort, and add-filter controls using generic picker nodes.' } },
+    },
+}
+
+export const MultipleTokensWrapping: Story = {
+    render: () => <Template manyTokens />,
+}
+
+export const EditableTokenFlow: Story = {
+    render: () => <Template />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'Click a token to open the same picker at its edit path. The back affordance returns to root; the path pill clears search and resets to root. The remove segment does not open edit.',
+            },
+        },
+    },
+}
+
+export const DisabledAndLoadingStates: Story = {
+    render: () => <Template disabled loading />,
+}
+
+export const LongTokenValues: Story = {
+    render: () => <Template longValues />,
+}
+
+export const FilterOnly: Story = {
+    render: () => {
+        const { rootNodes, tokens } = useStoryFilterRoot()
+        return (
+            <div className="p-4">
+                <FilterBar pickerRootNodes={rootNodes} pickerTokens={tokens} />
+            </div>
+        )
+    },
+}

--- a/frontend/src/lib/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/lib/components/FilterBar/FilterBar.tsx
@@ -1,0 +1,443 @@
+import { useActions, useValues } from 'kea'
+import { memo, ReactNode, useMemo, useState } from 'react'
+
+import { IconArrowRight, IconCalendar, IconFilter, IconRefresh, IconSort } from '@posthog/icons'
+
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from 'lib/ui/quill'
+import { cn } from 'lib/utils/css-classes'
+
+import { UniversalFiltersGroup } from '~/types'
+
+import { DateFilter } from '../DateFilter/DateFilter'
+import {
+    FilterPicker,
+    FilterPickerNode,
+    FilterPickerPath,
+    FilterPickerToken,
+    FilterPickerTokenPill,
+} from '../FilterPicker'
+import { ExcludedProperties, TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+import { UniversalFilterButton } from '../UniversalFilters/UniversalFilterButton'
+import UniversalFilters from '../UniversalFilters/UniversalFilters'
+import { universalFiltersLogic } from '../UniversalFilters/universalFiltersLogic'
+import { isUniversalGroupFilterLike } from '../UniversalFilters/utils'
+import { FilterMenuRoot, MenuNode, TaxonomicMenuFilter } from './FilterMenu'
+
+export type SortDirection = 'ASC' | 'DESC'
+
+export interface FilterBarSortOption {
+    value: string
+    label: string
+}
+
+export interface FilterBarToken {
+    key: string
+    label: ReactNode
+    parts?: ReactNode[]
+    title?: string
+    onRemove?: () => void
+    onClick?: () => void
+}
+
+export interface FilterBarNodeRoot {
+    kind: 'node'
+    node: MenuNode
+    token?: FilterBarToken | null
+}
+
+export type FilterBarRoot = FilterMenuRoot | FilterBarNodeRoot
+
+export interface FilterBarDateConfig {
+    dateFrom?: string | null
+    dateTo?: string | null
+    onDateChange: (dateFrom: string | null, dateTo: string | null) => void
+}
+
+export interface FilterBarReloadConfig {
+    onReload: () => void
+    loading?: boolean
+    disabled?: boolean
+}
+
+export interface FilterBarSortConfig {
+    options: FilterBarSortOption[]
+    value?: string
+    direction?: SortDirection
+    onChange: (value: string, direction: SortDirection) => void
+}
+
+export interface FilterBarProps {
+    pickerRootNodes?: FilterPickerNode[]
+    pickerTokens?: FilterPickerToken[]
+    pickerPlaceholder?: string
+    dateConfig?: FilterBarDateConfig
+    sortConfig?: FilterBarSortConfig
+    reloadConfig?: FilterBarReloadConfig
+    disabledReason?: string
+    loading?: boolean
+
+    /**
+     * Legacy compatibility wiring for Web analytics, marketing analytics, endpoints,
+     * customer analytics, and revenue analytics.
+     */
+    rootKey?: string
+    filterGroup?: UniversalFiltersGroup
+    onFilterChange?: (group: UniversalFiltersGroup) => void
+    taxonomicGroupTypes?: TaxonomicFilterGroupType[]
+    roots?: FilterBarRoot[]
+    excludedProperties?: ExcludedProperties
+    includeTaxonomicCategories?: boolean
+
+    /** Legacy toolbar props. Prefer dateConfig/sortConfig/reloadConfig. */
+    onReload?: () => void
+    reloadLoading?: boolean
+    dateFrom?: string | null
+    dateTo?: string | null
+    onDateChange?: (dateFrom: string | null, dateTo: string | null) => void
+    sortOptions?: FilterBarSortOption[]
+    sortValue?: string
+    sortDirection?: SortDirection
+    onSortChange?: (value: string, direction: SortDirection) => void
+    tokens?: FilterBarToken[]
+
+    className?: string
+}
+
+const ISLAND =
+    'flex items-center shrink-0 overflow-hidden rounded-lg border bg-[var(--color-bg-fill-input)] shadow-sm [&_.button-primitive]:!rounded-none'
+
+const GroupDivider = (): JSX.Element => <div className="w-px self-stretch bg-border" />
+
+export function FilterBar(props: FilterBarProps): JSX.Element {
+    const { rootKey, filterGroup, onFilterChange, taxonomicGroupTypes } = props
+
+    if (rootKey && filterGroup && onFilterChange && taxonomicGroupTypes) {
+        return (
+            <UniversalFilters
+                rootKey={rootKey}
+                group={filterGroup}
+                taxonomicGroupTypes={taxonomicGroupTypes}
+                onChange={onFilterChange}
+            >
+                <BarContents {...props} />
+            </UniversalFilters>
+        )
+    }
+
+    return <BarContents {...props} />
+}
+
+// Legacy compatibility bridge: adapts the older FilterMenu `MenuNode` tree into the generic
+// `FilterPickerNode` tree for Web/marketing/customer/revenue analytics and endpoints. Remove once those
+// consumers move to the generic picker API directly (see TASKS.md Batch 8 decision).
+function menuNodeToPickerNode(node: MenuNode): FilterPickerNode {
+    const shared = {
+        id: node.id,
+        label: node.label,
+        tokenLabel: node.pillLabel,
+        hint: node.hint,
+        section: node.section ? { id: node.section, label: node.section, icon: node.sectionIcon } : undefined,
+        searchPlaceholder: node.searchPlaceholder,
+    }
+
+    if (node.renderPanel) {
+        return { ...shared, kind: 'panel', renderPanel: ({ close }) => node.renderPanel?.({ close }) }
+    }
+
+    if (node.useChildren) {
+        return {
+            ...shared,
+            kind: 'branch',
+            getChildren: ({ query }) => {
+                const result = node.useChildren?.(query) ?? { nodes: [], isLoading: false }
+                return { ...result, nodes: result.nodes.map(menuNodeToPickerNode) }
+            },
+        }
+    }
+
+    return { ...shared, kind: 'action', onSelect: ({ close }) => node.onSelect?.({ close }) }
+}
+
+// Legacy compatibility bridge: adapts the older `FilterBarToken` into the generic `FilterPickerToken`.
+function legacyTokenToPickerToken(token: FilterBarToken, editPath?: FilterPickerPath): FilterPickerToken {
+    return {
+        id: token.key,
+        title: token.title ?? (typeof token.label === 'string' ? token.label : undefined),
+        editPath,
+        removable: !!token.onRemove,
+        editable: !!editPath || !!token.onClick,
+        onRemove: token.onRemove,
+        parts: token.parts?.length
+            ? token.parts.map((part, index) => ({ key: String(index), kind: 'text', label: part }))
+            : [{ key: 'label', kind: 'text', label: token.label }],
+    }
+}
+
+function BarContents({
+    pickerRootNodes,
+    pickerTokens,
+    pickerPlaceholder = 'Filter by property...',
+    dateConfig,
+    sortConfig,
+    reloadConfig,
+    disabledReason,
+    loading,
+    taxonomicGroupTypes = [],
+    roots,
+    excludedProperties,
+    includeTaxonomicCategories,
+    onReload,
+    reloadLoading,
+    dateFrom,
+    dateTo,
+    onDateChange,
+    sortOptions,
+    sortValue,
+    sortDirection = 'DESC',
+    onSortChange,
+    tokens,
+    className,
+}: FilterBarProps): JSX.Element {
+    const rootNodes = useMemo<FilterPickerNode[]>(
+        () =>
+            pickerRootNodes ??
+            roots?.flatMap((root) => ('node' in root ? [menuNodeToPickerNode(root.node)] : [])) ??
+            [],
+        [pickerRootNodes, roots]
+    )
+    const displayedTokens = useMemo<FilterPickerToken[]>(() => {
+        if (pickerTokens) {
+            return pickerTokens
+        }
+        const rootTokens =
+            roots?.flatMap((root) =>
+                'token' in root && root.token
+                    ? [legacyTokenToPickerToken(root.token, 'node' in root ? { nodeIds: [root.node.id] } : undefined)]
+                    : []
+            ) ?? []
+        return [...rootTokens, ...(tokens?.map((token) => legacyTokenToPickerToken(token)) ?? [])]
+    }, [pickerTokens, roots, tokens])
+
+    const activeDate = dateConfig ?? (onDateChange ? { dateFrom, dateTo, onDateChange } : undefined)
+    const activeSort =
+        sortConfig ??
+        (onSortChange && sortOptions?.length
+            ? { options: sortOptions, value: sortValue, direction: sortDirection, onChange: onSortChange }
+            : undefined)
+    const activeReload = reloadConfig ?? (onReload ? { onReload, loading: reloadLoading } : undefined)
+    const showLeftIsland = !!activeReload || !!activeDate
+    const showGenericPicker = !!pickerRootNodes?.length
+    const showLegacyTaxonomicPicker = !pickerRootNodes && taxonomicGroupTypes.length > 0
+
+    return (
+        <div className={cn('flex items-center gap-2', className)}>
+            {showLeftIsland && (
+                <div className={ISLAND}>
+                    {activeReload && (
+                        <ButtonPrimitive
+                            iconOnly
+                            size="sm"
+                            onClick={activeReload.onReload}
+                            disabled={activeReload.loading || activeReload.disabled || !!disabledReason || loading}
+                            tooltip={disabledReason ?? 'Reload'}
+                            aria-label="Reload"
+                        >
+                            {activeReload.loading ? <Spinner /> : <IconRefresh />}
+                        </ButtonPrimitive>
+                    )}
+                    {activeReload && activeDate && <GroupDivider />}
+                    {activeDate && (
+                        <DateFilter
+                            dateFrom={activeDate.dateFrom}
+                            dateTo={activeDate.dateTo}
+                            onChange={(from, to) => activeDate.onDateChange(from, to)}
+                            renderTrigger={({ ref, label, onClick, isOpen, disabledReason: dateDisabled, tooltip }) => (
+                                <ButtonPrimitive
+                                    ref={ref}
+                                    size="sm"
+                                    active={isOpen}
+                                    onClick={onClick}
+                                    disabled={!!dateDisabled || !!disabledReason || loading}
+                                    tooltip={disabledReason ?? dateDisabled ?? tooltip}
+                                >
+                                    <IconCalendar />
+                                    {label}
+                                </ButtonPrimitive>
+                            )}
+                        />
+                    )}
+                </div>
+            )}
+
+            {activeSort && (
+                <div className={ISLAND}>
+                    <SortControl
+                        options={activeSort.options}
+                        value={activeSort.value}
+                        direction={activeSort.direction ?? 'DESC'}
+                        onChange={activeSort.onChange}
+                    />
+                </div>
+            )}
+
+            {showGenericPicker && (
+                <div className={cn(ISLAND, 'mr-1')}>
+                    <FilterPicker
+                        rootNodes={rootNodes}
+                        rootSearchPlaceholder={pickerPlaceholder}
+                        trigger={
+                            <ButtonPrimitive size="sm" disabled={!!disabledReason || loading} tooltip={disabledReason}>
+                                <IconFilter />
+                                Filter
+                            </ButtonPrimitive>
+                        }
+                    />
+                </div>
+            )}
+
+            {showLegacyTaxonomicPicker && (
+                <div className={cn(ISLAND, 'mr-1')}>
+                    <TaxonomicMenuFilter
+                        taxonomicGroupTypes={taxonomicGroupTypes}
+                        roots={roots}
+                        excludedProperties={excludedProperties}
+                        includeTaxonomicCategories={includeTaxonomicCategories}
+                    />
+                </div>
+            )}
+
+            <FilterBarTokens tokens={displayedTokens} rootNodes={rootNodes} />
+            {showLegacyTaxonomicPicker && <FilterChips />}
+        </div>
+    )
+}
+
+const FilterBarTokens = memo(function FilterBarTokens({
+    tokens,
+    rootNodes,
+}: {
+    tokens: FilterPickerToken[]
+    rootNodes: FilterPickerNode[]
+}): JSX.Element | null {
+    if (!tokens.length) {
+        return null
+    }
+
+    return (
+        <div className="flex min-w-0 items-center flex-wrap gap-1">
+            {tokens.map((token) => (
+                <FilterBarToken key={token.id} token={token} rootNodes={rootNodes} />
+            ))}
+        </div>
+    )
+})
+
+const FilterBarToken = memo(function FilterBarToken({
+    token,
+    rootNodes,
+}: {
+    token: FilterPickerToken
+    rootNodes: FilterPickerNode[]
+}): JSX.Element {
+    const [open, setOpen] = useState(false)
+
+    if (!token.editPath || token.editable === false || !rootNodes.length) {
+        return <FilterPickerTokenPill token={token} onRemove={token.onRemove} className="max-w-64" />
+    }
+
+    return (
+        <FilterPicker
+            rootNodes={rootNodes}
+            initialPath={token.editPath}
+            open={open}
+            onOpenChange={setOpen}
+            trigger={
+                <FilterPickerTokenPill
+                    token={token}
+                    onEdit={() => setOpen(true)}
+                    onRemove={token.onRemove}
+                    className="max-w-64"
+                />
+            }
+        />
+    )
+})
+
+const DirectionArrow = ({ direction }: { direction: SortDirection }): JSX.Element => (
+    <IconArrowRight className={cn(direction === 'DESC' ? 'rotate-90' : '-rotate-90')} />
+)
+
+function SortControl({
+    options,
+    value,
+    direction,
+    onChange,
+}: {
+    options: FilterBarSortOption[]
+    value?: string
+    direction: SortDirection
+    onChange: (value: string, direction: SortDirection) => void
+}): JSX.Element {
+    const activeValue = value ?? options[0]?.value
+    const activeLabel = options.find((option) => option.value === activeValue)?.label ?? 'Sort'
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                render={
+                    <ButtonPrimitive size="sm" tooltip="Sort">
+                        <IconSort />
+                        {activeLabel}
+                    </ButtonPrimitive>
+                }
+            />
+            <DropdownMenuContent align="start" className="min-w-[210px]">
+                <DropdownMenuGroup>
+                    <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                        value={activeValue}
+                        onValueChange={(next: string) => onChange(next, direction)}
+                    >
+                        {options.map((option) => (
+                            <DropdownMenuRadioItem key={option.value} value={option.value}>
+                                {option.label}
+                            </DropdownMenuRadioItem>
+                        ))}
+                    </DropdownMenuRadioGroup>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => onChange(activeValue, direction === 'DESC' ? 'ASC' : 'DESC')}>
+                    <DirectionArrow direction={direction} />
+                    {direction === 'DESC' ? 'Descending' : 'Ascending'}
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}
+
+function FilterChips(): JSX.Element {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { removeGroupValue } = useActions(universalFiltersLogic)
+
+    return (
+        <div className="flex flex-1 min-w-0 items-center flex-wrap gap-1">
+            {filterGroup.values.map((filterOrGroup, index) =>
+                isUniversalGroupFilterLike(filterOrGroup) ? null : (
+                    <UniversalFilterButton key={index} filter={filterOrGroup} onClose={() => removeGroupValue(index)} />
+                )
+            )}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/FilterBar/FilterMenu.tsx
+++ b/frontend/src/lib/components/FilterBar/FilterMenu.tsx
@@ -1,0 +1,1063 @@
+/*
+ * Legacy FilterBar compatibility layer.
+ *
+ * Keep this file for current FilterBar consumers that still use the legacy roots,
+ * taxonomicGroupTypes, tokens, FilterChips, and TaxonomicMenuFilter API: Web analytics,
+ * marketing analytics, endpoints, customer analytics, and revenue analytics. New filter
+ * surfaces should prefer the generic FilterPicker API instead. Do not import this file
+ * from FilterPicker; keep the generic picker independent while these consumers migrate.
+ */
+
+import { useActions, useValues } from 'kea'
+import { ReactElement, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+    IconArrowLeft,
+    IconBrackets,
+    IconDatabase,
+    IconFilter,
+    IconHogQL,
+    IconPeople,
+    IconPerson,
+    IconWarning,
+} from '@posthog/icons'
+import { Button, useCalendar } from '@posthog/quill'
+
+import { DurationPicker } from 'lib/components/DurationPicker/DurationPicker'
+import { PropertyFilterBetween } from 'lib/components/PropertyFilters/components/PropertyFilterBetween'
+import {
+    propertyFilterTypeToPropertyDefinitionType,
+    taxonomicFilterTypeToPropertyFilterType,
+} from 'lib/components/PropertyFilters/utils'
+import { dayjs } from 'lib/dayjs'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from 'lib/ui/quill'
+import { cn } from 'lib/utils/css-classes'
+import {
+    chooseOperatorMap,
+    isOperatorBetween,
+    isOperatorDate,
+    isOperatorFlag,
+    isOperatorMulti,
+} from 'lib/utils/operators'
+
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import {
+    PropertyDefinitionType,
+    PropertyFilterType,
+    PropertyFilterValue,
+    PropertyOperator,
+    PropertyType,
+} from '~/types'
+
+import { operatorTokenLabel } from '../FilterPicker/adapters/propertyFilterOperatorAdapter'
+import { TaxonomicFilterHeadless, useTaxonomicFilterContext } from '../TaxonomicFilter/headless'
+import { useGroupList } from '../TaxonomicFilter/hooks/useGroupList'
+import { ExcludedProperties, TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../TaxonomicFilter/types'
+import { universalFiltersLogic } from '../UniversalFilters/universalFiltersLogic'
+import { FilterTokenPill } from './FilterTokenPill'
+
+/* -------------------------------------------------------------------------- */
+/*                                 Node model                                 */
+/* -------------------------------------------------------------------------- */
+
+export interface MenuNodeContext {
+    /** Close the whole menu — call after committing a filter. */
+    close: () => void
+}
+
+/**
+ * A node in the filter menu. Every menu item is a node. A node is one of:
+ *   - a **branch** (`useChildren`): emits child nodes for the current (level-scoped) search query;
+ *   - a **panel** (`renderPanel`): renders custom leaf UI (a date/duration/between picker);
+ *   - a **leaf** (`onSelect`): commits a filter on click.
+ * Branch children are themselves nodes, so the tree recurses to any depth.
+ */
+export interface MenuNode {
+    id: string
+    label: string
+    icon?: ReactNode
+    /** Optional root/menu section label used to group sibling nodes. */
+    section?: string
+    /** Optional icon shown next to the section label. */
+    sectionIcon?: ReactNode
+    /** Caption shown on the right (e.g. the source category). */
+    hint?: string
+    /** Compact label used in the current-path pill. */
+    pillLabel?: string
+    /** Search placeholder shown while this node is open. */
+    searchPlaceholder?: string
+    /** Called when this level mounts/open, useful for lazy-loading branch data. */
+    onOpen?: () => void
+    /** Called when this level's scoped search query changes. */
+    onQueryChange?: (query: string) => void
+    /** Branch: emits child nodes for `query`. Only invoked for the currently-open node. */
+    useChildren?: (query: string) => {
+        nodes: MenuNode[]
+        isLoading: boolean
+        hasMore?: boolean
+        loadMore?: () => void
+        isLoadingMore?: boolean
+    }
+    /** Panel: custom leaf UI rendered while this node is open, instead of child nodes. */
+    renderPanel?: (ctx: MenuNodeContext) => ReactNode
+    /** Inline custom content for stack pages. */
+    renderCustom?: ReactNode
+    /** Leaf: commit on click. */
+    onSelect?: (ctx: MenuNodeContext) => void
+}
+
+export interface TaxonomicCategoryNodeConfig {
+    kind?: 'taxonomic'
+    type: TaxonomicFilterGroupType
+    label: string
+    icon?: ReactNode
+    section?: string
+    allowList?: string[]
+}
+
+export interface CustomMenuNodeConfig {
+    kind: 'node'
+    node: MenuNode
+}
+
+export type FilterMenuRoot = TaxonomicCategoryNodeConfig | CustomMenuNodeConfig
+
+const isBranch = (node: MenuNode): boolean => !!node.useChildren || !!node.renderPanel
+
+/* -------------------------------------------------------------------------- */
+/*                               Navigator shell                              */
+/* -------------------------------------------------------------------------- */
+
+const SCROLL_PANEL = 'max-h-[22rem] overflow-y-auto overflow-x-hidden'
+
+/**
+ * Recursive node menu rendered as hover-opened flyout sub-menus. Every level (the root content and
+ * each sub-menu) has its own search input on top, scoped to that node's children.
+ */
+export function FilterNodeDropdown({
+    node,
+    initialPath = [],
+    children,
+}: {
+    node: MenuNode
+    initialPath?: MenuNode[]
+    children: ReactElement
+}): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const close = (): void => setOpen(false)
+
+    return (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+            <DropdownMenuTrigger render={children} />
+            <DropdownMenuContent align="start" className="w-[280px]">
+                {node.renderPanel ? (
+                    node.renderPanel({ close })
+                ) : (
+                    <NodeLevel node={node} initialPath={initialPath} close={close} />
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}
+
+export function NodeMenu({
+    roots,
+    placeholder = 'Filter by property...',
+}: {
+    roots: MenuNode[]
+    placeholder?: string
+}): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const [query, setQuery] = useState('')
+    const close = (): void => setOpen(false)
+
+    // A synthetic root whose children are the provided root nodes — makes every level uniform.
+    const rootNode = useMemo<MenuNode>(
+        () => ({
+            id: '__root__',
+            label: '',
+            searchPlaceholder: placeholder,
+            useChildren: (q: string) => {
+                const trimmed = q.trim().toLowerCase()
+                return {
+                    nodes: trimmed ? roots.filter((node) => node.label.toLowerCase().includes(trimmed)) : roots,
+                    isLoading: false,
+                }
+            },
+        }),
+        [roots, placeholder]
+    )
+
+    const [stack, setStack] = useState<MenuNode[]>([rootNode])
+    const activeNode = stack[stack.length - 1]
+
+    const breadcrumbParts = stack.filter((node) => node.id !== '__root__').map((node) => node.pillLabel ?? node.label)
+
+    useEffect(() => {
+        setStack((currentStack) => {
+            if (currentStack.length === 1) {
+                return [rootNode]
+            }
+
+            const latestRootNodes = rootNode.useChildren?.('')?.nodes ?? []
+            const latestActiveNode = latestRootNodes.find((candidate) => candidate.id === currentStack[1].id)
+            return [rootNode, latestActiveNode ?? currentStack[1], ...currentStack.slice(2)]
+        })
+    }, [rootNode])
+
+    const openNode = (nextNode: MenuNode): void => {
+        setQuery('')
+        setStack((currentStack) => [...currentStack, nextNode])
+    }
+
+    const goBack = (): void => {
+        setQuery('')
+        setStack((currentStack) => currentStack.slice(0, -1))
+    }
+
+    const resetMenu = (): void => {
+        setQuery('')
+        setStack([rootNode])
+    }
+
+    return (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+            <DropdownMenuTrigger
+                render={
+                    <div
+                        className="flex h-8 min-w-64 items-center gap-1.5 rounded-md px-2 text-sm bg-[var(--color-bg-fill-button-tertiary)] hover:bg-[var(--color-bg-fill-button-tertiary-hover)] border border-transparent"
+                        title={placeholder}
+                    >
+                        <IconFilter className="shrink-0 text-base" />
+                        <span className={cn('min-w-0 flex-1 truncate text-left', !query && 'text-tertiary')}>
+                            {query || 'Filter'}
+                        </span>
+                    </div>
+                }
+            />
+            <DropdownMenuContent align="start" className="w-64" sideOffset={-32}>
+                <NodeLevelPanel
+                    key={activeNode.id}
+                    node={activeNode}
+                    close={close}
+                    query={query}
+                    setQuery={setQuery}
+                    canGoBack={stack.length > 1}
+                    onBack={goBack}
+                    onOpen={openNode}
+                    onReset={resetMenu}
+                    breadcrumbParts={breadcrumbParts}
+                    showInlineSearch
+                />
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}
+
+// One menu panel with explicit drill-down navigation. We intentionally don't use DropdownMenuSub:
+// submenu primitives are hover/focus-driven, which makes click-only behavior flaky.
+function NodeLevel({
+    node,
+    initialPath = [],
+    close,
+}: {
+    node: MenuNode
+    initialPath?: MenuNode[]
+    close: () => void
+}): JSX.Element {
+    const initialPathKey = `${node.id}:${initialPath.map((pathNode) => pathNode.id).join('/')}`
+    const [stack, setStack] = useState<MenuNode[]>([node, ...initialPath])
+    const [query, setQuery] = useState('')
+    const activeNode = stack[stack.length - 1]
+
+    useEffect(() => {
+        setQuery('')
+        setStack([node, ...initialPath])
+        // Reset only when the requested path actually changes, not on every array identity change.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialPathKey])
+
+    const goBack = (): void => {
+        setQuery('')
+        setStack((currentStack) => currentStack.slice(0, -1))
+    }
+    const openNode = (nextNode: MenuNode): void => {
+        setQuery('')
+        setStack((currentStack) => [...currentStack, nextNode])
+    }
+    const breadcrumbParts = stack
+        .filter((stackNode) => stackNode.id !== '__root__')
+        .map((stackNode) => stackNode.pillLabel ?? stackNode.label)
+    const resetMenu = (): void => {
+        setQuery('')
+        setStack([node])
+    }
+
+    return (
+        <NodeLevelPanel
+            key={activeNode.id}
+            node={activeNode}
+            close={close}
+            query={query}
+            setQuery={setQuery}
+            canGoBack={stack.length > 1}
+            onBack={goBack}
+            onOpen={openNode}
+            onReset={resetMenu}
+            breadcrumbParts={breadcrumbParts}
+            showInlineSearch
+        />
+    )
+}
+
+function NodeLevelPanel({
+    node,
+    close,
+    query,
+    setQuery,
+    canGoBack,
+    onBack,
+    onOpen,
+    onReset,
+    breadcrumbParts,
+    showInlineSearch = false,
+}: {
+    node: MenuNode
+    close: () => void
+    query: string
+    setQuery: (query: string) => void
+    canGoBack: boolean
+    onBack: () => void
+    onOpen: (node: MenuNode) => void
+    onReset: () => void
+    breadcrumbParts: string[]
+    showInlineSearch?: boolean
+}): JSX.Element {
+    const { nodes, isLoading, hasMore, loadMore, isLoadingMore } = node.useChildren!(query)
+    const groupedNodes = useMemo(() => groupNodesBySection(nodes), [nodes])
+
+    useEffect(() => {
+        node.onOpen?.()
+    }, [node])
+
+    useEffect(() => {
+        node.onQueryChange?.(query)
+    }, [node, query])
+
+    return (
+        <>
+            {showInlineSearch && (
+                <>
+                    <LevelSearchInput
+                        value={query}
+                        onChange={setQuery}
+                        placeholder={node.searchPlaceholder}
+                        canGoBack={canGoBack}
+                        onBack={onBack}
+                    />
+                    <DropdownMenuSeparator />
+                </>
+            )}
+            {breadcrumbParts.length > 0 && (
+                <div className="flex px-2 pb-1">
+                    <FilterTokenPill parts={breadcrumbParts} onRemove={onReset} className="max-w-56" />
+                </div>
+            )}
+            <div
+                className={SCROLL_PANEL}
+                onScroll={(event) => {
+                    const target = event.currentTarget
+                    const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight
+                    if (distanceFromBottom < 48 && hasMore && !isLoadingMore) {
+                        loadMore?.()
+                    }
+                }}
+            >
+                {isLoading && !nodes.length ? (
+                    // Plain text, not a (disabled) menu item — Base UI auto-closes a sub-menu whose only
+                    // content is a disabled item, so an empty level would otherwise dismiss the flyout.
+                    <div className="px-2 py-1.5 text-xs text-tertiary">Loading…</div>
+                ) : !nodes.length ? (
+                    <div className="px-2 py-1.5 text-xs text-tertiary">No matches</div>
+                ) : (
+                    <>
+                        {groupedNodes.map(({ section, sectionIcon, nodes: sectionNodes }, sectionIndex) => (
+                            <div key={section ?? '__ungrouped__'}>
+                                {sectionIndex > 0 && <DropdownMenuSeparator />}
+                                {section && (
+                                    <div className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-semibold text-tertiary [&_svg]:size-3.5">
+                                        {sectionIcon}
+                                        <span>{section}</span>
+                                    </div>
+                                )}
+                                {sectionNodes.map((child) => (
+                                    <NodeItem
+                                        key={child.id}
+                                        node={child}
+                                        close={close}
+                                        onOpen={onOpen}
+                                        onReset={onReset}
+                                    />
+                                ))}
+                            </div>
+                        ))}
+                        {isLoadingMore && <div className="px-2 py-1.5 text-xs text-tertiary">Loading more…</div>}
+                    </>
+                )}
+            </div>
+        </>
+    )
+}
+
+function groupNodesBySection(nodes: MenuNode[]): { section?: string; sectionIcon?: ReactNode; nodes: MenuNode[] }[] {
+    const groups: { section?: string; sectionIcon?: ReactNode; nodes: MenuNode[] }[] = []
+
+    for (const node of nodes) {
+        const lastGroup = groups[groups.length - 1]
+        if (lastGroup && lastGroup.section === node.section) {
+            lastGroup.nodes.push(node)
+        } else {
+            groups.push({ section: node.section, sectionIcon: node.sectionIcon, nodes: [node] })
+        }
+    }
+
+    return groups
+}
+
+function NodeItem({
+    node,
+    close,
+    onOpen,
+    onReset,
+}: {
+    node: MenuNode
+    close: () => void
+    onOpen: (node: MenuNode) => void
+    onReset: () => void
+}): JSX.Element {
+    if (node.renderCustom) {
+        return <div className="px-2 py-1.5">{node.renderCustom}</div>
+    }
+
+    if (node.renderPanel) {
+        return (
+            <DropdownMenuItem closeOnClick={false} onClick={() => onOpen(panelNode(node, close))}>
+                <span className="truncate">{node.label}</span>
+                {node.hint && <span className="ml-auto pl-2 text-xxs uppercase text-tertiary">{node.hint}</span>}
+            </DropdownMenuItem>
+        )
+    }
+
+    if (isBranch(node)) {
+        return (
+            <DropdownMenuItem closeOnClick={false} onClick={() => onOpen(node)}>
+                <span className="truncate">{node.label}</span>
+                {node.hint && <span className="ml-auto pl-2 text-xxs uppercase text-tertiary">{node.hint}</span>}
+            </DropdownMenuItem>
+        )
+    }
+
+    return (
+        <DropdownMenuItem
+            onClick={() =>
+                node.onSelect?.({
+                    close: () => {
+                        onReset()
+                        close()
+                    },
+                })
+            }
+        >
+            <span className="truncate">{node.label}</span>
+            {node.hint && <span className="ml-auto pl-2 text-xxs uppercase text-tertiary">{node.hint}</span>}
+        </DropdownMenuItem>
+    )
+}
+
+function panelNode(node: MenuNode, close: () => void): MenuNode {
+    return {
+        id: `${node.id}:panel`,
+        label: node.label,
+        searchPlaceholder: node.label,
+        useChildren: () => ({
+            nodes: [
+                {
+                    id: `${node.id}:panel-content`,
+                    label: node.label,
+                    renderCustom: node.renderPanel?.({ close }),
+                },
+            ],
+            isLoading: false,
+        }),
+    }
+}
+
+// Base UI menus move focus to the first item on open (and have no `initialFocus`), so a deferred
+// focus on mount re-claims it for the input — fired on every open since the sub-menu mounts lazily.
+// `stopPropagation` keeps the menu's typeahead from swallowing typed characters.
+function LevelSearchInput({
+    value,
+    onChange,
+    placeholder,
+    canGoBack,
+    onBack,
+}: {
+    value: string
+    onChange: (v: string) => void
+    placeholder?: string
+    canGoBack: boolean
+    onBack: () => void
+}): JSX.Element {
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+        const raf = requestAnimationFrame(() => inputRef.current?.focus())
+        return () => cancelAnimationFrame(raf)
+    }, [])
+
+    return (
+        <div className="flex h-8 items-center gap-1.5 rounded-md px-2 text-sm bg-[var(--color-bg-fill-button-tertiary)] border border-transparent">
+            {canGoBack ? (
+                <button
+                    type="button"
+                    aria-label="Back"
+                    className="shrink-0 text-tertiary hover:text-primary"
+                    onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        onBack()
+                    }}
+                >
+                    <IconArrowLeft className="text-base" />
+                </button>
+            ) : (
+                <IconFilter aria-hidden className="shrink-0 text-base text-tertiary" />
+            )}
+            <input
+                ref={inputRef}
+                type="text"
+                aria-label={placeholder ?? 'Search'}
+                className="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm outline-none placeholder:text-tertiary"
+                placeholder="Filter"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === 'ArrowDown') {
+                        // Move into the list so the menu's native roving keyboard navigation takes over.
+                        const popup = e.currentTarget.closest(
+                            '[data-slot="dropdown-menu-content"],[data-slot="dropdown-menu-sub-content"]'
+                        )
+                        const firstItem = popup?.querySelector<HTMLElement>('[role="menuitem"]:not([data-disabled])')
+                        if (firstItem) {
+                            e.preventDefault()
+                            // Stop the menu from also advancing (it would skip past the first item).
+                            e.stopPropagation()
+                            firstItem.focus()
+                        }
+                        return
+                    }
+                    // Let dismiss/navigation keys reach the menu; swallow the rest so the menu's
+                    // type-ahead doesn't hijack characters meant for the search field.
+                    if (!['Escape', 'Tab', 'ArrowUp', 'Enter'].includes(e.key)) {
+                        e.stopPropagation()
+                    }
+                }}
+            />
+        </div>
+    )
+}
+
+/* -------------------------------------------------------------------------- */
+/*                        Taxonomic node implementation                       */
+/* -------------------------------------------------------------------------- */
+
+// Filter types with no operator → value shape: they commit a single filter on click (cohorts, feature
+// flags, HogQL). Quick-filter groups have an undefined filter type and are also leaves.
+const LEAF_FILTER_TYPES: ReadonlySet<PropertyFilterType> = new Set([
+    PropertyFilterType.Cohort,
+    PropertyFilterType.HogQL,
+    PropertyFilterType.Flag,
+])
+
+function taxonomicGroupIcon(groupType: TaxonomicFilterGroupType): ReactNode {
+    switch (groupType) {
+        case TaxonomicFilterGroupType.PersonProperties:
+            return <IconPerson />
+        case TaxonomicFilterGroupType.Cohorts:
+        case TaxonomicFilterGroupType.CohortsWithAllUsers:
+            return <IconPeople />
+        case TaxonomicFilterGroupType.HogQLExpression:
+            return <IconHogQL />
+        case TaxonomicFilterGroupType.ErrorTrackingIssues:
+            return <IconWarning />
+        case TaxonomicFilterGroupType.DataWarehouse:
+        case TaxonomicFilterGroupType.DataWarehouseProperties:
+        case TaxonomicFilterGroupType.DataWarehousePersonProperties:
+            return <IconDatabase />
+        default:
+            return <IconBrackets />
+    }
+}
+
+/** Root nodes (categories) for the taxonomic filter — each drills into properties → operator → value. */
+export function useTaxonomicRootNodes(): MenuNode[] {
+    const { groups } = useTaxonomicFilterContext()
+
+    return useMemo(
+        () =>
+            groups
+                // Skip meta groups (Recent / Pinned / Suggested) — only real property categories.
+                .filter((group) => !group.isMetaGroup)
+                .map<MenuNode>((group) => ({
+                    id: String(group.type),
+                    label: group.name,
+                    icon: taxonomicGroupIcon(group.type),
+                    searchPlaceholder: `Search ${group.name.toLowerCase()}…`,
+                    useChildren(query: string) {
+                        return useCategoryChildren(group, query)
+                    },
+                })),
+        [groups]
+    )
+}
+
+export function useUniversalPropertyFilterNode({
+    id,
+    label,
+    icon,
+    filterType,
+    propertyKey,
+    propertyType,
+    eventNames,
+}: {
+    id: string
+    label: string
+    icon?: ReactNode
+    filterType: PropertyFilterType
+    propertyKey: string
+    propertyType?: PropertyType
+    eventNames?: string[]
+}): MenuNode {
+    return useMemo(
+        () => ({
+            id,
+            label,
+            icon,
+            searchPlaceholder: 'Choose an operator…',
+            useChildren(operatorQuery: string) {
+                return useOperatorChildren(filterType, propertyKey, propertyType, operatorQuery, eventNames)
+            },
+        }),
+        [eventNames, filterType, icon, id, label, propertyKey, propertyType]
+    )
+}
+
+function useCategoryChildren(
+    group: TaxonomicFilterGroup,
+    query: string,
+    allowList?: string[]
+): {
+    nodes: MenuNode[]
+    isLoading: boolean
+    hasMore?: boolean
+    loadMore?: () => void
+    isLoadingMore?: boolean
+} {
+    const { getGroupListInput } = useTaxonomicFilterContext()
+    const { addGroupFilter } = useActions(universalFiltersLogic)
+    const [limit, setLimit] = useState(100)
+    const list = useGroupList({ ...getGroupListInput(group), searchQuery: query, limit })
+
+    const nodes = useMemo<MenuNode[]>(
+        () =>
+            list.items
+                .filter((item) => {
+                    if (!allowList) {
+                        return true
+                    }
+                    const rawName = group.getName?.(item) ?? (item as { name?: string }).name ?? ''
+                    const propertyKey = String(group.getValue?.(item) ?? rawName)
+                    return allowList.includes(propertyKey)
+                })
+                .map((item) => {
+                    const rawName = group.getName?.(item) ?? (item as { name?: string }).name ?? ''
+                    const label = getCoreFilterDefinition(rawName, group.type)?.label || rawName
+                    const propertyKey = String(group.getValue?.(item) ?? rawName)
+                    const propertyType = (item as { property_type?: PropertyType }).property_type
+                    const icon = group.getIcon?.(item)
+                    const filterType = taxonomicFilterTypeToPropertyFilterType(group.type)
+                    const canDrill = filterType !== undefined && !LEAF_FILTER_TYPES.has(filterType)
+
+                    // Cohorts / feature flags / HogQL commit directly via the canonical conversion.
+                    if (!canDrill) {
+                        return {
+                            id: `${group.type}:${propertyKey}`,
+                            label,
+                            icon,
+                            onSelect: ({ close }) => {
+                                addGroupFilter(group, group.getValue?.(item) ?? null, item as any)
+                                close()
+                            },
+                        }
+                    }
+
+                    return {
+                        id: `${group.type}:${propertyKey}`,
+                        label,
+                        icon,
+                        searchPlaceholder: 'Choose an operator…',
+                        useChildren(operatorQuery: string) {
+                            return useOperatorChildren(filterType, propertyKey, propertyType, operatorQuery)
+                        },
+                    }
+                }),
+        [group, list.items, allowList, addGroupFilter]
+    )
+
+    return {
+        nodes,
+        isLoading: list.isLoading,
+        hasMore: (list.isExpandable && !list.isExpanded) || list.totalResultCount > list.items.length,
+        loadMore: () => {
+            if (list.isExpandable && !list.isExpanded) {
+                list.expand()
+            } else {
+                setLimit((currentLimit) => currentLimit + 100)
+            }
+        },
+        isLoadingMore: list.isFetching && nodes.length > 0,
+    }
+}
+
+function useOperatorChildren(
+    filterType: PropertyFilterType | undefined,
+    propertyKey: string,
+    propertyType: PropertyType | undefined,
+    query: string,
+    eventNames: string[] = []
+): {
+    nodes: MenuNode[]
+    isLoading: boolean
+    hasMore?: boolean
+    loadMore?: () => void
+    isLoadingMore?: boolean
+} {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { setGroupValues } = useActions(universalFiltersLogic)
+    const { describeProperty } = useValues(propertyDefinitionsModel)
+
+    // The taxonomic item rarely carries `property_type`, so resolve it from the property definitions —
+    // this is what picks the type-appropriate operator set (numeric → >,<; string → contains; etc.).
+    const definitionType = propertyFilterTypeToPropertyDefinitionType(filterType) ?? PropertyDefinitionType.Event
+    const resolvedType = propertyType ?? describeProperty(propertyKey, definitionType) ?? undefined
+
+    const nodes = useMemo<MenuNode[]>(() => {
+        const commit = (operator: PropertyOperator, value: PropertyFilterValue, close: () => void): void => {
+            if (filterType) {
+                setGroupValues([...filterGroup.values, { key: propertyKey, type: filterType, operator, value } as any])
+            }
+            close()
+        }
+        const trimmed = query.trim().toLowerCase()
+
+        const operatorNodes = Object.entries(chooseOperatorMap(resolvedType))
+            .filter(([, label]) => label.toLowerCase().includes(trimmed))
+            .map<MenuNode>(([op, label]) => {
+                const operator = op as PropertyOperator
+
+                const symbol = operatorTokenLabel(operator, resolvedType)
+
+                if (isOperatorFlag(operator)) {
+                    return { id: op, label, pillLabel: symbol, onSelect: ({ close }) => commit(operator, null, close) }
+                }
+
+                if (isOperatorDate(operator)) {
+                    return {
+                        id: op,
+                        label,
+                        pillLabel: symbol,
+                        renderPanel: ({ close }) => (
+                            <DateOperatorPanel
+                                operator={operator}
+                                onApply={(value) => commit(operator, value, close)}
+                            />
+                        ),
+                    }
+                }
+                if (isOperatorBetween(operator)) {
+                    return {
+                        id: op,
+                        label,
+                        pillLabel: symbol,
+                        renderPanel: ({ close }) => (
+                            <div className="p-2" onKeyDown={(e) => e.stopPropagation()}>
+                                <PropertyFilterBetween
+                                    logicKey={propertyKey}
+                                    value={null}
+                                    onSet={(v) => commit(operator, v ?? null, close)}
+                                />
+                            </div>
+                        ),
+                    }
+                }
+                if (resolvedType === PropertyType.Duration) {
+                    return {
+                        id: op,
+                        label,
+                        renderPanel: ({ close }) => (
+                            <DurationPanel onPick={(seconds) => commit(operator, seconds, close)} />
+                        ),
+                    }
+                }
+
+                // String / numeric: drill into the property's values (the top search becomes value entry).
+                const numeric = resolvedType === PropertyType.Numeric
+                return {
+                    id: op,
+                    label,
+                    pillLabel: symbol,
+                    searchPlaceholder: numeric ? 'Type a number…' : 'Search or type a value…',
+                    useChildren(valueQuery: string) {
+                        return useValueChildren(
+                            filterType,
+                            propertyKey,
+                            operator,
+                            numeric,
+                            valueQuery,
+                            (value, close) => commit(operator, value, close),
+                            eventNames
+                        )
+                    },
+                }
+            })
+
+        if (resolvedType !== PropertyType.DateTime) {
+            return operatorNodes
+        }
+
+        const shortcutNodes = DATE_TIME_SHORTCUTS.filter((shortcut) =>
+            shortcut.label.toLowerCase().includes(trimmed)
+        ).map<MenuNode>((shortcut) => ({
+            id: `shortcut:${shortcut.id}`,
+            label: shortcut.label,
+            hint: 'Shortcut',
+            onSelect: ({ close }) => commit(PropertyOperator.IsDateAfter, shortcut.value, close),
+        }))
+
+        return [...shortcutNodes, ...operatorNodes]
+    }, [eventNames, filterType, propertyKey, resolvedType, query, filterGroup.values, setGroupValues])
+
+    return { nodes, isLoading: false }
+}
+
+const WEEK_DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+
+const DATE_TIME_SHORTCUTS: { id: string; label: string; value: string }[] = [
+    { id: 'last-hour', label: 'Last hour', value: '-1h' },
+    { id: 'last-24-hours', label: 'Last 24 hours', value: '-24h' },
+    { id: 'last-2-days', label: 'Last 2 days', value: '-2d' },
+    { id: 'last-7-days', label: 'Last 7 days', value: '-7d' },
+    { id: 'last-30-days', label: 'Last 30 days', value: '-30d' },
+]
+
+export function SingleDatePickerPanel({ onSelect }: { onSelect: (value: string) => void }): JSX.Element {
+    const { calendar, viewing, viewPreviousMonth, viewNextMonth } = useCalendar({ viewing: new Date() })
+
+    return (
+        <div className="w-64 p-2" onKeyDown={(e) => e.stopPropagation()}>
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <Button size="icon-sm" variant="default" onClick={viewPreviousMonth} aria-label="Previous month">
+                    <IconArrowLeft />
+                </Button>
+                <span className="text-sm font-medium">{dayjs(viewing).format('MMMM YYYY')}</span>
+                <Button size="icon-sm" variant="default" onClick={viewNextMonth} aria-label="Next month">
+                    <IconArrowLeft className="rotate-180" />
+                </Button>
+            </div>
+            <div className="grid grid-cols-7 gap-1 text-center text-xs text-tertiary">
+                {WEEK_DAYS.map((day) => (
+                    <div key={day}>{day}</div>
+                ))}
+            </div>
+            {calendar[0].map((week) => (
+                <div key={week[0].toISOString()} className="mt-1 grid grid-cols-7 gap-1">
+                    {week.map((day) => {
+                        const isCurrentMonth = day.getMonth() === viewing.getMonth()
+                        return (
+                            <Button
+                                key={day.toISOString()}
+                                size="icon-sm"
+                                variant="default"
+                                className={cn('tabular-nums', !isCurrentMonth && 'opacity-30')}
+                                onClick={() => onSelect(dayjs(day).format('YYYY-MM-DD'))}
+                            >
+                                {day.getDate()}
+                            </Button>
+                        )
+                    })}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+function DateOperatorPanel({
+    onApply,
+}: {
+    operator: PropertyOperator
+    onApply: (value: PropertyFilterValue) => void
+}): JSX.Element {
+    return <SingleDatePickerPanel onSelect={onApply} />
+}
+
+function useValueChildren(
+    filterType: PropertyFilterType | undefined,
+    propertyKey: string,
+    operator: PropertyOperator,
+    numeric: boolean,
+    query: string,
+    commit: (value: PropertyFilterValue, close: () => void) => void,
+    eventNames: string[] = []
+): { nodes: MenuNode[]; isLoading: boolean } {
+    const definitionType = propertyFilterTypeToPropertyDefinitionType(filterType) ?? PropertyDefinitionType.Event
+    const { options, formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    const { loadPropertyValues } = useActions(propertyDefinitionsModel)
+    const propertyOption = options[propertyKey]
+
+    const trimmed = numeric ? query.replace(/[^0-9.-]/g, '').trim() : query.trim()
+
+    useEffect(() => {
+        // Debounced + abort-stale inside the model, so calling on each keystroke is safe.
+        loadPropertyValues({
+            endpoint: undefined,
+            type: definitionType,
+            newInput: trimmed || undefined,
+            propertyKey,
+            eventNames,
+        })
+    }, [loadPropertyValues, definitionType, propertyKey, trimmed, eventNames])
+
+    const nodes = useMemo<MenuNode[]>(() => {
+        const finalValue = (raw: string | number): PropertyFilterValue => (isOperatorMulti(operator) ? [raw] : raw)
+        const values = propertyOption?.values ?? []
+        const result: MenuNode[] = []
+
+        // Free-text / custom value when it isn't already an exact known value.
+        if (trimmed && !values.some((value) => String(value.name) === trimmed)) {
+            result.push({
+                id: '__use__',
+                label: `Use “${trimmed}”`,
+                onSelect: ({ close }) => commit(finalValue(numeric ? Number(trimmed) : trimmed), close),
+            })
+        }
+        values.forEach((value, index) => {
+            result.push({
+                id: `value-${index}`,
+                label: String(formatPropertyValueForDisplay(propertyKey, value.name, definitionType)),
+                onSelect: ({ close }) => commit(finalValue(numeric ? Number(value.name) : String(value.name)), close),
+            })
+        })
+        return result
+    }, [
+        propertyOption?.values,
+        trimmed,
+        numeric,
+        operator,
+        propertyKey,
+        definitionType,
+        formatPropertyValueForDisplay,
+        commit,
+    ])
+
+    return { nodes, isLoading: propertyOption?.status === 'loading' && !(propertyOption?.values?.length ?? 0) }
+}
+
+// Duration values: the standard picker plus an Apply row (it has no commit affordance itself).
+function DurationPanel({ onPick }: { onPick: (seconds: number) => void }): JSX.Element {
+    const [seconds, setSeconds] = useState(0)
+    return (
+        <div className="flex flex-col gap-2 p-2" onKeyDown={(e) => e.stopPropagation()}>
+            <DurationPicker autoFocus value={seconds} onChange={setSeconds} />
+            <DropdownMenuItem onClick={() => onPick(seconds)}>Apply</DropdownMenuItem>
+        </div>
+    )
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   Wrapper                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Node menu wired to the taxonomic filter: mounts the headless root, builds taxonomic root nodes, and
+ * prepends any `extraRoots`. Selections commit into the surrounding `universalFiltersLogic`.
+ */
+export function TaxonomicMenuFilter({
+    taxonomicGroupTypes,
+    roots,
+    excludedProperties,
+    includeTaxonomicCategories = true,
+}: {
+    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+    /** Ordered product-specific roots shown before optional default taxonomic categories. */
+    roots?: FilterMenuRoot[]
+    /** Properties to hide from a taxonomic group (e.g. an `assignee` handled by a custom node). */
+    excludedProperties?: ExcludedProperties
+    includeTaxonomicCategories?: boolean
+}): JSX.Element {
+    return (
+        <TaxonomicFilterHeadless.Root
+            className="contents"
+            bindRootProps={false}
+            taxonomicGroupTypes={taxonomicGroupTypes}
+            excludedProperties={excludedProperties}
+            onChange={() => {}}
+        >
+            <TaxonomicNodeMenu roots={roots} includeTaxonomicCategories={includeTaxonomicCategories} />
+        </TaxonomicFilterHeadless.Root>
+    )
+}
+
+function TaxonomicNodeMenu({
+    roots = [],
+    includeTaxonomicCategories,
+}: {
+    roots?: FilterMenuRoot[]
+    includeTaxonomicCategories: boolean
+}): JSX.Element {
+    const { groups } = useTaxonomicFilterContext()
+    const taxonomicRoots = useTaxonomicRootNodes()
+    const productRoots = useMemo<MenuNode[]>(
+        () =>
+            roots.flatMap((root) => {
+                if ('node' in root) {
+                    return [root.node]
+                }
+                const config = root
+                const group = groups.find((candidate) => candidate.type === config.type)
+                if (!group) {
+                    return []
+                }
+                return [
+                    {
+                        id: String(config.type),
+                        label: config.label,
+                        icon: config.icon ?? taxonomicGroupIcon(config.type),
+                        section: config.section,
+                        searchPlaceholder: `Search ${config.label.toLowerCase()}…`,
+                        useChildren(query: string) {
+                            return useCategoryChildren(group, query, config.allowList)
+                        },
+                    },
+                ]
+            }),
+        [groups, roots]
+    )
+    return <NodeMenu roots={[...productRoots, ...(includeTaxonomicCategories ? taxonomicRoots : [])]} />
+}

--- a/frontend/src/lib/components/FilterBar/FilterTokenPill.tsx
+++ b/frontend/src/lib/components/FilterBar/FilterTokenPill.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, ReactNode } from 'react'
+
+import { FilterPickerTokenPill } from '../FilterPicker'
+import { FilterPickerTokenPart } from '../FilterPicker/FilterPicker.types'
+
+export const FilterTokenPill = forwardRef<
+    HTMLDivElement,
+    {
+        parts?: ReactNode[]
+        label?: ReactNode
+        title?: string
+        onRemove?: () => void
+        onClick?: () => void
+        className?: string
+    }
+>(function FilterTokenPill({ parts, label, title, onRemove, onClick, className }, ref): JSX.Element {
+    const tokenParts: FilterPickerTokenPart[] = parts?.length
+        ? parts.map((part, index) => ({ key: String(index), kind: 'text', label: part }))
+        : [{ key: 'label', kind: 'text', label }]
+
+    return (
+        <FilterPickerTokenPill
+            ref={ref}
+            token={{
+                id: title ?? 'filter-token',
+                parts: tokenParts,
+                title,
+                removable: !!onRemove,
+                editable: !!onClick,
+            }}
+            onEdit={onClick}
+            onRemove={onRemove}
+            className={className}
+        />
+    )
+})

--- a/frontend/src/lib/components/FilterPicker/FilterPicker.stories.tsx
+++ b/frontend/src/lib/components/FilterPicker/FilterPicker.stories.tsx
@@ -1,0 +1,416 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { ReactNode, useMemo, useState } from 'react'
+
+import { IconBrackets, IconClock, IconDatabase, IconPerson } from '@posthog/icons'
+import { Button } from '@posthog/quill'
+
+import { PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
+
+import { createPropertyFilterPickerNodes, createPropertyFilterToken } from './adapters'
+import { FilterPicker } from './FilterPicker'
+import { FilterPickerNode, FilterPickerToken } from './FilterPicker.types'
+import { FilterPickerTokenPill } from './FilterPickerTokenPill'
+
+const meta: Meta<typeof FilterPicker> = {
+    title: 'Filters/Filter Picker',
+    component: FilterPicker,
+    parameters: {
+        testOptions: { include3000: true },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof FilterPicker>
+
+const issueSection = { id: 'issue', label: 'Issue', icon: <IconBrackets /> }
+const personSection = { id: 'person', label: 'Person', icon: <IconPerson /> }
+const propertySection = { id: 'property', label: 'Properties', icon: <IconDatabase /> }
+
+const valueOptions = [
+    'Critical',
+    'High',
+    'Medium',
+    'Low',
+    'A very long property value that should truncate in narrow menus',
+]
+
+function matching(nodes: FilterPickerNode[], query: string): FilterPickerNode[] {
+    const trimmed = query.trim().toLowerCase()
+    return trimmed ? nodes.filter((node) => String(node.label).toLowerCase().includes(trimmed)) : nodes
+}
+
+function propertyNode(onSelect: (label: string) => void): FilterPickerNode {
+    return {
+        id: 'property.severity',
+        label: 'Exception severity with a very long display name',
+        tokenLabel: 'Severity',
+        kind: 'branch',
+        section: propertySection,
+        searchPlaceholder: 'Choose an operator…',
+        getChildren: ({ query }) => ({
+            isLoading: false,
+            nodes: matching(
+                [
+                    {
+                        id: 'property.severity.equals',
+                        label: 'equals',
+                        tokenLabel: '=',
+                        kind: 'branch',
+                        searchPlaceholder: 'Search or type a value…',
+                        getChildren: ({ query: valueQuery }) => ({
+                            isLoading: false,
+                            hasMore: true,
+                            loadMore: () => {},
+                            nodes: matching(
+                                valueOptions.map((label) => ({
+                                    id: `property.severity.equals.${label}`,
+                                    label,
+                                    kind: 'action' as const,
+                                    onSelect: ({ close }) => {
+                                        onSelect(label)
+                                        close()
+                                    },
+                                })),
+                                valueQuery
+                            ),
+                        }),
+                    },
+                    {
+                        id: 'property.severity.is-set',
+                        label: 'is set',
+                        tokenLabel: '∃',
+                        kind: 'action',
+                        onSelect: ({ close }) => {
+                            onSelect('is set')
+                            close()
+                        },
+                    },
+                ],
+                query
+            ),
+        }),
+    }
+}
+
+function baseNodes(onSelect: (label: string) => void): FilterPickerNode[] {
+    return [
+        {
+            id: 'status',
+            label: 'Status',
+            kind: 'branch',
+            section: issueSection,
+            searchPlaceholder: 'Search statuses…',
+            getChildren: ({ query }) => ({
+                isLoading: false,
+                nodes: matching(
+                    ['Active', 'Resolved', 'Suppressed'].map((label) => ({
+                        id: `status.${label.toLowerCase()}`,
+                        label,
+                        kind: 'action' as const,
+                        onSelect: ({ close }) => {
+                            onSelect(label)
+                            close()
+                        },
+                    })),
+                    query
+                ),
+            }),
+        },
+        {
+            id: 'assignee',
+            label: 'Assignee',
+            kind: 'branch',
+            section: personSection,
+            searchPlaceholder: 'Search assignees…',
+            getChildren: ({ query }) => ({
+                isLoading: false,
+                nodes: matching(
+                    ['Jane Cooper', 'Wade Warren', 'Product engineers'].map((label) => ({
+                        id: `assignee.${label}`,
+                        label,
+                        hint: label === 'Product engineers' ? 'Role' : 'User',
+                        kind: 'action' as const,
+                        onSelect: ({ close }) => {
+                            onSelect(label)
+                            close()
+                        },
+                    })),
+                    query
+                ),
+            }),
+        },
+        propertyNode(onSelect),
+    ]
+}
+
+function Trigger({ children }: { children?: ReactNode }): JSX.Element {
+    return <Button variant="outline">{children ?? 'Add filter'}</Button>
+}
+
+function Sandbox({ narrow = false }: { narrow?: boolean }): JSX.Element {
+    const [selected, setSelected] = useState('High')
+    const nodes = useMemo(() => baseNodes(setSelected), [])
+    const token: FilterPickerToken = {
+        id: 'severity-token',
+        editPath: { nodeIds: ['property.severity', 'property.severity.equals'] },
+        parts: [
+            { kind: 'property', label: 'Severity' },
+            { kind: 'operator', label: '=' },
+            { kind: 'value', label: selected },
+        ],
+        onRemove: () => setSelected(''),
+    }
+
+    return (
+        <div className={narrow ? 'w-56 p-4' : 'p-4'}>
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+                <FilterPicker rootNodes={nodes} trigger={<Trigger />} />
+                {selected && (
+                    <FilterPicker
+                        rootNodes={nodes}
+                        initialPath={token.editPath}
+                        trigger={<FilterPickerTokenPill token={token} onEdit={() => {}} />}
+                    />
+                )}
+            </div>
+            <div className="text-xs text-tertiary">Selected value: {selected || 'none'}</div>
+        </div>
+    )
+}
+
+export const RootWithSections: Story = {
+    render: () => <Sandbox />,
+}
+
+export const NestedPropertyOperatorValue: Story = {
+    render: () => <Sandbox />,
+}
+
+export const CustomPanel: Story = {
+    render: () => {
+        const nodes: FilterPickerNode[] = [
+            {
+                id: 'date',
+                label: 'Date',
+                kind: 'panel',
+                section: { id: 'time', label: 'Time', icon: <IconClock /> },
+                renderPanel: ({ close }) => (
+                    <div className="flex flex-col gap-2 p-2">
+                        <div className="text-sm font-semibold">Pick a date range</div>
+                        <Button size="sm" onClick={close}>
+                            Last 24 hours
+                        </Button>
+                        <Button size="sm" onClick={close}>
+                            Last 7 days
+                        </Button>
+                    </div>
+                ),
+            },
+        ]
+        return (
+            <div className="p-4">
+                <FilterPicker rootNodes={nodes} trigger={<Trigger />} />
+            </div>
+        )
+    },
+}
+
+export const LoadingAndEmpty: Story = {
+    render: () => {
+        const nodes: FilterPickerNode[] = [
+            {
+                id: 'loading',
+                label: 'Loading branch',
+                kind: 'branch',
+                getChildren: () => ({ isLoading: true, nodes: [] }),
+            },
+            {
+                id: 'empty',
+                label: 'Empty branch',
+                kind: 'branch',
+                getChildren: () => ({ isLoading: false, nodes: [], emptyMessage: 'Nothing here yet' }),
+            },
+        ]
+        return (
+            <div className="p-4">
+                <FilterPicker rootNodes={nodes} trigger={<Trigger />} />
+            </div>
+        )
+    },
+}
+
+export const EditableTokenPath: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Keyboard-only flow: open the token, type to search the scoped value list, use ArrowDown to move into results, Backspace/Tab normally, and the path pill reset returns to the root.',
+            },
+        },
+    },
+    render: () => <Sandbox />,
+}
+
+export const LongLabelsAndNarrowWidths: Story = {
+    render: () => <Sandbox narrow />,
+}
+
+export const PropertyFilterAdapter: Story = {
+    render: () => {
+        const [token, setToken] = useState<FilterPickerToken | null>(null)
+        const valueOptions = useMemo(
+            () => ['Chrome', 'Safari', 'Firefox', 'Mobile app'].map((label) => ({ label, value: label })),
+            []
+        )
+        const rootNodes = useMemo(
+            () =>
+                createPropertyFilterPickerNodes({
+                    properties: [
+                        {
+                            key: '$browser',
+                            label: 'Browser',
+                            type: PropertyFilterType.Event,
+                            propertyType: PropertyType.String,
+                            description: 'Event property',
+                        },
+                        {
+                            key: 'plan',
+                            label: 'Plan',
+                            type: PropertyFilterType.Person,
+                            propertyType: PropertyType.String,
+                            description: 'Person property',
+                        },
+                        {
+                            key: 'id',
+                            label: 'Cohort',
+                            type: PropertyFilterType.Cohort,
+                            propertyType: PropertyType.Cohort,
+                            description: 'Cohorts use the same token model',
+                        },
+                        {
+                            key: 'beta-checkout',
+                            label: 'Feature flag',
+                            type: PropertyFilterType.Flag,
+                            propertyType: PropertyType.Flag,
+                            description: 'Feature flags use the same token model',
+                        },
+                    ],
+                    rootSections: {
+                        [PropertyFilterType.Event]: propertySection,
+                        [PropertyFilterType.Person]: personSection,
+                        [PropertyFilterType.Cohort]: personSection,
+                        [PropertyFilterType.Flag]: personSection,
+                    },
+                    operatorAllowlist: {
+                        [PropertyType.String]: [
+                            PropertyOperator.Exact,
+                            PropertyOperator.IContains,
+                            PropertyOperator.IsSet,
+                        ],
+                        [PropertyType.Cohort]: [PropertyOperator.In, PropertyOperator.NotIn],
+                        [PropertyType.Flag]: [PropertyOperator.FlagEvaluatesTo],
+                    },
+                    valueLoader: ({ property, query }) => {
+                        if (property.type === PropertyFilterType.Cohort) {
+                            return {
+                                values: [
+                                    { label: 'Power users', value: 1 },
+                                    { label: 'Recently active', value: 2 },
+                                ],
+                            }
+                        }
+                        if (property.type === PropertyFilterType.Flag) {
+                            return {
+                                values: [
+                                    { label: 'true', value: true },
+                                    { label: 'false', value: false },
+                                ],
+                            }
+                        }
+                        return {
+                            values: valueOptions.filter((option) =>
+                                option.label.toLowerCase().includes(query.toLowerCase())
+                            ),
+                            allowCustomValues: true,
+                            hasMore: true,
+                            loadMore: () => {},
+                        }
+                    },
+                    eventNames: ['$exception'],
+                    onSelect: (filter, { close }) => {
+                        setToken(
+                            createPropertyFilterToken(filter, {
+                                editNodeIds: [
+                                    `property:${filter.type}:${filter.key}`,
+                                    `property:${filter.type}:${filter.key}:operator:${'operator' in filter ? filter.operator : PropertyOperator.Exact}`,
+                                ],
+                                onRemove: () => setToken(null),
+                            })
+                        )
+                        close()
+                    },
+                }),
+            [valueOptions]
+        )
+
+        return (
+            <div className="flex flex-col gap-3 p-4">
+                <FilterPicker rootNodes={rootNodes} trigger={<Trigger />} />
+                {token ? <FilterPickerTokenPill token={token} onEdit={() => {}} /> : null}
+            </div>
+        )
+    },
+}
+
+export const LoadMoreState: Story = {
+    render: () => {
+        const [visibleCount, setVisibleCount] = useState(3)
+        const nodes: FilterPickerNode[] = [
+            {
+                id: 'feature-flag',
+                label: 'Feature flag',
+                kind: 'branch',
+                getChildren: () => ({
+                    nodes: Array.from({ length: visibleCount }, (_, index) => ({
+                        id: `flag-${index}`,
+                        label: `Feature flag ${index + 1}`,
+                        kind: 'action' as const,
+                    })),
+                    hasMore: visibleCount < 9,
+                    loadMore: () => setVisibleCount((count) => Math.min(count + 3, 9)),
+                }),
+            },
+        ]
+
+        return (
+            <div className="p-4">
+                <FilterPicker rootNodes={nodes} trigger={<Trigger />} />
+            </div>
+        )
+    },
+}
+
+export const UnresolvedEditPathFallback: Story = {
+    render: () => (
+        <div className="flex flex-col gap-2 p-4">
+            <FilterPicker
+                rootNodes={baseNodes(() => {})}
+                initialPath={{ nodeIds: ['property.severity', 'missing-operator'] }}
+                trigger={
+                    <FilterPickerTokenPill
+                        token={{
+                            id: 'stale-token',
+                            parts: [
+                                { kind: 'property', label: 'Severity' },
+                                { kind: 'operator', label: '=' },
+                                { kind: 'value', label: 'Deleted value' },
+                            ],
+                        }}
+                    />
+                }
+            />
+            <div className="text-xs text-tertiary">
+                A stale edit path falls back to the root picker instead of opening a broken level.
+            </div>
+        </div>
+    ),
+}

--- a/frontend/src/lib/components/FilterPicker/FilterPicker.test.tsx
+++ b/frontend/src/lib/components/FilterPicker/FilterPicker.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { FilterPicker } from './FilterPicker'
+import { FilterPickerNode } from './FilterPicker.types'
+
+const valueNode: FilterPickerNode = { id: 'value', label: 'Active', kind: 'action' }
+const operatorNode: FilterPickerNode = {
+    id: 'operator',
+    label: 'Equals',
+    kind: 'branch',
+    searchPlaceholder: 'Search values…',
+    getChildren: () => ({ nodes: [valueNode], isLoading: false }),
+}
+const propertyNode: FilterPickerNode = {
+    id: 'property',
+    label: 'Status',
+    kind: 'branch',
+    searchPlaceholder: 'Choose an operator…',
+    getChildren: () => ({ nodes: [operatorNode], isLoading: false }),
+}
+
+const renderPicker = (open: boolean): ReturnType<typeof render> =>
+    render(
+        <FilterPicker
+            rootNodes={[propertyNode]}
+            trigger={<button type="button">Add filter</button>}
+            open={open}
+            initialPath={{ nodeIds: ['property', 'operator'] }}
+        />
+    )
+
+describe('FilterPicker', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('re-applies initialPath after an open/close/open cycle', async () => {
+        const { rerender } = renderPicker(true)
+
+        expect(await screen.findByPlaceholderText('Search values…')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument()
+
+        rerender(
+            <FilterPicker
+                rootNodes={[propertyNode]}
+                trigger={<button type="button">Add filter</button>}
+                open={false}
+                initialPath={{ nodeIds: ['property', 'operator'] }}
+            />
+        )
+        rerender(
+            <FilterPicker
+                rootNodes={[propertyNode]}
+                trigger={<button type="button">Add filter</button>}
+                open={true}
+                initialPath={{ nodeIds: ['property', 'operator'] }}
+            />
+        )
+
+        expect(await screen.findByPlaceholderText('Search values…')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument()
+    })
+
+    it('loads content only for the active node, never for resolved ancestors', async () => {
+        const propertyLoadContent = jest.fn()
+        const operatorLoadContent = jest.fn()
+        const operator: FilterPickerNode = {
+            id: 'operator',
+            label: 'Equals',
+            kind: 'branch',
+            searchPlaceholder: 'Search values…',
+            getChildren: () => ({ nodes: [valueNode], isLoading: false }),
+            loadContent: operatorLoadContent,
+        }
+        const property: FilterPickerNode = {
+            id: 'property',
+            label: 'Status',
+            kind: 'branch',
+            getChildren: () => ({ nodes: [operator], isLoading: false }),
+            loadContent: propertyLoadContent,
+        }
+
+        render(
+            <FilterPicker
+                rootNodes={[property]}
+                trigger={<button type="button">Add filter</button>}
+                open={true}
+                initialPath={{ nodeIds: ['property', 'operator'] }}
+            />
+        )
+
+        expect(await screen.findByPlaceholderText('Search values…')).toBeInTheDocument()
+        // The active node's content loads; the resolved ancestor's loadContent must not fire as a side effect.
+        expect(operatorLoadContent).toHaveBeenCalled()
+        expect(propertyLoadContent).not.toHaveBeenCalled()
+    })
+
+    it('back button on the value level returns to the operator level', async () => {
+        renderPicker(true)
+
+        expect(await screen.findByRole('button', { name: 'Active' })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Go back to previous filter level' }))
+
+        expect(await screen.findByRole('button', { name: 'Equals' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Active' })).not.toBeInTheDocument()
+    })
+
+    it('drills down and walks back through every level (uncontrolled)', async () => {
+        render(<FilterPicker rootNodes={[propertyNode]} trigger={<button type="button">Add filter</button>} />)
+
+        fireEvent.click(screen.getByText('Add filter'))
+        fireEvent.click(await screen.findByRole('button', { name: 'Status' }))
+        fireEvent.click(await screen.findByRole('button', { name: 'Equals' }))
+        expect(await screen.findByRole('button', { name: 'Active' })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Go back to previous filter level' }))
+        expect(await screen.findByRole('button', { name: 'Equals' })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Go back to previous filter level' }))
+        expect(await screen.findByRole('button', { name: 'Status' })).toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/lib/components/FilterPicker/FilterPicker.tsx
@@ -1,0 +1,301 @@
+import { ReactElement, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+
+import { IconArrowLeft, IconFilter } from '@posthog/icons'
+import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { FilterPickerNode, FilterPickerPath } from './FilterPicker.types'
+import { useFilterPickerNavigation } from './useFilterPickerNavigation'
+
+const SCROLL_PANEL_CLASSNAME = 'max-h-[22rem] overflow-y-auto overflow-x-hidden'
+
+export interface FilterPickerProps {
+    rootNodes: FilterPickerNode[]
+    trigger: ReactElement
+    initialPath?: FilterPickerPath
+    rootSearchPlaceholder?: string
+    onOpenChange?: (open: boolean) => void
+    open?: boolean
+    emptyMessage?: ReactNode
+}
+
+interface SectionGroup {
+    sectionKey: string
+    sectionLabel?: ReactNode
+    sectionIcon?: ReactNode
+    nodes: FilterPickerNode[]
+}
+
+function groupNodesBySection(nodes: FilterPickerNode[]): SectionGroup[] {
+    const groups: SectionGroup[] = []
+    for (const node of nodes) {
+        const sectionKey = node.section?.id ?? '__ungrouped__'
+        const lastGroup = groups[groups.length - 1]
+        if (lastGroup?.sectionKey === sectionKey) {
+            lastGroup.nodes.push(node)
+        } else {
+            groups.push({
+                sectionKey,
+                sectionLabel: node.section?.label,
+                sectionIcon: node.section?.icon,
+                nodes: [node],
+            })
+        }
+    }
+    return groups
+}
+
+export function FilterPicker({
+    rootNodes,
+    trigger,
+    initialPath,
+    rootSearchPlaceholder = 'Search filters…',
+    onOpenChange,
+    open: controlledOpen,
+    emptyMessage = 'No matches',
+}: FilterPickerProps): JSX.Element {
+    const [internalOpen, setInternalOpen] = useState(false)
+    const open = controlledOpen ?? internalOpen
+    const setOpen = (nextOpen: boolean): void => {
+        if (controlledOpen === undefined) {
+            setInternalOpen(nextOpen)
+        }
+        onOpenChange?.(nextOpen)
+    }
+
+    const navigation = useFilterPickerNavigation({ rootNodes, initialPath, rootSearchPlaceholder, open })
+    const close = (): void => setOpen(false)
+
+    // Structure (getChildren) is pure; this is where the active node's content is allowed to load.
+    const { activeNode, query, activePath } = navigation
+    useEffect(() => {
+        activeNode.loadContent?.({ query, path: activePath })
+        // activeNode is rebuilt every render; key the effect on its stable id plus the query instead.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeNode.id, query])
+
+    const breadcrumbParts = navigation.stack
+        .filter((node) => node.id !== navigation.rootNode.id)
+        .map((node) => node.breadcrumbLabel ?? node.tokenLabel ?? node.label)
+    const breadcrumbTitle = breadcrumbParts.filter((part): part is string => typeof part === 'string').join(' ')
+
+    const childrenResult = navigation.activeNode.getChildren?.({
+        query: navigation.query,
+        path: navigation.activePath,
+    }) ?? { nodes: [], isLoading: false }
+    const groupedNodes = useMemo(() => groupNodesBySection(childrenResult.nodes), [childrenResult.nodes])
+
+    const isPanel = navigation.activeNode.kind === 'panel' && !!navigation.activeNode.renderPanel
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger render={trigger} />
+            <PopoverContent align="start" className={cn('gap-1 p-1', isPanel ? 'w-auto' : 'w-72')} sideOffset={4}>
+                <SearchRow
+                    value={navigation.query}
+                    onChange={navigation.setQuery}
+                    placeholder={navigation.activeNode.searchPlaceholder ?? rootSearchPlaceholder}
+                    canGoBack={!navigation.isRoot}
+                    onBack={navigation.goBack}
+                />
+                {breadcrumbParts.length > 0 && (
+                    <div className="truncate px-2 py-1 text-sm font-medium text-primary" title={breadcrumbTitle}>
+                        {breadcrumbParts.map((part, index) => (
+                            <span key={index}>
+                                {index > 0 && ' '}
+                                {part}
+                            </span>
+                        ))}
+                    </div>
+                )}
+                <div className="-mx-1 my-1 h-px bg-border" />
+                {isPanel && navigation.activeNode.renderPanel ? (
+                    <div onKeyDown={(event) => event.stopPropagation()}>
+                        {navigation.activeNode.renderPanel({
+                            close,
+                            resetToRoot: navigation.resetToRoot,
+                            path: navigation.activePath,
+                            query: navigation.query,
+                            setQuery: navigation.setQuery,
+                        })}
+                    </div>
+                ) : (
+                    <div
+                        data-filter-picker-results
+                        className={SCROLL_PANEL_CLASSNAME}
+                        onScroll={(event) => {
+                            const target = event.currentTarget
+                            const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight
+                            if (distanceFromBottom < 48 && childrenResult.hasMore && !childrenResult.isLoadingMore) {
+                                childrenResult.loadMore?.()
+                            }
+                        }}
+                    >
+                        {childrenResult.isLoading && !childrenResult.nodes.length ? (
+                            <div className="px-2 py-1.5 text-xs text-tertiary">Loading…</div>
+                        ) : !childrenResult.nodes.length ? (
+                            <div className="px-2 py-1.5 text-xs text-tertiary">
+                                {childrenResult.emptyMessage ?? emptyMessage}
+                            </div>
+                        ) : (
+                            <>
+                                {groupedNodes.map((group, sectionIndex) => (
+                                    <div key={group.sectionKey}>
+                                        {sectionIndex > 0 && <div className="my-1 h-px bg-border" />}
+                                        {group.sectionLabel && (
+                                            <div className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-semibold text-tertiary [&_svg]:size-3.5">
+                                                {group.sectionIcon}
+                                                <span>{group.sectionLabel}</span>
+                                            </div>
+                                        )}
+                                        {group.nodes.map((node) => (
+                                            <FilterPickerItem
+                                                key={node.id}
+                                                node={node}
+                                                close={close}
+                                                openNode={navigation.openNode}
+                                                resetToRoot={navigation.resetToRoot}
+                                                path={navigation.activePath}
+                                            />
+                                        ))}
+                                    </div>
+                                ))}
+                                {childrenResult.isLoadingMore && (
+                                    <div className="px-2 py-1.5 text-xs text-tertiary">Loading more…</div>
+                                )}
+                                {childrenResult.hasMore && childrenResult.loadMore && !childrenResult.isLoadingMore && (
+                                    <div className="p-1">
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="w-full"
+                                            onClick={childrenResult.loadMore}
+                                        >
+                                            Load more
+                                        </Button>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
+    )
+}
+
+function FilterPickerItem({
+    node,
+    close,
+    openNode,
+    resetToRoot,
+    path,
+}: {
+    node: FilterPickerNode
+    close: () => void
+    openNode: (node: FilterPickerNode) => void
+    resetToRoot: () => void
+    path: FilterPickerPath
+}): JSX.Element {
+    const isBranch = node.kind === 'branch' || node.kind === 'panel'
+
+    return (
+        <button
+            type="button"
+            disabled={!!node.disabledReason}
+            aria-disabled={!!node.disabledReason}
+            title={node.disabledReason}
+            className="flex w-full items-center rounded-md px-2 py-1.5 text-left text-sm outline-none hover:bg-fill-button-tertiary-hover focus:bg-fill-button-tertiary-hover disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={() => {
+                if (node.disabledReason) {
+                    return
+                }
+                if (isBranch) {
+                    openNode(node)
+                    return
+                }
+                node.onSelect?.({
+                    close: () => {
+                        resetToRoot()
+                        close()
+                    },
+                    resetToRoot,
+                    path,
+                })
+            }}
+        >
+            <span className="min-w-0 flex-1 truncate">{node.label}</span>
+            {node.hint && <span className="ml-auto pl-2 text-xxs uppercase text-tertiary">{node.hint}</span>}
+        </button>
+    )
+}
+
+function SearchRow({
+    value,
+    onChange,
+    placeholder,
+    canGoBack,
+    onBack,
+}: {
+    value: string
+    onChange: (value: string) => void
+    placeholder: string
+    canGoBack: boolean
+    onBack: () => void
+}): JSX.Element {
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+        const raf = requestAnimationFrame(() => inputRef.current?.focus())
+        return () => cancelAnimationFrame(raf)
+    }, [])
+
+    return (
+        <div className="flex h-7 items-center gap-1.5 rounded-md border border-transparent bg-[var(--color-bg-fill-button-tertiary)] px-1.5 text-sm">
+            {canGoBack ? (
+                <button
+                    type="button"
+                    aria-label="Go back to previous filter level"
+                    className="shrink-0 text-tertiary hover:text-primary"
+                    onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        onBack()
+                    }}
+                >
+                    <IconArrowLeft className="text-base" />
+                </button>
+            ) : (
+                <IconFilter aria-hidden className="shrink-0 text-base text-tertiary" />
+            )}
+            <input
+                ref={inputRef}
+                type="text"
+                aria-label="Search filters"
+                className={cn(
+                    'min-w-0 flex-1 border-0 bg-transparent p-0 text-sm outline-none placeholder:text-tertiary'
+                )}
+                placeholder={placeholder}
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                onKeyDown={(event) => {
+                    if (event.key === 'ArrowDown') {
+                        const popup = event.currentTarget.closest('[data-slot="popover-content"]')
+                        const results = popup?.querySelector<HTMLElement>('[data-filter-picker-results]')
+                        const firstItem = results?.querySelector<HTMLElement>('button:not(:disabled)')
+                        if (firstItem) {
+                            event.preventDefault()
+                            event.stopPropagation()
+                            firstItem.focus()
+                        }
+                        return
+                    }
+                    if (!['Escape', 'Tab', 'ArrowUp', 'Enter'].includes(event.key)) {
+                        event.stopPropagation()
+                    }
+                }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/FilterPicker/FilterPicker.types.ts
+++ b/frontend/src/lib/components/FilterPicker/FilterPicker.types.ts
@@ -1,0 +1,82 @@
+import { ReactNode } from 'react'
+
+export interface FilterPickerPath {
+    nodeIds: string[]
+}
+
+export interface FilterPickerSection {
+    id: string
+    label: ReactNode
+    icon?: ReactNode
+}
+
+export interface FilterPickerChildrenContext {
+    query: string
+    path: FilterPickerPath
+}
+
+export interface FilterPickerChildrenResult {
+    nodes: FilterPickerNode[]
+    isLoading?: boolean
+    hasMore?: boolean
+    loadMore?: () => void
+    isLoadingMore?: boolean
+    emptyMessage?: ReactNode
+}
+
+export interface FilterPickerSelectContext {
+    close: () => void
+    resetToRoot: () => void
+    path: FilterPickerPath
+}
+
+export interface FilterPickerPanelContext extends FilterPickerSelectContext {
+    query: string
+    setQuery: (query: string) => void
+}
+
+export interface FilterPickerNode {
+    id: string
+    label: ReactNode
+    tokenLabel?: ReactNode
+    /** Word-form label shown in the in-picker breadcrumb (e.g. "contains"); falls back to tokenLabel/label. */
+    breadcrumbLabel?: ReactNode
+    searchableText?: string[]
+    description?: ReactNode
+    hint?: ReactNode
+    disabledReason?: string
+    section?: FilterPickerSection
+    kind: 'branch' | 'action' | 'panel'
+    searchPlaceholder?: string
+    /**
+     * Returns the child nodes to render for this node. MUST be pure and cheap: it is also called during
+     * path resolution on every render, so it may not fetch, dispatch, or mutate. Trigger any data loading
+     * from `loadContent` instead. The unfiltered result must be a superset of the query-filtered one so
+     * path resolution (which calls this with an empty query) can always find a committed child.
+     */
+    getChildren?: (context: FilterPickerChildrenContext) => FilterPickerChildrenResult
+    /**
+     * Imperative side-effect hook for the active node, called from an effect keyed on the node id + query.
+     * Use this to kick off async loads whose results then flow back through `getChildren`.
+     */
+    loadContent?: (context: FilterPickerChildrenContext) => void
+    onSelect?: (context: FilterPickerSelectContext) => void
+    renderPanel?: (context: FilterPickerPanelContext) => ReactNode
+}
+
+export interface FilterPickerTokenPart {
+    key?: string
+    kind: 'property' | 'operator' | 'value' | 'text'
+    label: ReactNode
+    ariaLabel?: string
+}
+
+export interface FilterPickerToken {
+    id: string
+    parts: FilterPickerTokenPart[]
+    title?: string
+    editPath?: FilterPickerPath
+    removable?: boolean
+    editable?: boolean
+    onRemove?: () => void
+}

--- a/frontend/src/lib/components/FilterPicker/FilterPickerTokenPill.test.tsx
+++ b/frontend/src/lib/components/FilterPicker/FilterPickerTokenPill.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { FilterPickerToken } from './FilterPicker.types'
+import { FilterPickerTokenPill } from './FilterPickerTokenPill'
+
+const token: FilterPickerToken = {
+    id: 'status-active',
+    parts: [
+        { kind: 'property', label: 'Status' },
+        { kind: 'operator', label: '=' },
+        { kind: 'value', label: 'Active' },
+    ],
+}
+
+describe('FilterPickerTokenPill', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('uses separate accessible edit and remove controls', async () => {
+        const onEdit = jest.fn()
+        const onRemove = jest.fn()
+
+        render(<FilterPickerTokenPill token={token} onEdit={onEdit} onRemove={onRemove} />)
+
+        await userEvent.click(screen.getByRole('button', { name: 'Edit filter: Status = Active' }))
+        expect(onEdit).toHaveBeenCalledTimes(1)
+        expect(onRemove).not.toHaveBeenCalled()
+
+        await userEvent.click(screen.getByRole('button', { name: 'Remove filter: Status = Active' }))
+        expect(onRemove).toHaveBeenCalledTimes(1)
+        expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not render a remove control when the token is not removable', () => {
+        render(<FilterPickerTokenPill token={{ ...token, removable: false }} onRemove={jest.fn()} />)
+
+        expect(screen.getByRole('button', { name: 'Filter: Status = Active' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Remove filter: Status = Active' })).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/FilterPickerTokenPill.tsx
+++ b/frontend/src/lib/components/FilterPicker/FilterPickerTokenPill.tsx
@@ -1,0 +1,70 @@
+import { forwardRef, Fragment, MouseEvent } from 'react'
+
+import { IconX } from '@posthog/icons'
+import { Button } from '@posthog/quill'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { FilterPickerToken, FilterPickerTokenPart } from './FilterPicker.types'
+
+function tokenText(parts: FilterPickerTokenPart[]): string {
+    return parts.map((part) => part.ariaLabel ?? String(part.label)).join(' ')
+}
+
+export const FilterPickerTokenPill = forwardRef<
+    HTMLDivElement,
+    {
+        token: FilterPickerToken
+        onEdit?: () => void
+        onRemove?: () => void
+        className?: string
+    }
+>(function FilterPickerTokenPill({ token, onEdit, onRemove, className }, ref): JSX.Element {
+    const label = tokenText(token.parts)
+    const canEdit = token.editable !== false && !!onEdit
+    const canRemove = token.removable === true || (token.removable !== false && (!!onRemove || !!token.onRemove))
+
+    return (
+        // data-orientation drives the button-group CSS that merges the buttons' shared border and corners,
+        // so the remove button connects to the label instead of floating as a separate pill.
+        <div
+            ref={ref}
+            role="group"
+            data-quill
+            data-slot="button-group"
+            data-orientation="horizontal"
+            className={cn('quill-button-group', className)}
+        >
+            <Button
+                size="sm"
+                variant="outline"
+                className={cn('max-w-[16rem] justify-start font-semibold', !canEdit && 'cursor-default')}
+                aria-label={canEdit ? `Edit filter: ${label}` : `Filter: ${label}`}
+                title={token.title ?? label}
+                onClick={canEdit ? onEdit : undefined}
+            >
+                <span className="flex min-w-0 items-center truncate">
+                    {token.parts.map((part, index) => (
+                        <Fragment key={part.key ?? index}>
+                            {index > 0 && <span className="mx-0.5" aria-hidden />}
+                            <span className="min-w-0 truncate">{part.label}</span>
+                        </Fragment>
+                    ))}
+                </span>
+            </Button>
+            {canRemove && (
+                <Button
+                    aria-label={`Remove filter: ${label}`}
+                    size="icon-sm"
+                    variant="outline"
+                    onClick={(event: MouseEvent) => {
+                        event.stopPropagation()
+                        ;(onRemove ?? token.onRemove)?.()
+                    }}
+                >
+                    <IconX className="size-3.5" />
+                </Button>
+            )}
+        </div>
+    )
+})

--- a/frontend/src/lib/components/FilterPicker/adapters/FilterPickerDateValue.tsx
+++ b/frontend/src/lib/components/FilterPicker/adapters/FilterPickerDateValue.tsx
@@ -1,0 +1,71 @@
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { Day, useCalendar } from '@posthog/quill'
+
+import { dayjs } from 'lib/dayjs'
+import { cn } from 'lib/utils/css-classes'
+
+export interface FilterPickerDateValueProps {
+    /** Receives the picked day as an ISO `YYYY-MM-DD` string. */
+    onSelect: (isoDate: string) => void
+}
+
+// Single-date inline calendar for the before/after/exact date operators. Quill's DateTimePicker is a
+// range picker with quick-range presets, which don't map onto a single-value operator — so we render a
+// minimal day grid off the headless useCalendar hook instead.
+export function FilterPickerDateValue({ onSelect }: FilterPickerDateValueProps): JSX.Element {
+    const { calendar, viewing, viewPreviousMonth, viewNextMonth } = useCalendar({ weekStartsOn: Day.MONDAY })
+    const weeks = calendar[0] ?? []
+    const today = dayjs()
+    const weekdayLabels = (weeks[0] ?? []).map((date) => dayjs(date).format('dd'))
+
+    return (
+        <div className="w-64 p-1">
+            <div className="flex items-center justify-between px-1 pb-1">
+                <button
+                    type="button"
+                    aria-label="Previous month"
+                    className="rounded-md p-1 text-tertiary hover:bg-fill-button-tertiary-hover hover:text-primary"
+                    onClick={viewPreviousMonth}
+                >
+                    <IconChevronLeft className="text-base" />
+                </button>
+                <span className="text-sm font-medium">{dayjs(viewing).format('MMMM YYYY')}</span>
+                <button
+                    type="button"
+                    aria-label="Next month"
+                    className="rounded-md p-1 text-tertiary hover:bg-fill-button-tertiary-hover hover:text-primary"
+                    onClick={viewNextMonth}
+                >
+                    <IconChevronRight className="text-base" />
+                </button>
+            </div>
+            <div className="grid grid-cols-7 gap-0.5 text-center text-xxs font-semibold uppercase text-tertiary">
+                {weekdayLabels.map((label, index) => (
+                    <span key={index}>{label}</span>
+                ))}
+            </div>
+            <div className="grid grid-cols-7 gap-0.5">
+                {weeks.flat().map((date) => {
+                    const isOutsideMonth = dayjs(date).month() !== dayjs(viewing).month()
+                    const isToday = dayjs(date).isSame(today, 'day')
+                    return (
+                        <button
+                            key={date.getTime()}
+                            type="button"
+                            aria-label={dayjs(date).format('LL')}
+                            className={cn(
+                                'flex h-7 items-center justify-center rounded-md text-sm outline-none',
+                                'hover:bg-fill-button-tertiary-hover focus:bg-fill-button-tertiary-hover',
+                                isOutsideMonth && 'text-tertiary',
+                                isToday && 'font-semibold text-accent'
+                            )}
+                            onClick={() => onSelect(dayjs(date).format('YYYY-MM-DD'))}
+                        >
+                            {dayjs(date).date()}
+                        </button>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/FilterPicker/adapters/index.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/index.ts
@@ -1,0 +1,3 @@
+export * from './propertyFilterNodeAdapter'
+export * from './propertyFilterOperatorAdapter'
+export * from './propertyFilterTokenAdapter'

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterNodeAdapter.test.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterNodeAdapter.test.ts
@@ -1,0 +1,60 @@
+import { PropertyFilterType, PropertyType } from '~/types'
+
+import { FilterPickerNode } from '../FilterPicker.types'
+import { CreatePropertyFilterNodesOptions, createPropertyFilterPickerNodes } from './propertyFilterNodeAdapter'
+
+const baseOptions: Omit<CreatePropertyFilterNodesOptions, 'properties'> = {
+    onSelect: () => {},
+    valueLoader: () => ({ values: [{ value: 'a', label: 'Value A' }] }),
+}
+
+function childLabels(node: FilterPickerNode): string[] {
+    const result = node.getChildren?.({ query: '', path: { nodeIds: [] } })
+    return (result?.nodes ?? []).map((child) => String(child.label))
+}
+
+describe('createPropertyFilterPickerNodes', () => {
+    it('auto-advances an auto category straight to the value step', () => {
+        const [node] = createPropertyFilterPickerNodes({
+            ...baseOptions,
+            properties: [
+                { key: 'id', label: 'Cohort', type: PropertyFilterType.Cohort, propertyType: PropertyType.Cohort },
+            ],
+        })
+
+        // The property node renders values directly (no intermediate operator list).
+        expect(childLabels(node)).toContain('Value A')
+        expect(node.breadcrumbLabel).toBe('Cohort')
+    })
+
+    it('keeps the operator step for multi-operator categories', () => {
+        const [node] = createPropertyFilterPickerNodes({
+            ...baseOptions,
+            properties: [
+                { key: 'name', label: 'Name', type: PropertyFilterType.Event, propertyType: PropertyType.String },
+            ],
+        })
+
+        // The property node renders operator choices, not values.
+        const labels = childLabels(node)
+        expect(labels.some((label) => label.includes('contains'))).toBe(true)
+        expect(labels).not.toContain('Value A')
+    })
+
+    it('lets a property opt out of auto-advance with operatorMode pick', () => {
+        const [node] = createPropertyFilterPickerNodes({
+            ...baseOptions,
+            properties: [
+                {
+                    key: 'id',
+                    label: 'Cohort',
+                    type: PropertyFilterType.Cohort,
+                    propertyType: PropertyType.Cohort,
+                    operatorMode: 'pick',
+                },
+            ],
+        })
+
+        expect(childLabels(node)).not.toContain('Value A')
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterNodeAdapter.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterNodeAdapter.ts
@@ -1,0 +1,272 @@
+import { createElement } from 'react'
+
+import { TaxonomicDefinitionTypes, TaxonomicFilterGroup } from 'lib/components/TaxonomicFilter/types'
+
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import { AnyPropertyFilter, PropertyFilterType, PropertyFilterValue, PropertyOperator, PropertyType } from '~/types'
+
+import {
+    FilterPickerChildrenResult,
+    FilterPickerNode,
+    FilterPickerPanelContext,
+    FilterPickerSelectContext,
+} from '../FilterPicker.types'
+import { FilterPickerDateValue } from './FilterPickerDateValue'
+import {
+    AUTO_ADVANCE_TYPES,
+    createFilterPickerOperatorOptions,
+    FilterPickerOperatorOption,
+    resolveDefaultOperator,
+} from './propertyFilterOperatorAdapter'
+
+export interface FilterPickerPropertyOption {
+    key: string
+    label: string
+    type: PropertyFilterType
+    propertyType?: PropertyType
+    description?: string
+    section?: FilterPickerNode['section']
+    taxonomicItem?: TaxonomicDefinitionTypes
+    group?: TaxonomicFilterGroup
+    /** Overrides the type's default operator (e.g. a String field that is really a version → semver). */
+    defaultOperator?: PropertyOperator
+    /** 'auto' skips the operator step and goes straight to value entry; 'pick' forces the operator list. */
+    operatorMode?: 'auto' | 'pick'
+}
+
+export interface FilterPickerValueOption {
+    value: PropertyFilterValue
+    label: string
+    description?: string
+}
+
+export interface PropertyValueLoaderResult {
+    values: FilterPickerValueOption[]
+    isLoading?: boolean
+    hasMore?: boolean
+    loadMore?: () => void
+    isLoadingMore?: boolean
+    allowCustomValues?: boolean
+    /** Imperative trigger to fetch values for this property/query. Called from FilterPicker's content effect. */
+    load?: () => void
+}
+
+export interface PropertyValueLoaderContext {
+    property: FilterPickerPropertyOption
+    operator: FilterPickerOperatorOption
+    query: string
+    eventNames?: string[]
+}
+
+export interface CreatePropertyFilterNodesOptions {
+    properties: FilterPickerPropertyOption[]
+    onSelect: (filter: AnyPropertyFilter, context: FilterPickerSelectContext) => void
+    valueLoader?: (context: PropertyValueLoaderContext) => PropertyValueLoaderResult
+    eventNames?: string[]
+    operatorAllowlist?: Partial<Record<PropertyType, PropertyOperator[]>>
+    rootSections?: Record<string, FilterPickerNode['section']>
+}
+
+function matchesQuery(text: string, query: string): boolean {
+    return !query.trim() || text.toLowerCase().includes(query.trim().toLowerCase())
+}
+
+function nodeIdForProperty(property: FilterPickerPropertyOption): string {
+    return `property:${property.type}:${property.key}`
+}
+
+function nodeIdForOperator(property: FilterPickerPropertyOption, operator: PropertyOperator): string {
+    return `${nodeIdForProperty(property)}:operator:${operator}`
+}
+
+function nodeIdForValue(
+    property: FilterPickerPropertyOption,
+    operator: PropertyOperator,
+    value: PropertyFilterValue
+): string {
+    return `${nodeIdForOperator(property, operator)}:value:${String(value)}`
+}
+
+function getDisplayLabel(property: FilterPickerPropertyOption): string {
+    return property.group
+        ? getCoreFilterDefinition(property.key, property.group.type)?.label || property.label || property.key
+        : property.label || property.key
+}
+
+function createFilter(
+    property: FilterPickerPropertyOption,
+    operator: PropertyOperator,
+    value: PropertyFilterValue
+): AnyPropertyFilter {
+    // AnyPropertyFilter is a discriminated union keyed on a literal `type`; this is a generic constructor
+    // over the broad PropertyFilterType, so a single typed assertion (never `as any`) is the right tool.
+    return {
+        key: property.key,
+        type: property.type,
+        operator,
+        value,
+        group_type_index: property.group?.groupTypeIndex,
+    } as AnyPropertyFilter
+}
+
+function DateValuePanel({
+    property,
+    operator,
+    options,
+    context,
+}: {
+    property: FilterPickerPropertyOption
+    operator: FilterPickerOperatorOption
+    options: CreatePropertyFilterNodesOptions
+    context: FilterPickerPanelContext
+}): JSX.Element {
+    return createElement(FilterPickerDateValue, {
+        onSelect: (isoDate: string) => {
+            options.onSelect(createFilter(property, operator.operator, isoDate), context)
+        },
+    })
+}
+
+function valueNodes(
+    property: FilterPickerPropertyOption,
+    operator: FilterPickerOperatorOption,
+    options: CreatePropertyFilterNodesOptions,
+    query: string
+): FilterPickerChildrenResult {
+    const loaded = options.valueLoader?.({ property, operator, query, eventNames: options.eventNames })
+    const values = loaded?.values ?? []
+    const nodes = values
+        .filter((value) => matchesQuery(value.label, query))
+        .map<FilterPickerNode>((value) => ({
+            id: nodeIdForValue(property, operator.operator, value.value),
+            label: value.label,
+            tokenLabel: value.label,
+            description: value.description,
+            kind: 'action',
+            onSelect: (context) => options.onSelect(createFilter(property, operator.operator, value.value), context),
+        }))
+
+    if (loaded?.allowCustomValues && query.trim() && !values.some((value) => value.label === query.trim())) {
+        nodes.unshift({
+            id: nodeIdForValue(property, operator.operator, query.trim()),
+            label: `Use "${query.trim()}"`,
+            tokenLabel: query.trim(),
+            kind: 'action',
+            onSelect: (context) => options.onSelect(createFilter(property, operator.operator, query.trim()), context),
+        })
+    }
+
+    return {
+        nodes,
+        isLoading: loaded?.isLoading,
+        hasMore: loaded?.hasMore,
+        loadMore: loaded?.loadMore,
+        isLoadingMore: loaded?.isLoadingMore,
+        emptyMessage: query ? 'No values found' : 'Start typing to search values',
+    }
+}
+
+// The breadcrumb reads as a phrase ("Source contains"), so strip the leading symbol the menu label carries
+// (e.g. "∋ contains" → "contains", "= equals" → "equals") while leaving symbol-free labels untouched.
+function operatorBreadcrumbLabel(menuLabel: string): string {
+    const [first, ...rest] = menuLabel.split(' ')
+    return rest.length && !/[\p{L}\p{N}]/u.test(first) ? rest.join(' ') : menuLabel
+}
+
+// The picker commits a single value per filter. That matches every operator the string/datetime/cohort
+// types expose; the multi-value `between`/`not between` operators are Numeric-only and are not added here
+// unless a consumer's `operatorAllowlist` forces them, in which case they'd need a dedicated multi-value UI.
+function operatorNode(
+    property: FilterPickerPropertyOption,
+    operator: FilterPickerOperatorOption,
+    options: CreatePropertyFilterNodesOptions
+): FilterPickerNode {
+    if (!operator.metadata.acceptsValue) {
+        return {
+            id: nodeIdForOperator(property, operator.operator),
+            label: operator.menuLabel,
+            tokenLabel: operator.tokenLabel,
+            breadcrumbLabel: operatorBreadcrumbLabel(operator.menuLabel),
+            kind: 'action',
+            onSelect: (context) => options.onSelect(createFilter(property, operator.operator, null), context),
+        }
+    }
+
+    return {
+        id: nodeIdForOperator(property, operator.operator),
+        label: operator.menuLabel,
+        tokenLabel: operator.tokenLabel,
+        breadcrumbLabel: operatorBreadcrumbLabel(operator.menuLabel),
+        kind: property.propertyType === PropertyType.DateTime ? 'panel' : 'branch',
+        searchPlaceholder: 'Search or type a value…',
+        getChildren:
+            property.propertyType === PropertyType.DateTime
+                ? undefined
+                : ({ query }) => valueNodes(property, operator, options, query),
+        loadContent:
+            property.propertyType === PropertyType.DateTime
+                ? undefined
+                : ({ query }) =>
+                      options.valueLoader?.({ property, operator, query, eventNames: options.eventNames }).load?.(),
+        renderPanel:
+            property.propertyType === PropertyType.DateTime
+                ? (context) => createElement(DateValuePanel, { property, operator, options, context })
+                : undefined,
+    }
+}
+
+export function createPropertyFilterPickerNodes(options: CreatePropertyFilterNodesOptions): FilterPickerNode[] {
+    return options.properties.map<FilterPickerNode>((property) => {
+        const propertyType = property.propertyType ?? PropertyType.String
+        const operatorAllowlist = options.operatorAllowlist?.[propertyType]
+        const defaultOperator = resolveDefaultOperator(propertyType, property.defaultOperator)
+        const operators = createFilterPickerOperatorOptions(propertyType, operatorAllowlist, defaultOperator)
+        const label = getDisplayLabel(property)
+        const section = property.section ?? options.rootSections?.[property.type]
+        const searchableText = [label, property.key, property.type]
+
+        // Skip the operator step for categories whose default operator dominates (or when only one exists).
+        // The property node becomes the value step directly, with the operator implied in its breadcrumb.
+        const autoAdvance =
+            property.operatorMode === 'auto' ||
+            (property.operatorMode !== 'pick' && (AUTO_ADVANCE_TYPES.has(propertyType) || operators.length === 1))
+
+        if (autoAdvance && operators.length) {
+            const operator = operators.find((option) => option.operator === defaultOperator) ?? operators[0]
+            const valueStep = operatorNode(property, operator, options)
+            return {
+                ...valueStep,
+                id: nodeIdForProperty(property),
+                label,
+                tokenLabel: label,
+                // Operator is implicit when auto-advancing, so the breadcrumb is just the property label.
+                breadcrumbLabel: label,
+                description: property.description,
+                section,
+                searchableText,
+            }
+        }
+
+        return {
+            id: nodeIdForProperty(property),
+            label,
+            tokenLabel: label,
+            description: property.description,
+            kind: 'branch',
+            section,
+            searchableText,
+            searchPlaceholder: 'Choose an operator…',
+            getChildren: ({ query }) => ({
+                nodes: operators
+                    .filter((operator) => matchesQuery(operator.menuLabel, query))
+                    .map((operator) => operatorNode(property, operator, options)),
+                emptyMessage: 'No operators found',
+            }),
+        }
+    })
+}
+
+export function editPathForPropertyFilter(filter: AnyPropertyFilter): string[] {
+    const operator = 'operator' in filter ? filter.operator : PropertyOperator.Exact
+    return [`property:${filter.type}:${filter.key}`, `property:${filter.type}:${filter.key}:operator:${operator}`]
+}

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterOperatorAdapter.test.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterOperatorAdapter.test.ts
@@ -1,0 +1,55 @@
+import { PropertyOperator, PropertyType } from '~/types'
+
+import { createFilterPickerOperatorOptions, resolveDefaultOperator } from './propertyFilterOperatorAdapter'
+
+describe('createFilterPickerOperatorOptions', () => {
+    it('does not offer semver operators on plain string properties', () => {
+        const operators = createFilterPickerOperatorOptions(PropertyType.String).map((option) => option.operator)
+        expect(operators).toContain(PropertyOperator.IContains)
+        expect(operators).not.toContain(PropertyOperator.SemverEq)
+    })
+
+    it('offers the semver operators only for the semver category', () => {
+        const operators = createFilterPickerOperatorOptions(PropertyType.Semver).map((option) => option.operator)
+        expect(operators).toContain(PropertyOperator.SemverEq)
+        expect(operators).not.toContain(PropertyOperator.IContains)
+    })
+
+    it('surfaces the default operator first', () => {
+        const operators = createFilterPickerOperatorOptions(
+            PropertyType.DateTime,
+            undefined,
+            PropertyOperator.IsDateAfter
+        )
+        expect(operators[0].operator).toBe(PropertyOperator.IsDateAfter)
+    })
+
+    it('labels cohort in/not-in as the verb, not "user"', () => {
+        const operators = createFilterPickerOperatorOptions(PropertyType.Cohort)
+        const inOption = operators.find((option) => option.operator === PropertyOperator.In)
+        expect(inOption?.menuLabel).toBe('in')
+        expect(inOption?.tokenLabel).toBe('in')
+    })
+
+    it('honours an explicit allowlist over the type policy', () => {
+        const operators = createFilterPickerOperatorOptions(PropertyType.String, [PropertyOperator.Exact]).map(
+            (option) => option.operator
+        )
+        expect(operators).toEqual([PropertyOperator.Exact])
+    })
+})
+
+describe('resolveDefaultOperator', () => {
+    it('returns the type default', () => {
+        expect(resolveDefaultOperator(PropertyType.Cohort)).toBe(PropertyOperator.In)
+        expect(resolveDefaultOperator(PropertyType.Semver)).toBe(PropertyOperator.SemverEq)
+    })
+
+    it('prefers a per-property override', () => {
+        expect(resolveDefaultOperator(PropertyType.String, PropertyOperator.SemverEq)).toBe(PropertyOperator.SemverEq)
+    })
+
+    it('is undefined when no default exists', () => {
+        expect(resolveDefaultOperator(PropertyType.String)).toBeUndefined()
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterOperatorAdapter.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterOperatorAdapter.ts
@@ -1,0 +1,209 @@
+import {
+    allOperatorsMapping,
+    chooseOperatorMap,
+    isOperatorBetween,
+    isOperatorDate,
+    isOperatorMulti,
+    isOperatorRange,
+    isOperatorSemver,
+} from 'lib/utils/operators'
+
+import { PropertyOperator, PropertyType } from '~/types'
+
+export interface FilterPickerOperatorOption {
+    operator: PropertyOperator
+    menuLabel: string
+    tokenLabel: string
+    metadata: {
+        acceptsValue: boolean
+        isDate: boolean
+        isNumeric: boolean
+        isBetween: boolean
+        isMultiSelect: boolean
+        isSetOperator: boolean
+        isSemver: boolean
+    }
+}
+
+const EXTRA_OPERATOR_LABELS: Partial<Record<PropertyOperator, string>> = {
+    [PropertyOperator.Between]: 'between',
+    [PropertyOperator.NotBetween]: 'not between',
+    [PropertyOperator.IContainsMulti]: 'contains any of',
+    [PropertyOperator.NotIContainsMulti]: "doesn't contain any of",
+}
+
+const EXTRA_OPERATOR_SYMBOLS: Partial<Record<PropertyOperator, string>> = {
+    [PropertyOperator.Between]: '↔',
+    [PropertyOperator.NotBetween]: '↮',
+    [PropertyOperator.IContainsMulti]: '∋',
+    [PropertyOperator.NotIContainsMulti]: '∌',
+}
+
+// The picker's canonical operator set per type. This is the source of truth for which operators a category
+// exposes, overridable by a consumer `operatorAllowlist`. It deliberately does NOT defer to the shared
+// `stringOperatorMap`, which leaks semver operators onto every String property — semver is its own category.
+export const OPERATOR_POLICY: Partial<Record<PropertyType, PropertyOperator[]>> = {
+    [PropertyType.String]: [
+        PropertyOperator.Exact,
+        PropertyOperator.IsNot,
+        PropertyOperator.IContains,
+        PropertyOperator.NotIContains,
+        PropertyOperator.Regex,
+        PropertyOperator.NotRegex,
+        PropertyOperator.IsSet,
+        PropertyOperator.IsNotSet,
+    ],
+    [PropertyType.StringArray]: [
+        PropertyOperator.Exact,
+        PropertyOperator.IsNot,
+        PropertyOperator.IContains,
+        PropertyOperator.NotIContains,
+        PropertyOperator.Regex,
+        PropertyOperator.NotRegex,
+    ],
+    [PropertyType.Semver]: [
+        PropertyOperator.SemverEq,
+        PropertyOperator.SemverNeq,
+        PropertyOperator.SemverGt,
+        PropertyOperator.SemverGte,
+        PropertyOperator.SemverLt,
+        PropertyOperator.SemverLte,
+        PropertyOperator.SemverTilde,
+        PropertyOperator.SemverCaret,
+        PropertyOperator.SemverWildcard,
+    ],
+    [PropertyType.DateTime]: [
+        PropertyOperator.IsDateExact,
+        PropertyOperator.IsDateBefore,
+        PropertyOperator.IsDateAfter,
+        PropertyOperator.IsSet,
+        PropertyOperator.IsNotSet,
+    ],
+    [PropertyType.Numeric]: [
+        PropertyOperator.Exact,
+        PropertyOperator.IsNot,
+        PropertyOperator.GreaterThan,
+        PropertyOperator.GreaterThanOrEqual,
+        PropertyOperator.LessThan,
+        PropertyOperator.LessThanOrEqual,
+        PropertyOperator.Between,
+        PropertyOperator.NotBetween,
+        PropertyOperator.IsSet,
+        PropertyOperator.IsNotSet,
+    ],
+    [PropertyType.Duration]: [
+        PropertyOperator.Exact,
+        PropertyOperator.GreaterThan,
+        PropertyOperator.GreaterThanOrEqual,
+        PropertyOperator.LessThan,
+        PropertyOperator.LessThanOrEqual,
+        PropertyOperator.IsSet,
+        PropertyOperator.IsNotSet,
+    ],
+    [PropertyType.Boolean]: [
+        PropertyOperator.Exact,
+        PropertyOperator.IsNot,
+        PropertyOperator.IsSet,
+        PropertyOperator.IsNotSet,
+    ],
+    [PropertyType.Cohort]: [PropertyOperator.In, PropertyOperator.NotIn],
+    [PropertyType.Assignee]: [PropertyOperator.Exact, PropertyOperator.IsNot, PropertyOperator.IsNotSet],
+    [PropertyType.Selector]: [PropertyOperator.Exact],
+    [PropertyType.Flag]: [PropertyOperator.FlagEvaluatesTo],
+}
+
+// The operator a category lands on by default — surfaced first in the list and used when the operator step
+// is skipped. A per-property `defaultOperator` overrides this (e.g. a String field that is really a version).
+export const DEFAULT_OPERATOR_BY_TYPE: Partial<Record<PropertyType, PropertyOperator>> = {
+    [PropertyType.Cohort]: PropertyOperator.In,
+    [PropertyType.DateTime]: PropertyOperator.IsDateExact,
+    [PropertyType.Semver]: PropertyOperator.SemverEq,
+    [PropertyType.Boolean]: PropertyOperator.Exact,
+}
+
+// Categories whose default operator dominates so strongly that the picker skips the operator step entirely
+// and goes straight to value entry. A property can opt in/out explicitly via `operatorMode`.
+export const AUTO_ADVANCE_TYPES = new Set<PropertyType>([PropertyType.Cohort, PropertyType.Boolean])
+
+export function resolveDefaultOperator(
+    propertyType: PropertyType | undefined,
+    override?: PropertyOperator
+): PropertyOperator | undefined {
+    return override ?? (propertyType ? DEFAULT_OPERATOR_BY_TYPE[propertyType] : undefined)
+}
+
+// Higher-priority labels for the picker. The shared cohortOperatorMap phrases these as "user in" / "user
+// not in" (meant to read "user in cohort X"), which makes the picker show the operator as "user"; here the
+// operator is just the verb.
+const PICKER_LABEL_OVERRIDES: Partial<Record<PropertyOperator, string>> = {
+    [PropertyOperator.In]: 'in',
+    [PropertyOperator.NotIn]: 'not in',
+}
+
+function operatorLabel(operator: PropertyOperator, propertyType?: PropertyType): string {
+    return (
+        PICKER_LABEL_OVERRIDES[operator] ??
+        chooseOperatorMap(propertyType)[operator] ??
+        allOperatorsMapping[operator] ??
+        EXTRA_OPERATOR_LABELS[operator] ??
+        operator
+    )
+}
+
+export function operatorTokenLabel(operator: PropertyOperator, propertyType?: PropertyType): string {
+    const label = operatorLabel(operator, propertyType)
+    const firstPart = label.split(' ')[0]
+    if (firstPart !== operator) {
+        return firstPart
+    }
+    return EXTRA_OPERATOR_SYMBOLS[operator] ?? firstPart
+}
+
+export function createFilterPickerOperatorOption(
+    operator: PropertyOperator,
+    propertyType?: PropertyType
+): FilterPickerOperatorOption {
+    // Only is_set/is_not_set take no value. In/NotIn are flagged by isOperatorFlag too, but for cohorts they
+    // do take a value (the cohort id), so they must keep their value step.
+    const isSetOperator = operator === PropertyOperator.IsSet || operator === PropertyOperator.IsNotSet
+    return {
+        operator,
+        menuLabel: operatorLabel(operator, propertyType),
+        tokenLabel: operatorTokenLabel(operator, propertyType),
+        metadata: {
+            acceptsValue: !isSetOperator,
+            isDate: isOperatorDate(operator),
+            isNumeric:
+                propertyType === PropertyType.Numeric ||
+                propertyType === PropertyType.Duration ||
+                isOperatorRange(operator),
+            isBetween: isOperatorBetween(operator),
+            isMultiSelect:
+                isOperatorMulti(operator) ||
+                operator === PropertyOperator.IContainsMulti ||
+                operator === PropertyOperator.NotIContainsMulti,
+            isSetOperator,
+            isSemver: isOperatorSemver(operator),
+        },
+    }
+}
+
+export function createFilterPickerOperatorOptions(
+    propertyType?: PropertyType,
+    operatorAllowlist?: PropertyOperator[],
+    defaultOperator?: PropertyOperator
+): FilterPickerOperatorOption[] {
+    // Resolution order: explicit consumer allowlist → the picker's per-type policy → the shared operator map
+    // as a last resort for types the policy doesn't cover.
+    const operators =
+        operatorAllowlist ??
+        (propertyType ? OPERATOR_POLICY[propertyType] : undefined) ??
+        (Object.keys(chooseOperatorMap(propertyType)) as PropertyOperator[])
+    const unique = Array.from(new Set(operators))
+    // Surface the default operator first so it is the highlighted/initial choice.
+    const ordered =
+        defaultOperator && unique.includes(defaultOperator)
+            ? [defaultOperator, ...unique.filter((operator) => operator !== defaultOperator)]
+            : unique
+    return ordered.map((operator) => createFilterPickerOperatorOption(operator, propertyType))
+}

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterTokenAdapter.test.tsx
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterTokenAdapter.test.tsx
@@ -1,0 +1,98 @@
+import { AnyPropertyFilter, CohortType, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { createPropertyFilterToken } from './propertyFilterTokenAdapter'
+
+describe('createPropertyFilterToken', () => {
+    it.each([
+        [
+            'status',
+            {
+                key: 'Status',
+                type: PropertyFilterType.ErrorTrackingIssue,
+                operator: PropertyOperator.Exact,
+                value: 'Active',
+            },
+            ['Status', '=', 'Active'],
+        ],
+        [
+            'assignee',
+            {
+                key: 'Assignee',
+                type: PropertyFilterType.ErrorTrackingIssue,
+                operator: PropertyOperator.Exact,
+                value: 'Jane',
+            },
+            ['Assignee', '=', 'Jane'],
+        ],
+        [
+            'cohort',
+            { key: 'id', type: PropertyFilterType.Cohort, operator: PropertyOperator.In, value: 7 },
+            ['Cohort', 'in', 'Power users'],
+        ],
+        [
+            'feature flag',
+            {
+                key: '$active_feature_flags',
+                type: PropertyFilterType.Event,
+                operator: PropertyOperator.IContains,
+                value: 'beta-checkout',
+                label: 'Feature flag',
+            },
+            ['Active feature flags', '∋', 'beta-checkout'],
+        ],
+        [
+            'property filter',
+            {
+                key: '$exception_types',
+                type: PropertyFilterType.Event,
+                operator: PropertyOperator.IContains,
+                value: 'TypeError',
+            },
+            ['Exception type', '∋', 'TypeError'],
+        ],
+    ])('formats %s tokens', (_name, filter, expectedParts) => {
+        const token = createPropertyFilterToken(filter as AnyPropertyFilter, {
+            cohortsById: { 7: { id: 7, name: 'Power users' } as CohortType },
+        })
+
+        expect(token.parts.map((part) => part.label)).toEqual(expectedParts)
+    })
+
+    it.each([
+        ['$exception_sources', 'Source'],
+        ['$app_version', 'Version'],
+    ])('allows adapters to render curated labels for %s', (key, label) => {
+        const token = createPropertyFilterToken(
+            {
+                key,
+                type: PropertyFilterType.Event,
+                operator: PropertyOperator.IContains,
+                value: 'value',
+            } as AnyPropertyFilter,
+            {
+                propertyLabelFormatter: (filter) =>
+                    ({ $exception_sources: 'Source', $app_version: 'Version' })[filter.key ?? ''],
+            }
+        )
+
+        expect(token.parts[0].label).toEqual(label)
+    })
+
+    it('uses the operator and optional suffix to keep token ids unique', () => {
+        const baseFilter = { key: '$exception_types', type: PropertyFilterType.Event, value: 'TypeError' }
+        const exactToken = createPropertyFilterToken({
+            ...baseFilter,
+            operator: PropertyOperator.Exact,
+        } as AnyPropertyFilter)
+        const containsToken = createPropertyFilterToken({
+            ...baseFilter,
+            operator: PropertyOperator.IContains,
+        } as AnyPropertyFilter)
+        const duplicateToken = createPropertyFilterToken(
+            { ...baseFilter, operator: PropertyOperator.Exact } as AnyPropertyFilter,
+            { idSuffix: 1 }
+        )
+
+        expect(new Set([exactToken.id, containsToken.id, duplicateToken.id]).size).toBe(3)
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/adapters/propertyFilterTokenAdapter.ts
+++ b/frontend/src/lib/components/FilterPicker/adapters/propertyFilterTokenAdapter.ts
@@ -1,0 +1,116 @@
+import { ReactNode } from 'react'
+
+import {
+    formatPropertyLabel,
+    PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE,
+} from 'lib/components/PropertyFilters/utils'
+
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import {
+    AnyPropertyFilter,
+    CohortPropertyFilter,
+    CohortType,
+    PropertyFilterType,
+    PropertyFilterValue,
+    PropertyOperator,
+} from '~/types'
+
+import { FilterPickerToken, FilterPickerTokenPart } from '../FilterPicker.types'
+import { operatorTokenLabel } from './propertyFilterOperatorAdapter'
+
+export type FilterPickerValueFormatter = (
+    value: PropertyFilterValue | undefined,
+    filter: AnyPropertyFilter
+) => ReactNode
+
+export type FilterPickerPropertyLabelFormatter = (filter: AnyPropertyFilter) => ReactNode
+
+function defaultValueFormatter(value: PropertyFilterValue | undefined): ReactNode {
+    if (Array.isArray(value)) {
+        return value.join(', ')
+    }
+    if (value === null || value === undefined) {
+        return ''
+    }
+    return String(value)
+}
+
+function defaultPropertyLabel(filter: AnyPropertyFilter): ReactNode {
+    if (filter.type === PropertyFilterType.Cohort) {
+        return 'Cohort'
+    }
+    const label = 'label' in filter ? filter.label : undefined
+    const taxonomicFilterGroupType = filter.type
+        ? PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE[filter.type]
+        : undefined
+    const coreLabel = taxonomicFilterGroupType
+        ? getCoreFilterDefinition(filter.key, taxonomicFilterGroupType)?.label
+        : undefined
+    return coreLabel || label || filter.key
+}
+
+function propertyValue(
+    filter: AnyPropertyFilter,
+    cohortsById: Partial<Record<CohortType['id'], CohortType>>,
+    valueFormatter: FilterPickerValueFormatter
+): ReactNode {
+    if (filter.type === PropertyFilterType.Cohort) {
+        const cohortFilter = filter as CohortPropertyFilter
+        const cohortId = typeof cohortFilter.value === 'number' ? cohortFilter.value : Number(cohortFilter.value)
+        return cohortFilter.cohort_name || cohortsById[cohortId]?.name || `ID ${cohortFilter.value}`
+    }
+    return valueFormatter('value' in filter ? filter.value : undefined, filter)
+}
+
+function tokenTitle(
+    filter: AnyPropertyFilter,
+    cohortsById: Partial<Record<CohortType['id'], CohortType>>,
+    valueFormatter: FilterPickerValueFormatter
+): string {
+    return formatPropertyLabel(filter, cohortsById, (value) => String(valueFormatter(value, filter)))
+}
+
+export interface CreatePropertyFilterTokenOptions {
+    cohortsById?: Partial<Record<CohortType['id'], CohortType>>
+    valueFormatter?: FilterPickerValueFormatter
+    propertyLabelFormatter?: FilterPickerPropertyLabelFormatter
+    editNodeIds?: string[]
+    idSuffix?: string | number
+    onRemove?: () => void
+}
+
+export function createPropertyFilterToken(
+    filter: AnyPropertyFilter,
+    options: CreatePropertyFilterTokenOptions = {}
+): FilterPickerToken {
+    const cohortsById = options.cohortsById ?? {}
+    const valueFormatter = options.valueFormatter ?? defaultValueFormatter
+    const propertyLabelFormatter = options.propertyLabelFormatter ?? defaultPropertyLabel
+    const operator = 'operator' in filter ? (filter.operator as PropertyOperator) : PropertyOperator.Exact
+    const parts: FilterPickerTokenPart[] = [
+        {
+            kind: 'property',
+            label: propertyLabelFormatter(filter),
+        },
+        {
+            kind: 'operator',
+            label: operatorTokenLabel(operator),
+        },
+        {
+            kind: 'value',
+            label: propertyValue(filter, cohortsById, valueFormatter),
+        },
+    ]
+
+    return {
+        id: `${filter.type}:${filter.key}:${operator}:${String('value' in filter ? filter.value : '')}${
+            options.idSuffix === undefined ? '' : `:${options.idSuffix}`
+        }`,
+        parts,
+        title: tokenTitle(filter, cohortsById, valueFormatter),
+        editPath: options.editNodeIds ? { nodeIds: options.editNodeIds } : undefined,
+        removable: !!options.onRemove,
+        editable: !!options.editNodeIds,
+        onRemove: options.onRemove,
+    }
+}

--- a/frontend/src/lib/components/FilterPicker/index.ts
+++ b/frontend/src/lib/components/FilterPicker/index.ts
@@ -1,0 +1,14 @@
+export { FilterPicker } from './FilterPicker'
+export { FilterPickerTokenPill } from './FilterPickerTokenPill'
+export { useFilterPickerNavigation } from './useFilterPickerNavigation'
+export type {
+    FilterPickerChildrenContext,
+    FilterPickerChildrenResult,
+    FilterPickerNode,
+    FilterPickerPanelContext,
+    FilterPickerPath,
+    FilterPickerSection,
+    FilterPickerSelectContext,
+    FilterPickerToken,
+    FilterPickerTokenPart,
+} from './FilterPicker.types'

--- a/frontend/src/lib/components/FilterPicker/useFilterPickerNavigation.test.tsx
+++ b/frontend/src/lib/components/FilterPicker/useFilterPickerNavigation.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { FilterPickerNode } from './FilterPicker.types'
+import { useFilterPickerNavigation } from './useFilterPickerNavigation'
+
+const leaf: FilterPickerNode = { id: 'leaf', label: 'Leaf', kind: 'action' }
+const branch: FilterPickerNode = {
+    id: 'branch',
+    label: 'Branch',
+    kind: 'branch',
+    getChildren: () => ({ nodes: [leaf], isLoading: false }),
+}
+const rootNodes: FilterPickerNode[] = [branch]
+
+describe('useFilterPickerNavigation', () => {
+    it('resolves initial paths and falls back to the deepest valid prefix when a segment is missing', () => {
+        const { result, rerender } = renderHook(
+            ({ initialPath }) => useFilterPickerNavigation({ rootNodes, initialPath }),
+            { initialProps: { initialPath: { nodeIds: ['branch', 'leaf'] } } }
+        )
+
+        expect(result.current.activePath.nodeIds).toEqual(['branch', 'leaf'])
+        expect(result.current.activeNode.id).toBe('leaf')
+
+        // 'branch' resolves but 'missing' does not, so the walk stops at 'branch' rather than collapsing to root.
+        rerender({ initialPath: { nodeIds: ['branch', 'missing'] } })
+
+        expect(result.current.activePath.nodeIds).toEqual(['branch'])
+        expect(result.current.activeNode.id).toBe('branch')
+    })
+
+    it('does not reset the stack on root node array identity churn', () => {
+        const { result, rerender } = renderHook(({ nodes }) => useFilterPickerNavigation({ rootNodes: nodes }), {
+            initialProps: { nodes: rootNodes },
+        })
+
+        act(() => result.current.openNode(branch))
+        expect(result.current.activePath.nodeIds).toEqual(['branch'])
+
+        rerender({ nodes: [...rootNodes] })
+
+        expect(result.current.activePath.nodeIds).toEqual(['branch'])
+    })
+
+    it('keeps the active path but refreshes node data when root nodes change', () => {
+        const updatedBranch: FilterPickerNode = { ...branch, label: 'Updated branch' }
+        const { result, rerender } = renderHook(({ nodes }) => useFilterPickerNavigation({ rootNodes: nodes }), {
+            initialProps: { nodes: rootNodes },
+        })
+
+        act(() => result.current.openNode(branch))
+        rerender({ nodes: [updatedBranch] })
+
+        expect(result.current.activePath.nodeIds).toEqual(['branch'])
+        expect(result.current.activeNode.label).toBe('Updated branch')
+    })
+
+    it('falls back to the nearest valid path when an active node disappears', () => {
+        const { result, rerender } = renderHook(({ nodes }) => useFilterPickerNavigation({ rootNodes: nodes }), {
+            initialProps: { nodes: rootNodes },
+        })
+
+        act(() => result.current.openNode(branch))
+        rerender({ nodes: [] })
+
+        expect(result.current.activePath.nodeIds).toEqual([])
+        expect(result.current.isRoot).toBe(true)
+    })
+
+    it('clears query when navigating back or resetting to root', () => {
+        const { result } = renderHook(() => useFilterPickerNavigation({ rootNodes }))
+
+        act(() => {
+            result.current.setQuery('status')
+            result.current.openNode(branch)
+        })
+        expect(result.current.query).toBe('')
+
+        act(() => result.current.setQuery('active'))
+        expect(result.current.query).toBe('active')
+
+        act(() => result.current.goBack())
+        expect(result.current.query).toBe('')
+        expect(result.current.isRoot).toBe(true)
+
+        act(() => {
+            result.current.openNode(branch)
+            result.current.setQuery('active')
+            result.current.resetToRoot()
+        })
+        expect(result.current.query).toBe('')
+        expect(result.current.isRoot).toBe(true)
+    })
+
+    it('can re-apply an edit path after resetting to root', () => {
+        const { result } = renderHook(() => useFilterPickerNavigation({ rootNodes }))
+
+        act(() => result.current.resetToRoot())
+        expect(result.current.isRoot).toBe(true)
+
+        act(() => result.current.resetToPath({ nodeIds: ['branch', 'leaf'] }))
+
+        expect(result.current.activePath.nodeIds).toEqual(['branch', 'leaf'])
+        expect(result.current.activeNode.id).toBe('leaf')
+    })
+})

--- a/frontend/src/lib/components/FilterPicker/useFilterPickerNavigation.ts
+++ b/frontend/src/lib/components/FilterPicker/useFilterPickerNavigation.ts
@@ -1,0 +1,189 @@
+import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { FilterPickerNode, FilterPickerPath } from './FilterPicker.types'
+
+const ROOT_ID = '__root__'
+
+function pathKey(path?: FilterPickerPath): string {
+    return path?.nodeIds.join('/') ?? ''
+}
+
+function createRootNode(rootNodesRef: MutableRefObject<FilterPickerNode[]>, placeholder?: string): FilterPickerNode {
+    return {
+        id: ROOT_ID,
+        label: '',
+        kind: 'branch',
+        searchPlaceholder: placeholder,
+        getChildren: ({ query }) => {
+            const rootNodes = rootNodesRef.current
+            const trimmed = query.trim().toLowerCase()
+            return {
+                isLoading: false,
+                nodes: trimmed
+                    ? rootNodes.filter((node) => {
+                          const searchableText = [
+                              node.label,
+                              node.description,
+                              node.hint,
+                              ...(node.searchableText ?? []),
+                          ]
+                              .filter(Boolean)
+                              .map(String)
+                              .join(' ')
+                              .toLowerCase()
+                          return searchableText.includes(trimmed)
+                      })
+                    : rootNodes,
+            }
+        },
+    }
+}
+
+function getNodeChildren(node: FilterPickerNode, path: FilterPickerPath): FilterPickerNode[] {
+    return node.getChildren?.({ query: '', path }).nodes ?? []
+}
+
+// Resolution walks the node tree by stable IDs. `getChildren` must be pure (see FilterPicker.types),
+// so calling it here on every render is side-effect-free. A segment that no longer resolves stops the walk
+// at the deepest valid prefix rather than collapsing to root — so an edit path like [property, operator]
+// still lands on the property's value step when a category auto-advances (no operator node exists), and a
+// partially-stale path lands as close as possible. Covered by useFilterPickerNavigation.test.
+function resolvePath(rootNode: FilterPickerNode, path?: FilterPickerPath): FilterPickerNode[] {
+    const stack = [rootNode]
+    if (!path?.nodeIds.length) {
+        return stack
+    }
+
+    let parent = rootNode
+    for (const nodeId of path.nodeIds) {
+        const parentPath = { nodeIds: stack.filter((node) => node.id !== ROOT_ID).map((node) => node.id) }
+        const nextNode = getNodeChildren(parent, parentPath).find((candidate) => candidate.id === nodeId)
+        if (!nextNode) {
+            return stack
+        }
+        stack.push(nextNode)
+        parent = nextNode
+    }
+    return stack
+}
+
+function resolveIds(rootNode: FilterPickerNode, path?: FilterPickerPath): string[] {
+    return resolvePath(rootNode, path)
+        .filter((node) => node.id !== ROOT_ID)
+        .map((node) => node.id)
+}
+
+export interface UseFilterPickerNavigationProps {
+    rootNodes: FilterPickerNode[]
+    initialPath?: FilterPickerPath
+    rootSearchPlaceholder?: string
+    /** When provided, the hook re-applies `initialPath` each time `open` transitions to true. */
+    open?: boolean
+}
+
+export interface UseFilterPickerNavigationResult {
+    rootNode: FilterPickerNode
+    stack: FilterPickerNode[]
+    activeNode: FilterPickerNode
+    activePath: FilterPickerPath
+    query: string
+    setQuery: (query: string) => void
+    openNode: (node: FilterPickerNode) => void
+    goBack: () => void
+    resetToRoot: () => void
+    resetToPath: (path?: FilterPickerPath) => void
+    isRoot: boolean
+}
+
+export function useFilterPickerNavigation({
+    rootNodes,
+    initialPath,
+    rootSearchPlaceholder,
+    open = true,
+}: UseFilterPickerNavigationProps): UseFilterPickerNavigationResult {
+    const rootNodesRef = useRef(rootNodes)
+    rootNodesRef.current = rootNodes
+
+    const rootNode = useMemo(() => createRootNode(rootNodesRef, rootSearchPlaceholder), [rootSearchPlaceholder])
+    const requestedPathKey = pathKey(initialPath)
+    const initialPathRef = useRef(initialPath)
+    initialPathRef.current = initialPath
+
+    // `requestedNodeIds` is the single source of truth for navigation. Everything else (the resolved stack,
+    // the active node, the active path) is derived from it against the current node tree, so the picker can
+    // never hold a path that no longer resolves.
+    const [requestedNodeIds, setRequestedNodeIds] = useState<string[]>(() =>
+        resolveIds(rootNode, initialPathRef.current)
+    )
+    const [query, setQuery] = useState('')
+
+    // Re-apply the requested edit path whenever the picker opens or the requested path changes. This is the
+    // only place `open` drives navigation — the parent must not also reset, or the two owners race (the bug
+    // that made token edits open at root). When closed we leave state untouched; the next open re-resolves.
+    useEffect(() => {
+        if (!open) {
+            return
+        }
+        setQuery('')
+        setRequestedNodeIds(resolveIds(rootNode, initialPathRef.current))
+    }, [open, requestedPathKey, rootNode])
+
+    // Resolution is cheap and pure, so it runs each render rather than being memoized: the node tree's
+    // *content* (e.g. freshly loaded values) changes without the `rootNodes` array identity changing, so a
+    // memo keyed on identity would serve stale nodes.
+    const requestedPath = useMemo<FilterPickerPath>(() => ({ nodeIds: requestedNodeIds }), [requestedNodeIds])
+    const stack = resolvePath(rootNode, requestedPath)
+    const resolvedNodeIds = stack.filter((node) => node.id !== ROOT_ID).map((node) => node.id)
+    // Use a control character (not `/`) as the dependency-key separator so node ids that themselves contain
+    // `/` can't collide; the resolved array is returned verbatim rather than reconstructed by splitting.
+    const resolvedKey = resolvedNodeIds.join('')
+
+    // Navigation callbacks operate on the *resolved* ids (via a ref) so they always build off a path that
+    // actually exists, even if `requestedNodeIds` still carries a now-stale tail.
+    const resolvedNodeIdsRef = useRef(resolvedNodeIds)
+    resolvedNodeIdsRef.current = resolvedNodeIds
+
+    // Recompute only when the resolved path string changes; the ref holds the matching array, which keeps
+    // activePath referentially stable across unrelated re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const activePath = useMemo<FilterPickerPath>(() => ({ nodeIds: resolvedNodeIdsRef.current }), [resolvedKey])
+
+    const openNode = useCallback((node: FilterPickerNode): void => {
+        setQuery('')
+        setRequestedNodeIds([...resolvedNodeIdsRef.current, node.id])
+    }, [])
+
+    const goBack = useCallback((): void => {
+        setQuery('')
+        setRequestedNodeIds(resolvedNodeIdsRef.current.slice(0, -1))
+    }, [])
+
+    const resetToRoot = useCallback((): void => {
+        setQuery('')
+        setRequestedNodeIds([])
+    }, [])
+
+    const resetToPath = useCallback(
+        (path?: FilterPickerPath): void => {
+            setQuery('')
+            setRequestedNodeIds(resolveIds(rootNode, path))
+        },
+        [rootNode]
+    )
+
+    const activeNode = stack[stack.length - 1]
+
+    return {
+        rootNode,
+        stack,
+        activeNode,
+        activePath,
+        query,
+        setQuery,
+        openNode,
+        goBack,
+        resetToRoot,
+        resetToPath,
+        isRoot: stack.length === 1,
+    }
+}

--- a/products/error_tracking/frontend/components/Assignee/assigneeSelectLogic.tsx
+++ b/products/error_tracking/frontend/components/Assignee/assigneeSelectLogic.tsx
@@ -38,7 +38,7 @@ export const assigneeSelectLogic = kea<assigneeSelectLogicType>([
             rolesLogic,
             ['roles', 'rolesLoading'],
         ],
-        actions: [membersLogic, ['setSearch as setMembersSearch', 'ensureAllMembersLoaded']],
+        actions: [membersLogic, ['setSearch as setMembersSearch', 'ensureAllMembersLoaded'], rolesLogic, ['loadRoles']],
     })),
 
     actions({
@@ -56,6 +56,7 @@ export const assigneeSelectLogic = kea<assigneeSelectLogicType>([
         },
         ensureAssigneeTypesLoaded: () => {
             actions.ensureAllMembersLoaded()
+            actions.loadRoles()
         },
     })),
 

--- a/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
+++ b/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
@@ -14,6 +14,7 @@ export type ErrorTrackingQueryOrderBy = ErrorTrackingQuery['orderBy']
 export type ErrorTrackingQueryOrderDirection = ErrorTrackingQuery['orderDirection']
 export type ErrorTrackingQueryAssignee = ErrorTrackingQuery['assignee']
 export type ErrorTrackingQueryStatus = ErrorTrackingQuery['status']
+export type ErrorTrackingStatusFilter = Exclude<ErrorTrackingQuery['status'], 'all'> | null
 
 export const ORDER_BY_OPTIONS: Record<ErrorTrackingQueryOrderBy, string> = {
     last_seen: 'Last seen',
@@ -25,7 +26,13 @@ export const ORDER_BY_OPTIONS: Record<ErrorTrackingQueryOrderBy, string> = {
 const DEFAULT_ORDER_BY: ErrorTrackingQueryOrderBy = 'last_seen'
 const DEFAULT_ORDER_DIRECTION = 'DESC'
 const DEFAULT_ASSIGNEE = null
-const DEFAULT_STATUS = 'active'
+const DEFAULT_STATUS: ErrorTrackingStatusFilter = null
+
+export function normalizeStatusFilter(
+    status: ErrorTrackingQuery['status'] | null | undefined
+): ErrorTrackingStatusFilter {
+    return status === 'all' ? null : ((status ?? null) as ErrorTrackingStatusFilter)
+}
 
 export interface IssueQueryOptionsLogicProps {
     logicKey: string
@@ -40,7 +47,7 @@ export const issueQueryOptionsLogic = kea<issueQueryOptionsLogicType>([
         setOrderBy: (orderBy: ErrorTrackingQueryOrderBy) => ({ orderBy }),
         setOrderDirection: (orderDirection: ErrorTrackingQueryOrderDirection) => ({ orderDirection }),
         setAssignee: (assignee: ErrorTrackingIssue['assignee']) => ({ assignee }),
-        setStatus: (status: ErrorTrackingQueryStatus) => ({ status }),
+        setStatus: (status: ErrorTrackingStatusFilter) => ({ status: normalizeStatusFilter(status) }),
     }),
 
     reducers({
@@ -66,7 +73,7 @@ export const issueQueryOptionsLogic = kea<issueQueryOptionsLogicType>([
             },
         ],
         status: [
-            DEFAULT_STATUS as ErrorTrackingQueryStatus,
+            DEFAULT_STATUS,
             { persist: true },
             {
                 setStatus: (_, { status }) => status,
@@ -122,8 +129,9 @@ export const issueQueryOptionsLogic = kea<issueQueryOptionsLogicType>([
                     actions.setOrderBy(params.orderBy)
                 }
             }
-            if (params.status && !equal(params.status, values.status)) {
-                actions.setStatus(params.status)
+            const status = normalizeStatusFilter(params.status)
+            if (!equal(status, values.status)) {
+                actions.setStatus(status)
             }
             if (params.assignee && !equal(params.assignee, values.assignee)) {
                 actions.setAssignee(params.assignee)

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -79,7 +79,7 @@ export function ErrorTrackingScene(): JSX.Element {
                     <ErrorTrackingIssueFilteringTool />
                     {hasSentExceptionEventLoading || hasSentExceptionEvent ? null : <IngestionStatusCheck />}
                     {hasSourceMapsBanner ? <SourceMapsBanner /> : null}
-                    <div className="border rounded bg-surface-primary p-2">
+                    <div className="pb-3">
                         <IssuesFilters />
                     </div>
                     <IssuesList />

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesFilters.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesFilters.tsx
@@ -1,32 +1,64 @@
-import { LemonDivider } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
-import { QuickFiltersSection } from 'lib/components/QuickFilters/QuickFiltersSection'
+import { FilterBar, FilterBarSortOption, SortDirection } from 'lib/components/FilterBar/FilterBar'
 
-import { QuickFilterContext } from '~/queries/schema/schema-general'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/insightVizKeys'
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
-import { ErrorFilters } from 'products/error_tracking/frontend/components/IssueFilters'
+import { issueFiltersLogic } from 'products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic'
+import {
+    ORDER_BY_OPTIONS,
+    issueQueryOptionsLogic,
+} from 'products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic'
+import { issuesDataNodeLogic } from 'products/error_tracking/frontend/logics/issuesDataNodeLogic'
 
-import { ERROR_TRACKING_SCENE_LOGIC_KEY } from '../../errorTrackingSceneLogic'
+import { errorTrackingSceneLogic } from '../../errorTrackingSceneLogic'
+import { useErrorTrackingFilterPicker } from './errorTrackingFilterPicker'
+import { insightProps } from './IssuesList'
+
+const SORT_OPTIONS: FilterBarSortOption[] = Object.entries(ORDER_BY_OPTIONS).map(([value, label]) => ({ value, label }))
 
 export function IssuesFilters(): JSX.Element {
+    const { dateRange, filterGroup } = useValues(issueFiltersLogic)
+    const { setDateRange, setFilterGroup } = useActions(issueFiltersLogic)
+    const { orderBy, orderDirection } = useValues(issueQueryOptionsLogic)
+    const { setOrderBy, setOrderDirection } = useActions(issueQueryOptionsLogic)
+    const { query } = useValues(errorTrackingSceneLogic)
+    const issueDataNodeLogicProps = useMemo(
+        () => ({ key: insightVizDataNodeKey(insightProps), query: query.source }),
+        [query.source]
+    )
+    const { responseLoading } = useValues(issuesDataNodeLogic(issueDataNodeLogicProps))
+    const { reloadData, cancelQuery } = useActions(issuesDataNodeLogic(issueDataNodeLogicProps))
+    const innerFilterGroup = filterGroup.values[0] as UniversalFiltersGroup
+    const { pickerRootNodes, pickerTokens } = useErrorTrackingFilterPicker({
+        filterGroup: innerFilterGroup,
+        onFilterChange: (group) => setFilterGroup({ type: FilterLogicalOperator.And, values: [group] }),
+    })
+
     return (
-        <ErrorFilters.Root>
-            <div className="flex gap-2 flex-wrap">
-                <ErrorFilters.DateRange />
-                <ErrorFilters.Status />
-                <ErrorFilters.Assignee />
-                <LemonDivider vertical />
-                <QuickFiltersSection
-                    context={QuickFilterContext.ErrorTrackingIssueFilters}
-                    logicKey={ERROR_TRACKING_SCENE_LOGIC_KEY}
-                />
-            </div>
-            <div className="flex gap-2 items-start">
-                <div className="flex-1">
-                    <ErrorFilters.FilterGroup />
-                </div>
-                <ErrorFilters.InternalAccounts />
-            </div>
-        </ErrorFilters.Root>
+        <FilterBar
+            pickerRootNodes={pickerRootNodes}
+            pickerTokens={pickerTokens}
+            dateFrom={dateRange?.date_from ?? null}
+            dateTo={dateRange?.date_to ?? null}
+            onDateChange={(date_from, date_to) => setDateRange({ date_from, date_to })}
+            sortOptions={SORT_OPTIONS}
+            sortValue={orderBy}
+            sortDirection={orderDirection as SortDirection}
+            onSortChange={(value, direction) => {
+                setOrderBy(value as typeof orderBy)
+                setOrderDirection(direction as typeof orderDirection)
+            }}
+            onReload={() => {
+                if (responseLoading) {
+                    cancelQuery()
+                } else {
+                    reloadData()
+                }
+            }}
+            reloadLoading={responseLoading}
+        />
     )
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useValues } from 'kea'
-import { useMemo } from 'react'
+import { useDeferredValue, useMemo } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
@@ -19,7 +19,6 @@ import {
 import { InsightLogicProps } from '~/types'
 
 import { IssueActions } from 'products/error_tracking/frontend/components/IssueActions/IssueActions'
-import { IssueQueryOptions } from 'products/error_tracking/frontend/components/IssueQueryOptions/IssueQueryOptions'
 import { IssueListTitleColumn, IssueListTitleHeader } from 'products/error_tracking/frontend/components/TableColumns'
 import { errorTrackingVolumeSparklineLogic } from 'products/error_tracking/frontend/components/VolumeSparkline/errorTrackingVolumeSparklineLogic'
 import {
@@ -34,12 +33,14 @@ import { issuesDataNodeLogic } from 'products/error_tracking/frontend/logics/iss
 import { errorTrackingSceneLogic } from 'products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic'
 import { ERROR_TRACKING_LISTING_RESOLUTION } from 'products/error_tracking/frontend/utils'
 
+const EMPTY_SPIKE_EVENTS: never[] = []
+
 const VolumeColumn: QueryContextColumnComponent = (props) => {
     const record = props.record as ErrorTrackingIssue
     const sparklineKey = record.id ?? 'issue-unknown'
     const baseData = useSparklineData(record.aggregations, ERROR_TRACKING_LISTING_RESOLUTION)
     const { spikeEventsByIssueId } = useValues(batchSpikeEventsLogic)
-    const spikeEvents = record.id ? (spikeEventsByIssueId[record.id] ?? []) : []
+    const spikeEvents = record.id ? (spikeEventsByIssueId[record.id] ?? EMPTY_SPIKE_EVENTS) : EMPTY_SPIKE_EVENTS
     const data = useMemo(() => applyVolumeSpikeHighlights(baseData, spikeEvents), [baseData, spikeEvents])
 
     const { hoveredDatum, isBarHighlighted } = useValues(errorTrackingVolumeSparklineLogic({ sparklineKey }))
@@ -131,46 +132,53 @@ const defaultColumns: Record<string, QueryContextColumn> = {
 }
 
 export const useIssueQueryContext = (): QueryContext => {
-    return {
-        columns: defaultColumns,
-        showOpenEditorButton: false,
-        insightProps: insightProps,
-        emptyStateHeading: 'No issues found',
-        emptyStateDetail: 'Try changing the date range, changing the filters or removing the assignee.',
-    }
+    return useMemo(
+        () => ({
+            columns: defaultColumns,
+            showOpenEditorButton: false,
+            insightProps: insightProps,
+            emptyStateHeading: 'No issues found',
+            emptyStateDetail: 'Try changing the date range, changing the filters or removing the assignee.',
+        }),
+        []
+    )
 }
 
-const insightProps: InsightLogicProps = {
+export const insightProps: InsightLogicProps = {
     dashboardItemId: 'new-ErrorTrackingQuery',
 }
 
 export function IssuesList(): JSX.Element {
     const { query } = useValues(errorTrackingSceneLogic)
+    const deferredQuery = useDeferredValue(query)
     const context = useIssueQueryContext()
+    const dataNodeProps = useMemo(
+        () => ({ key: insightVizDataNodeKey(insightProps), query: deferredQuery.source }),
+        [deferredQuery.source]
+    )
 
     return (
-        <BindLogic
-            logic={issuesDataNodeLogic}
-            props={{ key: insightVizDataNodeKey(insightProps), query: query.source }}
-        >
-            <SceneStickyBar showBorderBottom={false}>
-                <ListOptions />
-            </SceneStickyBar>
+        <BindLogic logic={issuesDataNodeLogic} props={dataNodeProps}>
+            <ListOptions />
 
             <div data-attr="error-tracking-issue-row">
-                <Query query={query} context={context} />
+                <Query query={deferredQuery} context={context} />
             </div>
         </BindLogic>
     )
 }
 
-export const ListOptions = (): JSX.Element => {
+export const ListOptions = (): JSX.Element | null => {
     const { selectedIssueIds } = useValues(bulkSelectLogic)
     const { results } = useValues(issuesDataNodeLogic)
 
     if (selectedIssueIds.length > 0) {
-        return <IssueActions issues={results} selectedIds={selectedIssueIds} />
+        return (
+            <SceneStickyBar showBorderBottom={false}>
+                <IssueActions issues={results} selectedIds={selectedIssueIds} />
+            </SceneStickyBar>
+        )
     }
 
-    return <IssueQueryOptions />
+    return null
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/errorTrackingFilterPicker.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/errorTrackingFilterPicker.tsx
@@ -1,0 +1,382 @@
+import { useActions, useValues } from 'kea'
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
+
+import { IconBrackets, IconCheckCircle, IconFlag, IconPerson } from '@posthog/icons'
+
+import { FilterPickerNode, FilterPickerToken } from 'lib/components/FilterPicker'
+import {
+    createPropertyFilterPickerNodes,
+    createPropertyFilterToken,
+    editPathForPropertyFilter,
+    PropertyValueLoaderContext,
+    PropertyValueLoaderResult,
+} from 'lib/components/FilterPicker/adapters'
+import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/PropertyFilters/utils'
+
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { AnyPropertyFilter, PropertyFilterType, PropertyType, UniversalFiltersGroup } from '~/types'
+
+import { AssigneeLabelDisplay } from 'products/error_tracking/frontend/components/Assignee/AssigneeDisplay'
+import { assigneeSelectLogic } from 'products/error_tracking/frontend/components/Assignee/assigneeSelectLogic'
+import {
+    ErrorTrackingStatusFilter,
+    issueQueryOptionsLogic,
+} from 'products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic'
+
+const ERROR_TRACKING_EVENT_NAMES = ['$exception']
+
+const STATUS_OPTIONS: { value: ErrorTrackingStatusFilter; label: string }[] = [
+    { value: null, label: 'All issues' },
+    { value: 'active', label: 'Active' },
+    { value: 'resolved', label: 'Resolved' },
+    { value: 'suppressed', label: 'Suppressed' },
+    { value: 'archived', label: 'Archived' },
+]
+
+const SECTIONS = {
+    issue: { id: 'issue', label: 'Issue', icon: <IconCheckCircle /> },
+    person: { id: 'person', label: 'Person', icon: <IconPerson /> },
+    exception: { id: 'exception', label: 'Exception', icon: <IconBrackets /> },
+    release: { id: 'release', label: 'Release', icon: <IconFlag /> },
+}
+
+const PROPERTY_LABELS: Record<string, string> = {
+    first_seen: 'First seen',
+    timestamp: 'Last seen',
+    email: 'Email',
+    $active_feature_flags: 'Feature flag',
+    id: 'Cohort',
+    $exception_types: 'Type',
+    $exception_values: 'Message',
+    $exception_sources: 'Source',
+    $exception_functions: 'Function',
+    $exception_releases: 'Name',
+    $app_version: 'Version',
+}
+
+// Status and assignee aren't AnyPropertyFilters (they live in issueQueryOptionsLogic, not the filter group),
+// so they can't go through createPropertyFilterToken. This keeps their token shape consistent with it.
+function buildControlToken(options: {
+    id: string
+    property: ReactNode
+    value: ReactNode
+    title: string
+    editNodeIds: string[]
+    onRemove: () => void
+}): FilterPickerToken {
+    return {
+        id: options.id,
+        parts: [
+            { kind: 'property', label: options.property },
+            { kind: 'operator', label: '=' },
+            { kind: 'value', label: options.value },
+        ],
+        title: options.title,
+        editPath: { nodeIds: options.editNodeIds },
+        removable: true,
+        onRemove: options.onRemove,
+    }
+}
+
+function useStatusNode(): { node: FilterPickerNode; token?: FilterPickerToken } {
+    const { status } = useValues(issueQueryOptionsLogic)
+    const { setStatus } = useActions(issueQueryOptionsLogic)
+    const statusLabel = STATUS_OPTIONS.find((option) => option.value === status)?.label ?? status
+
+    return useMemo(
+        () => ({
+            node: {
+                id: 'issue:status',
+                label: 'Status',
+                section: SECTIONS.issue,
+                kind: 'branch',
+                searchPlaceholder: 'Search statuses…',
+                getChildren: ({ query }) => ({
+                    nodes: STATUS_OPTIONS.filter((option) =>
+                        option.label.toLowerCase().includes(query.trim().toLowerCase())
+                    ).map((option) => ({
+                        id: `issue:status:value:${option.value ?? 'all'}`,
+                        label: option.label,
+                        kind: 'action',
+                        onSelect: ({ close }) => {
+                            setStatus(option.value)
+                            close()
+                        },
+                    })),
+                }),
+            },
+            token: status
+                ? buildControlToken({
+                      id: `status:${status}`,
+                      property: 'Status',
+                      value: statusLabel,
+                      title: `Status = ${statusLabel}`,
+                      editNodeIds: ['issue:status'],
+                      onRemove: () => setStatus(null),
+                  })
+                : undefined,
+        }),
+        [setStatus, status, statusLabel]
+    )
+}
+
+function useAssigneeNode(): { node: FilterPickerNode; token?: FilterPickerToken } {
+    const { assignee } = useValues(issueQueryOptionsLogic)
+    const { setAssignee } = useActions(issueQueryOptionsLogic)
+    const { meFirstMembers, roles, loading, resolveAssignee } = useValues(assigneeSelectLogic)
+    const { ensureAssigneeTypesLoaded } = useActions(assigneeSelectLogic)
+    const resolvedAssignee = resolveAssignee(assignee ?? null)
+
+    useEffect(() => {
+        ensureAssigneeTypesLoaded()
+    }, [ensureAssigneeTypesLoaded])
+
+    return useMemo(
+        () => ({
+            node: {
+                id: 'issue:assignee',
+                label: 'Assignee',
+                section: SECTIONS.issue,
+                kind: 'branch',
+                searchPlaceholder: 'Search assignees…',
+                getChildren: ({ query }) => {
+                    const trimmed = query.trim().toLowerCase()
+                    const filteredRoles = roles.filter((role) => role.name.toLowerCase().includes(trimmed))
+                    const filteredMembers = meFirstMembers.filter((member) => {
+                        const name = member.user.first_name || member.user.email || String(member.user.id)
+                        return name.toLowerCase().includes(trimmed)
+                    })
+
+                    return {
+                        isLoading: loading && !filteredRoles.length && !filteredMembers.length,
+                        nodes: [
+                            {
+                                id: 'issue:assignee:any',
+                                label: 'Any assignee',
+                                kind: 'action',
+                                onSelect: ({ close }) => {
+                                    setAssignee(null)
+                                    close()
+                                },
+                            },
+                            ...filteredRoles.map<FilterPickerNode>((role) => ({
+                                id: `issue:assignee:role:${role.id}`,
+                                label: role.name,
+                                hint: 'Role',
+                                kind: 'action',
+                                onSelect: ({ close }) => {
+                                    setAssignee({ type: 'role', id: role.id })
+                                    close()
+                                },
+                            })),
+                            ...filteredMembers.map<FilterPickerNode>((member) => ({
+                                id: `issue:assignee:user:${member.user.id}`,
+                                label: member.user.first_name || member.user.email || String(member.user.id),
+                                hint: 'User',
+                                kind: 'action',
+                                onSelect: ({ close }) => {
+                                    setAssignee({ type: 'user', id: member.user.id })
+                                    close()
+                                },
+                            })),
+                        ],
+                    }
+                },
+            },
+            token: assignee
+                ? buildControlToken({
+                      id: `assignee:${assignee.type}:${assignee.id}`,
+                      property: 'Assignee',
+                      value: <AssigneeLabelDisplay assignee={resolvedAssignee} size="small" />,
+                      title: 'Assignee',
+                      editNodeIds: ['issue:assignee'],
+                      onRemove: () => setAssignee(null),
+                  })
+                : undefined,
+        }),
+        [assignee, loading, meFirstMembers, resolvedAssignee, roles, setAssignee]
+    )
+}
+
+function useValueLoader(): (context: PropertyValueLoaderContext) => PropertyValueLoaderResult {
+    const { options, formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    const { loadPropertyValues } = useActions(propertyDefinitionsModel)
+    const { cohorts, cohortsLoading } = useValues(cohortsModel)
+    const lastLoadedValueKeyRef = useRef<string | null>(null)
+
+    return ({ property, query, eventNames }) => {
+        if (property.type === PropertyFilterType.Cohort) {
+            const trimmed = query.trim().toLowerCase()
+            return {
+                isLoading: cohortsLoading,
+                values: cohorts.results
+                    .filter((cohort) => (cohort.name ?? '').toLowerCase().includes(trimmed))
+                    .map((cohort) => ({ value: cohort.id, label: cohort.name ?? String(cohort.id) })),
+            }
+        }
+
+        const definitionType = propertyFilterTypeToPropertyDefinitionType(property.type)
+        const trimmed = query.trim()
+        const loadKey = `${definitionType}:${property.key}:${trimmed}:${eventNames?.join(',') ?? ''}`
+        const values = options[property.key]?.values ?? []
+        return {
+            isLoading: options[property.key]?.status === 'loading' && !values.length,
+            allowCustomValues: true,
+            values: values
+                .filter((value) => !trimmed || String(value.name).toLowerCase().includes(trimmed.toLowerCase()))
+                .map((value) => ({
+                    value: value.name,
+                    label: String(formatPropertyValueForDisplay(property.key, value.name, definitionType)),
+                })),
+            // Called from FilterPicker's content effect (never during render), so dispatching here is safe.
+            // The ref de-dupes repeat loads for the same property/query/event scope.
+            load: () => {
+                if (lastLoadedValueKeyRef.current === loadKey) {
+                    return
+                }
+                lastLoadedValueKeyRef.current = loadKey
+                loadPropertyValues({
+                    endpoint: undefined,
+                    type: definitionType,
+                    newInput: trimmed || undefined,
+                    propertyKey: property.key,
+                    eventNames,
+                })
+            },
+        }
+    }
+}
+
+export function useErrorTrackingFilterPicker({
+    filterGroup,
+    onFilterChange,
+}: {
+    filterGroup: UniversalFiltersGroup
+    onFilterChange: (group: UniversalFiltersGroup) => void
+}): { pickerRootNodes: FilterPickerNode[]; pickerTokens: FilterPickerToken[] } {
+    const status = useStatusNode()
+    const assignee = useAssigneeNode()
+    const valueLoader = useValueLoader()
+    const setGroupValues = useCallback(
+        (values: AnyPropertyFilter[]): void => onFilterChange({ ...filterGroup, values }),
+        [filterGroup, onFilterChange]
+    )
+    // The picker only ever adds leaf property filters (never nested groups), so narrow the loosely-typed
+    // group values to AnyPropertyFilter once here rather than casting at every use site.
+    const filterValues = useMemo(() => filterGroup.values as AnyPropertyFilter[], [filterGroup.values])
+    const { cohorts } = useValues(cohortsModel)
+
+    const propertyNodes = useMemo(
+        () =>
+            createPropertyFilterPickerNodes({
+                eventNames: ERROR_TRACKING_EVENT_NAMES,
+                valueLoader,
+                onSelect: (filter, { close }) => {
+                    setGroupValues([...filterValues, filter])
+                    close()
+                },
+                properties: [
+                    {
+                        key: 'first_seen',
+                        label: 'First seen',
+                        type: PropertyFilterType.ErrorTrackingIssue,
+                        propertyType: PropertyType.DateTime,
+                        section: SECTIONS.issue,
+                    },
+                    {
+                        key: 'timestamp',
+                        label: 'Last seen',
+                        type: PropertyFilterType.EventMetadata,
+                        propertyType: PropertyType.DateTime,
+                        section: SECTIONS.issue,
+                    },
+                    {
+                        key: 'email',
+                        label: 'Email',
+                        type: PropertyFilterType.Person,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.person,
+                    },
+                    {
+                        key: '$active_feature_flags',
+                        label: 'Feature flag',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.person,
+                    },
+                    {
+                        key: 'id',
+                        label: 'Cohort',
+                        type: PropertyFilterType.Cohort,
+                        propertyType: PropertyType.Cohort,
+                        section: SECTIONS.person,
+                    },
+                    {
+                        key: '$exception_types',
+                        label: 'Type',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.exception,
+                    },
+                    {
+                        key: '$exception_values',
+                        label: 'Message',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.exception,
+                    },
+                    {
+                        key: '$exception_sources',
+                        label: 'Source',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.exception,
+                    },
+                    {
+                        key: '$exception_functions',
+                        label: 'Function',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.exception,
+                    },
+                    {
+                        key: '$exception_releases',
+                        label: 'Name',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.String,
+                        section: SECTIONS.release,
+                    },
+                    {
+                        key: '$app_version',
+                        label: 'Version',
+                        type: PropertyFilterType.Event,
+                        propertyType: PropertyType.Semver,
+                        section: SECTIONS.release,
+                    },
+                ],
+            }),
+        [filterValues, setGroupValues, valueLoader]
+    )
+
+    const pickerTokens = useMemo(() => {
+        const cohortsById = Object.fromEntries(cohorts.results.map((cohort) => [cohort.id, cohort]))
+        const filterTokens = filterValues.map((filter, index) =>
+            createPropertyFilterToken(filter, {
+                cohortsById,
+                propertyLabelFormatter: (filter) =>
+                    (filter.key ? PROPERTY_LABELS[filter.key] : undefined) ??
+                    ('label' in filter ? filter.label : filter.key),
+                editNodeIds: editPathForPropertyFilter(filter),
+                idSuffix: index,
+                onRemove: () => setGroupValues(filterValues.filter((_, i) => i !== index)),
+            })
+        )
+        return [status.token, assignee.token, ...filterTokens].filter(Boolean) as FilterPickerToken[]
+    }, [assignee.token, cohorts.results, filterValues, setGroupValues, status.token])
+
+    return {
+        pickerRootNodes: [status.node, assignee.node, ...propertyNodes],
+        pickerTokens,
+    }
+}


### PR DESCRIPTION
## Problem

The Error tracking issue filters were built on the legacy TaxonomicFilter/UniversalFilters stack, which is hard to extend and couples the issue filters to product-wide filter components. We want a focused, headless filter picker that the Error tracking issues view (and later other products) can drive with their own property/operator/value definitions.

## Changes

A generic, headless filter picker plus its Error tracking wiring.

- **FilterPicker** — a custom popover that navigates a tree of filter nodes (`property → operator → value`) by stable ids. The navigation hook is the single owner of the active path and re-resolves it from the live node tree each render, so async-loaded children can never strand the path; a missing segment falls back to the deepest valid prefix. `getChildren` is pure/structural and any side-effecting load runs through a separate `loadContent` hook.
- **Adapters** translate PostHog's property/operator/token models into picker nodes. A per-type operator policy is the source of truth for which operators each category exposes — so plain `String` no longer offers semver operators, and `Semver` is its own category. Per-type default operators are surfaced first, and an auto-advance mode skips the operator step entirely for dominant-default categories (cohort, boolean).
- **DateTime** values use a single-date inline calendar (Quill `useCalendar`) that matches the single-value date operators, instead of a range picker.
- **Token pill** renders as a connected button-group (label + remove sharing one border); the in-picker breadcrumb is a plain phrase label ("Source contains").
- **FilterBar** hosts the picker alongside date-range, sort, and reload controls, and keeps the legacy taxonomic path as a documented compatibility layer for Web/marketing/customer/revenue analytics and endpoints.
- **Error tracking** wires its issue filters — status, assignee, cohort, exception type/message/source/function, release name/version, first/last seen — through the picker.

Frontend-only. Screenshots to be added on the PR (the reviewer-facing UI is the issues filter bar + picker popover).

## How did you test this code?

I'm an agent (Claude Code). I did **not** perform manual browser testing — the local dev stack's `celery-beat` was unhealthy and I had no browser-automation tool, so the interactive click-through and keyboard/a11y pass are still pending and should be done before merge.

Automated checks I actually ran:

- `hogli test frontend/src/lib/components/FilterPicker` — 31 tests across 6 suites pass (navigation/path resolution, content-split purity, back-navigation in both add and edit flows, operator policy, auto-advance, token formatting).
- `oxlint` on the touched directories — clean.
- `pnpm --filter=@posthog/frontend typescript:check` — no new errors introduced by this branch (verified by diffing the error set against `master`). The generic FilterPicker layer is type-clean. A few residual errors in `errorTrackingFilterPicker.tsx` are pre-existing kea typing issues in `issueQueryOptionsLogic`/`propertyDefinitionsModel`; locally they're amplified because this workspace's kea typegen wasn't running — CI runs typegen, so it should be clean there.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). No repo-provided skills were invoked. The work began from a deep review of an earlier prototype and was shaped iteratively from reviewer feedback.

Key decisions:

- **Navigation as a single-owner state machine.** An early version split path ownership between the popover and the hook, which produced a class of "edit opens at root" bugs; consolidated into the hook and made `getChildren` pure with a separate `loadContent` to keep data-fetching out of the render path.
- **Operator policy over the shared operator maps.** The shared `stringOperatorMap` leaks semver operators onto every String property; rather than mutating that app-wide map, the picker owns its own per-type policy (overridable by an allowlist) and routes version fields to the existing `Semver` category.
- **Auto-advance vs pre-select.** Categories with a dominant default (cohort, boolean) skip the operator step; multi-operator categories (date, semver) keep the step but surface the default first. Date stayed pre-select rather than auto-advance so before/after remain reachable.
- **Single-date calendar over the Quill range picker** for date values, since the operators are single-value.
- **Scope discipline.** Reverted an orphaned change to the shared headless taxonomic autocomplete and deleted an unused adapter once the picker no longer used TaxonomicFilter; kept the `DateFilter` `renderTrigger` addition because the new FilterBar date control renders through it.

Agent-authored; requires human review. Remaining follow-up: the deferred browser/a11y smoke.
