### PR TITLE
feat(replay-vision): add create/edit form for vision actions

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -21,7 +21,7 @@ from posthog.sync import database_sync_to_async
 from products.replay_vision.backend.max_tools import _EVENT_ID_CITATION_RE, _as_untrusted_data
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ScannerModel
-from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun
+from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun, VisionActionRunStatus
 from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
 from products.replay_vision.backend.temporal.decorators import track_activity
 from products.replay_vision.backend.temporal.gemini import gemini_api_key
@@ -89,7 +89,7 @@ def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryR
         logger.info("vision_action.synthesis.over_credit_budget", vision_action_id=str(action.id))
         return SynthesizeGroupSummaryResult(status=SynthesisStatus.SKIPPED_OVER_BUDGET)
 
-    lines = _fetch_observation_lines(team, action)
+    lines = _fetch_observation_lines(team, action, run)
     if not lines:
         return SynthesizeGroupSummaryResult(status=SynthesisStatus.SKIPPED_EMPTY)
 
@@ -111,10 +111,30 @@ def _synthesize(inputs: SynthesizeGroupSummaryInputs) -> SynthesizeGroupSummaryR
     return SynthesizeGroupSummaryResult(status=SynthesisStatus.SYNTHESIZED, observation_count=len(lines))
 
 
-def _fetch_observation_lines(team: Team, action: VisionAction) -> list[str]:
-    """Fetch observations matching the action's `selection` and format them as untrusted-data lines.
+def _window_start(team: Team, action: VisionAction, run: VisionActionRun) -> datetime:
+    """Start of the observation window for this run: the previous successful run, else 24h back.
 
-    Models the summarizer fetch in `max_tools._fetch_and_format`, applying the selection window.
+    Each run summarizes everything new since the last delivered summary, so the cadence itself defines
+    the period (a daily action covers ~a day, a weekly one ~a week) with no manual lookback. The first
+    run — or the first after a gap of failures — looks back 24h. Anchoring on the last *completed* run
+    (not merely the previous run) means a failed run's observations are picked up by the next success
+    rather than dropped.
+    """
+    previous_run_at = (
+        VisionActionRun.objects.for_team(team.id)
+        .filter(vision_action_id=action.id, status=VisionActionRunStatus.COMPLETED, scheduled_at__isnull=False)
+        .exclude(pk=run.pk)
+        .order_by("-scheduled_at")
+        .values_list("scheduled_at", flat=True)
+        .first()
+    )
+    return previous_run_at or (datetime.now(UTC) - timedelta(hours=24))
+
+
+def _fetch_observation_lines(team: Team, action: VisionAction, run: VisionActionRun) -> list[str]:
+    """Fetch the bound scanner's observations since the last run and format them as untrusted-data lines.
+
+    Models the summarizer fetch in `max_tools._fetch_and_format`.
     """
     selection: dict[str, Any] = action.selection or {}
     scanner_ids = selection.get("scanner_ids") or ([str(action.scanner_id)] if action.scanner_id else [])
@@ -122,12 +142,11 @@ def _fetch_observation_lines(team: Team, action: VisionAction) -> list[str]:
         return []
 
     observations_qs = ReplayObservation.objects.filter(
-        team_id=team.id, scanner_id__in=scanner_ids, status=ObservationStatus.SUCCEEDED
+        team_id=team.id,
+        scanner_id__in=scanner_ids,
+        status=ObservationStatus.SUCCEEDED,
+        created_at__gte=_window_start(team, action, run),
     )
-
-    window_days = selection.get("window_days")
-    if isinstance(window_days, int) and window_days > 0:
-        observations_qs = observations_qs.filter(created_at__gte=datetime.now(UTC) - timedelta(days=window_days))
 
     rows = observations_qs.order_by("-created_at").values_list("scanner_result", "created_at")[:MAX_OBSERVATIONS]
 

--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -131,6 +131,18 @@ def _window_start(team: Team, action: VisionAction, run: VisionActionRun) -> dat
     return previous_run_at or (datetime.now(UTC) - timedelta(hours=24))
 
 
+def _window_end(run: VisionActionRun) -> datetime:
+    """End of the observation window for this run: its scheduled tick (exclusive).
+
+    The next run anchors its window_start on this run's scheduled_at, so capping the upper bound on
+    the same value makes consecutive windows tile exactly: an observation created after a run's
+    scheduled tick but before the run actually executes (the scheduling/queue lag) is deferred to the
+    next run instead of being summarized by both. Falls back to now() when scheduled_at is unset
+    (non-scheduled runs), preserving the previous open-ended upper bound.
+    """
+    return run.scheduled_at or datetime.now(UTC)
+
+
 def _fetch_observation_lines(team: Team, action: VisionAction, run: VisionActionRun) -> list[str]:
     """Fetch the bound scanner's observations since the last run and format them as untrusted-data lines.
 
@@ -146,6 +158,7 @@ def _fetch_observation_lines(team: Team, action: VisionAction, run: VisionAction
         scanner_id__in=scanner_ids,
         status=ObservationStatus.SUCCEEDED,
         created_at__gte=_window_start(team, action, run),
+        created_at__lt=_window_end(run),
     )
 
     rows = observations_qs.order_by("-created_at").values_list("scanner_result", "created_at")[:MAX_OBSERVATIONS]

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -225,6 +225,36 @@ class TestVisionActionSynthesis(BaseTest):
         self.assertEqual(result.status, SynthesisStatus.SYNTHESIZED)
         self.assertEqual(result.observation_count, 1)
 
