### PR TITLE
refactor(hogql): compute unfiltered earliest timestamp via HogQL

### DIFF
--- a/ee/benchmarks/benchmarks.py
+++ b/ee/benchmarks/benchmarks.py
@@ -16,7 +16,7 @@ from posthog.queries.trends.trends import Trends
 from posthog.queries.session_recordings.session_recording_list import (
     SessionRecordingList,
 )
-from posthog.queries.util import get_earliest_timestamp
+from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered
 from posthog.models import Cohort, Team, Organization
 from products.actions.backend.models.action import Action
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
@@ -511,7 +511,7 @@ class QuerySuite:
 
     @benchmark_clickhouse
     def track_earliest_timestamp(self):
-        get_earliest_timestamp(2)
+        get_earliest_timestamp_unfiltered(self.team)
 
     @benchmark_clickhouse
     def track_event_property_values(self):

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -1,62 +1,10 @@
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
-
-from freezegun.api import freeze_time
-from posthog.test.base import _create_event
-
 from posthog.hogql.hogql import HogQLContext
 
 from posthog.clickhouse.client import sync_execute
 from posthog.models.cohort import Cohort
 from posthog.queries.breakdown_props import _parse_breakdown_cohorts
-from posthog.queries.util import get_earliest_timestamp
 
 from products.actions.backend.models.action import Action
-
-
-def test_get_earliest_timestamp(db, team):
-    with freeze_time("2021-01-21") as frozen_time:
-        _create_event(
-            team=team,
-            event="sign up",
-            distinct_id="1",
-            timestamp="2020-01-04T14:10:00Z",
-        )
-        _create_event(
-            team=team,
-            event="sign up",
-            distinct_id="1",
-            timestamp="2020-01-06T14:10:00Z",
-        )
-
-        assert get_earliest_timestamp(team.id) == datetime(2020, 1, 4, 14, 10, tzinfo=ZoneInfo("UTC"))
-
-        frozen_time.tick(timedelta(seconds=1))
-        _create_event(
-            team=team,
-            event="sign up",
-            distinct_id="1",
-            timestamp="1984-01-06T14:10:00Z",
-        )
-        _create_event(
-            team=team,
-            event="sign up",
-            distinct_id="1",
-            timestamp="2014-01-01T01:00:00Z",
-        )
-        _create_event(
-            team=team,
-            event="sign up",
-            distinct_id="1",
-            timestamp="2015-01-01T01:00:00Z",
-        )
-
-        assert get_earliest_timestamp(team.id) == datetime(2015, 1, 1, 1, tzinfo=ZoneInfo("UTC"))
-
-
-@freeze_time("2021-01-21")
-def test_get_earliest_timestamp_with_no_events(db, team):
-    assert get_earliest_timestamp(team.id) == datetime(2021, 1, 14, tzinfo=ZoneInfo("UTC"))
 
 
 def test_parse_breakdown_cohort_query(db, team):

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -65,6 +65,7 @@ from posthog.models.cohort.util import (
 )
 from posthog.models.cohort.validation import CohortTypeValidationSerializer
 from posthog.models.filters.filter import Filter
+from posthog.models.filters.utils import earliest_timestamp_func
 from posthog.models.person.person import READ_DB_FOR_PERSONS, PersonDistinctId
 from posthog.models.person.util import get_person_by_uuid, validate_person_uuids_exist
 from posthog.models.property.property import Property, PropertyGroup
@@ -73,7 +74,6 @@ from posthog.models.utils import UUIDT
 from posthog.queries.actor_base_query import get_serialized_people
 from posthog.queries.base import determine_parsed_date_for_property_matching, property_group_to_Q
 from posthog.queries.person_query import PersonQuery
-from posthog.queries.util import get_earliest_timestamp
 from posthog.renderers import SafeJSONRenderer
 from posthog.utils import format_query_params_absolute_url, str_to_bool
 
@@ -452,7 +452,7 @@ class CohortFiltersField(serializers.JSONField):
 
 class CohortSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    earliest_timestamp_func = get_earliest_timestamp
