### PR TITLE
feat(batch-exports): Track queue wait time in new histogram

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -20,6 +20,27 @@ from temporalio.worker import (
 
 from posthog.temporal.common.logger import get_write_only_logger
 
+BATCH_EXPORT_ACTIVITY_TYPES = {
+    "copy_into_redshift_activity_from_stage",
+    "export_to_file_download_bucket_with_temporary_credentials",
+    "insert_into_bigquery_activity_from_stage",
+    "insert_into_databricks_activity_from_stage",
+    "insert_into_internal_stage_activity",
+    "insert_into_postgres_activity_from_stage",
+    "insert_into_redshift_activity",
+    "insert_into_redshift_activity_from_stage",
+    "insert_into_s3_activity_from_stage",
+    "insert_into_snowflake_activity_from_stage",
+}
+BATCH_EXPORT_WORKFLOW_TYPES = {
+    "s3-export",
+    "bigquery-export",
+    "snowflake-export",
+    "redshift-export",
+    "postgres-export",
+    "databricks-export",
+}
+
 LOGGER = get_write_only_logger(__name__)
 
 
@@ -57,28 +78,32 @@ def get_export_finished_metric(status: str, model: str) -> MetricCounter:
     )
 
 
-BATCH_EXPORT_ACTIVITY_TYPES = {
-    "copy_into_redshift_activity_from_stage",
-    "export_to_file_download_bucket_with_temporary_credentials",
-    "insert_into_bigquery_activity_from_stage",
-    "insert_into_databricks_activity_from_stage",
-    "insert_into_internal_stage_activity",
-    "insert_into_postgres_activity_from_stage",
-    "insert_into_redshift_activity",
-    "insert_into_redshift_activity_from_stage",
-    "insert_into_s3_activity_from_stage",
-    "insert_into_snowflake_activity_from_stage",
-}
-BATCH_EXPORT_WORKFLOW_TYPES = {
-    "s3-export",
-    "bigquery-export",
-    "snowflake-export",
-    "redshift-export",
-    "postgres-export",
-    "databricks-export",
-}
-
 Attributes = dict[str, str | int | float | bool]
+
+
+def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
+    """Return a meter depending on in which context we are."""
+    basic_attributes = {}
+
+    if activity.in_activity():
+        meter = activity.metric_meter()
+
+        activity_info = activity.info()
+        if (workflow_type := activity_info.workflow_type) is not None:
+            basic_attributes["workflow_type"] = workflow_type
+        basic_attributes["activity_type"] = activity_info.activity_type
+
+    elif workflow.in_workflow():
+        meter = workflow.metric_meter()
+        basic_attributes["workflow_type"] = workflow.info().workflow_type
+
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+    if additional_attributes:
+        meter = meter.with_additional_attributes(additional_attributes)
+
+    return meter
 
 
 class BatchExportsMetricsInterceptor(Interceptor):
@@ -281,31 +306,6 @@ class ExecutionTimeRecorder:
         """Reset counter and bytes processed."""
         self._start_counter = None
         self.bytes_processed = None
