### PR TITLE
feat(data-warehouse): give the resync button user feedback

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -82,7 +82,7 @@ export function ConfigurationTab({
     onViewSyncHistory,
 }: ConfigurationTabProps): JSX.Element {
     const logic = schemaSceneLogic({ sourceId, schemaId: schema.id })
-    const { isProjectTime, refreshingSchemas } = useValues(logic)
+    const { isProjectTime, refreshingSchemas, resyncingSchema } = useValues(logic)
     const { setIsProjectTime, updateSchema, reloadSchema, resyncSchema, cancelSchema, deleteTable, refreshSchemas } =
         useActions(logic)
 
@@ -128,6 +128,7 @@ export function ConfigurationTab({
                     source={source}
                     schema={schema}
                     resyncSchema={resyncSchema}
+                    resyncingSchema={resyncingSchema}
                     deleteTable={deleteTable}
                 />
             )
@@ -882,11 +883,13 @@ function DangerZoneSection({
     source,
     schema,
     resyncSchema,
+    resyncingSchema,
     deleteTable,
 }: {
     source: ExternalDataSource | null
     schema: ExternalDataSourceSchema
     resyncSchema: (schema: ExternalDataSourceSchema) => void
+    resyncingSchema: boolean
     deleteTable: (schema: ExternalDataSourceSchema) => void
 }): JSX.Element {
     const hasFullCdcResync = schema.sync_type === 'cdc'
@@ -953,6 +956,7 @@ function DangerZoneSection({
                                                 secondaryButton: { children: 'Cancel', type: 'tertiary' },
                                             })
                                         }}
+                                        loading={resyncingSchema}
                                         disabledReason={disabledReason}
                                     >
                                         Full resync
@@ -965,6 +969,7 @@ function DangerZoneSection({
                                         type="secondary"
                                         status="danger"
                                         onClick={() => resyncSchema(schema)}
+                                        loading={resyncingSchema}
                                         disabledReason={disabledReason}
                                     >
                                         Delete table and resync

--- a/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.test.ts
@@ -1,0 +1,80 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+import { ExternalDataSchemaStatus, ExternalDataSchemaWithSource } from '~/types'
+
+import { schemaSceneLogic } from './schemaSceneLogic'
+
+jest.mock('lib/api')
+
+const makeSchema = (overrides: Partial<ExternalDataSchemaWithSource> = {}): ExternalDataSchemaWithSource =>
+    ({
+        id: 'schema-1',
+        name: 'public.events',
+        label: null,
+        should_sync: true,
+        incremental: true,
+        sync_type: 'incremental',
+        status: ExternalDataSchemaStatus.Completed,
+        source: { source_type: 'Postgres' },
+        ...overrides,
+    }) as ExternalDataSchemaWithSource
+
+describe('schemaSceneLogic', () => {
+    let logic: ReturnType<typeof schemaSceneLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.spyOn(api.externalDataSchemas, 'get').mockResolvedValue(makeSchema())
+
+        logic = schemaSceneLogic({ sourceId: 'source-1', schemaId: 'schema-1' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('resyncSchema toggles the loading flag around the request and resyncs by id', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        let resolveResync: (() => void) | null = null
+        const resyncSpy = jest
+            .spyOn(api.externalDataSchemas, 'resync')
+            .mockReturnValue(new Promise<void>((resolve) => (resolveResync = () => resolve())))
+
+        logic.actions.resyncSchema(makeSchema())
+        expect(logic.values.resyncingSchema).toBe(true)
+        expect(resyncSpy).toHaveBeenCalledWith('schema-1')
+
+        resolveResync!()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.resyncingSchema).toBe(false)
+    })
+
+    it('clears the loading flag even when the resync request fails', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        jest.spyOn(api.externalDataSchemas, 'resync').mockRejectedValue(new Error('boom'))
+
+        logic.actions.resyncSchema(makeSchema())
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.resyncingSchema).toBe(false)
+    })
+
+    it('optimistically marks the schema as running when a resync starts', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        // Keep the request pending so the optimistic status is observable before loadSchema refetches.
+        jest.spyOn(api.externalDataSchemas, 'resync').mockReturnValue(new Promise<void>(() => {}))
+
+        logic.actions.resyncSchema(makeSchema())
+
+        expect(logic.values.schema?.status).toBe(ExternalDataSchemaStatus.Running)
+    })
+})

--- a/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
@@ -134,6 +134,13 @@ export const schemaSceneLogic = kea<schemaSceneLogicType>([
                 refreshSchemas: () => true,
             },
         ],
+        resyncingSchema: [
+            false as boolean,
+            {
+                resyncSchema: () => true,
+                loadSchema: () => false,
+            },
+        ],
     })),
     selectors({
         schema: [(s) => [s.schemaData], (schemaData): ExternalDataSourceSchema | null => schemaData],
@@ -224,8 +231,9 @@ export const schemaSceneLogic = kea<schemaSceneLogicType>([
             try {
                 await api.externalDataSchemas.resync(schema.id)
                 posthog.capture('schema resynced', { sourceType: values.source?.source_type })
+                lemonToast.success(`Resync started for ${schema.label ?? schema.name}`)
             } catch (e: any) {
-                lemonToast.error(e?.message || 'Cant refresh schema at this time')
+                lemonToast.error(e?.message || "Couldn't start resync")
             } finally {
                 actions.loadSchema()
             }

--- a/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
@@ -66,6 +66,7 @@ export const schemaSceneLogic = kea<schemaSceneLogicType>([
         _setCurrentSection: (section: SchemaConfigurationSection) => ({ section }),
         setIsProjectTime: (isProjectTime: boolean) => ({ isProjectTime }),
         setRefreshingSchemas: (refreshing: boolean) => ({ refreshing }),
+        setResyncingSchema: (resyncing: boolean) => ({ resyncing }),
         updateSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
         reloadSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
         resyncSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
@@ -138,7 +139,7 @@ export const schemaSceneLogic = kea<schemaSceneLogicType>([
             false as boolean,
             {
                 resyncSchema: () => true,
-                loadSchema: () => false,
+                setResyncingSchema: (_, { resyncing }) => resyncing,
             },
         ],
     })),
@@ -235,6 +236,7 @@ export const schemaSceneLogic = kea<schemaSceneLogicType>([
             } catch (e: any) {
                 lemonToast.error(e?.message || "Couldn't start resync")
             } finally {
+                actions.setResyncingSchema(false)
                 actions.loadSchema()
             }
         },


### PR DESCRIPTION
## Problem

The "Delete table and resync" button in a data warehouse schema's Danger zone fired silently — no toast, no in-flight state. Users couldn't tell whether their click did anything, and the button stayed clickable mid-request (double-submit risk).

## Changes

- Success toast when a resync starts (`Resync started for <table>`), tightened the error fallback to `Couldn't start resync`.
- `loading` state on the **Delete table and resync** and **Full resync** buttons, driven by a new `resyncingSchema` flag in `schemaSceneLogic`, so they disable + spin while the request is in flight.

The schema status badge already flips to "Running" optimistically; this adds the missing confirmation and in-progress signals at the point of click.

## How did you test this code?

I'm an agent. I added `schemaSceneLogic.test.ts` covering the loading-flag toggle around the request, that it clears on failure, and the optimistic "Running" status. I could not execute the suite — this environment has no `node_modules` — so CI is the first run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, directed by Jovan. Scope was deliberately limited to feedback (toast + loading state); no confirmation dialog was added to the resync button since the ask was about post-click feedback. The `loading` flag is shared across both resync buttons, which is correct — only one resync runs per schema at a time.
