### PR TITLE
fix(replay): honor match-any operand for recording filters

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -8,7 +8,6 @@ from opentelemetry import trace
 from posthog.schema import (
     FilterLogicalOperator,
     HogQLQueryModifiers,
-    PropertyGroupFilterValue,
     PropertyOperator,
     RecordingOrder,
     RecordingPropertyFilter,
@@ -140,9 +139,12 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         if expanded_query.filter_test_accounts:
             self._test_account_filters = expand_test_account_filters(team)
 
-        # Route recording-type and $lib event filters from properties to having_predicates.
-        # Recording metrics (duration, click_count, etc.) are aggregated columns that
-        # only exist after GROUP BY, so they must go in HAVING rather than WHERE.
+        # Route recording-type and $lib event filters from the user's property group to HAVING.
+        # Recording metrics (duration, click_count, etc.) are aggregated columns that only exist
+        # after GROUP BY. These come from the user's filter group, so they follow the match-any/all
+        # operand — unlike predicates already in `having_predicates` (duration control, caller
+        # eligibility baselines), which are always AND'd.
+        self._operand_having_predicates: list[AnyPropertyFilter] = []
         if expanded_query.properties:
             remaining_properties = []
             for prop in expanded_query.properties:
@@ -153,9 +155,9 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
                         value=getattr(prop, "value", None),
                         operator=getattr(prop, "operator", PropertyOperator.EXACT),
                     )
-                    expanded_query.having_predicates = (expanded_query.having_predicates or []) + [recording_filter]
+                    self._operand_having_predicates.append(recording_filter)
                 elif getattr(prop, "type", None) == "recording":
-                    expanded_query.having_predicates = (expanded_query.having_predicates or []) + [prop]
+                    self._operand_having_predicates.append(prop)
                 else:
                     remaining_properties.append(prop)
             expanded_query.properties = remaining_properties if remaining_properties else None
@@ -428,13 +430,7 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
                 select=[ast.Field(chain=["log_source_id"])],
                 select_from=ast.JoinExpr(table=ast.Field(chain=["console_logs_log_entries"])),
                 where=property_to_expr(
-                    # convert to a property group so we can insert the correct operand
-                    PropertyGroupFilterValue(
-                        type=(
-                            FilterLogicalOperator.AND_ if self.property_operand == "AND" else FilterLogicalOperator.OR_
-                        ),
-                        values=self._query.console_log_filters,
-                    ),
+                    self.property_group_with_operand(self._query.console_log_filters),
                     team=self._team,
                 ),
             )
@@ -522,8 +518,20 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
             ),
         ]
 
+        # `having_predicates` holds always-apply constraints (duration control, caller eligibility
+        # baselines), so they're AND'd regardless of the user's operand.
         if self._query.having_predicates:
             exprs.append(property_to_expr(self._query.having_predicates, team=self._team, scope="replay"))
+
+        # User filter-group recording filters (e.g. visited_page) follow the match-any/all operand.
+        if self._operand_having_predicates:
+            exprs.append(
+                property_to_expr(
+                    self.property_group_with_operand(self._operand_having_predicates),
+                    team=self._team,
+                    scope="replay",
+                )
+            )
 
         exprs.extend(self._extra_having_predicates)
 

--- a/posthog/session_recordings/queries/sub_queries/base_query.py
+++ b/posthog/session_recordings/queries/sub_queries/base_query.py
@@ -1,12 +1,14 @@
+from collections.abc import Sequence
 from datetime import datetime
 
-from posthog.schema import DateRange, RecordingsQuery
+from posthog.schema import DateRange, FilterLogicalOperator, PropertyGroupFilterValue, RecordingsQuery
 
 from posthog.hogql import ast
 
 from posthog.constants import PropertyOperatorType
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
+from posthog.types import AnyPropertyFilter
 from posthog.utils import relative_date_parse
 
 
@@ -69,6 +71,13 @@ class SessionRecordingsListingBaseQuery:
 
     def wrapped_with_query_operand(self, exprs: list[ast.Expr]) -> ast.Expr:
         return ast.And(exprs=exprs) if self.property_operand == "AND" else ast.Or(exprs=exprs)
+
+    def property_group_with_operand(self, values: Sequence[AnyPropertyFilter]) -> PropertyGroupFilterValue:
+        """Group property filters under the user's AND/OR operand for property_to_expr."""
+        return PropertyGroupFilterValue(
+            type=FilterLogicalOperator.AND_ if self.property_operand == "AND" else FilterLogicalOperator.OR_,
+            values=list(values),
+        )
 
     @property
     def query_date_range(self):

