### PR TITLE
fix(data-warehouse): show cumulative row count for xmin schemas

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -176,7 +176,6 @@ async def validate_schema_and_update_table(
 
         _schema_id = external_data_schema.id
         _schema_name: str = external_data_schema.name
-        incremental_or_append = external_data_schema.should_use_incremental_field
 
         # The HogQL table name derives from the raw schema name (only lower-cased); the S3 folder is
         # the snake_cased `s3_folder_name`. They differ on purpose — see `resolve_table_and_folder_names`.
@@ -206,7 +205,7 @@ async def validate_schema_and_update_table(
                     table_created.format = table_params["format"]
                     table_created.url_pattern = new_url_pattern
                     table_created.queryable_folder = queryable_folder
-                    if incremental_or_append or external_data_schema.is_cdc:
+                    if external_data_schema.table_row_count_is_cumulative:
                         table_created.row_count = table_created.get_count()
                     else:
                         table_created.row_count = row_count

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -176,6 +176,13 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         return self.is_incremental or self.is_append or self.is_webhook
 
     @property
+    def table_row_count_is_cumulative(self) -> bool:
+        # These sync types append/merge into the warehouse table across runs, so its true size is the
+        # full table count — not the latest run's row_count, which is only that run's delta. Full refresh
+        # replaces the whole table, so there the run's row_count already equals the table size.
+        return self.should_use_incremental_field or self.is_cdc or self.is_xmin
+
+    @property
     def incremental_field(self) -> str | None:
         if self.sync_type_config:
             return self.sync_type_config.get("incremental_field", None)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -222,6 +222,22 @@ def test_is_xmin(sync_type: str | None, expected: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    "sync_type,expected",
+    [
+        (ExternalDataSchema.SyncType.XMIN, True),
+        (ExternalDataSchema.SyncType.INCREMENTAL, True),
+        (ExternalDataSchema.SyncType.APPEND, True),
+        (ExternalDataSchema.SyncType.WEBHOOK, True),
+        (ExternalDataSchema.SyncType.CDC, True),
+        (ExternalDataSchema.SyncType.FULL_REFRESH, False),
+        (None, False),
+    ],
+)
+def test_table_row_count_is_cumulative(sync_type: str | None, expected: bool) -> None:
+    assert ExternalDataSchema(sync_type=sync_type).table_row_count_is_cumulative is expected
+
+
+@pytest.mark.parametrize(
     "sync_type_config,expected",
     [
         ({"xmin_last_value": 42, "xmin_ceiling": (1 << 32) + 42, "xmin_num_wraparound": 1}, (42, (1 << 32) + 42, 1)),


### PR DESCRIPTION
## Problem

On the data source schemas page, the **Rows synced** column for a schema using xmin replication showed only the most recent sync's row count instead of the cumulative total of rows ingested.

That column renders `DataWarehouseTable.row_count`. When a sync finishes, `validate_schema_and_update_table` decides how to set `row_count`: for sync types that append/merge into the table across runs (incremental, append, webhook, CDC), it counts the whole table via `get_count()`; otherwise it stores just that run's delta — which is correct only for full refresh, where each run replaces the table. xmin was missing from the "counts the whole table" branch, so it fell through to the delta path and overwrote `row_count` with the latest run's count every sync.

xmin replication appends/merges across runs like incremental and CDC, so the table's true size has to come from `get_count()`.

## Changes

- Added xmin to the branch that sets `row_count` from `get_count()`, pulling the decision into a named property `ExternalDataSchema.table_row_count_is_cumulative` so the intent (which sync types accumulate vs. replace) is explicit and unit-testable.
- Replaced the inline `incremental_or_append or is_cdc` check in `validate_schema_and_update_table` with that property.

No migration — this only changes how an existing field is computed on the next sync.

## How did you test this code?

I'm an agent (Claude Code). Automated only:

- Added a parameterized unit test `test_table_row_count_is_cumulative` covering every sync type (xmin/incremental/append/webhook/CDC → cumulative; full refresh and unset → not). Ran it green.
- Confirmed the change is the single gating site for the schema table's `row_count`; the CDC companion table already uses `get_count()` and is unaffected.

The pre-existing DB-backed tests in `test_pipeline_sync.py` require a running stack and weren't run locally; the new test and the model logic are DB-free.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel reported the xmin "Rows synced" value looked like the last sync rather than the total. Traced it from the frontend column (`SchemasTab` → `schema.table.row_count`) back to `validate_schema_and_update_table`, where the sync-type branch omitted xmin. Chose to extract the decision into a model property rather than just appending `or is_xmin` inline, so the accumulate-vs-replace semantics are documented and testable in isolation. No skills were needed for this change.
