### PR TITLE
feat(inbox): gate slack notifications card behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -325,6 +325,7 @@ export const FEATURE_FLAGS = {
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
     HOGQL_INSIGHT_ALERTS: 'hogql-insight-alerts', // owner: @vdekrijger, gates alerts on SQL-backed (HogQL) insights
     IDENTITY_MATCHING: 'identity-matching', // owner: #team-growth
+    INBOX_SLACK_NOTIFICATIONS: 'inbox-slack-notifications', // owner: #team-self-driving, gates the Slack notifications config card in the inbox
     INSIGHT_ADD_TO_DASHBOARD_AAB: 'insight-add-to-dashboard-aab', // owner: @pauldambra #team-product-analytics multivariate=control,control_2,test
     INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features

--- a/frontend/src/scenes/inbox/components/config/AgentsTab.tsx
+++ b/frontend/src/scenes/inbox/components/config/AgentsTab.tsx
@@ -4,6 +4,9 @@ import { useEffect } from 'react'
 import { IconArrowLeft } from '@posthog/icons'
 import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 import { ExternalDataSourceType, SourceConfig } from '~/queries/schema/schema-general'
 
 import { availableSourcesLogic } from 'products/data_warehouse/frontend/scenes/NewSourceScene/availableSourcesLogic'
@@ -66,6 +69,7 @@ function BackLink({ onClick }: { onClick: () => void }): JSX.Element {
  */
 export function AgentsTab(): JSX.Element {
     const { sessionAnalysisSetupOpen, dataSourceSetupProduct } = useValues(signalSourcesLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const {
         loadSources,
         loadSourceConfigs,
@@ -127,12 +131,14 @@ export function AgentsTab(): JSX.Element {
                     {agentsBody}
                 </Subsection>
 
-                <Subsection
-                    title="Slack"
-                    description="Post reports to channels and ping suggested reviewers. Invite PostHog with /invite @PostHog in each channel you use."
-                >
-                    <SlackNotificationsSection />
-                </Subsection>
+                {featureFlags[FEATURE_FLAGS.INBOX_SLACK_NOTIFICATIONS] && (
+                    <Subsection
+                        title="Slack"
+                        description="Post reports to channels and ping suggested reviewers. Invite PostHog with /invite @PostHog in each channel you use."
+                    >
+                        <SlackNotificationsSection />
+                    </Subsection>
+                )}
 
                 <Subsection
                     title="Auto-start"


### PR DESCRIPTION
## Problem

The inbox Agents tab always shows the "Slack" subsection for configuring Slack notifications. We want to gate this behind a feature flag so #team-self-driving can control its rollout rather than shipping it to everyone at once.

## Changes

- Added the `inbox-slack-notifications` feature flag constant to `FEATURE_FLAGS`.
- In `AgentsTab`, the Slack `<Subsection>` (which renders `SlackNotificationsSection`) now only renders when `featureFlags[FEATURE_FLAGS.INBOX_SLACK_NOTIFICATIONS]` is on, following the existing `featureFlagLogic` pattern used elsewhere in the inbox.

The flag itself was created in the PostHog US project (rolled out to 0% initially).

## How did you test this code?

I'm an agent — I did not run the app manually. The change is a straightforward feature-flag gate following an established pattern; no automated tests were added or run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Located the Slack notifications card (`frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx`, rendered in `AgentsTab.tsx`), added a new `FEATURE_FLAGS` entry, and wrapped the Slack subsection in a flag check. No skills were required. The feature flag was created via the PostHog MCP.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782152228650369)*
