### PR TITLE
feat(analytics): add CLI source attribution for posthog-cli requests

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -272,6 +272,7 @@ def report_user_organization_membership_level_changed(
 class EventSource(StrEnum):
     WEB = "web"
     API = "api"
+    CLI = "cli"
     POSTHOG_AI = "posthog_ai"
     POSTHOG_CODE = "posthog_code"
     TERRAFORM = "terraform"
@@ -319,14 +320,17 @@ def get_event_source(request) -> EventSource:
     user_agent = request.headers.get("user-agent", "") or ""
     if not isinstance(user_agent, str):
         user_agent = ""
-    # Wizard, posthog-code etc. all wrap MCP — their UA tokens must win over the
-    # X-PostHog-Client header so the source reflects the outer caller.
+    # Wizard, posthog-code, posthog-cli etc. all wrap MCP — their UA tokens
+    # must win over the X-PostHog-Client header so the source reflects the
+    # outer caller.
     if "posthog/terraform-provider" in user_agent:
         return EventSource.TERRAFORM
     if "posthog/wizard" in user_agent:
         return EventSource.WIZARD
     if _POSTHOG_CODE_UA_RE.search(user_agent):
         return EventSource.POSTHOG_CODE
+    if user_agent == "posthog-cli" or user_agent.startswith("posthog-cli/"):
+        return EventSource.CLI
     if "posthog/mcp-server" in user_agent or request.headers.get("X-Posthog-Client") == "mcp":
         return EventSource.MCP
     # DRF sets successful_authenticator during view dispatch; before that

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -256,6 +256,9 @@ class TestGetEventSource(BaseTest):
     @parameterized.expand(
         [
             ("terraform", "posthog/terraform-provider 1.0", EventSource.TERRAFORM),
+            ("cli_exact", "posthog-cli", EventSource.CLI),
+            ("cli_with_version", "posthog-cli/0.7.30", EventSource.CLI),
+            ("cli_via_mcp_is_cli", "posthog-cli/posthog-cli posthog/mcp-server; version: 1.0.0", EventSource.CLI),
             ("wizard", "posthog/wizard 1.0", EventSource.WIZARD),
             ("posthog_code", "posthog/code 1.2.3", EventSource.POSTHOG_CODE),
             ("hog_dev_subdomain", "posthog/desktop.hog.dev 0.1.0", EventSource.POSTHOG_CODE),

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

The Rust CLI (`posthog-cli`) sends `User-Agent: posthog-cli` on all direct API requests, but `get_event_source` had no rule for it — so every product action (insight created, dashboard created, feature flag updated, etc.) fell through to `source=api`, indistinguishable from any other API client.

Other outer callers that wrap MCP already get their own source: `wizard`, `posthog_code`, `terraform`. The CLI was the odd one out.

## Changes

- Add `CLI = "cli"` to the `EventSource` enum
- Detect `posthog-cli` (exact) and `posthog-cli/...` (versioned) User-Agent strings in `get_event_source`, placed before the generic MCP check so the CLI's MCP-routed calls (`posthog api <tool>`) also resolve to `source=cli` — matching the precedent set by wizard and posthog-code
- Add parameterized test cases: exact UA, versioned UA, and the compound MCP-via-CLI UA (`posthog-cli/posthog-cli posthog/mcp-server; ...`)

The `$mcp_*` properties (client name, consumer, version) are still present on MCP-routed calls for deeper analysis.

## How did you test this code?

Agent-authored. Ran the full `test_event_usage.py` suite (51 tests pass), including the three new parameterized cases covering the exact UA, versioned UA, and compound MCP-via-CLI UA.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated how both CLIs (Rust `posthog-cli` and Node.js MCP CLI bundle) set their User-Agent headers, traced the server-side `get_event_source` detection chain, and identified that the CLI's compound MCP UA (`posthog-cli/posthog-cli posthog/mcp-server; ...`) needed careful ordering — placing the CLI check before the generic MCP check so both direct and MCP-routed CLI calls get `source=cli`, consistent with how wizard and posthog-code handle the same pattern.