### PR TITLE
fix(linkedin_ads): treat unconfigured OAuth app as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -47,6 +47,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # or expired refresh token). The only fix is the user re-authorizing, so stop retrying. The
             # message is already user-facing, so map it to itself (None).
             "Failed to refresh token for LinkedIn Ads integration. Please re-authorize the integration.": None,
+            # Raised by `oauth_config_for_kind` when the LinkedIn OAuth app credentials aren't set on
+            # this PostHog instance, so a token refresh can't proceed. This is an instance-side config
+            # gap the user can't fix, and retrying can't make the credentials appear — stop syncing and
+            # surface a clear message instead of looping until the activity's max attempts.
+            "LinkedIn Ads app not configured": "LinkedIn Ads isn't fully configured on this PostHog instance yet, so PostHog can't refresh your access token. Please contact PostHog support.",
             # LinkedIn rejects a non-numeric Account ID with a 400 whose message names the offending
             # key value (volatile) followed by this stable type-coercion phrase. The account id is a
             # fixed config value, so retrying can't help — fail fast and tell the user to fix it.

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -43,6 +43,17 @@ class TestLinkedInAdsSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "LinkedIn Ads app not configured",
+            "NotImplementedError: LinkedIn Ads app not configured",
+        ],
+    )
+    def test_app_not_configured_is_non_retryable(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
     def test_validate_credentials_missing_account_id(self):
         """Test credential validation with missing account ID."""
         invalid_config = LinkedinAdsSourceConfig(linkedin_ads_integration_id=456, account_id="")


### PR DESCRIPTION
## Problem

LinkedIn Ads imports were failing with an unhandled `NotImplementedError: LinkedIn Ads app not configured`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ef008-22aa-7b81-b2a2-a60ed66a7a37)).

The genuine call path is in the source's own code:

```
get_rows (linkedin_ads.py:154)
  → linkedin_ads_client (linkedin_ads.py:123)   # oauth_integration.refresh_access_token()
    → refresh_access_token (integration.py:1016)
      → oauth_config_for_kind (integration.py:478)  → raises NotImplementedError
```

When an access token is at least halfway to expiry, `linkedin_ads_client` refreshes it. `oauth_config_for_kind` raises `NotImplementedError("LinkedIn Ads app not configured")` when the instance's LinkedIn OAuth app credentials (`LINKEDIN_APP_CLIENT_ID` / `LINKEDIN_APP_CLIENT_SECRET`) are empty. This is a deterministic, instance-side configuration state — not a customer credential/config error and not an upstream LinkedIn error.

Because nothing about retrying within a deployment can make the credentials appear, the job would otherwise loop the same failure up to the activity's max attempts.

## Changes

Add `"LinkedIn Ads app not configured"` to `LinkedInAdsSource.get_non_retryable_errors()`, mapped to a clear, customer-facing message. The match string is the exact hardcoded internal message, so it's stable with zero false-positive risk.

This routes the error through the existing non-retryable path, which still retries 3× over a 24h Redis-keyed window before giving up — and the key expires after 24h. So a genuinely transient deploy gap (credentials briefly missing) still self-heals on the next scheduled sync, while a persistent gap stops hammering and surfaces a clear message rather than looping.

There's no code change to the source that can synthesize missing OAuth credentials, so classification at this layer is the right fix rather than wrapping the exception.

## How did you test this code?

I'm an agent. I added two parametrized cases asserting the new message is recognised as non-retryable and ran the source test suite:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py -q
# 20 passed
```

The existing "must stay retryable" / "must not match unrelated" tests continue to pass, confirming the new pattern doesn't widen matching onto transient errors. `ruff check` and `ruff format` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `linkedin_ads` data-import source. Confirmed the failure originates in the source's own frames (not just serialized log context) by pulling the full stack trace, then traced the raise into `oauth_config_for_kind`.

Decision: treat as non-retryable rather than a code fix. The error is deterministic per-deployment, not customer-actionable, and not a transient transport error — there's no source-level change that makes a refresh succeed without the OAuth app credentials. Per the triage guardrails, an ambiguous "stop retrying" case prefers `NonRetryableErrors`. Verified no existing open PR (including the maintainer's own) already addresses this `NotImplementedError`.
