### PR TITLE
feat(replay-vision): read API for vision action run history

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -505,6 +505,7 @@ SPECTACULAR_SETTINGS = {
         "ObservationStatusEnum": "products.replay_vision.backend.models.replay_observation.ObservationStatus",
         "ObservationTriggerEnum": "products.replay_vision.backend.models.replay_observation.ObservationTrigger",
         "ExportedRecordingStatusEnum": "products.replay.backend.models.exported_recording.ExportedRecording.Status",
+        "VisionActionRunStatusEnum": "products.replay_vision.backend.models.vision_action.VisionActionRunStatus",
         "AutonomyPriorityEnum": "products.signals.backend.models.AutonomyPriority",
         "UserInterviewSearchDocumentTypeEnum": "products.user_interviews.backend.facade.enums.SEARCH_DOCUMENT_TYPES",
         "BatchExportRunStatusEnum": "products.batch_exports.backend.models.batch_export.BatchExportRun.Status",

--- a/products/replay_vision/backend/api/__init__.py
+++ b/products/replay_vision/backend/api/__init__.py
@@ -1,12 +1,13 @@
 from products.replay_vision.backend.api.observations import ReplayObservationViewSet, SessionReplayObservationViewSet
 from products.replay_vision.backend.api.quota import VisionQuotaViewSet
 from products.replay_vision.backend.api.scanners import ReplayScannerViewSet
-from products.replay_vision.backend.api.vision_actions import VisionActionViewSet
+from products.replay_vision.backend.api.vision_actions import VisionActionRunViewSet, VisionActionViewSet
 
 __all__ = [
     "ReplayObservationViewSet",
     "ReplayScannerViewSet",
     "SessionReplayObservationViewSet",
+    "VisionActionRunViewSet",
     "VisionActionViewSet",
     "VisionQuotaViewSet",
 ]

--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -6,9 +6,9 @@ from django.db.models import QuerySet
 
 import structlog
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from rest_framework import serializers, viewsets
-from rest_framework.exceptions import PermissionDenied
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field, extend_schema_view
+from rest_framework import mixins, serializers, viewsets
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.serializers import BaseSerializer
 
@@ -24,7 +24,13 @@ from products.replay_vision.backend.feature_flag import (
     ReplayVisionEnabledPermission,
 )
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner
-from products.replay_vision.backend.models.vision_action import ActionMode, TriggerType, VisionAction
+from products.replay_vision.backend.models.vision_action import (
+    ActionMode,
+    TriggerType,
+    VisionAction,
+    VisionActionRun,
+    VisionActionRunStatus,
+)
 from products.replay_vision.backend.rrule import validate_rrule, validate_timezone
 
 logger = structlog.get_logger(__name__)
@@ -361,3 +367,92 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def perform_destroy(self, instance: VisionAction) -> None:
         archive_delivery(instance, team=self.team)
         super().perform_destroy(instance)
+
+
+class VisionActionRunSerializer(serializers.ModelSerializer):
+    """Read-only history of one VisionAction execution, backing the per-action run list + summary view."""
+
+    status = serializers.ChoiceField(
+        choices=VisionActionRunStatus.choices,
+        read_only=True,
+        help_text="Run outcome: running, completed, failed, or skipped.",
+    )
+    scheduled_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="The scheduled fire time this run was claimed for.",
+    )
+    observation_count = serializers.IntegerField(
+        read_only=True,
+        help_text="Number of observations that fed this run's summary.",
+    )
+    synthesized_markdown = serializers.CharField(
+        read_only=True,
+        allow_blank=True,
+        help_text="The synthesized group-summary report in Markdown. Empty until a run completes successfully.",
+    )
+    error_reason = serializers.SerializerMethodField(
+        help_text="Short human-readable reason a run skipped or failed; null on success.",
+    )
+
+    class Meta:
+        model = VisionActionRun
+        fields = [
+            "id",
+            "status",
+            "scheduled_at",
+            "observation_count",
+            "synthesized_markdown",
+            "error_reason",
+            "created_at",
+            "updated_at",
+        ]
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_error_reason(self, run: VisionActionRun) -> str | None:
+        error = run.error
+        if not isinstance(error, dict):
+            return None
+        # The engine stamps skip/abort reasons (e.g. {"skip_reason": ...}, {"aborted": ...}) or an
+        # exception summary; surface the first human-readable value rather than the raw payload.
+        for key in ("skip_reason", "aborted", "message", "error"):
+            value = error.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return None
+
+
+class VisionActionRunViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Read-only run history for a single vision action (nested under /vision/actions/{action_id}/runs/)."""
+
+    scope_object = "vision_action"
+    # Runs surface recording-derived summaries, so reading them requires session_recording read too.
+    required_scopes = ["vision_action:read", "session_recording:read"]
+    permission_classes = [ReplayVisionEnabledPermission, ReplayVisionActionsEnabledPermission]
+    serializer_class = VisionActionRunSerializer
+    # `objects` is fail-closed; `safely_get_queryset` re-scopes to the request team.
+    queryset = VisionActionRun.objects.unscoped()
+
+    def _action_for_url(self) -> VisionAction:
+        try:
+            action_id = uuid.UUID(self.kwargs["parent_lookup_vision_action_id"])
+        except (KeyError, ValueError):
+            raise NotFound()
+        action = VisionAction.objects.for_team(self.team_id).filter(id=action_id).first()
+        if action is None:
+            raise NotFound()
+        # Runs expose recording-derived summaries, so reading them inherits the action's RBAC and also
+        # requires session_recording read (mirrors the observations endpoint).
+        self.check_object_permissions(self.request, action)
+        if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
+            raise PermissionDenied("Reading vision action runs requires session_recording read access.")
+        return action
+
+    def safely_get_queryset(self, queryset: QuerySet[VisionActionRun]) -> QuerySet[VisionActionRun]:
+        action = self._action_for_url()
+        return queryset.filter(team_id=self.team_id, vision_action_id=action.id).order_by("-created_at", "id")

--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -408,17 +408,19 @@ class VisionActionRunSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
-    @extend_schema_field(OpenApiTypes.STR)
+    # allow_null so the generated TS/MCP type is `string | null` — get_error_reason returns null for
+    # successful runs, and a non-null hint would crash consumers that dereference it.
+    @extend_schema_field(serializers.CharField(allow_null=True))
     def get_error_reason(self, run: VisionActionRun) -> str | None:
-        error = run.error
-        if not isinstance(error, dict):
-            return None
-        # The engine stamps skip/abort reasons (e.g. {"skip_reason": ...}, {"aborted": ...}) or an
-        # exception summary; surface the first human-readable value rather than the raw payload.
-        for key in ("skip_reason", "aborted", "message", "error"):
+        error = run.error if isinstance(run.error, dict) else {}
+        # Surface only the engine's controlled skip/abort reasons. Failed runs also stamp error["message"]
+        # with raw exception text (str(e)[:500]) — don't echo that to API consumers; show a generic reason.
+        for key in ("skip_reason", "aborted"):
             value = error.get(key)
             if isinstance(value, str) and value.strip():
                 return value
+        if run.status == VisionActionRunStatus.FAILED:
+            return "Run failed"
         return None
 
 

--- a/products/replay_vision/backend/routes.py
+++ b/products/replay_vision/backend/routes.py
@@ -4,6 +4,7 @@ from products.replay_vision.backend.api import (
     ReplayObservationViewSet,
     ReplayScannerViewSet,
     SessionReplayObservationViewSet,
+    VisionActionRunViewSet,
     VisionActionViewSet,
     VisionQuotaViewSet,
 )
@@ -23,4 +24,9 @@ def register_routes(routers: RouterRegistry) -> None:
         r"vision/observations", SessionReplayObservationViewSet, "project_vision_observations", ["team_id"]
     )
     routers.register_legacy_dual_route(r"vision/quota", VisionQuotaViewSet, "project_vision_quota", ["team_id"])
-    routers.projects.register(r"vision/actions", VisionActionViewSet, "project_vision_actions", ["team_id"])
+    project_vision_actions_router = routers.projects.register(
+        r"vision/actions", VisionActionViewSet, "project_vision_actions", ["team_id"]
+    )
+    project_vision_actions_router.register(
+        r"runs", VisionActionRunViewSet, "project_vision_action_runs", ["team_id", "vision_action_id"]
+    )

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -290,6 +290,17 @@ class TestVisionActionRunViewSet(_VisionActionAPITestCase):
         self.assertEqual(resp.status_code, 200, resp.content)
         self.assertEqual(resp.json()["error_reason"], "over budget")
 
+    def test_failed_run_error_reason_does_not_leak_raw_exception(self) -> None:
+        # The engine stamps error["message"] with raw exception text (str(e)[:500]); the API must not
+        # echo it to callers — a failed run surfaces a generic reason instead.
+        run = self._create_run(
+            status=VisionActionRunStatus.FAILED,
+            error={"message": "Traceback: KeyError 'secret_token' in synthesize at line 42"},
+        )
+        resp = self.client.get(f"{self.runs_url()}{run.id}/")
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.json()["error_reason"], "Run failed")
+
     def test_runs_scoped_to_their_action(self) -> None:
         other_action = VisionAction.all_teams.create(team=self.team, scanner=self.scanner, name="other-action")
         mine = self._create_run(self.action)

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -9,7 +9,7 @@ from posthog.models import Organization, Team
 from posthog.models.integration import Integration
 
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
-from products.replay_vision.backend.models.vision_action import VisionAction
+from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun, VisionActionRunStatus
 
 
 class _VisionActionAPITestCase(APIBaseTest):
@@ -251,3 +251,82 @@ class TestVisionActionCrossTeamIDOR(_VisionActionAPITestCase):
             format="json",
         )
         self.assertEqual(resp.status_code, 400)
+
+
+class TestVisionActionRunViewSet(_VisionActionAPITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.action = VisionAction.all_teams.create(team=self.team, scanner=self.scanner, name="daily-summary")
+
+    def runs_url(self, action_id: str | None = None) -> str:
+        return f"/api/projects/{self.team.id}/vision/actions/{action_id or self.action.id}/runs/"
+
+    def _create_run(self, action: VisionAction | None = None, **overrides: Any) -> VisionActionRun:
+        defaults: dict[str, Any] = {
+            "team": self.team,
+            "vision_action": action or self.action,
+            "idempotency_key": f"key-{VisionActionRun.all_teams.count()}",
+            "status": VisionActionRunStatus.COMPLETED,
+        }
+        defaults.update(overrides)
+        return VisionActionRun.all_teams.create(**defaults)
+
+    def test_list_runs_for_action(self) -> None:
+        self._create_run(status=VisionActionRunStatus.COMPLETED, synthesized_markdown="# Themes", observation_count=3)
+        self._create_run(status=VisionActionRunStatus.SKIPPED, error={"skip_reason": "nothing to summarize"})
+
+        resp = self.client.get(self.runs_url())
+        self.assertEqual(resp.status_code, 200, resp.content)
+        results = resp.json()["results"]
+        self.assertEqual(len(results), 2)
+        completed = next(r for r in results if r["status"] == "completed")
+        self.assertEqual(completed["synthesized_markdown"], "# Themes")
+        self.assertEqual(completed["observation_count"], 3)
+        self.assertIsNone(completed["error_reason"])
+
+    def test_error_reason_surfaced(self) -> None:
+        run = self._create_run(status=VisionActionRunStatus.SKIPPED, error={"skip_reason": "over budget"})
+        resp = self.client.get(f"{self.runs_url()}{run.id}/")
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.json()["error_reason"], "over budget")
+
+    def test_runs_scoped_to_their_action(self) -> None:
+        other_action = VisionAction.all_teams.create(team=self.team, scanner=self.scanner, name="other-action")
+        mine = self._create_run(self.action)
+        self._create_run(other_action)
+
+        results = self.client.get(self.runs_url()).json()["results"]
+        self.assertEqual([r["id"] for r in results], [str(mine.id)])
+
+    def test_malformed_action_id_returns_404(self) -> None:
+        resp = self.client.get(self.runs_url("not-a-uuid"))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_flag_off_hides_endpoint(self) -> None:
+        self._create_run()
+
+        def _flags(flag_key: str, *args: Any, **kwargs: Any) -> bool:
+            return flag_key != "replay-vision-actions"
+
+        with patch("products.replay_vision.backend.feature_flag.posthoganalytics.feature_enabled", side_effect=_flags):
+            resp = self.client.get(self.runs_url())
+        self.assertEqual(resp.status_code, 404, resp.content)
+
+
+class TestVisionActionRunCrossTeamIDOR(_VisionActionAPITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.other_org = Organization.objects.create(name="other-org")
+        self.other_team = Team.objects.create(organization=self.other_org, name="other-team")
+        self.other_scanner = self._create_scanner(team=self.other_team, name="other-scanner")
+        self.other_action = VisionAction.all_teams.create(
+            team=self.other_team, scanner=self.other_scanner, name="other-action"
+        )
+        VisionActionRun.all_teams.create(
+            team=self.other_team, vision_action=self.other_action, idempotency_key="other-run"
+        )
+
+    def test_cannot_list_other_team_action_runs(self) -> None:
+        # The action belongs to another team, so the nested route must 404 rather than leak its runs.
+        resp = self.client.get(f"/api/projects/{self.team.id}/vision/actions/{self.other_action.id}/runs/")
+        self.assertEqual(resp.status_code, 404)

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -261,6 +261,58 @@ export interface PatchedVisionActionApi {
 }
 
 /**
+ * * `running` - Running
+ * * `completed` - Completed
+ * * `failed` - Failed
+ * * `skipped` - Skipped
+ */
+export type VisionActionRunStatusEnumApi =
+    (typeof VisionActionRunStatusEnumApi)[keyof typeof VisionActionRunStatusEnumApi]
+
+export const VisionActionRunStatusEnumApi = {
+    Running: 'running',
+    Completed: 'completed',
+    Failed: 'failed',
+    Skipped: 'skipped',
+} as const
+
+/**
+ * Read-only history of one VisionAction execution, backing the per-action run list + summary view.
+ */
+export interface VisionActionRunApi {
+    readonly id: string
+    /** Run outcome: running, completed, failed, or skipped.
+     *
+     * * `running` - Running
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped */
+    readonly status: VisionActionRunStatusEnumApi
+    /**
+     * The scheduled fire time this run was claimed for.
+     * @nullable
+     */
+    readonly scheduled_at: string | null
+    /** Number of observations that fed this run's summary. */
+    readonly observation_count: number
+    /** The synthesized group-summary report in Markdown. Empty until a run completes successfully. */
+    readonly synthesized_markdown: string
+    /** Short human-readable reason a run skipped or failed; null on success. */
+    readonly error_reason: string
+    readonly created_at: string
+    readonly updated_at: string
+}
+
+export interface PaginatedVisionActionRunListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: VisionActionRunApi[]
+}
+
+/**
  * * `pending` - Pending
  * * `running` - Running
  * * `succeeded` - Succeeded
@@ -763,6 +815,17 @@ export type VisionActionsListParams = {
      * Filter to the actions belonging to one scanner.
      */
     scanner?: string
+}
+
+export type VisionActionsRunsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
 }
 
 export type VisionObservationsListParams = {

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -297,8 +297,11 @@ export interface VisionActionRunApi {
     readonly observation_count: number
     /** The synthesized group-summary report in Markdown. Empty until a run completes successfully. */
     readonly synthesized_markdown: string
-    /** Short human-readable reason a run skipped or failed; null on success. */
-    readonly error_reason: string
+    /**
+     * Short human-readable reason a run skipped or failed; null on success.
+     * @nullable
+     */
+    readonly error_reason: string | null
     readonly created_at: string
     readonly updated_at: string
 }

--- a/products/replay_vision/frontend/generated/api.ts
+++ b/products/replay_vision/frontend/generated/api.ts
@@ -17,6 +17,7 @@ import type {
     PaginatedReplayObservationListApi,
     PaginatedReplayScannerListApi,
     PaginatedVisionActionListApi,
+    PaginatedVisionActionRunListApi,
     PatchedReplayScannerApi,
     PatchedVisionActionApi,
     ReplayObservationApi,
@@ -24,7 +25,9 @@ import type {
     ScannerCreatorsResponseApi,
     ScannerStatsResponseApi,
     VisionActionApi,
+    VisionActionRunApi,
     VisionActionsListParams,
+    VisionActionsRunsListParams,
     VisionObservationsListParams,
     VisionQuotaApi,
     VisionScannersListParams,
@@ -149,6 +152,60 @@ export const visionActionsDestroy = async (projectId: string, id: string, option
     return apiMutator<void>(getVisionActionsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getVisionActionsRunsListUrl = (
+    projectId: string,
+    visionActionId: string,
+    params?: VisionActionsRunsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/vision/actions/${visionActionId}/runs/?${stringifiedParams}`
+        : `/api/projects/${projectId}/vision/actions/${visionActionId}/runs/`
+}
+
+/**
+ * Read-only run history for a single vision action (nested under /vision/actions/{action_id}/runs/).
+ */
+export const visionActionsRunsList = async (
+    projectId: string,
+    visionActionId: string,
+    params?: VisionActionsRunsListParams,
+    options?: RequestInit
+): Promise<PaginatedVisionActionRunListApi> => {
+    return apiMutator<PaginatedVisionActionRunListApi>(getVisionActionsRunsListUrl(projectId, visionActionId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getVisionActionsRunsRetrieveUrl = (projectId: string, visionActionId: string, id: string) => {
+    return `/api/projects/${projectId}/vision/actions/${visionActionId}/runs/${id}/`
+}
+
+/**
+ * Read-only run history for a single vision action (nested under /vision/actions/{action_id}/runs/).
+ */
+export const visionActionsRunsRetrieve = async (
+    projectId: string,
+    visionActionId: string,
+    id: string,
+    options?: RequestInit
+): Promise<VisionActionRunApi> => {
+    return apiMutator<VisionActionRunApi>(getVisionActionsRunsRetrieveUrl(projectId, visionActionId, id), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -24,6 +24,12 @@ tools:
     vision-actions-retrieve:
         operation: vision_actions_retrieve
         enabled: false
+    vision-actions-runs-list:
+        operation: vision_actions_runs_list
+        enabled: false
+    vision-actions-runs-retrieve:
+        operation: vision_actions_runs_retrieve
+        enabled: false
     vision-observations-list:
         operation: vision_observations_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -35269,8 +35269,11 @@ export namespace Schemas {
       readonly observation_count: number;
       /** The synthesized group-summary report in Markdown. Empty until a run completes successfully. */
       readonly synthesized_markdown: string;
-      /** Short human-readable reason a run skipped or failed; null on success. */
-      readonly error_reason: string;
+      /**
+         * Short human-readable reason a run skipped or failed; null on success.
+         * @nullable
+         */
+      readonly error_reason: string | null;
       readonly created_at: string;
       readonly updated_at: string;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -35232,6 +35232,58 @@ export namespace Schemas {
       results: VisionAction[];
     }
 
+    /**
+     * * `running` - Running
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped
+     */
+    export type VisionActionRunStatusEnum = typeof VisionActionRunStatusEnum[keyof typeof VisionActionRunStatusEnum];
+
+
+    export const VisionActionRunStatusEnum = {
+      Running: 'running',
+      Completed: 'completed',
+      Failed: 'failed',
+      Skipped: 'skipped',
+    } as const;
+
+    /**
+     * Read-only history of one VisionAction execution, backing the per-action run list + summary view.
+     */
+    export interface VisionActionRun {
+      readonly id: string;
+      /** Run outcome: running, completed, failed, or skipped.
+       *
+       * * `running` - Running
+       * * `completed` - Completed
+       * * `failed` - Failed
+       * * `skipped` - Skipped */
+      readonly status: VisionActionRunStatusEnum;
+      /**
+         * The scheduled fire time this run was claimed for.
+         * @nullable
+         */
+      readonly scheduled_at: string | null;
+      /** Number of observations that fed this run's summary. */
+      readonly observation_count: number;
+      /** The synthesized group-summary report in Markdown. Empty until a run completes successfully. */
+      readonly synthesized_markdown: string;
+      /** Short human-readable reason a run skipped or failed; null on success. */
+      readonly error_reason: string;
+      readonly created_at: string;
+      readonly updated_at: string;
+    }
+
+    export interface PaginatedVisionActionRunList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: VisionActionRun[];
+    }
+
     export interface WarehouseColumnAnnotation {
       readonly id: string;
       /** ID of the data warehouse table this annotation describes. */
@@ -66122,6 +66174,17 @@ export namespace Schemas {
      * Filter to the actions belonging to one scanner.
      */
     scanner?: string;
+    };
+
+    export type VisionActionsRunsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
     };
 
     export type VisionObservationsListParams = {


### PR DESCRIPTION
## Problem

Vision actions ("and then…" scheduled summaries) run on a cadence and persist each execution as a `VisionActionRun` — status, the synthesized summary, observation count, and any skip/failure reason. The engine already writes these rows, but there's no way to read them. Without an API, the UI can't show users what an action actually did: its run history or the past summaries it produced.

## Changes

Adds a read-only nested endpoint:

```
GET /api/projects/:team_id/vision/actions/:id/runs/        # list
GET /api/projects/:team_id/vision/actions/:id/runs/:run_id # retrieve
```

It returns each run's `status`, `scheduled_at`, `observation_count`, the `synthesized_markdown` report, and a derived `error_reason` (a short human-readable string pulled from the run's stored skip/abort/exception payload, rather than leaking the raw internals).

- Mirrors the existing nested `observations` endpoint: read-only `GenericViewSet` (list + retrieve) nested under the action.
- Scoped to the request team **and** the parent action — cross-team or malformed ids return 404, never leak.
- Gated behind `replay-vision-actions`, and requires `session_recording:read` since runs surface recording-derived summaries (same bar as the observations endpoint).
- No migration — `VisionActionRun` already exists; this only exposes it.

This is the backend for the upcoming per-action detail/run-history view (next PR).

## How did you test this code?

I'm an agent (PostHog Code). I added and ran automated tests — no manual testing:

- `TestVisionActionRunViewSet` — list, retrieve, `error_reason` derivation, scoping to the parent action, malformed-id 404, flag-off 404.
- `TestVisionActionRunCrossTeamIDOR` — another team's action runs return 404.
- Full `test_vision_actions_api.py` (26 tests) green; `tach check` clean; `hogli build:openapi` regenerated the frontend + MCP types with no schema warnings.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Kim Dugan is the DRI.

Built with PostHog Code (Claude). Invoked the `/improving-drf-endpoints` skill while shaping the serializer/viewset.

Decisions:
- Nested under the action (`/actions/{id}/runs/`) rather than a top-level `?action=` filter — it's the natural parent/child read and mirrors `scanners/{id}/observations/`.
- The nested lookup is named `vision_action_id` (not `action_id`) so it maps to the model's FK column and drf-spectacular derives the path-param type automatically (a mismatched name produced a schema warning that fails `--fail-on-warn`).
- `error_reason` is a typed `SerializerMethodField` that surfaces a single readable string from the run's `error` JSON, keeping the raw payload (and any internals) out of the API.
- Added a `VisionActionRunStatusEnum` entry to `ENUM_NAME_OVERRIDES` to avoid an OpenAPI enum-name collision on the `status` field.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
