### PR TITLE
fix(google_search_console): return actionable 400 when sites listing is forbidden

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 
+import requests
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
@@ -1013,7 +1014,19 @@ class IntegrationViewSet(
             return Response(cached)
 
         session = google_search_console_session(instance.id, instance.team_id)
-        sites = list_sites(session)
+        try:
+            sites = list_sites(session)
+        except requests.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code in (401, 403):
+                # The token refreshed fine but the connected Google account isn't authorized to
+                # read Search Console — a customer-side connection issue, not a PostHog bug. Return
+                # an actionable 400 rather than letting the HTTPError surface as an unhandled 500.
+                raise ValidationError(
+                    "Google Search Console rejected the credentials. Please reconnect your account "
+                    "and ensure it has read access to the property."
+                )
+            raise
         response_data = {"sites": sites}
         cache.set(cache_key, response_data, GSC_AUTOCOMPLETE_CACHE_TTL_SECONDS)
         return Response(response_data)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3773,20 +3773,21 @@ class TestGoogleSearchConsoleSitesEndpoint:
         response.status_code = status_code
         return requests.HTTPError(f"{status_code} Client Error", response=response)
 
-    @parameterized.expand([("forbidden", 403), ("unauthorized", 401)])
     @patch(_LIST_SITES_PATH)
     @patch(_SESSION_PATH)
-    def test_auth_error_returns_actionable_400(
-        self, _name, status_code, mock_session, mock_list_sites, client: HttpClient
-    ):
+    def test_auth_error_returns_actionable_400(self, mock_session, mock_list_sites, client: HttpClient):
+        # 401 and 403 both mean the connected account can't read Search Console — the endpoint should
+        # turn either into an actionable 400 rather than letting it surface as an unhandled 500.
         integration = self._create_gsc_integration()
-        mock_list_sites.side_effect = self._http_error(status_code)
-
         client.force_login(self.user)
-        response = client.get(self._url(integration.id))
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
-        assert "reconnect your account" in str(response.json()).lower()
+        for status_code in (401, 403):
+            mock_list_sites.side_effect = self._http_error(status_code)
+
+            response = client.get(self._url(integration.id))
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+            assert "reconnect your account" in str(response.json()).lower()
 
     @patch(_LIST_SITES_PATH)
     @patch(_SESSION_PATH)
@@ -3803,9 +3804,12 @@ class TestGoogleSearchConsoleSitesEndpoint:
     @patch(_LIST_SITES_PATH)
     @patch(_SESSION_PATH)
     def test_non_auth_http_error_is_not_swallowed(self, mock_session, mock_list_sites, client: HttpClient):
+        # Only 401/403 are converted to a 400 — any other status keeps surfacing as a server error so
+        # a genuine bug isn't masked by the auth handling.
         integration = self._create_gsc_integration()
         mock_list_sites.side_effect = self._http_error(500)
 
         client.force_login(self.user)
-        with pytest.raises(requests.HTTPError):
-            client.get(self._url(integration.id))
+        response = client.get(self._url(integration.id))
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, response.content

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -15,6 +15,7 @@ from django.core.cache import cache
 from django.test.client import Client as HttpClient
 from django.utils import timezone
 
+import requests
 from parameterized import parameterized
 from rest_framework import status
 
@@ -3735,3 +3736,76 @@ class TestIntegrationRequestAccessAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         mock_task.delay.assert_not_called()
         mock_report.assert_not_called()
+
+
+class TestGoogleSearchConsoleSitesEndpoint:
+    _SESSION_PATH = (
+        "posthog.temporal.data_imports.sources.google_search_console."
+        "google_search_console.google_search_console_session"
+    )
+    _LIST_SITES_PATH = "posthog.temporal.data_imports.sources.google_search_console.google_search_console.list_sites"
+
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "gsc@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+
+    def _create_gsc_integration(self) -> Integration:
+        # No refresh_token → `_ensure_oauth_token_valid` treats the access token as valid and skips refresh.
+        return Integration.objects.create(
+            team=self.team,
+            kind="google-search-console",
+            config={},
+            sensitive_config={"access_token": "ya29.test"},
+            integration_id="gsc_test",
+            created_by=self.user,
+        )
+
+    def _url(self, integration_id: int) -> str:
+        return f"/api/environments/{self.team.pk}/integrations/{integration_id}/google_search_console_sites/"
+
+    @staticmethod
+    def _http_error(status_code: int) -> requests.HTTPError:
+        response = requests.Response()
+        response.status_code = status_code
+        return requests.HTTPError(f"{status_code} Client Error", response=response)
+
+    @parameterized.expand([("forbidden", 403), ("unauthorized", 401)])
+    @patch(_LIST_SITES_PATH)
+    @patch(_SESSION_PATH)
+    def test_auth_error_returns_actionable_400(
+        self, _name, status_code, mock_session, mock_list_sites, client: HttpClient
+    ):
+        integration = self._create_gsc_integration()
+        mock_list_sites.side_effect = self._http_error(status_code)
+
+        client.force_login(self.user)
+        response = client.get(self._url(integration.id))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "reconnect your account" in str(response.json()).lower()
+
+    @patch(_LIST_SITES_PATH)
+    @patch(_SESSION_PATH)
+    def test_success_returns_sites(self, mock_session, mock_list_sites, client: HttpClient):
+        integration = self._create_gsc_integration()
+        mock_list_sites.return_value = [{"siteUrl": "https://example.com/", "permissionLevel": "siteOwner"}]
+
+        client.force_login(self.user)
+        response = client.get(self._url(integration.id))
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["sites"] == [{"siteUrl": "https://example.com/", "permissionLevel": "siteOwner"}]
+
+    @patch(_LIST_SITES_PATH)
+    @patch(_SESSION_PATH)
+    def test_non_auth_http_error_is_not_swallowed(self, mock_session, mock_list_sites, client: HttpClient):
+        integration = self._create_gsc_integration()
+        mock_list_sites.side_effect = self._http_error(500)
+
+        client.force_login(self.user)
+        with pytest.raises(requests.HTTPError):
+            client.get(self._url(integration.id))


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` — `403 Client Error: Forbidden for url: https://searchconsole.googleapis.com/webmasters/v3/sites` ([issue](https://us.posthog.com/project/2/error_tracking/019ef08b-3025-7b42-9f29-13dee0f84bb6)).

The exception type and message point at the `google_search_console` import source, but the stack trace tells a different story. The failure does **not** come from the Temporal import pipeline — it originates in the integration setup autocomplete endpoint:

```
posthog/api/integration.py  →  google_search_console_sites   (line 1015)
posthog/temporal/.../google_search_console.py  →  list_sites  (line 171, raise_for_status)
```

The `$current_url` is `/api/projects/@current/integrations/<id>/google_search_console_sites/` — the GET that populates the property dropdown when a user connects Search Console. `list_sites` is a shared helper, so the source-module frame shows up, but the real gap is in the API endpoint.

When the connected Google account refreshes its token fine but isn't authorized to read Search Console (no access granted, scope missing, or the property isn't visible), the `403` bubbles out of `list_sites` as an unhandled `HTTPError`, returning a 500 to the frontend and logging an error-tracking event for what is a customer-side connection issue.

