### PR TITLE
fix(cdp): auto-disable sources on terminal destination errors

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -35,6 +35,7 @@ import { isNonFailureStatus } from '../utils/non-failure-status-codes'
 import { HogInputsService } from './hog-inputs.service'
 import { EmailService } from './messaging/email.service'
 import { RecipientTokensService } from './messaging/recipient-tokens.service'
+import { detectTerminalError } from './monitoring/terminal-errors'
 import {
     SelfLoopGuardMode,
     isPostHogIngestUrl,
@@ -884,6 +885,17 @@ export class HogExecutorService {
         } = {
             status: fetchResponse?.status ?? 500,
             body,
+        }
+
+        // Flag non-retryable, configuration-level destination errors (e.g. Slack `not_in_channel`).
+        // The watcher reads this to auto-disable the source instead of letting it fail forever.
+        const terminalError = detectTerminalError(hogVmResponse, params.url)
+        if (terminalError) {
+            result.terminalError = terminalError
+            addLog(
+                'error',
+                `Auto-disabling due to a terminal destination error (${terminalError.reason}): ${terminalError.message}`
+            )
         }
 
         // Finally we create the response object as the VM expects

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
@@ -51,6 +51,12 @@ export class HogFunctionHandler implements ActionHandler {
         ]
         result.metrics = [...result.metrics, ...functionResult.metrics]
 
+        // Surface a terminal destination error (e.g. Slack `not_in_channel`) onto the flow
+        // result so the watcher auto-disables the whole flow rather than just this action.
+        if (functionResult.terminalError) {
+            result.terminalError = functionResult.terminalError
+        }
+
         if (!functionResult.finished) {
             // Set the state of the function result on the substate of the flow for the next execution
             result.invocation.state.currentAction!.hogFunctionState = functionResult.invocation.state

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -428,6 +428,7 @@ describe('HogWatcher', () => {
             await watcher.observeResults([result])
 
             expect((await watcher.getPersistedState(hogFlow.id)).state).toEqual(HogWatcherState.forcefully_disabled)
+            expect(onStateChangeSpy).toHaveBeenCalledTimes(1)
         })
 
         it('does not disable results without a terminal error', async () => {

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -4,7 +4,9 @@ import { logger } from '~/utils/logger'
 
 import { Hub, ProjectId, Team } from '../../../types'
 import { closeHub, createHub } from '../../../utils/db/hub'
+import { FixtureHogFlowBuilder } from '../../_tests/builders/hogflow.builder'
 import { createExampleInvocation, createHogFunction } from '../../_tests/fixtures'
+import { createExampleHogFlowInvocation } from '../../_tests/fixtures-hogflows'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, HogFunctionType } from '../../types'
 import { createInvocationResult } from '../../utils/invocation-utils'
 import { BASE_REDIS_KEY, HogWatcherConfig, HogWatcherService, HogWatcherState } from './hog-watcher.service'
@@ -402,6 +404,50 @@ describe('HogWatcher', () => {
                     }
                 `)
             })
+        })
+    })
+
+    describe('terminal errors', () => {
+        const terminalError = { reason: 'slack:not_in_channel', message: 'PostHog is not a member of this channel.' }
+
+        it('force-disables a hog function that hit a terminal error', async () => {
+            const result = createResult({})
+            result.terminalError = terminalError
+
+            await watcher.observeResults([result])
+
+            expect((await watcher.getPersistedState(hogFunctionId)).state).toEqual(HogWatcherState.forcefully_disabled)
+            expect(onStateChangeSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it('force-disables a hog flow that hit a terminal error', async () => {
+            const hogFlow = new FixtureHogFlowBuilder().withTeamId(2).build()
+            const invocation = createExampleHogFlowInvocation(hogFlow)
+            const result = createInvocationResult(invocation, {}, { finished: true, terminalError })
+
+            await watcher.observeResults([result])
+
+            expect((await watcher.getPersistedState(hogFlow.id)).state).toEqual(HogWatcherState.forcefully_disabled)
+        })
+
+        it('does not disable results without a terminal error', async () => {
+            await watcher.observeResults([createResult({})])
+            expect((await watcher.getPersistedState(hogFunctionId)).state).toEqual(HogWatcherState.healthy)
+        })
+
+        it('only disables a source once per batch of repeated terminal errors', async () => {
+            const results = Array(5)
+                .fill(null)
+                .map(() => {
+                    const result = createResult({})
+                    result.terminalError = terminalError
+                    return result
+                })
+
+            await watcher.observeResults(results)
+
+            expect((await watcher.getPersistedState(hogFunctionId)).state).toEqual(HogWatcherState.forcefully_disabled)
+            expect(onStateChangeSpy).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -9,6 +9,7 @@ import { TeamManager } from '~/utils/team-manager'
 
 import {
     CyclotronJobInvocation,
+    CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
     HogFunctionTiming,
@@ -53,6 +54,19 @@ export type HogWatcherFunctionState = {
     state: HogWatcherState
 }
 
+/**
+ * The minimal shape the watcher needs to track and report on a source's state. HogFunctions
+ * satisfy this directly; HogFlows are adapted via `watchedSourceFromResult` so the same
+ * disable/observe machinery works for both. Only these fields are read by the watcher.
+ */
+export type WatchedSource = {
+    id: string
+    team_id: number
+    type: string
+    name?: string
+    template_id?: string | null
+}
+
 const hogFunctionStateChange = new Counter({
     name: 'cdp_hog_function_state_change',
     help: 'Number of times a transformation state changed',
@@ -72,6 +86,23 @@ export const isHogFunctionResult = (
     result: CyclotronJobInvocationResult
 ): result is CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> => {
     return 'hogFunction' in result.invocation
+}
+
+// Extract the watched source from a result, whether it wraps a HogFunction or a HogFlow.
+export const watchedSourceFromResult = (result: CyclotronJobInvocationResult): WatchedSource | null => {
+    if (isHogFunctionResult(result)) {
+        return result.invocation.hogFunction
+    }
+    const invocation = result.invocation as CyclotronJobInvocationHogFlow
+    if (invocation.hogFlow) {
+        return {
+            id: invocation.hogFlow.id,
+            team_id: invocation.teamId,
+            type: 'hog_flow',
+            name: invocation.hogFlow.name,
+        }
+    }
+    return null
 }
 
 // Helper if you don't care about the forced side of things
@@ -151,7 +182,7 @@ export class HogWatcherService {
         state,
         previousState,
     }: {
-        hogFunction: HogFunctionType
+        hogFunction: WatchedSource
         state: HogWatcherState
         previousState: HogWatcherState
     }) {
@@ -332,7 +363,7 @@ export class HogWatcherService {
     }
 
     public async doStageChanges(
-        changes: [HogFunctionType, HogWatcherState][],
+        changes: [WatchedSource, HogWatcherState][],
         forceReset: boolean = false
     ): Promise<void> {
         const res = await this.redis.usePipeline({ name: 'forceStateChange' }, (pipeline) => {
@@ -382,11 +413,46 @@ export class HogWatcherService {
         )
     }
 
-    public async forceStateChange(hogFunction: HogFunctionType, state: HogWatcherState): Promise<void> {
+    public async forceStateChange(hogFunction: WatchedSource, state: HogWatcherState): Promise<void> {
         await this.doStageChanges([[hogFunction, state]])
     }
 
+    /**
+     * Force-disable any source that hit a terminal, non-retryable destination error (e.g. Slack
+     * `not_in_channel`). Unlike the cost-based token bucket this applies to both HogFunctions and
+     * HogFlows, and uses `forcefully_disabled` so the source stays off until a human reconfigures
+     * it and re-enables — a config error will never fix itself on retry.
+     */
+    private async observeTerminalErrors(results: CyclotronJobInvocationResult[]): Promise<void> {
+        const changes: [WatchedSource, HogWatcherState][] = []
+        const seen = new Set<string>()
+
+        for (const result of results) {
+            if (!result.terminalError) {
+                continue
+            }
+            const source = watchedSourceFromResult(result)
+            if (!source || seen.has(source.id)) {
+                continue
+            }
+            seen.add(source.id)
+            logger.warn('[HogWatcherService] Auto-disabling source due to terminal error', {
+                sourceId: source.id,
+                sourceType: source.type,
+                teamId: source.team_id,
+                reason: result.terminalError.reason,
+            })
+            changes.push([source, HogWatcherState.forcefully_disabled])
+        }
+
+        if (changes.length > 0) {
+            await this.doStageChanges(changes, true)
+        }
+    }
+
     public async observeResults(results: CyclotronJobInvocationResult[]): Promise<void> {
+        await this.observeTerminalErrors(results)
+
         const functionCosts: Record<
             CyclotronJobInvocation['functionId'],
             {

--- a/nodejs/src/cdp/services/monitoring/terminal-errors.test.ts
+++ b/nodejs/src/cdp/services/monitoring/terminal-errors.test.ts
@@ -1,0 +1,44 @@
+import { detectTerminalError } from './terminal-errors'
+
+describe('detectTerminalError', () => {
+    const slackUrl = 'https://slack.com/api/chat.postMessage'
+
+    it.each([
+        'not_in_channel',
+        'account_inactive',
+        'is_archived',
+        'channel_not_found',
+        'invalid_auth',
+        'token_revoked',
+    ])('detects terminal Slack error %s', (error) => {
+        const result = detectTerminalError({ status: 200, body: { ok: false, error } }, slackUrl)
+        expect(result).toEqual({ reason: `slack:${error}`, message: expect.any(String) })
+    })
+
+    it('ignores transient/unknown Slack errors', () => {
+        expect(detectTerminalError({ status: 200, body: { ok: false, error: 'rate_limited' } }, slackUrl)).toBeNull()
+        expect(detectTerminalError({ status: 200, body: { ok: false, error: 'internal_error' } }, slackUrl)).toBeNull()
+    })
+
+    it('ignores successful Slack responses', () => {
+        expect(detectTerminalError({ status: 200, body: { ok: true } }, slackUrl)).toBeNull()
+    })
+
+    it('ignores non-Slack URLs even with a matching error code', () => {
+        const result = detectTerminalError(
+            { status: 200, body: { ok: false, error: 'not_in_channel' } },
+            'https://example.com/api/post'
+        )
+        expect(result).toBeNull()
+    })
+
+    it('handles non-object and missing bodies safely', () => {
+        expect(detectTerminalError({ status: 200, body: 'plain text' }, slackUrl)).toBeNull()
+        expect(detectTerminalError({ status: 200, body: null }, slackUrl)).toBeNull()
+        expect(detectTerminalError({ status: 200, body: undefined }, slackUrl)).toBeNull()
+    })
+
+    it('requires ok === false (not merely falsy)', () => {
+        expect(detectTerminalError({ status: 200, body: { error: 'not_in_channel' } }, slackUrl)).toBeNull()
+    })
+})

--- a/nodejs/src/cdp/services/monitoring/terminal-errors.ts
+++ b/nodejs/src/cdp/services/monitoring/terminal-errors.ts
@@ -1,0 +1,84 @@
+/**
+ * Terminal destination errors — a shared, extensible classifier for fetch responses that
+ * will never succeed on retry until a human reconfigures something (a revoked token, a bot
+ * removed from a channel, a deleted resource). When a CDP source (HogFunction or HogFlow)
+ * hits one of these, retrying forever is pointless and actively harmful: it wastes quota and,
+ * for the shared PostHog Slack app, degrades delivery for every other tenant. The watcher uses
+ * this to auto-disable the offending source instead of letting it fail unchecked.
+ *
+ * To support a new destination, add a detector to `TERMINAL_ERROR_DETECTORS`.
+ */
+
+export type TerminalError = {
+    // Stable identifier used in logs/metrics/analytics (e.g. `slack:not_in_channel`).
+    reason: string
+    // Actionable, user-facing explanation surfaced in the source's logs.
+    message: string
+}
+
+export type FetchResponseForClassification = {
+    status: number
+    body: unknown
+}
+
+export type TerminalErrorDetector = (response: FetchResponseForClassification, url: string) => TerminalError | null
+
+// Slack returns HTTP 200 with `{ ok: false, error: "<code>" }` for application-level errors.
+// These codes are configuration problems that a retry can never fix on its own. Kept in sync
+// with `SLACK_USER_CONFIG_ERRORS` in `ee/tasks/subscriptions/__init__.py` (the equivalent
+// auto-disable path for the subscriptions product).
+export const SLACK_TERMINAL_ERROR_CODES = new Set<string>([
+    'not_in_channel',
+    'account_inactive',
+    'is_archived',
+    'channel_not_found',
+    'invalid_auth',
+    'token_revoked',
+])
+
+const SLACK_TERMINAL_ERROR_MESSAGES: Record<string, string> = {
+    not_in_channel:
+        'PostHog is not a member of this Slack channel. Re-add the PostHog app to the channel, then re-enable.',
+    channel_not_found: 'The configured Slack channel no longer exists. Pick a valid channel, then re-enable.',
+    is_archived: 'The configured Slack channel is archived. Pick an active channel, then re-enable.',
+    account_inactive:
+        'The Slack workspace connection is inactive (the bot was removed or the workspace was deactivated). Reconnect Slack, then re-enable.',
+    invalid_auth: 'The Slack workspace connection is no longer valid. Reconnect Slack, then re-enable.',
+    token_revoked: 'The Slack workspace connection was revoked. Reconnect Slack, then re-enable.',
+}
+
+const detectSlackTerminalError: TerminalErrorDetector = (response, url) => {
+    if (!url.startsWith('https://slack.com/api/')) {
+        return null
+    }
+    const body = response.body
+    if (typeof body !== 'object' || body === null) {
+        return null
+    }
+    const { ok, error } = body as { ok?: unknown; error?: unknown }
+    if (ok !== false || typeof error !== 'string' || !SLACK_TERMINAL_ERROR_CODES.has(error)) {
+        return null
+    }
+    return {
+        reason: `slack:${error}`,
+        message:
+            SLACK_TERMINAL_ERROR_MESSAGES[error] ??
+            `Slack rejected the request with a terminal error (${error}). Reconfigure the destination, then re-enable.`,
+    }
+}
+
+export const TERMINAL_ERROR_DETECTORS: TerminalErrorDetector[] = [detectSlackTerminalError]
+
+/**
+ * Inspect a completed fetch response and return a `TerminalError` if it is a non-retryable,
+ * configuration-level failure, or `null` otherwise.
+ */
+export const detectTerminalError = (response: FetchResponseForClassification, url: string): TerminalError | null => {
+    for (const detector of TERMINAL_ERROR_DETECTORS) {
+        const terminalError = detector(response, url)
+        if (terminalError) {
+            return terminalError
+        }
+    }
+    return null
+}

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -13,6 +13,7 @@ import {
     PersonPropertyFilter,
     Team,
 } from '../types'
+import { TerminalError } from './services/monitoring/terminal-errors'
 
 export type HogBytecode = any[]
 
@@ -292,6 +293,9 @@ export type CyclotronJobInvocationResult<T extends CyclotronJobInvocation = Cycl
     capturedPostHogEvents: HogFunctionCapturedEvent[]
     warehouseWebhookPayloads: WarehouseWebhookPayload[]
     execResult?: unknown
+    // Set when a fetch hit a non-retryable, configuration-level destination error (e.g. Slack
+    // `not_in_channel`). Signals the watcher to auto-disable the source — see `terminal-errors.ts`.
+    terminalError?: TerminalError
 }
 
 export type CyclotronJobInvocationHogFunctionContext = {

--- a/nodejs/src/cdp/utils/invocation-utils.ts
+++ b/nodejs/src/cdp/utils/invocation-utils.ts
@@ -66,7 +66,14 @@ export function createInvocationResult<T extends CyclotronJobInvocation>(
     > = {},
     resultParams: Pick<
         Partial<CyclotronJobInvocationResult>,
-        'finished' | 'capturedPostHogEvents' | 'warehouseWebhookPayloads' | 'logs' | 'metrics' | 'error' | 'execResult'
+        | 'finished'
+        | 'capturedPostHogEvents'
+        | 'warehouseWebhookPayloads'
+        | 'logs'
+        | 'metrics'
+        | 'error'
+        | 'execResult'
+        | 'terminalError'
     > = {}
 ): CyclotronJobInvocationResult<T> {
     return {


### PR DESCRIPTION
## Problem

A HogFlow Slack destination that hits a terminal, non-retryable Slack error — `not_in_channel`, `channel_not_found`, `invalid_auth`, etc. — keeps firing on every matching event forever. Nothing disables it: the hog watcher's token bucket is cost-based (and skips HogFlows entirely), and Slack returns HTTP 200 for these so the fetch-retry logic never classifies them as failures. The result is zero delivered messages, an owner who likely doesn't know, and wasted retries that degrade the shared PostHog Slack app for every other tenant.

The subscriptions product already auto-disables on this exact set of Slack errors (`SLACK_USER_CONFIG_ERRORS`), but HogFunctions and HogFlows had no equivalent.

## Changes

- **New shared classifier** (`nodejs/src/cdp/services/monitoring/terminal-errors.ts`): a small registry of per-destination detectors that inspect a completed fetch response and return a `TerminalError` when the failure is configuration-level and will never recover on retry. The Slack detector mirrors the subscriptions `SLACK_USER_CONFIG_ERRORS` set. Adding a new destination is one entry in `TERMINAL_ERROR_DETECTORS` — that's the reusable pattern.
- **Detection** in `HogExecutorService.executeFetch`: after the response body is parsed, flag a terminal error on the result and log an actionable, user-facing message. HogFlows propagate the flag from the inner function result up to the flow result.
- **Auto-disable** in `HogWatcherService.observeResults`: a new pass force-disables (`forcefully_disabled`) any source carrying a terminal error. It runs before the cost-based logic so it covers HogFlows too (which the token bucket ignores). `forcefully_disabled` means the source stays off until a human reconfigures and re-enables it — a config error won't fix itself. The watcher's state-change machinery (`doStageChanges` / `forceStateChange`) was generalized from `HogFunctionType` to a minimal `WatchedSource` shape so the same path serves both functions and flows; the existing disabled-state gate in the flow/function pipelines then blocks further invocations.

## How did you test this code?

I'm an agent (PostHog Slack app). I added and ran automated tests; I did not manually exercise a live Slack integration.

- `terminal-errors.test.ts` — unit tests for the classifier (all six terminal Slack codes, transient/unknown codes ignored, non-Slack URLs ignored, malformed bodies). **Ran locally, passing.**
- `hog-watcher.service.test.ts` — added cases asserting force-disable for both a HogFunction and a HogFlow result, no-op without a terminal error, and single-disable-per-batch dedup. These require Redis, which wasn't available in my environment, so I did **not** run them here; they follow the existing `doStageChanges` test patterns.
- `tsc --noEmit`, eslint, and prettier all clean on the changed files (one pre-existing `@posthog/cyclotron` type error in an untouched file remains because that Rust binding wasn't built locally).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread, in response to a Signals scout inbox item. No repo skills were applicable to this plugin-server CDP change, so none were invoked.

Key decisions:
- **Detect at the fetch layer, not by parsing error strings.** The Slack hog template throws a generic `Error` with the response body stringified in; matching on that text is fragile and breaks if a user customizes the hog. Inspecting the parsed `{status, body}` in `executeFetch` is robust and destination-agnostic.
- **Reuse the watcher's existing disabled state** rather than flipping a DB column. The flow/function pipelines already gate on `HogWatcherState.disabled`, and HogFunctions surface watcher state in the UI. `forcefully_disabled` (vs auto `disabled`) signals "needs human action" and won't auto-recover via token refill.
- **Generalize `WatchedSource`** instead of forcing HogFlows into the `HogFunctionType` shape — the watcher only ever reads `id`/`team_id`/`type`/`name`/`template_id`.

Possible follow-ups for reviewers to weigh: emitting a notification (like subscriptions' disabled-email) so owners learn their flow was disabled, and registering detectors for other destinations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1782152325661299?thread_ts=1782152325.661299&cid=C09BDQLM8KA)*
