### PR TITLE
chore(admin): disallow child model count to hit persons db

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -20,29 +20,20 @@ from posthog.admin.inlines.project_inline import ProjectInline
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
 from posthog.models.organization import Organization
+from posthog.person_db_router import PERSONS_DB_MODELS
 
-# Registry of models to count for bulk-delete report.
+# Registry of default-db models to count for bulk-delete report.
 # Format: (model_import_path, filter_field, display_name)
 # This mirrors delete_bulky_postgres_data() in posthog/models/team/util.py
 # When bulk-delete changes, update this list accordingly.
-# Note: CohortPeople and BatchExport require special handling (see below)
+# Note: BatchExport requires special handling (see below)
 BULK_DELETE_MODEL_REGISTRY: tuple[tuple[str, str, str], ...] = (
     ("products.early_access_features.backend.models.EarlyAccessFeature", "team_id", "Early Access Features"),
-    ("posthog.models.person.PersonDistinctId", "team_id", "Person Distinct IDs"),
-    ("posthog.models.person.PersonlessDistinctId", "team_id", "Personless Distinct IDs"),
     (
         "products.error_tracking.backend.models.ErrorTrackingIssueFingerprintV2",
         "team_id",
         "Error Tracking Fingerprints",
     ),
-    (
-        "products.feature_flags.backend.models.feature_flag.FeatureFlagHashKeyOverride",
-        "team_id",
-        "Feature Flag Overrides",
-    ),
-    ("posthog.models.group.group.Group", "team_id", "Groups"),
-    ("posthog.models.group_type_mapping.GroupTypeMapping", "team_id", "Group Type Mappings"),
-    ("posthog.models.person.Person", "team_id", "Persons"),
     (
         "products.product_analytics.backend.models.insight_caching_state.InsightCachingState",
         "team_id",
@@ -50,13 +41,24 @@ BULK_DELETE_MODEL_REGISTRY: tuple[tuple[str, str, str], ...] = (
     ),
 )
 
+# Subset of persons-db models that are part of the bulk-delete path.
+# Maps model_name (lowercase, matching person_db_router.PERSONS_DB_MODELS) to display name.
+BULK_DELETE_PERSONS_DB_MODELS: dict[str, str] = {
+    "cohortpeople": "Cohort People",
+    "featureflaghashkeyoverride": "Feature Flag Overrides",
+    "group": "Groups",
+    "grouptypemapping": "Group Type Mappings",
+    "person": "Persons",
+    "persondistinctid": "Person Distinct IDs",
+    "personlessdistinctid": "Personless Distinct IDs",
+}
+
 
 def get_model_counts_for_organization(organization: Organization) -> list[dict]:
     """
     Returns counts of all bulk-delete models for teams in this organization.
+    Models in the persons database are listed but not counted.
     """
-    from products.cohorts.backend.models.cohort import Cohort, CohortPeople
-
     team_ids = list(organization.teams.values_list("id", flat=True))
     if not team_ids:
         return []
@@ -83,32 +85,6 @@ def get_model_counts_for_organization(organization: Organization) -> list[dict]:
                 }
             )
 
-    # CohortPeople is in persons_db, Cohort is in default db - can't do cross-db JOIN
-    # Must first get cohort_ids from default db, then count CohortPeople by cohort_id
-    try:
-        cohort_ids = list(Cohort.objects.filter(team_id__in=team_ids).values_list("id", flat=True))
-        cohort_people_count = (
-            # nosemgrep: no-direct-persons-db-orm
-            CohortPeople.objects.filter(cohort_id__in=cohort_ids).count()
-            if cohort_ids
-            else 0  # nosemgrep: no-direct-persons-db-orm
-        )  # nosemgrep: no-direct-persons-db-orm
-        results.append(
-            {
-                "name": "Cohort People",
-                "count": cohort_people_count,
-                "model": CohortPeople._meta.label,
-            }
-        )
-    except Exception as e:
-        results.append(
-            {
-                "name": "Cohort People",
-                "count": f"Error: {e}",
-                "model": "products.cohorts.backend.models.CohortPeople",
-            }
-        )
-
     # BatchExport requires deleted=False filter to match delete_batch_exports() behavior
     try:
         from products.batch_exports.backend.models.batch_export import BatchExport
