### PR TITLE
fix(experiments): enforce conclusion_comment max length server-side

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -178,6 +178,7 @@ class ExperimentBaseSerializer(UserAccessControlSerializerMixin, serializers.Mod
         help_text="Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.",
     )
     conclusion_comment = serializers.CharField(
+        max_length=400,
         required=False,
         allow_null=True,
         allow_blank=True,
@@ -619,6 +620,7 @@ class EndExperimentSerializer(serializers.Serializer):
         help_text="The conclusion of the experiment.",
     )
     conclusion_comment = serializers.CharField(
+        max_length=400,
         required=False,
         allow_null=True,
         allow_blank=True,

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -576,6 +576,27 @@ class TestExperimentCRUD(APILicensedTest):
         assert experiment.end_date is not None
         self.assertEqual(experiment.end_date.strftime("%Y-%m-%dT%H:%M"), end_date)
 
+    @parameterized.expand(
+        [
+            ("at_limit", 400, status.HTTP_200_OK),
+            ("over_limit", 401, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_conclusion_comment_enforces_max_length(self, _name: str, length: int, expected_status: int) -> None:
+        experiment = Experiment.objects.create(team=self.team, name="Test Experiment", created_by=self.user)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment.id}",
+            {"conclusion": "won", "conclusion_comment": "a" * length},
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+        experiment.refresh_from_db()
+        if expected_status == status.HTTP_200_OK:
+            self.assertEqual(experiment.conclusion_comment, "a" * length)
+        else:
+            self.assertIsNone(experiment.conclusion_comment)
+
     @patch("products.experiments.backend.experiment_service.report_user_action")
     def test_creating_experiment_reports_user_action(self, mock_report_user_action):
         ff_key = "tracked-experiment"

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -385,6 +385,7 @@ export interface ExperimentBasicApi {
     conclusion?: ConclusionEnumApi | null
     /**
      * Comment about the experiment conclusion.
+     * @maxLength 400
      * @nullable
      */
     conclusion_comment?: string | null
@@ -708,6 +709,7 @@ export interface ExperimentApi {
     conclusion?: ConclusionEnumApi | null
     /**
      * Comment about the experiment conclusion.
+     * @maxLength 400
      * @nullable
      */
     conclusion_comment?: string | null
@@ -808,6 +810,7 @@ export interface PatchedExperimentApi {
     conclusion?: ConclusionEnumApi | null
     /**
      * Comment about the experiment conclusion.
+     * @maxLength 400
      * @nullable
      */
     conclusion_comment?: string | null
@@ -847,6 +850,7 @@ export interface EndExperimentApi {
     conclusion?: ConclusionEnumApi | null
     /**
      * Optional comment about the experiment conclusion.
+     * @maxLength 400
      * @nullable
      */
     conclusion_comment?: string | null
@@ -1027,6 +1031,7 @@ export interface ShipVariantApi {
     conclusion?: ConclusionEnumApi | null
     /**
      * Optional comment about the experiment conclusion.
+     * @maxLength 400
      * @nullable
      */
     conclusion_comment?: string | null

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -193,6 +193,8 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
  *
  * Returns 400 if the experiment is not running.
  */
+export const experimentsEndCreateBodyConclusionCommentMax = 400
+
 export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
     conclusion: zod
         .union([
@@ -207,7 +209,11 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'The conclusion of the experiment.\n\n\* `won` - won\n\* `lost` - lost\n\* `inconclusive` - inconclusive\n\* `stopped_early` - stopped_early\n\* `invalid` - invalid'
         ),
-    conclusion_comment: zod.string().nullish().describe('Optional comment about the experiment conclusion.'),
+    conclusion_comment: zod
+        .string()
+        .max(experimentsEndCreateBodyConclusionCommentMax)
+        .nullish()
+        .describe('Optional comment about the experiment conclusion.'),
 })
 
 /**
@@ -277,6 +283,8 @@ export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
  * Returns 400 if the experiment is in draft state, the variant_key is not found
  * on the flag, or the experiment has no linked feature flag.
  */
+export const experimentsShipVariantCreateBodyConclusionCommentMax = 400
+
 export const experimentsShipVariantCreateBodyReleaseToEveryoneDefault = false
 
 export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
@@ -293,7 +301,11 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'The conclusion of the experiment.\n\n\* `won` - won\n\* `lost` - lost\n\* `inconclusive` - inconclusive\n\* `stopped_early` - stopped_early\n\* `invalid` - invalid'
         ),
-    conclusion_comment: zod.string().nullish().describe('Optional comment about the experiment conclusion.'),
+    conclusion_comment: zod
+        .string()
+        .max(experimentsShipVariantCreateBodyConclusionCommentMax)
+        .nullish()
+        .describe('Optional comment about the experiment conclusion.'),
     variant_key: zod.string().describe('The key of the variant to ship.'),
     release_to_everyone: zod
         .boolean()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17760,6 +17760,7 @@ export namespace Schemas {
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
+         * @maxLength 400
          * @nullable
          */
       conclusion_comment?: string | null;
@@ -20547,6 +20548,7 @@ export namespace Schemas {
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
+         * @maxLength 400
          * @nullable
          */
       conclusion_comment?: string | null;
@@ -20631,6 +20633,7 @@ export namespace Schemas {
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
+         * @maxLength 400
          * @nullable
          */
       conclusion_comment?: string | null;
@@ -35463,6 +35466,7 @@ export namespace Schemas {
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
+         * @maxLength 400
          * @nullable
          */
       conclusion_comment?: string | null;
@@ -45456,6 +45460,7 @@ export namespace Schemas {
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
+         * @maxLength 400
          * @nullable
          */
       conclusion_comment?: string | null;

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -237,6 +237,8 @@ export const experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOne
 export const experimentsCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
 
 export const experimentsCreateBodyAllowUnknownEventsDefault = false
+export const experimentsCreateBodyConclusionCommentMax = 400
+
 export const experimentsCreateBodyUpdateFeatureFlagParamsDefault = false
 
 export const ExperimentsCreateBody = /* @__PURE__ */ zod
@@ -2501,7 +2503,11 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.\n\n* `won` - won\n* `lost` - lost\n* `inconclusive` - inconclusive\n* `stopped_early` - stopped_early\n* `invalid` - invalid'
             ),
-        conclusion_comment: zod.string().nullish().describe('Comment about the experiment conclusion.'),
+        conclusion_comment: zod
+            .string()
+            .max(experimentsCreateBodyConclusionCommentMax)
+            .nullish()
+            .describe('Comment about the experiment conclusion.'),
         primary_metrics_ordered_uuids: zod.unknown().optional(),
         secondary_metrics_ordered_uuids: zod.unknown().optional(),
         only_count_matured_users: zod.boolean().optional(),
@@ -2607,6 +2613,8 @@ export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePro
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemStartEventOnePropertiesOneItemTypeDefault = `event`
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMin = 0
 export const experimentsPartialUpdateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
+
+export const experimentsPartialUpdateBodyConclusionCommentMax = 400
 
 export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
@@ -4876,7 +4884,11 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
             .describe(
                 'Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.\n\n* `won` - won\n* `lost` - lost\n* `inconclusive` - inconclusive\n* `stopped_early` - stopped_early\n* `invalid` - invalid'
             ),
-        conclusion_comment: zod.string().nullish().describe('Comment about the experiment conclusion.'),
+        conclusion_comment: zod
+            .string()
+            .max(experimentsPartialUpdateBodyConclusionCommentMax)
+            .nullish()
+            .describe('Comment about the experiment conclusion.'),
         primary_metrics_ordered_uuids: zod.unknown().optional(),
         secondary_metrics_ordered_uuids: zod.unknown().optional(),
         only_count_matured_users: zod.boolean().optional(),
@@ -5023,6 +5035,8 @@ export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPerc
 export const experimentsDuplicateCreateBodyMetricsSecondaryOneItemUpperBoundPercentileOneMax = 1
 
 export const experimentsDuplicateCreateBodyAllowUnknownEventsDefault = false
+export const experimentsDuplicateCreateBodyConclusionCommentMax = 400
+
 export const experimentsDuplicateCreateBodyUpdateFeatureFlagParamsDefault = false
 
 export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
@@ -7295,7 +7309,11 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
             .describe(
                 'Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.\n\n* `won` - won\n* `lost` - lost\n* `inconclusive` - inconclusive\n* `stopped_early` - stopped_early\n* `invalid` - invalid'
             ),
-        conclusion_comment: zod.string().nullish().describe('Comment about the experiment conclusion.'),
+        conclusion_comment: zod
+            .string()
+            .max(experimentsDuplicateCreateBodyConclusionCommentMax)
+            .nullish()
+            .describe('Comment about the experiment conclusion.'),
         primary_metrics_ordered_uuids: zod.unknown().optional(),
         secondary_metrics_ordered_uuids: zod.unknown().optional(),
         only_count_matured_users: zod.boolean().optional(),
@@ -7343,6 +7361,8 @@ export const ExperimentsEndCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const experimentsEndCreateBodyConclusionCommentMax = 400
+
 export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
     conclusion: zod
         .union([
@@ -7357,7 +7377,11 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'The conclusion of the experiment.\n\n* `won` - won\n* `lost` - lost\n* `inconclusive` - inconclusive\n* `stopped_early` - stopped_early\n* `invalid` - invalid'
         ),
-    conclusion_comment: zod.string().nullish().describe('Optional comment about the experiment conclusion.'),
+    conclusion_comment: zod
+        .string()
+        .max(experimentsEndCreateBodyConclusionCommentMax)
+        .nullish()
+        .describe('Optional comment about the experiment conclusion.'),
 })
 
 /**
@@ -7463,6 +7487,8 @@ export const ExperimentsShipVariantCreateParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const experimentsShipVariantCreateBodyConclusionCommentMax = 400
+
 export const experimentsShipVariantCreateBodyReleaseToEveryoneDefault = false
 
 export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
@@ -7479,7 +7505,11 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'The conclusion of the experiment.\n\n* `won` - won\n* `lost` - lost\n* `inconclusive` - inconclusive\n* `stopped_early` - stopped_early\n* `invalid` - invalid'
         ),
-    conclusion_comment: zod.string().nullish().describe('Optional comment about the experiment conclusion.'),
+    conclusion_comment: zod
+        .string()
+        .max(experimentsShipVariantCreateBodyConclusionCommentMax)
+        .nullish()
+        .describe('Optional comment about the experiment conclusion.'),
     variant_key: zod.string().describe('The key of the variant to ship.'),
     release_to_everyone: zod
         .boolean()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
@@ -27,6 +27,7 @@
         "conclusion_comment": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-end.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-end.json
@@ -17,6 +17,7 @@
         "conclusion_comment": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-ship-variant.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-ship-variant.json
@@ -17,6 +17,7 @@
         "conclusion_comment": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -25,6 +25,7 @@
         "conclusion_comment": {
             "anyOf": [
                 {
+                    "maxLength": 400,
                     "type": "string"
                 },
                 {


### PR DESCRIPTION
## Problem

The experiment conclusion comment field is supposed to cap at 400 characters, but the cap is enforced **only in the browser** by the textarea's `maxLength={400}` attribute. That attribute blocks typing and pasting, but not drag-and-drop, autofill, IME/dictation, browser extensions, or direct API writes. The backend never checked: the model column is an unbounded `TextField` and neither serializer set `max_length`, so the API happily stored 700+ character comments. A user reported a saved comment showing `702/400`.

## Changes

Add `max_length=400` to `conclusion_comment` on both the main experiment serializer and `EndExperimentSerializer` (which `ShipVariantSerializer` inherits). This matches how `name` (400) and `description` (3000) are already constrained in the same file — the canonical pattern across PostHog serializers is server-side length enforcement, and this field was simply missing it.

Server-side validation is the real guarantee; the UI `maxLength` stays as the first line of defense.

## How did you test this code?

I'm an agent (PostHog Slack app). Added a parameterized regression test (`test_conclusion_comment_enforces_max_length`) asserting a 400-char comment saves (200) and a 401-char comment is rejected (400, nothing persisted). The test **collects** correctly under pytest, but I could not execute the DB-backed suite or run `hogli build:openapi` in my sandbox — it has no Postgres server (client tools only, and PostHog's migrations aren't SQLite-compatible). CI will run both.

⚠️ **Follow-up needed:** the `max_length` flows into the generated OpenAPI/MCP type artifacts (`api.zod.ts`, `api.schemas.ts`, the `services/mcp` generated tree, tool-schema snapshots). Those need `hogli build:openapi` run in a DB-backed environment to refresh — I couldn't regenerate them here, so the generated-types drift check will fail until that runs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a Slack report that the conclusion field accepted >400 characters. Traced the limit to a UI-only `maxLength` with no backend or model-level constraint, then surveyed the codebase to confirm the norm is server-side enforcement (mostly via model `CharField(max_length=...)` auto-derived by DRF `ModelSerializer`s; sometimes explicit `serializers.CharField(max_length=...)`). Chose the explicit-serializer approach because the underlying column is a `TextField` and changing it would need a migration — adding `max_length` on the two serializer fields is the minimal, consistent fix and mirrors the adjacent `name`/`description` fields.

Skill invoked: `/improving-drf-endpoints` (per repo rule for serializer changes); confirmed both fields already carry `help_text`.

Open decision for reviewers: the column itself stays unbounded, so any comment already saved over 400 chars will fail validation on its next edit until trimmed. If that's a concern, the alternative is a higher server bound (e.g. 1000) while keeping the UI at 400.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1782147072582919)*