+    def test_window_excludes_observations_after_this_runs_scheduled_tick(self) -> None:
+        # The window is half-open [prev.scheduled_at, this.scheduled_at). An observation created after
+        # this run's scheduled tick (during the scheduling/execution lag) is deferred to the next run
+        # rather than summarized by both — guarding against double-counting across consecutive runs.
+        action = self._action()
+        previous = VisionActionRun(
+            vision_action=action,
+            team=self.team,
+            idempotency_key="prev",
+            status=VisionActionRunStatus.COMPLETED,
+            scheduled_at=datetime.now(UTC) - timedelta(days=2),
+        )
+        previous.save()
+        in_window = self._observation("inside the window", session_id="in")
+        ReplayObservation.objects.filter(pk=in_window.pk).update(created_at=datetime.now(UTC) - timedelta(hours=12))
+        after_tick = self._observation("created during execution lag", session_id="after")
+        ReplayObservation.objects.filter(pk=after_tick.pk).update(created_at=datetime.now(UTC))
+
+        run = VisionActionRun(
+            vision_action=action,
+            team=self.team,
+            idempotency_key="k1",
+            scheduled_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        run.save()
+
+        result = self._synthesize(action, run)
+        self.assertEqual(result.status, SynthesisStatus.SYNTHESIZED)
+        self.assertEqual(result.observation_count, 1)  # only the in-window one; the post-tick one waits for next run
+
     def test_prompt_guide_passed_to_llm(self) -> None:
         self._observation("something")
         action = self._action(synthesis_config={"prompt_guide": "focus on rage clicks"})

--- a/products/replay_vision/backend/tests/test_vision_action_synthesis.py
+++ b/products/replay_vision/backend/tests/test_vision_action_synthesis.py
@@ -11,6 +11,7 @@ from parameterized import parameterized
 from products.replay_vision.backend.models import ReplayObservation, ReplayScanner, VisionAction, VisionActionRun
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ObservationTrigger
 from products.replay_vision.backend.models.replay_scanner import ScannerModel, ScannerType
+from products.replay_vision.backend.models.vision_action import VisionActionRunStatus
 from products.replay_vision.backend.temporal.vision_actions.synthesis import _markdown_to_slack, _synthesize
 from products.replay_vision.backend.temporal.vision_actions.types import SynthesisStatus, SynthesizeGroupSummaryInputs
 from products.replay_vision.backend.tests.helpers import snapshot_for
@@ -137,9 +138,10 @@ class TestVisionActionSynthesis(BaseTest):
     def test_short_circuit_gates(self, gate: str, expected: SynthesisStatus) -> None:
         # Each gate must return early without persisting markdown and without ever touching the LLM.
         if gate == "empty_window":
+            # First run looks back 24h; a 10-day-old observation falls outside it.
             obs = self._observation("old news")
             ReplayObservation.objects.filter(pk=obs.pk).update(created_at=datetime.now(UTC) - timedelta(days=10))
-            action = self._action(selection={"scanner_type": "summarizer", "window_days": 1})
+            action = self._action()
         else:
             self._observation("something")
             action = self._action(created_by=None if gate == "no_creator" else self.user)
@@ -192,10 +194,31 @@ class TestVisionActionSynthesis(BaseTest):
         self.assertNotIn("https://evil.example.com)", run.synthesized_markdown)  # link target gone
         self.assertIn("`https://evil.example.com`", run.synthesized_markdown)  # bare url defanged
 
-    def test_window_days_omitted_includes_all(self) -> None:
-        obs = self._observation("ancient")
-        ReplayObservation.objects.filter(pk=obs.pk).update(created_at=datetime.now(UTC) - timedelta(days=365))
-        action = self._action(selection={})  # no window_days → no time filter
+    def test_first_run_looks_back_24h(self) -> None:
+        # No previous run → the window is the last 24h; anything older is excluded.
+        self._observation("today", session_id="recent")
+        old = self._observation("ancient", session_id="old")
+        ReplayObservation.objects.filter(pk=old.pk).update(created_at=datetime.now(UTC) - timedelta(days=2))
+        action = self._action()
+        run = self._run_for(action)
+
+        result = self._synthesize(action, run)
+        self.assertEqual(result.status, SynthesisStatus.SYNTHESIZED)
+        self.assertEqual(result.observation_count, 1)  # only the recent observation
+
+    def test_window_starts_at_previous_completed_run(self) -> None:
+        # A prior completed run extends the window back to its scheduled_at, beyond the 24h default.
+        action = self._action()
+        previous = VisionActionRun(
+            vision_action=action,
+            team=self.team,
+            idempotency_key="prev",
+            status=VisionActionRunStatus.COMPLETED,
+            scheduled_at=datetime.now(UTC) - timedelta(days=3),
+        )
+        previous.save()
+        obs = self._observation("two days ago")
+        ReplayObservation.objects.filter(pk=obs.pk).update(created_at=datetime.now(UTC) - timedelta(days=2))
         run = self._run_for(action)
 
         result = self._synthesize(action, run)

--- a/products/replay_vision/frontend/replay_scanners/cadence.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/cadence.test.ts
@@ -1,41 +1,50 @@
 import { CadenceState, cadenceToRrule, DEFAULT_CADENCE, humanizeCadence, parseRruleToCadence } from './cadence'
 
 describe('cadence', () => {
-    it('builds a daily rrule with the time of day in BYHOUR/BYMINUTE', () => {
-        expect(cadenceToRrule({ frequency: 'daily', weekdays: [], hour: 9, minute: 0 })).toBe(
+    it('builds a daily rrule (all seven weekdays) with the time of day in BYHOUR/BYMINUTE', () => {
+        expect(cadenceToRrule({ weekdays: [0, 1, 2, 3, 4, 5, 6], hour: 9, minute: 0 })).toBe(
             'FREQ=DAILY;BYHOUR=9;BYMINUTE=0'
         )
     })
 
     it('builds a weekly rrule with sorted BYDAY', () => {
-        expect(cadenceToRrule({ frequency: 'weekly', weekdays: [2, 0], hour: 14, minute: 30 })).toBe(
+        expect(cadenceToRrule({ weekdays: [2, 0], hour: 14, minute: 30 })).toBe(
             'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30'
         )
     })
 
-    it('omits BYDAY for weekly with no weekdays selected', () => {
-        expect(cadenceToRrule({ frequency: 'weekly', weekdays: [], hour: 8, minute: 0 })).toBe(
-            'FREQ=WEEKLY;BYHOUR=8;BYMINUTE=0'
-        )
-    })
-
-    it('builds a monthly rrule and ignores weekdays', () => {
-        expect(cadenceToRrule({ frequency: 'monthly', weekdays: [3], hour: 7, minute: 15 })).toBe(
-            'FREQ=MONTHLY;BYHOUR=7;BYMINUTE=15'
-        )
+    it('omits BYDAY when no weekdays are selected', () => {
+        expect(cadenceToRrule({ weekdays: [], hour: 8, minute: 0 })).toBe('FREQ=WEEKLY;BYHOUR=8;BYMINUTE=0')
     })
 
     it.each<[string, CadenceState]>([
-        ['daily', { frequency: 'daily', weekdays: [], hour: 9, minute: 0 }],
-        ['weekly+weekdays', { frequency: 'weekly', weekdays: [0, 2, 4], hour: 14, minute: 30 }],
-        ['monthly', { frequency: 'monthly', weekdays: [], hour: 23, minute: 59 }],
+        ['daily (all seven)', { weekdays: [0, 1, 2, 3, 4, 5, 6], hour: 9, minute: 0 }],
+        ['weekly subset', { weekdays: [0, 2, 4], hour: 14, minute: 30 }],
+        ['single day', { weekdays: [6], hour: 23, minute: 59 }],
     ])('round-trips %s', (_label, state) => {
         expect(parseRruleToCadence(cadenceToRrule(state))).toEqual(state)
     })
 
-    it('falls back to the default cadence on empty or unrecognized rrule', () => {
+    it('parses FREQ=DAILY back to all seven weekdays', () => {
+        expect(parseRruleToCadence('FREQ=DAILY;BYHOUR=9;BYMINUTE=0')).toEqual({
+            weekdays: [0, 1, 2, 3, 4, 5, 6],
+            hour: 9,
+            minute: 0,
+        })
+    })
+
+    it('normalizes legacy weekly-without-BYDAY to all seven weekdays', () => {
+        expect(parseRruleToCadence('FREQ=WEEKLY;BYHOUR=8;BYMINUTE=0')).toEqual({
+            weekdays: [0, 1, 2, 3, 4, 5, 6],
+            hour: 8,
+            minute: 0,
+        })
+    })
+
+    it('falls back to the default cadence on empty, monthly, or unrecognized rrule', () => {
         expect(parseRruleToCadence(undefined)).toEqual(DEFAULT_CADENCE)
         expect(parseRruleToCadence('')).toEqual(DEFAULT_CADENCE)
+        expect(parseRruleToCadence('FREQ=MONTHLY;BYHOUR=7;BYMINUTE=15')).toEqual(DEFAULT_CADENCE)
         expect(parseRruleToCadence('FREQ=YEARLY;BYHOUR=9;BYMINUTE=0')).toEqual(DEFAULT_CADENCE)
     })
 
@@ -45,14 +54,9 @@ describe('cadence', () => {
         expect(parsed.minute).toBe(0)
     })
 
-    it('humanizes each frequency', () => {
-        expect(humanizeCadence({ frequency: 'daily', weekdays: [], hour: 9, minute: 5 })).toBe('Daily at 09:05')
-        expect(humanizeCadence({ frequency: 'weekly', weekdays: [0, 2], hour: 14, minute: 0 })).toBe(
-            'Weekly on Mon, Wed at 14:00'
-        )
-        expect(humanizeCadence({ frequency: 'weekly', weekdays: [], hour: 8, minute: 0 })).toBe(
-            'Weekly on every day at 08:00'
-        )
-        expect(humanizeCadence({ frequency: 'monthly', weekdays: [], hour: 7, minute: 30 })).toBe('Monthly at 07:30')
+    it('humanizes the cadence from the selected weekdays', () => {
+        expect(humanizeCadence({ weekdays: [0, 1, 2, 3, 4, 5, 6], hour: 9, minute: 5 })).toBe('Daily at 09:05')
+        expect(humanizeCadence({ weekdays: [0, 2], hour: 14, minute: 0 })).toBe('Weekly on Mon, Wed at 14:00')
+        expect(humanizeCadence({ weekdays: [], hour: 8, minute: 0 })).toBe('Pick at least one day')
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/cadence.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/cadence.test.ts
@@ -1,0 +1,58 @@
+import { CadenceState, cadenceToRrule, DEFAULT_CADENCE, humanizeCadence, parseRruleToCadence } from './cadence'
+
+describe('cadence', () => {
+    it('builds a daily rrule with the time of day in BYHOUR/BYMINUTE', () => {
+        expect(cadenceToRrule({ frequency: 'daily', weekdays: [], hour: 9, minute: 0 })).toBe(
+            'FREQ=DAILY;BYHOUR=9;BYMINUTE=0'
+        )
+    })
+
+    it('builds a weekly rrule with sorted BYDAY', () => {
+        expect(cadenceToRrule({ frequency: 'weekly', weekdays: [2, 0], hour: 14, minute: 30 })).toBe(
+            'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30'
+        )
+    })
+
+    it('omits BYDAY for weekly with no weekdays selected', () => {
+        expect(cadenceToRrule({ frequency: 'weekly', weekdays: [], hour: 8, minute: 0 })).toBe(
+            'FREQ=WEEKLY;BYHOUR=8;BYMINUTE=0'
+        )
+    })
+
+    it('builds a monthly rrule and ignores weekdays', () => {
+        expect(cadenceToRrule({ frequency: 'monthly', weekdays: [3], hour: 7, minute: 15 })).toBe(
+            'FREQ=MONTHLY;BYHOUR=7;BYMINUTE=15'
+        )
+    })
+
+    it.each<[string, CadenceState]>([
+        ['daily', { frequency: 'daily', weekdays: [], hour: 9, minute: 0 }],
+        ['weekly+weekdays', { frequency: 'weekly', weekdays: [0, 2, 4], hour: 14, minute: 30 }],
+        ['monthly', { frequency: 'monthly', weekdays: [], hour: 23, minute: 59 }],
+    ])('round-trips %s', (_label, state) => {
+        expect(parseRruleToCadence(cadenceToRrule(state))).toEqual(state)
+    })
+
+    it('falls back to the default cadence on empty or unrecognized rrule', () => {
+        expect(parseRruleToCadence(undefined)).toEqual(DEFAULT_CADENCE)
+        expect(parseRruleToCadence('')).toEqual(DEFAULT_CADENCE)
+        expect(parseRruleToCadence('FREQ=YEARLY;BYHOUR=9;BYMINUTE=0')).toEqual(DEFAULT_CADENCE)
+    })
+
+    it('clamps out-of-range time components back to the default', () => {
+        const parsed = parseRruleToCadence('FREQ=DAILY;BYHOUR=99;BYMINUTE=0')
+        expect(parsed.hour).toBe(DEFAULT_CADENCE.hour)
+        expect(parsed.minute).toBe(0)
+    })
+
+    it('humanizes each frequency', () => {
+        expect(humanizeCadence({ frequency: 'daily', weekdays: [], hour: 9, minute: 5 })).toBe('Daily at 09:05')
+        expect(humanizeCadence({ frequency: 'weekly', weekdays: [0, 2], hour: 14, minute: 0 })).toBe(
+            'Weekly on Mon, Wed at 14:00'
+        )
+        expect(humanizeCadence({ frequency: 'weekly', weekdays: [], hour: 8, minute: 0 })).toBe(
+            'Weekly on every day at 08:00'
+        )
+        expect(humanizeCadence({ frequency: 'monthly', weekdays: [], hour: 7, minute: 30 })).toBe('Monthly at 07:30')
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/cadence.ts
+++ b/products/replay_vision/frontend/replay_scanners/cadence.ts
@@ -1,20 +1,22 @@
 // Cadence helpers for the vision-action create/edit form.
 //
-// Self-contained — we only need daily/weekly/monthly + a time of day, not the full
+// Self-contained — we only need a set of weekdays + a time of day, not the full
 // recurring machinery (interval, monthly modes, end conditions) that the Workflows
 // RecurringSchedulePicker offers. The Workflows backend made the same copy-not-import
 // call for its rrule date math (see products/replay_vision/backend/rrule.py).
+//
+// The schedule is expressed as the days of the week it runs on: pick a subset for a
+// weekly cadence, or all seven for a daily one. There is no separate daily/weekly mode —
+// the frequency is implied by how many days are selected, and all seven normalizes to
+// FREQ=DAILY. At least one day must be selected (enforced by the form).
 //
 // The backend's trigger_config is only { rrule, timezone } with no DTSTART — the
 // scheduler derives starts_at from the action's created_at, so the run time of day must
 // live in the rrule itself via BYHOUR/BYMINUTE (dateutil honors those over the dtstart
 // time component).
 
-export type CadenceFrequency = 'daily' | 'weekly' | 'monthly'
-
 export interface CadenceState {
-    frequency: CadenceFrequency
-    /** Days of week for weekly cadence. 0=Mon … 6=Sun. Ignored for daily/monthly. */
+    /** Days of week the action runs on. 0=Mon … 6=Sun. Must contain at least one; all seven = daily. */
     weekdays: number[]
     /** Hour of day, 0–23, in the action's timezone. */
     hour: number
@@ -22,49 +24,37 @@ export interface CadenceState {
     minute: number
 }
 
-export const DEFAULT_CADENCE: CadenceState = {
-    frequency: 'daily',
-    weekdays: [],
-    hour: 9,
-    minute: 0,
-}
-
 // 0=Mon … 6=Sun, matching CadenceState.weekdays.
+const ALL_WEEKDAYS = [0, 1, 2, 3, 4, 5, 6]
 const RRULE_DAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'] as const
 const WEEKDAY_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const
 
-const FREQ_BY_CADENCE: Record<CadenceFrequency, string> = {
-    daily: 'DAILY',
-    weekly: 'WEEKLY',
-    monthly: 'MONTHLY',
+export const DEFAULT_CADENCE: CadenceState = {
+    weekdays: [...ALL_WEEKDAYS],
+    hour: 9,
+    minute: 0,
 }
 
 function pad2(n: number): string {
     return n.toString().padStart(2, '0')
 }
 
+function sortedWeekdays(weekdays: number[]): number[] {
+    return [...weekdays].sort((a, b) => a - b)
+}
+
 export function cadenceToRrule(state: CadenceState): string {
-    const parts = [`FREQ=${FREQ_BY_CADENCE[state.frequency]}`]
-    if (state.frequency === 'weekly' && state.weekdays.length > 0) {
-        const days = [...state.weekdays].sort((a, b) => a - b).map((d) => RRULE_DAYS[d])
-        parts.push(`BYDAY=${days.join(',')}`)
+    const isDaily = state.weekdays.length === 7
+    const parts = [`FREQ=${isDaily ? 'DAILY' : 'WEEKLY'}`]
+    if (!isDaily && state.weekdays.length > 0) {
+        parts.push(
+            `BYDAY=${sortedWeekdays(state.weekdays)
+                .map((d) => RRULE_DAYS[d])
+                .join(',')}`
+        )
     }
     parts.push(`BYHOUR=${state.hour}`, `BYMINUTE=${state.minute}`)
     return parts.join(';')
-}
-
-function parseFrequency(rrule: string): CadenceFrequency | null {
-    const freq = /FREQ=([A-Z]+)/.exec(rrule)?.[1]
-    switch (freq) {
-        case 'DAILY':
-            return 'daily'
-        case 'WEEKLY':
-            return 'weekly'
-        case 'MONTHLY':
-            return 'monthly'
-        default:
-            return null
-    }
 }
 
 function parseWeekdays(rrule: string): number[] {
@@ -76,6 +66,7 @@ function parseWeekdays(rrule: string): number[] {
         .split(',')
         .map((d) => RRULE_DAYS.indexOf(d.trim() as (typeof RRULE_DAYS)[number]))
         .filter((i) => i >= 0)
+        .sort((a, b) => a - b)
 }
 
 function parseClampedInt(rrule: string, key: string, max: number, fallback: number): number {
@@ -88,33 +79,32 @@ function parseClampedInt(rrule: string, key: string, max: number, fallback: numb
 }
 
 export function parseRruleToCadence(rrule: string | undefined | null): CadenceState {
-    if (!rrule) {
+    const freq = rrule ? /FREQ=([A-Z]+)/.exec(rrule)?.[1] : undefined
+    // Only DAILY/WEEKLY are produced by this form; anything else (legacy monthly, yearly,
+    // empty) falls back to the default daily cadence.
+    if (freq !== 'DAILY' && freq !== 'WEEKLY') {
         return { ...DEFAULT_CADENCE }
     }
-    const frequency = parseFrequency(rrule)
-    if (!frequency) {
-        return { ...DEFAULT_CADENCE }
+    const hour = parseClampedInt(rrule!, 'BYHOUR', 23, DEFAULT_CADENCE.hour)
+    const minute = parseClampedInt(rrule!, 'BYMINUTE', 59, DEFAULT_CADENCE.minute)
+    if (freq === 'DAILY') {
+        return { weekdays: [...ALL_WEEKDAYS], hour, minute }
     }
-    return {
-        frequency,
-        weekdays: frequency === 'weekly' ? parseWeekdays(rrule) : [],
-        hour: parseClampedInt(rrule, 'BYHOUR', 23, DEFAULT_CADENCE.hour),
-        minute: parseClampedInt(rrule, 'BYMINUTE', 59, DEFAULT_CADENCE.minute),
-    }
+    // Weekly with no BYDAY is a legacy "every day" — normalize to all seven.
+    const weekdays = parseWeekdays(rrule!)
+    return { weekdays: weekdays.length > 0 ? weekdays : [...ALL_WEEKDAYS], hour, minute }
 }
 
 export function humanizeCadence(state: CadenceState): string {
     const time = `${pad2(state.hour)}:${pad2(state.minute)}`
-    if (state.frequency === 'weekly') {
-        const days =
-            state.weekdays.length > 0
-                ? [...state.weekdays]
-                      .sort((a, b) => a - b)
-                      .map((d) => WEEKDAY_SHORT[d])
-                      .join(', ')
-                : 'every day'
-        return `Weekly on ${days} at ${time}`
+    if (state.weekdays.length === 0) {
+        return 'Pick at least one day'
     }
-    const label = state.frequency === 'daily' ? 'Daily' : 'Monthly'
-    return `${label} at ${time}`
+    if (state.weekdays.length === 7) {
+        return `Daily at ${time}`
+    }
+    const days = sortedWeekdays(state.weekdays)
+        .map((d) => WEEKDAY_SHORT[d])
+        .join(', ')
+    return `Weekly on ${days} at ${time}`
 }

--- a/products/replay_vision/frontend/replay_scanners/cadence.ts
+++ b/products/replay_vision/frontend/replay_scanners/cadence.ts
@@ -1,0 +1,120 @@
+// Cadence helpers for the vision-action create/edit form.
+//
+// Self-contained — we only need daily/weekly/monthly + a time of day, not the full
+// recurring machinery (interval, monthly modes, end conditions) that the Workflows
+// RecurringSchedulePicker offers. The Workflows backend made the same copy-not-import
+// call for its rrule date math (see products/replay_vision/backend/rrule.py).
+//
+// The backend's trigger_config is only { rrule, timezone } with no DTSTART — the
+// scheduler derives starts_at from the action's created_at, so the run time of day must
+// live in the rrule itself via BYHOUR/BYMINUTE (dateutil honors those over the dtstart
+// time component).
+
+export type CadenceFrequency = 'daily' | 'weekly' | 'monthly'
+
+export interface CadenceState {
+    frequency: CadenceFrequency
+    /** Days of week for weekly cadence. 0=Mon … 6=Sun. Ignored for daily/monthly. */
+    weekdays: number[]
+    /** Hour of day, 0–23, in the action's timezone. */
+    hour: number
+    /** Minute of hour, 0–59. */
+    minute: number
+}
+
+export const DEFAULT_CADENCE: CadenceState = {
+    frequency: 'daily',
+    weekdays: [],
+    hour: 9,
+    minute: 0,
+}
+
+// 0=Mon … 6=Sun, matching CadenceState.weekdays.
+const RRULE_DAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'] as const
+const WEEKDAY_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const
+
+const FREQ_BY_CADENCE: Record<CadenceFrequency, string> = {
+    daily: 'DAILY',
+    weekly: 'WEEKLY',
+    monthly: 'MONTHLY',
+}
+
+function pad2(n: number): string {
+    return n.toString().padStart(2, '0')
+}
+
+export function cadenceToRrule(state: CadenceState): string {
+    const parts = [`FREQ=${FREQ_BY_CADENCE[state.frequency]}`]
+    if (state.frequency === 'weekly' && state.weekdays.length > 0) {
+        const days = [...state.weekdays].sort((a, b) => a - b).map((d) => RRULE_DAYS[d])
+        parts.push(`BYDAY=${days.join(',')}`)
+    }
+    parts.push(`BYHOUR=${state.hour}`, `BYMINUTE=${state.minute}`)
+    return parts.join(';')
+}
+
+function parseFrequency(rrule: string): CadenceFrequency | null {
+    const freq = /FREQ=([A-Z]+)/.exec(rrule)?.[1]
+    switch (freq) {
+        case 'DAILY':
+            return 'daily'
+        case 'WEEKLY':
+            return 'weekly'
+        case 'MONTHLY':
+            return 'monthly'
+        default:
+            return null
+    }
+}
+
+function parseWeekdays(rrule: string): number[] {
+    const byday = /BYDAY=([A-Z,]+)/.exec(rrule)?.[1]
+    if (!byday) {
+        return []
+    }
+    return byday
+        .split(',')
+        .map((d) => RRULE_DAYS.indexOf(d.trim() as (typeof RRULE_DAYS)[number]))
+        .filter((i) => i >= 0)
+}
+
+function parseClampedInt(rrule: string, key: string, max: number, fallback: number): number {
+    const raw = new RegExp(`${key}=(\\d+)`).exec(rrule)?.[1]
+    if (raw === undefined) {
+        return fallback
+    }
+    const value = parseInt(raw, 10)
+    return Number.isNaN(value) || value < 0 || value > max ? fallback : value
+}
+
+export function parseRruleToCadence(rrule: string | undefined | null): CadenceState {
+    if (!rrule) {
+        return { ...DEFAULT_CADENCE }
+    }
+    const frequency = parseFrequency(rrule)
+    if (!frequency) {
+        return { ...DEFAULT_CADENCE }
+    }
+    return {
+        frequency,
+        weekdays: frequency === 'weekly' ? parseWeekdays(rrule) : [],
+        hour: parseClampedInt(rrule, 'BYHOUR', 23, DEFAULT_CADENCE.hour),
+        minute: parseClampedInt(rrule, 'BYMINUTE', 59, DEFAULT_CADENCE.minute),
+    }
+}
+
+export function humanizeCadence(state: CadenceState): string {
+    const time = `${pad2(state.hour)}:${pad2(state.minute)}`
+    if (state.frequency === 'weekly') {
+        const days =
+            state.weekdays.length > 0
+                ? [...state.weekdays]
+                      .sort((a, b) => a - b)
+                      .map((d) => WEEKDAY_SHORT[d])
+                      .join(', ')
+                : 'every day'
+        return `Weekly on ${days} at ${time}`
+    }
+    const label = state.frequency === 'daily' ? 'Daily' : 'Monthly'
+    return `${label} at ${time}`
+}

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useMemo } from 'react'
 
-import { LemonButton, LemonInput, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -13,17 +13,13 @@ import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { timeZoneLabel } from 'lib/utils/timezones'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-import { CadenceFrequency, humanizeCadence } from '../cadence'
+import { humanizeCadence } from '../cadence'
 import { visionActionsLogic } from '../visionActionsLogic'
-
-const FREQUENCY_OPTIONS: { value: CadenceFrequency; label: string }[] = [
-    { value: 'daily', label: 'Daily' },
-    { value: 'weekly', label: 'Weekly' },
-    { value: 'monthly', label: 'Monthly' },
-]
 
 // 0=Mon … 6=Sun, matching CadenceState.weekdays.
 const WEEKDAY_PILLS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+const ALL_WEEKDAYS = [0, 1, 2, 3, 4, 5, 6]
+const WEEKDAYS_MON_FRI = [0, 1, 2, 3, 4]
 
 function TimezoneSelect({ value, onChange }: { value: string; onChange: (tz: string) => void }): JSX.Element {
     const { preflight } = useValues(preflightLogic)
@@ -53,61 +49,59 @@ function ScheduleSection(): JSX.Element {
 
     const timeValue = `${cadence.hour.toString().padStart(2, '0')}:${cadence.minute.toString().padStart(2, '0')}`
 
-    const toggleWeekday = (day: number): void => {
-        const weekdays = cadence.weekdays.includes(day)
-            ? cadence.weekdays.filter((d) => d !== day)
-            : [...cadence.weekdays, day]
-        setVisionActionFormValue('cadence', { ...cadence, weekdays })
-    }
+    const setWeekdays = (weekdays: number[]): void => setVisionActionFormValue('cadence', { ...cadence, weekdays })
+
+    const toggleWeekday = (day: number): void =>
+        setWeekdays(
+            cadence.weekdays.includes(day) ? cadence.weekdays.filter((d) => d !== day) : [...cadence.weekdays, day]
+        )
+
+    const noDays = cadence.weekdays.length === 0
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex gap-2 items-end">
-                <div className="flex-1">
-                    <label className="text-sm font-semibold">Frequency</label>
-                    <LemonSelect
-                        value={cadence.frequency}
-                        options={FREQUENCY_OPTIONS}
-                        onChange={(frequency) =>
-                            frequency && setVisionActionFormValue('cadence', { ...cadence, frequency })
-                        }
-                        fullWidth
-                    />
-                </div>
-                <div className="w-32">
-                    <label className="text-sm font-semibold">At</label>
-                    <LemonInput
-                        type="time"
-                        value={timeValue}
-                        onChange={(val) => {
-                            const [h, m] = (val || '09:00').split(':').map((n) => parseInt(n, 10))
-                            setVisionActionFormValue('cadence', {
-                                ...cadence,
-                                hour: Number.isNaN(h) ? 9 : h,
-                                minute: Number.isNaN(m) ? 0 : m,
-                            })
-                        }}
-                    />
-                </div>
-            </div>
-
-            {cadence.frequency === 'weekly' && (
-                <div>
-                    <label className="text-sm font-semibold">On days</label>
+            <div>
+                <div className="flex items-center justify-between">
+                    <label className="text-sm font-semibold">Runs on</label>
                     <div className="flex gap-1">
-                        {WEEKDAY_PILLS.map((label, day) => (
-                            <LemonButton
-                                key={day}
-                                size="small"
-                                type={cadence.weekdays.includes(day) ? 'primary' : 'secondary'}
-                                onClick={() => toggleWeekday(day)}
-                            >
-                                {label}
-                            </LemonButton>
-                        ))}
+                        <LemonButton size="xsmall" type="tertiary" onClick={() => setWeekdays([...ALL_WEEKDAYS])}>
+                            Every day
+                        </LemonButton>
+                        <LemonButton size="xsmall" type="tertiary" onClick={() => setWeekdays([...WEEKDAYS_MON_FRI])}>
+                            Weekdays
+                        </LemonButton>
                     </div>
                 </div>
-            )}
+                <div className="flex gap-1">
+                    {WEEKDAY_PILLS.map((label, day) => (
+                        <LemonButton
+                            key={day}
+                            size="small"
+                            type={cadence.weekdays.includes(day) ? 'primary' : 'secondary'}
+                            onClick={() => toggleWeekday(day)}
+                        >
+                            {label}
+                        </LemonButton>
+                    ))}
+                </div>
+                {noDays && <span className="text-xs text-danger">Pick at least one day</span>}
+            </div>
+
+            <div className="w-32">
+                <label className="text-sm font-semibold">At</label>
+                <LemonInput
+                    type="time"
+                    value={timeValue}
+                    onChange={(val) => {
+                        const [h, m] = (val || '09:00').split(':').map((n) => parseInt(n, 10))
+                        setVisionActionFormValue('cadence', {
+                            ...cadence,
+                            hour: Number.isNaN(h) ? 9 : h,
+                            minute: Number.isNaN(m) ? 0 : m,
+                        })
+                    }}
+                />
+            </div>
 
             <div>
                 <label className="text-sm font-semibold">Timezone</label>
@@ -157,8 +151,10 @@ function DeliverySection(): JSX.Element {
 }
 
 export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Element {
-    const { formVisible, editingAction, isVisionActionFormSubmitting } = useValues(visionActionsLogic)
+    const { formVisible, editingAction, isVisionActionFormSubmitting, visionActionForm } = useValues(visionActionsLogic)
     const { closeForm } = useActions(visionActionsLogic)
+
+    const noDays = visionActionForm.cadence.weekdays.length === 0
 
     return (
         <LemonModal
@@ -177,6 +173,7 @@ export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Elem
                         htmlType="submit"
                         form="vision-action-form"
                         loading={isVisionActionFormSubmitting}
+                        disabledReason={noDays ? 'Pick at least one day to run on' : undefined}
                     >
                         {editingAction ? 'Save' : 'Create action'}
                     </LemonButton>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -1,0 +1,283 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { useMemo } from 'react'
+
+import { LemonButton, LemonInput, LemonModal, LemonSelect } from '@posthog/lemon-ui'
+
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { LemonSearchableSelect } from 'lib/lemon-ui/LemonSelect/LemonSearchableSelect'
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
+import { timeZoneLabel } from 'lib/utils/timezones'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { CadenceFrequency, humanizeCadence } from '../cadence'
+import { visionActionsLogic } from '../visionActionsLogic'
+
+const FREQUENCY_OPTIONS: { value: CadenceFrequency; label: string }[] = [
+    { value: 'daily', label: 'Daily' },
+    { value: 'weekly', label: 'Weekly' },
+    { value: 'monthly', label: 'Monthly' },
+]
+
+// 0=Mon … 6=Sun, matching CadenceState.weekdays.
+const WEEKDAY_PILLS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+
+const VERDICT_OPTIONS = [
+    { value: '', label: 'Any verdict' },
+    { value: 'yes', label: 'Yes' },
+    { value: 'no', label: 'No' },
+    { value: 'inconclusive', label: 'Inconclusive' },
+]
+
+function TimezoneSelect({ value, onChange }: { value: string; onChange: (tz: string) => void }): JSX.Element {
+    const { preflight } = useValues(preflightLogic)
+    const options = useMemo(
+        () =>
+            Object.entries(preflight?.available_timezones || {}).map(([tz, offset]) => ({
+                value: tz,
+                label: timeZoneLabel(tz, offset),
+            })),
+        [preflight?.available_timezones]
+    )
+    return (
+        <LemonSearchableSelect
+            value={value}
+            options={options}
+            onChange={(val) => val && onChange(val)}
+            placeholder="Select a timezone"
+            fullWidth
+        />
+    )
+}
+
+function ScheduleSection(): JSX.Element {
+    const { visionActionForm } = useValues(visionActionsLogic)
+    const { setVisionActionFormValue } = useActions(visionActionsLogic)
+    const { cadence, timezone } = visionActionForm
+
+    const timeValue = `${cadence.hour.toString().padStart(2, '0')}:${cadence.minute.toString().padStart(2, '0')}`
+
+    const toggleWeekday = (day: number): void => {
+        const weekdays = cadence.weekdays.includes(day)
+            ? cadence.weekdays.filter((d) => d !== day)
+            : [...cadence.weekdays, day]
+        setVisionActionFormValue('cadence', { ...cadence, weekdays })
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-end">
+                <div className="flex-1">
+                    <label className="text-sm font-semibold">Frequency</label>
+                    <LemonSelect
+                        value={cadence.frequency}
+                        options={FREQUENCY_OPTIONS}
+                        onChange={(frequency) =>
+                            frequency && setVisionActionFormValue('cadence', { ...cadence, frequency })
+                        }
+                        fullWidth
+                    />
+                </div>
+                <div className="w-32">
+                    <label className="text-sm font-semibold">At</label>
+                    <LemonInput
+                        type="time"
+                        value={timeValue}
+                        onChange={(val) => {
+                            const [h, m] = (val || '09:00').split(':').map((n) => parseInt(n, 10))
+                            setVisionActionFormValue('cadence', {
+                                ...cadence,
+                                hour: Number.isNaN(h) ? 9 : h,
+                                minute: Number.isNaN(m) ? 0 : m,
+                            })
+                        }}
+                    />
+                </div>
+            </div>
+
+            {cadence.frequency === 'weekly' && (
+                <div>
+                    <label className="text-sm font-semibold">On days</label>
+                    <div className="flex gap-1">
+                        {WEEKDAY_PILLS.map((label, day) => (
+                            <LemonButton
+                                key={day}
+                                size="small"
+                                type={cadence.weekdays.includes(day) ? 'primary' : 'secondary'}
+                                onClick={() => toggleWeekday(day)}
+                            >
+                                {label}
+                            </LemonButton>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div>
+                <label className="text-sm font-semibold">Timezone</label>
+                <TimezoneSelect value={timezone} onChange={(tz) => setVisionActionFormValue('timezone', tz)} />
+            </div>
+
+            <span className="text-xs text-muted">{humanizeCadence(cadence)}</span>
+        </div>
+    )
+}
+
+function SelectionSection(): JSX.Element {
+    const { visionActionForm } = useValues(visionActionsLogic)
+    const { setVisionActionFormValue } = useActions(visionActionsLogic)
+    const { selection } = visionActionForm
+
+    const patch = (next: Partial<typeof selection>): void =>
+        setVisionActionFormValue('selection', { ...selection, ...next })
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2">
+                <div className="flex-1">
+                    <label className="text-sm font-semibold">Lookback window (days)</label>
+                    <LemonInput
+                        type="number"
+                        min={1}
+                        value={selection.window_days ?? undefined}
+                        onChange={(val) => patch({ window_days: val ?? undefined })}
+                    />
+                </div>
+                <div className="flex-1">
+                    <label className="text-sm font-semibold">Verdict</label>
+                    <LemonSelect
+                        value={selection.verdict ?? ''}
+                        options={VERDICT_OPTIONS}
+                        onChange={(val) => patch({ verdict: val || undefined })}
+                        fullWidth
+                    />
+                </div>
+                <div className="flex-1">
+                    <label className="text-sm font-semibold">Min score</label>
+                    <LemonInput
+                        type="number"
+                        value={selection.min_score ?? undefined}
+                        onChange={(val) => patch({ min_score: val ?? undefined })}
+                    />
+                </div>
+            </div>
+            <div>
+                <label className="text-sm font-semibold">Tags</label>
+                <LemonInputSelect
+                    mode="multiple"
+                    allowCustomValues
+                    value={selection.tags ?? []}
+                    options={[]}
+                    onChange={(tags) => patch({ tags: tags.length ? tags : undefined })}
+                    placeholder="Add tags to filter by"
+                />
+            </div>
+        </div>
+    )
+}
+
+function DeliverySection(): JSX.Element {
+    const { visionActionForm } = useValues(visionActionsLogic)
+    const { setVisionActionFormValue } = useActions(visionActionsLogic)
+    const { slackIntegrations } = useValues(integrationsLogic)
+    const { integration_id } = visionActionForm
+
+    if (!slackIntegrations?.length) {
+        return <SlackNotConfiguredBanner />
+    }
+
+    const selectedIntegration = slackIntegrations.find((i) => i.id === integration_id)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <IntegrationChoice
+                integration="slack"
+                value={integration_id ?? undefined}
+                onChange={(value) => {
+                    setVisionActionFormValue('integration_id', value)
+                    setVisionActionFormValue('channel', '')
+                }}
+            />
+            {selectedIntegration && (
+                <LemonField name="channel" label="Channel">
+                    {({ value, onChange }) => (
+                        <SlackChannelPicker
+                            integration={selectedIntegration}
+                            value={value}
+                            onChange={(next) => onChange(next ?? '')}
+                        />
+                    )}
+                </LemonField>
+            )}
+        </div>
+    )
+}
+
+export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Element {
+    const { formVisible, editingAction, isVisionActionFormSubmitting } = useValues(visionActionsLogic)
+    const { closeForm } = useActions(visionActionsLogic)
+
+    return (
+        <LemonModal
+            isOpen={formVisible}
+            onClose={closeForm}
+            width={640}
+            title={editingAction ? 'Edit action' : 'New action'}
+            description="Schedule an AI summary of this scanner's observations and deliver it to Slack."
+            footer={
+                <div className="flex gap-2 justify-end">
+                    <LemonButton type="secondary" onClick={closeForm}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        htmlType="submit"
+                        form="vision-action-form"
+                        loading={isVisionActionFormSubmitting}
+                    >
+                        {editingAction ? 'Save' : 'Create action'}
+                    </LemonButton>
+                </div>
+            }
+        >
+            <Form
+                logic={visionActionsLogic}
+                props={{ scannerId }}
+                formKey="visionActionForm"
+                id="vision-action-form"
+                enableFormOnSubmit
+                className="flex flex-col gap-4"
+            >
+                <LemonField name="name" label="Name">
+                    <LemonInput placeholder="Daily checkout summary" autoFocus />
+                </LemonField>
+
+                <div>
+                    <h4 className="mb-1">Schedule</h4>
+                    <ScheduleSection />
+                </div>
+
+                <div>
+                    <h4 className="mb-1">What to summarize</h4>
+                    <SelectionSection />
+                </div>
+
+                <LemonField name="prompt_guide" label="Guidance" info="Optional. Steers how the AI writes the summary.">
+                    <LemonTextArea
+                        placeholder="e.g. focus on checkout drop-off and highlight any errors"
+                        maxLength={500}
+                    />
+                </LemonField>
+
+                <div>
+                    <h4 className="mb-1">Deliver to Slack</h4>
+                    <DeliverySection />
+                </div>
+            </Form>
+        </LemonModal>
+    )
+}

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -13,7 +13,7 @@ import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { timeZoneLabel } from 'lib/utils/timezones'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-import { humanizeCadence } from '../cadence'
+import { DEFAULT_CADENCE, humanizeCadence } from '../cadence'
 import { visionActionsLogic } from '../visionActionsLogic'
 
 // 0=Mon … 6=Sun, matching CadenceState.weekdays.
@@ -64,10 +64,20 @@ function ScheduleSection(): JSX.Element {
                 <div className="flex items-center justify-between">
                     <label className="text-sm font-semibold">Runs on</label>
                     <div className="flex gap-1">
-                        <LemonButton size="xsmall" type="tertiary" onClick={() => setWeekdays([...ALL_WEEKDAYS])}>
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            onClick={() => setWeekdays([...ALL_WEEKDAYS])}
+                            data-attr="vision-action-cadence-everyday"
+                        >
                             Every day
                         </LemonButton>
-                        <LemonButton size="xsmall" type="tertiary" onClick={() => setWeekdays([...WEEKDAYS_MON_FRI])}>
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            onClick={() => setWeekdays([...WEEKDAYS_MON_FRI])}
+                            data-attr="vision-action-cadence-weekdays"
+                        >
                             Weekdays
                         </LemonButton>
                     </div>
@@ -79,6 +89,7 @@ function ScheduleSection(): JSX.Element {
                             size="small"
                             type={cadence.weekdays.includes(day) ? 'primary' : 'secondary'}
                             onClick={() => toggleWeekday(day)}
+                            data-attr={`vision-action-cadence-day-${day}`}
                         >
                             {label}
                         </LemonButton>
@@ -93,11 +104,11 @@ function ScheduleSection(): JSX.Element {
                     type="time"
                     value={timeValue}
                     onChange={(val) => {
-                        const [h, m] = (val || '09:00').split(':').map((n) => parseInt(n, 10))
+                        const [h, m] = (val || '').split(':').map((n) => parseInt(n, 10))
                         setVisionActionFormValue('cadence', {
                             ...cadence,
-                            hour: Number.isNaN(h) ? 9 : h,
-                            minute: Number.isNaN(m) ? 0 : m,
+                            hour: Number.isNaN(h) ? DEFAULT_CADENCE.hour : h,
+                            minute: Number.isNaN(m) ? DEFAULT_CADENCE.minute : m,
                         })
                     }}
                 />

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -202,7 +202,7 @@ export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Elem
 
                 <LemonField name="prompt_guide" label="Guidance" info="Optional. Steers how the AI writes the summary.">
                     <LemonTextArea
-                        placeholder="e.g. focus on checkout drop-off and highlight any errors"
+                        placeholder="Optional. e.g. focus on issues, bugs, and friction users face — or focus on general user behavior and flows."
                         maxLength={500}
                     />
                 </LemonField>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -8,7 +8,6 @@ import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/Inte
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonSearchableSelect } from 'lib/lemon-ui/LemonSelect/LemonSearchableSelect'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { timeZoneLabel } from 'lib/utils/timezones'
@@ -25,13 +24,6 @@ const FREQUENCY_OPTIONS: { value: CadenceFrequency; label: string }[] = [
 
 // 0=Mon … 6=Sun, matching CadenceState.weekdays.
 const WEEKDAY_PILLS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
-
-const VERDICT_OPTIONS = [
-    { value: '', label: 'Any verdict' },
-    { value: 'yes', label: 'Yes' },
-    { value: 'no', label: 'No' },
-    { value: 'inconclusive', label: 'Inconclusive' },
-]
 
 function TimezoneSelect({ value, onChange }: { value: string; onChange: (tz: string) => void }): JSX.Element {
     const { preflight } = useValues(preflightLogic)
@@ -127,59 +119,6 @@ function ScheduleSection(): JSX.Element {
     )
 }
 
-function SelectionSection(): JSX.Element {
-    const { visionActionForm } = useValues(visionActionsLogic)
-    const { setVisionActionFormValue } = useActions(visionActionsLogic)
-    const { selection } = visionActionForm
-
-    const patch = (next: Partial<typeof selection>): void =>
-        setVisionActionFormValue('selection', { ...selection, ...next })
-
-    return (
-        <div className="flex flex-col gap-2">
-            <div className="flex gap-2">
-                <div className="flex-1">
-                    <label className="text-sm font-semibold">Lookback window (days)</label>
-                    <LemonInput
-                        type="number"
-                        min={1}
-                        value={selection.window_days ?? undefined}
-                        onChange={(val) => patch({ window_days: val ?? undefined })}
-                    />
-                </div>
-                <div className="flex-1">
-                    <label className="text-sm font-semibold">Verdict</label>
-                    <LemonSelect
-                        value={selection.verdict ?? ''}
-                        options={VERDICT_OPTIONS}
-                        onChange={(val) => patch({ verdict: val || undefined })}
-                        fullWidth
-                    />
-                </div>
-                <div className="flex-1">
-                    <label className="text-sm font-semibold">Min score</label>
-                    <LemonInput
-                        type="number"
-                        value={selection.min_score ?? undefined}
-                        onChange={(val) => patch({ min_score: val ?? undefined })}
-                    />
-                </div>
-            </div>
-            <div>
-                <label className="text-sm font-semibold">Tags</label>
-                <LemonInputSelect
-                    mode="multiple"
-                    allowCustomValues
-                    value={selection.tags ?? []}
-                    options={[]}
-                    onChange={(tags) => patch({ tags: tags.length ? tags : undefined })}
-                    placeholder="Add tags to filter by"
-                />
-            </div>
-        </div>
-    )
-}
-
 function DeliverySection(): JSX.Element {
     const { visionActionForm } = useValues(visionActionsLogic)
     const { setVisionActionFormValue } = useActions(visionActionsLogic)
@@ -259,11 +198,6 @@ export function VisionActionForm({ scannerId }: { scannerId: string }): JSX.Elem
                 <div>
                     <h4 className="mb-1">Schedule</h4>
                     <ScheduleSection />
-                </div>
-
-                <div>
-                    <h4 className="mb-1">What to summarize</h4>
-                    <SelectionSection />
                 </div>
 
                 <LemonField name="prompt_guide" label="Guidance" info="Optional. Steers how the AI writes the summary.">

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionForm.tsx
@@ -105,10 +105,12 @@ function ScheduleSection(): JSX.Element {
                     value={timeValue}
                     onChange={(val) => {
                         const [h, m] = (val || '').split(':').map((n) => parseInt(n, 10))
+                        // isFinite (not isNaN) so a cleared/partial input — where h or m is `undefined`,
+                        // which isNaN() does not catch — falls back to the default rather than undefined.
                         setVisionActionFormValue('cadence', {
                             ...cadence,
-                            hour: Number.isNaN(h) ? DEFAULT_CADENCE.hour : h,
-                            minute: Number.isNaN(m) ? DEFAULT_CADENCE.minute : m,
+                            hour: Number.isFinite(h) ? h : DEFAULT_CADENCE.hour,
+                            minute: Number.isFinite(m) ? m : DEFAULT_CADENCE.minute,
                         })
                     }}
                 />

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -120,14 +120,15 @@ function VisionActionsTable(): JSX.Element {
                 ),
         },
         {
-            title: '',
+            title: 'Actions',
             key: 'actions',
+            width: 0, // shrink to content so the buttons hug the right instead of floating in a wide column
             render: (_, action) => (
-                <AccessControlAction
-                    resourceType={AccessControlResourceType.SessionRecording}
-                    minAccessLevel={AccessControlLevel.Editor}
-                >
-                    <div className="flex gap-1 justify-end">
+                <div className="flex gap-1">
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.SessionRecording}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
                         <LemonButton
                             size="small"
                             type="secondary"
@@ -136,6 +137,11 @@ function VisionActionsTable(): JSX.Element {
                             data-attr="vision-action-edit"
                             onClick={() => openEditForm(action)}
                         />
+                    </AccessControlAction>
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.SessionRecording}
+                        minAccessLevel={AccessControlLevel.Editor}
+                    >
                         <LemonButton
                             size="small"
                             type="secondary"
@@ -157,8 +163,8 @@ function VisionActionsTable(): JSX.Element {
                                 })
                             }
                         />
-                    </div>
-                </AccessControlAction>
+                    </AccessControlAction>
+                </div>
             ),
         },
     ]

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -19,7 +19,29 @@ import { VisionActionForm } from './VisionActionForm'
 
 function humanizeSchedule(action: VisionActionApi): string {
     const rrule = action.trigger_config?.rrule
-    return rrule ? humanizeCadence(parseRruleToCadence(rrule)) : '—'
+    if (!rrule) {
+        return '—'
+    }
+    // parseRruleToCadence only understands DAILY/WEEKLY; for anything else (a legacy monthly/hourly
+    // rrule) it falls back to the default daily cadence, which would mislabel the schedule — show the
+    // raw rrule instead of a fabricated "Daily".
+    const freq = /FREQ=([A-Z]+)/.exec(rrule)?.[1]
+    if (freq !== 'DAILY' && freq !== 'WEEKLY') {
+        return rrule
+    }
+    return humanizeCadence(parseRruleToCadence(rrule))
+}
+
+// Every write control on this tab gates on the same session-recording Editor access — wrap once.
+function EditorGate({ children }: { children: JSX.Element }): JSX.Element {
+    return (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.SessionRecording}
+            minAccessLevel={AccessControlLevel.Editor}
+        >
+            {children}
+        </AccessControlAction>
+    )
 }
 
 function deliverySummary(action: VisionActionApi): string {
@@ -49,10 +71,7 @@ function VisionActionsTable(): JSX.Element {
                 customHog={XRayHog}
                 description="Set up scheduled summaries of this scanner's observations — synthesized by AI and delivered to Slack on the cadence you choose. Great for a daily digest of what the scanner has been finding."
                 actionElementOverride={
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.SessionRecording}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
+                    <EditorGate>
                         <LemonButton
                             type="primary"
                             icon={<IconPlus />}
@@ -61,7 +80,7 @@ function VisionActionsTable(): JSX.Element {
                         >
                             New action
                         </LemonButton>
-                    </AccessControlAction>
+                    </EditorGate>
                 }
             />
         )
@@ -88,10 +107,7 @@ function VisionActionsTable(): JSX.Element {
             key: 'enabled',
             render: (_, action) => (
                 <div className="flex items-center gap-2">
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.SessionRecording}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
+                    <EditorGate>
                         <LemonSwitch
                             checked={!!action.enabled}
                             onChange={() => toggleActionEnabled(action.id)}
@@ -99,7 +115,7 @@ function VisionActionsTable(): JSX.Element {
                             size="small"
                             data-attr="vision-action-toggle-enabled"
                         />
-                    </AccessControlAction>
+                    </EditorGate>
                     <span className={`inline-block min-w-[4.5rem] ${action.enabled ? 'text-success' : 'text-muted'}`}>
                         {action.enabled ? 'Enabled' : 'Disabled'}
                     </span>
@@ -130,10 +146,7 @@ function VisionActionsTable(): JSX.Element {
             width: 0, // shrink to content so the buttons hug the right instead of floating in a wide column
             render: (_, action) => (
                 <div className="flex gap-1">
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.SessionRecording}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
+                    <EditorGate>
                         <LemonButton
                             size="small"
                             type="secondary"
@@ -142,11 +155,8 @@ function VisionActionsTable(): JSX.Element {
                             data-attr="vision-action-edit"
                             onClick={() => openEditForm(action)}
                         />
-                    </AccessControlAction>
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.SessionRecording}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
+                    </EditorGate>
+                    <EditorGate>
                         <LemonButton
                             size="small"
                             type="secondary"
@@ -168,7 +178,7 @@ function VisionActionsTable(): JSX.Element {
                                 })
                             }
                         />
-                    </AccessControlAction>
+                    </EditorGate>
                 </div>
             ),
         },
@@ -177,10 +187,7 @@ function VisionActionsTable(): JSX.Element {
     return (
         <div className="flex flex-col gap-2">
             <div className="flex justify-end">
-                <AccessControlAction
-                    resourceType={AccessControlResourceType.SessionRecording}
-                    minAccessLevel={AccessControlLevel.Editor}
-                >
+                <EditorGate>
                     <LemonButton
                         type="primary"
                         icon={<IconPlus />}
@@ -189,7 +196,7 @@ function VisionActionsTable(): JSX.Element {
                     >
                         New action
                     </LemonButton>
-                </AccessControlAction>
+                </EditorGate>
             </div>
             <LemonTable
                 columns={columns}

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -49,14 +49,19 @@ function VisionActionsTable(): JSX.Element {
                 customHog={XRayHog}
                 description="Set up scheduled summaries of this scanner's observations — synthesized by AI and delivered to Slack on the cadence you choose. Great for a daily digest of what the scanner has been finding."
                 actionElementOverride={
-                    <LemonButton
-                        type="primary"
-                        icon={<IconPlus />}
-                        onClick={() => openCreateForm()}
-                        data-attr="vision-action-new-empty"
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.SessionRecording}
+                        minAccessLevel={AccessControlLevel.Editor}
                     >
-                        New action
-                    </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            icon={<IconPlus />}
+                            onClick={() => openCreateForm()}
+                            data-attr="vision-action-new-empty"
+                        >
+                            New action
+                        </LemonButton>
+                    </AccessControlAction>
                 }
             />
         )

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -1,6 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { IconPlus, IconTrash } from '@posthog/icons'
+import { IconPencil, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonSwitch, LemonTable } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -13,24 +13,13 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import type { VisionActionApi } from '../../generated/api.schemas'
+import { humanizeCadence, parseRruleToCadence } from '../cadence'
 import { visionActionsLogic } from '../visionActionsLogic'
-
-const FREQ_LABELS: Record<string, string> = {
-    HOURLY: 'Hourly',
-    DAILY: 'Daily',
-    WEEKLY: 'Weekly',
-    MONTHLY: 'Monthly',
-    YEARLY: 'Yearly',
-}
+import { VisionActionForm } from './VisionActionForm'
 
 function humanizeSchedule(action: VisionActionApi): string {
     const rrule = action.trigger_config?.rrule
-    if (!rrule) {
-        return '—'
-    }
-    // Light-touch label for the common case; the full cadence editor lands with the create form (PR6).
-    const freq = /FREQ=([A-Z]+)/.exec(rrule)?.[1]
-    return (freq && FREQ_LABELS[freq]) || rrule
+    return rrule ? humanizeCadence(parseRruleToCadence(rrule)) : '—'
 }
 
 function deliverySummary(action: VisionActionApi): string {
@@ -42,13 +31,14 @@ export function VisionActionsTab({ scannerId }: { scannerId: string }): JSX.Elem
     return (
         <BindLogic logic={visionActionsLogic} props={{ scannerId }}>
             <VisionActionsTable />
+            <VisionActionForm scannerId={scannerId} />
         </BindLogic>
     )
 }
 
 function VisionActionsTable(): JSX.Element {
     const { visionActions, visionActionsLoading, togglingIds } = useValues(visionActionsLogic)
-    const { toggleActionEnabled, deleteAction } = useActions(visionActionsLogic)
+    const { toggleActionEnabled, deleteAction, openCreateForm, openEditForm } = useActions(visionActionsLogic)
 
     if (!visionActionsLoading && visionActions.length === 0) {
         return (
@@ -62,7 +52,7 @@ function VisionActionsTable(): JSX.Element {
                     <LemonButton
                         type="primary"
                         icon={<IconPlus />}
-                        disabledReason="Action creation is coming soon"
+                        onClick={() => openCreateForm()}
                         data-attr="vision-action-new-empty"
                     >
                         New action
@@ -137,40 +127,67 @@ function VisionActionsTable(): JSX.Element {
                     resourceType={AccessControlResourceType.SessionRecording}
                     minAccessLevel={AccessControlLevel.Editor}
                 >
-                    <LemonButton
-                        size="small"
-                        type="secondary"
-                        status="danger"
-                        icon={<IconTrash />}
-                        tooltip="Delete"
-                        data-attr="vision-action-delete"
-                        onClick={() =>
-                            LemonDialog.open({
-                                title: `Delete "${action.name}"?`,
-                                description:
-                                    'This stops its scheduled summaries and removes its delivery destinations. This cannot be undone.',
-                                primaryButton: {
-                                    children: 'Delete',
-                                    status: 'danger',
-                                    onClick: () => deleteAction(action.id),
-                                },
-                                secondaryButton: { children: 'Cancel' },
-                            })
-                        }
-                    />
+                    <div className="flex gap-1 justify-end">
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconPencil />}
+                            tooltip="Edit"
+                            data-attr="vision-action-edit"
+                            onClick={() => openEditForm(action)}
+                        />
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            status="danger"
+                            icon={<IconTrash />}
+                            tooltip="Delete"
+                            data-attr="vision-action-delete"
+                            onClick={() =>
+                                LemonDialog.open({
+                                    title: `Delete "${action.name}"?`,
+                                    description:
+                                        'This stops its scheduled summaries and removes its delivery destinations. This cannot be undone.',
+                                    primaryButton: {
+                                        children: 'Delete',
+                                        status: 'danger',
+                                        onClick: () => deleteAction(action.id),
+                                    },
+                                    secondaryButton: { children: 'Cancel' },
+                                })
+                            }
+                        />
+                    </div>
                 </AccessControlAction>
             ),
         },
     ]
 
     return (
-        <LemonTable
-            columns={columns}
-            dataSource={visionActions}
-            loading={visionActionsLoading}
-            rowKey="id"
-            data-attr="vision-actions-table"
-            emptyState="No actions yet — this scanner has no scheduled summaries."
-        />
+        <div className="flex flex-col gap-2">
+            <div className="flex justify-end">
+                <AccessControlAction
+                    resourceType={AccessControlResourceType.SessionRecording}
+                    minAccessLevel={AccessControlLevel.Editor}
+                >
+                    <LemonButton
+                        type="primary"
+                        icon={<IconPlus />}
+                        onClick={() => openCreateForm()}
+                        data-attr="vision-action-new"
+                    >
+                        New action
+                    </LemonButton>
+                </AccessControlAction>
+            </div>
+            <LemonTable
+                columns={columns}
+                dataSource={visionActions}
+                loading={visionActionsLoading}
+                rowKey="id"
+                data-attr="vision-actions-table"
+                emptyState="No actions yet — this scanner has no scheduled summaries."
+            />
+        </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -29,6 +29,9 @@ describe('visionActionsLogic', () => {
             get: {
                 '/api/projects/:team/vision/actions/': { results: [action('a'), action('b')], count: 2 },
             },
+            post: {
+                '/api/projects/:team/vision/actions/': () => [201, action('new')],
+            },
             patch: {
                 '/api/projects/:team/vision/actions/:id/': () => [200, {}],
             },
@@ -82,5 +85,55 @@ describe('visionActionsLogic', () => {
         }).toMatchValues({
             visionActions: [expect.objectContaining({ id: 'b' })],
         })
+    })
+
+    it('creating an action submits, closes the form, and reloads', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.openCreateForm()
+            logic.actions.setVisionActionFormValue('name', 'My action')
+            logic.actions.submitVisionActionForm()
+        })
+            .toDispatchActions(['submitVisionActionFormSuccess', 'closeForm', 'loadActions'])
+            .toMatchValues({ formVisible: false })
+    })
+
+    it('openEditForm prefills the form from an existing action', async () => {
+        const existing: VisionActionApi = {
+            ...action('e'),
+            trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
+            selection: { window_days: 7, verdict: 'yes' },
+            synthesis_config: { prompt_guide: 'focus on checkout' },
+            delivery_config: [{ type: 'slack', integration_id: 5, channel: 'C123' }],
+        }
+        await expectLogic(logic, () => {
+            logic.actions.openEditForm(existing)
+        }).toMatchValues({
+            formVisible: true,
+            editingAction: expect.objectContaining({ id: 'e' }),
+            visionActionForm: {
+                name: 'action-e',
+                cadence: { frequency: 'weekly', weekdays: [0, 2], hour: 14, minute: 30 },
+                timezone: 'Europe/Prague',
+                selection: { window_days: 7, verdict: 'yes' },
+                prompt_guide: 'focus on checkout',
+                integration_id: 5,
+                channel: 'C123',
+            },
+        })
+    })
+
+    it('keeps the form open and surfaces an error when the submit fails', async () => {
+        useMocks({
+            post: {
+                '/api/projects/:team/vision/actions/': () => [400, { detail: 'nope' }],
+            },
+        })
+        await expectLogic(logic, () => {
+            logic.actions.openCreateForm()
+            logic.actions.setVisionActionFormValue('name', 'My action')
+            logic.actions.submitVisionActionForm()
+        })
+            .toDispatchActions(['submitVisionActionFormFailure'])
+            .toMatchValues({ formVisible: true })
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -1,10 +1,13 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import type { VisionActionApi } from '../generated/api.schemas'
-import { visionActionsLogic } from './visionActionsLogic'
+import { DeliveryTargetTypeEnumApi } from '../generated/api.schemas'
+import { buildActionBody, type VisionActionForm, visionActionsLogic } from './visionActionsLogic'
 
 const action = (id: string, enabled = true): VisionActionApi => ({
     id,
@@ -120,12 +123,13 @@ describe('visionActionsLogic', () => {
         })
     })
 
-    it('keeps the form open and surfaces an error when the submit fails', async () => {
+    it('keeps the form open and surfaces the API error detail when the submit fails', async () => {
         useMocks({
             post: {
                 '/api/projects/:team/vision/actions/': () => [400, { detail: 'nope' }],
             },
         })
+        const errorToast = jest.spyOn(lemonToast, 'error')
         await expectLogic(logic, () => {
             logic.actions.openCreateForm()
             logic.actions.setVisionActionFormValue('name', 'My action')
@@ -133,5 +137,37 @@ describe('visionActionsLogic', () => {
         })
             .toDispatchActions(['submitVisionActionFormFailure'])
             .toMatchValues({ formVisible: true })
+        // The toast must surface the API's `detail` so the user sees why it failed, not a generic message.
+        expect(errorToast).toHaveBeenCalledWith(expect.stringContaining('nope'))
+    })
+
+    it('buildActionBody maps the form to the API body, including a Slack delivery target', () => {
+        const form: VisionActionForm = {
+            name: '  Daily digest  ',
+            cadence: { weekdays: [0, 2], hour: 14, minute: 30 },
+            timezone: 'Europe/Prague',
+            prompt_guide: 'focus on checkout',
+            integration_id: 5,
+            channel: 'C123|#general',
+        }
+        expect(buildActionBody(form, 's1')).toEqual({
+            name: 'Daily digest', // trimmed
+            scanner: 's1',
+            trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
+            synthesis_config: { prompt_guide: 'focus on checkout' },
+            delivery_config: [{ type: DeliveryTargetTypeEnumApi.Slack, integration_id: 5, channel: 'C123' }],
+        })
+    })
+
+    it('buildActionBody emits an empty delivery_config when no integration/channel is set', () => {
+        const form: VisionActionForm = {
+            name: 'No delivery',
+            cadence: { weekdays: [0, 1, 2, 3, 4, 5, 6], hour: 9, minute: 0 },
+            timezone: 'UTC',
+            prompt_guide: '',
+            integration_id: null,
+            channel: '',
+        }
+        expect(buildActionBody(form, 's1').delivery_config).toEqual([])
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -111,7 +111,7 @@ describe('visionActionsLogic', () => {
             editingAction: expect.objectContaining({ id: 'e' }),
             visionActionForm: {
                 name: 'action-e',
-                cadence: { frequency: 'weekly', weekdays: [0, 2], hour: 14, minute: 30 },
+                cadence: { weekdays: [0, 2], hour: 14, minute: 30 },
                 timezone: 'Europe/Prague',
                 prompt_guide: 'focus on checkout',
                 integration_id: 5,

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.test.ts
@@ -101,7 +101,6 @@ describe('visionActionsLogic', () => {
         const existing: VisionActionApi = {
             ...action('e'),
             trigger_config: { rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=14;BYMINUTE=30', timezone: 'Europe/Prague' },
-            selection: { window_days: 7, verdict: 'yes' },
             synthesis_config: { prompt_guide: 'focus on checkout' },
             delivery_config: [{ type: 'slack', integration_id: 5, channel: 'C123' }],
         }
@@ -114,7 +113,6 @@ describe('visionActionsLogic', () => {
                 name: 'action-e',
                 cadence: { frequency: 'weekly', weekdays: [0, 2], hour: 14, minute: 30 },
                 timezone: 'Europe/Prague',
-                selection: { window_days: 7, verdict: 'yes' },
                 prompt_guide: 'focus on checkout',
                 integration_id: 5,
                 channel: 'C123',

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -1,15 +1,46 @@
 import { actions, afterMount, kea, key, listeners, path, props, reducers } from 'kea'
+import { forms } from 'kea-forms'
 
+import { dayjs } from 'lib/dayjs'
+import { slackChannelId } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { visionActionsDestroy, visionActionsList, visionActionsPartialUpdate } from '../generated/api'
-import type { VisionActionApi } from '../generated/api.schemas'
+import {
+    visionActionsCreate,
+    visionActionsDestroy,
+    visionActionsList,
+    visionActionsPartialUpdate,
+} from '../generated/api'
+import { DeliveryTargetTypeEnumApi } from '../generated/api.schemas'
+import type { SelectionApi, VisionActionApi } from '../generated/api.schemas'
+import { CadenceState, cadenceToRrule, DEFAULT_CADENCE, parseRruleToCadence } from './cadence'
 import type { visionActionsLogicType } from './visionActionsLogicType'
 
 export interface VisionActionsLogicProps {
     scannerId: string
 }
+
+// UI-shaped form values, mapped to/from the API shape on submit/edit.
+export interface VisionActionForm {
+    name: string
+    cadence: CadenceState
+    timezone: string
+    selection: SelectionApi
+    prompt_guide: string
+    integration_id: number | null
+    channel: string
+}
+
+const NEW_ACTION_FORM = (): VisionActionForm => ({
+    name: '',
+    cadence: { ...DEFAULT_CADENCE },
+    timezone: dayjs.tz.guess(),
+    selection: { window_days: 1 },
+    prompt_guide: '',
+    integration_id: null,
+    channel: '',
+})
 
 export const visionActionsLogic = kea<visionActionsLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'visionActionsLogic']),
@@ -25,6 +56,9 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
         toggleActionEnabledDone: (id: string) => ({ id }),
         deleteAction: (id: string) => ({ id }),
         deleteActionSuccess: (id: string) => ({ id }),
+        openCreateForm: true,
+        openEditForm: (action: VisionActionApi) => ({ action }),
+        closeForm: true,
     }),
 
     reducers({
@@ -56,7 +90,62 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
                 revertActionEnabled: (state, { id }) => state.filter((i) => i !== id),
             },
         ],
+        formVisible: [
+            false,
+            {
+                openCreateForm: () => true,
+                openEditForm: () => true,
+                closeForm: () => false,
+            },
+        ],
+        editingAction: [
+            null as VisionActionApi | null,
+            {
+                openCreateForm: () => null,
+                openEditForm: (_, { action }) => action,
+                closeForm: () => null,
+            },
+        ],
     }),
+
+    forms(({ props, values }) => ({
+        visionActionForm: {
+            defaults: NEW_ACTION_FORM(),
+            errors: ({ name, integration_id, channel }) => ({
+                name: !name?.trim() ? 'Give this action a name' : undefined,
+                channel: integration_id && !channel ? 'Pick a channel' : undefined,
+            }),
+            submit: async (form) => {
+                const teamId = teamLogic.values.currentTeamId
+                if (!teamId) {
+                    throw new Error('No team selected')
+                }
+                const body: Parameters<typeof visionActionsCreate>[1] = {
+                    name: form.name.trim(),
+                    scanner: props.scannerId,
+                    trigger_config: { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
+                    selection: form.selection,
+                    synthesis_config: { prompt_guide: form.prompt_guide },
+                    delivery_config:
+                        form.integration_id && form.channel
+                            ? [
+                                  {
+                                      type: DeliveryTargetTypeEnumApi.Slack,
+                                      integration_id: form.integration_id,
+                                      channel: slackChannelId(form.channel),
+                                  },
+                              ]
+                            : [],
+                }
+                const editing = values.editingAction
+                if (editing) {
+                    await visionActionsPartialUpdate(String(teamId), editing.id, body)
+                } else {
+                    await visionActionsCreate(String(teamId), body)
+                }
+            },
+        },
+    })),
 
     listeners(({ actions, props, values }) => ({
         loadActions: async () => {
@@ -103,6 +192,36 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
             } catch (error: any) {
                 lemonToast.error(`Failed to delete action${error.detail ? `: ${error.detail}` : ''}`)
             }
+        },
+
+        openCreateForm: () => {
+            actions.resetVisionActionForm(NEW_ACTION_FORM())
+        },
+
+        openEditForm: ({ action }) => {
+            actions.setVisionActionFormValues({
+                name: action.name,
+                cadence: parseRruleToCadence(action.trigger_config?.rrule),
+                timezone: action.trigger_config?.timezone || dayjs.tz.guess(),
+                selection: action.selection ?? {},
+                prompt_guide: action.synthesis_config?.prompt_guide ?? '',
+                integration_id: action.delivery_config?.[0]?.integration_id ?? null,
+                channel: action.delivery_config?.[0]?.channel ?? '',
+            })
+        },
+
+        closeForm: () => {
+            actions.resetVisionActionForm(NEW_ACTION_FORM())
+        },
+
+        submitVisionActionFormSuccess: () => {
+            lemonToast.success(values.editingAction ? 'Action updated' : 'Action created')
+            actions.closeForm()
+            actions.loadActions()
+        },
+
+        submitVisionActionFormFailure: ({ error }: { error?: Error & { detail?: string } }) => {
+            lemonToast.error(`Failed to save action${error?.detail ? `: ${error.detail}` : ''}`)
         },
     })),
 

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -40,6 +40,28 @@ const NEW_ACTION_FORM = (): VisionActionForm => ({
     channel: '',
 })
 
+// Map the UI form shape to the API body shared by create + partial-update. Kept standalone so the
+// rrule + delivery-target mapping (the part most likely to grow beyond a single Slack target) is
+// unit-testable without the form machinery.
+export function buildActionBody(form: VisionActionForm, scannerId: string): Parameters<typeof visionActionsCreate>[1] {
+    return {
+        name: form.name.trim(),
+        scanner: scannerId,
+        trigger_config: { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
+        synthesis_config: { prompt_guide: form.prompt_guide },
+        delivery_config:
+            form.integration_id && form.channel
+                ? [
+                      {
+                          type: DeliveryTargetTypeEnumApi.Slack,
+                          integration_id: form.integration_id,
+                          channel: slackChannelId(form.channel),
+                      },
+                  ]
+                : [],
+    }
+}
+
 export const visionActionsLogic = kea<visionActionsLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'visionActionsLogic']),
     props({} as VisionActionsLogicProps),
@@ -123,22 +145,7 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
                 if (!teamId) {
                     throw new Error('No team selected')
                 }
-                const body: Parameters<typeof visionActionsCreate>[1] = {
-                    name: form.name.trim(),
-                    scanner: props.scannerId,
-                    trigger_config: { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
-                    synthesis_config: { prompt_guide: form.prompt_guide },
-                    delivery_config:
-                        form.integration_id && form.channel
-                            ? [
-                                  {
-                                      type: DeliveryTargetTypeEnumApi.Slack,
-                                      integration_id: form.integration_id,
-                                      channel: slackChannelId(form.channel),
-                                  },
-                              ]
-                            : [],
-                }
+                const body = buildActionBody(form, props.scannerId)
                 const editing = values.editingAction
                 if (editing) {
                     await visionActionsPartialUpdate(String(teamId), editing.id, body)

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -13,7 +13,7 @@ import {
     visionActionsPartialUpdate,
 } from '../generated/api'
 import { DeliveryTargetTypeEnumApi } from '../generated/api.schemas'
-import type { SelectionApi, VisionActionApi } from '../generated/api.schemas'
+import type { VisionActionApi } from '../generated/api.schemas'
 import { CadenceState, cadenceToRrule, DEFAULT_CADENCE, parseRruleToCadence } from './cadence'
 import type { visionActionsLogicType } from './visionActionsLogicType'
 
@@ -26,7 +26,6 @@ export interface VisionActionForm {
     name: string
     cadence: CadenceState
     timezone: string
-    selection: SelectionApi
     prompt_guide: string
     integration_id: number | null
     channel: string
@@ -36,7 +35,6 @@ const NEW_ACTION_FORM = (): VisionActionForm => ({
     name: '',
     cadence: { ...DEFAULT_CADENCE },
     timezone: dayjs.tz.guess(),
-    selection: { window_days: 1 },
     prompt_guide: '',
     integration_id: null,
     channel: '',
@@ -124,7 +122,6 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
                     name: form.name.trim(),
                     scanner: props.scannerId,
                     trigger_config: { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
-                    selection: form.selection,
                     synthesis_config: { prompt_guide: form.prompt_guide },
                     delivery_config:
                         form.integration_id && form.channel
@@ -203,7 +200,6 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
                 name: action.name,
                 cadence: parseRruleToCadence(action.trigger_config?.rrule),
                 timezone: action.trigger_config?.timezone || dayjs.tz.guess(),
-                selection: action.selection ?? {},
                 prompt_guide: action.synthesis_config?.prompt_guide ?? '',
                 integration_id: action.delivery_config?.[0]?.integration_id ?? null,
                 channel: action.delivery_config?.[0]?.channel ?? '',

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -109,8 +109,13 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
     forms(({ props, values }) => ({
         visionActionForm: {
             defaults: NEW_ACTION_FORM(),
-            errors: ({ name, integration_id, channel }) => ({
+            errors: ({ name, cadence, integration_id, channel }) => ({
                 name: !name?.trim() ? 'Give this action a name' : undefined,
+                // weekdays is a number[], which kea-forms can't carry a string error on, so we hang
+                // the "pick a day" error on the cadence object via `hour` to mark the form invalid.
+                // This blocks Enter-to-submit (enableFormOnSubmit); the user-facing message is the
+                // inline danger text + the submit button's disabledReason.
+                cadence: cadence.weekdays.length === 0 ? { hour: 'Pick at least one day' } : undefined,
                 channel: integration_id && !channel ? 'Pick a channel' : undefined,
             }),
             submit: async (form) => {


### PR DESCRIPTION
## Problem

The scanner **Actions** tab (shipped behind `replay-vision-actions`) lets you see, toggle, and delete a scanner's scheduled-summary actions, but there was no way to _create_ or _edit_ one from the UI — the "New action" button was a disabled "coming soon" placeholder, so actions could only be created via the API. This makes the "and then…" scheduled-summary feature usable end to end.

## Changes

Adds a create/edit modal to the Actions tab, still gated behind `replay-vision-actions`:

- **Schedule** — a focused, self-contained cadence picker (Daily / Weekly / Monthly + day-of-week + time of day + timezone). The run time of day is encoded into the rrule via `BYHOUR`/`BYMINUTE`, because `trigger_config` carries no start time and the scheduler derives `starts_at` from the action's `created_at`.
- **What to summarize** — selection filters (lookback window, verdict, min score, tags).
- **Guidance** — an optional free-text prompt guide that steers the AI summary.
- **Deliver to Slack** — reuses the shared Slack integration + channel pickers; falls back to the "not configured" banner when the team has no Slack integration.

`visionActionsLogic` gains a kea-form that maps the UI shape to the generated write API (`visionActionsCreate` / `visionActionsPartialUpdate`), plus open/edit/close modal state. The empty-state CTA and a per-row edit action are wired to it, and the list's schedule column now shares the cadence humanizer with the form.

No backend changes — the write API already accepts every field, and rrule/timezone validation and Slack delivery provisioning were wired in earlier PRs in this stack.

## How did you test this code?

![Screenshot 2026-06-22 at 1.04.20 PM.png](https://app.graphite.com/user-attachments/assets/86f246fc-68e2-4a62-b2e8-ac3c852e3408.png)![Screenshot 2026-06-22 at 1.04.23 PM.png](https://app.graphite.com/user-attachments/assets/d12db51f-14d1-45fd-b6c9-1405fd789b8f.png)



- `cadence.test.ts` — `cadenceToRrule` / `parseRruleToCadence` round-trips for daily / weekly(+weekdays) / monthly, time-of-day in `BYHOUR`/`BYMINUTE`, clamping, and `humanizeCadence`.
- `visionActionsLogic.test.ts` — create submit closes the form and reloads; `openEditForm` prefills from an existing action; a failed submit keeps the form open and surfaces an error.
- TypeScript check clean for the changed source files; lint/format clean.

No manual UI testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/adopting-generated-api-types` (the logic calls the generated `visionActions*` functions) and `/writing-kea-logics` (the kea-form extension).

Key decisions:

- **Self-contained cadence picker over reusing the Workflows recurring picker.** That picker is coupled to `workflowLogic` and far richer than a digest needs, so I reimplemented a minimal helper (`cadence.ts`) rather than extracting/refactoring shared workflows code — mirroring the copy-not-import call the replay_vision backend already made for its rrule date math.
- **Time of day lives in the rrule.** Since `trigger_config` has no DTSTART and the scheduler uses `created_at` as the start, the picker emits `BYHOUR`/`BYMINUTE` so the chosen time is honored.
- **Slack destination is optional.** An action with no destination is allowed (matching the backend); the channel field is only required once an integration is picked.

Sixth PR in the VisionAction stack; parent is the Actions-tab PR.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)