### PR TITLE
feat(signals): add health checks to the agents roster UI

### DIFF
--- a/frontend/src/scenes/inbox/components/config/AgentsRoster.tsx
+++ b/frontend/src/scenes/inbox/components/config/AgentsRoster.tsx
@@ -157,6 +157,7 @@ export function AgentsRoster(): JSX.Element {
         linearIssuesConfig,
         zendeskTicketsConfig,
         pgAnalyzeIssuesConfig,
+        healthChecksConfig,
         errorTrackingIsFullyEnabled,
         isSessionAnalysisToggling,
         isConversationsToggling,
@@ -167,6 +168,7 @@ export function AgentsRoster(): JSX.Element {
         isLinearIssuesToggling,
         isZendeskTicketsToggling,
         isPgAnalyzeIssuesToggling,
+        isHealthChecksToggling,
     } = useValues(signalSourcesLogic)
     const {
         toggleSessionAnalysis,
@@ -174,6 +176,7 @@ export function AgentsRoster(): JSX.Element {
         toggleErrorTracking,
         toggleEvalReports,
         toggleAnomalyInvestigation,
+        toggleHealthChecks,
         initiateDataWarehouseSourceToggle,
     } = useActions(signalSourcesLogic)
 
@@ -222,6 +225,13 @@ export function AgentsRoster(): JSX.Element {
                         requiresSetup: false,
                         syncStatus: anomalyInvestigationConfig?.status,
                     }
+                case 'health_checks':
+                    return {
+                        armed: !!healthChecksConfig?.enabled,
+                        loading: isHealthChecksToggling,
+                        requiresSetup: false,
+                        syncStatus: healthChecksConfig?.status,
+                    }
                 case 'github':
                     return dwState(githubIssuesConfig, isGithubIssuesToggling)
                 case 'linear':
@@ -243,6 +253,8 @@ export function AgentsRoster(): JSX.Element {
             isEvalReportsToggling,
             anomalyInvestigationConfig,
             isAnomalyInvestigationToggling,
+            healthChecksConfig,
+            isHealthChecksToggling,
             githubIssuesConfig,
             isGithubIssuesToggling,
             linearIssuesConfig,
@@ -272,6 +284,9 @@ export function AgentsRoster(): JSX.Element {
                 case 'analytics':
                     toggleAnomalyInvestigation()
                     return
+                case 'health_checks':
+                    toggleHealthChecks()
+                    return
                 case 'github':
                     initiateDataWarehouseSourceToggle('Github')
                     return
@@ -292,6 +307,7 @@ export function AgentsRoster(): JSX.Element {
             toggleSessionAnalysis,
             toggleEvalReports,
             toggleAnomalyInvestigation,
+            toggleHealthChecks,
             initiateDataWarehouseSourceToggle,
         ]
     )

--- a/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
+++ b/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
@@ -12,6 +12,7 @@ export type AgentRosterSource =
     | 'session_replay'
     | 'llm_analytics'
     | 'analytics'
+    | 'health_checks'
     | 'github'
     | 'linear'
     | 'zendesk'
@@ -84,6 +85,12 @@ export const AGENT_ROSTER_GROUPS: AgentRosterGroup[] = [
                 docsUrl: 'https://posthog.com/docs/product-analytics',
                 docsLabel: 'Product analytics',
                 alpha: true,
+            },
+            {
+                source: 'health_checks',
+                sourceProduct: SignalSourceProduct.HealthChecks,
+                label: 'Health checks',
+                description: 'Instrumentation issues - missing events, proxy gaps, and outdated SDKs.',
             },
         ],
     },


### PR DESCRIPTION
## Problem

Health checks (instrumentation issues - missing events, proxy gaps, outdated SDKs) was a selectable signal source in the old `SourcesList` UI, but the new `AgentsRoster` card grid that replaced it never surfaced the option. The backend source (`health_checks` / `health_issue`), the generated enum values, the `sourceProductIcons` meta, and all of the `signalSourcesLogic` wiring already existed. Users just had no way to arm it from the new UI.

## Changes

Adds a **Health checks** card to the agents roster under the "PostHog data" group. No logic or backend changes were needed.

- `agentRosterMeta.ts` - new `health_checks` entry in the `AgentRosterSource` union and a card definition in `AGENT_ROSTER_GROUPS` (placed after Product analytics), pointing at the existing `SignalSourceProduct.HealthChecks` icon meta (`IconHeartPlus`).
- `AgentsRoster.tsx` - wires `healthChecksConfig` / `isHealthChecksToggling` into `stateFor` and `toggleHealthChecks` into `handleToggle`, plus their dependency arrays. This mirrors the existing native PostHog sources (error tracking, support, session replay, AI observability, product analytics).

Everything on the logic side was already present and untouched: the `toggleHealthChecks` action, its optimistic reducer, the `healthChecksConfig` / `isHealthChecksToggling` selectors, and the toggle listener that emits `SignalSourceProduct.HealthChecks` + `SignalSourceType.HealthIssue`.

## How did you test this code?

I'm an agent. The change is mechanical and mirrors the existing native-source wiring one-for-one.

- Ran `pnpm --filter=@posthog/frontend typescript:check`: my two files add no new type errors (verified by stashing my changes and confirming the error count is identical - the one remaining error is a pre-existing missing-dev-dep in an unrelated test file in this environment).
- Ran the formatter/linter. `oxlint --fix` also auto-touched several unrelated files with pre-existing lint drift; I reverted all of those so the diff stays scoped to the two intended files.

No new tests: this surfaces already-wired logic in the UI, and there is no existing roster-rendering test suite this would meaningfully extend. I did not do manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael asked to surface the previously-existing health-checks signal source in the new roster UI, and pointed at an earlier attempt (this same PR branch) as a starting point. I explored the current code and found the codebase had moved on since that attempt: the "PostHog data" group now also has `llm_analytics` and `analytics`, and the enum member is `SignalSourceProduct.HealthChecks` (not the `HEALTH_CHECKS` referenced in the original attempt). So I rebuilt the change against the current shape rather than replaying the old diff.

Decisions:
- Placed the card at the end of the "PostHog data" group.
- Left it non-alpha and without a docs link, matching how the source read in the old `SourcesList`.
- Used a plain hyphen in the description rather than an en-dash, per repo copy conventions.

No repo skills applied - this is a purely-frontend roster change with no migration, serializer, or API surface touched. Tools used: Claude Code (Opus 4.8).
