### PR TITLE
fix(notebooks): Fixes people node in markdown notebooks, enables filtering

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
@@ -314,7 +314,19 @@ export function buildInsertCommands(
             label: 'People',
             category: 'Data',
             icon: <IconList />,
-            run: (targetNodeId) => insertRegisteredComponent(targetNodeId, 'Person'),
+            run: (targetNodeId) =>
+                insertComponent(targetNodeId, 'Query', {
+                    query: {
+                        kind: 'DataTableNode',
+                        source: {
+                            kind: 'ActorsQuery',
+                            select: ['person_display_name -- Person', 'id', 'created_at'],
+                            // ActorsQuery hits ClickHouse, which requires a product query tag.
+                            // Match the notebook query tagging convention (see NotebookSQLEditor).
+                            tags: { productKey: 'notebooks', scene: 'Notebook' },
+                        },
+                    },
+                }),
         },
         {
             key: 'data-session-recordings',

--- a/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/InsertMenu.tsx
@@ -3,6 +3,10 @@ import { ReactNode, type CSSProperties, useEffect, useRef } from 'react'
 
 import { IconCode, IconDatabase, IconGraph, IconList, IconPencil, IconSparkles } from '@posthog/icons'
 
+import { Scene } from 'scenes/sceneTypes'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
 import {
     INSERT_MENU_GAP,
     INSERT_MENU_MAX_HEIGHT,
@@ -323,7 +327,7 @@ export function buildInsertCommands(
                             select: ['person_display_name -- Person', 'id', 'created_at'],
                             // ActorsQuery hits ClickHouse, which requires a product query tag.
                             // Match the notebook query tagging convention (see NotebookSQLEditor).
-                            tags: { productKey: 'notebooks', scene: 'Notebook' },
+                            tags: { productKey: ProductKey.NOTEBOOKS, scene: Scene.Notebook },
                         },
                     },
                 }),

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { KeyboardEvent, ReactNode, memo, useState } from 'react'
 
-import { IconDatabase, IconEye, IconGraph, IconHide, IconList, IconPencil, IconTrash } from '@posthog/icons'
+import { IconDatabase, IconEye, IconGraph, IconHide, IconList, IconPencil, IconPeople, IconTrash } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import { PostHogErrorBoundary } from '@posthog/react'
 
