### PR TITLE
chore(replay): add skill for analysing exported session recordings

### DIFF
--- a/products/replay/skills/analysing-exported-session-recordings/SKILL.md
+++ b/products/replay/skills/analysing-exported-session-recordings/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: analysing-exported-session-recordings
+description: >-
+  Decode and analyse a downloaded session-recording export zip (the `data/` blocks
+  plus ClickHouse metadata) to understand what is making a recording large or slow:
+  size composition by DOM mutations vs full snapshots vs network bodies, biggest
+  payloads, content-type breakdown, churned tags/attributes. Use when asked "why is
+  this recording so big?", "what's in this export?", "break down replay size for
+  this session", "analyse the exported recording", or to validate whether a
+  size-reduction change (e.g. skipping binary network bodies) would actually help a
+  given session. Pairs with `exporting-session-recordings`, which produces the zip
+  this skill reads.
+---
+
+# Analysing exported session recordings
+
+An export bundles a recording's raw v2 storage blocks (under `data/`) plus its
+ClickHouse metadata (`session-replay-events.json`, `events.json`).
+Use this skill to crack those blocks open and measure what the recording is made of,
+so size or performance conclusions rest on decoded data — not on raw bytes.
+
+Get the zip first via the `exporting-session-recordings` skill.
+
+## The one thing that will mislead you: the blocks are double-compressed
+
+A `data/` block is **not** readable JSON. It is two layers deep, and skipping either
+layer makes the bytes look like binary garbage or "corruption" that isn't there:
+
+1. **Whole block: snappy-compressed.** The exporter fetches blocks with
+   `decompress=False` (`export_recording/activities.py`), so it writes the raw S3
+   object. Each block is `snappy`-compressed and written at its byte offset, zero-padded
+   (so a `data/` file is mostly `\x00` with the real block at the end). Snappy keeps
+   literal text runs verbatim with binary copy-tokens between them, which is why a raw
+   block reads as "half JSON, half binary".
+2. **Per field: gzip-compressed.** Once snappy-decompressed, a block is JSONL of
+   `["windowId", {event}]` rows. Events tagged `cv: "2024-10"` have their heavy DOM
+   fields (full-snapshot `data`; mutation `adds`/`attributes`/`texts`/`removes`)
+   individually gzip-compressed and stored as a binary-in-JSON string via fflate
+   `strFromU8(gzipSync(strToU8(json)), true)` — each string char is one gzip byte.
+
+**Do not measure or draw conclusions from the raw block bytes.** Reading them as UTF-8
+produces phantom `U+FFFD` runs and wildly wrong size splits (e.g. network bodies look
+tiny because they are still snappy-compressed). Always decode both layers first, then
+measure. The decoder script below does this; reach for it before hand-rolling anything.
+
+The exporter is lossless — it round-trips the raw S3 block (base64 through Redis, binary
+write). Do **not** "fix" the exporter to decompress: export and import are a matched pair
+that re-upload the raw blocks, so changing the export format breaks `import_recording`.
+The decode belongs on the read side.
+
+## Decoding and the size report
+
+`scripts/decode_recording_export.py` does snappy-then-gzip and reports composition.
+It needs a snappy codec (`pip install python-snappy`, or `cramjam`).
+
+```bash
+# size + composition report (accepts the zip directly, or an already-extracted dir)
+python scripts/decode_recording_export.py export-<session_id>.zip
+
+# also emit fully-decoded events (DOM fields un-gzipped and inlined) for deeper digging
+python scripts/decode_recording_export.py export-<session_id>.zip --dump-jsonl decoded.jsonl
+```
+
+The report gives you:
+
+- **Decompressed DOM payload** split across full snapshots vs mutation
+  `adds`/`attributes`/`texts`/`removes` — `adds` and repeated full snapshots are the
+  usual DOM-side offenders.
+- **Network bodies** by response content-type — these are stored **un-gzipped** in the
+  JSONL, so compare them to DOM on **decoded** size, never on raw bytes.
+- **Top tag names and mutated attribute keys**, to see what the DOM churn actually is
+  (e.g. SVG icon trees, inline `style` animation churn).
+
+## Reading the numbers honestly
+
+- **Compare like with like.** DOM fields are gzip-then-snappy; network bodies are
+  plaintext-then-snappy. The report's decompressed sizes tell you what is _in_ the
+  recording (and what the player must hold), which is the right lens for "what should we
+  cut". For "what does it cost to store/ingest", remember network bodies compress far
+  better than already-gzipped DOM, so their stored share is smaller than their decoded
+  share.
+- **A handful of blocks may fail to snappy-decompress** (empty/edge blocks). The script
+  logs and skips them; a few skips do not move the totals.
+- **Blocks are sequential byte ranges and should not overlap** — if you write your own
+  pass, sanity-check for duplicate `(name, timestamp, kind, len)` bodies before trusting
+  a total.
+
+## Worked example (validated)
+
+A long single-page-app session decoded to ~70 MiB of DOM payload but **~253 MiB of
+network bodies**, of which `binary/octet-stream` (136 MiB), `image/webp` (18.5 MiB) and
+`image/svg+xml` (3.5 MiB) were binary assets captured as text. The lesson that earned
+this skill: measuring those same bodies on the raw (still-snappy) bytes reported only
+single-digit MiB and pointed at the wrong culprit. Decoded, the conclusion flips —
+skipping binary network bodies (`feat(replay): skip binary/asset bodies in network
+capture`, posthog-js #3912) is the dominant lever for a session like this, not a
+rounding error. Decode before you conclude.

--- a/products/replay/skills/analysing-exported-session-recordings/scripts/decode_recording_export.py
+++ b/products/replay/skills/analysing-exported-session-recordings/scripts/decode_recording_export.py
@@ -78,24 +78,34 @@ def _strip_null_padding(raw: bytes) -> bytes:
     return raw[start:end]
 
 
+def _block_to_text(name: str, raw: bytes, snappy_decompress: Callable[[bytes], bytes]) -> str | None:
+    block = _strip_null_padding(raw)
+    if not block:
+        return None
+    try:
+        return snappy_decompress(block).decode("utf-8", "replace")
+    except Exception as err:  # noqa: BLE001 — a single bad block shouldn't abort the run
+        print(f"  ! skipped block {name}: {err}", file=sys.stderr)
+        return None
+
+
 def iter_block_text(source: Path, snappy_decompress: Callable[[bytes], bytes]) -> Iterator[str]:
-    """Yield the snappy-decompressed UTF-8 text of every data block in the export."""
+    """Yield the snappy-decompressed UTF-8 text of every data block, one block in memory at a time."""
     if source.is_dir():
         block_paths = sorted((source / "data").glob("*")) if (source / "data").is_dir() else sorted(source.glob("*"))
-        readers = [(p.name, p.read_bytes) for p in block_paths if p.is_file()]
+        for path in block_paths:
+            if path.is_file():
+                text = _block_to_text(path.name, path.read_bytes(), snappy_decompress)
+                if text is not None:
+                    yield text
     else:
+        # keep a single zip handle open for the whole iteration; read+decode one block at a time
         with zipfile.ZipFile(source) as zf:
-            names = [n for n in zf.namelist() if n.startswith("data/") and not n.endswith("/")]
-            readers = [(n, (lambda n=n: zipfile.ZipFile(source).read(n))) for n in names]
-
-    for name, read in readers:
-        block = _strip_null_padding(read())
-        if not block:
-            continue
-        try:
-            yield snappy_decompress(block).decode("utf-8", "replace")
-        except Exception as err:  # noqa: BLE001 — a single bad block shouldn't abort the run
-            print(f"  ! skipped block {name}: {err}", file=sys.stderr)
+            for name in zf.namelist():
+                if name.startswith("data/") and not name.endswith("/"):
+                    text = _block_to_text(name, zf.read(name), snappy_decompress)
+                    if text is not None:
+                        yield text
 
 
 def iter_records(block_text: str) -> Iterator[dict]:

--- a/products/replay/skills/analysing-exported-session-recordings/scripts/decode_recording_export.py
+++ b/products/replay/skills/analysing-exported-session-recordings/scripts/decode_recording_export.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Decode and analyse a session-recording export zip.
+
+An export (see the `exporting-session-recordings` skill) bundles the recording's
+raw v2 storage blocks under `data/` plus ClickHouse metadata. The blocks are the
+RAW S3 objects: each is snappy-compressed, written at its byte offset and
+zero-padded (the exporter fetches with decompress=False). Inside, once
+snappy-decompressed, each block is JSONL of `["windowId", {event}]` rows; events
+tagged `cv: "2024-10"` have their heavy DOM fields individually gzip-compressed
+and stored as binary-in-JSON strings (fflate `strFromU8(gzipSync(...), true)`).
+
+So fully decoding is two layers: snappy (whole block) then gzip (per field).
+
+Usage:
+    python decode_recording_export.py <export.zip|dir> [--report] [--dump-jsonl OUT.jsonl]
+
+Requires a snappy codec: `python-snappy` (preferred) or `cramjam`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import gzip
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Callable, Iterator
+
+EVENT_TYPES = {0: "DomContentLoaded", 1: "Load", 2: "FullSnapshot", 3: "Incremental", 4: "Meta", 5: "Custom", 6: "Plugin"}
+INCREMENTAL_SOURCES = {
+    0: "Mutation",
+    1: "MouseMove",
+    2: "MouseInteraction",
+    3: "Scroll",
+    4: "ViewportResize",
+    5: "Input",
+    6: "TouchMove",
+    7: "MediaInteraction",
+    8: "StyleSheetRule",
+    9: "CanvasMutation",
+    10: "Font",
+    11: "Log",
+    12: "Drag",
+    13: "StyleDeclaration",
+    14: "Selection",
+    15: "AdoptedStyleSheet",
+}
+COMPRESSED_MUTATION_FIELDS = ("adds", "attributes", "texts", "removes")
+TAG_RE = re.compile(rb'"tagName":"([^"]+)"')
+ATTR_KEY_RE = re.compile(rb'"([a-zA-Z_:-]+)":')
+
+
+def _load_snappy() -> Callable[[bytes], bytes]:
+    try:
+        import snappy  # noqa: PLC0415 — optional codec, resolved at runtime
+
+        return snappy.decompress
+    except ImportError:
+        pass
+    try:
+        import cramjam  # noqa: PLC0415 — fallback codec, resolved at runtime
+
+        return lambda b: bytes(cramjam.snappy.decompress(b))
+    except ImportError as err:
+        raise SystemExit("Need a snappy codec. Install with `pip install python-snappy` (or `cramjam`).") from err
+
+
+def _strip_null_padding(raw: bytes) -> bytes:
+    start = 0
+    while start < len(raw) and raw[start] == 0:
+        start += 1
+    end = len(raw)
+    while end > start and raw[end - 1] == 0:
+        end -= 1
+    return raw[start:end]
+
+
+def iter_block_text(source: Path, snappy_decompress: Callable[[bytes], bytes]) -> Iterator[str]:
+    """Yield the snappy-decompressed UTF-8 text of every data block in the export."""
+    if source.is_dir():
+        block_paths = sorted((source / "data").glob("*")) if (source / "data").is_dir() else sorted(source.glob("*"))
+        readers = [(p.name, p.read_bytes) for p in block_paths if p.is_file()]
+    else:
+        with zipfile.ZipFile(source) as zf:
+            names = [n for n in zf.namelist() if n.startswith("data/") and not n.endswith("/")]
+            readers = [(n, (lambda n=n: zipfile.ZipFile(source).read(n))) for n in names]
+
+    for name, read in readers:
+        block = _strip_null_padding(read())
+        if not block:
+            continue
+        try:
+            yield snappy_decompress(block).decode("utf-8", "replace")
+        except Exception as err:  # noqa: BLE001 — a single bad block shouldn't abort the run
+            print(f"  ! skipped block {name}: {err}", file=sys.stderr)
+
+
+def iter_records(block_text: str) -> Iterator[dict]:
+    """Yield the event dict from each `["windowId", {event}]` JSONL row."""
+    for line in block_text.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, list) and len(row) == 2 and isinstance(row[1], dict):
+            yield row[1]
+
+
+def gunzip_field(field: str) -> bytes:
+    """Reverse fflate `strFromU8(gzipSync(...), true)`: each char is one gzip byte."""
+    return gzip.decompress(bytes(ord(c) & 0xFF for c in field))
+
+
+class Report:
+    def __init__(self) -> None:
+        self.records = 0
+        self.gz_ok = 0
+        self.gz_fail = 0
+        self.dom_bytes: collections.Counter[str] = collections.Counter()
+        self.dom_n: collections.Counter[str] = collections.Counter()
+        self.tags: collections.Counter[str] = collections.Counter()
+        self.attrs: collections.Counter[str] = collections.Counter()
+        self.net_body_bytes = 0
+        self.net_bodies = 0
+        self.net_bytes_by_content_type: collections.Counter[str] = collections.Counter()
+
+    def add_dom(self, label: str, decompressed: bytes, collect_tags: bool, collect_attrs: bool) -> None:
+        self.dom_bytes[label] += len(decompressed)
+        self.dom_n[label] += 1
+        if collect_tags:
+            for tag in TAG_RE.findall(decompressed):
+                self.tags[tag.decode("utf-8", "replace").lower()] += 1
+        if collect_attrs:
+            for attr in ATTR_KEY_RE.findall(decompressed):
+                self.attrs[attr.decode()] += 1
+
+
+def analyse(source: Path) -> Report:
+    snappy_decompress = _load_snappy()
+    report = Report()
+    for block_text in iter_block_text(source, snappy_decompress):
+        for event in iter_records(block_text):
+            report.records += 1
+            cv = event.get("cv")
+            data = event.get("data")
+            event_type = event.get("type")
+
+            if cv == "2024-10" and event_type == 2 and isinstance(data, str):
+                _decode_into(report, "FullSnapshot", data, collect_tags=True, collect_attrs=False)
+            elif cv == "2024-10" and event_type == 3 and isinstance(data, dict):
+                for field in COMPRESSED_MUTATION_FIELDS:
+                    value = data.get(field)
+                    if isinstance(value, str):
+                        _decode_into(
+                            report,
+                            f"mutation.{field}",
+                            value,
+                            collect_tags=(field == "adds"),
+                            collect_attrs=(field == "attributes"),
+                        )
+            elif event_type == 6 and isinstance(data, dict):
+                _measure_network(report, data)
+    return report
+
+
+def _decode_into(report: Report, label: str, field: str, collect_tags: bool, collect_attrs: bool) -> None:
+    try:
+        decompressed = gunzip_field(field)
+    except Exception:  # noqa: BLE001 — count and move on; one field shouldn't abort
+        report.gz_fail += 1
+        return
+    report.gz_ok += 1
+    report.add_dom(label, decompressed, collect_tags, collect_attrs)
+
+
+def _measure_network(report: Report, data: dict) -> None:
+    payload = data.get("payload")
+    requests = payload.get("requests") if isinstance(payload, dict) else None
+    for request in requests or []:
+        content_type = "unknown"
+        headers = request.get("responseHeaders") or {}
+        if isinstance(headers, dict):
+            for header, value in headers.items():
+                if header.lower() == "content-type" and isinstance(value, str):
+                    content_type = value.split(";")[0].strip()
+        for key in ("requestBody", "responseBody"):
+            body = request.get(key)
+            if isinstance(body, str):
+                report.net_body_bytes += len(body)
+                report.net_bodies += 1
+                report.net_bytes_by_content_type[content_type] += len(body)
+
+
+def print_report(report: Report) -> None:
+    dom_total = sum(report.dom_bytes.values())
+    print(f"records parsed: {report.records:,}   gzip fields ok={report.gz_ok:,} fail={report.gz_fail:,}\n")
+    print(f"=== decompressed DOM payload: {dom_total:,} bytes ({dom_total / 1024 / 1024:.1f} MiB) ===")
+    for label, by in report.dom_bytes.most_common():
+        share = 100 * by / dom_total if dom_total else 0
+        print(f"  {label:20} n={report.dom_n[label]:7,}  {by:14,} ({by / 1024 / 1024:7.1f} MiB, {share:4.1f}%)")
+
+    net_total = report.net_body_bytes
+    print(f"\n=== network bodies: {net_total:,} bytes ({net_total / 1024 / 1024:.1f} MiB) across {report.net_bodies:,} bodies ===")
+    print("  (these are stored UN-gzipped in the JSONL, unlike DOM fields — compare decoded sizes, not raw bytes)")
+    for ct, by in report.net_bytes_by_content_type.most_common(10):
+        share = 100 * by / net_total if net_total else 0
+        print(f"    {by / 1024 / 1024:8.1f} MiB ({share:4.1f}%)  {ct}")
+
+    print("\n=== top tagNames (FullSnapshot + adds) ===")
+    for tag, n in report.tags.most_common(20):
+        print(f"  {n:9,}  {tag}")
+
+    print("\n=== top mutated attribute keys ===")
+    for attr, n in report.attrs.most_common(20):
+        print(f"  {n:9,}  {attr}")
+
+
+def dump_jsonl(source: Path, out_path: Path) -> None:
+    """Write fully-decoded events (DOM fields un-gzipped, inlined) to a JSONL file."""
+    snappy_decompress = _load_snappy()
+    written = 0
+    with out_path.open("w") as out:
+        for block_text in iter_block_text(source, snappy_decompress):
+            for event in iter_records(block_text):
+                cv = event.get("cv")
+                data = event.get("data")
+                if cv == "2024-10" and event.get("type") == 2 and isinstance(data, str):
+                    try:
+                        event["data"] = json.loads(gunzip_field(data))
+                        event.pop("cv", None)
+                    except Exception:  # noqa: BLE001
+                        pass
+                elif cv == "2024-10" and event.get("type") == 3 and isinstance(data, dict):
+                    for field in COMPRESSED_MUTATION_FIELDS:
+                        value = data.get(field)
+                        if isinstance(value, str):
+                            try:
+                                data[field] = json.loads(gunzip_field(value))
+                            except Exception:  # noqa: BLE001
+                                pass
+                    event.pop("cv", None)
+                out.write(json.dumps(event, separators=(",", ":")))
+                out.write("\n")
+                written += 1
+    print(f"wrote {written:,} decoded events to {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Decode and analyse a session-recording export zip.")
+    parser.add_argument("source", type=Path, help="path to export-<id>.zip or an extracted export directory")
+    parser.add_argument("--report", action="store_true", help="print the size/composition report (default)")
+    parser.add_argument("--dump-jsonl", type=Path, metavar="OUT", help="write fully-decoded events to a JSONL file")
+    args = parser.parse_args()
+
+    if not args.source.exists():
+        raise SystemExit(f"no such path: {args.source}")
+
+    if args.dump_jsonl:
+        dump_jsonl(args.source, args.dump_jsonl)
+    if args.report or not args.dump_jsonl:
+        print_report(analyse(args.source))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

