### PR TITLE
chore(devex): add skip-agent-review label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
        ❌ feat: Added retention export.   (capitalized, period, no scope)
      Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
      Public OSS repo: no internal customers, incidents, or operational metrics.
+     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
 -->
 
 ## Problem


### PR DESCRIPTION
Adds a `skip-agent-review` label for PRs that don't need Copilot or Greptile review (trivial chores, doc tweaks, etc.). Updates the PR template header so agents know to apply it.

The label needs to be configured in Copilot/Greptile settings to actually suppress their reviews — this PR just establishes the convention and creates the label.