+    earliest_timestamp_func = earliest_timestamp_func
     _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
     _create_static_person_ids = serializers.ListField(
         required=False, child=serializers.CharField(), write_only=True, default=[]

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -16,9 +16,9 @@ from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQu
 from posthog.hogql_queries.insights.utils.breakdowns import NOT_IN_COHORT_ID
 from posthog.hogql_queries.insights.utils.utils import get_start_of_interval_hogql, get_start_of_interval_hogql_str
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.hogql_queries.utils.timestamp_utils import format_label_date
+from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_unfiltered
 from posthog.queries.breakdown_props import get_breakdown_cohort_name
-from posthog.queries.util import correct_result_for_sampling, get_earliest_timestamp, get_interval_func_ch
+from posthog.queries.util import correct_result_for_sampling, get_interval_func_ch
 from posthog.utils import DATERANGE_MAP, relative_date_parse
 
 
@@ -456,7 +456,7 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         date_range = self._date_range()
 
         if date_range.date_from() is None:
-            _date_from = get_earliest_timestamp(team.pk)
+            _date_from = get_earliest_timestamp_unfiltered(team)
         else:
             _date_from = date_range.date_from()
 

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -10,7 +10,7 @@ from posthog.schema import DateRange, IntervalType
 from posthog.hogql.parser import ast
 
 from posthog.models.team import Team, WeekStartDay
-from posthog.queries.util import get_earliest_timestamp, get_trunc_func_ch
+from posthog.queries.util import get_trunc_func_ch
 from posthog.utils import DEFAULT_DATE_FROM_DAYS, relative_date_parse, relative_date_parse_with_delta_mapping
 
 IntervalLiteral = Literal["second", "minute", "hour", "day", "week", "month"]
@@ -129,7 +129,10 @@ class QueryDateRange:
         if self._earliest_timestamp_fallback:
             return self._earliest_timestamp_fallback
 
-        return get_earliest_timestamp(self._team.pk)
+        # Imported here to break the cycle: timestamp_utils imports QueryDateRange.
+        from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered  # noqa: PLC0415
+
+        return get_earliest_timestamp_unfiltered(self._team)
 
     def date_from(self) -> datetime:
         date_from: datetime

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -1,5 +1,6 @@
 import datetime
 
+from freezegun.api import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
 
 from django.core.cache import cache
@@ -10,7 +11,11 @@ from dateutil import parser
 from posthog.schema import ActionsNode, DateRange, EventsNode, IntervalType
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
+from posthog.hogql_queries.utils.timestamp_utils import (
+    format_label_date,
+    get_earliest_timestamp_from_series,
+    get_earliest_timestamp_unfiltered,
+)
 from posthog.models.team import WeekStartDay
 
 from products.actions.backend.models.action import Action
@@ -339,3 +344,42 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         # should still return the earliest timestamp from the first query
         cached_earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
         self.assertEqual(cached_earliest_timestamp, earliest_timestamp)
+
+    @freeze_time("2021-01-21")
+    def test_unfiltered_earliest_timestamp_returns_earliest_event(self):
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2020-01-04T14:10:00Z")
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2020-01-06T14:10:00Z")
+        flush_persons_and_events()
+
+        assert get_earliest_timestamp_unfiltered(self.team) == datetime.datetime(
+            2020, 1, 4, 14, 10, tzinfo=datetime.UTC
+        )
+
+    @freeze_time("2021-01-21")
+    def test_unfiltered_earliest_timestamp_floors_at_2015(self):
+        # Events before 2015-01-01 are treated as corrupt and ignored.
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="1984-01-06T14:10:00Z")
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2014-01-01T01:00:00Z")
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2015-01-01T01:00:00Z")
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2020-01-04T14:10:00Z")
+        flush_persons_and_events()
+
+        assert get_earliest_timestamp_unfiltered(self.team) == datetime.datetime(2015, 1, 1, 1, tzinfo=datetime.UTC)
+
+    @freeze_time("2021-01-21")
+    def test_unfiltered_earliest_timestamp_falls_back_when_no_events(self):
+        # No events: fall back to now - DEFAULT_EARLIEST_TIME_DELTA (one week).
+        assert get_earliest_timestamp_unfiltered(self.team) == datetime.datetime(2021, 1, 14, tzinfo=datetime.UTC)
+
+    @freeze_time("2021-01-21")
+    def test_unfiltered_earliest_timestamp_caches_real_result(self):
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2021-01-01T12:00:00Z")
+        flush_persons_and_events()
+
+        earliest_timestamp = get_earliest_timestamp_unfiltered(self.team)
+
+        # A later-added earlier event should not change the cached value within the TTL.
+        _create_event(team=self.team, event="sign up", distinct_id="1", timestamp="2020-01-01T12:00:00Z")
+        flush_persons_and_events()
+
+        assert get_earliest_timestamp_unfiltered(self.team) == earliest_timestamp

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from django.conf import settings
 from django.core.cache import cache