@@ -458,6 +458,9 @@ export function getQueryComponentTitleDisplay(
     }
     if (sourceKind === 'EventsQuery') {
         return { label: 'Events', tone: 'data', icon: <IconList /> }
+    }
+    if (sourceKind === 'ActorsQuery') {
+        return { label: 'People', tone: 'data', icon: <IconPeople /> }
     }
 
     return {

--- a/frontend/src/lib/components/MarkdownNotebook/utils.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/utils.ts
@@ -5,6 +5,7 @@ import {
     NotebookInlineMark,
     NotebookInlineNode,
     NotebookListItem,
+    NotebookPropValue,
 } from './types'
 
 export function hashString(value: string): string {
@@ -290,6 +291,20 @@ export function isNotebookPropValue(value: unknown): value is NotebookComponentP
     }
 
     return false
+}
+
+// Project a value onto the serializable NotebookPropValue space — the same JSON.stringify
+// normalization markdown serialization applies — dropping nested `undefined` (e.g. an absent
+// `label`/`group_type_index` on a person-property filter inside a query). Counterpart to the
+// isNotebookPropValue guard: where the guard rejects dirty values, this cleans them. Returns
+// `undefined` for values JSON can't represent (top-level `undefined`, functions, symbols), so
+// callers can omit the key entirely.
+export function toSerializablePropValue(value: unknown): NotebookPropValue | undefined {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined) {
+        return undefined
+    }
+    return JSON.parse(serialized) as NotebookPropValue
 }
 
 function sortProps(props: NotebookComponentProps): NotebookComponentProps {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
@@ -8,6 +8,7 @@ import {
     getEditableNodeAttributeKeys,
     getMarkdownNodeAttributeLabel,
     getSerializableAttributeInputValue,
+    getSerializableProps,
 } from './markdownNotebookRegistry'
 
 describe('markdownNotebookRegistry', () => {
@@ -73,5 +74,63 @@ describe('markdownNotebookRegistry', () => {
         expect(getSerializableAttributeInputValue(NotebookNodeType.Group, 'groupTypeIndex', ' not-a-number ')).toEqual(
             'not-a-number'
         )
+    })
+
+    describe('getSerializableProps', () => {
+        it('preserves a query whose nested filter carries undefined fields, stripping the undefined', () => {
+            // Regression: a completed person-property filter from the DataTable arrives with absent
+            // label/group_type_index as `undefined`. Previously the whole `query` prop was dropped,
+            // so the People table never re-queried when a filter was added.
+            const result = getSerializableProps({
+                query: {
+                    kind: 'DataTableNode',
+                    source: {
+                        kind: 'ActorsQuery',
+                        properties: [
+                            { type: 'person', key: 'email', operator: 'exact', value: 'x@y.com', label: undefined },
+                        ],
+                    },
+                },
+            })
+
+            expect(result.query).toEqual({
+                kind: 'DataTableNode',
+                source: {
+                    kind: 'ActorsQuery',
+                    properties: [{ type: 'person', key: 'email', operator: 'exact', value: 'x@y.com' }],
+                },
+            })
+        })
+
+        it('keeps a fully-serializable filter (e.g. cohort) untouched', () => {
+            const query = {
+                kind: 'DataTableNode',
+                source: {
+                    kind: 'ActorsQuery',
+                    properties: [{ type: 'cohort', key: 'id', value: 42, operator: 'in' }],
+                },
+            }
+
+            expect(getSerializableProps({ query }).query).toEqual(query)
+        })
+
+        it.each([
+            ['undefined', { a: undefined }, {}],
+            ['function', { a: () => undefined }, {}],
+        ])('omits the key entirely when the value is not serializable (%s)', (_label, attributes, expected) => {
+            expect(getSerializableProps(attributes as any)).toEqual(expected)
+        })
+
+        it('preserves primitive, array and nested object props', () => {
+            expect(
+                getSerializableProps({ id: 'abc', count: 3, enabled: true, items: ['a', 'b'], nested: { x: 1 } } as any)
+            ).toEqual({ id: 'abc', count: 3, enabled: true, items: ['a', 'b'], nested: { x: 1 } })
+        })
+
+        it('strips undefined nested in an object while keeping its siblings', () => {
+            expect(getSerializableProps({ nested: { keep: 'yes', drop: undefined } } as any)).toEqual({
+                nested: { keep: 'yes' },
+            })
+        })
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -714,8 +714,17 @@ export function getSerializableAttributeInputValue(
 
 export function getSerializableProps(attributes: Partial<NotebookNodeAttributes<any>>): NotebookComponentProps {
     return Object.entries(attributes).reduce<NotebookComponentProps>((props, [key, value]) => {
-        if (value !== undefined && isNotebookPropValue(value)) {
-            props[key] = value as NotebookPropValue
+        if (value === undefined) {
+            return props
+        }
+        // Deep-strip nested `undefined` before validating, mirroring the legacy notebook attribute
+        // pipeline (useSyncedAttributes JSON-serializes attributes). Otherwise a single nested
+        // `undefined` — e.g. a person-property filter's absent `label`/`group_type_index` inside
+        // `query.source.properties` — fails isNotebookPropValue and the whole `query` prop is dropped,
+        // silently discarding the edit so the node never re-queries.
+        const normalized: unknown = typeof value === 'object' ? JSON.parse(JSON.stringify(value)) : value
+        if (isNotebookPropValue(normalized)) {
+            props[key] = normalized
         }
         return props
     }, {})

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -48,7 +48,7 @@ import {
     NotebookComponentRegistry,
     NotebookPropValue,
 } from 'lib/components/MarkdownNotebook/types'
-import { isNotebookPropValue } from 'lib/components/MarkdownNotebook/utils'
+import { isNotebookPropValue, toSerializablePropValue } from 'lib/components/MarkdownNotebook/utils'
 
 import { NODE_ICONS } from '../nodeIcons'
 import { NotebookNodeContext } from '../Nodes/NotebookNodeContext'
@@ -714,16 +714,12 @@ export function getSerializableAttributeInputValue(
 
 export function getSerializableProps(attributes: Partial<NotebookNodeAttributes<any>>): NotebookComponentProps {
     return Object.entries(attributes).reduce<NotebookComponentProps>((props, [key, value]) => {
-        if (value === undefined) {
-            return props
-        }
-        // Deep-strip nested `undefined` before validating, mirroring the legacy notebook attribute
-        // pipeline (useSyncedAttributes JSON-serializes attributes). Otherwise a single nested
-        // `undefined` — e.g. a person-property filter's absent `label`/`group_type_index` inside
-        // `query.source.properties` — fails isNotebookPropValue and the whole `query` prop is dropped,
-        // silently discarding the edit so the node never re-queries.
-        const normalized: unknown = typeof value === 'object' ? JSON.parse(JSON.stringify(value)) : value
-        if (isNotebookPropValue(normalized)) {
+        // Normalize before validating, mirroring the legacy notebook flow(via useSyncedAttributes).
+        // Otherwise isNotebookPropValue rejects an object with a single nested `undefined` property and—
+        // it gets ignored. e.g. a person-property filter's absent `label`/`group_type_index` inside
+        // `query.source.properties` — fails isNotebookPropValue and the whole `query` prop is dropped
+        const normalized = toSerializablePropValue(value)
+        if (normalized !== undefined && isNotebookPropValue(normalized)) {
             props[key] = normalized
         }
         return props


### PR DESCRIPTION
## Problem

People node was inserting a 'Person' component, instead of the 'People' component we've had in V1.

## Changes
- This PR lets users add a 'People' node in the notebook. 
- Adds logic to apply/remove filtering to it.

Notes:
The filter pop-up stays too much to the left of the node, also happens in V1 notebooks. Will get to that in a separate PR.

## How did you test this code

<img width="1090" height="834" alt="2026-06-22 16 28 30" src="https://github.com/user-attachments/assets/a54646f1-2108-48c2-ac7d-2806e2373e13" />

