### PR TITLE
fix(exports): prevent replay image-export renderer OOM

### DIFF
--- a/frontend/src/exporter/scenes/ExporterRecordingScene.tsx
+++ b/frontend/src/exporter/scenes/ExporterRecordingScene.tsx
@@ -3,6 +3,13 @@ import { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/ses
 
 import { ExportedData } from '../types'
 
+// Image exports render a single frame in a headless, memory-constrained browser. A recording whose
+// keyframes are sparse near the seeked offset would otherwise make rrweb load the whole session into the
+// DOM and OOM the renderer (surfaces as BrowserlessUnavailable "page has been closed"). Cap how many
+// snapshot sources a seek loads so the export renders a best-effort frame instead of dying. Higher
+// recovers more keyframe-poor recordings at the cost of renderer memory.
+const EXPORTER_MAX_SEEK_FILL_SOURCES = 150
+
 export default function ExporterRecordingScene({
     recording,
     mode,
@@ -27,6 +34,7 @@ export default function ExporterRecordingScene({
             withSidebar={showInspector ?? false}
             noBorder={noBorder ?? false}
             accessToken={exportToken}
+            maxSeekFillSources={EXPORTER_MAX_SEEK_FILL_SOURCES}
         />
     )
 }

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -44,6 +44,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         pinned,
         setPinned,
         accessToken,
+        maxSeekFillSources,
         onRecordingDeleted,
         playNextRecording,
     } = props
@@ -62,6 +63,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         pinned,
         setPinned,
         accessToken,
+        maxSeekFillSources,
         onRecordingDeleted,
         playNextRecording,
     }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -41,6 +41,8 @@ export interface SessionRecordingDataCoordinatorLogicProps {
     blobV2PollingDisabled?: boolean
     playerKey?: string
     accessToken?: string
+    // Export seek-fill cap; see ExporterRecordingScene for the rationale. Undefined outside exports.
+    maxSeekFillSources?: number
 }
 
 // For a short window after a recording starts it may still be ingesting, so a missing full
@@ -59,11 +61,13 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
     path((key) => ['scenes', 'session-recordings', 'sessionRecordingDataCoordinatorLogic', key]),
     props({} as SessionRecordingDataCoordinatorLogicProps),
     key(({ sessionRecordingId }) => sessionRecordingId || 'no-session-recording-id'),
-    connect(({ sessionRecordingId, blobV2PollingDisabled, accessToken }: SessionRecordingDataCoordinatorLogicProps) => {
+    connect((props: SessionRecordingDataCoordinatorLogicProps) => {
+        const { sessionRecordingId, blobV2PollingDisabled, accessToken, maxSeekFillSources } = props
         const metaLogic = sessionRecordingMetaLogic({
             sessionRecordingId,
             blobV2PollingDisabled,
             accessToken,
+            maxSeekFillSources,
         })
         const eventsLogic = sessionEventsDataLogic({
             sessionRecordingId,
@@ -77,6 +81,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             sessionRecordingId,
             blobV2PollingDisabled,
             accessToken,
+            maxSeekFillSources,
         })
         return {
             actions: [

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingMetaLogic.ts
@@ -18,16 +18,20 @@ export interface SessionRecordingMetaLogicProps {
     blobV2PollingDisabled?: boolean
     playerKey?: string
     accessToken?: string
+    // Forwarded to snapshotDataLogic so the export seek-fill cap survives regardless of which builder
+    // mounts that (sessionRecordingId-keyed) logic first. See sessionRecordingDataCoordinatorLogic.
+    maxSeekFillSources?: number
 }
 
 export const sessionRecordingMetaLogic = kea<sessionRecordingMetaLogicType>([
     path((key) => ['scenes', 'session-recordings', 'sessionRecordingMetaLogic', key]),
     props({} as SessionRecordingMetaLogicProps),
     key(({ sessionRecordingId }) => sessionRecordingId || 'no-session-recording-id'),
-    connect(({ sessionRecordingId, blobV2PollingDisabled }: SessionRecordingMetaLogicProps) => {
+    connect(({ sessionRecordingId, blobV2PollingDisabled, maxSeekFillSources }: SessionRecordingMetaLogicProps) => {
         const snapshotLogic = snapshotDataLogic({
             sessionRecordingId,
             blobV2PollingDisabled,
+            maxSeekFillSources,
         })
         const registryLogic = windowIdRegistryLogic({ sessionRecordingId })
         return {

--- a/frontend/src/scenes/session-recordings/player/snapshot-store/LoadingScheduler.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-store/LoadingScheduler.test.ts
@@ -54,7 +54,49 @@ function createLoadedStore(
     return store
 }
 
+function driveSeekToCompletion(scheduler: LoadingScheduler, store: SnapshotStore, batchSize: number = 10): number {
+    let totalLoaded = 0
+    for (let i = 0; i < 2000; i++) {
+        const batch = scheduler.getNextBatch(store, batchSize)
+        if (!batch || batch.sourceIndices.length === 0) {
+            break
+        }
+        for (const idx of batch.sourceIndices) {
+            store.markLoaded(idx, [makeSnapshot(tsForMinute(idx))])
+        }
+        totalLoaded += batch.sourceIndices.length
+        // Stop once the seek resolves or gives up — we only want to measure the seek's own fill.
+        if (!scheduler.isSeeking) {
+            break
+        }
+    }
+    return totalLoaded
+}
+
 describe('LoadingScheduler', () => {
+    describe('bounded seek fill', () => {
+        // A keyframe-poor recording: no FullSnapshot anywhere, so a seek to the middle can't find one
+        // and falls into the backward (step 4) then forward (step 5) search.
+        it('uncapped scheduler loads essentially the whole recording (interactive playback unchanged)', () => {
+            const store = createLoadedStore(300, [], [])
+            const scheduler = new LoadingScheduler()
+            scheduler.seekTo(tsForMinute(150))
+
+            expect(driveSeekToCompletion(scheduler, store)).toBeGreaterThan(250)
+        })
+
+        it('caps the seek fill instead of loading the whole recording when maxSeekFillSources is set', () => {
+            const store = createLoadedStore(300, [], [])
+            const scheduler = new LoadingScheduler({ maxSeekFillSources: 30 })
+            scheduler.seekTo(tsForMinute(150))
+
+            const loaded = driveSeekToCompletion(scheduler, store)
+            // ~window (11) + 30 back + 30 forward — bounded, never the whole 300.
+            expect(loaded).toBeGreaterThan(0)
+            expect(loaded).toBeLessThan(120)
+        })
+    })
+
     describe('buffer ahead', () => {
         it('starts in buffer_ahead mode', () => {
             const scheduler = new LoadingScheduler()

--- a/frontend/src/scenes/session-recordings/player/snapshot-store/LoadingScheduler.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-store/LoadingScheduler.ts
@@ -10,6 +10,14 @@ export class LoadingScheduler {
     private seekRangeEnd: number | null = null
     private seekRangeStart: number | null = null
 
+    // Bounds how many sources a seek fills in each direction from the target before giving up to a
+    // best-effort frame, instead of materialising the whole recording (default: unbounded). The headless
+    // image-export player sets this — loading a large keyframe-poor session OOMs the renderer.
+    private readonly maxSeekFillSources: number
+    constructor(options: { maxSeekFillSources?: number } = {}) {
+        this.maxSeekFillSources = options.maxSeekFillSources ?? Infinity
+    }
+
     seekTo(targetTimestamp: number, targetWindowId?: number): void {
         this.mode = { kind: 'seek', targetTimestamp, targetWindowId }
         this.seekRangeEnd = null
@@ -110,9 +118,10 @@ export class LoadingScheduler {
 
         // Step 4: No FullSnapshot found yet, search backward.
         // Loop through ranges to skip over already-loaded sections.
+        const backwardFloor = Math.max(0, targetIndex - this.maxSeekFillSources)
         let currentStart = this.seekRangeStart ?? targetIndex
-        while (currentStart > 0) {
-            const searchStart = Math.max(0, currentStart - batchSize)
+        while (currentStart > backwardFloor) {
+            const searchStart = Math.max(backwardFloor, currentStart - batchSize)
             const searchEnd = currentStart - 1
 
             const backwardIndices = store.getUnloadedIndicesInRange(searchStart, searchEnd)
@@ -126,7 +135,7 @@ export class LoadingScheduler {
             // All sources in this range are loaded — advance past them
             currentStart = searchStart
         }
-        this.seekRangeStart = 0
+        this.seekRangeStart = backwardFloor
 
         // Step 5: Backward search exhausted — no FullSnapshot exists at or before
         // the target, so playback there can only start from one after it (the
@@ -137,10 +146,8 @@ export class LoadingScheduler {
             .fullSnapshotsAfter(targetTs)
             .some((fs) => targetWindowId === undefined || fs.windowId === targetWindowId)
         if (!hasRecoveryCandidate) {
-            const forwardIndices = store.getUnloadedIndicesInRange(
-                (this.seekRangeEnd ?? targetIndex) + 1,
-                store.sourceCount - 1
-            )
+            const forwardCeil = Math.min(store.sourceCount - 1, targetIndex + this.maxSeekFillSources)
+            const forwardIndices = store.getUnloadedIndicesInRange((this.seekRangeEnd ?? targetIndex) + 1, forwardCeil)
             if (forwardIndices.length > 0) {
                 const batch = this.truncateToContiguous(forwardIndices.slice(0, batchSize))
                 this.seekRangeEnd = Math.max(this.seekRangeEnd ?? 0, batch[batch.length - 1])

--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
@@ -33,6 +33,8 @@ export interface SnapshotLogicProps {
     // allows disabling polling for new sources in tests
     blobV2PollingDisabled?: boolean
     accessToken?: string
+    // Export seek-fill cap; see ExporterRecordingScene for the rationale. Undefined outside exports.
+    maxSeekFillSources?: number
 }
 
 // Reactivity note (#53893): `cache.store` (SnapshotStore) and `cache.scheduler`
@@ -558,10 +560,10 @@ export const snapshotDataLogic = kea<snapshotDataLogicType>([
             },
         ],
     })),
-    afterMount(({ actions, cache }) => {
+    afterMount(({ actions, cache, props }) => {
         cache.playerActive = true
         cache.store = new SnapshotStore()
-        cache.scheduler = new LoadingScheduler()
+        cache.scheduler = new LoadingScheduler({ maxSeekFillSources: props.maxSeekFillSources })
         actions.storeUpdated()
 
         cache.disposables.add(() => {

--- a/products/exports/backend/tasks/image_exporter.py
+++ b/products/exports/backend/tasks/image_exporter.py
@@ -170,6 +170,9 @@ def _export_to_png(
         wait_for_css_selector: CSSSelector
         screenshot_height: int = 600
         page_load_timeout: int = 40
+        # Replays rebuild a full DOM in the renderer; 2x device scale quadruples the framebuffer and OOMs
+        # heavy sessions. The replay branch drops to 1x (a thumbnail doesn't need retina); others keep 2x.
+        device_scale_factor: int = 2
         if exported_asset.insight is not None:
             show_legend = exported_asset.insight.show_legend
             legend_param = "&legend=true" if show_legend else ""
@@ -201,6 +204,7 @@ def _export_to_png(
             wait_for_css_selector = exported_asset.export_context.get("css_selector", ".replayer-wrapper")
             screenshot_width = exported_asset.export_context.get("width", 1400)
             screenshot_height = exported_asset.export_context.get("height", 600)
+            device_scale_factor = 1
 
             logger.info(
                 "exporting_replay",
@@ -255,6 +259,7 @@ def _export_to_png(
                 screenshot_height,
                 max_height_pixels,
                 page_load_timeout,
+                device_scale_factor=device_scale_factor,
             )
         except Exception as e:
             IMAGE_EXPORT_RENDER_DURATION.labels(backend="browserless", outcome="failure").observe(
@@ -372,6 +377,7 @@ def _screenshot_asset_browserless(
     screenshot_height: int = 600,
     max_height_pixels: Optional[int] = None,
     page_load_timeout: int = 40,
+    device_scale_factor: int = 2,
 ) -> None:
     endpoint = _build_cdp_endpoint(
         settings.BROWSERLESS_CDP_URL, settings.BROWSERLESS_TOKEN, settings.BROWSERLESS_SESSION_TIMEOUT_MS
@@ -392,7 +398,7 @@ def _screenshot_asset_browserless(
         page = None
         try:
             context = browser.new_context(
-                device_scale_factor=2,
+                device_scale_factor=device_scale_factor,
                 viewport={"width": screenshot_width, "height": screenshot_height},
             )
             page = context.new_page()

--- a/products/exports/backend/tasks/test/test_image_exporter.py
+++ b/products/exports/backend/tasks/test/test_image_exporter.py
@@ -109,6 +109,20 @@ class TestImageExporter(APIBaseTest):
             assert self.exported_asset.content == b"image_data"
             assert self.exported_asset.content_location is None
 
+    def test_replay_export_renders_at_lower_device_scale_than_insight(self, *args: Any) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(self.exported_asset)  # insight asset from setup
+        assert image_exporter._screenshot_asset_browserless.call_args.kwargs["device_scale_factor"] == 2
+
+        recording_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            export_context={"session_recording_id": "abc-123", "timestamp": 8000},
+        )
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(recording_asset)
+        assert image_exporter._screenshot_asset_browserless.call_args.kwargs["device_scale_factor"] == 1
+
     @patch("products.exports.backend.models.exported_asset.UUIDT")
     def test_image_exporter_writes_to_object_storage_when_object_storage_is_enabled(
         self, mocked_uuidt: Any, *args: Any
@@ -772,6 +786,32 @@ class TestScreenshotAssetBrowserless(SimpleTestCase):
         # The re-raise preserves the original timeout as its cause (the message carries no secret, so chaining is safe).
         assert isinstance(ctx.exception.__cause__, PlaywrightTimeoutError)
         assert "Timeout 30000ms exceeded" in str(ctx.exception.__cause__)
+
+    @parameterized.expand([("retina", 2), ("single", 1)])
+    def test_device_scale_factor_is_passed_to_browser_context(self, _name: str, device_scale: int) -> None:
+        page = MagicMock()
+        # Stop right after the context is created so we can assert how it was built.
+        page.goto.side_effect = PlaywrightTimeoutError("stop after context creation")
+        context = MagicMock()
+        context.new_page.return_value = page
+        browser = MagicMock()
+        browser.new_context.return_value = context
+        playwright_obj = MagicMock()
+        playwright_obj.chromium.connect_over_cdp.return_value = browser
+        sync_playwright_cm = MagicMock()
+        sync_playwright_cm.__enter__.return_value = playwright_obj
+
+        with (
+            patch("products.exports.backend.tasks.image_exporter.sync_playwright", return_value=sync_playwright_cm),
+            patch.object(settings, "BROWSERLESS_CDP_URL", "wss://chrome.browserless.io"),
+            patch("products.exports.backend.tasks.image_exporter.capture_exception"),
+        ):
+            with self.assertRaises(PlaywrightTimeoutError):
+                image_exporter._screenshot_asset_browserless(
+                    "p", "u", 800, ".replayer-wrapper", device_scale_factor=device_scale
+                )
+
+        assert browser.new_context.call_args.kwargs["device_scale_factor"] == device_scale
 
 
 class TestDimensionHelpers(SimpleTestCase):

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'


### PR DESCRIPTION
## Problem

Session-replay PNG exports (a thumbnail of a recording at a given time offset) intermittently failed: the headless Chromium renderer's page closed mid-render, surfacing as a retryable `BrowserlessUnavailable` (`Target page, context or browser has been closed`) that exhausted the export retry budget before giving up. The failures were **deterministic per-recording** and **replay-only** — insight/dashboard/heatmap exports never hit it.

Root cause is the replay player's seek loader. To render frame `t`, rrweb needs a FullSnapshot at or before `t`. When a recording has no usable keyframe near the seeked offset, `LoadingScheduler.getSeekBatch` searches **backward to source 0** (step 4) and then **forward to the end** (step 5), materialising the *entire* session into rrweb's reconstructed DOM. In a memory-constrained headless renderer — made worse by a 2× device scale — that OOMs the renderer. (Found via SLO triage → production log analysis → a unit test that reproduces the unbounded load.)

```mermaid
flowchart TD
    A[Seek to frame t — no FullSnapshot near the offset] --> B{maxSeekFillSources cap set?}
    B -- "no (interactive, unbounded)" --> C[search backward to source 0<br/>and forward to the end<br/>= whole session in the rrweb DOM]
    C --> D[headless renderer OOMs<br/>page closes, export fails]
    B -- "yes (export = 150)" --> E[search at most 150 sources<br/>each direction, then give up]
    E --> F[best-effort frame, bounded memory]
```

## Changes

Two bounds, defending different memory axes:

- **DOM size** — `LoadingScheduler` takes an optional `maxSeekFillSources` cap (default unbounded) that limits the backward/forward seek fill. It is threaded **only** into the export render context (`ExporterRecordingScene` passes 150), so interactive playback is unchanged. The cap is forwarded through **every** builder that mounts the `sessionRecordingId`-keyed `snapshotDataLogic` — the player, the coordinator, **and** `metaLogic` — so mount ordering can't silently drop it.
- **Raster memory** — replay exports render at `device_scale_factor` 1 instead of 2 (decided in `_export_to_png`, where the export type is known structurally, and passed down to `_screenshot_asset_browserless`). A thumbnail doesn't need retina, and 2× quadruples the framebuffer.

A capped seek renders a best-effort frame instead of OOMing.

## How did you test this code?

I am an agent (Claude Code) — automated tests only, no manual testing:

- `LoadingScheduler.test.ts` — a test reproduces the unbounded fill (a keyframe-poor 300-source recording loads ~all 300 sources for a single seek) and proves the cap bounds it (~70). The uncapped path is asserted to still load the whole recording, i.e. byte-for-byte unchanged.
- `test_image_exporter.py` — replay exports render at device scale 1 while insight/dashboard/heatmap keep 2 (decision tested at the `_export_to_png` level; the param→`new_context` passthrough tested at `_screenshot_asset_browserless`).
- Full session-recordings player-logic suites + export suites pass; TypeScript and lint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced through SLO failure triage (`/slo-failures-daily`), then narrowed by production log analysis: the failures were renderer-side, replay-only, and deterministic per-recording — the signature of rendered content OOMing the Chromium renderer, not infra flakiness. A unit test then reproduced the unbounded seek fill in code, confirming the root cause. This **replaces an abandoned fail-fast approach** (closed #65201) — SLO data showed those page-closed exports recover on retry often enough that failing fast would convert recoverable exports into hard failures; the real fix is bounding the memory, not the retries.

Key decisions:

- **Export-only cap.** Interactive playback keeps the unbounded fill — it runs in the user's full browser, not a memory-constrained headless renderer. A general interactive bound is a noted follow-up.
- **Cap threaded through all `snapshotDataLogic` mounts including `metaLogic`.** Review flagged that, because `snapshotDataLogic` is keyed only by `sessionRecordingId` and `metaLogic` mounts it without the cap, the export cap otherwise survived only by mount-ordering luck and could silently re-OOM on a future refactor. Forwarding the cap everywhere makes it ordering-independent.

Skills invoked: `/slo-failures-daily`, `/simplify`, `/review-swarm`.

Known follow-ups: (1) a general (larger) seek-fill bound for interactive playback; (2) a signal/metric when a seek terminates via the cap, so a degraded best-effort frame isn't indistinguishable from a correct render; (3) calibrate the `150` cap with the replay team.
