### PR TITLE
feat(llma): add file context to AI playground messages

### DIFF
--- a/products/ai_observability/frontend/playground/AIObservabilityPlaygroundScene.tsx
+++ b/products/ai_observability/frontend/playground/AIObservabilityPlaygroundScene.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import {
     IconChevronRight,
+    IconDocument,
     IconGear,
     IconPencil,
     IconPlay,
@@ -11,6 +12,7 @@ import {
     IconRevert,
     IconStack,
     IconTrash,
+    IconUpload,
     IconWrench,
     IconCopy,
 } from '@posthog/icons'
@@ -53,6 +55,7 @@ import {
     getLinkedSourceLabel,
     llmPlaygroundPromptsLogic,
     type Message,
+    type MessageFile,
     type MessageRole,
     type PromptConfig,
 } from './llmPlaygroundPromptsLogic'
@@ -86,6 +89,9 @@ const EXAMPLE_TOOL = [
         },
     },
 ]
+
+const MESSAGE_FILE_ACCEPT =
+    '.txt,.text,.md,.markdown,.json,.jsonl,.csv,.tsv,.yaml,.yml,.xml,.html,.htm,.css,.scss,.js,.jsx,.ts,.tsx,.py,.rb,.go,.rs,.java,.kt,.c,.h,.cpp,.cc,.cs,.php,.swift,.sh,.bash,.zsh,.sql,.toml,.ini,.cfg,.env,.log,text/*'
 
 function CollapsibleChevron({ collapsed }: { collapsed: boolean }): JSX.Element {
     return (
@@ -1000,6 +1006,60 @@ function SystemMessageDisplay({ promptId }: { promptId: string }): JSX.Element {
     )
 }
 
+function MessageFilesControl({
+    promptId,
+    index,
+    files,
+}: {
+    promptId: string
+    index: number
+    files: MessageFile[]
+}): JSX.Element {
+    const { submitting } = useValues(llmPlaygroundRunLogic)
+    const { attachFilesToMessage, removeMessageFile } = useActions(llmPlaygroundPromptsLogic)
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    return (
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+            <input
+                ref={inputRef}
+                className="hidden"
+                type="file"
+                multiple
+                accept={MESSAGE_FILE_ACCEPT}
+                onChange={(e) => {
+                    if (e.target.files?.length) {
+                        attachFilesToMessage(index, Array.from(e.target.files), promptId)
+                    }
+                    // Reset so re-selecting the same file fires onChange again
+                    e.target.value = ''
+                }}
+                data-attr="llma-playground-message-file-input"
+            />
+            <LemonButton
+                size="xsmall"
+                type="tertiary"
+                icon={<IconUpload />}
+                onClick={() => inputRef.current?.click()}
+                disabledReason={submitting ? 'Generating...' : undefined}
+                tooltip="Attach text files as context. Their contents are added to this message when you run."
+            >
+                Attach files
+            </LemonButton>
+            {files.map((file) => (
+                <LemonTag
+                    key={file.id}
+                    icon={<IconDocument />}
+                    closable={!submitting}
+                    onClose={() => removeMessageFile(index, file.id, promptId)}
+                >
+                    <span className="max-w-[180px] truncate">{file.name}</span>
+                </LemonTag>
+            ))}
+        </div>
+    )
+}
+
 function MessageDisplay({
     promptId,
     message,
@@ -1087,7 +1147,9 @@ function MessageDisplay({
                         <span className="text-xs text-muted truncate flex-1">
                             {message.content
                                 ? message.content.slice(0, 80) + (message.content.length > 80 ? '…' : '')
-                                : `Empty ${message.role} message`}
+                                : message.files?.length
+                                  ? `${message.files.length} file${message.files.length === 1 ? '' : 's'} attached`
+                                  : `Empty ${message.role} message`}
                         </span>
                     )}
                 </div>
@@ -1112,6 +1174,9 @@ function MessageDisplay({
                             maxRows={undefined}
                             onPressCmdEnter={() => submitPrompt()}
                         />
+                    )}
+                    {message.role === 'user' && (
+                        <MessageFilesControl promptId={promptId} index={index} files={message.files ?? []} />
                     )}
                 </AnimatedCollapsible>
             </div>

--- a/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
@@ -8,7 +8,13 @@ import { initKeaTests } from '~/test/init'
 
 import { modelPickerLogic, type ModelOption } from '../modelPickerLogic'
 import { llmPlaygroundModelLogic } from './llmPlaygroundModelLogic'
-import { createPromptConfig, llmPlaygroundPromptsLogic } from './llmPlaygroundPromptsLogic'
+import {
+    buildMessageContentWithFiles,
+    createPromptConfig,
+    llmPlaygroundPromptsLogic,
+    MAX_MESSAGE_FILE_BYTES,
+    messageHasContent,
+} from './llmPlaygroundPromptsLogic'
 import { llmPlaygroundRunLogic } from './llmPlaygroundRunLogic'
 
 const MOCK_MODEL_OPTIONS: ModelOption[] = [
@@ -657,6 +663,165 @@ describe('llmPlaygroundLogic', () => {
             llmPlaygroundPromptsLogic.actions.addResultToConversation(response)
 
             expect(llmPlaygroundPromptsLogic.values.messages).toEqual(original)
+        })
+    })
+
+    describe('Message file attachments', () => {
+        it('should append files to a message and accumulate across calls', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: 'Review this' }])
+
+            llmPlaygroundPromptsLogic.actions.addMessageFiles(0, [{ id: 'f1', name: 'a.py', content: 'print(1)' }])
+            llmPlaygroundPromptsLogic.actions.addMessageFiles(0, [{ id: 'f2', name: 'b.md', content: '# notes' }])
+
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toEqual([
+                { id: 'f1', name: 'a.py', content: 'print(1)' },
+                { id: 'f2', name: 'b.md', content: '# notes' },
+            ])
+        })
+
+        it('should remove a file by id and clear the files array when empty', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([
+                {
+                    role: 'user',
+                    content: 'Review this',
+                    files: [
+                        { id: 'f1', name: 'a.py', content: 'print(1)' },
+                        { id: 'f2', name: 'b.md', content: '# notes' },
+                    ],
+                },
+            ])
+
+            llmPlaygroundPromptsLogic.actions.removeMessageFile(0, 'f1')
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toEqual([
+                { id: 'f2', name: 'b.md', content: '# notes' },
+            ])
+
+            llmPlaygroundPromptsLogic.actions.removeMessageFile(0, 'f2')
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toBeUndefined()
+        })
+
+        it('should ignore file mutations on out-of-range indices', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: 'Only message' }])
+
+            llmPlaygroundPromptsLogic.actions.addMessageFiles(5, [{ id: 'f1', name: 'a.py', content: 'x' }])
+            llmPlaygroundPromptsLogic.actions.removeMessageFile(-1, 'f1')
+
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toBeUndefined()
+        })
+
+        it('reads selected files and stores their content (attachFilesToMessage)', async () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: 'Review' }])
+            const file = { name: 'a.py', size: 8, text: async () => 'print(1)' } as unknown as File
+
+            llmPlaygroundPromptsLogic.actions.attachFilesToMessage(0, [file])
+            await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
+
+            const files = llmPlaygroundPromptsLogic.values.messages[0].files
+            expect(files).toHaveLength(1)
+            expect(files?.[0]).toMatchObject({ name: 'a.py', content: 'print(1)' })
+            expect(files?.[0].id).toBeTruthy()
+        })
+
+        it('rejects files over the size cap and does not attach them', async () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: 'Review' }])
+            const big = {
+                name: 'big.txt',
+                size: MAX_MESSAGE_FILE_BYTES + 1,
+                text: async () => 'x',
+            } as unknown as File
+
+            llmPlaygroundPromptsLogic.actions.attachFilesToMessage(0, [big])
+            await expectLogic(llmPlaygroundPromptsLogic).toFinishAllListeners()
+
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toBeUndefined()
+        })
+
+        it('drops attached files when a message role changes away from user', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([
+                { role: 'user', content: 'Review', files: [{ id: 'f1', name: 'a.py', content: 'print(1)' }] },
+            ])
+
+            llmPlaygroundPromptsLogic.actions.updateMessage(0, { role: 'assistant' })
+
+            expect(llmPlaygroundPromptsLogic.values.messages[0].role).toBe('assistant')
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toBeUndefined()
+        })
+
+        it('keeps attached files when editing a user message in place', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([
+                { role: 'user', content: 'Review', files: [{ id: 'f1', name: 'a.py', content: 'print(1)' }] },
+            ])
+
+            llmPlaygroundPromptsLogic.actions.updateMessage(0, { content: 'Updated' })
+
+            expect(llmPlaygroundPromptsLogic.values.messages[0].files).toEqual([
+                { id: 'f1', name: 'a.py', content: 'print(1)' },
+            ])
+        })
+
+        it('should treat a message with only files as runnable', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([
+                { role: 'user', content: '   ', files: [{ id: 'f1', name: 'a.py', content: 'print(1)' }] },
+            ])
+
+            expect(llmPlaygroundPromptsLogic.values.hasRunnablePrompts).toBe(true)
+        })
+
+        it('should not be runnable with neither content nor files', () => {
+            llmPlaygroundPromptsLogic.actions.setMessages([{ role: 'user', content: '   ' }])
+
+            expect(llmPlaygroundPromptsLogic.values.hasRunnablePrompts).toBe(false)
+        })
+
+        describe('messageHasContent', () => {
+            it('is true for typed content', () => {
+                expect(messageHasContent({ role: 'user', content: 'hi' })).toBe(true)
+            })
+            it('is true for files without typed content', () => {
+                expect(
+                    messageHasContent({ role: 'user', content: ' ', files: [{ id: 'f', name: 'a', content: 'x' }] })
+                ).toBe(true)
+            })
+            it('is false for empty content and no files', () => {
+                expect(messageHasContent({ role: 'user', content: '   ' })).toBe(false)
+                expect(messageHasContent({ role: 'user', content: '', files: [] })).toBe(false)
+            })
+        })
+
+        describe('buildMessageContentWithFiles', () => {
+            it('returns the plain content when no files are attached', () => {
+                expect(buildMessageContentWithFiles({ role: 'user', content: 'just text' })).toBe('just text')
+            })
+            it('prepends file blocks before the typed content', () => {
+                expect(
+                    buildMessageContentWithFiles({
+                        role: 'user',
+                        content: 'Summarize',
+                        files: [{ id: 'f1', name: 'notes.md', content: '# hello' }],
+                    })
+                ).toBe('<file name="notes.md">\n# hello\n</file>\n\nSummarize')
+            })
+            it('joins multiple file blocks and omits empty typed content', () => {
+                expect(
+                    buildMessageContentWithFiles({
+                        role: 'user',
+                        content: '   ',
+                        files: [
+                            { id: 'f1', name: 'a.txt', content: 'A' },
+                            { id: 'f2', name: 'b.txt', content: 'B' },
+                        ],
+                    })
+                ).toBe('<file name="a.txt">\nA\n</file>\n\n<file name="b.txt">\nB\n</file>')
+            })
+            it('sanitizes file names that would break the <file> wrapper', () => {
+                expect(
+                    buildMessageContentWithFiles({
+                        role: 'user',
+                        content: '',
+                        files: [{ id: 'f1', name: 'a"<>\n.txt', content: 'X' }],
+                    })
+                ).toBe('<file name="a.txt">\nX\n</file>')
+            })
         })
     })
 

