### PR TITLE
chore(support): Add report a bug button to Support SidePanel [SUPPORT SUPERDAY]

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { incidentStatusLogic } from 'lib/components/HelpMenu/incidentStatusLogic'
@@ -487,6 +487,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

The support side panel's "Share feedback" section lets users jump to feature requests, the roadmap, and what we're building, but there's no direct path to report a bug. Users hit a bug and have to go find the GitHub issue tracker themselves. This adds the missing one-click route.

## Changes

Adds a "Report a bug" button right below "Request a feature" in the support side panel's "Share feedback" section. It links to the existing `bug_report.yml` GitHub issue template (with the `bug` label pre-applied), mirroring how the "Request a feature" button links to `feature_request.yml` with `enhancement`.

- New `LemonButton` using `IconBug`, same `type="secondary" status="alt"` styling as its siblings
- Imports `IconBug` from `@posthog/icons`

One file changed: `frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx` (+12/−1).

<img width="329" height="280" alt="image" src="https://github.com/user-attachments/assets/0495fd39-77ee-44e3-994e-1b2e2e0f82c4" />

## How did you test this code?

Manually verified in a local dev instance: opened the support side panel, confirmed the "Report a bug" button renders under "Request a feature", and that it opens the GitHub bug report template with the `bug` label pre-filled. No automated tests added — this is a static link button with no logic to cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
