### PR TITLE
feat(hogql): expose posthog_filesystem as system.file_system

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -635,6 +635,27 @@ exports: PostgresTable = PostgresTable(
     },
 )
 
+# The project's virtual file tree (posthog_filesystem). Channels are folders and
+# tasks/canvases are filed under them by `path`; `surface` separates products
+# (e.g. "web" vs "desktop"). Scoped to a channel via startsWith(path, ...).
+file_system: PostgresTable = PostgresTable(
+    name="file_system",
+    postgres_table_name="posthog_filesystem",
+    fields={
+        "id": StringDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "path": StringDatabaseField(name="path"),
+        "depth": IntegerDatabaseField(name="depth", nullable=True),
+        "type": StringDatabaseField(name="type"),
+        "ref": StringDatabaseField(name="ref", nullable=True),
+        "href": StringDatabaseField(name="href", nullable=True),
+        "meta": StringJSONDatabaseField(name="meta", nullable=True),
+        "surface": StringDatabaseField(name="surface", nullable=True),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+        "created_by_id": IntegerDatabaseField(name="created_by_id", nullable=True),
+    },
+)
+
 activity_logs: PostgresTable = PostgresTable(
     name="activity_logs",
     postgres_table_name="posthog_activitylog",
@@ -1287,6 +1308,7 @@ class SystemTables(TableNode):
         "experiments": TableNode(name="experiments", table=experiments),
         "exports": TableNode(name="exports", table=exports),
         "feature_flags": TableNode(name="feature_flags", table=feature_flags),
+        "file_system": TableNode(name="file_system", table=file_system),
         "groups": TableNode(name="groups", table=groups),
         "group_type_mappings": TableNode(name="group_type_mappings", table=group_type_mappings),
         "hog_flows": TableNode(name="hog_flows", table=hog_flows),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -651,6 +651,7 @@ file_system: PostgresTable = PostgresTable(
         "href": StringDatabaseField(name="href", nullable=True),
         "meta": StringJSONDatabaseField(name="meta", nullable=True),
         "surface": StringDatabaseField(name="surface", nullable=True),
+        "shortcut": BooleanDatabaseField(name="shortcut", nullable=True),
         "created_at": DateTimeDatabaseField(name="created_at"),
         "created_by_id": IntegerDatabaseField(name="created_by_id", nullable=True),
     },

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -518,6 +518,18 @@ def _create_task_run(team: Team, label: str):
     return TaskRun.objects.create(task=task, team=team, status=TaskRun.Status.QUEUED)
 
 
+def _create_file_system(team: Team, label: str):
+    from posthog.models.file_system.file_system import FileSystem
+
+    return FileSystem.objects.create(
+        team=team,
+        path=f"Channels/{label}",
+        type="task",
+        ref=label,
+        surface="desktop",
+    )
+
+
 def _create_sandbox_environment(team: Team, label: str):
     SandboxEnvironment = apps.get_model("tasks", "SandboxEnvironment")
 
@@ -613,6 +625,7 @@ SYSTEM_TABLE_FACTORIES = [
     ("experiments", _create_experiment),
     ("exports", _create_export),
     ("feature_flags", _create_feature_flag),
+    ("file_system", _create_file_system),
     ("groups", _create_group),
     ("group_type_mappings", _create_group_type_mapping),
     ("hog_flows", _create_hog_flow),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -5491,6 +5491,114 @@
           "row_count": null,
           "type": "system"
       },
+      "system.file_system": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "path": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "path",
+                  "id": null,
+                  "name": "path",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "depth": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "depth",
+                  "id": null,
+                  "name": "depth",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "ref": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "ref",
+                  "id": null,
+                  "name": "ref",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "href": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "href",
+                  "id": null,
+                  "name": "href",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "meta": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "meta",
+                  "id": null,
+                  "name": "meta",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "surface": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "surface",
+                  "id": null,
+                  "name": "surface",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              }
+          },
+          "id": "system.file_system",
+          "name": "system.file_system",
+          "row_count": null,
+          "type": "system"
+      },
       "system.groups": {
           "fields": {
               "id": {
@@ -13495,6 +13603,114 @@
           },
           "id": "system.feature_flags",
           "name": "system.feature_flags",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.file_system": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "path": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "path",
+                  "id": null,
+                  "name": "path",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "depth": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "depth",
+                  "id": null,
+                  "name": "depth",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "ref": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "ref",
+                  "id": null,
+                  "name": "ref",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "href": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "href",
+                  "id": null,
+                  "name": "href",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "meta": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "meta",
+                  "id": null,
+                  "name": "meta",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "surface": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "surface",
+                  "id": null,
+                  "name": "surface",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              }
+          },
+          "id": "system.file_system",
+          "name": "system.file_system",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -5573,6 +5573,16 @@
                   "table": null,
                   "type": "string"
               },
+              "shortcut": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "shortcut",
+                  "id": null,
+                  "name": "shortcut",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
+              },
               "created_at": {
                   "chain": null,
                   "fields": null,
@@ -13687,6 +13697,16 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "shortcut": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "shortcut",
+                  "id": null,
+                  "name": "shortcut",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
               },
               "created_at": {
                   "chain": null,

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -110,7 +110,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.cohort_calculation_history', 'system.cohorts', 'system.data_modeling_jobs', 'system.data_modeling_views', 'system.data_warehouse_tables', 'system.exports', 'system.groups', 'system.group_type_mappings', 'system.ingestion_warnings', 'system.insight_variables', 'system.tags', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.cohort_calculation_history', 'system.cohorts', 'system.data_modeling_jobs', 'system.data_modeling_views', 'system.data_warehouse_tables', 'system.exports', 'system.file_system', 'system.groups', 'system.group_type_mappings', 'system.ingestion_warnings', 'system.insight_variables', 'system.tags', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.


### PR DESCRIPTION
## Problem

The PostHog Code desktop app's freeform canvases (channel "home canvas") read a channel's virtual file tree — folders, tasks, canvases — over HogQL via the `ph.query` bridge. The home canvas template queries `system.file_system`, but no such table is registered, so every query fails with `Unknown table 'system.file_system'`. The template swallows the error and renders empty "No canvases yet" / "No tasks yet" sections even when the channel has content.

## Change

Register a `system.file_system` HogQL table mapping the `posthog_filesystem` Postgres table, exposing the columns the desktop app needs:

- `id, team_id, path, depth, type, ref, href, meta, surface, created_at, created_by_id`

Channels are folders; tasks/canvases are filed under them by `path`, and `surface` separates products (e.g. `web` vs `desktop`). The desktop app scopes a query to a channel via `startsWith(path, <channelPath>/)`.

Includes the isolation-test factory registration and the regenerated serialized-schema snapshot.

## Testing

- `pytest posthog/hogql/database/test/test_database.py -k snapshot`
- `pytest posthog/hogql/database/schema/test/test_system_tables.py`

Generated-By: PostHog Code
Task-Id: 72b75e7a-2101-4267-9b5b-1cf9debbf435