@@ -127,6 +103,16 @@ def get_model_counts_for_organization(organization: Organization) -> list[dict]:
                 "name": "Batch Exports",
                 "count": f"Error: {e}",
                 "model": "products.batch_exports.backend.models.batch_export.BatchExport",
+            }
+        )
+
+    for model_name, display_name in BULK_DELETE_PERSONS_DB_MODELS.items():
+        assert model_name in PERSONS_DB_MODELS, f"{model_name} not in PERSONS_DB_MODELS"
+        results.append(
+            {
+                "name": display_name,
+                "count": None,
+                "persons_db": True,
             }
         )
 
@@ -436,6 +422,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         organization = Organization.objects.get(id=organization_id)
         counts = get_model_counts_for_organization(organization)
         total = sum(c["count"] for c in counts if isinstance(c["count"], int))
+        has_persons_db_models = any(c.get("persons_db") for c in counts)
 
         return render(
             request,
@@ -444,6 +431,7 @@ class OrganizationAdmin(admin.ModelAdmin):
                 "organization": organization,
                 "counts": counts,
                 "total": total,
+                "has_persons_db_models": has_persons_db_models,
             },
         )
 

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -107,7 +107,8 @@ def get_model_counts_for_organization(organization: Organization) -> list[dict]:
         )
 
     for model_name, display_name in BULK_DELETE_PERSONS_DB_MODELS.items():
-        assert model_name in PERSONS_DB_MODELS, f"{model_name} not in PERSONS_DB_MODELS"
+        if model_name not in PERSONS_DB_MODELS:
+            raise ValueError(f"{model_name} is listed in BULK_DELETE_PERSONS_DB_MODELS but not in PERSONS_DB_MODELS")
         results.append(
             {
                 "name": display_name,

--- a/posthog/templates/admin/organization/model_counts.html
+++ b/posthog/templates/admin/organization/model_counts.html
@@ -18,7 +18,9 @@
         <tr>
             <td style="padding: 10px; border: 1px solid #ddd;">{{ item.name }}</td>
             <td style="text-align: right; padding: 10px; border: 1px solid #ddd;">
-                {% if item.count is not None %}
+                {% if item.persons_db %}
+                    <em style="color: #888;">Persons database &mdash; count unavailable</em>
+                {% elif item.count is not None %}
                     {{ item.count|default:0 }}
                 {% else %}
                     -
@@ -29,11 +31,18 @@
     </tbody>
     <tfoot>
         <tr style="background: #f5f5f5; font-weight: bold;">
-            <td style="padding: 10px; border: 1px solid #ddd;">Total Records</td>
+            <td style="padding: 10px; border: 1px solid #ddd;">Total Records (default database only)</td>
             <td style="text-align: right; padding: 10px; border: 1px solid #ddd;">{{ total|default:0 }}</td>
         </tr>
     </tfoot>
 </table>
+
+{% if has_persons_db_models %}
+<p style="color: #888; font-style: italic;">
+    Some models live in the persons database and cannot be counted from this admin view.
+    These models will still be deleted as part of organization deletion.
+</p>
+{% endif %}
 
 <p style="margin-top: 20px;">
     <a href="{% url 'admin:posthog_organization_change' organization.id %}">&larr; Back to Organization</a>


### PR DESCRIPTION
## Problem

The "Child model counts: View counts" button on the Organzation Admin page loaded a page that would kick off count queries against some very large tables (filtered by team id) in the persons database. Because we have many teams that these queries would never finish for, we cannot support this access pattern to the tables that live in the persons database.

## Changes

- replaces executing the record count query for tables that live in the persons database with the message "Persons database — count unavailable"

## How did you test this code?

Built it locally and tested it in the admin
<img width="1488" height="722" alt="Screenshot 2026-06-22 at 2 09 46 PM" src="https://github.com/user-attachments/assets/ad5c8e95-6668-4ea7-960f-7a4929b68572" />


