### PR TITLE
chore(devex): add skip-agent-review label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
        ❌ feat: Added retention export.   (capitalized, period, no scope)
      Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
      Public OSS repo: no internal customers, incidents, or operational metrics.
+     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
 -->
 
 ## Problem

--- a/products/engineering_analytics/turbo.json
+++ b/products/engineering_analytics/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/products/legal_documents/turbo.json
+++ b/products/legal_documents/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/products/metrics/turbo.json
+++ b/products/metrics/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/products/tasks/turbo.json
+++ b/products/tasks/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/products/visual_review/turbo.json
+++ b/products/visual_review/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/products/wizard/turbo.json
+++ b/products/wizard/turbo.json
@@ -2,7 +2,7 @@
     "extends": ["//"],
     "tasks": {
         "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**"],
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],
             "cache": true
         }

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -20,11 +20,13 @@ from .isolation import (
     IsolationStatus,
     compute_isolation_status,
     has_legacy_interface_leaks,
+    has_routes_module,
     has_tach_interface,
     is_isolated_product,
     iter_interface_blocks as _iter_interface_blocks,
     names_from_pattern as _names_from_pattern,
     pattern_targets_public_surface as _pattern_targets_public_surface,
+    routes_in_turbo_inputs,
 )
 from .paths import TACH_TOML, get_tach_block
 
@@ -694,17 +696,34 @@ class IsolationChainCheck(ProductCheck):
                 '"backend/presentation/**"] to turn the skip on'
             )
 
+        # Watching the route registration: routes.py is the product's route-registration entry
+        # point (public API surface, imported by core to assemble the router), but it lives at
+        # backend/ root — outside the facade/presentation globs. A narrowed product that has one
+        # must add it to the inputs, or a routes-only change is invisible to the skip and runs no
+        # Django suite. (Mutually exclusive with needs_turn_on, which requires no narrowing.)
+        routes_unwatched = (
+            has_narrowed and has_routes_module(ctx.backend_dir) and not routes_in_turbo_inputs(ctx.product_dir)
+        )
+        if routes_unwatched:
+            result.issues.append(
+                "turbo.json narrows contract-check inputs but omits backend/routes.py — routes.py is the "
+                "product's route-registration entry point (public API surface, imported by core), so a "
+                'routes-only change would skip the Django suite. Add "backend/routes.py" to the '
+                "contract-check inputs"
+            )
+
         # Note: a product that has the contract-check script *and* deferred
         # presentation-wave ignore_imports entries is hard-blocked by
         # PackageJsonScriptsCheck — the skip can't be enabled until the wave empties them.
 
         if result.issues or result.warnings:
-            # The turn-on issue can't co-occur with the facade/turbo mismatch issues above
-            # (it requires a real facade, a tach interface, a script, and no narrowing — each
-            # of which negates one of those), so when it fires it's the sole issue and the
-            # annotation belongs on turbo.json, not facade/api.py.
+            # needs_turn_on and routes_unwatched both point at turbo.json; neither can co-occur with
+            # the facade/turbo mismatch issues above the way they're gated, so turbo.json wins when
+            # either fires, otherwise the annotation belongs on facade/api.py.
             result.file = (
-                f"products/{ctx.name}/turbo.json" if needs_turn_on else f"products/{ctx.name}/backend/facade/api.py"
+                f"products/{ctx.name}/turbo.json"
+                if needs_turn_on or routes_unwatched
+                else f"products/{ctx.name}/backend/facade/api.py"
             )
         if result.issues:
             result.lines = [f"✗ {len(result.issues)} issue(s)"] + [f"  → {i}" for i in result.issues]

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -705,11 +705,11 @@ class IsolationChainCheck(ProductCheck):
             has_narrowed and has_routes_module(ctx.backend_dir) and not routes_in_turbo_inputs(ctx.product_dir)
         )
         if routes_unwatched:
+            routes_glob = "backend/routes/**" if (ctx.backend_dir / "routes").is_dir() else "backend/routes.py"
             result.issues.append(
-                "turbo.json narrows contract-check inputs but omits backend/routes.py — routes.py is the "
+                f"turbo.json narrows contract-check inputs but omits {routes_glob} — the routes module is the "
                 "product's route-registration entry point (public API surface, imported by core), so a "
-                'routes-only change would skip the Django suite. Add "backend/routes.py" to the '
-                "contract-check inputs"
+                f'routes-only change would skip the Django suite. Add "{routes_glob}" to the contract-check inputs'
             )
 
         # Note: a product that has the contract-check script *and* deferred
