### PR TITLE
fix(dagster): route duckling alerts to managed warehouse

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1779,7 +1779,7 @@ def register_persons_files_with_duckling(
 @asset(
     partitions_def=duckling_events_partitions_def,
     name="duckling_events_backfill",
-    tags={"owner": JobOwners.TEAM_DATA_STACK.value, **EVENTS_CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_MANAGED_WAREHOUSE.value, **EVENTS_CONCURRENCY_TAG},
 )
 def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
     """Backfill events from ClickHouse to a customer's duckling.
@@ -1949,7 +1949,7 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
 @asset(
     partitions_def=duckling_persons_partitions_def,
     name="duckling_persons_backfill",
-    tags={"owner": JobOwners.TEAM_DATA_STACK.value, **PERSONS_CONCURRENCY_TAG},
+    tags={"owner": JobOwners.TEAM_MANAGED_WAREHOUSE.value, **PERSONS_CONCURRENCY_TAG},
 )
 def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
     """Backfill persons from ClickHouse to a customer's duckling.
@@ -2462,8 +2462,7 @@ duckling_events_backfill_job = define_asset_job(
     name="duckling_events_backfill_job",
     selection=["duckling_events_backfill"],
     tags={
-        "owner": JobOwners.TEAM_DATA_STACK.value,
-        "disable_slack_notifications": True,
+        "owner": JobOwners.TEAM_MANAGED_WAREHOUSE.value,
         **EVENTS_CONCURRENCY_TAG,
     },
 )
@@ -2667,8 +2666,7 @@ duckling_persons_backfill_job = define_asset_job(
     name="duckling_persons_backfill_job",
     selection=["duckling_persons_backfill"],
     tags={
-        "owner": JobOwners.TEAM_DATA_STACK.value,
-        "disable_slack_notifications": True,
+        "owner": JobOwners.TEAM_MANAGED_WAREHOUSE.value,
         **PERSONS_CONCURRENCY_TAG,
     },
 )

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -9,6 +9,7 @@ import duckdb
 import psycopg
 from parameterized import parameterized
 
+from posthog.dags.common import JobOwners
 from posthog.dags.events_backfill_to_duckling import (
     DUCKLAKE_ALIAS,
     DUCKLING_BACKFILL_CONCURRENCY_TAG,
@@ -38,7 +39,9 @@ from posthog.dags.events_backfill_to_duckling import (
     _set_table_partitioning,
     _validate_identifier,
     delete_events_partition_data,
+    duckling_events_backfill_job,
     duckling_events_full_backfill_sensor,
+    duckling_persons_backfill_job,
     export_events_to_duckling_s3,
     export_persons_full_to_duckling_s3,
     export_persons_to_duckling_s3,
@@ -51,6 +54,18 @@ from posthog.dags.events_backfill_to_duckling import (
     register_persons_files_with_duckling,
     table_exists,
 )
+
+
+class TestDucklingBackfillAlertRouting:
+    @parameterized.expand(
+        [
+            ("events", duckling_events_backfill_job),
+            ("persons", duckling_persons_backfill_job),
+        ]
+    )
+    def test_backfill_jobs_alert_managed_warehouse(self, _name, job):
+        assert job.tags["owner"] == JobOwners.TEAM_MANAGED_WAREHOUSE.value
+        assert "disable_slack_notifications" not in job.tags
 
 
 class TestResolveDucklingTarget:


### PR DESCRIPTION
## Problem

Duckling backfill Dagster jobs are owned by the team that operates the managed warehouse path, but their run tags still route failures to the Data stack owner and suppress Slack notifications. A failed duckling events or persons backfill should surface in the Managed Warehouse alert channel through the existing Dagster failure sensor.

## Changes

- Change the duckling events and persons backfill asset/job owner tags to `team-managed-warehouse`.
- Remove `disable_slack_notifications` from the runnable duckling backfill jobs so Dagster failure alerts are sent.
- Add a focused test that locks the job tags to Managed Warehouse ownership and verifies Slack notifications are not suppressed.

## How did you test this code?

Automated tests run by Codex:

```bash
flox activate -- bash -c "bin/hogli test posthog/dags/test_events_backfill_to_duckling.py::TestDucklingBackfillAlertRouting"
flox activate -- bash -c "ruff check posthog/dags/events_backfill_to_duckling.py posthog/dags/test_events_backfill_to_duckling.py --fix && ruff format posthog/dags/events_backfill_to_duckling.py posthog/dags/test_events_backfill_to_duckling.py"
```

The first run of `TestDucklingBackfillAlertRouting` failed before the implementation change, then passed after the tag update.

I also attempted:

```bash
flox activate -- bash -c "bin/hogli test posthog/dags/tests/test_slack_alerts.py"
```

That was blocked locally because the `test_dagster` Postgres database on `localhost:5432` was not running.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this scoped routing change after verifying that Dagster job failure alerts are handled in the PostHog repo by the shared failure sensor, not by the charts/vmalert stack. No repo-provided skills were invoked; this did not touch DRF endpoints, migrations, ClickHouse migrations, frontend API types, or notification framework implementation.