### PR TITLE
fix(exports): don't retry renders when a page closes mid-render

### DIFF
--- a/products/exports/backend/tasks/failure_handler.py
+++ b/products/exports/backend/tasks/failure_handler.py
@@ -69,6 +69,13 @@ class BrowserlessUnavailable(Exception):
     pass
 
 
+class PageClosedDuringRender(Exception):
+    """Page/context closed mid-render (transport still up). Non-retryable system failure: a closed page
+    won't recover on a fresh retry, so it's kept out of EXCEPTIONS_TO_RETRY (see NON_RETRYABLE_SYSTEM_ERRORS)."""
+
+    pass
+
+
 class ExcelColumnLimitExceeded(Exception):
     """Raised when export data exceeds openpyxl's 18,278 column limit (ZZZ)."""
 
@@ -130,9 +137,15 @@ TIMEOUT_ERRORS = (
     ExportCancelled,
 )
 
+# Render-backend failures that classify as "system" for observability but are deliberately excluded
+# from EXCEPTIONS_TO_RETRY (a closed page won't recover on retry). Kept separate so the retry sets —
+# SYSTEM_ERROR_NAMES feeds RETRYABLE_ERROR_NAMES in temporal/exports/activities.py — never pick them up.
+NON_RETRYABLE_SYSTEM_ERRORS = (PageClosedDuringRender,)
+
 # Exception class names for string-based classification (used in backfill)
 USER_QUERY_ERROR_NAMES = frozenset(cls.__name__ for cls in USER_QUERY_ERRORS)
 SYSTEM_ERROR_NAMES = frozenset(cls.__name__ for cls in EXCEPTIONS_TO_RETRY)
+NON_RETRYABLE_SYSTEM_ERROR_NAMES = frozenset(cls.__name__ for cls in NON_RETRYABLE_SYSTEM_ERRORS)
 # "TimeoutException" kept literally: historical ExportedAsset rows from the retired selenium
 # render path stored that exception name and must still classify as timeouts.
 TIMEOUT_ERROR_NAMES = frozenset(cls.__name__ for cls in TIMEOUT_ERRORS) | {"TimeoutException"}
@@ -147,7 +160,7 @@ def classify_failure_type(exception: Exception | str) -> str:
             return FAILURE_TYPE_TIMEOUT_GENERATION
         if isinstance(exception, USER_QUERY_ERRORS):
             return FAILURE_TYPE_USER
-        if isinstance(exception, EXCEPTIONS_TO_RETRY):
+        if isinstance(exception, (*EXCEPTIONS_TO_RETRY, *NON_RETRYABLE_SYSTEM_ERRORS)):
             return FAILURE_TYPE_SYSTEM
         return FAILURE_TYPE_UNKNOWN
 
@@ -159,7 +172,7 @@ def classify_failure_type(exception: Exception | str) -> str:
             return FAILURE_TYPE_TIMEOUT_GENERATION
         if exception_type in USER_QUERY_ERROR_NAMES:
             return FAILURE_TYPE_USER
-        if exception_type in SYSTEM_ERROR_NAMES:
+        if exception_type in SYSTEM_ERROR_NAMES or exception_type in NON_RETRYABLE_SYSTEM_ERROR_NAMES:
             return FAILURE_TYPE_SYSTEM
     return FAILURE_TYPE_UNKNOWN
 

--- a/products/exports/backend/tasks/image_exporter.py
+++ b/products/exports/backend/tasks/image_exporter.py
@@ -35,6 +35,7 @@ from products.exports.backend.tasks.exporter_utils import log_error_if_site_url_
 from products.exports.backend.tasks.failure_handler import (
     BrowserlessUnavailable,
     InvalidExportContext,
+    PageClosedDuringRender,
     classify_failure_type,
 )
 from products.product_analytics.backend.api.insight_variable import map_stale_to_latest
@@ -356,6 +357,20 @@ def _is_browserless_connection_error(error: Exception) -> bool:
     return any(indicator in message for indicator in _BROWSERLESS_CONNECTION_ERROR_INDICATORS)
 
 
