### PR TITLE
fix(intercom): drain companies scroll before fetching segments

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -383,17 +383,25 @@ def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
 def _company_segments_generator(session: Session) -> Iterator[dict[str, Any]]:
     """Walk all companies and yield each attached segment with `company_id`
     injected. Full refresh — Intercom has no server-side timestamp filter on
-    either parent or child."""
-    for company in _iter_companies(session):
+    either parent or child.
+
+    The scroll is drained up front rather than interleaved with the per-company
+    segment fetches: Intercom expires an idle companies scroll after ~1 minute,
+    and a slow stretch of `/companies/{id}/segments` calls between two scroll
+    pages lets the cursor lapse — the next continuation then 404s mid-walk.
+    Draining first keeps the scroll requests back-to-back so it stays alive;
+    only the ids are held, so the memory cost stays flat regardless of count."""
+    company_ids = [company["id"] for company in _iter_companies(session)]
+    for company_id in company_ids:
         try:
-            payload = _intercom_get(session, f"/companies/{company['id']}/segments")
+            payload = _intercom_get(session, f"/companies/{company_id}/segments")
         except HTTPError as exc:
             if _is_not_found(exc):
-                logger.warning("intercom_company_not_found", company_id=company["id"])
+                logger.warning("intercom_company_not_found", company_id=company_id)
                 continue
             raise
         for seg in payload.get("data", []) or []:
-            seg["company_id"] = company["id"]
+            seg["company_id"] = company_id
             yield seg
 
 

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -312,15 +312,16 @@ class TestSubstreamGenerators:
             list(_conversation_parts_generator(mock_session, "updated_at", None))
 
     def test_company_segments_skips_404_parent(self):
-        # The parent companies walk (scroll) and the per-company segments fetch
-        # both go through GET, so the calls interleave on `session.get` in order:
-        # scroll page -> segments(co1) -> segments(co2) -> empty scroll page.
+        # The scroll is drained fully before any per-company segment fetch, so
+        # `session.get` is called in order: scroll page -> empty scroll page ->
+        # segments(co1) -> segments(co2). A 404 on a single segment fetch (the
+        # company vanished between listing and fetch) skips that company only.
         mock_session = mock.MagicMock()
         mock_session.get.side_effect = [
             _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "scroll_param": "s1"}),
+            _make_response({"data": [], "scroll_param": "s2"}),
             _make_response(None, status_code=404, text="Not Found"),
             _make_response({"data": [{"id": "s2"}]}),
-            _make_response({"data": [], "scroll_param": "s2"}),
         ]
 
         segments = list(_company_segments_generator(mock_session))
@@ -329,9 +330,13 @@ class TestSubstreamGenerators:
         assert segments[0]["company_id"] == "co2"
 
     def test_company_segments_reraises_non_404(self):
+        # 500 is retried inline by `_scroll_companies_get`; a non-404 on the
+        # per-company segment fetch (not the scroll) must surface. Drain the
+        # scroll first, then fail the segment fetch with a 500.
         mock_session = mock.MagicMock()
         mock_session.get.side_effect = [
             _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": []}),
             _make_response(None, status_code=500, text="Server Error"),
         ]
 
@@ -342,9 +347,9 @@ class TestSubstreamGenerators:
         mock_session = mock.MagicMock()
         mock_session.get.side_effect = [
             _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "scroll_param": "s1"}),
+            _make_response({"data": [], "scroll_param": "s2"}),
             _make_response({"data": [{"id": "s1"}]}),
             _make_response({"data": [{"id": "s2"}, {"id": "s3"}]}),
-            _make_response({"data": [], "scroll_param": "s2"}),
         ]
 
         segments = list(_company_segments_generator(mock_session))
@@ -352,6 +357,28 @@ class TestSubstreamGenerators:
         assert [s["id"] for s in segments] == ["s1", "s2", "s3"]
         assert segments[0]["company_id"] == "co1"
         assert segments[1]["company_id"] == "co2"
+
+    def test_company_segments_drains_scroll_before_fetching_segments(self):
+        # Intercom expires an idle companies scroll after ~1 min. Fetching
+        # segments between scroll pages let the cursor lapse mid-walk, 404ing the
+        # next continuation. The scroll must be fully walked before any segment
+        # fetch, so the scroll requests stay back-to-back.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": [{"id": "co2"}], "scroll_param": "s2"}),
+            _make_response({"data": []}),
+            _make_response({"data": [{"id": "seg1"}]}),
+            _make_response({"data": [{"id": "seg2"}]}),
+        ]
+
+        segments = list(_company_segments_generator(mock_session))
+
+        assert [s["id"] for s in segments] == ["seg1", "seg2"]
+        urls = [call.args[0] for call in mock_session.get.call_args_list]
+        last_scroll = max(i for i, u in enumerate(urls) if u.endswith("/companies/scroll"))
+        first_segments = min(i for i, u in enumerate(urls) if u.endswith("/segments"))
+        assert last_scroll < first_segments
 
     def test_iter_companies_walks_scroll(self):
         # `POST /companies/list` is capped at 10,000 companies (60 * 167 page


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` in the Intercom warehouse source: `404 Client Error: Not Found for url: https://api.intercom.io/companies/scroll?scroll_param=<redacted>` ([issue](https://us.posthog.com/project/2/error_tracking/019eef73-bd06-7703-bc39-fde03918b5b3)).

The 404 is on a scroll **continuation** (the URL carries a `scroll_param`), so auth and config are fine — the scroll *opened* successfully. The cursor itself is gone.

Root cause: the `company_segments` substream consumed the companies scroll lazily. `_company_segments_generator` walked `_iter_companies` one company at a time, doing a per-company `GET /companies/{id}/segments` between scroll pages. Intercom expires an idle companies scroll after ~1 minute, so a slow stretch of segment fetches (a large page, plus 429/5xx backoffs) let the cursor lapse mid-walk — and the next continuation 404'd, aborting the whole sync.

This is a fixable fragility in our pagination, not an upstream/credential error, so it does not belong in `NonRetryableErrors`. Treating the 404 as end-of-scroll would silently drop the remaining companies, and re-opening can't resume a scroll from a point (only restart from the beginning, duplicating rows).

## Changes

Drain the companies scroll fully before fetching any segments. `_company_segments_generator` now materializes the company ids up front, which drives the scroll requests back-to-back so the cursor never goes idle long enough to expire, then fetches segments. Only the ids are held, so memory stays flat regardless of company count.

## How did you test this code?

I'm an agent. I ran the source's unit tests (`posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py`, 83 passed) and ruff check/format on the changed files.

Added a regression test (`test_company_segments_drains_scroll_before_fetching_segments`) asserting every scroll-page request precedes the first segment fetch. Updated the existing `company_segments` tests whose mock `session.get` ordering assumed the old interleaved walk.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue via the PostHog error-tracking MCP tools — pulled the stack trace (`_company_segments_generator` → `_iter_companies` → `_scroll_companies_get` → `_intercom_get`), which placed the failure squarely in this source on a scroll continuation.

Decision: fixable bug, not `NonRetryableErrors`. The scroll open succeeded, so it's our walk holding one cursor open across slow interleaved child work that's at fault — draining first removes the idle gaps that expire the cursor. Checked open PRs for duplicates; the only intercom one (#60702) is a stale draft about per-row 403s on child fetches, a different root cause.