@@ -717,9 +717,11 @@ class IsolationChainCheck(ProductCheck):
         # PackageJsonScriptsCheck — the skip can't be enabled until the wave empties them.
 
         if result.issues or result.warnings:
-            # needs_turn_on and routes_unwatched both point at turbo.json; neither can co-occur with
-            # the facade/turbo mismatch issues above the way they're gated, so turbo.json wins when
-            # either fires, otherwise the annotation belongs on facade/api.py.
+            # needs_turn_on and routes_unwatched both point at turbo.json. needs_turn_on can't
+            # co-occur with the facade/turbo mismatch issues above (it requires a real facade, a
+            # script, and no narrowing). routes_unwatched can co-occur with them (it only needs
+            # has_narrowed + a routes module), but turbo.json is still where the routes omission is
+            # fixed, so it wins; the co-firing mismatch issues still print in the lint output.
             result.file = (
                 f"products/{ctx.name}/turbo.json"
                 if needs_turn_on or routes_unwatched

--- a/tools/hogli-commands/hogli_commands/product/isolation.py
+++ b/tools/hogli-commands/hogli_commands/product/isolation.py
@@ -192,29 +192,45 @@ def contract_check_inputs(product_dir: Path) -> list[str]:
     return contract_task.get("inputs", [])
 
 
+# A contract-check input is "on the public surface" when it targets the facade, the presentation
+# layer, or the routes registration module. Anchored on the path separator so a near-miss like
+# backend/facade_legacy/** can't pass; removeprefix (not lstrip, which strips a char set) trims
+# only a literal "./" so a "../escape/**" can't be normalized into a surface path.
+_FACADE_PRESENTATION_PREFIXES = ("backend/facade/", "backend/presentation/")
+_ROUTES_PREFIXES = ("backend/routes.py", "backend/routes/")
+
+
+def _input_targets_facade_or_presentation(glob: str) -> bool:
+    return glob.removeprefix("./").startswith(_FACADE_PRESENTATION_PREFIXES)
+
+
 def _input_targets_surface(glob: str) -> bool:
-    """A contract-check input confined to the product's public surface (facade, presentation, or
-    routes) — i.e. it does not broaden the skip back out to all of backend/."""
-    normalized = glob.lstrip("./")
-    return normalized.startswith(
-        ("backend/facade", "backend/presentation", "backend/routes", "facade", "presentation", "routes")
-    )
+    return glob.removeprefix("./").startswith(_FACADE_PRESENTATION_PREFIXES + _ROUTES_PREFIXES)
 
 
 def has_narrowed_turbo_inputs(product_dir: Path) -> bool:
-    """True only when contract-check inputs are confined to the public surface. A broad glob like
-    backend/** alongside a facade entry would keep the skip inert — every change still re-runs the
-    Django suite — so every positive input must target the surface, not merely one of them."""
+    """True only when contract-check inputs are confined to the public surface AND at least one
+    targets facade/presentation. A broad glob like backend/** alongside a facade entry keeps the
+    skip inert, and a routes-only narrowing isn't a real contract surface — both are rejected.
+    Negated globs ('!...') are excluded from the surface test."""
     inputs = [i for i in contract_check_inputs(product_dir) if not i.startswith("!")]
     if not inputs:
         return False
-    return all(_input_targets_surface(i) for i in inputs) and any("facade" in i or "presentation" in i for i in inputs)
+    return all(_input_targets_surface(i) for i in inputs) and any(
+        _input_targets_facade_or_presentation(i) for i in inputs
+    )
 
 
 def routes_in_turbo_inputs(product_dir: Path) -> bool:
-    """True if contract-check inputs watch the routes module — without it a routes-only
-    change is invisible to the skip and runs no Django suite."""
-    return any("routes" in i for i in contract_check_inputs(product_dir))
+    """True if contract-check inputs watch the routes module specifically — backend/routes.py or a
+    backend/routes/ package. Anchored and negation-aware, so a glob that merely contains 'routes',
+    or a negated exclusion like !backend/routes.py, doesn't falsely count the routes module as
+    watched (without it, a routes-only change is invisible to the skip and runs no Django suite)."""
+    return any(
+        i.removeprefix("./").startswith(_ROUTES_PREFIXES)
+        for i in contract_check_inputs(product_dir)
+        if not i.startswith("!")
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/product/isolation.py
+++ b/tools/hogli-commands/hogli_commands/product/isolation.py
@@ -100,6 +100,16 @@ def has_real_facade(backend_dir: Path) -> bool:
     return facade_api.exists() and has_any_function_defs(facade_api)
 
 
+def has_routes_module(backend_dir: Path) -> bool:
+    """The product-local route-registration entry point (a routes.py file or routes/ package).
+
+    Core imports it to assemble the API router, so it is public contract surface — not an
+    internal. That is why it does not mark a product as un-isolatable (see
+    pattern_targets_public_surface), but it does need watching once turbo inputs are narrowed.
+    """
+    return (backend_dir / "routes.py").exists() or (backend_dir / "routes").is_dir()
+
+
 def has_tach_interface(name: str, tach_content: str | None = None) -> bool:
     """True if the product is named in a tach [[interfaces]] block (inline or global).
 
@@ -167,19 +177,44 @@ def has_contract_check_script(product_dir: Path) -> bool:
     return "backend:contract-check" in scripts
 
 
-def has_narrowed_turbo_inputs(product_dir: Path) -> bool:
+def contract_check_inputs(product_dir: Path) -> list[str]:
+    """The product's backend:contract-check `inputs` globs (empty if no override)."""
     turbo_json = product_dir / "turbo.json"
     if not turbo_json.exists():
-        return False
+        return []
     try:
         tasks = json.loads(turbo_json.read_text()).get("tasks", {})
     except json.JSONDecodeError:
-        return False
+        return []
     contract_task = tasks.get("backend:contract-check")
     if not contract_task:
+        return []
+    return contract_task.get("inputs", [])
+
+
+def _input_targets_surface(glob: str) -> bool:
+    """A contract-check input confined to the product's public surface (facade, presentation, or
+    routes) — i.e. it does not broaden the skip back out to all of backend/."""
+    normalized = glob.lstrip("./")
+    return normalized.startswith(
+        ("backend/facade", "backend/presentation", "backend/routes", "facade", "presentation", "routes")
+    )
+
+
+def has_narrowed_turbo_inputs(product_dir: Path) -> bool:
+    """True only when contract-check inputs are confined to the public surface. A broad glob like
+    backend/** alongside a facade entry would keep the skip inert — every change still re-runs the
+    Django suite — so every positive input must target the surface, not merely one of them."""
+    inputs = [i for i in contract_check_inputs(product_dir) if not i.startswith("!")]
+    if not inputs:
         return False
-    inputs = contract_task.get("inputs", [])
-    return any("facade" in i or "presentation" in i for i in inputs)
+    return all(_input_targets_surface(i) for i in inputs) and any("facade" in i or "presentation" in i for i in inputs)
+
+
+def routes_in_turbo_inputs(product_dir: Path) -> bool:
+    """True if contract-check inputs watch the routes module — without it a routes-only
+    change is invisible to the skip and runs no Django suite."""
+    return any("routes" in i for i in contract_check_inputs(product_dir))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -25,7 +25,7 @@ from hogli_commands.product.checks import (
     validate_interface_blocks,
     validate_tach_references,
 )
-from hogli_commands.product.isolation import has_narrowed_turbo_inputs
+from hogli_commands.product.isolation import has_narrowed_turbo_inputs, routes_in_turbo_inputs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -357,6 +357,19 @@ class TestIsolationChainRoutes:
         result = chain_check.run(ctx)
         assert not result.issues
 
+    def test_narrowed_with_routes_package_dir_not_in_inputs_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # routes/ as a package directory (not a routes.py file) is the other form has_routes_module
+        # accepts — it must be demanded in the inputs the same way.
+        _seal_externally(monkeypatch)
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        (ctx.backend_dir / "routes").mkdir()
+        (ctx.product_dir / "turbo.json").write_text(json.dumps(_NARROWED_TURBO))
+        result = chain_check.run(ctx)
+        # the message must point at the package glob, not backend/routes.py
+        assert any("backend/routes/**" in i for i in result.issues)
+
     def test_narrowed_without_routes_module_is_not_demanded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -390,11 +403,35 @@ class TestNarrowedTurboDetection:
             (["backend/**"], False),
             (["**/*.py"], False),
             ([], False),
+            # near-misses must not pass as surface (anchored on the path separator)
+            (["backend/facade_legacy/**"], False),
+            (["backend/routesmap/**"], False),
+            # a routes input whose path merely contains "presentation" is not a facade/presentation surface
+            (["backend/routes/presentation_router.py"], False),
         ],
     )
     def test_has_narrowed_turbo_inputs(self, tmp_path: Path, inputs: list[str], expected: bool) -> None:
         (tmp_path / "turbo.json").write_text(json.dumps({"tasks": {"backend:contract-check": {"inputs": inputs}}}))
         assert has_narrowed_turbo_inputs(tmp_path) is expected