+from django.utils import timezone
 
 from dateutil.relativedelta import MO, SU, relativedelta
 
@@ -23,6 +24,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
+from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
 from posthog.models.team import WeekStartDay
 from posthog.utils import get_safe_cache
 
@@ -30,6 +32,8 @@ from products.actions.backend.models.action import Action
 
 EARLIEST_TIMESTAMP_CACHE_TTL = 24 * 60 * 60
 EARLIEST_EVENT_TIMESTAMP = datetime.fromisoformat("1980-01-01T00:00:00Z")
+# Floor for the team-wide unfiltered earliest timestamp: events before 2015 are treated as corrupt.
+UNFILTERED_EARLIEST_TIMESTAMP_FLOOR = datetime.fromisoformat("2015-01-01T00:00:00Z")
 
 
 def _get_data_warehouse_earliest_timestamp_query(
@@ -195,6 +199,42 @@ def get_earliest_timestamp_from_series(
             timestamps = [future.result() for future in futures]
 
     return min(timestamps)
+
+
+def get_earliest_timestamp_unfiltered(team: Team) -> datetime:
+    """
+    Get the team-wide, unfiltered earliest event timestamp (the earliest event of any kind).
+
+    Used for "all time" date filtering when no specific series is given. Mirrors the value of the
+    legacy raw-SQL earliest-timestamp helper: floored at 2015-01-01, falling back to
+    now - DEFAULT_EARLIEST_TIME_DELTA when the team has no events.
+    """
+    cache_key = f"earliest_timestamp_unfiltered_{team.pk}"
+    cached_result = get_safe_cache(cache_key)
+    if cached_result is not None:
+        return cached_result
+
+    query = ast.SelectQuery(
+        select=[ast.Field(chain=["timestamp"])],
+        select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+        where=ast.CompareOperation(
+            op=ast.CompareOperationOp.Gt,
+            left=ast.Field(chain=["timestamp"]),
+            right=ast.Constant(value=UNFILTERED_EARLIEST_TIMESTAMP_FLOOR),
+        ),
+        order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="ASC")],
+        limit=ast.Constant(value=1),
+    )
+
+    result = execute_hogql_query(query=query, team=team)
+    if result and len(result.results) > 0 and len(result.results[0]) > 0:
+        earliest_timestamp = result.results[0][0]
+        # Only cache real results: a team with no events yet should keep re-checking rather than
+        # pinning a "now - delta" fallback for the full TTL.
+        cache.set(cache_key, earliest_timestamp, timeout=EARLIEST_TIMESTAMP_CACHE_TTL)
+        return earliest_timestamp
+
+    return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
 
 
 def _get_week_boundaries(input_date: date, week_start_day: WeekStartDay) -> tuple[date, date]:

--- a/posthog/models/filters/test/test_stickiness_filter.py
+++ b/posthog/models/filters/test/test_stickiness_filter.py
@@ -1,7 +1,7 @@
 from posthog.test.base import BaseTest
 
 from posthog.models.filters.stickiness_filter import StickinessFilter
-from posthog.queries.util import get_earliest_timestamp
+from posthog.models.filters.utils import earliest_timestamp_func
 
 
 class TestStickinessFilter(BaseTest):
@@ -16,7 +16,7 @@ class TestStickinessFilter(BaseTest):
                 "sampling_factor": 0.1,
             },
             team=self.team,