+# Intentionally narrower than _BROWSERLESS_CONNECTION_ERROR_INDICATORS: a genuine transport drop
+# (websocket/econnrefused/"connection closed") must stay retryable, so only page/target-closed
+# phrasing belongs here. The page-closed branch below must also stay ordered before the transport check.
+_PAGE_CLOSED_ERROR_INDICATORS = (
+    "target page, context or browser has been closed",
+    "target closed",
+)
+
+
+def _is_page_closed_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(indicator in message for indicator in _PAGE_CLOSED_ERROR_INDICATORS)
+
+
 def _save_debug_screenshot(take_screenshot: Callable[[str], object], image_path: str) -> None:
     try:
         take_screenshot(image_path)
@@ -440,6 +455,10 @@ def _screenshot_asset_browserless(
         except PlaywrightTimeoutError:
             raise
         except PlaywrightError as e:
+            # A page/context closed mid-render (transport still up) won't recover on a fresh retry of
+            # the same render, so fail fast and non-retryably rather than re-spending the budget 5x.
+            if _is_page_closed_error(e) and not disconnected[0]:
+                raise PageClosedDuringRender(_redact_browserless_token(str(e))) from None
             if disconnected[0] or _is_browserless_connection_error(e):
                 raise BrowserlessUnavailable(_redact_browserless_token(str(e))) from None
 

--- a/products/exports/backend/tasks/test/test_failure_handler.py
+++ b/products/exports/backend/tasks/test/test_failure_handler.py
@@ -6,10 +6,12 @@ from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from products.exports.backend.tasks.failure_handler import (
+    EXCEPTIONS_TO_RETRY,
     FAILURE_TYPE_SYSTEM,
     FAILURE_TYPE_TIMEOUT_GENERATION,
     FAILURE_TYPE_UNKNOWN,
     FAILURE_TYPE_USER,
+    PageClosedDuringRender,
     classify_failure_type,
     is_user_query_error_type,
 )
@@ -73,6 +75,7 @@ class TestClassifyFailureType(TestCase):
             ("OperationalError", FAILURE_TYPE_SYSTEM),
             ("ClickHouseAtCapacity", FAILURE_TYPE_SYSTEM),
             ("ReadTimeoutError", FAILURE_TYPE_SYSTEM),
+            ("PageClosedDuringRender", FAILURE_TYPE_SYSTEM),
             # Unknown errors
             ("ValueError", FAILURE_TYPE_UNKNOWN),
             ("RuntimeError", FAILURE_TYPE_UNKNOWN),
@@ -81,6 +84,11 @@ class TestClassifyFailureType(TestCase):
     )
     def test_classify_failure_type(self, exception_type: str, expected: str) -> None:
         assert classify_failure_type(exception_type) == expected
+
+    def test_page_closed_during_render_is_system_but_not_retryable(self) -> None:
+        assert classify_failure_type(PageClosedDuringRender("page gone")) == FAILURE_TYPE_SYSTEM
+        # must never become retryable — that would re-enable the retries this fail-fast path removes
+        assert PageClosedDuringRender not in EXCEPTIONS_TO_RETRY
 
     def test_drf_validation_error_instance_classifies_as_user(self) -> None:
         # The funnel validation rules raise rest_framework.exceptions.ValidationError

--- a/products/exports/backend/tasks/test/test_image_exporter.py
+++ b/products/exports/backend/tasks/test/test_image_exporter.py
@@ -34,7 +34,12 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.exports.backend.tasks import image_exporter
-from products.exports.backend.tasks.failure_handler import BrowserlessUnavailable, InvalidExportContext
+from products.exports.backend.tasks.failure_handler import (
+    EXCEPTIONS_TO_RETRY,
+    BrowserlessUnavailable,
+    InvalidExportContext,
+    PageClosedDuringRender,
+)
 from products.product_analytics.backend.api.insight_variable import map_stale_to_latest
 from products.product_analytics.backend.models.insight import Insight
 from products.product_analytics.backend.models.insight_variable import InsightVariable