+
+
+class TestRoutesInTurboInputs:
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            (["backend/facade/**", "backend/routes.py"], True),
+            (["backend/routes/**"], True),
+            (["backend/facade/**", "backend/presentation/**"], False),
+            # 'routes' substring in an unrelated glob must NOT count as watching the routes module
+            (["backend/presentation/routes_views.py"], False),
+            (["backend/logic/routes_helpers/**"], False),
+            # a negated routes exclusion must NOT count as watched
+            (["backend/facade/**", "!backend/routes.py"], False),
+        ],
+    )
+    def test_routes_in_turbo_inputs(self, tmp_path: Path, inputs: list[str], expected: bool) -> None:
+        (tmp_path / "turbo.json").write_text(json.dumps({"tasks": {"backend:contract-check": {"inputs": inputs}}}))
+        assert routes_in_turbo_inputs(tmp_path) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -25,6 +25,7 @@ from hogli_commands.product.checks import (
     validate_interface_blocks,
     validate_tach_references,
 )
+from hogli_commands.product.isolation import has_narrowed_turbo_inputs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -263,6 +264,17 @@ _NARROWED_TURBO = {
     },
 }
 
+_NARROWED_TURBO_WITH_ROUTES = {
+    "extends": ["//"],
+    "tasks": {
+        "backend:contract-check": {
+            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
+            "outputs": [],
+            "cache": True,
+        }
+    },
+}
+
 chain_check = IsolationChainCheck()
 
 
