### PR TITLE
feat(hogql): add parse_string_literal_text to the rust parser

### DIFF
--- a/posthog/hogql/scripts/_diagnostic_common.py
+++ b/posthog/hogql/scripts/_diagnostic_common.py
@@ -65,20 +65,9 @@ def _parse_full_template_string(query: str, backend: Any = None) -> Any:
 
 
 def _parse_string_literal_text(query: str, backend: Any = None) -> str:
-    """Entry point for the `string_literal` rule — the standalone
-    string-literal/identifier unquoter, NOT a grammar rule. Dispatches by
-    backend family (`cpp*` → the C++ wheel, `rust*` → the Rust wheel) so the
-    grind can fuzz the two implementations for byte-for-byte parity. Returns the
-    decoded string; raises the `BaseHogQLError` subclasses both wheels raise
-    (`SyntaxError` on mismatched quotes, `ParsingError` on empty input), which
-    `_safe_parse` buckets as a `reject`.
-
-    The C++ *wheel* aborts the process on empty input (an uncaught C++
-    `ParsingError` the binding fails to catch), so an empty input would kill the
-    grind. The strategy never emits `""`, but the shrinker can probe it, so we
-    short-circuit it to the `ParsingError` the C++ *function* declares — keeping
-    the grind alive and matching what the Rust wheel raises."""
+    """Dispatch the unquoter by backend family (`cpp*`/`rust*`) for parity fuzzing; raises like both wheels."""
     use_cpp = backend is None or str(backend).startswith("cpp")
+    # cpp wheel aborts the process on "" (uncaught C++ ParsingError); raise the class it declares so the grind survives.
     if use_cpp and query == "":
         raise ParsingError("Encountered an unexpected empty string input")
     fn = _cpp_parse_string_literal_text if use_cpp else _rust_parse_string_literal_text

--- a/posthog/hogql/scripts/_diagnostic_common.py
+++ b/posthog/hogql/scripts/_diagnostic_common.py
@@ -40,7 +40,10 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any, NoReturn
 