-            get_earliest_timestamp=get_earliest_timestamp,
+            get_earliest_timestamp=earliest_timestamp_func,
         )
         self.assertEqual(
             filter.to_dict(),

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -16,9 +16,11 @@ GroupTypeIndex = Literal[0, 1, 2, 3, 4]
 
 
 def earliest_timestamp_func(team_id: int):
-    from posthog.queries.util import get_earliest_timestamp
+    # Imported here to break a circular import: hogql_queries pulls in filter machinery.
+    from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered  # noqa: PLC0415
+    from posthog.models.team import Team  # noqa: PLC0415
 
-    return get_earliest_timestamp(team_id)
+    return get_earliest_timestamp_unfiltered(Team.objects.get(pk=team_id))
 
 
 def get_filter(team, data: Optional[dict] = None, request: Optional[Request] = None):

--- a/posthog/queries/funnels/funnel_trends.py
+++ b/posthog/queries/funnels/funnel_trends.py
@@ -7,12 +7,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.funnels.base import ClickhouseFunnelBase
 from posthog.queries.funnels.utils import get_funnel_order_class
-from posthog.queries.util import (
-    correct_result_for_sampling,
-    get_earliest_timestamp,
-    get_interval_func_ch,
-    get_start_of_interval_sql,
-)
+from posthog.queries.util import correct_result_for_sampling, get_interval_func_ch, get_start_of_interval_sql
 
 TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
 HUMAN_READABLE_TIMESTAMP_FORMAT = "%-d-%b-%Y"
@@ -102,8 +97,11 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
         ) = self.get_steps_reached_conditions()
         interval_func = get_interval_func_ch(self._filter.interval)
 
+        # Imported here to avoid a circular import at module load (timestamp_utils pulls in HogQL).
+        from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered  # noqa: PLC0415
+
         if self._filter.date_from is None:
-            _date_from = get_earliest_timestamp(self._team.pk)
+            _date_from = get_earliest_timestamp_unfiltered(self._team)
         else:
             _date_from = self._filter.date_from
 

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -11,7 +11,7 @@ from posthog.models.filters import AnyFilter
 from posthog.models.filters.base_filter import BaseFilter
 from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.team import Team
-from posthog.queries.util import TIME_IN_SECONDS, get_earliest_timestamp, get_start_of_interval_sql
+from posthog.queries.util import TIME_IN_SECONDS, get_start_of_interval_sql
 from posthog.utils import DEFAULT_DATE_FROM_DAYS, relative_date_parse, relative_date_parse_with_delta_mapping
 
 
@@ -70,7 +70,10 @@ class QueryDateRange:
         if self._earliest_timestamp_fallback:
             return self._earliest_timestamp_fallback
 
-        return get_earliest_timestamp(self._team.pk)
+        # Imported here to avoid a circular import at module load (timestamp_utils pulls in HogQL).
+        from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered  # noqa: PLC0415
+
+        return get_earliest_timestamp_unfiltered(self._team)
 
     @property
     def date_from_param(self) -> datetime:

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -19,7 +19,7 @@ from posthog.models.filters.properties_timeline_filter import PropertiesTimeline
 from posthog.models.filters.utils import validate_group_type_index
 from posthog.models.property.util import get_property_string_expr
 from posthog.models.team import Team
-from posthog.queries.util import correct_result_for_sampling, get_earliest_timestamp
+from posthog.queries.util import correct_result_for_sampling
 
 logger = structlog.get_logger(__name__)
 