--- a/posthog/session_recordings/queries/sub_queries/person_props_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/person_props_subquery.py
@@ -1,4 +1,4 @@
-from posthog.schema import FilterLogicalOperator, PropertyGroupFilterValue, RecordingsQuery
+from posthog.schema import PropertyGroupFilterValue, RecordingsQuery
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
@@ -31,14 +31,7 @@ class PersonsPropertiesSubQuery(SessionRecordingsListingBaseQuery):
     @property
     def person_properties(self) -> PropertyGroupFilterValue | None:
         person_property_groups = [g for g in (self._query.properties or []) if is_person_property(g)]
-        return (
-            PropertyGroupFilterValue(
-                type=FilterLogicalOperator.AND_ if self.property_operand == "AND" else FilterLogicalOperator.OR_,
-                values=person_property_groups,
-            )
-            if person_property_groups
-            else None
-        )
+        return self.property_group_with_operand(person_property_groups) if person_property_groups else None
 
     @property
     def _where_predicates(self) -> ast.Expr:

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recording_list_from_query.py
@@ -3235,6 +3235,59 @@ class TestSessionRecordingsListFromQuery(ClickhouseTestMixin, APIBaseTest):
             [session_id_three],
         )
 
+        # Two AND'd visited_page filters require both pages in one session - none match
+        two_page_filters = (
+            '[{"key": "visited_page", "value": ["https://example.com/pricing"], "operator": "exact", "type": "recording"},'
+            ' {"key": "visited_page", "value": ["https://example.com/billing"], "operator": "exact", "type": "recording"}]'
+        )
+        self._assert_query_matches_session_ids(
+            {"properties": two_page_filters},
+            [],
+        )
+
+        # Same two filters OR'd - match either page
+        self._assert_query_matches_session_ids(
+            {"properties": two_page_filters, "operand": "OR"},
+            [session_id_one, session_id_two],
+        )
+
+    def test_duration_always_anded_with_visited_page_under_or(self):
+        user = "test_duration_visited_page-user"
+        Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
+
+        # Visited /pricing but too short to clear the duration control
+        short_session = "short pricing session"
+        produce_replay_summary(
+            distinct_id=user,
+            session_id=short_session,
+            first_timestamp=self.an_hour_ago,
+            last_timestamp=(self.an_hour_ago + relativedelta(seconds=10)),
+            team_id=self.team.id,
+            all_urls=["https://example.com/pricing"],
+        )
+
+        # Visited /pricing and long enough to clear the duration control
+        long_session = "long pricing session"
+        produce_replay_summary(
+            distinct_id=user,
+            session_id=long_session,
+            first_timestamp=self.an_hour_ago,
+            last_timestamp=(self.an_hour_ago + relativedelta(seconds=120)),
+            team_id=self.team.id,
+            all_urls=["https://example.com/pricing"],
+        )
+
+        # The duration control is always AND'd, even under operand OR, so the short session that
+        # matches visited_page but fails the duration bound is still excluded.
+        self._assert_query_matches_session_ids(
+            {
+                "operand": "OR",
+                "having_predicates": '[{"type":"recording","key":"duration","value":60,"operator":"gt"}]',
+                "properties": '[{"key": "visited_page", "value": ["https://example.com/pricing"], "operator": "exact", "type": "recording"}]',
+            },
+            [long_session],
+        )
+
     @also_test_with_materialized_columns(
         event_properties=["is_internal_user"],
         person_properties=["email"],


### PR DESCRIPTION
## Problem

Session-replay "visited page" filters were AND'd in the SQL HAVING clause, ignoring the "match any" (OR) operand. Filtering for visited page A or B or C returned nothing while A or B returned data — adding an OR'd page shrank results instead of widening them. (Event-property filters like `current_url` use the WHERE path and were unaffected.)

## Changes

Route the user's filter-group recording filters (visited_page) through an operand-aware property group, mirroring the WHERE path. Always-apply HAVING constraints — the duration control and the summarization-sweep eligibility baselines — stay AND'd regardless of operand. Extracts a shared `property_group_with_operand` helper, also adopted by the existing console-log and person-property paths.

## How did you test this code?

Agent-authored (Claude Code); no manual UI testing. Added regression tests: visited_page under AND vs OR (verified failing without the fix) and duration staying AND'd under OR. Ran the recording-filter test slice — passing. (Remaining local failures are unrelated person-property materialized-column snapshot drift and are green in CI.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. A parallel Claude+Codex review caught that the first cut applied the operand to *all* HAVING predicates, which would have OR'd the duration control and the summarization-sweep eligibility baselines under "match any"; the fix was scoped to only the user's filter-group filters.