-
-
-def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
-    """Return a meter depending on in which context we are."""
-    basic_attributes = {}
-
-    if activity.in_activity():
-        meter = activity.metric_meter()
-
-        activity_info = activity.info()
-        if (workflow_type := activity_info.workflow_type) is not None:
-            basic_attributes["workflow_type"] = workflow_type
-        basic_attributes["activity_type"] = activity_info.activity_type
-
-    elif workflow.in_workflow():
-        meter = workflow.metric_meter()
-        basic_attributes["workflow_type"] = workflow.info().workflow_type
-
-    else:
-        raise RuntimeError("Not within workflow or activity context")
-
-    if additional_attributes:
-        meter = meter.with_additional_attributes(additional_attributes)
-
-    return meter
 
 
 def log_execution_time(

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -98,6 +98,9 @@ def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricM
         basic_attributes["workflow_type"] = workflow.info().workflow_type
 
     else:
+        if settings.DEBUG or settings.TEST:
+            return MetricMeter.noop
+
         raise RuntimeError("Not within workflow or activity context")
 
     if additional_attributes:

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -58,14 +58,16 @@ def get_export_finished_metric(status: str, model: str) -> MetricCounter:
 
 
 BATCH_EXPORT_ACTIVITY_TYPES = {
+    "copy_into_redshift_activity_from_stage",
+    "export_to_file_download_bucket_with_temporary_credentials",
+    "insert_into_bigquery_activity_from_stage",
+    "insert_into_databricks_activity_from_stage",
     "insert_into_internal_stage_activity",
-    "insert_into_s3_activity_from_stage",
-    "insert_into_snowflake_activity_from_stage",
+    "insert_into_postgres_activity_from_stage",
     "insert_into_redshift_activity",
     "insert_into_redshift_activity_from_stage",
-    "copy_into_redshift_activity_from_stage",
-    "insert_into_postgres_activity_from_stage",
-    "insert_into_databricks_activity_from_stage",
+    "insert_into_s3_activity_from_stage",
+    "insert_into_snowflake_activity_from_stage",
 }
 BATCH_EXPORT_WORKFLOW_TYPES = {
     "s3-export",

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -97,8 +97,7 @@ class BatchExportsMetricsInterceptor(Interceptor):
 
 class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor):
     async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
-        activity_info = activity.info()
-        activity_type = activity_info.activity_type
+        activity_type = activity.info().activity_type
 
         if activity_type not in BATCH_EXPORT_ACTIVITY_TYPES:
             return await super().execute_activity(input)
@@ -129,8 +128,6 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
         histogram_attributes: Attributes = {
             "interval": interval,
         }
-        if activity_info.workflow_type is not None:
-            histogram_attributes["workflow_type"] = activity_info.workflow_type
 
         meter = get_metric_meter(histogram_attributes)
 
@@ -153,7 +150,7 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
             name="batch_exports_activity_success_attempts",
             description="Counter tracking the attempts it took to complete activities",
         )
-        attempts_success_counter.add(activity_info.attempt)
+        attempts_success_counter.add(activity.info().attempt)
 
         return result
 
@@ -288,10 +285,20 @@ class ExecutionTimeRecorder:
 
 def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
     """Return a meter depending on in which context we are."""
+    basic_attributes = {}
+
     if activity.in_activity():
         meter = activity.metric_meter()
+
+        activity_info = activity.info()
+        if (workflow_type := activity_info.workflow_type) is not None:
+            basic_attributes["workflow_type"] = workflow_type
+        basic_attributes["activity_type"] = activity_info.activity_type
+
     elif workflow.in_workflow():
         meter = workflow.metric_meter()
+        basic_attributes["workflow_type"] = workflow.info().workflow_type
+
     else:
         raise RuntimeError("Not within workflow or activity context")
 

--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -83,7 +83,7 @@ Attributes = dict[str, str | int | float | bool]
 
 def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
     """Return a meter depending on in which context we are."""
-    basic_attributes = {}
+    basic_attributes: Attributes = {}
 
     if activity.in_activity():
         meter = activity.metric_meter()
@@ -104,7 +104,11 @@ def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricM
         raise RuntimeError("Not within workflow or activity context")
 
     if additional_attributes:
-        meter = meter.with_additional_attributes(additional_attributes)
+        attributes: Attributes = {**basic_attributes, **additional_attributes}
+    else:
+        attributes = basic_attributes
+
+    meter = meter.with_additional_attributes(attributes)
 
     return meter
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -1,4 +1,5 @@
 import math
+import time
 import uuid
 import typing
 import asyncio
@@ -9,6 +10,7 @@ import collections.abc
 from django.conf import settings
 
 import pyarrow as pa
+from temporalio.common import MetricHistogram
 
 from posthog.schema import EventPropertyFilter, HogQLPropertyFilter, HogQLQueryModifiers, MaterializationMode
 