--- a/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -71,7 +71,7 @@ export function buildMessageContentWithFiles(message: Message): string {
         return message.content
     }
     const fileBlocks = message.files
-        .map((file) => `<file name="${sanitizeFileName(file.name)}">\n${file.content}\n</file>`)
+        .map((file) => `<file name="${sanitizeFileName(file.name)}">\n${file.content.replace(/<\/file>/gi, '<\\/file>')}\n</file>`)
         .join('\n\n')
     const typed = message.content.trim()
     return typed ? `${fileBlocks}\n\n${message.content}` : fileBlocks

--- a/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -33,9 +33,48 @@ export function cleanSourceSearchParams(searchParams: Record<string, any>): Reco
 export type MessageRole = 'user' | 'assistant' | 'system'
 export type ReasoningLevel = 'minimal' | 'low' | 'medium' | 'high' | null
 
+/** A text file attached to a message as inline context. */
+export interface MessageFile {
+    id: string
+    name: string
+    content: string
+}
+
+// Per-file cap on attached message context. Files are inlined into the prompt as text, so this
+// keeps a single attachment from blowing past model context windows or the request size limit.
+export const MAX_MESSAGE_FILE_BYTES = 1_000_000
+
 export interface Message {
     role: MessageRole
     content: string
+    files?: MessageFile[]
+}
+
+/** A message contributes to a run if it has typed content or at least one attached file. */
+export function messageHasContent(message: Message): boolean {
+    return message.content.trim().length > 0 || !!message.files?.length
+}
+
+/** Strip characters that would break the `<file name="...">` framing the model sees. */
+function sanitizeFileName(name: string): string {
+    return name.replace(/["<>\r\n]/g, '').trim() || 'file'
+}
+
+/**
+ * Combine a message's typed content with its attached files into a single string for the LLM.
+ * Each file is wrapped in a labeled block and placed before the typed text, so the model reads
+ * the supplied context first and the user's instruction last. Returns the plain content when
+ * there are no files attached.
+ */
+export function buildMessageContentWithFiles(message: Message): string {
+    if (!message.files?.length) {
+        return message.content
+    }
+    const fileBlocks = message.files
+        .map((file) => `<file name="${sanitizeFileName(file.name)}">\n${file.content}\n</file>`)
+        .join('\n\n')
+    const typed = message.content.trim()
+    return typed ? `${fileBlocks}\n\n${message.content}` : fileBlocks
 }
 
 export interface PromptConfig {
@@ -461,6 +500,9 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         setMessages: (messages: Message[], promptId?: string) => ({ messages, promptId }),
         deleteMessage: (index: number, promptId?: string) => ({ index, promptId }),
         addMessage: (message?: Partial<Message>, promptId?: string) => ({ message, promptId }),
+        attachFilesToMessage: (index: number, files: File[], promptId?: string) => ({ index, files, promptId }),
+        addMessageFiles: (index: number, files: MessageFile[], promptId?: string) => ({ index, files, promptId }),
+        removeMessageFile: (index: number, fileId: string, promptId?: string) => ({ index, fileId, promptId }),
         addResultToConversation: (response: string, promptId?: string) => ({ response, promptId }),
         updateMessage: (index: number, payload: Partial<Message>, promptId?: string) => ({ index, payload, promptId }),
         clearLinkedSource: true,
@@ -570,6 +612,33 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                         const defaultMessage: Message = { role: 'user', content: '' }
                         return { ...prompt, messages: [...prompt.messages, { ...defaultMessage, ...message }] }
                     }),
+                addMessageFiles: (
+                    state: PromptConfig[],
+                    { index, files, promptId }: { index: number; files: MessageFile[]; promptId?: string }
+                ) =>
+                    updatePromptConfigs(state, promptId, (prompt) => {
+                        if (index < 0 || index >= prompt.messages.length || files.length === 0) {
+                            return prompt
+                        }
+                        const newMessages = [...prompt.messages]
+                        const target = newMessages[index]
+                        newMessages[index] = { ...target, files: [...(target.files ?? []), ...files] }
+                        return { ...prompt, messages: newMessages }
+                    }),
+                removeMessageFile: (
+                    state: PromptConfig[],
+                    { index, fileId, promptId }: { index: number; fileId: string; promptId?: string }
+                ) =>
+                    updatePromptConfigs(state, promptId, (prompt) => {
+                        if (index < 0 || index >= prompt.messages.length) {
+                            return prompt
+                        }
+                        const newMessages = [...prompt.messages]
+                        const target = newMessages[index]
+                        const nextFiles = (target.files ?? []).filter((file) => file.id !== fileId)
+                        newMessages[index] = { ...target, files: nextFiles.length > 0 ? nextFiles : undefined }
+                        return { ...prompt, messages: newMessages }
+                    }),
                 addResultToConversation: (
                     state: PromptConfig[],
                     { response, promptId }: { response: string; promptId?: string }
@@ -595,7 +664,10 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                             return prompt
                         }
                         const newMessages = [...prompt.messages]
-                        newMessages[index] = { ...newMessages[index], ...payload }
+                        const merged = { ...newMessages[index], ...payload }
+                        // Only user messages carry attached files; drop them if the role changes away,
+                        // so they can't linger as hidden context the UI no longer exposes.
+                        newMessages[index] = merged.role === 'user' ? merged : { ...merged, files: undefined }
                         return { ...prompt, messages: newMessages }
                     }),
                 clearLinkedSource: (state: PromptConfig[]) =>