We had a downloaded session-recording export and needed to answer "what's making this recording so big?" — but the export's `data/` blocks aren't readable JSON. They're double-compressed, and the first attempts at measuring size drew the wrong conclusions because they read the raw (still-compressed) bytes. There was no skill capturing how to decode an export or the trap that makes naive analysis misleading.

## Changes

Adds the `analysing-exported-session-recordings` skill under `products/replay/skills/`:

- **`SKILL.md`** documents the two-layer block format — snappy for the whole block (the exporter writes raw S3 blocks via `decompress=False`), then per-field gzip for the heavy DOM fields (`cv: "2024-10"`, fflate `strFromU8(gzipSync(...), true)`). It front-loads the failure mode: reading raw block bytes produces phantom `U+FFFD` and badly wrong size splits, so you must decode both layers before measuring. It also notes the exporter is lossless and must not be changed to decompress (export/import round-trip the raw blocks).
- **`scripts/decode_recording_export.py`** is a reusable decoder: snappy → JSONL → gzip per field. It accepts a zip or extracted dir, prints a size/composition report (DOM by mutation type vs full snapshots, network bodies by content-type, top tags/attributes), and `--dump-jsonl` emits fully-decoded events for deeper digging.

Pairs with the existing `exporting-session-recordings` skill, which produces the zip.

## How did you test this code?

I'm an agent. I ran the decoder against a real ~300 MB export end to end: 105,185 gzip fields decoded with zero failures, and the size report matched an independent verification pass (including a duplicate-body check to rule out double-counting across blocks). `python -m py_compile` passes; the script is intentionally ruff-excluded like other skill scripts. `hogli build:skills --lint` passes (92 skills, including this one). No automated unit tests were added for the script.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code while investigating why certain customers' recordings are large. The analysis kept reaching wrong conclusions until we traced the export format to ground: the `data/` blocks are snappy-compressed (literal runs verbatim + binary copy-tokens, which masquerades as "binary corruption"), and inside, DOM fields are individually gzip-compressed. Decoding both layers flipped the headline finding — network bodies, dominated by binary/asset content types captured as text, far outweighed DOM payload for the session we examined. The skill exists to stop that mistake recurring: decode before you conclude.

Decisions: kept the fix on the read side (a decoder script) rather than changing the exporter, since export/import are a matched pair that round-trip raw S3 blocks. Snappy codec is resolved at runtime with a `python-snappy` → `cramjam` fallback so the script works in either environment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