@@ -27,6 +29,7 @@ from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import get_write_only_logger
 
 from products.batch_exports.backend.service import BackfillDetails
+from products.batch_exports.backend.temporal.metrics import get_metric_meter
 from products.batch_exports.backend.temporal.record_batch_model import RecordBatchModel
 from products.batch_exports.backend.temporal.sql import (
     SELECT_FROM_DISTRIBUTED_EVENTS_RECENT,
@@ -42,6 +45,13 @@ from products.batch_exports.backend.temporal.sql import (
 LOGGER = get_write_only_logger(__name__)
 
 
+class QueuedRecordBatch(typing.NamedTuple):
+    """A record batch in queue, tracking the time it entered."""
+
+    record_batch: pa.RecordBatch
+    enqueued_at: int
+
+
 class RecordBatchQueue(asyncio.Queue):
     """A queue of pyarrow RecordBatch instances limited by bytes."""
 
@@ -50,14 +60,28 @@ class RecordBatchQueue(asyncio.Queue):
         self._bytes_size = 0
         self._schema_set = asyncio.Event()
         self.record_batch_schema: pa.Schema | None = None
+        self._histogram: MetricHistogram | None = None
         # This is set by `asyncio.Queue.__init__` calling `_init`
-        self._queue: collections.deque
+        self._queue: collections.deque[QueuedRecordBatch]
+
+    @property
+    def histogram(self) -> MetricHistogram:
+        if self._histogram is None:
+            meter = get_metric_meter()
+            self._histogram = meter.create_histogram(
+                "batch_exports_queue_wait_time", description="Time spent by record batches waiting in queue"
+            )
+        return self._histogram
 
     def _get(self) -> pa.RecordBatch:
         """Override parent `_get` to keep track of bytes."""
-        item = self._queue.popleft()
-        self._bytes_size -= item.get_total_buffer_size()
-        return item
+        record_batch, enqueued_at = self._queue.popleft()
+        self._bytes_size -= record_batch.get_total_buffer_size()
+
+        queued_time = time.perf_counter_ns() - enqueued_at
+        self.histogram.record(queued_time)
+
+        return record_batch
 
     def _put(self, item: pa.RecordBatch) -> None:
         """Override parent `_put` to keep track of bytes."""
@@ -66,7 +90,7 @@ class RecordBatchQueue(asyncio.Queue):
         if not self._schema_set.is_set():
             self.set_schema(item)
 
-        self._queue.append(item)
+        self._queue.append(QueuedRecordBatch(item, time.perf_counter_ns()))
 
     def set_schema(self, record_batch: pa.RecordBatch) -> None:
         """Used to keep track of schema of events in queue."""

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -111,9 +111,7 @@ async def test_interceptor_calls_histogram_metrics(
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-        mocked_meter.assert_any_call(
-            {"interval": "hour", "status": "COMPLETED", "exception": "", "workflow_type": "postgres-export"}
-        )
+        mocked_meter.assert_any_call({"interval": "hour", "status": "COMPLETED", "exception": ""})
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
             name="batch_exports_workflow_interval_execution_latency",
             description="Histogram tracking execution latency for batch export workflows by interval",


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

We don't have good metrics in batch exports. This means we have blindspots when discussing performance. We should address this by adding a ton of metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Starting with a relatively simple one, let's track time spent waiting in queue for batch exports. For each record batch, we record when they join the queue, and compute their wait time when they leave the queue.

Additionally a few other changes:
* A couple of activities were not being tracked (BigQuery + file download), now they are.
* Moved constants to the top in the metrics module
* Made capturing workflow_type and activity_type defaults, as we always want these (at least in the current usage).
  * When not in an activity or workflow, and in DEBUG or TEST, we explicitly return the NoOp metric meter, so that this doesn't impact tests or local dev.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I have not.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Chatted a bit about different possible implementations, rubber-duck style. But all code is written by me.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