Two notes on why this isn't a `NonRetryableErrors` change:

- `get_non_retryable_errors` is only consulted by the import pipeline's retry handler. This error never flows through that path, so adding a string there would have no effect.
- The import pipeline already treats `403 Client Error` as non-retryable, and `validate_credentials` already maps 401/403 to a friendly reconnect message. The setup endpoint was the one caller doing neither.

## Changes

`google_search_console_sites` now catches `requests.HTTPError`. For 401/403 it raises a `ValidationError` (400) with an actionable reconnect message, matching the wording already used in `validate_credentials`. Any other HTTP status still propagates untouched, so genuine/unexpected failures stay visible in error tracking.

This turns a noisy 500 into a clean, actionable 400. The frontend (`googleSearchConsoleIntegrationLogic`) already treats any non-2xx as a load failure, so behavior there is unchanged aside from no longer triggering a server error.

## How did you test this code?

I'm an agent. I added automated tests in `posthog/api/test/test_integration.py` (`TestGoogleSearchConsoleSitesEndpoint`):

- 401 and 403 from `list_sites` → endpoint returns 400 with the reconnect message (parameterized).
- success path → 200 with the sites payload.
- a non-auth (500) `HTTPError` is **not** swallowed — it still propagates.

I could not execute the DB-backed tests in this sandbox (no Postgres reachable), but verified they collect cleanly with `pytest --collect-only`. They need a database to run in CI.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, which is what revealed the failure was in the API endpoint rather than the import pipeline. Invoked the `/improving-drf-endpoints` skill before touching the viewset.

Decision: not a `NonRetryableErrors` case (wrong code path — that map only governs the import retry handler, and the pipeline already handles 403 there). Scoped the fix to the one caller missing graceful auth handling, and deliberately kept non-auth HTTP errors propagating so the change can't mask a real bug.