@@ -325,6 +337,64 @@ class TestIsolationChainTurnOn:
         ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
         result = chain_check.run(ctx)
         assert not any("inert" in i for i in result.issues)
+
+
+class TestIsolationChainRoutes:
+    def test_narrowed_with_routes_not_in_inputs_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seal_externally(monkeypatch)
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        (ctx.backend_dir / "routes.py").write_text("")
+        (ctx.product_dir / "turbo.json").write_text(json.dumps(_NARROWED_TURBO))
+        result = chain_check.run(ctx)
+        assert any("routes.py" in i for i in result.issues)
+        assert result.file == "products/my_product/turbo.json"
+
+    def test_narrowed_with_routes_in_inputs_passes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seal_externally(monkeypatch)
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        (ctx.backend_dir / "routes.py").write_text("")
+        (ctx.product_dir / "turbo.json").write_text(json.dumps(_NARROWED_TURBO_WITH_ROUTES))
+        result = chain_check.run(ctx)
+        assert not result.issues
+
+    def test_narrowed_without_routes_module_is_not_demanded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No routes.py at all — nothing to watch, so the routes demand must not fire.
+        _seal_externally(monkeypatch)
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        (ctx.product_dir / "turbo.json").write_text(json.dumps(_NARROWED_TURBO))
+        result = chain_check.run(ctx)
+        assert not any("routes.py" in i for i in result.issues)
+
+    def test_unnarrowed_with_routes_is_not_demanded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Not narrowed (no turbo.json) — contract-check still watches all of backend/, so routes.py
+        # is already covered and the routes demand must not fire.
+        _seal_externally(monkeypatch)
+        ctx = _make_product(tmp_path, scripts=_WITH_SCRIPT, isolated=True)
+        (ctx.backend_dir / "routes.py").write_text("")
+        result = chain_check.run(ctx)
+        assert not any("routes.py" in i for i in result.issues)
+
+
+class TestNarrowedTurboDetection:
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            (["backend/facade/**", "backend/presentation/**"], True),
+            (["backend/facade/**", "backend/presentation/**", "backend/routes.py"], True),
+            (["backend/presentation/**"], True),
+            (["backend/facade/**", "!backend/facade/**/__pycache__/**"], True),
+            # a broad glob alongside a surface glob keeps the skip inert — must not count as narrowed
+            (["backend/**", "backend/facade/**"], False),
+            (["backend/**"], False),
+            (["**/*.py"], False),
+            ([], False),
+        ],
+    )
+    def test_has_narrowed_turbo_inputs(self, tmp_path: Path, inputs: list[str], expected: bool) -> None:
+        (tmp_path / "turbo.json").write_text(json.dumps({"tasks": {"backend:contract-check": {"inputs": inputs}}}))
+        assert has_narrowed_turbo_inputs(tmp_path) is expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a `skip-agent-review` label for PRs that don't need Copilot or Greptile review (trivial chores, doc tweaks, etc.). Updates the PR template header so agents know to apply it.

The label itself needs to be configured in Copilot/Greptile settings to actually suppress their reviews — this PR just creates the convention and the label.