-from posthog.hogql.errors import BaseHogQLError
+from hogql_parser import parse_string_literal_text as _cpp_parse_string_literal_text
+from hogql_parser_rs import parse_string_literal_text as _rust_parse_string_literal_text
+
+from posthog.hogql.errors import BaseHogQLError, ParsingError
 from posthog.hogql.parser import (
     HogQLParserShadowMismatch,
     parse_expr,
@@ -61,6 +64,27 @@ def _parse_full_template_string(query: str, backend: Any = None) -> Any:
     return parse_string_template(body, backend=backend)
 
 
+def _parse_string_literal_text(query: str, backend: Any = None) -> str:
+    """Entry point for the `string_literal` rule — the standalone
+    string-literal/identifier unquoter, NOT a grammar rule. Dispatches by
+    backend family (`cpp*` → the C++ wheel, `rust*` → the Rust wheel) so the
+    grind can fuzz the two implementations for byte-for-byte parity. Returns the
+    decoded string; raises the `BaseHogQLError` subclasses both wheels raise
+    (`SyntaxError` on mismatched quotes, `ParsingError` on empty input), which
+    `_safe_parse` buckets as a `reject`.
+
+    The C++ *wheel* aborts the process on empty input (an uncaught C++
+    `ParsingError` the binding fails to catch), so an empty input would kill the
+    grind. The strategy never emits `""`, but the shrinker can probe it, so we
+    short-circuit it to the `ParsingError` the C++ *function* declares — keeping
+    the grind alive and matching what the Rust wheel raises."""
+    use_cpp = backend is None or str(backend).startswith("cpp")
+    if use_cpp and query == "":
+        raise ParsingError("Encountered an unexpected empty string input")
+    fn = _cpp_parse_string_literal_text if use_cpp else _rust_parse_string_literal_text
+    return fn(query)
+
+
 # Maps a diagnostic `--rule` value to its parser entry point. `program`
 # covers the Hog imperative-statement layer (let / if / while / for /
 # fn / try-catch / return / throw / blocks); `full_template_string` is the
@@ -72,6 +96,7 @@ _PARSER_FOR_RULE: dict[str, Callable[..., Any]] = {
     "select": parse_select,
     "program": parse_program,
     "full_template_string": _parse_full_template_string,
+    "string_literal": _parse_string_literal_text,
 }
 
 # ---------------------------------------------------------------------------

--- a/posthog/hogql/scripts/pbt_diagnostic.py
+++ b/posthog/hogql/scripts/pbt_diagnostic.py
@@ -82,7 +82,12 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 django.setup()
 
-from hypothesis import assume, given, settings
+from hypothesis import (
+    assume,
+    given,
+    settings,
+    strategies as st,
+)
 
 # Eager so a missing `hogql-parser-parity` dep group fails at script-load,
 # not mid-grind where shrink_to_shape would lose every finding so far.
@@ -110,6 +115,33 @@ from posthog.hogql.test.test_parser_grammar_pbt import (
     _apply_jiggle,
     _apply_mutation,
 )
+
+# ---------------------------------------------------------------------------
+# string_literal strategy
+# ---------------------------------------------------------------------------
+#
+# `parse_string_literal_text` is the standalone unquoter, not a grammar rule,
+# so it has no auto-generated strategy. Generate quoted literals directly,
+# biasing the alphabet toward the chars that drive the unquoter's branches:
+# the four quote chars, backslash, the escape letters cpp recognises
+# (b f r n t 0 a v), a few it doesn't (x y o), braces, and a couple of
+# multibyte chars (so the byte-level quote strip is checked against the
+# char-level Rust scan).
+_SL_QUOTE_PAIRS = [("'", "'"), ('"', '"'), ("`", "`"), ("{", "}")]
+# Deliberately excludes the NUL byte: the cpp wheel's `PyArg_ParseTuple("s")`
+# rejects embedded nulls (ValueError) while PyO3's `&str` accepts them, an
+# arg-parsing quirk unrelated to the decode logic this grind targets.
+_SL_ALPHABET = "'\"`{}\\bfrnt0avxyo ab\n\té£"
+
+
+def string_literal_strategy() -> st.SearchStrategy[str]:
+    body = st.text(alphabet=_SL_ALPHABET, max_size=12)
+    quoted = st.builds(lambda pair, b: pair[0] + b + pair[1], st.sampled_from(_SL_QUOTE_PAIRS), body)
+    # Raw, never-empty forms (often mismatched/unquoted) exercise the
+    # SyntaxError parity path. `min_size=1` so the cpp wheel never sees "".
+    raw = st.text(alphabet=_SL_ALPHABET, min_size=1, max_size=14)
+    return st.one_of(quoted, raw)
+
 
 # ---------------------------------------------------------------------------
 # Auto-shrinker
@@ -158,7 +190,11 @@ def _print_failure_sample(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--n", type=int, default=int(os.environ.get("N", "500")))
-    parser.add_argument("--rule", choices=("expr", "select", "program", "full_template_string"), default="expr")
+    parser.add_argument(
+        "--rule",
+        choices=("expr", "select", "program", "full_template_string", "string_literal"),
+        default="expr",
+    )
     parser.add_argument("--jiggle", action="store_true")
     parser.add_argument(
         "--mutate",
@@ -258,6 +294,7 @@ def main() -> int:
         "select": select_strategy,
         "program": program_strategy,
         "full_template_string": fullTemplateString_strategy,
+        "string_literal": string_literal_strategy,
     }[args.rule]()
     strategy = base_strategy
     # Grammar-aware mutation runs first, on the clean space-separated query —

--- a/posthog/hogql/scripts/pbt_diagnostic.py
+++ b/posthog/hogql/scripts/pbt_diagnostic.py
@@ -77,11 +77,7 @@ import traceback
 from collections import Counter
 from typing import Any
 
-# The parser core reads `settings.TEST` (in posthog/hogql/parser.py) but never
-# touches the app registry, so configuring the settings module is enough — we
-# deliberately skip `django.setup()`. Calling it would run every app's `ready()`
-# hook (DB queries, redis, self-capture token init) just to fuzz a parser, which
-# fails noisily when Postgres/redis are down and adds startup latency for nothing.
+# Skip django.setup(): parser core only reads settings.TEST, so settings alone avoids ready()-hook DB/redis init.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 
 from hypothesis import (
@@ -121,26 +117,16 @@ from posthog.hogql.test.test_parser_grammar_pbt import (
 # ---------------------------------------------------------------------------
 # string_literal strategy
 # ---------------------------------------------------------------------------
-#
-# `parse_string_literal_text` is the standalone unquoter, not a grammar rule,
-# so it has no auto-generated strategy. Generate quoted literals directly,
-# biasing the alphabet toward the chars that drive the unquoter's branches:
-# the four quote chars, backslash, the escape letters cpp recognises
-# (b f r n t 0 a v), a few it doesn't (x y o), braces, and a couple of
-# multibyte chars (so the byte-level quote strip is checked against the
-# char-level Rust scan).
+# No generated strategy (the unquoter isn't a grammar rule): build quoted literals over a branch-driving alphabet.
 _SL_QUOTE_PAIRS = [("'", "'"), ('"', '"'), ("`", "`"), ("{", "}")]
-# Deliberately excludes the NUL byte: the cpp wheel's `PyArg_ParseTuple("s")`
-# rejects embedded nulls (ValueError) while PyO3's `&str` accepts them, an
-# arg-parsing quirk unrelated to the decode logic this grind targets.
+# Excludes NUL: the cpp wheel's PyArg_ParseTuple("s") rejects it (ValueError) while PyO3's &str accepts it.
 _SL_ALPHABET = "'\"`{}\\bfrnt0avxyo ab\n\té£"
 
 
 def string_literal_strategy() -> st.SearchStrategy[str]:
     body = st.text(alphabet=_SL_ALPHABET, max_size=12)
     quoted = st.builds(lambda pair, b: pair[0] + b + pair[1], st.sampled_from(_SL_QUOTE_PAIRS), body)
-    # Raw, never-empty forms (often mismatched/unquoted) exercise the
-    # SyntaxError parity path. `min_size=1` so the cpp wheel never sees "".
+    # Raw never-empty forms (mismatched/unquoted) exercise the SyntaxError path; min_size=1 so cpp never sees "".
     raw = st.text(alphabet=_SL_ALPHABET, min_size=1, max_size=14)
     return st.one_of(quoted, raw)
 

--- a/posthog/hogql/scripts/pbt_diagnostic.py
+++ b/posthog/hogql/scripts/pbt_diagnostic.py
@@ -64,8 +64,8 @@ Typical usage:
 """
 
 # ruff: noqa: T201 (this is a CLI script — print is the output channel)
-# ruff: noqa: E402 (django.setup() must run between import django and the
-#                   project-app imports below)
+# ruff: noqa: E402 (DJANGO_SETTINGS_MODULE must be set before the project-app
+#                   imports below)
 
 from __future__ import annotations
 
@@ -77,10 +77,12 @@ import traceback
 from collections import Counter
 from typing import Any
 
-import django
-
+# The parser core reads `settings.TEST` (in posthog/hogql/parser.py) but never
+# touches the app registry, so configuring the settings module is enough — we
+# deliberately skip `django.setup()`. Calling it would run every app's `ready()`
+# hook (DB queries, redis, self-capture token init) just to fuzz a parser, which
+# fails noisily when Postgres/redis are down and adds startup latency for nothing.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
-django.setup()
 
 from hypothesis import (
     assume,

--- a/posthog/hogql/scripts/pbt_diagnostic.py
+++ b/posthog/hogql/scripts/pbt_diagnostic.py
@@ -75,6 +75,7 @@ import json
 import argparse
 import traceback
 from collections import Counter
+from collections.abc import Callable
 from typing import Any
 
 # Skip django.setup(): parser core only reads settings.TEST, so settings alone avoids ready()-hook DB/redis init.
@@ -277,13 +278,15 @@ def main() -> int:
     # abort the whole grind. Keyed by normalised `<ExcType>: …`.
     crash_buckets: dict[str, list[str]] = {}
 
-    base_strategy = {
+    # `Callable[..., ...]` so the no-arg `string_literal_strategy` and the `depth`-taking grammar strategies unify.
+    strategies_by_rule: dict[str, Callable[..., st.SearchStrategy[str]]] = {
         "expr": expr_strategy,
         "select": select_strategy,
         "program": program_strategy,
         "full_template_string": fullTemplateString_strategy,
         "string_literal": string_literal_strategy,
-    }[args.rule]()
+    }
+    base_strategy = strategies_by_rule[args.rule]()
     strategy = base_strategy
     # Grammar-aware mutation runs first, on the clean space-separated query —
     # the whitespace jiggle below would otherwise break its tokenisation.

--- a/posthog/hogql/test/_test_parse_string.py
+++ b/posthog/hogql/test/_test_parse_string.py
@@ -30,6 +30,12 @@ def parse_string_test_factory(backend: HogQLParserBackend):
             self.assertEqual(parse_string("{a{{sd}"), "a{sd")
             self.assertEqual(parse_string("{a}sd}"), "a}sd")
 
+        def test_quote_run_collapse(self):
+            # Odd/long quote runs pin sequential-replace semantics (rust str::replace vs cpp replace_all).
+            self.assertEqual(parse_string("''''''"), "''")
+            self.assertEqual(parse_string("'a'''b'"), "a''b")
+            self.assertEqual(parse_string("`a```b`"), "a``b")
+
         def test_escaped_quotes_slash(self):
             self.assertEqual(parse_string("`a\\`sd`"), "a`sd")
             self.assertEqual(parse_string("'a\\'sd'"), "a'sd")

--- a/posthog/hogql/test/_test_parse_string.py
+++ b/posthog/hogql/test/_test_parse_string.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
 
 from hogql_parser import parse_string_literal_text as parse_string_cpp
+from hogql_parser_rs import parse_string_literal_text as parse_string_rust
 
 from posthog.hogql.constants import HogQLParserBackend
 from posthog.hogql.errors import SyntaxError
@@ -8,7 +9,12 @@ from posthog.hogql.parse_string import parse_string_literal_text as parse_string
 
 
 def parse_string_test_factory(backend: HogQLParserBackend):
-    parse_string = parse_string_py if backend == "python" else parse_string_cpp
+    if backend == "python":
+        parse_string = parse_string_py
+    elif backend.startswith("rust"):
+        parse_string = parse_string_rust
+    else:
+        parse_string = parse_string_cpp
 
     class TestParseString(BaseTest):
         def test_quote_types(self):

--- a/posthog/hogql/test/_test_parse_string.py
+++ b/posthog/hogql/test/_test_parse_string.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from posthog.test.base import BaseTest
 
 from hogql_parser import parse_string_literal_text as parse_string_cpp
@@ -9,6 +11,7 @@ from posthog.hogql.parse_string import parse_string_literal_text as parse_string
 
 
 def parse_string_test_factory(backend: HogQLParserBackend):
+    parse_string: Callable[[str], str]
     if backend == "python":
         parse_string = parse_string_py
     elif backend.startswith("rust"):

--- a/posthog/hogql/test/test_parse_string_rust.py
+++ b/posthog/hogql/test/test_parse_string_rust.py
@@ -1,0 +1,5 @@
+from ._test_parse_string import parse_string_test_factory
+
+
+class TestParseStringRust(parse_string_test_factory("rust-json")):  # type: ignore
+    pass

--- a/posthog/hogql/test/test_parse_string_rust.py
+++ b/posthog/hogql/test/test_parse_string_rust.py
@@ -1,5 +1,18 @@
+from unittest import TestCase
+
+from hogql_parser_rs import parse_string_literal_text
+
+from posthog.hogql.errors import ParsingError
+
 from ._test_parse_string import parse_string_test_factory
 
 
 class TestParseStringRust(parse_string_test_factory("rust-json")):  # type: ignore
     pass
+
+
+class TestParseStringRustEmptyInput(TestCase):
+    # Empty input can't go in the shared factory: cpp's wheel aborts the process on "", python raises SyntaxError.
+    def test_empty_input_raises_parsing_error(self):
+        with self.assertRaises(ParsingError):
+            parse_string_literal_text("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.97",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.98",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.98",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.99",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.96",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.97",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.96"
+version = "1.3.97"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.97"
+version = "1.3.98"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.98"
+version = "1.3.99"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.97); each ships as its own PyPI wheel.
-version = "1.3.97"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.98); each ships as its own PyPI wheel.
+version = "1.3.98"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.96); each ships as its own PyPI wheel.
-version = "1.3.96"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.97); each ships as its own PyPI wheel.
+version = "1.3.97"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.98); each ships as its own PyPI wheel.
-version = "1.3.98"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.99); each ships as its own PyPI wheel.
+version = "1.3.99"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.96).
-version = "1.3.96"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.97).
+version = "1.3.97"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.97).
-version = "1.3.97"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.98).
+version = "1.3.98"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.98).
-version = "1.3.98"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.99).
+version = "1.3.99"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/src/error.rs
+++ b/rust/hogql/parser/src/error.rs
@@ -28,11 +28,7 @@ pub struct ParseError {
 pub enum ErrorKind {
     Syntax,
     NotImplemented,
-    /// An internal problem in the parser layer. Maps to the `ParsingError`
-    /// envelope type, which `pyobject::Converter` raises as
-    /// `posthog.hogql.errors.ParsingError` — matching the C++ parser's
-    /// `ParsingError` class. Emitted by the standalone
-    /// `parse_string_literal_text` entry point on empty input.
+    /// Parser-layer error → `ParsingError` (cpp parity); emitted by `parse_string_literal_text` on empty input.
     Parsing,
 }
 

--- a/rust/hogql/parser/src/error.rs
+++ b/rust/hogql/parser/src/error.rs
@@ -33,7 +33,7 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
-    fn type_str(self) -> &'static str {
+    pub(crate) fn type_str(self) -> &'static str {
         match self {
             ErrorKind::Syntax => "SyntaxError",
             ErrorKind::NotImplemented => "NotImplementedError",

--- a/rust/hogql/parser/src/error.rs
+++ b/rust/hogql/parser/src/error.rs
@@ -28,6 +28,12 @@ pub struct ParseError {
 pub enum ErrorKind {
     Syntax,
     NotImplemented,
+    /// An internal problem in the parser layer. Maps to the `ParsingError`
+    /// envelope type, which `pyobject::Converter` raises as
+    /// `posthog.hogql.errors.ParsingError` — matching the C++ parser's
+    /// `ParsingError` class. Emitted by the standalone
+    /// `parse_string_literal_text` entry point on empty input.
+    Parsing,
 }
 
 impl ErrorKind {
@@ -35,6 +41,7 @@ impl ErrorKind {
         match self {
             ErrorKind::Syntax => "SyntaxError",
             ErrorKind::NotImplemented => "NotImplementedError",
+            ErrorKind::Parsing => "ParsingError",
         }
     }
 }
@@ -56,6 +63,16 @@ impl ParseError {
             start,
             end,
             kind: ErrorKind::NotImplemented,
+            fatal: false,
+        }
+    }
+
+    pub fn parsing(message: impl Into<String>, start: usize, end: usize) -> Self {
+        Self {
+            message: message.into(),
+            start,
+            end,
+            kind: ErrorKind::Parsing,
             fatal: false,
         }
     }

--- a/rust/hogql/parser/src/lib.rs
+++ b/rust/hogql/parser/src/lib.rs
@@ -169,7 +169,15 @@ fn parse_full_template_string_py(py: Python<'_>, string: &str) -> PyResult<PyObj
 /// Errors route through the shared converter so `SyntaxError`/`ParsingError` match the C++ wheel's classes.
 #[pyfunction]
 fn parse_string_literal_text(py: Python<'_>, text: &str) -> PyResult<String> {
-    parse::parse_string_literal_text(text).map_err(|err| raise_parse_error(py, err))
+    // catch_unwind like the other entry points: a future panic in the decoder must not cross FFI as a PanicException.
+    match std::panic::catch_unwind(AssertUnwindSafe(|| parse::parse_string_literal_text(text))) {
+        Ok(Ok(decoded)) => Ok(decoded),
+        Ok(Err(err)) => Err(raise_parse_error(py, err)),
+        Err(_) => Err(raise_parse_error(
+            py,
+            error::ParseError::not_implemented("internal panic in parse_string_literal_text", 0, 0),
+        )),
+    }
 }
 
 /// Raise the matching Python exception for `err` via the shared [`pyobject::Converter`].

--- a/rust/hogql/parser/src/lib.rs
+++ b/rust/hogql/parser/src/lib.rs
@@ -165,28 +165,19 @@ fn parse_full_template_string_py(py: Python<'_>, string: &str) -> PyResult<PyObj
     })
 }
 
-/// Standalone string-literal/identifier unquoter — the byte-for-byte twin of
-/// the C++ wheel's `parse_string_literal_text`. Given a quoted literal (quotes
-/// included), returns the decoded inner text. Closes the last cpp/rust API gap.
-///
-/// On error, routes the `ParseError` through the same JSON-envelope → exception
-/// converter the `parse_*_py` entry points use ([`run_py`]'s error path), so a
-/// mismatched-quote `SyntaxError` and an empty-input `ParsingError` surface as
-/// the matching `posthog.hogql.errors` classes the C++ wheel raises.
+/// Byte-for-byte twin of the C++ wheel's `parse_string_literal_text`, closing the last cpp/rust API gap.
+/// Errors route through the shared converter so `SyntaxError`/`ParsingError` match the C++ wheel's classes.
 #[pyfunction]
 fn parse_string_literal_text(py: Python<'_>, text: &str) -> PyResult<String> {
     parse::parse_string_literal_text(text).map_err(|err| raise_parse_error(py, err))
 }
 
-/// Convert a [`error::ParseError`] into the matching Python exception via the
-/// shared [`pyobject::Converter`]. `convert_root` on an `{"error": true, …}`
-/// envelope always returns `Err(PyErr)`; the `Ok` / converter-construction
-/// arms are unreachable in practice but keep this total without crossing the
-/// FFI boundary with a panic.
+/// Raise the matching Python exception for `err` via the shared [`pyobject::Converter`].
 fn raise_parse_error(py: Python<'_>, err: error::ParseError) -> PyErr {
     let value = err.to_json_value();
     match pyobject::Converter::new(py) {
         Ok(converter) => match converter.convert_root(&value) {
+            // Unreachable: an error envelope always raises; fall back without an FFI-crossing panic.
             Ok(_) => PyValueError::new_err("internal: parser error envelope did not raise"),
             Err(e) => e,
         },

--- a/rust/hogql/parser/src/lib.rs
+++ b/rust/hogql/parser/src/lib.rs
@@ -22,7 +22,6 @@
     clippy::doc_lazy_continuation
 )]
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::panic::AssertUnwindSafe;
 
@@ -180,17 +179,15 @@ fn parse_string_literal_text(py: Python<'_>, text: &str) -> PyResult<String> {
     }
 }
 
-/// Raise the matching Python exception for `err` via the shared [`pyobject::Converter`].
+/// Raise the matching `posthog.hogql.errors` exception for `err`, importing only the errors module (not the AST/enum-laden `Converter`).
 fn raise_parse_error(py: Python<'_>, err: error::ParseError) -> PyErr {
-    let value = err.to_json_value();
-    match pyobject::Converter::new(py) {
-        Ok(converter) => match converter.convert_root(&value) {
-            // Unreachable: an error envelope always raises; fall back without an FFI-crossing panic.
-            Ok(_) => PyValueError::new_err("internal: parser error envelope did not raise"),
-            Err(e) => e,
-        },
-        Err(e) => e,
-    }
+    pyobject::raise_error_envelope(
+        py,
+        err.kind.type_str(),
+        &err.message,
+        Some(err.start as u64),
+        Some(err.end as u64),
+    )
 }
 
 #[pymodule]

--- a/rust/hogql/parser/src/lib.rs
+++ b/rust/hogql/parser/src/lib.rs
@@ -22,6 +22,7 @@
     clippy::doc_lazy_continuation
 )]
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::panic::AssertUnwindSafe;
 
@@ -164,6 +165,35 @@ fn parse_full_template_string_py(py: Python<'_>, string: &str) -> PyResult<PyObj
     })
 }
 
+/// Standalone string-literal/identifier unquoter — the byte-for-byte twin of
+/// the C++ wheel's `parse_string_literal_text`. Given a quoted literal (quotes
+/// included), returns the decoded inner text. Closes the last cpp/rust API gap.
+///
+/// On error, routes the `ParseError` through the same JSON-envelope → exception
+/// converter the `parse_*_py` entry points use ([`run_py`]'s error path), so a
+/// mismatched-quote `SyntaxError` and an empty-input `ParsingError` surface as
+/// the matching `posthog.hogql.errors` classes the C++ wheel raises.
+#[pyfunction]
+fn parse_string_literal_text(py: Python<'_>, text: &str) -> PyResult<String> {
+    parse::parse_string_literal_text(text).map_err(|err| raise_parse_error(py, err))
+}
+
+/// Convert a [`error::ParseError`] into the matching Python exception via the
+/// shared [`pyobject::Converter`]. `convert_root` on an `{"error": true, …}`
+/// envelope always returns `Err(PyErr)`; the `Ok` / converter-construction
+/// arms are unreachable in practice but keep this total without crossing the
+/// FFI boundary with a panic.
+fn raise_parse_error(py: Python<'_>, err: error::ParseError) -> PyErr {
+    let value = err.to_json_value();
+    match pyobject::Converter::new(py) {
+        Ok(converter) => match converter.convert_root(&value) {
+            Ok(_) => PyValueError::new_err("internal: parser error envelope did not raise"),
+            Err(e) => e,
+        },
+        Err(e) => e,
+    }
+}
+
 #[pymodule]
 fn hogql_parser_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_expr_json, m)?)?;
@@ -176,6 +206,7 @@ fn hogql_parser_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_select_py, m)?)?;
     m.add_function(wrap_pyfunction!(parse_program_py, m)?)?;
     m.add_function(wrap_pyfunction!(parse_full_template_string_py, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_string_literal_text, m)?)?;
 
     #[cfg(feature = "coverage")]
     {

--- a/rust/hogql/parser/src/parse.rs
+++ b/rust/hogql/parser/src/parse.rs
@@ -975,19 +975,8 @@ pub(crate) fn identifier_text(src: &str, kind: TokenKind) -> String {
     }
 }
 
-/// Standalone, LENIENT string-literal/identifier unquoter — the byte-for-byte
-/// twin of cpp's `parse_string_literal_text` in
-/// [`common/hogql_parser/string.cpp`], exposed via the
-/// `parse_string_literal_text` PyO3 entry point for cpp-wheel API parity.
-///
-/// Deliberately NOT routed through [`decode_quoted_body`] /
-/// [`unquote_single_string`] / [`identifier_text`], which implement the
-/// STRICTER in-parser quoted body: those reject a backslash-escaped quote
-/// (e.g. `` \` `` stays `` \` ``), whereas this accepts BOTH the doubled-quote
-/// and backslash-escaped-quote forms for all four quote types — including the
-/// `{...}` placeholder quoting the in-parser path never encounters. Mirrors
-/// cpp's `replace_all`-based collapse exactly so callers get a true drop-in
-/// twin.
+/// Lenient cpp `parse_string_literal_text` twin (`string.cpp`), exposed via PyO3 for cpp-wheel API parity.
+/// Accepts doubled + backslash-escaped quotes (4 quote types, incl. `{...}`) unlike the strict [`decode_quoted_body`].
 pub(crate) fn parse_string_literal_text(text: &str) -> Result<String, ParseError> {
     if text.is_empty() {
         return Err(ParseError::parsing(
@@ -999,10 +988,7 @@ pub(crate) fn parse_string_literal_text(text: &str) -> Result<String, ParseError
     let bytes = text.as_bytes();
     let first = bytes[0];
     let last = bytes[bytes.len() - 1];
-    // Strip the surrounding quotes, then collapse the doubled- and
-    // backslash-escaped-quote forms. The quote bytes are ASCII, so byte 1 and
-    // byte `len-1` are valid char boundaries once an arm matches; the `_` arm
-    // never slices, so a non-ASCII single char can't panic the strip.
+    // Quote bytes are ASCII, so the byte 1/len-1 slice is char-boundary-safe; the `_` arm never slices.
     let stripped = match (first, last) {
         (b'\'', b'\'') => inner_between_quotes(text)
             .replace("''", "'")
@@ -1029,11 +1015,7 @@ pub(crate) fn parse_string_literal_text(text: &str) -> Result<String, ParseError
     Ok(replace_common_escape_characters(&stripped))
 }
 
-/// Drop the first and last byte (the surrounding quotes). Mirrors cpp's
-/// `text.substr(1, size - 2)`: a length-1 input (a lone quote) yields `""`
-/// rather than panicking on the reversed byte range. Only called after the
-/// caller has confirmed both ends are ASCII quote bytes, so byte 1 and byte
-/// `len-1` are char boundaries.
+/// Drop the surrounding quote bytes, cpp `substr(1, size-2)`-style: a length-1 input yields `""`, not a panic.
 fn inner_between_quotes(text: &str) -> &str {
     if text.len() < 2 {
         ""
@@ -1042,13 +1024,7 @@ fn inner_between_quotes(text: &str) -> &str {
     }
 }
 
-/// Byte-for-byte twin of cpp's `replace_common_escape_characters`
-/// ([`common/hogql_parser/string.cpp`]): a single left-to-right pass where a
-/// consumed `\\` is decoded before the next char is inspected. `\0` is dropped
-/// (NUL ignored); `\b \f \r \n \t \a \v \\` map to their control chars; any
-/// other `\X` (or a trailing lone `\\`) keeps the backslash verbatim. The
-/// escape targets are all ASCII, so a char-wise scan matches cpp's byte scan
-/// and never splits a multibyte char.
+/// Twin of cpp's `replace_common_escape_characters`: single pass, `\0` dropped, unknown `\X` keeps the backslash.
 fn replace_common_escape_characters(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut chars = text.chars().peekable();
@@ -1486,10 +1462,7 @@ mod tests {
     use super::*;
     use crate::error::ErrorKind;
 
-    /// `parse_string_literal_text` is the byte-for-byte twin of cpp's
-    /// `parse_string_literal_text`. These cases mirror the cross-backend
-    /// parity factory in `posthog/hogql/test/_test_parse_string.py` (which
-    /// can't run without a DB) so the unquoting logic is pinned DB-free.
+    /// Parity cases mirroring the DB-bound `_test_parse_string.py` factory, pinned DB-free here.
     #[test]
     fn parse_string_literal_text_matches_cpp() {
         let f = |s: &str| parse_string_literal_text(s).expect("should decode");
@@ -1507,8 +1480,7 @@ mod tests {
         assert_eq!(f("{a{{sd}"), "a{sd");
         assert_eq!(f("{a}sd}"), "a}sd");
 
-        // Backslash-escaped quotes (the lenient form the strict in-parser
-        // decoder rejects).
+        // Backslash-escaped quotes (the lenient form the strict in-parser decoder rejects).
         assert_eq!(f("`a\\`sd`"), "a`sd");
         assert_eq!(f("'a\\'sd'"), "a'sd");
         assert_eq!(f("\"a\\\"sd\""), "a\"sd");
@@ -1541,8 +1513,7 @@ mod tests {
         assert_eq!(f("{ünïcödé}"), "ünïcödé");
     }
 
-    /// Mismatched quotes raise `SyntaxError`; an empty input raises
-    /// `ParsingError` (the class cpp's `parse_string_literal_text` throws).
+    /// Mismatched quotes raise `SyntaxError`; empty input raises `ParsingError` (cpp's declared class).
     #[test]
     fn parse_string_literal_text_error_paths() {
         let mismatched = parse_string_literal_text("`asd'").expect_err("mismatched quotes");

--- a/rust/hogql/parser/src/parse.rs
+++ b/rust/hogql/parser/src/parse.rs
@@ -975,6 +975,141 @@ pub(crate) fn identifier_text(src: &str, kind: TokenKind) -> String {
     }
 }
 
+/// Standalone, LENIENT string-literal/identifier unquoter — the byte-for-byte
+/// twin of cpp's `parse_string_literal_text` in
+/// [`common/hogql_parser/string.cpp`], exposed via the
+/// `parse_string_literal_text` PyO3 entry point for cpp-wheel API parity.
+///
+/// Deliberately NOT routed through [`decode_quoted_body`] /
+/// [`unquote_single_string`] / [`identifier_text`], which implement the
+/// STRICTER in-parser quoted body: those reject a backslash-escaped quote
+/// (e.g. `` \` `` stays `` \` ``), whereas this accepts BOTH the doubled-quote
+/// and backslash-escaped-quote forms for all four quote types — including the
+/// `{...}` placeholder quoting the in-parser path never encounters. Mirrors
+/// cpp's `replace_all`-based collapse exactly so callers get a true drop-in
+/// twin.
+pub(crate) fn parse_string_literal_text(text: &str) -> Result<String, ParseError> {
+    if text.is_empty() {
+        return Err(ParseError::parsing(
+            "Encountered an unexpected empty string input",
+            0,
+            0,
+        ));
+    }
+    let bytes = text.as_bytes();
+    let first = bytes[0];
+    let last = bytes[bytes.len() - 1];
+    // Strip the surrounding quotes, then collapse the doubled- and
+    // backslash-escaped-quote forms. The quote bytes are ASCII, so byte 1 and
+    // byte `len-1` are valid char boundaries once an arm matches; the `_` arm
+    // never slices, so a non-ASCII single char can't panic the strip.
+    let stripped = match (first, last) {
+        (b'\'', b'\'') => inner_between_quotes(text)
+            .replace("''", "'")
+            .replace("\\'", "'"),
+        (b'"', b'"') => inner_between_quotes(text)
+            .replace("\"\"", "\"")
+            .replace("\\\"", "\""),
+        (b'`', b'`') => inner_between_quotes(text)
+            .replace("``", "`")
+            .replace("\\`", "`"),
+        (b'{', b'}') => inner_between_quotes(text)
+            .replace("{{", "{")
+            .replace("\\{", "{"),
+        _ => {
+            return Err(ParseError::syntax(
+                format!(
+                    "Invalid string literal, must start and end with the same quote type: {text}"
+                ),
+                0,
+                0,
+            ));
+        }
+    };
+    Ok(replace_common_escape_characters(&stripped))
+}
+
+/// Drop the first and last byte (the surrounding quotes). Mirrors cpp's
+/// `text.substr(1, size - 2)`: a length-1 input (a lone quote) yields `""`
+/// rather than panicking on the reversed byte range. Only called after the
+/// caller has confirmed both ends are ASCII quote bytes, so byte 1 and byte
+/// `len-1` are char boundaries.
+fn inner_between_quotes(text: &str) -> &str {
+    if text.len() < 2 {
+        ""
+    } else {
+        &text[1..text.len() - 1]
+    }
+}
+
+/// Byte-for-byte twin of cpp's `replace_common_escape_characters`
+/// ([`common/hogql_parser/string.cpp`]): a single left-to-right pass where a
+/// consumed `\\` is decoded before the next char is inspected. `\0` is dropped
+/// (NUL ignored); `\b \f \r \n \t \a \v \\` map to their control chars; any
+/// other `\X` (or a trailing lone `\\`) keeps the backslash verbatim. The
+/// escape targets are all ASCII, so a char-wise scan matches cpp's byte scan
+/// and never splits a multibyte char.
+fn replace_common_escape_characters(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(&next) = chars.peek() {
+                match next {
+                    'b' => {
+                        out.push('\u{08}');
+                        chars.next();
+                        continue;
+                    }
+                    'f' => {
+                        out.push('\u{0C}');
+                        chars.next();
+                        continue;
+                    }
+                    'r' => {
+                        out.push('\r');
+                        chars.next();
+                        continue;
+                    }
+                    'n' => {
+                        out.push('\n');
+                        chars.next();
+                        continue;
+                    }
+                    't' => {
+                        out.push('\t');
+                        chars.next();
+                        continue;
+                    }
+                    // cpp drops the NUL: `\0` consumes both and emits nothing.
+                    '0' => {
+                        chars.next();
+                        continue;
+                    }
+                    'a' => {
+                        out.push('\u{07}');
+                        chars.next();
+                        continue;
+                    }
+                    'v' => {
+                        out.push('\u{0B}');
+                        chars.next();
+                        continue;
+                    }
+                    '\\' => {
+                        out.push('\\');
+                        chars.next();
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
 /// Keywords accepted as the type-cast target on the `::` postfix. Maps to
 /// the grammar's `columnTypeCastIdentifier` rule: IDENTIFIER /
 /// QUOTED_IDENTIFIER / interval-units / `DATE` / `TIME` / `TIMESTAMP` /
@@ -1349,6 +1484,81 @@ fn build_char_offsets(src: &str) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ErrorKind;
+
+    /// `parse_string_literal_text` is the byte-for-byte twin of cpp's
+    /// `parse_string_literal_text`. These cases mirror the cross-backend
+    /// parity factory in `posthog/hogql/test/_test_parse_string.py` (which
+    /// can't run without a DB) so the unquoting logic is pinned DB-free.
+    #[test]
+    fn parse_string_literal_text_matches_cpp() {
+        let f = |s: &str| parse_string_literal_text(s).expect("should decode");
+
+        // Quote types.
+        assert_eq!(f("`asd`"), "asd");
+        assert_eq!(f("'asd'"), "asd");
+        assert_eq!(f("\"asd\""), "asd");
+        assert_eq!(f("{asd}"), "asd");
+
+        // Doubled-quote escapes.
+        assert_eq!(f("`a``sd`"), "a`sd");
+        assert_eq!(f("'a''sd'"), "a'sd");
+        assert_eq!(f("\"a\"\"sd\""), "a\"sd");
+        assert_eq!(f("{a{{sd}"), "a{sd");
+        assert_eq!(f("{a}sd}"), "a}sd");
+
+        // Backslash-escaped quotes (the lenient form the strict in-parser
+        // decoder rejects).
+        assert_eq!(f("`a\\`sd`"), "a`sd");
+        assert_eq!(f("'a\\'sd'"), "a'sd");
+        assert_eq!(f("\"a\\\"sd\""), "a\"sd");
+        assert_eq!(f("{a\\{sd}"), "a{sd");
+
+        // Common escapes; `\0` is dropped.
+        assert_eq!(f("`a\nsd`"), "a\nsd");
+        assert_eq!(f("`a\\bsd`"), "a\u{08}sd");
+        assert_eq!(f("`a\\fsd`"), "a\u{0C}sd");
+        assert_eq!(f("`a\\rsd`"), "a\rsd");
+        assert_eq!(f("`a\\nsd`"), "a\nsd");
+        assert_eq!(f("`a\\tsd`"), "a\tsd");
+        assert_eq!(f("`a\\asd`"), "a\u{07}sd");
+        assert_eq!(f("`a\\vsd`"), "a\u{0B}sd");
+        assert_eq!(f("`a\\\\sd`"), "a\\sd");
+        assert_eq!(f("`a\\0sd`"), "asd");
+
+        // Unknown escapes keep the backslash.
+        assert_eq!(f("`a\\xsd`"), "a\\xsd");
+        assert_eq!(f("`a\\ysd`"), "a\\ysd");
+        assert_eq!(f("`a\\osd`"), "a\\osd");
+
+        // Backslash sequencing.
+        assert_eq!(f("`a\\\\nsd`"), "a\\nsd");
+        assert_eq!(f("`a\\\\n\\sd`"), "a\\n\\sd");
+        assert_eq!(f("`a\\\\n\\\\tsd`"), "a\\n\\tsd");
+
+        // Multibyte content survives the byte-level quote strip.
+        assert_eq!(f("`café`"), "café");
+        assert_eq!(f("{ünïcödé}"), "ünïcödé");
+    }
+
+    /// Mismatched quotes raise `SyntaxError`; an empty input raises
+    /// `ParsingError` (the class cpp's `parse_string_literal_text` throws).
+    #[test]
+    fn parse_string_literal_text_error_paths() {
+        let mismatched = parse_string_literal_text("`asd'").expect_err("mismatched quotes");
+        assert!(matches!(mismatched.kind, ErrorKind::Syntax));
+        assert_eq!(
+            mismatched.message,
+            "Invalid string literal, must start and end with the same quote type: `asd'"
+        );
+
+        let empty = parse_string_literal_text("").expect_err("empty input");
+        assert!(matches!(empty.kind, ErrorKind::Parsing));
+        assert_eq!(
+            empty.message,
+            "Encountered an unexpected empty string input"
+        );
+    }
 
     /// `checkpoint` + `restore` on a freshly-constructed parser must
     /// leave it indistinguishable from one constructed at the same

--- a/rust/hogql/parser/src/parse.rs
+++ b/rust/hogql/parser/src/parse.rs
@@ -1480,6 +1480,11 @@ mod tests {
         assert_eq!(f("{a{{sd}"), "a{sd");
         assert_eq!(f("{a}sd}"), "a}sd");
 
+        // Odd / long quote runs — pins str::replace against cpp's sequential replace_all.
+        assert_eq!(f("''''''"), "''");
+        assert_eq!(f("'a'''b'"), "a''b");
+        assert_eq!(f("`a```b`"), "a``b");
+
         // Backslash-escaped quotes (the lenient form the strict in-parser decoder rejects).
         assert_eq!(f("`a\\`sd`"), "a`sd");
         assert_eq!(f("'a\\'sd'"), "a'sd");

--- a/rust/hogql/parser/src/pyobject.rs
+++ b/rust/hogql/parser/src/pyobject.rs
@@ -9,13 +9,45 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 use serde_json::Value;
 
-/// Cached refs: AST module, two error classes, two StrEnum types from `_ENUM_FIELDS` in `json_ast.py`, and the `int` builtin for big-int parsing. Built once per call and reused across the walk; cheaper than `import` + `getattr` per node.
+/// Raise the matching `posthog.hogql.errors` exception for a parser error envelope, importing ONLY the errors module — error paths don't pay for the success-path converter's AST/enum imports. Mirrors `json_ast.py`'s `SyntaxError`/`ParsingError`/else mapping; shared by `Converter::build_error` and the standalone `parse_string_literal_text` entry point.
+pub(crate) fn raise_error_envelope(
+    py: Python<'_>,
+    error_type: &str,
+    message: &str,
+    start: Option<u64>,
+    end: Option<u64>,
+) -> PyErr {
+    let errors_module = match py.import_bound("posthog.hogql.errors") {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+    let cls_name = match error_type {
+        "SyntaxError" => "SyntaxError",
+        "ParsingError" => "ParsingError",
+        _ => "ExposedHogQLError",
+    };
+    let cls = match errors_module.getattr(cls_name) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    let kwargs = PyDict::new_bound(py);
+    if let Err(e) = kwargs.set_item("start", start) {
+        return e;
+    }
+    if let Err(e) = kwargs.set_item("end", end) {
+        return e;
+    }
+    let args = PyTuple::new_bound(py, [message]);
+    match cls.call(&args, Some(&kwargs)) {
+        Ok(exc) => PyErr::from_value_bound(exc),
+        Err(e) => e,
+    }
+}
+
+/// Cached refs: AST module, two StrEnum types from `_ENUM_FIELDS` in `json_ast.py`, and the `int` builtin for big-int parsing. Built once per call and reused across the walk; cheaper than `import` + `getattr` per node.
 pub struct Converter<'py> {
     py: Python<'py>,
     ast_module: Bound<'py, PyModule>,
-    exposed_error: Bound<'py, PyAny>,
-    syntax_error: Bound<'py, PyAny>,
-    parsing_error: Bound<'py, PyAny>,
     arith_op_enum: Bound<'py, PyAny>,
     compare_op_enum: Bound<'py, PyAny>,
     /// Python builtin `int` class. Mirrors `PyEmitter::cls_int`; cached so big-int literals don't pay `py.eval_bound("int", ...)` per call.
@@ -25,19 +57,12 @@ pub struct Converter<'py> {
 impl<'py> Converter<'py> {
     pub fn new(py: Python<'py>) -> PyResult<Self> {
         let ast_module = py.import_bound("posthog.hogql.ast")?;
-        let errors_module = py.import_bound("posthog.hogql.errors")?;
-        let exposed_error = errors_module.getattr("ExposedHogQLError")?;
-        let syntax_error = errors_module.getattr("SyntaxError")?;
-        let parsing_error = errors_module.getattr("ParsingError")?;
         let arith_op_enum = ast_module.getattr("ArithmeticOperationOp")?;
         let compare_op_enum = ast_module.getattr("CompareOperationOp")?;
         let cls_int = py.import_bound("builtins")?.getattr("int")?;
         Ok(Self {
             py,
             ast_module,
-            exposed_error,
-            syntax_error,
-            parsing_error,
             arith_op_enum,
             compare_op_enum,
             cls_int,
@@ -211,25 +236,7 @@ impl<'py> Converter<'py> {
             .get("end")
             .and_then(|v| v.get("offset"))
             .and_then(Value::as_u64);
-
-        let cls = match error_type {
-            "SyntaxError" => &self.syntax_error,
-            "ParsingError" => &self.parsing_error,
-            _ => &self.exposed_error,
-        };
-
-        let kwargs = PyDict::new_bound(self.py);
-        if let Err(e) = kwargs.set_item("start", start) {
-            return e;
-        }
-        if let Err(e) = kwargs.set_item("end", end) {
-            return e;
-        }
-        let args = PyTuple::new_bound(self.py, [message]);
-        match cls.call(&args, Some(&kwargs)) {
-            Ok(exc) => PyErr::from_value_bound(exc),
-            Err(e) => e,
-        }
+        raise_error_envelope(self.py, error_type, message, start, end)
     }
 
     /// Build a Python `int` from an integer literal in the lossless-string envelope (decimal or `0x…` hex, optional leading `-`). Rust can't natively represent arbitrary-precision ints, so we hand the raw digits to Python's `int(text, base)` constructor via the cached `cls_int`.

--- a/rust/hogql/parser/src/pyobject.rs
+++ b/rust/hogql/parser/src/pyobject.rs
@@ -15,6 +15,7 @@ pub struct Converter<'py> {
     ast_module: Bound<'py, PyModule>,
     exposed_error: Bound<'py, PyAny>,
     syntax_error: Bound<'py, PyAny>,
+    parsing_error: Bound<'py, PyAny>,
     arith_op_enum: Bound<'py, PyAny>,
     compare_op_enum: Bound<'py, PyAny>,
     /// Python builtin `int` class. Mirrors `PyEmitter::cls_int`; cached so big-int literals don't pay `py.eval_bound("int", ...)` per call.
@@ -27,6 +28,7 @@ impl<'py> Converter<'py> {
         let errors_module = py.import_bound("posthog.hogql.errors")?;
         let exposed_error = errors_module.getattr("ExposedHogQLError")?;
         let syntax_error = errors_module.getattr("SyntaxError")?;
+        let parsing_error = errors_module.getattr("ParsingError")?;
         let arith_op_enum = ast_module.getattr("ArithmeticOperationOp")?;
         let compare_op_enum = ast_module.getattr("CompareOperationOp")?;
         let cls_int = py.import_bound("builtins")?.getattr("int")?;
@@ -35,13 +37,14 @@ impl<'py> Converter<'py> {
             ast_module,
             exposed_error,
             syntax_error,
+            parsing_error,
             arith_op_enum,
             compare_op_enum,
             cls_int,
         })
     }
 
-    /// Top-level entry: convert the root `Value` to a Python AST instance. Raises `ExposedHogQLError` / `SyntaxError` if the parser returned an error envelope.
+    /// Top-level entry: convert the root `Value` to a Python AST instance. Raises `ExposedHogQLError` / `SyntaxError` / `ParsingError` if the parser returned an error envelope.
     pub fn convert_root(&self, value: &Value) -> PyResult<PyObject> {
         self.convert(value)
     }
@@ -211,6 +214,7 @@ impl<'py> Converter<'py> {
 
         let cls = match error_type {
             "SyntaxError" => &self.syntax_error,
+            "ParsingError" => &self.parsing_error,
             _ => &self.exposed_error,
         };
 

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.97"
+version = "1.3.98"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/91/a927bd361bc5a7d21aba307856bb3e6637d580debd3a6f6f3adc8992b127/hogql_parser_rs-1.3.97.tar.gz", hash = "sha256:0bc3747fc559e7f539924a02d763971958099ce673cb428481a6fc4d706f88e6", size = 301791, upload-time = "2026-06-22T17:52:05.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/a1/4ebd21d693fd9013ab3305b85a0b98b6fc63f22178696293fb83c64e6898/hogql_parser_rs-1.3.98.tar.gz", hash = "sha256:a782ca4f73caa8c89a38a91e69353f3061361933fe041d2475593d948b588f71", size = 301132, upload-time = "2026-06-23T16:08:33.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/32/08e62a4a288a15b1b82e09b9f54929d526fac522c73f7ce484d34038c9ff/hogql_parser_rs-1.3.97-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:15b0422327698101ffd4da48eb4774f9b3143c76a84cbb3eb9d68d16e6b43c0c", size = 742549, upload-time = "2026-06-22T17:51:56.646Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/8b/2a7b439b667b4463d86aa39e15e491aa3968f97ae99f1fc5c41fc6e022a2/hogql_parser_rs-1.3.97-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9efd855cff70740ccb9ccf23e921af5fc619b4725b37763250be014807b01e95", size = 699099, upload-time = "2026-06-22T17:51:58.08Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/60/40cc24df4c1ab2f6a7ae32cc5af3758fc46383486f57acabec1817c400e9/hogql_parser_rs-1.3.97-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f36674c6b0b6e5969960f6e988e118eb813cacc56655497780823b07c433c6f7", size = 2502929, upload-time = "2026-06-22T17:51:59.461Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/66/83aec226190c7cbc6ef858857fa1ebbce9d1e99b8147eea1eb7083528b91/hogql_parser_rs-1.3.97-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d353bd8e1e0d9c2e4c628d30f453a242cc8bd65639aa8cda5c6fbaee02364a6a", size = 2764027, upload-time = "2026-06-22T17:52:01.023Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/bd/5611ec7523f6fa6a79923db219c37324e5fbbe485834e8e15527c93d4eca/hogql_parser_rs-1.3.97-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2e733b1987ac6c7655ddaee96e2783b60605ec223353429545f4d9542e277843", size = 2676594, upload-time = "2026-06-22T17:52:02.406Z" },
-    { url = "https://files.pythonhosted.org/packages/95/20/8ced46dc146902886a44a43006cff541af313fed39a7c347dd58f7451e38/hogql_parser_rs-1.3.97-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8487bcc638f069dea3f7c3ac3b7ec0eb13dd7acb7a0d8a981efe344ceef737ec", size = 2726070, upload-time = "2026-06-22T17:52:04.076Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c2/f86f0bd8dab9527e12b15d133dbda5dad84d6736d6f22ccb9ee225598ac1/hogql_parser_rs-1.3.98-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6bcc53014886153dce8c47d957116bfd937114336552301b565ad49b709ab3f9", size = 743068, upload-time = "2026-06-23T16:08:22.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fd/7f6986913d82ed3a591f12b832bc4320320fe549fc54a9f4b1baf8213d54/hogql_parser_rs-1.3.98-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:47e3634add58f229fbbd04c946eb0adf16cc3e756a22cd4d58c1de07c1384926", size = 699518, upload-time = "2026-06-23T16:08:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a5/48218de412e8411e1f9a4f5358d1358cac3bea0ef6d425e66a6523665f95/hogql_parser_rs-1.3.98-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a026fc8dca5c4aeb5e50ed390176cfb1bd84095e1920f966ca82a0d96bc42566", size = 2504289, upload-time = "2026-06-23T16:08:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/db/dc/2385dd3ccc0f9b7dc6167b03f36f81e17a4a70af35a7e3497a5fff576901/hogql_parser_rs-1.3.98-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f39bbb3256eb5de28c818f045b99c62677fba130250ee1787490c255e0565bc", size = 2765410, upload-time = "2026-06-23T16:08:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/25/43/a8379d3f28f31e45adaf635958fd438c90b472e1a73f84ca529bf680eb39/hogql_parser_rs-1.3.98-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:639ad9a85c03876ae36389e89ddb58452fe4589b8a1968d768d9da57b9e37c30", size = 2677381, upload-time = "2026-06-23T16:08:29.872Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1f/5ce9d5c855b50bad8741af6ad7cf47d48afa178045c6a6e0f1cb895905b4/hogql_parser_rs-1.3.98-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b827e4d842558b12dbbd86541480989dc461444305962a92647db25a3348f3a3", size = 2727400, upload-time = "2026-06-23T16:08:31.848Z" },
 ]
 
 [[package]]
@@ -5865,7 +5865,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.97" },
+    { name = "hogql-parser-rs", specifier = "==1.3.98" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.98"
+version = "1.3.99"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/a1/4ebd21d693fd9013ab3305b85a0b98b6fc63f22178696293fb83c64e6898/hogql_parser_rs-1.3.98.tar.gz", hash = "sha256:a782ca4f73caa8c89a38a91e69353f3061361933fe041d2475593d948b588f71", size = 301132, upload-time = "2026-06-23T16:08:33.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/89/3724e75e34ebcf5309f05ff3d2dd8f85ef84bbc21bd385f98f16689c9ae3/hogql_parser_rs-1.3.99.tar.gz", hash = "sha256:aaf8cbbf3d9e77706b3c8b35f016a3b39da6529f8172b1dccc5a7ed6b5489728", size = 301257, upload-time = "2026-06-23T16:17:47.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/c2/f86f0bd8dab9527e12b15d133dbda5dad84d6736d6f22ccb9ee225598ac1/hogql_parser_rs-1.3.98-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6bcc53014886153dce8c47d957116bfd937114336552301b565ad49b709ab3f9", size = 743068, upload-time = "2026-06-23T16:08:22.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/fd/7f6986913d82ed3a591f12b832bc4320320fe549fc54a9f4b1baf8213d54/hogql_parser_rs-1.3.98-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:47e3634add58f229fbbd04c946eb0adf16cc3e756a22cd4d58c1de07c1384926", size = 699518, upload-time = "2026-06-23T16:08:24.757Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a5/48218de412e8411e1f9a4f5358d1358cac3bea0ef6d425e66a6523665f95/hogql_parser_rs-1.3.98-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a026fc8dca5c4aeb5e50ed390176cfb1bd84095e1920f966ca82a0d96bc42566", size = 2504289, upload-time = "2026-06-23T16:08:26.294Z" },
-    { url = "https://files.pythonhosted.org/packages/db/dc/2385dd3ccc0f9b7dc6167b03f36f81e17a4a70af35a7e3497a5fff576901/hogql_parser_rs-1.3.98-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f39bbb3256eb5de28c818f045b99c62677fba130250ee1787490c255e0565bc", size = 2765410, upload-time = "2026-06-23T16:08:28.062Z" },
-    { url = "https://files.pythonhosted.org/packages/25/43/a8379d3f28f31e45adaf635958fd438c90b472e1a73f84ca529bf680eb39/hogql_parser_rs-1.3.98-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:639ad9a85c03876ae36389e89ddb58452fe4589b8a1968d768d9da57b9e37c30", size = 2677381, upload-time = "2026-06-23T16:08:29.872Z" },
-    { url = "https://files.pythonhosted.org/packages/29/1f/5ce9d5c855b50bad8741af6ad7cf47d48afa178045c6a6e0f1cb895905b4/hogql_parser_rs-1.3.98-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b827e4d842558b12dbbd86541480989dc461444305962a92647db25a3348f3a3", size = 2727400, upload-time = "2026-06-23T16:08:31.848Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/7d4d58eea85de62802baaeb32c36b3c6c759966d6bf7d86a7cd0592e19c3/hogql_parser_rs-1.3.99-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:03bc570d3febd063e13619f69630f1ca979a4eeb65648611b0a0636db500fd0a", size = 741679, upload-time = "2026-06-23T16:17:36.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/79/ff03eb9dbc1a49eb1ce9798e357d6c70756965d53ab7c0f281871020d7c9/hogql_parser_rs-1.3.99-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:27790a9533636a0cbe00edc62ac1df882a08f503ea35ce01f519a76a7738ad6c", size = 698323, upload-time = "2026-06-23T16:17:37.838Z" },
+    { url = "https://files.pythonhosted.org/packages/60/16/4bd3ef88afdfc9eab8fdb0f50d3f5c28f74c0de034513005aa9dea1be120/hogql_parser_rs-1.3.99-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:211db8cdc9b996b85f945a92ccc2716f4ae39d4bcce4c3b80d76b4a8ddd9ec3b", size = 2501932, upload-time = "2026-06-23T16:17:40.181Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a5/6c26c5af1d47e9be5077149bbf5d67d3d80ea23e766018164b87d9a89353/hogql_parser_rs-1.3.99-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8639d89da19b8760e5b89a79ac4b37d52272f45d61c5b7f78f65cecf171f275", size = 2763536, upload-time = "2026-06-23T16:17:42.159Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/38/154333afcab0b24ff9c34e6058ad3d208daa2c9749f463dac8f036cb0f90/hogql_parser_rs-1.3.99-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:334a43a4dd4488e578efa7fc79198399acc8eca8d20b736788eb291108d5888c", size = 2675863, upload-time = "2026-06-23T16:17:43.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a6/e984a79999a15dedb70140ba72a658863927d239bc94052c468656fa1254/hogql_parser_rs-1.3.99-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0b2f18f897dfd0467980e4e21a5889ccf727fa24d9ec10d8995e280151f16284", size = 2725837, upload-time = "2026-06-23T16:17:45.703Z" },
 ]
 
 [[package]]
@@ -5865,7 +5865,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.98" },
+    { name = "hogql-parser-rs", specifier = "==1.3.99" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-15T10:42:02.393902Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.96"
+version = "1.3.97"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/60/cac3721a48f28bdfa77db1db58648fb1549403d7046049d1cdc824996103/hogql_parser_rs-1.3.96.tar.gz", hash = "sha256:3816a9cf46402613de5f091cacb53bd7ef47ef75a07b3883a8cf751ba8205b96", size = 299083, upload-time = "2026-06-19T14:47:07.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/91/a927bd361bc5a7d21aba307856bb3e6637d580debd3a6f6f3adc8992b127/hogql_parser_rs-1.3.97.tar.gz", hash = "sha256:0bc3747fc559e7f539924a02d763971958099ce673cb428481a6fc4d706f88e6", size = 301791, upload-time = "2026-06-22T17:52:05.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/2d/a61b36fc1182663666a61852f5707407a66a1098d646aff32cb823b0abec/hogql_parser_rs-1.3.96-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:54a3fde8bff8b7520fd6d694ad3d7b0f2a9fbf31b011138d0a792e1d11f6a8b4", size = 737814, upload-time = "2026-06-19T14:46:58.479Z" },
-    { url = "https://files.pythonhosted.org/packages/24/2f/20bce1c5e9f36d7ef091c68ec336f378c9642649d0ffde4fa4ddd270b44d/hogql_parser_rs-1.3.96-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:71532f82f48346a214eab561aa507a9af141dac4c58197bdddbb8026f555f353", size = 691868, upload-time = "2026-06-19T14:47:00.141Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4d/e6e2d27d36faf02716137e74345900890d1214f5780435870d7d46d0e1f8/hogql_parser_rs-1.3.96-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9d20d0b614b73755c7ab371dd0cb35880dff6aa1760ba02f22aebf31d629306a", size = 2491584, upload-time = "2026-06-19T14:47:01.56Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/85/93deb3367b6ed59eedb4df973c4d896643af221c061a508c8e1336923c4d/hogql_parser_rs-1.3.96-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1506600700ea429cd143bfdfe1202f9a2a9125ac07b7dbe396bba30751bdde36", size = 2755411, upload-time = "2026-06-19T14:47:02.955Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ff/f0964b0dc341e8e0b07c7b27e79cc87da0c411b837bad1bf756f173d8dc7/hogql_parser_rs-1.3.96-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e4616e02a46c607855c62ba91c76fb7a2201b3b478aa745c47b0f805a7b60fdf", size = 2663214, upload-time = "2026-06-19T14:47:04.623Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/9d/9f48796c76ad3e6ad5beb97d36e558f1ccb10196730ddbd6c41d9975c0e3/hogql_parser_rs-1.3.96-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80db7f3ccb2d55fa748c6f12400c9f1c11aabc835aa4ec330332e630e32a71c1", size = 2714547, upload-time = "2026-06-19T14:47:06.476Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/08e62a4a288a15b1b82e09b9f54929d526fac522c73f7ce484d34038c9ff/hogql_parser_rs-1.3.97-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:15b0422327698101ffd4da48eb4774f9b3143c76a84cbb3eb9d68d16e6b43c0c", size = 742549, upload-time = "2026-06-22T17:51:56.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/2a7b439b667b4463d86aa39e15e491aa3968f97ae99f1fc5c41fc6e022a2/hogql_parser_rs-1.3.97-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9efd855cff70740ccb9ccf23e921af5fc619b4725b37763250be014807b01e95", size = 699099, upload-time = "2026-06-22T17:51:58.08Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/60/40cc24df4c1ab2f6a7ae32cc5af3758fc46383486f57acabec1817c400e9/hogql_parser_rs-1.3.97-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f36674c6b0b6e5969960f6e988e118eb813cacc56655497780823b07c433c6f7", size = 2502929, upload-time = "2026-06-22T17:51:59.461Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/83aec226190c7cbc6ef858857fa1ebbce9d1e99b8147eea1eb7083528b91/hogql_parser_rs-1.3.97-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d353bd8e1e0d9c2e4c628d30f453a242cc8bd65639aa8cda5c6fbaee02364a6a", size = 2764027, upload-time = "2026-06-22T17:52:01.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/bd/5611ec7523f6fa6a79923db219c37324e5fbbe485834e8e15527c93d4eca/hogql_parser_rs-1.3.97-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2e733b1987ac6c7655ddaee96e2783b60605ec223353429545f4d9542e277843", size = 2676594, upload-time = "2026-06-22T17:52:02.406Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/8ced46dc146902886a44a43006cff541af313fed39a7c347dd58f7451e38/hogql_parser_rs-1.3.97-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8487bcc638f069dea3f7c3ac3b7ec0eb13dd7acb7a0d8a981efe344ceef737ec", size = 2726070, upload-time = "2026-06-22T17:52:04.076Z" },
 ]
 
 [[package]]
@@ -5865,7 +5865,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.96" },
+    { name = "hogql-parser-rs", specifier = "==1.3.97" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },


### PR DESCRIPTION
## Problem

The HogQL parser ships two backends with near-identical Python APIs: the C++ wheel (`hogql_parser`) and the Rust wheel (`hogql_parser_rs`). The Rust wheel was missing exactly one function the C++ wheel exposes: `parse_string_literal_text`. Without it, Python callers that just need to unquote a string literal or identifier had to round-trip through `parse_expr(...).value`. As the project moves to Rust as the default parser (keeping C++ only as the reference oracle), this was the last API-parity gap.

## Changes

- **New `parse_string_literal_text` PyO3 entry point** on `hogql_parser_rs` — a byte-for-byte twin of the C++ `parse_string_literal_text` in `common/hogql_parser/string.cpp`.
- The decoder is a **new standalone function**, deliberately not built on the strict in-parser `decode_quoted_body`. The standalone unquoter is more lenient: it handles all four quote types (`'…'`, `"…"`, `` `…` ``, `{…}`) and accepts **both** the doubled-quote and backslash-escaped-quote forms, whereas the in-parser path rejects e.g. a backslash-escaped backtick.
- **Errors** route through a shared `raise_error_envelope` helper that imports only `posthog.hogql.errors`: mismatched quotes raise `SyntaxError`, empty input raises `ParsingError`, matching the classes the C++ wheel raises. The same helper backs the existing AST error path, so the error type→class mapping lives in one place. (The C++ *wheel* actually aborts the process on empty input — an uncaught C++ exception — so the Rust path is strictly safer there while still raising the class the C++ *function* declares.)
- The entry point is wrapped in `catch_unwind` like every other PyO3 entry point, so a future panic in the decoder surfaces as the parser's `NotImplementedError` envelope rather than crossing the FFI boundary as a `PanicException`.
- **Parser-parity tooling:** added a `string_literal` rule to the PBT grind (`posthog/hogql/scripts/pbt_diagnostic.py`) that fuzzes the C++ and Rust unquoters for byte-for-byte parity — a 200k-example run found zero divergences. Also dropped `django.setup()` from the diagnostic, since the parser core only needs `settings.TEST`, not the Django app registry (setup() was running every app's `ready()` hook — DB/redis/self-capture init — just to fuzz a parser).
- **Tests:** extended the cross-backend parity factory to cover the Rust function (including odd/long quote-run cases that pin the sequential-replace semantics), added a Rust-only Python-level test asserting `ParsingError` on empty input (the one case the twins can't share in the factory), and added DB-free Rust unit tests in `parse.rs`.
- **Version bump** `hogql-parser-rs` → 1.3.99 (`Cargo.toml`, the wheel's `pyproject.toml`, `Cargo.lock`, root `pyproject.toml` pin) so CI builds and publishes the new wheel; `uv.lock` is left for CI's commit-pin step.

## How did you test this code?

I'm an agent. Automated checks I ran locally:

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (20 passing, including parity + error-path tests) on the parser crate.
- Built the wheel with `maturin develop --release` and verified the Python boundary: valid decodes across all four quote types / escape forms match `hogql_parser.parse_string_literal_text` byte-for-byte; mismatched quotes raise `SyntaxError`; empty input raises `posthog.hogql.errors.ParsingError`; and the shared AST error path (`parse_expr_py` on bad input) still raises `SyntaxError`.
- The `string_literal` PBT grind at 200k examples (C++ oracle vs Rust candidate): 0 divergences.
- Ran a multi-agent self-review over the diff and addressed the actionable findings (empty-input test, odd-quote-run regression cases, `catch_unwind` guard, errors-only error path).
- `ruff check` / `ruff format --check` on the touched Python files.

The pytest parity files (`test_parse_string_{cpp,python,rust}.py`) need Postgres, which isn't available in my local env, so they run on CI. The Rust unit tests mirror the factory cases DB-free.

Note on the bump flow: the test jobs on a bump push install the **stale** wheel and fail until the publish job commit-pins the new `uv.lock` — the run on that commit-pin commit is the one that validates.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal parser API parity; no user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by Robbie.

Built with Claude Code (Opus 4.8). Key decisions:

- Wrote a fresh standalone decoder rather than reusing `decode_quoted_body` / `unquote_single_string`, because the standalone C++ function is intentionally more lenient (accepts backslash-escaped quotes and `{…}` quoting) — reusing the strict in-parser path would have diverged from the C++ twin.
- Added a `Parsing` variant to the Rust `ErrorKind` so empty input raises `posthog.hogql.errors.ParsingError`, matching the C++ function's declared throw. Additive and only reachable from the new entry point.
- Extracted error raising into a shared `raise_error_envelope` (errors-module-only), so neither the string entry point nor the AST converter imports the AST/enum machinery just to raise an exception.
- The empty-input behaviour is a deliberate, documented divergence: the C++ wheel aborts the process there, the Rust wheel raises a catchable `ParsingError`. It can't go in the shared parity factory (it would crash the C++ backend), so it's pinned by a Rust-only test.