@@ -840,7 +912,7 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
         hasRunnablePrompts: [
             (s) => [s.promptConfigs],
             (promptConfigs: PromptConfig[]): boolean =>
-                promptConfigs.some((prompt) => prompt.messages.some((message) => message.content.trim().length > 0)),
+                promptConfigs.some((prompt) => prompt.messages.some(messageHasContent)),
         ],
     }),
 
@@ -881,6 +953,37 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
             posthog.capture('llma playground message removed', {
                 message_count: values.activePromptConfig?.messages.length ?? 0,
             })
+        },
+        attachFilesToMessage: async ({ index, files, promptId }) => {
+            const read = await Promise.all(
+                files.map(async (file): Promise<MessageFile | null> => {
+                    if (file.size > MAX_MESSAGE_FILE_BYTES) {
+                        lemonToast.error(
+                            `"${file.name}" is too large (max ${Math.round(MAX_MESSAGE_FILE_BYTES / 1000)} KB)`
+                        )
+                        return null
+                    }
+                    try {
+                        const content = await file.text()
+                        return { id: uuid(), name: file.name, content }
+                    } catch {
+                        lemonToast.error(`Could not read "${file.name}"`)
+                        return null
+                    }
+                })
+            )
+            const valid = read.filter((file): file is MessageFile => file !== null)
+            if (valid.length > 0) {
+                actions.addMessageFiles(index, valid, promptId)
+            }
+        },
+        addMessageFiles: ({ files }) => {
+            posthog.capture('llma playground message file attached', {
+                file_count: files.length,
+            })
+        },
+        removeMessageFile: () => {
+            posthog.capture('llma playground message file removed')
         },
         setTools: ({ tools }) => {
             posthog.capture('llma playground tools configured', {

--- a/products/ai_observability/frontend/playground/llmPlaygroundRunLogic.test.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundRunLogic.test.ts
@@ -90,6 +90,58 @@ describe('llmPlaygroundRunLogic', () => {
         streamSpy.mockRestore()
     })
 
+    it('injects attached file content into the completion request messages', async () => {
+        const streamSpy = jest.spyOn(api, 'stream').mockImplementation(async (_url, options: any) => {
+            options.onMessage?.({ data: JSON.stringify({ type: 'text', text: 'ok' }) })
+        })
+
+        const logic = llmPlaygroundRunLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        llmPlaygroundPromptsLogic.actions.setModel('gpt-5-mini')
+        llmPlaygroundPromptsLogic.actions.setMessages([
+            { role: 'user', content: 'Summarize', files: [{ id: 'f1', name: 'notes.md', content: '# hello' }] },
+        ])
+        llmPlaygroundRunLogic.actions.submitPrompt()
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(streamSpy).toHaveBeenCalledTimes(1)
+        expect(streamSpy.mock.calls[0][1]?.data).toMatchObject({
+            messages: [{ role: 'user', content: '<file name="notes.md">\n# hello\n</file>\n\nSummarize' }],
+        })
+
+        logic.unmount()
+        streamSpy.mockRestore()
+    })
+
+    it('runs a message that has only attached files and no typed content', async () => {
+        const streamSpy = jest.spyOn(api, 'stream').mockImplementation(async (_url, options: any) => {
+            options.onMessage?.({ data: JSON.stringify({ type: 'text', text: 'ok' }) })
+        })
+
+        const logic = llmPlaygroundRunLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        llmPlaygroundPromptsLogic.actions.setModel('gpt-5-mini')
+        llmPlaygroundPromptsLogic.actions.setMessages([
+            { role: 'user', content: '   ', files: [{ id: 'f1', name: 'data.csv', content: 'a,b\n1,2' }] },
+        ])
+        llmPlaygroundRunLogic.actions.submitPrompt()
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(streamSpy).toHaveBeenCalledTimes(1)
+        expect(streamSpy.mock.calls[0][1]?.data).toMatchObject({
+            messages: [{ role: 'user', content: '<file name="data.csv">\na,b\n1,2\n</file>' }],
+        })
+
+        logic.unmount()
+        streamSpy.mockRestore()
+    })
+
     it('surfaces backend error message and captures exception when stream fails with ApiError', async () => {
         const apiError = new ApiError('fallback message', 400, undefined, {
             error: 'Thinking is not supported for this model',

--- a/products/ai_observability/frontend/playground/llmPlaygroundRunLogic.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundRunLogic.ts
@@ -10,7 +10,13 @@ import { uuid } from 'lib/utils/dom'
 import type { ModelOption } from '../modelPickerLogic'
 import { llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { llmPlaygroundModelLogic } from './llmPlaygroundModelLogic'
-import { llmPlaygroundPromptsLogic, type Message, type PromptConfig } from './llmPlaygroundPromptsLogic'
+import {
+    buildMessageContentWithFiles,
+    llmPlaygroundPromptsLogic,
+    messageHasContent,
+    type Message,
+    type PromptConfig,
+} from './llmPlaygroundPromptsLogic'
 import type { llmPlaygroundRunLogicType } from './llmPlaygroundRunLogicType'
 import { resolveProviderKeyForPrompt } from './playgroundModelMatching'
 
@@ -233,7 +239,7 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                 .map((prompt: PromptConfig, index: number) => ({
                     prompt,
                     index,
-                    messagesToSend: prompt.messages.filter((m) => m.content.trim()),
+                    messagesToSend: prompt.messages.filter(messageHasContent),
                 }))
                 .filter((item: { messagesToSend: Message[] }) => item.messagesToSend.length > 0)
 
@@ -247,6 +253,9 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                 prompt_count: runnablePrompts.length,
                 models: runnablePrompts.map(({ prompt }) => prompt.model),
                 has_tools: runnablePrompts.some(({ prompt }) => !!prompt.tools?.length),
+                has_files: runnablePrompts.some(({ messagesToSend }) =>
+                    messagesToSend.some((message) => !!message.files?.length)
+                ),
                 total_message_count: runnablePrompts.reduce(
                     (sum, { messagesToSend }) => sum + messagesToSend.length,
                     0
@@ -322,7 +331,7 @@ export const llmPlaygroundRunLogic = kea<llmPlaygroundRunLogicType>([
                             system: prompt.systemPrompt,
                             messages: messagesToSend
                                 .filter((m: Message) => m.role === 'user' || m.role === 'assistant')
-                                .map((m: Message) => ({ role: m.role, content: m.content })),
+                                .map((m: Message) => ({ role: m.role, content: buildMessageContentWithFiles(m) })),
                             model: selectedModel.id,
                             provider: selectedModelProvider,
                             thinking: prompt.thinking,


### PR DESCRIPTION
## Problem

The LLM playground lets you iterate on prompts, but there's no way to give the model supporting material — a code file, a CSV, a spec — without pasting it into the message by hand. For anyone testing prompts that operate over a document, that's clumsy and easy to get wrong.

## Changes

Adds the ability to attach text/code/doc files to a **user** message in the playground.

- **Attach UI** on user messages: an "Attach files" button plus removable chips per attached file (`AIObservabilityPlaygroundScene.tsx`). Disabled while a run is in flight.
- **Inline injection**: at request-build time each file is wrapped in a labeled `<file name="…">…</file>` block and placed *before* the typed text, so the model reads the supplied context first and the instruction last. This is done by combining into the message's string `content`, so it's fully provider-agnostic — **no backend changes**.
- **Runnable semantics**: a message with only files (no typed text) now counts as runnable.
- File reading and validation (1 MB/file cap, decoding, error toasts) live in the kea logic via an `attachFilesToMessage` listener; the React component just hands raw `File` objects to the action.
- Files are dropped if a message's role changes away from `user`, so they can't linger as hidden context the UI no longer exposes.
- File names are sanitized before being framed for the model so a crafted name can't break the `<file>` wrapper.
- Analytics: `has_files` on prompt-submit, plus file attach/remove events.

No screenshots — this is a small additive control (button + chips) inside the existing message card.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** manually click through the UI. I added and ran automated Jest tests:

- `llmPlaygroundLogic.test.ts` — file add/remove reducers, the `attachFilesToMessage` listener (reads content, rejects oversize files), role-change dropping files, the `hasRunnablePrompts` selector with files-only messages, and `buildMessageContentWithFiles` / `messageHasContent` / filename sanitization helpers.
- `llmPlaygroundRunLogic.test.ts` — file content is injected into the completion request payload, and a files-only message runs.

All 128 tests in the two suites pass. `oxfmt --check` and `oxlint` are clean on the changed files. The repo-wide `tsgo` typecheck couldn't run locally (this worktree is missing the gitignored kea-typegen `*LogicType.ts` outputs, which affects the whole product); CI regenerates those before typechecking.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — additive UI affordance within an existing feature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Scope was confirmed with the human up front: text/code/doc files only (not images or PDFs), attached per user message — which is why the implementation inlines file content as text rather than building provider-specific multimodal payloads. That choice kept it backend-free; the backend already passes message content straight through to providers.

A self-review pass (the `/review` skill) surfaced four follow-ups that are folded into this PR: removed a stray scratch file, moved file-reading/validation from the component into the logic layer for testability, added a guard so attachments don't survive a role switch into hidden context, and sanitized file names before framing them for the model.

Note for the reviewer: the branch was cut from an older master and may want a rebase before merge, but the change is isolated to five playground files and nothing else touches them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
