### PR TITLE
fix: revenuecat decimal price field typing

### DIFF
--- a/posthog/temporal/data_imports/sources/revenuecat/event_schema.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/event_schema.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-
 REVENUECAT_EVENT_DOUBLE_FIELDS = frozenset({"price", "price_in_purchased_currency"})
 
 

--- a/posthog/temporal/data_imports/sources/revenuecat/event_schema.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/event_schema.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+
+REVENUECAT_EVENT_DOUBLE_FIELDS = frozenset({"price", "price_in_purchased_currency"})
+
+
+def normalize_revenuecat_event_types(row: dict[str, Any]) -> dict[str, Any]:
+    for field in REVENUECAT_EVENT_DOUBLE_FIELDS:
+        value = row.get(field)
+        if isinstance(value, int) and not isinstance(value, bool):
+            row[field] = float(value)
+    return row

--- a/posthog/temporal/data_imports/sources/revenuecat/source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/source.py
@@ -34,6 +34,7 @@ from posthog.temporal.data_imports.sources.revenuecat.constants import (
     EVENT_RESOURCE_NAME,
     RESOURCE_TO_REVENUECAT_EVENT_TYPE,
 )
+from posthog.temporal.data_imports.sources.revenuecat.event_schema import normalize_revenuecat_event_types
 from posthog.temporal.data_imports.sources.revenuecat.revenuecat import RevenueCatResumeConfig
 from posthog.temporal.data_imports.sources.revenuecat.settings import (
     REVENUECAT_API_ENDPOINTS,
@@ -79,6 +80,7 @@ def _webhook_table_transformer(table: pa.Table) -> pa.Table:
         # but we accept a JSON-serialized string too in case the upstream
         # buffering layer flattens nested structures.
         row = orjson.loads(event) if isinstance(event, (str, bytes)) else dict(event)
+        row = normalize_revenuecat_event_types(row)
         row["api_version"] = api_version
         event_ts_ms = row.get("event_timestamp_ms")
         if isinstance(event_ts_ms, int) and not isinstance(event_ts_ms, bool):

--- a/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat_source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat_source.py
@@ -3,8 +3,8 @@ from typing import cast
 
 from unittest.mock import MagicMock, patch
 
-import deltalake
 import pyarrow as pa
+import deltalake
 
 from posthog.schema import SourceFieldInputConfig
 

--- a/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat_source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat_source.py
@@ -3,12 +3,13 @@ from typing import cast
 
 from unittest.mock import MagicMock, patch
 
+import deltalake
 import pyarrow as pa
 
 from posthog.schema import SourceFieldInputConfig
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
-from posthog.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
+from posthog.temporal.data_imports.pipelines.pipeline.utils import evolve_pyarrow_schema, table_from_py_list
 from posthog.temporal.data_imports.sources.common.base import (
     ExternalWebhookInfo,
     WebhookCreationResult,
@@ -406,3 +407,48 @@ class TestRevenueCatWebhookTableTransformer:
         result = _webhook_table_transformer(table)
 
         assert result.num_rows == 0
+
+    def test_price_fields_are_stable_doubles_across_whole_and_decimal_values(self):
+        first_batch = _webhook_table_transformer(
+            table_from_py_list(
+                [
+                    {
+                        "api_version": "1.0",
+                        "event": {
+                            "id": "evt-1",
+                            "type": "INITIAL_PURCHASE",
+                            "event_timestamp_ms": 1658726374000,
+                            "price": 19,
+                            "price_in_purchased_currency": 19,
+                        },
+                    }
+                ]
+            )
+        )
+        delta_schema = deltalake.Schema.from_arrow(first_batch.schema)
+
+        next_batch = _webhook_table_transformer(
+            table_from_py_list(
+                [
+                    {
+                        "api_version": "1.0",
+                        "event": {
+                            "id": "evt-2",
+                            "type": "RENEWAL",
+                            "event_timestamp_ms": 1659331174000,
+                            "price": 19.99,
+                            "price_in_purchased_currency": 19.99,
+                        },
+                    }
+                ]
+            )
+        )
+
+        evolved = evolve_pyarrow_schema(next_batch, delta_schema)
+
+        assert first_batch.schema.field("price").type == pa.float64()
+        assert first_batch.schema.field("price_in_purchased_currency").type == pa.float64()
+        assert evolved.schema.field("price").type == pa.float64()
+        assert evolved.schema.field("price_in_purchased_currency").type == pa.float64()
+        assert evolved.column("price").to_pylist() == [19.99]
+        assert evolved.column("price_in_purchased_currency").to_pylist() == [19.99]


### PR DESCRIPTION
## Problem

RevenueCat event fields `price` and `price_in_purchased_currency` can contain decimal values.

If an initial synced batch contains only whole-number values, PyArrow can infer those fields as `int64`. A later valid decimal value, such as `19.99`, then fails when cast to the existing schema:

```text
pyarrow.lib.ArrowInvalid: Float value 19.99 was truncated converting to int64
```

## Fix

Normalize RevenueCat event price fields before Arrow schema inference.

Integer-looking values for `price` and `price_in_purchased_currency` are converted to `float`, so the first batch is typed as double-compatible and later decimal values cast cleanly.

## Test

Added a RevenueCat webhook transformer regression covering an integer-valued first batch followed by a decimal-valued later batch.

The test verifies:

* `price` remains `pa.float64()`;
* `price_in_purchased_currency` remains `pa.float64()`;
* decimal values such as `19.99` are preserved.

## Local verification

`git diff --check` passes.

Focused pytest command attempted:

```bash
TEST=1 SECRET_KEY=local-test-only .venv/bin/python -m pytest -o addopts='' posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat_source.py::TestRevenueCatWebhookTableTransformer::test_price_fields_are_stable_doubles_across_whole_and_decimal_values -q
```

This local partial environment is currently missing a full PostHog app dependency:

```text
ModuleNotFoundError: No module named 'social_django'
```

Standalone repro verification:

Before fix:

```text
first_batch price type=int64
later_batch price type=double
later_batch price value=19.99
pyarrow.lib.ArrowInvalid: Float value 19.99 was truncated converting to int64
```

After fix:

```text
first_batch price type=double
later_batch price type=double
later_batch price value=19.99
casted price type=double
casted price value=19.99
```