@@ -123,12 +123,15 @@ def parse_response(
 def get_active_user_params(filter: Filter, entity: Entity, team_id: int) -> tuple[dict[str, Any], dict[str, Any]]:
     diff = timedelta(days=7 if entity.math == WEEKLY_ACTIVE else 30)
 
+    # Imported here to avoid a circular import at module load (timestamp_utils pulls in HogQL).
+    from posthog.hogql_queries.utils.timestamp_utils import get_earliest_timestamp_unfiltered  # noqa: PLC0415
+
     date_from: datetime.datetime
     if filter.date_from:
         date_from = filter.date_from
     else:
         try:
-            date_from = get_earliest_timestamp(team_id)
+            date_from = get_earliest_timestamp_unfiltered(Team.objects.get(pk=team_id))
         except IndexError:
             raise ValidationError("Active User queries require a lower date bound")
     date_to = filter.date_to

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -1,19 +1,14 @@
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from enum import Enum, auto
 from typing import Any, Optional, Union, overload
 from zoneinfo import ZoneInfo
-
-from django.utils import timezone
 
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import PersonsOnEventsMode
 
-from posthog.cache_utils import cache_for
-from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
 from posthog.models.team.team import Team, WeekStartDay
-from posthog.queries.insight import insight_sync_execute
 
 
 class PersonPropertiesMode(Enum):
@@ -53,12 +48,6 @@ def alias_poe_mode_for_legacy(persons_on_events_mode: PersonsOnEventsMode | None
     return persons_on_events_mode
 
 
-EARLIEST_TIMESTAMP = "2015-01-01"
-
-GET_EARLIEST_TIMESTAMP_SQL = """
-SELECT timestamp from events WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s order by timestamp limit 1
-"""
-
 TIME_IN_SECONDS: dict[str, Any] = {
     "hour": 3600,
     "day": 3600 * 24,
@@ -91,21 +80,6 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
             raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
         timestamp = timestamp.replace(tzinfo=ZoneInfo(convert_to_timezone)).astimezone(ZoneInfo("UTC"))
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
-
-
-@cache_for(timedelta(seconds=2))
-def get_earliest_timestamp(team_id: int) -> datetime:
-    results = insight_sync_execute(
-        GET_EARLIEST_TIMESTAMP_SQL,
-        {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP},
-        query_type="get_earliest_timestamp",
-        team_id=team_id,
-    )
-
-    if len(results) > 0:
-        return results[0][0]
-    else:
-        return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
 
 
 def get_start_of_interval_sql(


### PR DESCRIPTION
## Problem

`posthog/queries/util.py` exposed `get_earliest_timestamp(team_id)` — a hand-written `FROM events` raw-SQL read (`GET_EARLIEST_TIMESTAMP_SQL`) for the team-wide, unfiltered earliest event timestamp used by "all time" date filtering. It is live: imported by HogQL query runners (funnel trends, `QueryDateRange`) as well as legacy code paths. Because it bypasses HogQL, any change to how events are physically stored has to special-case this reader separately.

This moves that read onto HogQL so the events-table/storage decision lives in HogQL's seams rather than in bespoke SQL.

## Changes

- New `get_earliest_timestamp_unfiltered(team)` in `posthog/hogql_queries/utils/timestamp_utils.py`, next to the existing per-series twin. It runs a small HogQL query (`SELECT timestamp FROM events WHERE timestamp > 2015-01-01 ORDER BY timestamp ASC LIMIT 1`) and preserves the legacy value exactly: the 2015-01-01 floor, and the `now - DEFAULT_EARLIEST_TIME_DELTA` (one week) fallback when a team has no events. It uses an order-by-limit-1 (not `min()`) so the empty case still produces no row and hits the fallback.
- Caches real results for 24h under a dedicated key (the value is effectively static), and deliberately does **not** cache the no-events fallback so a brand-new team isn't pinned to "no events" for a day.
- Repointed every importer of the old helper — the two HogQL runners, the legacy `posthog/queries/` callers, the stickiness/cohort callback chain (`earliest_timestamp_func`), and the benchmark.
- Deleted `GET_EARLIEST_TIMESTAMP_SQL`, `get_earliest_timestamp`, and the now-dead imports/constant from `posthog/queries/util.py`.

The legacy `posthog/queries/` modules load early via the property-util import chain, so those call sites use deferred imports of `timestamp_utils` (which pulls in HogQL) to avoid a circular import.

## How did you test this code?

I'm an agent; I ran only automated tests (no manual testing):

- `posthog/hogql_queries/utils/test/test_timestamp_utils.py` — added equivalence tests for the new helper (team with events, the 2015 floor excluding older events, the no-events fallback, and cache behavior). Full file green (26 passed including the relocated cases).
- `ee/clickhouse/queries/test/test_util.py` and `posthog/models/filters/test/test_stickiness_filter.py` — repointed; green.
- `posthog/hogql_queries/utils/test/test_query_date_range.py`, `posthog/queries/test/test_query_date_range.py`, `posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py` — 123 passed, 4 snapshots passed with no diffs.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). This is spec C1 of a cleanup series that routes hand-written `FROM events` reads through HogQL so an opt-in native-JSON events schema needs the schema decision in only two seams.

Key decisions:
- Matched the legacy semantics precisely (2015 floor, one-week empty fallback, first-row-not-`min()`) rather than reusing the per-series twin's 1980 floor / 1980 fallback — the two are conceptually similar but not interchangeable, so they keep separate cache keys.
- Chose the 24h cache TTL from `timestamp_utils` over the old 2-second TTL since the unfiltered earliest is near-static, but skip caching the fallback to avoid masking newly-arrived events for new teams.
- The spec named "two callers"; the definition-of-done grep requires zero importers, so all importers (including legacy and the callback chain) were repointed.
