### PR TITLE
refactor(persons): list persons via ActorsQuery

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 import builtins
 from collections.abc import Callable
@@ -29,7 +30,7 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 
-from posthog.schema import ProductKey
+from posthog.schema import ActorsQuery, ProductKey
 
 from posthog.hogql.constants import CSV_EXPORT_LIMIT
 
@@ -67,8 +68,6 @@ from posthog.queries.actor_base_query import ActorBaseQuery, get_serialized_peop
 from posthog.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
 from posthog.queries.funnels.funnel_strict_persons import ClickhouseFunnelStrictActors
 from posthog.queries.funnels.funnel_unordered_persons import ClickhouseFunnelUnorderedActors
-from posthog.queries.insight import insight_sync_execute
-from posthog.queries.person_query import PersonQuery
 from posthog.queries.properties_timeline import PropertiesTimeline
 from posthog.queries.trends.lifecycle import Lifecycle
 from posthog.queries.trends.trends_actors import TrendsActors
@@ -500,18 +499,39 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         elif not filter.limit:
             filter = filter.shallow_clone({LIMIT: DEFAULT_PAGE_LIMIT})
 
-        person_query = PersonQuery(filter, team.pk)
-        paginated_query, paginated_params = person_query.get_query(paginate=True, filter_future_persons=True)
+        from posthog.hogql import ast  # noqa: PLC0415 — deferred to avoid a circular import at module load
+        from posthog.hogql.query import execute_hogql_query  # noqa: PLC0415
 