@@ -719,6 +724,30 @@ class TestScreenshotAssetBrowserless(SimpleTestCase):
                 with self.assertRaises(BrowserlessUnavailable):
                     image_exporter._screenshot_asset_browserless("p", "u", 800, ".ExportedInsight")
 
+    def test_page_closed_mid_render_is_not_retryable(self) -> None:
+        page = MagicMock()
+        page.wait_for_selector.side_effect = PlaywrightError(
+            "Page.wait_for_selector: Target page, context or browser has been closed"
+        )
+        context = MagicMock()
+        context.new_page.return_value = page
+        browser = MagicMock()  # browser.on("disconnected", ...) never fires: transport stays up
+        browser.new_context.return_value = context
+        playwright_obj = MagicMock()
+        playwright_obj.chromium.connect_over_cdp.return_value = browser
+        sync_playwright_cm = MagicMock()
+        sync_playwright_cm.__enter__.return_value = playwright_obj
+
+        with (
+            patch("products.exports.backend.tasks.image_exporter.sync_playwright", return_value=sync_playwright_cm),
+            patch.object(settings, "BROWSERLESS_CDP_URL", "wss://chrome.browserless.io"),
+        ):
+            with self.assertRaises(PageClosedDuringRender) as ctx:
+                image_exporter._screenshot_asset_browserless("p", "u", 800, ".replayer-wrapper")
+
+        # identity (the routing decision) plus the property that matters: Temporal won't retry it
+        assert not isinstance(ctx.exception, EXCEPTIONS_TO_RETRY)
+
     def test_connect_error_redacts_token_and_breaks_chain(self) -> None:
         token = "super-secret-token"
         leaked = (
@@ -834,6 +863,25 @@ class TestIsBrowserlessConnectionError(SimpleTestCase):
     )
     def test_is_browserless_connection_error(self, _name: str, message: str, expected: bool) -> None:
         assert image_exporter._is_browserless_connection_error(Exception(message)) is expected
+
+
+class TestIsPageClosedError(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("full_playwright_string", "Page.wait_for_selector: Target page, context or browser has been closed", True),
+            ("target_closed", "Target closed", True),
+            # genuine transport drops must NOT match — they stay retryable BrowserlessUnavailable
+            ("websocket", "WebSocket error: connection lost", False),
+            ("econnrefused", "connect ECONNREFUSED 1.2.3.4:443", False),
+            ("connection_closed", "Connection closed while reading", False),
+            ("disconnected", "Browser disconnected unexpectedly", False),
+            # narrower than the connection helper: bare "has been closed" without the target prefix is not page-closed
+            ("bare_has_been_closed", "Browser has been closed", False),
+            ("empty", "", False),
+        ]
+    )
+    def test_is_page_closed_error(self, _name: str, message: str, expected: bool) -> None:
+        assert image_exporter._is_page_closed_error(Exception(message)) is expected
 
 
 @override_settings(BROWSERLESS_CDP_URL="wss://chrome.browserless.example")

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

Session-replay and heatmap image exports render a page in headless Chrome (Browserless) and wait for a content selector. When Browserless closes the page/context mid-render while the underlying CDP transport stays up, the resulting Playwright error (`Target page, context or browser has been closed`) matched our generic connection-error indicators and was re-raised as `BrowserlessUnavailable` — which is in `EXCEPTIONS_TO_RETRY`.

The export activity then retried (up to 10 attempts), re-running the full render each time on a page that is already gone. The whole retry budget was spent before the export was finally marked failed. Surfaced via SLO failure triage on the `export` operation.

**Before — a closed page is retried as a transient transport failure:**

```mermaid
sequenceDiagram
    participant A as Export activity
    participant B as Browserless
    A->>B: render page and wait for selector
    B--xA: page closed mid-render, transport still up
    Note over A: matched connection indicators<br/>raised as retryable BrowserlessUnavailable
    loop up to 10 attempts
        A->>B: re-render the same already-gone page
        B--xA: same error
    end
    A->>A: export marked failed, full retry budget spent
```

