### PR TITLE
fix(security): surface command_execution audit logs above SDK warning ceiling

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -65,7 +65,6 @@ structlog.configure(
     cache_logger_on_first_use=True,
 )
 
-
 # Configure all logs to be handled by structlog `ProcessorFormatter` and
 # rendered either as pretty colored console lines or as single JSON lines.
 LOGGING = {
@@ -115,6 +114,7 @@ LOGGING = {
         "posthog.tasks.hypercache_verification": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.storage.hypercache_verifier": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.auth.mfa": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        "posthog.security.command_exec_audit": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.temporal.data_imports.pipelines.pipeline_v3.load": {
             "level": "DEBUG",
             "handlers": ["console"],


### PR DESCRIPTION
## Problem

Command execution audit logs were being dropped because the entire `posthog.*` logger namespace is pinned to `Warning`.

## Changes

Added a custom configuration for `posthog.security.command_exec_audit` to avoid dropping `INFO` logs.

## How did you test this code?

Manually tested locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