-        raw_paginated_result = insight_sync_execute(
-            paginated_query,
-            {**paginated_params, **filter.hogql_context.values},
-            filter=filter,
-            query_type="person_list",
-            team_id=team.pk,
-            # workload=Workload.OFFLINE,  # this endpoint is only used by external API requests
+        from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner  # noqa: PLC0415
+        from posthog.models.person.util import get_person_by_distinct_id  # noqa: PLC0415
+
+        person_properties: list[dict] = []
+        raw_properties = request.GET.get("properties")
+        if raw_properties:
+            for prop in json.loads(raw_properties):
+                # Legacy person filters default to the "exact" operator; ActorsQuery requires it explicitly.
+                if prop.get("type") != "cohort":
+                    prop.setdefault("operator", "exact")
+                person_properties.append(prop)
+        if filter.email:
+            person_properties.append({"type": "person", "key": "email", "value": filter.email, "operator": "exact"})
+        if filter.distinct_id:
+            # Exact match on any of the person's distinct IDs; no matching person => no results.
+            matched = get_person_by_distinct_id(team.pk, filter.distinct_id)
+            person_properties.append({"type": "hogql", "key": f"id = toUUID('{matched.uuid}')" if matched else "1 = 2"})
+        actors_query = ActorsQuery(
+            select=["id"],
+            properties=person_properties,
+            search=filter.search or None,
+            orderBy=["created_at DESC", "id DESC"],
+            limit=filter.limit,
+            offset=filter.offset,
         )
-        actor_ids = [row[0] for row in raw_paginated_result]
+        # Use .calculate() (not .run()) — it applies the limit/offset paginator but skips the
+        # insight-caching wrapper. With an id-only select there's no actor-column hydration, so
+        # we still hydrate the person objects ourselves via get_serialized_people.
+        actors_runner = ActorsQueryRunner(team=team, query=actors_query)
+        actor_ids = [row[0] for row in actors_runner.calculate().results]
         serialized_actors = get_serialized_people(team, actor_ids)
 
         restricted_person_properties = self.get_serializer_context().get("restricted_person_properties")
@@ -530,16 +550,14 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # TODO: Use a more scalable solution before PostHog 3000 navigation is released, and remove this param
         total_count: Optional[int] = None
         if "include_total" in request.GET:
-            total_query, total_params = person_query.get_query(paginate=False, filter_future_persons=True)
-            total_query_aggregated = f"SELECT count() FROM ({total_query})"
-            raw_paginated_result = insight_sync_execute(
-                total_query_aggregated,
-                {**total_params, **filter.hogql_context.values},
-                filter=filter,
-                query_type="person_list_total",
-                team_id=team.pk,
+            count_inner = actors_runner.to_query()
+            count_inner.limit = None
+            count_inner.offset = None
+            count_query = ast.SelectQuery(
+                select=[ast.Call(name="count", args=[])],
+                select_from=ast.JoinExpr(table=count_inner),
             )
-            total_count = raw_paginated_result[0][0]
+            total_count = execute_hogql_query(count_query, team=team).results[0][0]
 
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None
         previous_url = (

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1602,7 +1602,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         create_person(team_id=self.team.pk, version=0)
 
         returned_ids = []
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(19):
             response = self.client.get("/api/person/?limit=10").json()
         self.assertEqual(len(response["results"]), 9)
         returned_ids += [x["distinct_ids"][0] for x in response["results"]]
@@ -1613,7 +1613,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         created_ids.reverse()  # ids are returned in desc order
         self.assertEqual(returned_ids, created_ids, returned_ids)
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(22):
             response_include_total = self.client.get("/api/person/?limit=10&include_total").json()
         self.assertEqual(response_include_total["count"], 20)  #  With `include_total`, the total count is returned too
 


### PR DESCRIPTION
> Stacked on #65317 → #65313 → … → #65304. Continues C3.3 (migrating person/actor REST endpoints off legacy `posthog/queries/`).

## Problem

The persons `list` endpoint (`/api/person/`) is the highest-traffic legacy reader — a production query-log check (US, 3 days) shows ~2.6M queries, overwhelmingly via `personal_api_key`. It built person UUIDs with the legacy `PersonQuery` + `insight_sync_execute` (a hand-written persons/events raw-SQL reader 63448 must otherwise keep schema-aware).

## Changes

`posthog/api/person.py` `list` now builds an `ActorsQuery` and runs it via `ActorsQueryRunner.calculate()` to get the member UUIDs; `get_serialized_people` (already the HogQL/personhog path) still produces the response objects, so the JSON contract is unchanged. Filter mapping:

- `properties` → `ActorsQuery.properties` (legacy filters default `operator` to `exact`, injected to satisfy `PersonPropertyFilter`).
- `email` → person-property `exact` filter.
- `distinct_id` → resolved to the person's UUID via `get_person_by_distinct_id` (personhog-routed), then an `id = toUUID(...)` HogQL filter; no match → `1 = 2` (empty), matching the legacy "exact, any distinct id" semantics.
- `search` → `ActorsQuery.search` (PersonStrategy already searches email/name/uuid/distinct_id, matching legacy).
- ordering → `created_at DESC, id DESC` (legacy order).
- `include_total` → `count()` over the query with limit/offset stripped.

`.calculate()` (not `.run()`) is used so the limit/offset paginator is applied while skipping the insight-caching wrapper; with an id-only `select` there's no actor-column hydration, so we still hydrate ourselves. Removed the now-unused `PersonQuery` / `insight_sync_execute` imports.

### Behavior notes for review

- **Dropped `filter_future_persons`.** The legacy list hard-coded excluding persons with `created_at > now()+1day` (a corrupt-data guard). It has no test coverage and the modern in-app `ActorsQuery` persons path doesn't apply it, so dropping it makes the REST endpoint consistent with the in-app path. Flagging explicitly in case anyone relied on it.
- **Postgres query count rises ~11 → ~19 per request** (visible in `test_pagination_limit`, updated). This is the inherent HogQL database-build overhead (group-type mappings, schema) that the raw-SQL path skipped — it's the same path the in-app Persons scene already uses. On a 2.6M/day endpoint this is a real per-request increase; calling it out for the query-perf review since it's a deliberate tradeoff of the HogQL migration, not an accident.

## How did you test this code?

I'm an agent; automated tests only. Full `posthog/api/test/test_person.py` is the parity oracle — 146 passed (covers property/email/distinct_id/search filters, pagination, the ClickHouse-but-not-Postgres dedup case, CSV export, `include_total`, PII restriction). Snapshot `.ambr` changes (query text changed) were regenerated to verify, then discarded — CI owns snapshots.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). Part of C3.3. I used the metabase query-log skill to confirm this is the highest-traffic legacy person endpoint before porting, so the parity bar (full suite) and the perf callout above are deliberate. One bug found and fixed mid-port: an initial `to_query()`-direct approach dropped the limit (the paginator lives in `.calculate()`), caught by `test_pagination_limit`.