## Changes

- New `PageClosedDuringRender` exception, raised when the render page/context is closed **and the transport is still up** (`not disconnected[0]`). It is deliberately **not** in `EXCEPTIONS_TO_RETRY`, so the export fails fast in a single attempt instead of re-spending the budget on a render that cannot recover.
- Genuine transport drops (the `disconnected` event fired, or websocket / `ECONNREFUSED` / "connection closed" messages) still raise the retryable `BrowserlessUnavailable` — unchanged behavior. The new branch is ordered before the transport check and gated on `not disconnected[0]` to keep that case retryable.
- `PageClosedDuringRender` classifies as a `system` failure for observability (matching the attribution this case had before, when it was `BrowserlessUnavailable`) via a `NON_RETRYABLE_SYSTEM_ERRORS` set that the retry sets never read — so the failure metric stays correct without the exception becoming retryable.

**After — page-closed-with-transport-up fails fast:**

```mermaid
sequenceDiagram
    participant A as Export activity
    participant B as Browserless
    A->>B: render page and wait for selector
    B--xA: page closed mid-render, transport still up
    Note over A: raised as non-retryable PageClosedDuringRender
    A->>A: export fails fast after a single attempt
```

**Full routing in `_screenshot_asset_browserless`:**

```mermaid
flowchart TD
    A[PlaywrightError during render] --> B{page or context closed<br/>and transport still up?}
    B -- yes --> C[PageClosedDuringRender<br/>non-retryable, classified system]
    B -- no --> D{transport dropped<br/>or connection-error message?}
    D -- yes --> E[BrowserlessUnavailable<br/>retryable, classified system]
    D -- no --> F[re-raise original<br/>capture_exception]
```

**Same `system` attribution, different retry behavior** — classification and retryability are deliberately decoupled:

| Exception | When | `failure_type` | Retried by Temporal? |
|---|---|---|---|
| `BrowserlessUnavailable` | transport dropped (websocket / `ECONNREFUSED` / disconnected) | `system` | yes — a fresh session can recover |
| `PageClosedDuringRender` | page/context closed, transport still up | `system` | **no** — fails fast in one attempt |

## How did you test this code?

I am an agent (Claude Code) — automated tests only, no manual testing:

- `test_image_exporter.py` — strengthened the page-closed test to assert the exception identity **and** non-retryability; added `TestIsPageClosedError` pinning that transport-drop strings do not match the page-closed indicators.
- `test_failure_handler.py` — added a classification case plus a test locking `PageClosedDuringRender` to `system` while asserting it stays out of `EXCEPTIONS_TO_RETRY`.
- Full `products/exports/backend/tasks/test/` suites pass (113 tests); `ruff` and `ty` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs needed (internal export failure-handling change).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced and shipped through an SLO triage chain: `/slo-failures-daily` flagged the `export` / `BrowserlessUnavailable` finding, `/slo-fix-this` drove the TDD loop (failing test → fix → green), then `/simplify` and `/review-swarm` hardened it before this PR. Tooling: Claude Code with the `slo-failures-daily`, `slo-fix-this`, `simplify`, and `review-swarm` skills.

Key decisions:

- Blast radius gated on `not disconnected[0]` so only the "page gone but transport alive" case becomes non-retryable; real transport drops keep their retry recovery.
- `/review-swarm` (four reviewers) converged on an observability regression — the new exception would have classified as `unknown` instead of the `system` bucket it had on master. Fixed by decoupling classification from retryability rather than adding it to `EXCEPTIONS_TO_RETRY`, which would have re-enabled the retries this PR removes.

**Known trade-off / post-deploy watch:** the heatmap render path's worst-case wait budget can exceed Browserless's session timeout. If Browserless closes a page mid-render on a *legitimately* long render while keeping the transport up, that render now fails fast instead of retrying — a fresh-session retry might have succeeded. This is the intended trade-off (a closed page rarely recovers in place), but worth watching `PageClosedDuringRender` volume (now `failure_type=system`) after rollout to confirm it is noise, not lost renders.
